### PR TITLE
Pin trivy action to a release tag

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           egress-policy: audit
       - uses: actions/checkout@v6
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
## Summary
- replace the mutable `aquasecurity/trivy-action@master` ref with the verified release tag `v0.36.0`
- keep the scope limited to the security workflow
- preserve current Trivy scan behavior while making the workflow deterministic

## Testing
- make check
- local YAML syntax validation
