### PR TITLE
Update changelog count in update-readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Patchloom is a Rust CLI for agent-grade repo operations. It provides ten command
 | `make integration-test` | Run integration tests (`cargo test --test integration`) |
 | `make clippy` | Run `cargo clippy --all-targets --all-features -- -D warnings` |
 | `make check` | Run all of the above in sequence: `fmt-check`, `build`, `test`, `integration-test`, `clippy` |
-| `make update-readme` | Update the test count in README.md from actual `cargo test` output |
+| `make update-readme` | Update README.md and CHANGELOG.md test counts from actual `cargo test` output |
 
 Always run `make check` before committing. It is the full CI gate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,4 +37,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `file.create` after `file.delete` in the same tx plan no longer silently loses the file
-- Makefile `update-readme` dynamically reads version and command count instead of hardcoding
+- Makefile `update-readme` dynamically reads version, command count, and test counts instead of hardcoding

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,12 @@ clippy: ## Run clippy linter
 
 check: fmt-check build test integration-test clippy ## Run all checks (full CI gate)
 
-update-readme: ## Update test count in README.md
+update-readme: ## Update README.md and CHANGELOG.md test counts
 	@unit=$$(cargo test --lib 2>&1 | grep '^test result' | sed 's/.*ok\. \([0-9]*\) passed.*/\1/'); \
 	integ=$$(cargo test --test integration 2>&1 | grep '^test result' | sed 's/.*ok\. \([0-9]*\) passed.*/\1/'); \
 	total=$$((unit + integ)); \
 	cmds=$$(cargo run --quiet -- --help 2>/dev/null | sed -n '/^Commands:/,/^$$/p' | grep '^ ' | grep -cv '^ *help'); \
 	ver=$$(grep '^V[0-9]' README.md | head -1 | sed 's/^\(V[0-9]*\).*/\1/'); \
 	sed -i "s/V[0-9]* with [0-9]* commands and [0-9]* passing tests\./$$ver with $$cmds commands and $$total passing tests./" README.md; \
-	echo "README.md updated: $$ver, $$cmds commands, $$total tests ($$unit unit + $$integ integration)"
+	sed -i "/^## \[Unreleased\]/,/^## \[/ s/- [0-9]* tests ([0-9]* unit + [0-9]* integration)/- $$total tests ($$unit unit + $$integ integration)/" CHANGELOG.md; \
+	echo "README.md and CHANGELOG.md updated: $$ver, $$cmds commands, $$total tests ($$unit unit + $$integ integration)"


### PR DESCRIPTION
## Summary
- update `make update-readme` so it refreshes the changelog test count inside `Unreleased`
- update the Makefile and AGENTS help text to describe the broader target behavior
- keep the supported docs refresh path in sync so README and changelog counts do not drift separately

## Testing
- make update-readme
- make check