### PR TITLE
Use host shell for tx lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Plans support three lifecycle arrays and an optional write policy:
 - **write_policy**: Optional object with `ensure_final_newline` (bool), `normalize_eol` (`"lf"` or `"crlf"`), and `trim_trailing_whitespace` (bool). Applied to all pending content (including `file.create`) before writing to disk.
 - **strict**: Optional boolean (default: `false`). When `true`, a format or validation failure reverts all file writes and exits with code 7 (ROLLBACK) instead of code 6. Created files are removed; modified files are restored to their original content.
 
-All shell commands in `format` and `validate` execute via `sh -c` on the host; only use plans from trusted sources.
+All shell commands in `format` and `validate` execute via the host platform shell (`sh -c` on Unix, `cmd /C` on Windows); only use plans from trusted sources.
 
 ### Operation ordering
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -51,44 +51,46 @@ pub struct TxArgs {
     pub write: crate::cli::global::WriteFlags,
 }
 
+const DEFAULT_LIFECYCLE_TIMEOUT_SECS: u64 = 60;
+const SHELL_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+fn host_shell_command(cmd: &str) -> std::process::Command {
+    #[cfg(windows)]
+    {
+        let mut command = std::process::Command::new("cmd");
+        command.arg("/C").arg(cmd);
+        command
+    }
+    #[cfg(not(windows))]
+    {
+        let mut command = std::process::Command::new("sh");
+        command.arg("-c").arg(cmd);
+        command
+    }
+}
+
 /// Run a shell command with a timeout. Returns the exit status on success,
 /// or an error if the command times out or fails to start.
 fn run_shell_with_timeout(
     cmd: &str,
     timeout_secs: u64,
 ) -> anyhow::Result<std::process::ExitStatus> {
-    let mut child = std::process::Command::new("sh")
-        .arg("-c")
-        .arg(cmd)
+    let mut child = host_shell_command(cmd)
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
         .spawn()?;
 
-    let pid = child.id();
-    let (tx, rx) = std::sync::mpsc::channel();
-
-    // Wait for the child in a dedicated thread so the main thread
-    // can enforce the timeout without polling.
-    std::thread::spawn(move || {
-        let result = child.wait();
-        let _ = tx.send(result);
-    });
-
-    match rx.recv_timeout(Duration::from_secs(timeout_secs)) {
-        Ok(result) => Ok(result?),
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            // Kill the child process so the wait thread can exit.
-            let _ = std::process::Command::new("kill")
-                .arg("-9")
-                .arg(pid.to_string())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status();
-            // Drain the channel so the thread can exit cleanly.
-            let _ = rx.recv();
+    let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
             anyhow::bail!("timed out after {timeout_secs}s");
         }
-        Err(e) => anyhow::bail!("wait channel error: {e}"),
+        std::thread::sleep(SHELL_POLL_INTERVAL);
     }
 }
 
