### PR TITLE
Reject tx replace plans missing a replacement mode

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -637,6 +637,7 @@ The operations below are the building blocks inside `operations`.
 
 - **What it does:** Runs text replacement inside a transaction.
 - **Use when:** A text rewrite needs to share atomic rollback, formatting, or validation with other operations.
+- **Requires:** Exactly one of `to`, `insert_before`, or `insert_after`, matching top level `replace`.
 - **Related:** top level `replace`
 
 <!-- ref:tx-op:doc.set -->

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -138,15 +138,18 @@ fn validate_replace_fields(
     let has_insert_before = insert_before.is_some();
     let has_insert_after = insert_after.is_some();
 
-    if has_insert_before && has_insert_after {
-        anyhow::bail!("insert_before and insert_after cannot both be set");
+    match (has_to, has_insert_before, has_insert_after) {
+        (false, false, false) => {
+            anyhow::bail!("replace operation requires one of to, insert_before, or insert_after");
+        }
+        (_, true, true) => {
+            anyhow::bail!("insert_before and insert_after cannot both be set");
+        }
+        (true, true, false) | (true, false, true) => {
+            anyhow::bail!("to cannot be combined with insert_before or insert_after");
+        }
+        _ => Ok(()),
     }
-
-    if has_to && (has_insert_before || has_insert_after) {
-        anyhow::bail!("to cannot be combined with insert_before or insert_after");
-    }
-
-    Ok(())
 }
 
 fn validate_operation(op: &Operation) -> anyhow::Result<()> {
@@ -1465,6 +1468,25 @@ mod tests {
 
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::PARSE_ERROR);
+    }
+
+    #[test]
+    fn replace_requires_replacement_mode() {
+        let plan_json = serde_json::json!({
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "hello"
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "replace operation requires one of to, insert_before, or insert_after"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4720,6 +4720,72 @@ fn test_tx_json_output_on_parse_error() {
 }
 
 #[test]
+fn test_tx_replace_requires_replacement_mode() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {
+                "op": "replace",
+                "path": file.to_str().unwrap(),
+                "from": "hello"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(4);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn test_tx_json_output_on_replace_missing_mode_parse_error() {
+    let dir = TempDir::new().unwrap();
+    let plan_file = dir.path().join("bad.json");
+    fs::write(
+        &plan_file,
+        serde_json::to_string(&serde_json::json!({
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "hello"
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(4));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["status"], "error");
+    assert_eq!(json["error_kind"], "parse_error");
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("parse_error"));
+    assert!(error.contains("replace operation requires one of to, insert_before, or insert_after"));
+}
+
+#[test]
 fn test_tx_json_output_on_replace_conflict_parse_error() {
     let dir = TempDir::new().unwrap();
     let plan_file = dir.path().join("bad.json");


### PR DESCRIPTION
## Summary
Reject `tx` `replace` plans that omit all replacement-mode fields.

## Problem
Top-level `replace` already requires exactly one of `--to`, `--insert-before`, or `--insert-after`, but `tx` still accepted a `replace` operation with none of those fields. That silently treated the operation like deletion, removed the matched text, and exited success.

## Change
- validate `tx` `replace` operations so exactly one of `to`, `insert_before`, or `insert_after` is required
- keep existing parse errors for conflicting field combinations
- add unit and integration regressions for the missing-mode parse error
- document the requirement in the transaction reference docs

## Validation
- `cargo test replace_requires_replacement_mode`
- `cargo test test_tx_replace_requires_replacement_mode`
- `cargo test test_tx_json_output_on_replace_missing_mode_parse_error`
- `make check`

Refs #106
