### PR TITLE
Add if_exists to tx replace for idempotent plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 401 tests (166 unit + 235 integration)
+- 403 tests (166 unit + 237 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 12 commands and 401 passing tests.
+V2 with 12 commands and 403 passing tests.
 
 ## Install
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -252,6 +252,7 @@ fn execute_operation(
             insert_after,
             case_insensitive,
             multiline,
+            ..
         } => {
             let regex_mode = mode.as_deref() == Some("regex");
             let use_regex = regex_mode || *case_insensitive;
@@ -903,12 +904,14 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // 4. Execute all operations, collecting changes in memory (no writes).
     let mut pending: HashMap<PathBuf, (String, String)> = HashMap::new();
     let mut deletions: HashSet<PathBuf> = HashSet::new();
-    let mut has_replace_operation = false;
+    let mut has_non_idempotent_replace = false;
     let mut total_replace_matches = 0usize;
 
     for (i, op) in plan.operations.iter().enumerate() {
-        if matches!(op, Operation::Replace { .. }) {
-            has_replace_operation = true;
+        if let Operation::Replace { if_exists, .. } = op {
+            if !if_exists {
+                has_non_idempotent_replace = true;
+            }
         }
         match execute_operation(op, &mut pending, &mut deletions) {
             Ok(match_count) => {
@@ -952,7 +955,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         .count();
     let no_effective_changes = changes.is_empty() && pending_deletions == 0;
     let replace_no_matches =
-        has_replace_operation && total_replace_matches == 0 && no_effective_changes;
+        has_non_idempotent_replace && total_replace_matches == 0 && no_effective_changes;
 
     if global.check {
         if no_effective_changes {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -48,6 +48,8 @@ pub enum Operation {
         case_insensitive: bool,
         #[serde(default)]
         multiline: bool,
+        #[serde(default)]
+        if_exists: bool,
     },
     #[serde(rename = "doc.set")]
     DocSet {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4452,6 +4452,66 @@ fn test_tx_json_check_replace_no_match_exits_3_without_success_payload() {
 }
 
 #[test]
+fn test_tx_replace_if_exists_no_match_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "foo bar\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "zzz",
+            "to": "ZZZ",
+            "if_exists": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "foo bar\n");
+}
+
+#[test]
+fn test_tx_replace_if_exists_still_replaces_when_found() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "foo bar\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "foo",
+            "to": "baz",
+            "if_exists": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "baz bar\n");
+}
+
+#[test]
 fn test_tx_replace_no_match_does_not_hide_other_changes() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary
Add `if_exists` support to tx replace operations for parity with standalone `replace --if-exists`.

## Problem
Standalone `replace --if-exists` returns success on no matches for idempotent workflows. The tx plan schema had no `if_exists` field, so agents could not express "replace if present, succeed otherwise" inside a transaction plan. The entire transaction failed with exit 3 for what should be a no-op.

## Change
- add `if_exists` boolean field (default false) to `Operation::Replace` in `src/plan.rs`
- when `if_exists` is true, the replace operation does not contribute to the `NO_MATCHES` exit check
- add integration tests for both the no-match-succeeds and still-replaces-when-found cases
- refresh README and CHANGELOG test totals to 403

## Validation
- `make check`

Closes #126