### PR TITLE
Add stderr diagnostics for silently skipped files

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -129,7 +129,12 @@ fn collect_replacements(
 
         let data = match fs::read(path) {
             Ok(d) => d,
-            Err(_) => continue,
+            Err(e) => {
+                if !global.quiet {
+                    eprintln!("replace: skipping {}: {e}", path.display());
+                }
+                continue;
+            }
         };
 
         if data.is_empty() || is_binary(&data) {
@@ -138,7 +143,12 @@ fn collect_replacements(
 
         let content = match String::from_utf8(data) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(_) => {
+                if !global.quiet {
+                    eprintln!("replace: skipping {} (invalid UTF-8)", path.display());
+                }
+                continue;
+            }
         };
 
         let (replaced, count) = replace_content(

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -105,7 +105,12 @@ fn collect_matches(args: &SearchArgs, global: &GlobalFlags) -> anyhow::Result<Se
 
         let content = match fs::read_to_string(path) {
             Ok(c) => c,
-            Err(_) => continue,
+            Err(e) => {
+                if !global.quiet {
+                    eprintln!("search: skipping {}: {e}", path.display());
+                }
+                continue;
+            }
         };
 
         let mut count = 0usize;

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -312,12 +312,18 @@ fn execute_operation(
                     let content = if pending.contains_key(&file_path) {
                         match read_file_content(pending, &file_path) {
                             Ok(c) => c.to_owned(),
-                            Err(_) => continue,
+                            Err(e) => {
+                                eprintln!("tx: replace: skipping {}: {e}", file_path.display());
+                                continue;
+                            }
                         }
                     } else {
                         match std::fs::read_to_string(&file_path) {
                             Ok(s) => s,
-                            Err(_) => continue,
+                            Err(e) => {
+                                eprintln!("tx: replace: skipping {}: {e}", file_path.display());
+                                continue;
+                            }
                         }
                     };
                     let (replaced, match_count) =


### PR DESCRIPTION
## Summary
Add stderr diagnostics when search, replace, and tx glob replace skip files due to read errors or encoding issues.

## Problem
All three commands silently skipped files on read errors and encoding failures with `Err(_) => continue`. Agents got no indication that files were skipped or why, making match-count drops invisible to debug.

## Change
- add `eprintln!` diagnostics for file-read failures in `search` and `replace` (respects `--quiet`)
- add `eprintln!` diagnostics for invalid UTF-8 in `replace` (respects `--quiet`)
- add `eprintln!` diagnostics for file-read failures in `tx` glob replace

## Validation
- `make check`

Closes #134