### PR TITLE
Fix tx empty-file rollback semantics

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -708,13 +708,14 @@ fn build_tx_output(
     ok: bool,
     changes: &[(PathBuf, String, String)],
     deletions: &HashSet<PathBuf>,
+    existed_before: &HashSet<PathBuf>,
 ) -> TxOutput {
     let mut tx_changes = Vec::new();
     let mut created = 0usize;
     let mut deleted_count = 0usize;
     let mut modified = 0usize;
 
-    for (path, original, _) in changes {
+    for (path, _original, _) in changes {
         let path_str = path.to_string_lossy().to_string();
         if deletions.contains(path) {
             tx_changes.push(TxChange {
@@ -722,7 +723,7 @@ fn build_tx_output(
                 action: "deleted",
             });
             deleted_count += 1;
-        } else if original.is_empty() {
+        } else if !existed_before.contains(path) {
             tx_changes.push(TxChange {
                 path: path_str,
                 action: "created",
@@ -852,6 +853,12 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     }
 
+    let existed_before: HashSet<PathBuf> = pending
+        .keys()
+        .filter(|path| path.exists())
+        .cloned()
+        .collect();
+
     // 5. Apply write policy and collect actual file changes.
     let mut changes: Vec<(PathBuf, String, String)> = Vec::new();
     for (path, (original, current)) in &pending {
@@ -873,13 +880,20 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if global.check {
         if changes.is_empty() && pending_deletions == 0 {
             if global.json {
-                let output = build_tx_output("success", true, &changes, &deletions);
+                let output =
+                    build_tx_output("success", true, &changes, &deletions, &existed_before);
                 println!("{}", serde_json::to_string_pretty(&output)?);
             }
             return Ok(exit::SUCCESS);
         }
         if global.json {
-            let output = build_tx_output("changes_detected", true, &changes, &deletions);
+            let output = build_tx_output(
+                "changes_detected",
+                true,
+                &changes,
+                &deletions,
+                &existed_before,
+            );
             println!("{}", serde_json::to_string_pretty(&output)?);
         } else if !global.quiet {
             println!("{} file(s) would change", changes.len() + pending_deletions);
@@ -987,7 +1001,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 // Restore original file contents.
                 let noop_policy = WritePolicy::default();
                 for (path, original, _) in &changes {
-                    if original.is_empty() && !deletions.contains(path) {
+                    if !existed_before.contains(path) && !deletions.contains(path) {
                         // File was created by the tx; remove it.
                         let _ = std::fs::remove_file(path);
                     } else {
@@ -997,7 +1011,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 // Restore files that were deleted.
                 for path in &deletions {
                     if let Some((orig, _)) = pending.get(path) {
-                        if !orig.is_empty() {
+                        if existed_before.contains(path) {
                             let _ = atomic_write(path, orig, &noop_policy);
                         }
                     }
@@ -1025,7 +1039,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
 
         if global.json {
-            let output = build_tx_output("success", true, &changes, &deletions);
+            let output = build_tx_output("success", true, &changes, &deletions, &existed_before);
             println!("{}", serde_json::to_string_pretty(&output)?);
         }
         return Ok(exit::SUCCESS);
@@ -1033,7 +1047,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // Default / --diff mode: show unified diffs.
     if global.json {
-        let output = build_tx_output("success", true, &changes, &deletions);
+        let output = build_tx_output("success", true, &changes, &deletions, &existed_before);
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else if !changes.is_empty() {
         print_diffs(&changes);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3775,6 +3775,41 @@ fn test_tx_strict_mode_reverts_on_validate_failure() {
 }
 
 #[test]
+fn test_tx_strict_mode_restores_modified_empty_file_on_failure() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.txt");
+    fs::write(&file, "").unwrap();
+
+    let plan = serde_json::json!({
+        "strict": true,
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "",
+            "to": "changed"
+        }],
+        "validate": [{
+            "cmd": shell_exit_1(),
+            "required": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(7); // ROLLBACK
+
+    assert!(file.exists(), "modified empty file should not be deleted");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "");
+}
+
+#[test]
 fn test_tx_strict_mode_removes_created_files_on_failure() {
     let dir = TempDir::new().unwrap();
     let new_file = dir.path().join("new.txt");
@@ -3839,6 +3874,75 @@ fn test_tx_json_output_on_apply() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["status"], "success");
     assert_eq!(json["files_changed"], 1);
+    assert_eq!(json["changes"][0]["action"], "modified");
+}
+
+#[test]
+fn test_tx_json_output_on_modified_empty_file_reports_modified() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.txt");
+    fs::write(&file, "").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "",
+            "to": "changed"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["files_changed"], 1);
+    assert_eq!(json["files_created"], 0);
+    assert_eq!(json["changes"][0]["action"], "modified");
+}
+
+#[test]
+fn test_tx_json_output_on_modified_empty_file_reports_modified_in_check_mode() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.txt");
+    fs::write(&file, "").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "",
+            "to": "changed"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["status"], "changes_detected");
+    assert_eq!(json["files_changed"], 1);
+    assert_eq!(json["files_created"], 0);
     assert_eq!(json["changes"][0]["action"], "modified");
 }
 
@@ -4168,6 +4272,39 @@ fn test_tx_json_output_on_strict_validation_failure_preserves_reason() {
     assert!(error.contains("strict mode -- all changes reverted"));
     assert!(error.contains("required validation failed (step 1, exit code 1)"));
     assert!(error.contains("exit code 1"));
+}
+
+#[test]
+fn test_tx_strict_mode_restores_deleted_empty_file_on_failure() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.txt");
+    fs::write(&file, "").unwrap();
+
+    let plan = serde_json::json!({
+        "strict": true,
+        "operations": [{
+            "op": "file.delete",
+            "path": file.to_str().unwrap()
+        }],
+        "validate": [{
+            "cmd": shell_exit_1(),
+            "required": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(7); // ROLLBACK
+
+    assert!(file.exists(), "deleted empty file should be restored");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- restore pre-existing empty files correctly during strict tx rollback
- classify modified pre-existing empty files as `modified` instead of `created` in tx JSON output
- add regression coverage for empty-file rollback and apply/check JSON classification

## Testing
- make check