### PR TITLE
Refine reference docs coverage gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 352 tests (157 unit + 195 integration)
+- 353 tests (157 unit + 196 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 10 commands and 352 passing tests.
+V2 with 10 commands and 353 passing tests.
 
 ## Install
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -289,6 +289,13 @@ These are meaningful command-specific modes that change how a top-level command 
 - **Use when:** File recreation is intentional and should replace previous contents deterministically.
 - **Prefer instead:** Use default create behavior when accidental overwrite would be dangerous.
 
+<!-- ref:patch-mode:file -->
+### `patch --file`
+
+- **What it does:** Reads the unified diff from a file path.
+- **Use when:** The patch already exists as a saved artifact that should be reviewed, reused, or passed around directly.
+- **Prefer instead:** Use `patch --stdin` when another tool is piping the patch text dynamically.
+
 <!-- ref:patch-mode:stdin -->
 ### `patch --stdin`
 

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -17,9 +17,11 @@ pub struct CreateArgs {
     /// Content to write (alternative to --stdin).
     #[arg(long)]
     pub content: Option<String>,
+    // ref:create-mode:stdin
     /// Read content from stdin.
     #[arg(long)]
     pub stdin: bool,
+    // ref:create-mode:force
     /// Overwrite if file already exists.
     #[arg(long)]
     pub force: bool,

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -38,6 +38,7 @@ pub enum DocAction {
     DeleteWhere {
         file: String,
         selector: String,
+        // ref:doc-mode:predicate
         /// Predicate in key=value format.
         #[arg(long)]
         predicate: String,
@@ -45,6 +46,7 @@ pub enum DocAction {
     /// Merge a partial object from stdin or argument.
     Merge {
         file: String,
+        // ref:doc-mode:stdin
         #[arg(long)]
         stdin: bool,
         #[arg(long)]

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -25,6 +25,7 @@ pub enum MdAction {
         #[arg(long)]
         heading: String,
         /// Read replacement content from stdin.
+        // ref:md-mode:stdin
         #[arg(long)]
         stdin: bool,
         /// Replacement content as argument.
@@ -37,6 +38,7 @@ pub enum MdAction {
         file: String,
         #[arg(long)]
         heading: String,
+        // ref:md-mode:stdin
         #[arg(long)]
         stdin: bool,
         #[arg(long)]
@@ -48,6 +50,7 @@ pub enum MdAction {
         file: String,
         #[arg(long)]
         heading: String,
+        // ref:md-mode:stdin
         #[arg(long)]
         stdin: bool,
         #[arg(long)]

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -17,18 +17,22 @@ pub struct PatchArgs {
 pub enum PatchAction {
     /// Check whether a patch applies cleanly.
     Check {
+        // ref:patch-mode:file
         /// Path to a diff file.
         #[arg(long)]
         file: Option<String>,
+        // ref:patch-mode:stdin
         /// Read diff from stdin.
         #[arg(long)]
         stdin: bool,
     },
     /// Apply a unified diff.
     Apply {
+        // ref:patch-mode:file
         /// Path to a diff file.
         #[arg(long)]
         file: Option<String>,
+        // ref:patch-mode:stdin
         /// Read diff from stdin.
         #[arg(long)]
         stdin: bool,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -21,18 +21,23 @@ pub struct ReplaceArgs {
     /// Treat --from as a literal string (default).
     #[arg(long)]
     pub literal: bool,
+    // ref:replace-mode:regex
     /// Treat --from as a regex.
     #[arg(long)]
     pub regex: bool,
+    // ref:replace-mode:if-exists
     /// Return success even if no matches found (idempotent mode).
     #[arg(long)]
     pub if_exists: bool,
+    // ref:replace-mode:multiline
     /// Enable multiline matching (dot matches newlines in regex mode).
     #[arg(long, short = 'U')]
     pub multiline: bool,
+    // ref:replace-mode:nth
     /// Replace only the Nth occurrence (1-based).
     #[arg(long)]
     pub nth: Option<usize>,
+    // ref:replace-mode:case-insensitive
     /// Case-insensitive matching.
     #[arg(long, short = 'i')]
     pub case_insensitive: bool,

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -22,18 +22,23 @@ pub struct SearchArgs {
     /// Lines of context around matches.
     #[arg(long, short = 'C')]
     pub context: Option<usize>,
+    // ref:search-mode:files-with-matches
     /// Only print file paths with matches.
     #[arg(long)]
     pub files_with_matches: bool,
+    // ref:search-mode:count
     /// Only print match counts per file.
     #[arg(long)]
     pub count: bool,
+    // ref:search-mode:invert-match
     /// Show lines that do NOT match the pattern.
     #[arg(long, short = 'v')]
     pub invert_match: bool,
+    // ref:search-mode:multiline
     /// Enable multiline matching (dot matches newlines).
     #[arg(long, short = 'U')]
     pub multiline: bool,
+    // ref:search-mode:case-insensitive
     /// Case-insensitive matching.
     #[arg(long, short = 'i')]
     pub case_insensitive: bool,

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -47,6 +47,7 @@ struct TxChange {
 
 #[derive(Debug, Args)]
 pub struct TxArgs {
+    // ref:tx-mode:plan-stdin
     /// Path to a plan JSON file, or `-` for stdin.
     #[arg(long)]
     pub plan: String,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5583,6 +5583,16 @@ fn collect_serde_rename_values(path: &Path, anchor: &str) -> Vec<String> {
         .collect()
 }
 
+fn collect_source_ref_markers(path: &Path) -> Vec<String> {
+    let source = fs::read_to_string(path).unwrap();
+    let re = regex::Regex::new(r"(?m)^\s*//\s*ref:([a-z0-9._:-]+)\s*$").unwrap();
+    re.captures_iter(&source)
+        .map(|caps| caps[1].to_string())
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
 fn expected_reference_markers() -> Vec<String> {
     let root = repo_root();
     let cmd_dir = root.join("src").join("cmd");
@@ -5628,27 +5638,16 @@ fn expected_reference_markers() -> Vec<String> {
         }
     }
 
-    for name in [
-        "files-with-matches",
-        "count",
-        "invert-match",
-        "multiline",
-        "case-insensitive",
-    ] {
-        markers.insert(format!("search-mode:{name}"));
+    for entry in fs::read_dir(&cmd_dir).unwrap() {
+        let path = entry.unwrap().path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+
+        for marker in collect_source_ref_markers(&path) {
+            markers.insert(marker);
+        }
     }
-    for name in ["regex", "if-exists", "nth", "multiline", "case-insensitive"] {
-        markers.insert(format!("replace-mode:{name}"));
-    }
-    for name in ["stdin", "force"] {
-        markers.insert(format!("create-mode:{name}"));
-    }
-    markers.insert("patch-mode:stdin".to_string());
-    for name in ["predicate", "stdin"] {
-        markers.insert(format!("doc-mode:{name}"));
-    }
-    markers.insert("md-mode:stdin".to_string());
-    markers.insert("tx-mode:plan-stdin".to_string());
 
     markers.into_iter().collect()
 }
@@ -5673,29 +5672,74 @@ fn reference_section<'a>(reference: &'a str, markers: &[(String, usize)], marker
     &reference[start..end]
 }
 
-#[test]
-fn test_reference_doc_covers_meaningful_feature_inventory() {
-    let reference = fs::read_to_string(reference_path()).unwrap();
-    let markers = reference_markers(&reference);
-    let actual_marker_names: Vec<String> = markers.iter().map(|(name, _)| name.clone()).collect();
+fn reference_doc_validation_errors(reference: &str) -> Vec<String> {
+    let markers = reference_markers(reference);
+    let actual_marker_names: std::collections::BTreeSet<String> =
+        markers.iter().map(|(name, _)| name.clone()).collect();
     let expected_markers = expected_reference_markers();
-
     let missing_markers: Vec<String> = expected_markers
         .iter()
         .filter(|marker| !actual_marker_names.contains(*marker))
         .cloned()
         .collect();
-    assert!(
-        missing_markers.is_empty(),
-        "reference doc is missing markers for:\n{}",
-        missing_markers.join("\n")
-    );
+    let mut errors = Vec::new();
+
+    if !missing_markers.is_empty() {
+        errors.push(format!(
+            "reference doc is missing markers for:\n{}",
+            missing_markers.join("\n")
+        ));
+    }
 
     for marker in expected_markers {
-        let section = reference_section(&reference, &markers, &marker);
-        assert!(
-            section.contains("**Use when:**"),
-            "reference section `{marker}` must include a `Use when` stanza"
-        );
+        if !actual_marker_names.contains(&marker) {
+            continue;
+        }
+
+        let section = reference_section(reference, &markers, &marker);
+        if !section.contains("**Use when:**") {
+            errors.push(format!(
+                "reference section `{marker}` must include a `Use when` stanza"
+            ));
+        }
     }
+
+    errors
+}
+
+fn reference_without_use_when(reference: &str, marker: &str) -> String {
+    let markers = reference_markers(reference);
+    let section = reference_section(reference, &markers, marker);
+    let use_when_start = section
+        .find("- **Use when:**")
+        .unwrap_or_else(|| panic!("reference section `{marker}` should include `Use when`"));
+    let use_when_end = section[use_when_start..]
+        .find('\n')
+        .map(|offset| use_when_start + offset + 1)
+        .unwrap_or(section.len());
+    let broken_section = format!("{}{}", &section[..use_when_start], &section[use_when_end..]);
+
+    reference.replacen(section, &broken_section, 1)
+}
+
+#[test]
+fn test_reference_doc_covers_meaningful_feature_inventory() {
+    let reference = fs::read_to_string(reference_path()).unwrap();
+    let errors = reference_doc_validation_errors(&reference);
+
+    assert!(errors.is_empty(), "{}", errors.join("\n\n"));
+}
+
+#[test]
+fn test_reference_doc_requires_use_when_stanza() {
+    let reference = fs::read_to_string(reference_path()).unwrap();
+    let broken = reference_without_use_when(&reference, "patch-mode:file");
+    let errors = reference_doc_validation_errors(&broken);
+
+    assert!(
+        errors.iter().any(|error| error
+            .contains("reference section `patch-mode:file` must include a `Use when` stanza")),
+        "expected missing `Use when` error, got:\n{}",
+        errors.join("\n\n")
+    );
 }


### PR DESCRIPTION
## Summary
- derive notable command-mode coverage from source-owned `ref:` markers in command definitions
- document and enforce `patch --file` alongside `patch --stdin`
- add a focused negative regression for missing `Use when` guidance and refresh public test counts

## Testing
- cargo test --test integration test_reference_doc_
- make check