@@ -891,7 +893,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let mut lifecycle_failed = false;
         if let Some(ref format_steps) = plan.format {
             for step in format_steps {
-                let timeout_secs = step.timeout.unwrap_or(60);
+                let timeout_secs = step.timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
                 match run_shell_with_timeout(&step.cmd, timeout_secs) {
                     Ok(status) if !status.success() => {
                         eprintln!("tx: format step failed: {}", step.cmd);
@@ -912,7 +914,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         if !lifecycle_failed {
             if let Some(ref validate) = plan.validate {
                 for step in validate {
-                    let timeout_secs = step.timeout.unwrap_or(60);
+                    let timeout_secs = step.timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
                     let success = match run_shell_with_timeout(&step.cmd, timeout_secs) {
                         Ok(status) => status.success(),
                         Err(e) => {
@@ -990,6 +992,28 @@ mod tests {
     use super::*;
     use std::fs;
     use tempfile::TempDir;
+
+    fn shell_true() -> &'static str {
+        #[cfg(windows)]
+        {
+            "exit /b 0"
+        }
+        #[cfg(not(windows))]
+        {
+            "true"
+        }
+    }
+
+    fn shell_false() -> &'static str {
+        #[cfg(windows)]
+        {
+            "exit /b 1"
+        }
+        #[cfg(not(windows))]
+        {
+            "false"
+        }
+    }
 
     fn default_global() -> GlobalFlags {
         GlobalFlags::default()
@@ -1107,7 +1131,7 @@ mod tests {
         let plan_json = serde_json::json!({
             "operations": [],
             "validate": [
-                {"cmd": "true", "required": true}
+                {"cmd": shell_true(), "required": true}
             ]
         });
 
@@ -1132,7 +1156,7 @@ mod tests {
         let plan_json = serde_json::json!({
             "operations": [],
             "validate": [
-                {"cmd": "false", "required": true}
+                {"cmd": shell_false(), "required": true}
             ]
         });
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,6 +4,63 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
+fn shell_false() -> &'static str {
+    #[cfg(windows)]
+    {
+        "exit /b 1"
+    }
+    #[cfg(not(windows))]
+    {
+        "false"
+    }
+}
+
+fn shell_exit_1() -> &'static str {
+    #[cfg(windows)]
+    {
+        "exit /b 1"
+    }
+    #[cfg(not(windows))]
+    {
+        "exit 1"
+    }
+}
+
+fn shell_sleep_300() -> &'static str {
+    #[cfg(windows)]
+    {
+        "powershell -Command \"Start-Sleep -Seconds 300\""
+    }
+    #[cfg(not(windows))]
+    {
+        "sleep 300"
+    }
+}
+
+fn shell_touch(path: &Path) -> String {
+    let path = path.display();
+    #[cfg(windows)]
+    {
+        format!("powershell -Command \"New-Item -ItemType File -Path '{path}' -Force | Out-Null\"")
+    }
+    #[cfg(not(windows))]
+    {
+        format!("touch '{path}'")
+    }
+}
+
+fn shell_test_exists(path: &Path) -> String {
+    let path = path.display();
+    #[cfg(windows)]
+    {
+        format!("if exist \"{path}\" (exit /b 0) else (exit /b 1)")
+    }
+    #[cfg(not(windows))]
+    {
+        format!("test -f '{path}'")
+    }
+}
+
 // ---------------------------------------------------------------------------
 // search
 // ---------------------------------------------------------------------------
@@ -2228,7 +2285,7 @@ fn test_tx_validate_required_failure_exits_6() {
             {"op": "replace", "path": "test.txt", "from": "old", "to": "new"}
         ],
         "validate": [
-            {"cmd": "false", "required": true}
+            {"cmd": shell_false(), "required": true}
         ]
     });
     let plan_file = dir.path().join("plan.json");
@@ -2436,7 +2493,7 @@ fn test_tx_optional_validation_failure_ignored() {
             {"op": "replace", "path": "test.txt", "from": "old", "to": "new"}
         ],
         "validate": [
-            {"cmd": "false", "required": false}
+            {"cmd": shell_false(), "required": false}
         ]
     });
     let plan_file = dir.path().join("plan.json");
@@ -3061,8 +3118,8 @@ fn test_tx_format_step_runs_between_write_and_validate() {
             "from": "before",
             "to": "after"
         }],
-        "format": [{"cmd": format!("touch {}", marker.to_str().unwrap())}],
-        "validate": [{"cmd": format!("test -f {}", marker.to_str().unwrap()), "required": true}]
+        "format": [{"cmd": shell_touch(&marker)}],
+        "validate": [{"cmd": shell_test_exists(&marker), "required": true}]
     });
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
@@ -3451,7 +3508,7 @@ fn test_tx_validate_timeout_kills_hanging_command() {
             "to": "changed"
         }],
         "validate": [{
-            "cmd": "sleep 300",
+            "cmd": shell_sleep_300(),
             "required": true,
             "timeout": 1
         }]
@@ -3484,7 +3541,7 @@ fn test_tx_format_timeout_kills_hanging_command() {
             "to": "changed"
         }],
         "format": [{
-            "cmd": "sleep 300",
+            "cmd": shell_sleep_300(),
             "timeout": 1
         }]
     });
@@ -3517,7 +3574,7 @@ fn test_tx_strict_mode_reverts_on_format_failure() {
             "to": "changed"
         }],
         "format": [{
-            "cmd": "exit 1"
+            "cmd": shell_exit_1()
         }]
     });
     let plan_file = dir.path().join("plan.json");
@@ -3551,7 +3608,7 @@ fn test_tx_strict_mode_reverts_on_validate_failure() {
             "to": "changed"
         }],
         "validate": [{
-            "cmd": "exit 1",
+            "cmd": shell_exit_1(),
             "required": true
         }]
     });
@@ -3583,7 +3640,7 @@ fn test_tx_strict_mode_removes_created_files_on_failure() {
             "content": "should be removed"
         }],
         "validate": [{
-            "cmd": "exit 1",
+            "cmd": shell_exit_1(),
             "required": true
         }]
     });
@@ -3814,7 +3871,7 @@ fn test_tx_json_output_on_validation_failure() {
             "to": "world"
         }],
         "validate": [{
-            "cmd": "false",
+            "cmd": shell_false(),
             "required": true,
             "timeout": 5
         }]
@@ -3851,7 +3908,7 @@ fn test_tx_strict_mode_restores_deleted_file_on_failure() {
             "path": file.to_str().unwrap()
         }],
         "validate": [{
-            "cmd": "exit 1",
+            "cmd": shell_exit_1(),
             "required": true
         }]
     });
@@ -3885,7 +3942,7 @@ fn test_tx_non_strict_format_failure_exits_6_not_7() {
             "to": "changed"
         }],
         "format": [{
-            "cmd": "exit 1"
+            "cmd": shell_exit_1()
         }]
     });
     let plan_file = dir.path().join("plan.json");
@@ -4011,11 +4068,11 @@ fn test_tx_format_and_validate_success_path() {
             "to": "changed"
         }],
         "format": [{
-            "cmd": format!("touch {}", marker.to_str().unwrap()),
+            "cmd": shell_touch(&marker),
             "timeout": 10
         }],
         "validate": [{
-            "cmd": format!("test -f {}", marker.to_str().unwrap()),
+            "cmd": shell_test_exists(&marker),
             "required": true,
             "timeout": 10
         }]


### PR DESCRIPTION
## Summary
- run tx format and validate commands through the host platform shell
- replace the Unix-only timeout kill path with a cross-platform child process timeout loop
- make tx lifecycle tests and docs match the platform-aware behavior

## Testing
- make check
