### PR TITLE
Reject invalid tx replace field combinations

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -129,6 +129,63 @@ fn op_label(op: &Operation) -> &'static str {
     }
 }
 
+fn validate_replace_fields(
+    to: &Option<String>,
+    insert_before: &Option<String>,
+    insert_after: &Option<String>,
+) -> anyhow::Result<()> {
+    let has_to = to.is_some();
+    let has_insert_before = insert_before.is_some();
+    let has_insert_after = insert_after.is_some();
+
+    if has_insert_before && has_insert_after {
+        anyhow::bail!("insert_before and insert_after cannot both be set");
+    }
+
+    if has_to && (has_insert_before || has_insert_after) {
+        anyhow::bail!("to cannot be combined with insert_before or insert_after");
+    }
+
+    Ok(())
+}
+
+fn validate_operation(op: &Operation) -> anyhow::Result<()> {
+    match op {
+        Operation::Replace {
+            to,
+            insert_before,
+            insert_after,
+            ..
+        } => validate_replace_fields(to, insert_before, insert_after),
+        _ => Ok(()),
+    }
+}
+
+fn validate_plan_operations(plan: &Plan) -> anyhow::Result<()> {
+    for op in &plan.operations {
+        validate_operation(op)?;
+    }
+
+    Ok(())
+}
+
+fn replacement_text(
+    from: &str,
+    to: &Option<String>,
+    insert_before: &Option<String>,
+    insert_after: &Option<String>,
+) -> String {
+    if let Some(text) = insert_before {
+        return format!("{text}{from}");
+    }
+
+    if let Some(text) = insert_after {
+        return format!("{from}{text}");
+    }
+
+    to.clone().unwrap_or_default()
+}
+
 fn parse_selector(input: &str) -> anyhow::Result<selector::Selector> {
     selector::parse(input).map_err(|e| anyhow::anyhow!("selector error: {e}"))
 }
@@ -258,13 +315,7 @@ fn execute_operation(
             insert_before,
             insert_after,
         } => {
-            let effective_to = if let Some(ref text) = insert_before {
-                format!("{text}{from}")
-            } else if let Some(ref text) = insert_after {
-                format!("{from}{text}")
-            } else {
-                to.clone().unwrap_or_default()
-            };
+            let effective_to = replacement_text(from, to, insert_before, insert_after);
             let compiled_re = if mode.as_deref() == Some("regex") {
                 Some(Regex::new(from)?)
             } else {
@@ -864,6 +915,15 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     };
 
+    if let Err(e) = validate_plan_operations(&plan) {
+        if global.json {
+            emit_error_json("parse_error", &e.to_string());
+        } else {
+            eprintln!("tx: plan parse error: {e}");
+        }
+        return Ok(exit::PARSE_ERROR);
+    }
+
     // 3. Set working directory (plan.cwd overrides global --cwd).
     if let Some(ref cwd) = plan.cwd {
         std::env::set_current_dir(cwd)?;
@@ -1405,6 +1465,48 @@ mod tests {
 
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::PARSE_ERROR);
+    }
+
+    #[test]
+    fn replace_conflicting_insert_fields_return_parse_error() {
+        let plan_json = serde_json::json!({
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "hello",
+                "insert_before": "X",
+                "insert_after": "Y"
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "insert_before and insert_after cannot both be set"
+        );
+    }
+
+    #[test]
+    fn replace_to_with_insert_returns_parse_error() {
+        let plan_json = serde_json::json!({
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "hello",
+                "to": "world",
+                "insert_before": "X"
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "to cannot be combined with insert_before or insert_after"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3510,6 +3510,70 @@ fn test_tx_replace_insert_before_in_plan() {
 }
 
 #[test]
+fn test_tx_replace_rejects_both_insert_before_and_after() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {
+                "op": "replace",
+                "path": file.to_str().unwrap(),
+                "from": "hello",
+                "insert_before": "X",
+                "insert_after": "Y"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(4);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn test_tx_replace_rejects_to_with_insert() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {
+                "op": "replace",
+                "path": file.to_str().unwrap(),
+                "from": "hello",
+                "to": "goodbye",
+                "insert_before": "X"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(4);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
 fn test_replace_case_insensitive() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -4650,8 +4714,48 @@ fn test_tx_json_output_on_parse_error() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
     assert_eq!(json["status"], "error");
+    assert_eq!(json["error_kind"], "parse_error");
     assert!(!json["error"].as_str().unwrap().is_empty());
     assert!(json["error"].as_str().unwrap().contains("parse_error"));
+}
+
+#[test]
+fn test_tx_json_output_on_replace_conflict_parse_error() {
+    let dir = TempDir::new().unwrap();
+    let plan_file = dir.path().join("bad.json");
+    fs::write(
+        &plan_file,
+        serde_json::to_string(&serde_json::json!({
+            "operations": [{
+                "op": "replace",
+                "path": "data.txt",
+                "from": "hello",
+                "insert_before": "X",
+                "insert_after": "Y"
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(4));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["status"], "error");
+    assert_eq!(json["error_kind"], "parse_error");
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("parse_error"));
+    assert!(error.contains("insert_before and insert_after cannot both be set"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Reject invalid `tx` replace field combinations during plan validation.

## Problem
`tx` plans could combine `to`, `insert_before`, and `insert_after` in ways the top-level `replace` CLI already rejects. The transaction path silently picked one branch and surfaced the failure as rollback behavior instead of a parse error.

## Change
- validate conflicting `replace` fields before executing `tx` operations
- return `PARSE_ERROR (4)` for invalid plans
- add unit and integration coverage for exit codes and JSON error output

## Validation
- `make check`

## Issue
Refs #104