### PR TITLE
Fix release reusable workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,6 +344,7 @@ jobs:
     secrets: inherit
     # publish jobs get escalated permissions
     permissions:
+      "contents": "read"
       "id-token": "write"
       "packages": "write"
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -25,6 +25,8 @@ publish-jobs = ["homebrew", "./publish-crates"]
 hosting = "github"
 # Which actions to run on pull requests
 pr-run-mode = "plan"
+# Allow customized CI without failing dist plan freshness checks
+allow-dirty = ["ci"]
 # Which phase dist should use to create the GitHub release
 github-release = "host"
 # Path that installers should place binaries in


### PR DESCRIPTION
## Summary
- add the missing `contents: read` permission to the release workflow reusable `publish-crates` caller job
- keep the scope tight to the PR-only release workflow failure mode
- preserve the existing publish gating while removing avoidable CI noise

## Testing
- make check
- local YAML syntax validation
