### PR TITLE
Sync CHANGELOG and reference docs with recent features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
-- 10 commands: `search`, `replace`, `patch`, `md`, `doc`, `hygiene`, `create`, `delete`, `tx`, `completions`
+- 12 commands: `search`, `replace`, `patch`, `md`, `doc`, `hygiene`, `create`, `delete`, `read`, `status`, `tx`, `completions`
 - 22 transaction plan operation types for atomic multi-file changes
 - `format` and `validate` lifecycle arrays in tx plans with configurable timeout
 - `--nth N` flag for replace (standalone and tx) to target a specific occurrence
@@ -25,7 +25,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dual license: MIT OR Apache-2.0
 - CONTRIBUTING.md, SECURITY.md, AGENTS.md
 - CI with fmt, clippy, tests, MSRV check, and dependency audit
+- `read` command for file content inspection with optional line range
+- `status` command showing uncommitted changes vs git HEAD
+- `replace --insert-before` and `--insert-after` modes for inserting text around matches
+- `replace --if-exists` flag for idempotent replacements that succeed on no match
+- `search --assert-count N` mode for CI invariant checks
+- YAML and TOML plan format support for `tx` (auto-detected from file extension, or `--plan-format`)
 - `--plan -` reads tx plan from stdin
+- tx replace `case_insensitive` and `multiline` fields for parity with standalone replace
+- tx replace `if_exists` field for idempotent replacements inside transactions
+- `delete --json` structured output for consistency with other write commands
+- Stderr diagnostics for silently skipped files in search, replace, and tx glob replace
 - Documentation for tx operation ordering semantics
 - Documentation for `write_policy` in tx plans (applies to all operations including `file.create`)
 - `strict` mode for tx plans: reverts all writes on format/validate failure (exit code 7)
@@ -38,3 +48,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `file.create` after `file.delete` in the same tx plan no longer silently loses the file
 - Makefile `update-readme` dynamically reads version, command count, and test counts instead of hardcoding
+- Empty `--from` string in replace and tx replace is now rejected instead of silently inserting between every character
+- tx replace with conflicting fields (`to` + `insert_before`, or `insert_before` + `insert_after`) now returns PARSE_ERROR instead of undefined behavior
+- tx replace plans missing all of `to`, `insert_before`, and `insert_after` now return PARSE_ERROR instead of silently deleting matches
+- Replace-only tx plans with zero matches now return NO_MATCHES (exit 3) instead of SUCCESS
+- tx glob replace no longer buffers non-matching files into pending state

--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ The `tx` command accepts a JSON plan with an array of operations:
     { "op": "replace", "path": "src/main.rs", "from": "old", "to": "new" },
     { "op": "replace", "path": "src/main.rs", "from": "old", "to": "new", "nth": 2 },
     { "op": "replace", "glob": "*.rs", "mode": "regex", "from": "v\\d+", "to": "v2" },
+    { "op": "replace", "path": "src/lib.rs", "from": "old_api", "to": "new_api", "case_insensitive": true },
+    { "op": "replace", "path": "src/lib.rs", "from": "legacy_call", "to": "modern_call", "if_exists": true },
     { "op": "doc.set", "path": "config.json", "key": "version", "value": "2.0" },
     { "op": "doc.delete", "path": "config.json", "key": "deprecated" },
     { "op": "doc.merge", "path": "config.json", "value": {"new_key": true} },

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -639,7 +639,7 @@ The operations below are the building blocks inside `operations`.
 - **Use when:** A text rewrite needs to share atomic rollback, formatting, or validation with other operations.
 - **Requires:** Exactly one of `to`, `insert_before`, or `insert_after`, matching top level `replace`.
 - **Regex insert semantics:** In regex mode, `insert_before` and `insert_after` preserve the matched text, they do not insert the raw pattern string.
-- **Optional fields:** `case_insensitive` (bool, default false) and `multiline` (bool, default false) match the top level `replace --case-insensitive` and `--multiline` flags.
+- **Optional fields:** `case_insensitive` (bool, default false), `multiline` (bool, default false), and `if_exists` (bool, default false) match the top level `replace --case-insensitive`, `--multiline`, and `--if-exists` flags.
 - **Related:** top level `replace`
 
 <!-- ref:tx-op:doc.set -->


### PR DESCRIPTION
## Summary

Brings CHANGELOG.md, reference docs, and README tx example up to date with features and fixes landed in PRs #103-#137.

## Problem

Documentation drift accumulated across 13 PRs in this session cycle:
- CHANGELOG said "10 commands" but patchloom has 12 (`read` and `status` missing)
- ~10 features and 5 fixes were not listed in CHANGELOG
- tx replace reference docs listed `case_insensitive` and `multiline` but omitted `if_exists`
- README tx plan example had no `case_insensitive` or `if_exists` examples

## Changes

| File | Change |
|---|---|
| `CHANGELOG.md` | Fix command count 10 to 12, add 10 features to Added, add 5 fixes to Fixed |
| `docs/reference/README.md` | Add `if_exists` to tx replace optional fields |
| `README.md` | Add `case_insensitive` and `if_exists` examples to tx plan format snippet |

## Validation

`make check` passes: 166 unit + 239 integration tests, clippy clean.

Closes #138