### PR TITLE
Clarify README source install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ V2 with 10 commands and 327 passing tests.
 
 Not yet published to crates.io. Build from source:
 
-```
+```bash
+git clone https://github.com/patchloom/patchloom.git
+cd patchloom
 cargo build --release
+# Binary is at target/release/patchloom
 ```
 
 Once published:

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4718,6 +4718,22 @@ fn test_smoke_shell_completion_docs_include_elvish() {
 }
 
 #[test]
+fn test_smoke_readme_source_install_flow() {
+    let source_install_flow = "git clone https://github.com/patchloom/patchloom.git\ncd patchloom\ncargo build --release\n# Binary is at target/release/patchloom";
+
+    for (path, label) in [
+        (installation_path(), "installation guide"),
+        (readme_path(), "README"),
+    ] {
+        let content = fs::read_to_string(path).unwrap();
+        assert!(
+            content.contains(source_install_flow),
+            "{label} should document the first-run source install flow"
+        );
+    }
+}
+
+#[test]
 fn test_smoke_readme_command_examples() {
     let readme = fs::read_to_string(readme_path()).unwrap();
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
## Summary
- upgrade the README source install snippet from a bare build step to a copy-paste-ready clone and build flow
- make the README and installation guide share the same first-run source install path
- add a smoke test so that first-run source install flow does not drift in docs

## Testing
- make check
