### PR TITLE
Add five agent-productivity features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Patchloom is a Rust CLI for agent-grade repo operations. It provides ten commands (`search`, `replace`, `patch`, `md`, `doc`, `hygiene`, `create`, `delete`, `tx`, `completions`) that let AI coding agents perform structured file searches, mechanical replacements, diff-based patching, markdown section editing, JSON/YAML/TOML document manipulation, whitespace normalization, file creation, file deletion, multi-operation atomic transactions, and shell completion generation. All write operations are dry-run by default and support `--check` (report changes), `--diff` (preview), and `--apply` (mutate) modes.
+Patchloom is a Rust CLI for agent-grade repo operations. It provides twelve commands (`search`, `replace`, `patch`, `md`, `doc`, `hygiene`, `create`, `delete`, `read`, `status`, `tx`, `completions`) that let AI coding agents perform structured file searches, mechanical replacements, diff-based patching, markdown section editing, JSON/YAML/TOML document manipulation, whitespace normalization, file creation, file deletion, multi-operation atomic transactions, and shell completion generation. All write operations are dry-run by default and support `--check` (report changes), `--diff` (preview), and `--apply` (mutate) modes.
 
 ## Dev commands
 
@@ -41,6 +41,8 @@ src/
                        prepend, update, move, ensure, delete-where, select, flatten, diff)
   cmd/hygiene.rs       Final newline, line ending, and trailing whitespace normalization
   cmd/create.rs        Create a new file with content
+  cmd/read.rs          Read file contents with optional line range
+  cmd/status.rs        Show uncommitted file changes vs git HEAD
   cmd/tx.rs            Transaction engine: execute a multi-operation plan atomically
   selector/mod.rs      Re-exports selector parser and evaluator
   selector/parser.rs   Path selector parser (key, index, wildcard, predicate segments)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 353 tests (157 unit + 196 integration)
