### PR TITLE
Redact tx lifecycle command text in errors

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -909,13 +909,13 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let mut lifecycle_failed = false;
         let mut lifecycle_error = None;
         if let Some(ref format_steps) = plan.format {
-            for step in format_steps {
+            for (index, step) in format_steps.iter().enumerate() {
                 let timeout_secs = step.timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
                 match run_shell_with_timeout(&step.cmd, timeout_secs) {
                     Ok(status) if !status.success() => {
                         let msg = format!(
-                            "format step failed: {} ({})",
-                            step.cmd,
+                            "format step failed (step {}, {})",
+                            index + 1,
                             describe_exit_status(status)
                         );
                         eprintln!("tx: {msg}");
@@ -924,7 +924,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         break;
                     }
                     Err(e) => {
-                        let msg = format!("format step error: {} -- {e}", step.cmd);
+                        let msg = format!("format step error (step {}): {e}", index + 1);
                         eprintln!("tx: {msg}");
                         lifecycle_error = Some(msg);
                         lifecycle_failed = true;
@@ -938,14 +938,14 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         // 8. Run validation steps.
         if !lifecycle_failed {
             if let Some(ref validate) = plan.validate {
-                for step in validate {
+                for (index, step) in validate.iter().enumerate() {
                     let timeout_secs = step.timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
                     let success = match run_shell_with_timeout(&step.cmd, timeout_secs) {
                         Ok(status) if status.success() => true,
                         Ok(status) => {
                             let msg = format!(
-                                "required validation failed: {} ({})",
-                                step.cmd,
+                                "required validation failed (step {}, {})",
+                                index + 1,
                                 describe_exit_status(status)
                             );
                             eprintln!("tx: {msg}");
@@ -953,7 +953,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                             false
                         }
                         Err(e) => {
-                            let msg = format!("validation error: {} -- {e}", step.cmd);
+                            let msg = format!("validation error (step {}): {e}", index + 1);
                             eprintln!("tx: {msg}");
                             lifecycle_error = Some(msg);
                             false

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -49,6 +49,17 @@ fn shell_touch(path: &Path) -> String {
     }
 }
 
+fn shell_fail_with_secret(secret: &str) -> String {
+    #[cfg(windows)]
+    {
+        format!("cmd /C \"set PATCHLOOM_SECRET={secret}&& exit /b 1\"")
+    }
+    #[cfg(not(windows))]
+    {
+        format!("PATCHLOOM_SECRET='{secret}' false")
+    }
+}
+
 fn shell_test_exists(path: &Path) -> String {
     let path = path.display();
     #[cfg(windows)]
@@ -3994,6 +4005,86 @@ fn test_tx_json_output_on_parse_error() {
 }
 
 #[test]
+fn test_tx_validation_failure_redacts_shell_command_in_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let secret = "TOKEN=super-secret-value";
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "hello",
+            "to": "world"
+        }],
+        "validate": [{
+            "cmd": shell_fail_with_secret(secret),
+            "required": true,
+            "timeout": 5
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("required validation failed (step 1, exit code 1)"));
+    assert!(!stderr.contains(secret));
+}
+
+#[test]
+fn test_tx_json_output_on_validation_failure_redacts_shell_command() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let secret = "TOKEN=super-secret-value";
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "hello",
+            "to": "world"
+        }],
+        "validate": [{
+            "cmd": shell_fail_with_secret(secret),
+            "required": true,
+            "timeout": 5
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("validation_failed"));
+    assert!(error.contains("required validation failed (step 1, exit code 1)"));
+    assert!(!error.contains(secret));
+}
+
+#[test]
 fn test_tx_json_output_on_validation_failure() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -4030,7 +4121,7 @@ fn test_tx_json_output_on_validation_failure() {
     assert_eq!(json["ok"], false);
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("validation_failed"));
-    assert!(error.contains("required validation failed"));
+    assert!(error.contains("required validation failed (step 1, exit code 1)"));
     assert!(error.contains("exit code 1"));
 }
 
@@ -4073,7 +4164,7 @@ fn test_tx_json_output_on_strict_validation_failure_preserves_reason() {
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("rollback"));
     assert!(error.contains("strict mode -- all changes reverted"));
-    assert!(error.contains("required validation failed"));
+    assert!(error.contains("required validation failed (step 1, exit code 1)"));
     assert!(error.contains("exit code 1"));
 }
 
@@ -4141,6 +4232,84 @@ fn test_tx_non_strict_format_failure_exits_6_not_7() {
 
     // File should still be modified (non-strict doesn't revert).
     assert_eq!(fs::read_to_string(&file).unwrap(), "changed\n");
+}
+
+#[test]
+fn test_tx_format_failure_redacts_shell_command_in_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    let secret = "TOKEN=super-secret-value";
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "original",
+            "to": "changed"
+        }],
+        "format": [{
+            "cmd": shell_fail_with_secret(secret),
+            "timeout": 5
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains("format step failed (step 1, exit code 1)"));
+    assert!(!stderr.contains(secret));
+}
+
+#[test]
+fn test_tx_json_output_on_format_failure_redacts_shell_command() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    let secret = "TOKEN=super-secret-value";
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "original",
+            "to": "changed"
+        }],
+        "format": [{
+            "cmd": shell_fail_with_secret(secret),
+            "timeout": 5
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("validation_failed"));
+    assert!(error.contains("format step failed (step 1, exit code 1)"));
+    assert!(!error.contains(secret));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- redact raw format and validate shell commands from tx lifecycle failure output
- keep the step number and exit status in both stderr and JSON errors
- add regression tests for validate and format failures in both stderr and JSON output

## Testing
- make check