### PR TITLE
Reject empty from string in replace and tx replace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 403 tests (166 unit + 237 integration)
+- 405 tests (166 unit + 239 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 12 commands and 403 passing tests.
+V2 with 12 commands and 405 passing tests.
 
 ## Install
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -189,6 +189,10 @@ fn make_diff_output(replacements: &[FileReplacement]) -> String {
 pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     std::env::set_current_dir(global.resolve_cwd()?)?;
 
+    if args.from.is_empty() {
+        anyhow::bail!("--from must not be empty");
+    }
+
     match validate_replace_mode(
         args.to.is_some(),
         args.insert_before.is_some(),

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -135,28 +135,34 @@ fn op_label(op: &Operation) -> &'static str {
 fn validate_operation(op: &Operation) -> anyhow::Result<()> {
     match op {
         Operation::Replace {
+            from,
             to,
             insert_before,
             insert_after,
             ..
-        } => match validate_replace_mode(
-            to.is_some(),
-            insert_before.is_some(),
-            insert_after.is_some(),
-        ) {
-            Ok(()) => Ok(()),
-            Err(ReplaceModeError::MissingMode) => {
-                anyhow::bail!(
-                    "replace operation requires one of to, insert_before, or insert_after"
-                )
+        } => {
+            if from.is_empty() {
+                anyhow::bail!("replace operation requires a non-empty from field");
             }
-            Err(ReplaceModeError::BothInsertModes) => {
-                anyhow::bail!("insert_before and insert_after cannot both be set")
+            match validate_replace_mode(
+                to.is_some(),
+                insert_before.is_some(),
+                insert_after.is_some(),
+            ) {
+                Ok(()) => Ok(()),
+                Err(ReplaceModeError::MissingMode) => {
+                    anyhow::bail!(
+                        "replace operation requires one of to, insert_before, or insert_after"
+                    )
+                }
+                Err(ReplaceModeError::BothInsertModes) => {
+                    anyhow::bail!("insert_before and insert_after cannot both be set")
+                }
+                Err(ReplaceModeError::ToWithInsert) => {
+                    anyhow::bail!("to cannot be combined with insert_before or insert_after")
+                }
             }
-            Err(ReplaceModeError::ToWithInsert) => {
-                anyhow::bail!("to cannot be combined with insert_before or insert_after")
-            }
-        },
+        }
         _ => Ok(()),
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -583,6 +583,56 @@ fn test_search_invert_match_multiline_rejected() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_replace_empty_from_rejected() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("--from")
+        .arg("")
+        .arg("--to")
+        .arg("X")
+        .arg("--apply")
+        .arg(file.to_str().unwrap())
+        .assert()
+        .failure();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn test_tx_replace_empty_from_rejected() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "",
+            "to": "X"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(4);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
 fn test_replace_invalid_regex_fails() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -4774,10 +4824,10 @@ fn test_tx_strict_mode_restores_modified_empty_file_on_failure() {
     let plan = serde_json::json!({
         "strict": true,
         "operations": [{
-            "op": "replace",
+            "op": "file.create",
             "path": file.to_str().unwrap(),
-            "from": "",
-            "to": "changed"
+            "content": "changed",
+            "force": true
         }],
         "validate": [{
             "cmd": shell_exit_1(),
@@ -4876,10 +4926,10 @@ fn test_tx_json_output_on_modified_empty_file_reports_modified() {
 
     let plan = serde_json::json!({
         "operations": [{
-            "op": "replace",
+            "op": "file.create",
             "path": file.to_str().unwrap(),
-            "from": "",
-            "to": "changed"
+            "content": "changed",
+            "force": true
         }]
     });
     let plan_file = dir.path().join("plan.json");
@@ -4910,10 +4960,10 @@ fn test_tx_json_output_on_modified_empty_file_reports_modified_in_check_mode() {
 
     let plan = serde_json::json!({
         "operations": [{
-            "op": "replace",
+            "op": "file.create",
             "path": file.to_str().unwrap(),
-            "from": "",
-            "to": "changed"
+            "content": "changed",
+            "force": true
         }]
     });
     let plan_file = dir.path().join("plan.json");


### PR DESCRIPTION
## Summary
Reject empty `from` strings in both standalone `replace` and tx `replace` operations.

## Problem
An empty `from` string caused `replace` to insert the replacement text between every character, silently corrupting file content. An agent sending `{"from": "", "to": "\n"}` would corrupt every file in a glob sweep without any error.

## Change
- add early validation in `src/cmd/replace.rs` that rejects empty `--from`
- add validation in `src/cmd/tx.rs` `validate_operation` that rejects empty `from` fields with `PARSE_ERROR`
- update 3 existing tests that used `from: ""` to write to empty files (switched to `file.create` with `force: true`)
- add integration tests for both standalone and tx rejection of empty `from`
- refresh README and CHANGELOG test totals to 405

## Validation
- `make check`

Closes #128