+- 379 tests (161 unit + 218 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 10 commands and 353 passing tests.
+V2 with 12 commands and 379 passing tests.
 
 ## Install
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -2,7 +2,7 @@
 
 ## Commands
 
-Patchloom has 10 commands, each targeting a different kind of repo operation:
+Patchloom has 12 commands, each targeting a different kind of repo operation:
 
 - **search** / **replace** -- text-level find and replace across files
 - **patch** -- apply unified diffs
@@ -10,6 +10,8 @@ Patchloom has 10 commands, each targeting a different kind of repo operation:
 - **doc** -- parser-backed JSON, YAML, and TOML mutations
 - **hygiene** -- whitespace and line-ending normalization
 - **create** / **delete** -- file lifecycle
+- **read** -- file content inspection with optional line range
+- **status** -- uncommitted change summary from git
 - **tx** -- atomic multi-operation transactions
 - **completions** -- shell completion generation
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -193,6 +193,22 @@ These are the main entry points. If you are deciding between commands, start her
 - **Prefer instead:** Use standalone commands when one direct operation is enough.
 - **Related:** [examples/README.md](../../examples/README.md), `tx` fields, `tx` operations
 
+<!-- ref:command:read -->
+## `read`
+
+- **What it does:** Prints the contents of a file, optionally restricted to a line range.
+- **Use when:** An agent needs to inspect a file or file section before deciding on an edit.
+- **Prefer instead:** Use `search` when you need pattern matching, or `doc get` when the file is structured and you want a single value.
+- **Related:** `search`, `doc get`
+
+<!-- ref:command:status -->
+## `status`
+
+- **What it does:** Shows which files have uncommitted changes compared to git HEAD.
+- **Use when:** An agent needs a quick summary of the working tree before committing, staging, or choosing which files to process.
+- **Prefer instead:** Use `git status` directly when you need full git porcelain output or staging details.
+- **Related:** `search`, `read`
+
 <!-- ref:command:completions -->
 ## `completions`
 
@@ -240,6 +256,13 @@ These are meaningful command-specific modes that change how a top-level command 
 - **Use when:** The target text may appear in inconsistent capitalization across files.
 - **Prefer instead:** Use case-sensitive search when exact spelling matters and false positives would be noisy.
 
+<!-- ref:search-mode:assert-count -->
+### `search --assert-count`
+
+- **What it does:** Succeeds (exit 0) only if the total match count equals the given number. Exits 2 otherwise.
+- **Use when:** An agent or CI pipeline needs to verify an invariant (e.g. "exactly 18 markers exist") in one call instead of searching and then comparing the count manually.
+- **Prefer instead:** Use plain `search --count` when you want to see counts without a pass/fail assertion.
+
 <!-- ref:replace-mode:regex -->
 ### `replace --regex`
 
@@ -260,6 +283,20 @@ These are meaningful command-specific modes that change how a top-level command 
 - **What it does:** Replaces only the Nth occurrence of the target.
 - **Use when:** Replacing every occurrence would be too broad and the exact positional match matters.
 - **Prefer instead:** Use plain replace when every occurrence should change, or regex when the target can be narrowed semantically.
+
+<!-- ref:replace-mode:insert-before -->
+### `replace --insert-before`
+
+- **What it does:** Inserts text before each match instead of replacing it. The matched text is preserved.
+- **Use when:** You need to add a line or annotation above an existing anchor without repeating the anchor in the replacement text.
+- **Prefer instead:** Use `--to` when the matched text should actually change, not just receive a prefix.
+
+<!-- ref:replace-mode:insert-after -->
+### `replace --insert-after`
+
+- **What it does:** Inserts text after each match instead of replacing it. The matched text is preserved.
+- **Use when:** You need to append content after an existing anchor, such as adding a comment or tag after a specific line.
+- **Prefer instead:** Use `--to` when the matched text should actually change, not just receive a suffix.
 
 <!-- ref:replace-mode:multiline -->
 ### `replace --multiline`
@@ -330,6 +367,13 @@ These are meaningful command-specific modes that change how a top-level command 
 - **What it does:** Reads the transaction plan JSON from stdin instead of a plan file.
 - **Use when:** The plan is generated on the fly or piped from another tool.
 - **Prefer instead:** Use `--plan <file>` when the plan should be stored, reviewed, or reused.
+
+<!-- ref:tx-mode:plan-yaml -->
+### `tx --plan-format yaml`
+
+- **What it does:** Tells `tx` to parse the plan as YAML (or TOML) instead of JSON. Auto-detected from file extension for plan files; required when piping YAML from stdin.
+- **Use when:** The plan is easier to write or generate in YAML/TOML, or when JSON verbosity is friction for inline agent-generated plans.
+- **Prefer instead:** Use JSON plans when interoperability or strict schema validation matters more than writability.
 
 ## `doc` actions
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -4,8 +4,10 @@ pub mod doc;
 pub mod hygiene;
 pub mod md;
 pub mod patch;
+pub mod read;
 pub mod replace;
 pub mod search;
+pub mod status;
 pub mod tx;
 
 use crate::cli::Cli;
@@ -21,8 +23,12 @@ pub enum Command {
     Search(search::SearchArgs),
     /// Mechanical string replacement with diff preview.
     Replace(replace::ReplaceArgs),
+    /// Show which files have uncommitted changes.
+    Status(status::StatusArgs),
     /// Preview or apply unified diffs safely.
     Patch(patch::PatchArgs),
+    /// Read file contents with optional line range.
+    Read(read::ReadArgs),
     /// Markdown section-aware operations.
     Md(md::MdArgs),
     /// Parser-backed JSON, YAML, and TOML operations.
@@ -47,7 +53,9 @@ pub fn dispatch(cli: Cli) -> anyhow::Result<u8> {
             clap_complete::generate(shell, &mut cmd, "patchloom", &mut std::io::stdout());
             Ok(crate::exit::SUCCESS)
         }
+        Command::Read(args) => read::run(args, &global),
         Command::Search(args) => search::run(args, &global),
+        Command::Status(args) => status::run(args, &global),
         Command::Create(args) => {
             global.merge_write(&args.write);
             create::run(args, &global)

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -1,0 +1,136 @@
+use crate::cli::global::GlobalFlags;
+use crate::exit;
+use clap::Args;
+use serde::Serialize;
+use std::fs;
+
+#[derive(Debug, Args)]
+pub struct ReadArgs {
+    /// Path to the file to read.
+    pub file: String,
+    /// Line range to display (1-based inclusive, e.g. "50:120").
+    #[arg(long)]
+    pub lines: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReadOutput {
+    ok: bool,
+    path: String,
+    start_line: usize,
+    end_line: usize,
+    total_lines: usize,
+    content: String,
+}
+
+fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usize>)> {
+    if let Some((start_str, end_str)) = spec.split_once(':') {
+        let start: usize = start_str
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid start line: {start_str}"))?;
+        let end: usize = end_str
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid end line: {end_str}"))?;
+        if start == 0 {
+            anyhow::bail!("line numbers are 1-based, got 0");
+        }
+        if end < start {
+            anyhow::bail!("end line {end} is before start line {start}");
+        }
+        Ok((start, Some(end)))
+    } else {
+        let start: usize = spec
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid line number: {spec}"))?;
+        if start == 0 {
+            anyhow::bail!("line numbers are 1-based, got 0");
+        }
+        Ok((start, Some(start)))
+    }
+}
+
+pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    std::env::set_current_dir(global.resolve_cwd()?)?;
+
+    let content = match fs::read_to_string(&args.file) {
+        Ok(c) => c,
+        Err(e) => {
+            if !global.quiet {
+                eprintln!("error: {}: {e}", args.file);
+            }
+            return Ok(exit::FAILURE);
+        }
+    };
+
+    let all_lines: Vec<&str> = content.lines().collect();
+    let total_lines = all_lines.len();
+
+    let (start, end) = if let Some(ref spec) = args.lines {
+        let (s, e) = parse_line_range(spec)?;
+        let end = e.unwrap_or(total_lines).min(total_lines);
+        (s, end)
+    } else {
+        (1, total_lines)
+    };
+
+    let selected: Vec<&str> = if total_lines == 0 {
+        Vec::new()
+    } else {
+        let start_idx = (start - 1).min(total_lines);
+        let end_idx = end.min(total_lines);
+        all_lines[start_idx..end_idx].to_vec()
+    };
+
+    let selected_content = if selected.is_empty() {
+        String::new()
+    } else {
+        let mut s = selected.join("\n");
+        // Preserve trailing newline if the original content had one and we
+        // include the last line.
+        if content.ends_with('\n') && end >= total_lines {
+            s.push('\n');
+        }
+        s
+    };
+
+    if global.json {
+        let output = ReadOutput {
+            ok: true,
+            path: args.file.clone(),
+            start_line: start,
+            end_line: end,
+            total_lines,
+            content: selected_content,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else if !global.quiet {
+        print!("{selected_content}");
+    }
+
+    Ok(exit::SUCCESS)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_range_start_end() {
+        assert_eq!(parse_line_range("5:10").unwrap(), (5, Some(10)));
+    }
+
+    #[test]
+    fn parse_range_single_line() {
+        assert_eq!(parse_line_range("7").unwrap(), (7, Some(7)));
+    }
+
+    #[test]
+    fn parse_range_zero_fails() {
+        assert!(parse_line_range("0:5").is_err());
+    }
+
+    #[test]
+    fn parse_range_end_before_start_fails() {
+        assert!(parse_line_range("10:5").is_err());
+    }
+}

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -15,7 +15,15 @@ pub struct ReplaceArgs {
     pub from: String,
     /// Text to replace with.
     #[arg(long)]
-    pub to: String,
+    pub to: Option<String>,
+    // ref:replace-mode:insert-before
+    /// Insert text before each match instead of replacing.
+    #[arg(long, conflicts_with = "insert_after")]
+    pub insert_before: Option<String>,
+    // ref:replace-mode:insert-after
+    /// Insert text after each match instead of replacing.
+    #[arg(long, conflicts_with = "insert_before")]
+    pub insert_after: Option<String>,
     /// Paths to operate on.
     pub paths: Vec<String>,
     /// Treat --from as a literal string (default).
@@ -137,6 +145,29 @@ fn replace_content(
     }
 }
 
+/// Compute the effective replacement text from the args.
+/// When using regex mode with insert, `$0` refers to the full match so the
+/// matched text is preserved rather than the raw pattern string.
+fn effective_to(args: &ReplaceArgs) -> String {
+    if let Some(ref text) = args.insert_before {
+        let anchor = if args.regex || args.case_insensitive {
+            "$0".to_string()
+        } else {
+            args.from.clone()
+        };
+        format!("{text}{anchor}")
+    } else if let Some(ref text) = args.insert_after {
+        let anchor = if args.regex || args.case_insensitive {
+            "$0".to_string()
+        } else {
+            args.from.clone()
+        };
+        format!("{anchor}{text}")
+    } else {
+        args.to.clone().unwrap_or_default()
+    }
+}
+
 /// Walk files and collect all replacements.
 fn collect_replacements(
     args: &ReplaceArgs,
@@ -144,6 +175,7 @@ fn collect_replacements(
 ) -> anyhow::Result<Vec<FileReplacement>> {
     let glob_matcher = crate::build_glob_matcher(global)?;
     let file_paths = crate::collect_file_paths(&args.paths, global)?;
+    let to = effective_to(args);
 
     let compiled_re = if args.regex {
         Some(
@@ -185,13 +217,8 @@ fn collect_replacements(
             Err(_) => continue,
         };
 
-        let (replaced, count) = replace_content(
-            &content,
-            &args.from,
-            &args.to,
-            compiled_re.as_ref(),
-            args.nth,
-        );
+        let (replaced, count) =
+            replace_content(&content, &args.from, &to, compiled_re.as_ref(), args.nth);
 
         if count > 0 {
             replacements.push(FileReplacement {
@@ -232,6 +259,14 @@ fn make_diff_output(replacements: &[FileReplacement]) -> String {
 
 pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     std::env::set_current_dir(global.resolve_cwd()?)?;
+
+    // Validate: exactly one of --to, --insert-before, or --insert-after.
+    if args.to.is_none() && args.insert_before.is_none() && args.insert_after.is_none() {
+        anyhow::bail!("one of --to, --insert-before, or --insert-after must be provided");
+    }
+    if args.to.is_some() && (args.insert_before.is_some() || args.insert_after.is_some()) {
+        anyhow::bail!("--to cannot be combined with --insert-before or --insert-after");
+    }
 
     let replacements = collect_replacements(&args, global)?;
 
@@ -340,7 +375,9 @@ mod tests {
     fn make_args(from: &str, to: &str, paths: Vec<String>) -> ReplaceArgs {
         ReplaceArgs {
             from: from.to_string(),
-            to: to.to_string(),
+            to: Some(to.to_string()),
+            insert_before: None,
+            insert_after: None,
             paths,
             literal: true,
             regex: false,
@@ -378,7 +415,9 @@ mod tests {
 
         let args = ReplaceArgs {
             from: r"foo\d+".to_string(),
-            to: "replaced".to_string(),
+            to: Some("replaced".to_string()),
+            insert_before: None,
+            insert_after: None,
             paths: vec![dir.path().to_string_lossy().into_owned()],
             literal: false,
             regex: true,
@@ -403,7 +442,9 @@ mod tests {
 
         let args = ReplaceArgs {
             from: r#"version = "(\d+)\.(\d+)\.(\d+)""#.to_string(),
-            to: r#"version = "$1.$2.99""#.to_string(),
+            to: Some(r#"version = "$1.$2.99""#.to_string()),
+            insert_before: None,
+            insert_after: None,
             paths: vec![dir.path().to_string_lossy().into_owned()],
             literal: false,
             regex: true,
@@ -503,7 +544,9 @@ mod tests {
 
         let args = ReplaceArgs {
             from: "zzz_no_match_zzz".to_string(),
-            to: "replacement".to_string(),
+            to: Some("replacement".to_string()),
+            insert_before: None,
+            insert_after: None,
             paths: vec![dir.path().to_string_lossy().into_owned()],
             literal: true,
             regex: false,
@@ -525,7 +568,9 @@ mod tests {
 
         let args = ReplaceArgs {
             from: "hello".to_string(),
-            to: "hi".to_string(),
+            to: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
             paths: vec![dir.path().to_string_lossy().into_owned()],
             literal: true,
             regex: false,
@@ -595,7 +640,9 @@ mod tests {
 
         let args = ReplaceArgs {
             from: r"start.*end".to_string(),
-            to: "replaced".to_string(),
+            to: Some("replaced".to_string()),
+            insert_before: None,
+            insert_after: None,
             paths: vec![dir.path().to_string_lossy().into_owned()],
             literal: false,
             regex: true,
@@ -620,7 +667,9 @@ mod tests {
 
         let args = ReplaceArgs {
             from: r"start.*end".to_string(),
-            to: "replaced".to_string(),
+            to: Some("replaced".to_string()),
+            insert_before: None,
+            insert_after: None,
             paths: vec![dir.path().to_string_lossy().into_owned()],
             literal: false,
             regex: true,

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -42,6 +42,10 @@ pub struct SearchArgs {
     /// Case-insensitive matching.
     #[arg(long, short = 'i')]
     pub case_insensitive: bool,
+    // ref:search-mode:assert-count
+    /// Assert that the total match count equals N. Exits 0 if exact, 2 otherwise.
+    #[arg(long)]
+    pub assert_count: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -300,6 +304,21 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let results = collect_matches(&args, global)?;
 
+    // --assert-count mode: succeed only if total count equals N.
+    if let Some(expected) = args.assert_count {
+        let actual: usize = results.file_match_counts.values().sum();
+        if actual == expected {
+            if !global.quiet {
+                eprintln!("assert-count: {actual} matches (expected {expected})");
+            }
+            return Ok(exit::SUCCESS);
+        }
+        if !global.quiet {
+            eprintln!("assert-count: expected {expected} matches, found {actual}");
+        }
+        return Ok(exit::CHANGES_DETECTED);
+    }
+
     let has_matches = if args.count || args.files_with_matches {
         !results.file_match_counts.is_empty()
     } else {
@@ -353,6 +372,7 @@ mod tests {
             invert_match: false,
             multiline: false,
             case_insensitive: false,
+            assert_count: None,
         }
     }
 

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -1,0 +1,94 @@
+use crate::cli::global::GlobalFlags;
+use crate::exit;
+use clap::Args;
+use serde::Serialize;
+use std::process;
+
+#[derive(Debug, Args)]
+pub struct StatusArgs {
+    /// Paths to check (defaults to current directory).
+    pub paths: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct StatusOutput {
+    ok: bool,
+    modified: Vec<String>,
+    created: Vec<String>,
+    deleted: Vec<String>,
+    total_changes: usize,
+}
+
+pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    std::env::set_current_dir(global.resolve_cwd()?)?;
+
+    let mut cmd = process::Command::new("git");
+    cmd.arg("status").arg("--porcelain=v1").arg("--no-renames");
+    for path in &args.paths {
+        cmd.arg("--").arg(path);
+    }
+    let output = cmd.output()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git status failed: {stderr}");
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let glob_matcher = crate::build_glob_matcher(global)?;
+
+    let mut modified = Vec::new();
+    let mut created = Vec::new();
+    let mut deleted = Vec::new();
+
+    for line in stdout.lines() {
+        if line.len() < 4 {
+            continue;
+        }
+        let xy = &line[..2];
+        let file = line[3..].to_string();
+
+        if let Some(ref matcher) = glob_matcher {
+            if !crate::matches_glob(std::path::Path::new(&file), Some(matcher)) {
+                continue;
+            }
+        }
+
+        match xy.trim() {
+            "??" | "A" | "AM" => created.push(file),
+            "D" => deleted.push(file),
+            _ => modified.push(file),
+        }
+    }
+
+    let total_changes = modified.len() + created.len() + deleted.len();
+
+    if global.json {
+        let out = StatusOutput {
+            ok: true,
+            modified: modified.clone(),
+            created: created.clone(),
+            deleted: deleted.clone(),
+            total_changes,
+        };
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else if !global.quiet {
+        for f in &modified {
+            println!("M  {f}");
+        }
+        for f in &created {
+            println!("A  {f}");
+        }
+        for f in &deleted {
+            println!("D  {f}");
+        }
+        if total_changes > 0 {
+            println!("{total_changes} file(s) changed");
+        }
+    }
+
+    if total_changes > 0 {
+        Ok(exit::CHANGES_DETECTED)
+    } else {
+        Ok(exit::SUCCESS)
+    }
+}

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -51,6 +51,10 @@ pub struct TxArgs {
     /// Path to a plan JSON file, or `-` for stdin.
     #[arg(long)]
     pub plan: String,
+    // ref:tx-mode:plan-yaml
+    /// Plan format when reading from stdin (json, yaml, toml). Auto-detected from file extension otherwise.
+    #[arg(long)]
+    pub plan_format: Option<String>,
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,
 }
@@ -251,7 +255,16 @@ fn execute_operation(
             from,
             to,
             nth,
+            insert_before,
+            insert_after,
         } => {
+            let effective_to = if let Some(ref text) = insert_before {
+                format!("{text}{from}")
+            } else if let Some(ref text) = insert_after {
+                format!("{from}{text}")
+            } else {
+                to.clone().unwrap_or_default()
+            };
             let compiled_re = if mode.as_deref() == Some("regex") {
                 Some(Regex::new(from)?)
             } else {
@@ -261,7 +274,7 @@ fn execute_operation(
             if let Some(p) = path {
                 let file_path = PathBuf::from(p);
                 let content = read_file_content(pending, &file_path)?;
-                let replaced = do_replace(content, from, to, compiled_re.as_ref(), *nth);
+                let replaced = do_replace(content, from, &effective_to, compiled_re.as_ref(), *nth);
                 update_file_content(pending, deletions, &file_path, replaced);
             } else if let Some(pattern) = glob {
                 let matcher = Glob::new(pattern)?.compile_matcher();
@@ -284,7 +297,8 @@ fn execute_operation(
                         Ok(c) => c,
                         Err(_) => continue,
                     };
-                    let replaced = do_replace(content, from, to, compiled_re.as_ref(), *nth);
+                    let replaced =
+                        do_replace(content, from, &effective_to, compiled_re.as_ref(), *nth);
                     update_file_content(pending, deletions, &file_path, replaced);
                 }
             } else {
@@ -832,8 +846,13 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             .map_err(|e| anyhow::anyhow!("failed to read plan file '{}': {e}", args.plan))?
     };
 
-    // 2. Parse plan JSON.
-    let plan = match plan::parse_plan(&plan_text) {
+    // 2. Parse plan (JSON, YAML, or TOML).
+    let plan_path = if args.plan == "-" {
+        None
+    } else {
+        Some(args.plan.as_str())
+    };
+    let plan = match plan::parse_plan_auto(&plan_text, plan_path, args.plan_format.as_deref()) {
         Ok(p) => p,
         Err(e) => {
             if global.json {
@@ -1193,6 +1212,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -1228,6 +1248,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -1269,6 +1290,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -1297,6 +1319,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -1322,6 +1345,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -1347,6 +1371,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -1373,6 +1398,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let global = default_global();
@@ -1402,6 +1428,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -1437,6 +1464,7 @@ mod tests {
 
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
             write: Default::default(),
         };
         let mut global = default_global();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -40,8 +40,10 @@ pub enum Operation {
         path: Option<String>,
         mode: Option<String>,
         from: String,
-        to: String,
+        to: Option<String>,
         nth: Option<usize>,
+        insert_before: Option<String>,
+        insert_after: Option<String>,
     },
     #[serde(rename = "doc.set")]
     DocSet {
@@ -167,6 +169,42 @@ pub struct ValidationStep {
 pub fn parse_plan(input: &str) -> anyhow::Result<Plan> {
     let plan: Plan = serde_json::from_str(input)?;
     Ok(plan)
+}
+
+/// Parse a plan from a YAML string.
+pub fn parse_plan_yaml(input: &str) -> anyhow::Result<Plan> {
+    let plan: Plan = serde_yaml_ng::from_str(input)?;
+    Ok(plan)
+}
+
+/// Parse a plan from a TOML string.
+pub fn parse_plan_toml(input: &str) -> anyhow::Result<Plan> {
+    let plan: Plan = toml_edit::de::from_str(input)?;
+    Ok(plan)
+}
+
+/// Detect plan format from a file path extension and parse accordingly.
+pub fn parse_plan_auto(
+    input: &str,
+    path: Option<&str>,
+    format_hint: Option<&str>,
+) -> anyhow::Result<Plan> {
+    let fmt = format_hint.or_else(|| {
+        path.and_then(|p| {
+            if p.ends_with(".yaml") || p.ends_with(".yml") {
+                Some("yaml")
+            } else if p.ends_with(".toml") {
+                Some("toml")
+            } else {
+                None
+            }
+        })
+    });
+    match fmt {
+        Some("yaml" | "yml") => parse_plan_yaml(input),
+        Some("toml") => parse_plan_toml(input),
+        _ => parse_plan(input),
+    }
 }
 
 #[cfg(test)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -188,6 +188,76 @@ fn test_cwd_nonexistent_directory_fails() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_search_assert_count_exact_match() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "foo\nbar\nfoo\n").unwrap();
+    fs::write(dir.path().join("b.txt"), "foo\n").unwrap();
+
+    // 3 matching lines total: 2 in a.txt + 1 in b.txt
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("--literal")
+        .arg("--assert-count")
+        .arg("3")
+        .arg("foo")
+        .arg(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_search_assert_count_mismatch() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "foo bar\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("--literal")
+        .arg("--assert-count")
+        .arg("5")
+        .arg("foo")
+        .arg(dir.path())
+        .assert()
+        .code(2);
+}
+
+#[test]
+fn test_search_assert_count_zero() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "no match here\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("--literal")
+        .arg("--assert-count")
+        .arg("0")
+        .arg("zzz")
+        .arg(dir.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_search_assert_count_zero_but_found() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("--literal")
+        .arg("--assert-count")
+        .arg("0")
+        .arg("hello")
+        .arg(dir.path())
+        .assert()
+        .code(2);
+}
+
+#[test]
 fn test_search_multiline_spans_lines() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("code.rs");
@@ -886,6 +956,227 @@ fn test_hygiene_fix_apply() {
 // ---------------------------------------------------------------------------
 // create
 // ---------------------------------------------------------------------------
+
+// ── read command ────────────────────────────────────────────────────
+
+#[test]
+fn test_read_prints_file_contents() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("hello.txt");
+    fs::write(&file, "line1\nline2\nline3\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("read")
+        .arg(file.to_str().unwrap())
+        .assert()
+        .success()
+        .stdout("line1\nline2\nline3\n");
+}
+
+#[test]
+fn test_read_lines_range() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("five.txt");
+    fs::write(&file, "a\nb\nc\nd\ne\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("read")
+        .arg(file.to_str().unwrap())
+        .arg("--lines")
+        .arg("2:4")
+        .assert()
+        .success()
+        .stdout("b\nc\nd");
+}
+
+#[test]
+fn test_read_nonexistent_file_fails() {
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("read")
+        .arg("/tmp/patchloom-nonexistent-file-xyz")
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn test_read_json_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\nworld\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("read")
+        .arg(file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["total_lines"], 2);
+    assert_eq!(json["start_line"], 1);
+    assert_eq!(json["end_line"], 2);
+    assert!(json["content"].as_str().unwrap().contains("hello"));
+}
+
+#[test]
+fn test_read_respects_cwd() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("inner.txt"), "content\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("read")
+        .arg("inner.txt")
+        .assert()
+        .success()
+        .stdout("content\n");
+}
+
+// ── status command ─────────────────────────────────────────────────
+
+#[test]
+fn test_status_clean_repo() {
+    let dir = TempDir::new().unwrap();
+    // Initialize a git repo with one committed file.
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "a.txt"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("status")
+        .assert()
+        .success(); // exit 0 = no changes
+}
+
+#[test]
+fn test_status_modified_file() {
+    let dir = TempDir::new().unwrap();
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "a.txt"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Modify the committed file.
+    fs::write(dir.path().join("a.txt"), "changed\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("status")
+        .assert()
+        .code(2); // exit 2 = changes detected
+}
+
+#[test]
+fn test_status_json_output() {
+    let dir = TempDir::new().unwrap();
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "a.txt"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    // Create untracked file.
+    fs::write(dir.path().join("new.txt"), "new\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("status")
+        .output()
+        .unwrap();
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["total_changes"], 1);
+    assert!(json["created"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|v| v.as_str().unwrap() == "new.txt"));
+}
+
+// ── create command ─────────────────────────────────────────────────
 
 #[test]
 fn test_create_new_file() {
@@ -3070,6 +3361,155 @@ fn test_search_case_insensitive() {
 }
 
 #[test]
+fn test_replace_insert_before() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "    /// Doc comment.\n    pub field: bool,\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("--from")
+        .arg("    /// Doc comment.")
+        .arg("--insert-before")
+        .arg("    // marker\n")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "    // marker\n    /// Doc comment.\n    pub field: bool,\n"
+    );
+}
+
+#[test]
+fn test_replace_insert_after() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "line1\nanchor\nline3\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("--from")
+        .arg("anchor")
+        .arg("--insert-after")
+        .arg(" // tagged")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line1\nanchor // tagged\nline3\n"
+    );
+}
+
+#[test]
+fn test_replace_insert_before_with_regex() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "aaa\nbbb\nccc\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("--from")
+        .arg("b+")
+        .arg("--regex")
+        .arg("--insert-before")
+        .arg("X")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "aaa\nXbbb\nccc\n");
+}
+
+#[test]
+fn test_replace_insert_before_nth() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "x a x a x\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("--from")
+        .arg("a")
+        .arg("--insert-before")
+        .arg("[")
+        .arg("--nth")
+        .arg("2")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "x a x [a x\n");
+}
+
+#[test]
+fn test_replace_insert_before_and_to_conflict() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("--from")
+        .arg("hello")
+        .arg("--to")
+        .arg("world")
+        .arg("--insert-before")
+        .arg("X")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .failure();
+}
+
+#[test]
+fn test_tx_replace_insert_before_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.txt");
+    fs::write(&file, "    /// Old doc.\n    pub val: i32,\n").unwrap();
+
+    let plan = serde_json::json!({
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [
+            {
+                "op": "replace",
+                "path": file.to_str().unwrap(),
+                "from": "    /// Old doc.",
+                "insert_before": "    // ref:marker\n"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "    // ref:marker\n    /// Old doc.\n    pub val: i32,\n"
+    );
+}
+
+#[test]
 fn test_replace_case_insensitive() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -4671,6 +5111,97 @@ fn test_tx_write_policy_ensure_final_newline_on_file_create() {
         .success();
 
     assert_eq!(fs::read_to_string(&file).unwrap(), "no trailing newline\n");
+}
+
+#[test]
+fn test_tx_yaml_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("target.txt");
+    fs::write(&file, "old value\n").unwrap();
+
+    let yaml_plan = format!(
+        "operations:\n  - op: replace\n    path: \"{}\"\n    from: old\n    to: new\n",
+        file.to_str().unwrap()
+    );
+    let plan_file = dir.path().join("plan.yaml");
+    fs::write(&plan_file, &yaml_plan).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "new value\n");
+}
+
+#[test]
+fn test_tx_toml_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("target.txt");
+    fs::write(&file, "hello world\n").unwrap();
+
+    let toml_plan = format!(
+        "[[operations]]\nop = \"replace\"\npath = \"{}\"\nfrom = \"hello\"\nto = \"goodbye\"\n",
+        file.to_str().unwrap()
+    );
+    let plan_file = dir.path().join("plan.toml");
+    fs::write(&plan_file, &toml_plan).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "goodbye world\n");
+}
+
+#[test]
+fn test_tx_yaml_plan_from_stdin() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "aaa\n").unwrap();
+
+    let yaml_plan = format!(
+        "operations:\n  - op: replace\n    path: \"{}\"\n    from: aaa\n    to: bbb\n",
+        file.to_str().unwrap()
+    );
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg("-")
+        .arg("--plan-format")
+        .arg("yaml")
+        .arg("--apply")
+        .write_stdin(yaml_plan)
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "bbb\n");
+}
+
+#[test]
+fn test_tx_malformed_yaml_returns_parse_error() {
+    let dir = TempDir::new().unwrap();
+    let plan_file = dir.path().join("bad.yaml");
+    fs::write(&plan_file, "this: is: not: valid: yaml: [").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .assert()
+        .code(4);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Five new features to reduce agent tool-call overhead:

1. **`read` command** -- file content inspection with optional `--lines START:END` range and `--json` output
2. **`replace --insert-before` / `--insert-after`** -- insert text around matches without replacing them; works in standalone and `tx` plans
3. **`search --assert-count N`** -- verify match count in one call (exit 0 if exact, exit 2 if mismatch)
4. **YAML/TOML plan format** -- `tx` auto-detects plan format from file extension; `--plan-format yaml|toml` for stdin
5. **`status` command** -- shows uncommitted file changes vs git HEAD with `--json` output

## Motivation

Session tool-call analysis showed that `read_file` was the most frequent call (39 calls), batch edits like adding `// ref:` markers required 22 individual `search_replace` calls, and verification required multiple grep-then-compare patterns. These features directly address those gaps.

## Testing

- 379 tests (161 unit + 218 integration), all passing
- `make check` green (fmt, build, test, integration-test, clippy)
- Docs reference gate passes with all new markers