### PR TITLE
Stabilize Gitleaks install in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,9 +49,12 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
         run: |
-          VER=$(curl -sL https://api.github.com/repos/gitleaks/gitleaks/releases/latest \
-            | jq -r '.tag_name' | sed 's/^v//')
-          curl -sfL "https://github.com/gitleaks/gitleaks/releases/download/v${VER}/gitleaks_${VER}_linux_x64.tar.gz" \
-            | tar xz -C /usr/local/bin gitleaks
+          archive="${RUNNER_TEMP}/gitleaks.tar.gz"
+          curl --retry 5 --retry-all-errors --retry-delay 2 -sSfL \
+            -o "$archive" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf "$archive" -C /usr/local/bin gitleaks
       - run: gitleaks detect --source . --exit-code 1


### PR DESCRIPTION
## Summary
- pin the Gitleaks CLI version in the security workflow
- download the release archive to disk with retries before extraction
- avoid the brittle latest-release API lookup and streamed tar extraction path

## Why
- PR 76 exposed a flaky Gitleaks install step in CI
- the failure was in the workflow, not in the docs change under review

## Verification
- local pinned download and extraction of gitleaks 8.30.1
- local `gitleaks detect --source . --exit-code 1` in the repo