### PR TITLE
Rename misleading tx stdin unit test

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1257,7 +1257,7 @@ mod tests {
     }
 
     #[test]
-    fn plan_from_stdin() {
+    fn parse_plan_json_string() {
         let plan_json =
             r#"{"operations": [{"op": "replace", "path": "test.txt", "from": "a", "to": "b"}]}"#;
         let plan = plan::parse_plan(plan_json).unwrap();


### PR DESCRIPTION
## Summary
- rename the tx unit test that only parses an inline JSON string
- keep the existing integration test as the real stdin coverage

## Testing
- make check