### PR TITLE
Fix tx create-delete no-op handling

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -646,15 +646,20 @@ fn execute_operation(
 
         Operation::FileDelete { path } => {
             let file_path = PathBuf::from(path);
-            let content_was_empty = read_file_content(pending, &file_path)?.is_empty();
-            // Mark current content as empty so the diff shows full deletion.
-            update_file_content(pending, deletions, &file_path, String::new());
-            // If the file was created in this plan (original is empty AND
-            // it doesn't exist on disk), remove from pending; no disk delete.
-            // Otherwise, schedule for actual deletion (covers empty on-disk files).
-            if content_was_empty && !file_path.exists() {
+            let created_in_tx = match pending.get(&file_path) {
+                Some((original, _)) => original.is_empty() && !file_path.exists(),
+                None => {
+                    let _ = read_file_content(pending, &file_path)?;
+                    false
+                }
+            };
+
+            if created_in_tx {
                 pending.remove(&file_path);
+                deletions.remove(&file_path);
             } else {
+                // Mark current content as empty so the diff shows full deletion.
+                update_file_content(pending, deletions, &file_path, String::new());
                 deletions.insert(file_path);
             }
         }
@@ -1196,6 +1201,31 @@ mod tests {
 
         // Verify hygiene.fix.
         assert!(fs::read_to_string(&no_nl).unwrap().ends_with('\n'));
+    }
+
+    #[test]
+    fn create_then_delete_in_same_tx_becomes_noop() {
+        let dir = TempDir::new().unwrap();
+        let new_file = dir.path().join("new.txt");
+        let plan_json = serde_json::json!({
+            "operations": [
+                {"op": "file.create", "path": new_file.to_str().unwrap(), "content": "hello"},
+                {"op": "file.delete", "path": new_file.to_str().unwrap()}
+            ]
+        });
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            write: Default::default(),
+        };
+        let mut global = default_global();
+        global.check = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(!new_file.exists());
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2074,6 +2074,68 @@ fn test_tx_file_create_and_delete() {
 }
 
 #[test]
+fn test_tx_check_create_then_delete_is_noop() {
+    let dir = TempDir::new().unwrap();
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "file.create", "path": "new.txt", "content": "hello"},
+            {"op": "file.delete", "path": "new.txt"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .arg("--check")
+        .assert()
+        .success();
+
+    assert!(
+        !dir.path().join("new.txt").exists(),
+        "file should not exist after create+delete no-op check"
+    );
+}
+
+#[test]
+fn test_tx_json_output_create_then_delete_is_noop() {
+    let dir = TempDir::new().unwrap();
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "file.create", "path": "new.txt", "content": "hello"},
+            {"op": "file.delete", "path": "new.txt"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["files_created"], 0);
+    assert_eq!(json["files_deleted"], 0);
+    assert_eq!(json["files_changed"], 0);
+    assert_eq!(json["changes"].as_array().unwrap().len(), 0);
+}
+
+#[test]
 fn test_tx_file_delete_existing() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("doomed.txt");


### PR DESCRIPTION
## Summary
- treat file.create followed by file.delete in the same tx plan as a true no-op
- keep tx --check and JSON output clean for that net-zero case
- add unit and integration regression coverage for the no-op path

## Verification
- make check

## Follow-up
- broader tx command coupling cleanup is tracked in #91