### PR TITLE
Return NO_MATCHES for tx replace no-op plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 393 tests (166 unit + 227 integration)
+- 397 tests (166 unit + 231 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 12 commands and 393 passing tests.
+V2 with 12 commands and 397 passing tests.
 
 ## Install
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -239,7 +239,7 @@ fn execute_operation(
     op: &Operation,
     pending: &mut HashMap<PathBuf, (String, String)>,
     deletions: &mut HashSet<PathBuf>,
-) -> anyhow::Result<()> {
+) -> anyhow::Result<usize> {
     match op {
         Operation::Replace {
             glob,
@@ -263,12 +263,14 @@ fn execute_operation(
             if let Some(p) = path {
                 let file_path = PathBuf::from(p);
                 let content = read_file_content(pending, &file_path)?;
-                let (replaced, _) =
+                let (replaced, match_count) =
                     replace_content(content, from, &replacement, compiled_re.as_ref(), *nth);
                 update_file_content(pending, deletions, &file_path, replaced);
+                return Ok(match_count);
             } else if let Some(pattern) = glob {
                 let matcher = Glob::new(pattern)?.compile_matcher();
                 let walker = WalkBuilder::new(".").build();
+                let mut total_matches = 0usize;
                 for entry in walker {
                     let entry = match entry {
                         Ok(e) => e,
@@ -287,10 +289,12 @@ fn execute_operation(
                         Ok(c) => c,
                         Err(_) => continue,
                     };
-                    let (replaced, _) =
+                    let (replaced, match_count) =
                         replace_content(content, from, &replacement, compiled_re.as_ref(), *nth);
+                    total_matches += match_count;
                     update_file_content(pending, deletions, &file_path, replaced);
                 }
+                return Ok(total_matches);
             } else {
                 anyhow::bail!("replace operation requires either 'path' or 'glob'");
             }
@@ -671,7 +675,7 @@ fn execute_operation(
         }
     }
 
-    Ok(())
+    Ok(0)
 }
 
 // ---------------------------------------------------------------------------
@@ -873,16 +877,26 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // 4. Execute all operations, collecting changes in memory (no writes).
     let mut pending: HashMap<PathBuf, (String, String)> = HashMap::new();
     let mut deletions: HashSet<PathBuf> = HashSet::new();
+    let mut has_replace_operation = false;
+    let mut total_replace_matches = 0usize;
 
     for (i, op) in plan.operations.iter().enumerate() {
-        if let Err(e) = execute_operation(op, &mut pending, &mut deletions) {
-            let msg = format!("operation {} ({}) failed: {e}", i + 1, op_label(op));
-            if global.json {
-                emit_error_json("rollback", &msg);
-            } else {
-                eprintln!("tx: {msg}");
+        if matches!(op, Operation::Replace { .. }) {
+            has_replace_operation = true;
+        }
+        match execute_operation(op, &mut pending, &mut deletions) {
+            Ok(match_count) => {
+                total_replace_matches += match_count;
             }
-            return Ok(exit::ROLLBACK);
+            Err(e) => {
+                let msg = format!("operation {} ({}) failed: {e}", i + 1, op_label(op));
+                if global.json {
+                    emit_error_json("rollback", &msg);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::ROLLBACK);
+            }
         }
     }
 
@@ -910,8 +924,15 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         .iter()
         .filter(|p| !changes.iter().any(|(c, _, _)| c == *p))
         .count();
+    let no_effective_changes = changes.is_empty() && pending_deletions == 0;
+    let replace_no_matches =
+        has_replace_operation && total_replace_matches == 0 && no_effective_changes;
+
     if global.check {
-        if changes.is_empty() && pending_deletions == 0 {
+        if no_effective_changes {
+            if replace_no_matches {
+                return Ok(exit::NO_MATCHES);
+            }
             if global.json {
                 let output =
                     build_tx_output("success", true, &changes, &deletions, &existed_before);
@@ -1071,11 +1092,18 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::VALIDATION_FAILED);
         }
 
+        if replace_no_matches {
+            return Ok(exit::NO_MATCHES);
+        }
         if global.json {
             let output = build_tx_output("success", true, &changes, &deletions, &existed_before);
             println!("{}", serde_json::to_string_pretty(&output)?);
         }
         return Ok(exit::SUCCESS);
+    }
+
+    if replace_no_matches {
+        return Ok(exit::NO_MATCHES);
     }
 
     // Default / --diff mode: show unified diffs.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4254,6 +4254,134 @@ fn test_tx_replace_nth_in_plan() {
 }
 
 #[test]
+fn test_tx_replace_apply_no_match_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "foo bar\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "zzz",
+            "to": "ZZZ"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(3);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "foo bar\n");
+}
+
+#[test]
+fn test_tx_replace_check_no_match_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "foo bar\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "zzz",
+            "to": "ZZZ"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--check")
+        .assert()
+        .code(3);
+}
+
+#[test]
+fn test_tx_json_check_replace_no_match_exits_3_without_success_payload() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "foo bar\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "zzz",
+            "to": "ZZZ"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(String::from_utf8_lossy(&output.stdout).trim().is_empty());
+}
+
+#[test]
+fn test_tx_replace_no_match_does_not_hide_other_changes() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    let config = dir.path().join("config.json");
+    fs::write(&file, "foo bar\n").unwrap();
+    fs::write(&config, r#"{"name":"test"}"#).unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {
+                "op": "replace",
+                "path": file.to_str().unwrap(),
+                "from": "zzz",
+                "to": "ZZZ"
+            },
+            {
+                "op": "doc.ensure",
+                "path": config.to_str().unwrap(),
+                "key": "version",
+                "value": "1.0"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    let config_value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&config).unwrap()).unwrap();
+    assert_eq!(config_value["version"], "1.0");
+}
+
+#[test]
 fn test_tx_patch_apply_in_plan() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("hello.txt");


### PR DESCRIPTION
## Summary
Return `NO_MATCHES` for replace-only `tx` plans that match nothing and produce no effective changes.

## Problem
Top-level `replace` returns exit 3 when nothing matches, unless `--if-exists` is set. `tx` replace previously reported success for the same no-match case, which hid stale patterns, wrong paths, and out-of-range `nth` values inside replace-only transactions.

## Change
- track replace match counts while executing `tx` operations
- return `NO_MATCHES` when a transaction includes replace operations, ends with zero replace matches, and produces zero effective changes
- preserve existing success behavior for intentional non-replace no-op transactions and mixed plans that still change something
- add integration coverage for `--apply`, `--check`, JSON check mode, and a mixed replace plus doc.ensure plan
- refresh README and CHANGELOG test totals to 397 passing tests

## Validation
- `cargo test --test integration test_tx_replace_`
- `cargo test --test integration test_tx_json_check_replace_no_match_exits_3_without_success_payload`
- `make check`

Closes #112