### PR TITLE
Add --json output to delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 397 tests (166 unit + 231 integration)
+- 399 tests (166 unit + 233 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 12 commands and 397 passing tests.
+V2 with 12 commands and 399 passing tests.
 
 ## Install
 

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -1,6 +1,7 @@
 use crate::cli::global::GlobalFlags;
 use crate::exit;
 use clap::Args;
+use serde::Serialize;
 
 #[derive(Debug, Args)]
 pub struct DeleteArgs {
@@ -9,6 +10,13 @@ pub struct DeleteArgs {
     pub file: String,
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,
+}
+
+#[derive(Debug, Serialize)]
+struct DeleteOutput {
+    ok: bool,
+    path: String,
+    applied: bool,
 }
 
 pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
@@ -21,7 +29,14 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if global.check {
-        if !global.quiet {
+        if global.json {
+            let output = DeleteOutput {
+                ok: true,
+                path: args.file.clone(),
+                applied: false,
+            };
+            println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if !global.quiet {
             println!("would delete {}", args.file);
         }
         return Ok(exit::CHANGES_DETECTED);
@@ -29,13 +44,29 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if global.apply {
         std::fs::remove_file(path)?;
-        if !global.quiet {
+        if global.json {
+            let output = DeleteOutput {
+                ok: true,
+                path: args.file.clone(),
+                applied: true,
+            };
+            println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if !global.quiet {
             println!("deleted {}", args.file);
         }
         return Ok(exit::SUCCESS);
     }
 
     // Default: dry-run.
-    println!("would delete {}", args.file);
+    if global.json {
+        let output = DeleteOutput {
+            ok: true,
+            path: args.file.clone(),
+            applied: false,
+        };
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        println!("would delete {}", args.file);
+    }
     Ok(exit::SUCCESS)
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3722,6 +3722,56 @@ fn test_delete_removes_file() {
 }
 
 #[test]
+fn test_delete_json_apply_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doomed.txt");
+    fs::write(&file, "bye\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("delete")
+        .arg("--file")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(!file.exists());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["applied"], true);
+    assert!(json["path"].as_str().unwrap().contains("doomed.txt"));
+}
+
+#[test]
+fn test_delete_json_check_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("safe.txt");
+    fs::write(&file, "keep\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("delete")
+        .arg("--file")
+        .arg(file.to_str().unwrap())
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(file.exists());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["applied"], false);
+    assert!(json["path"].as_str().unwrap().contains("safe.txt"));
+}
+
+#[test]
 fn test_delete_check_mode_does_not_remove() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("safe.txt");


### PR DESCRIPTION
## Summary
Add structured JSON output to the `delete` command for consistency with every other write command.

## Problem
Every write command (`create`, `replace`, `doc`, `md`, `hygiene`, `tx`) emits structured JSON when `--json` is passed. `delete` ignored the flag and only printed plain text. This broke the uniform structured-output contract that AI agents and CI pipelines rely on.

## Change
- add a `DeleteOutput` struct with `ok`, `path`, and `applied` fields
- emit JSON in all three modes (`--check`, `--apply`, default dry-run)
- add integration tests for `--json --apply` and `--json --check`
- refresh README and CHANGELOG test totals to 399

## Validation
- `make check`

Closes #120