### PR TITLE
Tighten README and quickstart wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 10 commands and 332 passing tests.
+V2 with 10 commands and 337 passing tests.
 
 ## Install
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -51,7 +51,6 @@ patchloom doc set package.json version "2.0.0" --apply
 
 ## Step 4: Run an atomic transaction
 
-Create a plan file called `bump.json`.
 Adapt the paths and heading to files that actually exist in your repo.
 This example assumes `package.json`, `README.md`, and `CHANGELOG.md`
 exist, and that `CHANGELOG.md` contains a `## Unreleased` heading:


### PR DESCRIPTION
## Summary
- refresh the README status line to the current passing test count
- remove a duplicated sentence from the quickstart tx walkthrough

## Testing
- cargo test --test integration test_smoke_quickstart_command_flow
- cargo test --test integration test_smoke_quickstart_transaction_snippet
- cargo test --test integration test_smoke_readme_command_examples