### PR TITLE
Share replace semantics between replace and tx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 379 tests (161 unit + 218 integration)
+- 393 tests (166 unit + 227 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 12 commands and 379 passing tests.
+V2 with 12 commands and 393 passing tests.
 
 ## Install
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -638,6 +638,7 @@ The operations below are the building blocks inside `operations`.
 - **What it does:** Runs text replacement inside a transaction.
 - **Use when:** A text rewrite needs to share atomic rollback, formatting, or validation with other operations.
 - **Requires:** Exactly one of `to`, `insert_before`, or `insert_after`, matching top level `replace`.
+- **Regex insert semantics:** In regex mode, `insert_before` and `insert_after` preserve the matched text, they do not insert the raw pattern string.
 - **Related:** top level `replace`
 
 <!-- ref:tx-op:doc.set -->

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -1,9 +1,12 @@
 use crate::cli::global::GlobalFlags;
 use crate::diff::{format_diff_result, unified_diff, DiffResult};
 use crate::exit;
+use crate::ops::replace::{
+    replace_content, replacement_text, validate_replace_mode, ReplaceModeError,
+};
 use crate::write::{atomic_write, policy_from_flags};
 use clap::Args;
-use regex::{Regex, RegexBuilder};
+use regex::RegexBuilder;
 use serde::Serialize;
 use std::fs;
 use std::path::Path;
@@ -79,93 +82,14 @@ struct FileReplacement {
 
 use crate::is_binary;
 
-/// Count occurrences and produce replaced content.
-fn replace_content(
-    content: &str,
-    from: &str,
-    to: &str,
-    compiled_re: Option<&Regex>,
-    nth: Option<usize>,
-) -> (String, usize) {
-    if let Some(n) = nth {
-        // Replace only the Nth occurrence (1-based).
-        if let Some(re) = compiled_re {
-            let mut count = 0usize;
-            let mut result = String::with_capacity(content.len());
-            for m in re.find_iter(content) {
-                count += 1;
-                if count == n {
-                    result.push_str(&content[..m.start()]);
-                    let mut dst = String::new();
-                    if let Some(caps) = re.captures(&content[m.start()..]) {
-                        caps.expand(to, &mut dst);
-                    }
-                    result.push_str(&dst);
-                    result.push_str(&content[m.end()..]);
-                    return (result, 1);
-                }
-            }
-            (content.to_owned(), 0)
-        } else {
-            let mut count = 0usize;
-            let mut result = String::with_capacity(content.len());
-            for (start, _) in content.match_indices(from) {
-                count += 1;
-                if count == n {
-                    result.push_str(&content[..start]);
-                    result.push_str(to);
-                    result.push_str(&content[start + from.len()..]);
-                    return (result, 1);
-                }
-            }
-            (content.to_owned(), 0)
-        }
-    } else if let Some(re) = compiled_re {
-        // Single-pass: count replacements while producing the result.
-        let mut count = 0usize;
-        let replaced = re
-            .replace_all(content, |caps: &regex::Captures| {
-                count += 1;
-                let mut dst = String::new();
-                caps.expand(to, &mut dst);
-                dst
-            })
-            .to_string();
-        if count == 0 {
-            return (content.to_owned(), 0);
-        }
-        (replaced, count)
-    } else {
-        let count = content.matches(from).count();
-        if count == 0 {
-            return (content.to_owned(), 0);
-        }
-        let replaced = content.replace(from, to);
-        (replaced, count)
-    }
-}
-
-/// Compute the effective replacement text from the args.
-/// When using regex mode with insert, `$0` refers to the full match so the
-/// matched text is preserved rather than the raw pattern string.
-fn effective_to(args: &ReplaceArgs) -> String {
-    if let Some(ref text) = args.insert_before {
-        let anchor = if args.regex || args.case_insensitive {
-            "$0".to_string()
-        } else {
-            args.from.clone()
-        };
-        format!("{text}{anchor}")
-    } else if let Some(ref text) = args.insert_after {
-        let anchor = if args.regex || args.case_insensitive {
-            "$0".to_string()
-        } else {
-            args.from.clone()
-        };
-        format!("{anchor}{text}")
-    } else {
-        args.to.clone().unwrap_or_default()
-    }
+fn build_replacement(args: &ReplaceArgs) -> String {
+    replacement_text(
+        &args.from,
+        &args.to,
+        &args.insert_before,
+        &args.insert_after,
+        args.regex || args.case_insensitive,
+    )
 }
 
 /// Walk files and collect all replacements.
@@ -175,7 +99,7 @@ fn collect_replacements(
 ) -> anyhow::Result<Vec<FileReplacement>> {
     let glob_matcher = crate::build_glob_matcher(global)?;
     let file_paths = crate::collect_file_paths(&args.paths, global)?;
-    let to = effective_to(args);
+    let replacement = build_replacement(args);
 
     let compiled_re = if args.regex {
         Some(
@@ -217,8 +141,13 @@ fn collect_replacements(
             Err(_) => continue,
         };
 
-        let (replaced, count) =
-            replace_content(&content, &args.from, &to, compiled_re.as_ref(), args.nth);
+        let (replaced, count) = replace_content(
+            &content,
+            &args.from,
+            &replacement,
+            compiled_re.as_ref(),
+            args.nth,
+        );
 
         if count > 0 {
             replacements.push(FileReplacement {
@@ -260,12 +189,21 @@ fn make_diff_output(replacements: &[FileReplacement]) -> String {
 pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     std::env::set_current_dir(global.resolve_cwd()?)?;
 
-    // Validate: exactly one of --to, --insert-before, or --insert-after.
-    if args.to.is_none() && args.insert_before.is_none() && args.insert_after.is_none() {
-        anyhow::bail!("one of --to, --insert-before, or --insert-after must be provided");
-    }
-    if args.to.is_some() && (args.insert_before.is_some() || args.insert_after.is_some()) {
-        anyhow::bail!("--to cannot be combined with --insert-before or --insert-after");
+    match validate_replace_mode(
+        args.to.is_some(),
+        args.insert_before.is_some(),
+        args.insert_after.is_some(),
+    ) {
+        Ok(()) => {}
+        Err(ReplaceModeError::MissingMode) => {
+            anyhow::bail!("one of --to, --insert-before, or --insert-after must be provided")
+        }
+        Err(ReplaceModeError::BothInsertModes) => {
+            anyhow::bail!("--insert-before and --insert-after cannot be combined")
+        }
+        Err(ReplaceModeError::ToWithInsert) => {
+            anyhow::bail!("--to cannot be combined with --insert-before or --insert-after")
+        }
     }
 
     let replacements = collect_replacements(&args, global)?;

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -9,6 +9,9 @@ use crate::ops::md::{
     table_append_for_tx, upsert_bullet_in,
 };
 use crate::ops::patch::apply_patch_with_loader;
+use crate::ops::replace::{
+    replace_content, replacement_text, validate_replace_mode, ReplaceModeError,
+};
 use crate::plan::{self, Operation, Plan};
 use crate::selector;
 use crate::write::{apply_policy, atomic_write, WritePolicy};
@@ -129,29 +132,6 @@ fn op_label(op: &Operation) -> &'static str {
     }
 }
 
-fn validate_replace_fields(
-    to: &Option<String>,
-    insert_before: &Option<String>,
-    insert_after: &Option<String>,
-) -> anyhow::Result<()> {
-    let has_to = to.is_some();
-    let has_insert_before = insert_before.is_some();
-    let has_insert_after = insert_after.is_some();
-
-    match (has_to, has_insert_before, has_insert_after) {
-        (false, false, false) => {
-            anyhow::bail!("replace operation requires one of to, insert_before, or insert_after");
-        }
-        (_, true, true) => {
-            anyhow::bail!("insert_before and insert_after cannot both be set");
-        }
-        (true, true, false) | (true, false, true) => {
-            anyhow::bail!("to cannot be combined with insert_before or insert_after");
-        }
-        _ => Ok(()),
-    }
-}
-
 fn validate_operation(op: &Operation) -> anyhow::Result<()> {
     match op {
         Operation::Replace {
@@ -159,7 +139,24 @@ fn validate_operation(op: &Operation) -> anyhow::Result<()> {
             insert_before,
             insert_after,
             ..
-        } => validate_replace_fields(to, insert_before, insert_after),
+        } => match validate_replace_mode(
+            to.is_some(),
+            insert_before.is_some(),
+            insert_after.is_some(),
+        ) {
+            Ok(()) => Ok(()),
+            Err(ReplaceModeError::MissingMode) => {
+                anyhow::bail!(
+                    "replace operation requires one of to, insert_before, or insert_after"
+                )
+            }
+            Err(ReplaceModeError::BothInsertModes) => {
+                anyhow::bail!("insert_before and insert_after cannot both be set")
+            }
+            Err(ReplaceModeError::ToWithInsert) => {
+                anyhow::bail!("to cannot be combined with insert_before or insert_after")
+            }
+        },
         _ => Ok(()),
     }
 }
@@ -170,23 +167,6 @@ fn validate_plan_operations(plan: &Plan) -> anyhow::Result<()> {
     }
 
     Ok(())
-}
-
-fn replacement_text(
-    from: &str,
-    to: &Option<String>,
-    insert_before: &Option<String>,
-    insert_after: &Option<String>,
-) -> String {
-    if let Some(text) = insert_before {
-        return format!("{text}{from}");
-    }
-
-    if let Some(text) = insert_after {
-        return format!("{from}{text}");
-    }
-
-    to.clone().unwrap_or_default()
 }
 
 fn parse_selector(input: &str) -> anyhow::Result<selector::Selector> {
@@ -226,53 +206,6 @@ fn update_file_content(
         *current = new_content;
     } else {
         pending.insert(path.to_path_buf(), (String::new(), new_content));
-    }
-}
-
-// ---------------------------------------------------------------------------
-// String replacement helper
-// ---------------------------------------------------------------------------
-
-fn do_replace(
-    content: &str,
-    from: &str,
-    to: &str,
-    compiled_re: Option<&Regex>,
-    nth: Option<usize>,
-) -> String {
-    if let Some(n) = nth {
-        // Replace only the Nth occurrence (1-based).
-        let mut count = 0usize;
-        if let Some(re) = compiled_re {
-            let mut result = String::with_capacity(content.len());
-            for m in re.find_iter(content) {
-                count += 1;
-                if count == n {
-                    result.push_str(&content[..m.start()]);
-                    result.push_str(to);
-                    result.push_str(&content[m.end()..]);
-                    return result;
-                }
-            }
-            // Nth occurrence not found; return content unchanged.
-            content.to_string()
-        } else {
-            let mut result = String::with_capacity(content.len());
-            for (start, _) in content.match_indices(from) {
-                count += 1;
-                if count == n {
-                    result.push_str(&content[..start]);
-                    result.push_str(to);
-                    result.push_str(&content[start + from.len()..]);
-                    return result;
-                }
-            }
-            content.to_string()
-        }
-    } else if let Some(re) = compiled_re {
-        re.replace_all(content, to).to_string()
-    } else {
-        content.replace(from, to)
     }
 }
 
@@ -318,8 +251,10 @@ fn execute_operation(
             insert_before,
             insert_after,
         } => {
-            let effective_to = replacement_text(from, to, insert_before, insert_after);
-            let compiled_re = if mode.as_deref() == Some("regex") {
+            let use_match_anchor = mode.as_deref() == Some("regex");
+            let replacement =
+                replacement_text(from, to, insert_before, insert_after, use_match_anchor);
+            let compiled_re = if use_match_anchor {
                 Some(Regex::new(from)?)
             } else {
                 None
@@ -328,7 +263,8 @@ fn execute_operation(
             if let Some(p) = path {
                 let file_path = PathBuf::from(p);
                 let content = read_file_content(pending, &file_path)?;
-                let replaced = do_replace(content, from, &effective_to, compiled_re.as_ref(), *nth);
+                let (replaced, _) =
+                    replace_content(content, from, &replacement, compiled_re.as_ref(), *nth);
                 update_file_content(pending, deletions, &file_path, replaced);
             } else if let Some(pattern) = glob {
                 let matcher = Glob::new(pattern)?.compile_matcher();
@@ -351,8 +287,8 @@ fn execute_operation(
                         Ok(c) => c,
                         Err(_) => continue,
                     };
-                    let replaced =
-                        do_replace(content, from, &effective_to, compiled_re.as_ref(), *nth);
+                    let (replaced, _) =
+                        replace_content(content, from, &replacement, compiled_re.as_ref(), *nth);
                     update_file_content(pending, deletions, &file_path, replaced);
                 }
             } else {
@@ -1508,6 +1444,20 @@ mod tests {
             err.to_string(),
             "insert_before and insert_after cannot both be set"
         );
+    }
+
+    #[test]
+    fn regex_insert_before_uses_match_anchor_in_replacement_text() {
+        let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true);
+
+        assert_eq!(text, "X${0}");
+    }
+
+    #[test]
+    fn regex_insert_after_uses_match_anchor_in_replacement_text() {
+        let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true);
+
+        assert_eq!(text, "${0}X");
     }
 
     #[test]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -172,6 +172,123 @@ pub(crate) mod doc {
     }
 }
 
+pub(crate) mod replace {
+    use regex::Regex;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) enum ReplaceModeError {
+        MissingMode,
+        BothInsertModes,
+        ToWithInsert,
+    }
+
+    pub(crate) fn validate_replace_mode(
+        has_to: bool,
+        has_insert_before: bool,
+        has_insert_after: bool,
+    ) -> Result<(), ReplaceModeError> {
+        match (has_to, has_insert_before, has_insert_after) {
+            (false, false, false) => Err(ReplaceModeError::MissingMode),
+            (_, true, true) => Err(ReplaceModeError::BothInsertModes),
+            (true, true, false) | (true, false, true) => Err(ReplaceModeError::ToWithInsert),
+            _ => Ok(()),
+        }
+    }
+
+    pub(crate) fn replacement_text(
+        from: &str,
+        to: &Option<String>,
+        insert_before: &Option<String>,
+        insert_after: &Option<String>,
+        use_match_anchor: bool,
+    ) -> String {
+        let anchor = if use_match_anchor { "${0}" } else { from };
+
+        if let Some(text) = insert_before {
+            return format!("{text}{anchor}");
+        }
+
+        if let Some(text) = insert_after {
+            return format!("{anchor}{text}");
+        }
+
+        to.clone().unwrap_or_default()
+    }
+
+    fn expand_regex_replacement(caps: &regex::Captures<'_>, replacement: &str) -> String {
+        let mut expanded = String::new();
+        caps.expand(replacement, &mut expanded);
+        expanded
+    }
+
+    pub(crate) fn replace_content(
+        content: &str,
+        from: &str,
+        to: &str,
+        compiled_re: Option<&Regex>,
+        nth: Option<usize>,
+    ) -> (String, usize) {
+        match (nth, compiled_re) {
+            (Some(n), Some(re)) => {
+                let mut count = 0usize;
+                let mut result = String::with_capacity(content.len());
+                for m in re.find_iter(content) {
+                    count += 1;
+                    if count != n {
+                        continue;
+                    }
+
+                    result.push_str(&content[..m.start()]);
+                    if let Some(caps) = re.captures(&content[m.start()..]) {
+                        let replacement = expand_regex_replacement(&caps, to);
+                        result.push_str(&replacement);
+                    }
+                    result.push_str(&content[m.end()..]);
+                    return (result, 1);
+                }
+                (content.to_owned(), 0)
+            }
+            (Some(n), None) => {
+                let mut count = 0usize;
+                let mut result = String::with_capacity(content.len());
+                for (start, _) in content.match_indices(from) {
+                    count += 1;
+                    if count != n {
+                        continue;
+                    }
+
+                    result.push_str(&content[..start]);
+                    result.push_str(to);
+                    result.push_str(&content[start + from.len()..]);
+                    return (result, 1);
+                }
+                (content.to_owned(), 0)
+            }
+            (None, Some(re)) => {
+                let mut count = 0usize;
+                let replaced = re
+                    .replace_all(content, |caps: &regex::Captures| {
+                        count += 1;
+                        expand_regex_replacement(caps, to)
+                    })
+                    .to_string();
+                if count == 0 {
+                    return (content.to_owned(), 0);
+                }
+                (replaced, count)
+            }
+            (None, None) => {
+                let count = content.matches(from).count();
+                if count == 0 {
+                    return (content.to_owned(), 0);
+                }
+                let replaced = content.replace(from, to);
+                (replaced, count)
+            }
+        }
+    }
+}
+
 pub(crate) mod md {
     use std::collections::HashSet;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3431,6 +3431,28 @@ fn test_replace_insert_before_with_regex() {
 }
 
 #[test]
+fn test_replace_insert_after_with_regex() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "aaa\nbbb\nccc\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("--from")
+        .arg("b+")
+        .arg("--regex")
+        .arg("--insert-after")
+        .arg("X")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "aaa\nbbbX\nccc\n");
+}
+
+#[test]
 fn test_replace_insert_before_nth() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("data.txt");
@@ -3507,6 +3529,66 @@ fn test_tx_replace_insert_before_in_plan() {
         fs::read_to_string(&file).unwrap(),
         "    // ref:marker\n    /// Old doc.\n    pub val: i32,\n"
     );
+}
+
+#[test]
+fn test_tx_replace_insert_before_with_regex_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "aaa\nbbb\nccc\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "mode": "regex",
+            "from": "b+",
+            "insert_before": "X"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "aaa\nXbbb\nccc\n");
+}
+
+#[test]
+fn test_tx_replace_insert_after_with_regex_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "aaa\nbbb\nccc\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "mode": "regex",
+            "from": "b+",
+            "insert_after": "X"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "aaa\nbbbX\nccc\n");
 }
 
 #[test]
