### PR TITLE
Align source install docs with cargo install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,12 @@ V2 with 10 commands and 332 passing tests.
 
 ## Install
 
-Not yet published to crates.io. Build from source:
+Not yet published to crates.io. Install from source:
 
 ```bash
 git clone https://github.com/patchloom/patchloom.git
 cd patchloom
-cargo build --release
-# Binary is at target/release/patchloom
+cargo install --path .
 ```
 
 Once published:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,18 +2,11 @@
 
 ## From source (current)
 
-Patchloom is not yet published to crates.io. Build from source:
+Patchloom is not yet published to crates.io. Install from source:
 
 ```bash
 git clone https://github.com/patchloom/patchloom.git
 cd patchloom
-cargo build --release
-# Binary is at target/release/patchloom
-```
-
-Optionally install it to your PATH:
-
-```bash
 cargo install --path .
 ```
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4777,8 +4777,8 @@ fn test_smoke_shell_completion_docs_include_elvish() {
 }
 
 #[test]
-fn test_smoke_readme_source_install_flow() {
-    let source_install_flow = "git clone https://github.com/patchloom/patchloom.git\ncd patchloom\ncargo build --release\n# Binary is at target/release/patchloom";
+fn test_smoke_source_install_docs_use_cargo_install_path() {
+    let source_install_flow = "git clone https://github.com/patchloom/patchloom.git\ncd patchloom\ncargo install --path .";
 
     for (path, label) in [
         (installation_path(), "installation guide"),


### PR DESCRIPTION
## Summary
- update the first-run source install flow to use `cargo install --path .`
- align the installation guide with README
- rename the smoke test to match the guarded contract

## Why
- new contributors should get the install-to-PATH flow first
- the top-level README and installation guide should agree

## Verification
- make check