### PR TITLE
Refresh README test count to 328

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 10 commands and 327 passing tests.
+V2 with 10 commands and 328 passing tests.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- refresh the README status line after the Product Manager iteration added one more passing test
- keep the documented test count aligned with the repo-supported `make update-readme` output

## Testing
- make update-readme
- make check