@@ -5503,6 +5585,38 @@ fn test_replace_nth_regex_replaces_only_nth() {
 
     let content = fs::read_to_string(&file).unwrap();
     assert_eq!(content, "v1.0 and vX.Y and v3.0\n");
+}
+
+#[test]
+fn test_tx_replace_nth_regex_with_capture_groups_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "version = \"1.2.3\"\nversion = \"4.5.6\"\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "mode": "regex",
+            "from": r#"version = "(\d+)\.(\d+)\.(\d+)""#,
+            "to": r#"version = "$1.$2.99""#,
+            "nth": 2
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, "version = \"1.2.3\"\nversion = \"4.5.99\"\n");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Share replacement-mode validation and replacement construction between top-level `replace` and `tx`, while fixing regex insert semantics drift.

## Problem
`tx` had drifted from top-level `replace` in two places: regex insert operations did not preserve the matched text consistently, and the replacement contract lived in separate implementations. This also left `insert_after` coverage and tx regex-insert docs incomplete.

## Change
- move shared replacement-mode validation and replacement construction into `src/ops.rs`
- make both `replace` and `tx` use the shared helper
- fix regex insert anchoring so insert modes preserve matched text in both commands
- add regression coverage for regex `insert_after` and tx regex nth capture-group replacement
- document tx regex insert semantics
- refresh README and changelog test counts to 393 passing tests

## Validation
- `make check`
- reviewer pass on the final diff

Refs #108
Refs #109
Refs #110