### PR TITLE
Add case_insensitive and multiline to tx replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 399 tests (166 unit + 233 integration)
+- 401 tests (166 unit + 235 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 12 commands and 399 passing tests.
+V2 with 12 commands and 401 passing tests.
 
 ## Install
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -639,6 +639,7 @@ The operations below are the building blocks inside `operations`.
 - **Use when:** A text rewrite needs to share atomic rollback, formatting, or validation with other operations.
 - **Requires:** Exactly one of `to`, `insert_before`, or `insert_after`, matching top level `replace`.
 - **Regex insert semantics:** In regex mode, `insert_before` and `insert_after` preserve the matched text, they do not insert the raw pattern string.
+- **Optional fields:** `case_insensitive` (bool, default false) and `multiline` (bool, default false) match the top level `replace --case-insensitive` and `--multiline` flags.
 - **Related:** top level `replace`
 
 <!-- ref:tx-op:doc.set -->

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -18,7 +18,7 @@ use crate::write::{apply_policy, atomic_write, WritePolicy};
 use clap::Args;
 use globset::Glob;
 use ignore::WalkBuilder;
-use regex::Regex;
+use regex::RegexBuilder;
 use serde::Serialize;
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -250,12 +250,25 @@ fn execute_operation(
             nth,
             insert_before,
             insert_after,
+            case_insensitive,
+            multiline,
         } => {
-            let use_match_anchor = mode.as_deref() == Some("regex");
-            let replacement =
-                replacement_text(from, to, insert_before, insert_after, use_match_anchor);
-            let compiled_re = if use_match_anchor {
-                Some(Regex::new(from)?)
+            let regex_mode = mode.as_deref() == Some("regex");
+            let use_regex = regex_mode || *case_insensitive;
+            let replacement = replacement_text(from, to, insert_before, insert_after, use_regex);
+            let compiled_re = if regex_mode {
+                Some(
+                    RegexBuilder::new(from)
+                        .case_insensitive(*case_insensitive)
+                        .dot_matches_new_line(*multiline)
+                        .build()?,
+                )
+            } else if *case_insensitive {
+                Some(
+                    RegexBuilder::new(&regex::escape(from))
+                        .case_insensitive(true)
+                        .build()?,
+                )
             } else {
                 None
             };

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -44,6 +44,10 @@ pub enum Operation {
         nth: Option<usize>,
         insert_before: Option<String>,
         insert_after: Option<String>,
+        #[serde(default)]
+        case_insensitive: bool,
+        #[serde(default)]
+        multiline: bool,
     },
     #[serde(rename = "doc.set")]
     DocSet {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4274,6 +4274,67 @@ fn test_tx_md_dedupe_headings_in_plan() {
 }
 
 #[test]
+fn test_tx_replace_case_insensitive_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "Hello HELLO hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "hello",
+            "to": "HI",
+            "case_insensitive": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "HI HI HI\n");
+}
+
+#[test]
+fn test_tx_replace_multiline_regex_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "start\nmiddle\nend\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "mode": "regex",
+            "from": "start.middle",
+            "to": "REPLACED",
+            "multiline": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "REPLACED\nend\n");
+}
+
+#[test]
 fn test_tx_replace_nth_in_plan() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary
Add `case_insensitive` and `multiline` fields to `tx` replace operations for parity with standalone `replace`.

## Problem
Standalone `replace` supports `--case-insensitive` and `--multiline`, but the `tx` plan schema had no equivalent fields. These features were unreachable inside transactions, breaking the documented contract that tx replace matches top-level replace.

## Change
- add `case_insensitive` and `multiline` boolean fields (default false) to `Operation::Replace` in `src/plan.rs`
- wire both through the regex builder in `src/cmd/tx.rs`
- add integration tests for case-insensitive and multiline regex tx replace
- update reference docs to document the new optional fields
- refresh README and CHANGELOG test totals to 401

## Validation
- `make check`

Closes #122