### PR TITLE
Skip buffering non-matching files in tx glob replace

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -298,14 +298,27 @@ fn execute_operation(
                     {
                         continue;
                     }
-                    let content = match read_file_content(pending, &file_path) {
-                        Ok(c) => c,
-                        Err(_) => continue,
+                    // If the file is already in pending (modified by an earlier
+                    // operation), use that content. Otherwise read from disk
+                    // without inserting into pending so non-matching files don't
+                    // get buffered.
+                    let content = if pending.contains_key(&file_path) {
+                        match read_file_content(pending, &file_path) {
+                            Ok(c) => c.to_owned(),
+                            Err(_) => continue,
+                        }
+                    } else {
+                        match std::fs::read_to_string(&file_path) {
+                            Ok(s) => s,
+                            Err(_) => continue,
+                        }
                     };
                     let (replaced, match_count) =
-                        replace_content(content, from, &replacement, compiled_re.as_ref(), *nth);
+                        replace_content(&content, from, &replacement, compiled_re.as_ref(), *nth);
                     total_matches += match_count;
-                    update_file_content(pending, deletions, &file_path, replaced);
+                    if match_count > 0 {
+                        update_file_content(pending, deletions, &file_path, replaced);
+                    }
                 }
                 return Ok(total_matches);
             } else {


### PR DESCRIPTION
## Summary
Avoid buffering every glob-matched file into the pending HashMap when there are zero replacement matches.

## Problem
The tx glob replace path read every walked file into `pending` via `read_file_content`, even when `replace_content` found zero matches. For a glob replace across a large repo, I/O and allocation cost scaled with the number of glob-matched files rather than the number of files with actual matches.

## Change
- in the glob branch, read files directly with `fs::read_to_string` unless they are already in `pending` from an earlier tx operation
- only call `update_file_content` when `match_count > 0`
- files already in `pending` still use `read_file_content` to preserve in-flight state

## Validation
- `make check` (all 235 integration tests pass)

Closes #124