### PR TITLE
Document elvish completion install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ patchloom --json tx --plan plan.json --apply
 
 Generate shell completions for your shell:
 
-```
+```bash
 # bash
 patchloom completions bash > /etc/bash_completion.d/patchloom
 
@@ -369,6 +369,9 @@ patchloom completions zsh > ~/.zfunc/_patchloom
 
 # fish
 patchloom completions fish > ~/.config/fish/completions/patchloom.fish
+
+# elvish
+patchloom completions elvish > ~/.config/elvish/rc.elv
 ```
 
 ## Transaction plan format

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -48,6 +48,9 @@ patchloom completions zsh > ~/.zfunc/_patchloom
 
 # fish
 patchloom completions fish > ~/.config/fish/completions/patchloom.fish
+
+# elvish
+patchloom completions elvish > ~/.config/elvish/rc.elv
 ```
 
 ## Verify

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4304,6 +4304,13 @@ fn quickstart_path() -> PathBuf {
         .join("quickstart.md")
 }
 
+fn installation_path() -> PathBuf {
+    repo_root()
+        .join("docs")
+        .join("getting-started")
+        .join("installation.md")
+}
+
 fn readme_path() -> PathBuf {
     repo_root().join("README.md")
 }
@@ -4694,6 +4701,20 @@ fn test_smoke_quickstart_transaction_snippet() {
     assert!(fs::read_to_string(dir.path().join("CHANGELOG.md"))
         .unwrap()
         .contains("- Bumped to v2.0.0"));
+}
+
+#[test]
+fn test_smoke_shell_completion_docs_include_elvish() {
+    for (path, label) in [
+        (installation_path(), "installation guide"),
+        (readme_path(), "README"),
+    ] {
+        let content = fs::read_to_string(path).unwrap();
+        assert!(
+            content.contains("patchloom completions elvish"),
+            "{label} should document elvish completions"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- document the elvish completion install path in the README shell completions section
- add the same elvish example to the installation guide
- add a focused smoke test so the docs keep mentioning elvish completions

## Testing
- cargo test --test integration test_smoke_shell_completion_docs_include_elvish -- --exact
- make check
