### PR TITLE
Refresh README test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 10 commands and 326 passing tests.
+V2 with 10 commands and 327 passing tests.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- refresh the README status line using the repo-supported README.md updated: V2, 10 commands, 327 tests (152 unit + 175 integration) target
- bring the documented passing test count back in sync with the current suite

## Testing
- make update-readme
- make check
