### PR TITLE
Refresh documented test counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 337 tests (155 unit + 182 integration)
+- 350 tests (157 unit + 193 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 10 commands and 349 passing tests.
+V2 with 10 commands and 350 passing tests.
 
 ## Install
 


### PR DESCRIPTION
## Summary
- refresh the README passing-test count after the latest added regression test
- refresh the unreleased changelog test breakdown to match the current green gate

## Testing
- make check