### PR TITLE
Support multi-file read in a single invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 405 tests (166 unit + 239 integration)
+- 410 tests (166 unit + 244 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 12 commands and 405 passing tests.
+V2 with 12 commands and 410 passing tests.
 
 ## Install
 

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -6,8 +6,9 @@ use std::fs;
 
 #[derive(Debug, Args)]
 pub struct ReadArgs {
-    /// Path to the file to read.
-    pub file: String,
+    /// Paths to the files to read.
+    #[arg(required = true, num_args = 1..)]
+    pub files: Vec<String>,
     /// Line range to display (1-based inclusive, e.g. "50:120").
     #[arg(long)]
     pub lines: Option<String>,
@@ -49,24 +50,14 @@ fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usize>)> {
     }
 }
 
-pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
-    std::env::set_current_dir(global.resolve_cwd()?)?;
-
-    let content = match fs::read_to_string(&args.file) {
-        Ok(c) => c,
-        Err(e) => {
-            if !global.quiet {
-                eprintln!("error: {}: {e}", args.file);
-            }
-            return Ok(exit::FAILURE);
-        }
-    };
+fn read_one_file(path: &str, lines_spec: &Option<String>) -> Result<ReadOutput, String> {
+    let content = fs::read_to_string(path).map_err(|e| format!("{path}: {e}"))?;
 
     let all_lines: Vec<&str> = content.lines().collect();
     let total_lines = all_lines.len();
 
-    let (start, end) = if let Some(ref spec) = args.lines {
-        let (s, e) = parse_line_range(spec)?;
+    let (start, end) = if let Some(ref spec) = lines_spec {
+        let (s, e) = parse_line_range(spec).map_err(|e| e.to_string())?;
         let end = e.unwrap_or(total_lines).min(total_lines);
         (s, end)
     } else {
@@ -85,29 +76,68 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         String::new()
     } else {
         let mut s = selected.join("\n");
-        // Preserve trailing newline if the original content had one and we
-        // include the last line.
         if content.ends_with('\n') && end >= total_lines {
             s.push('\n');
         }
         s
     };
 
-    if global.json {
-        let output = ReadOutput {
-            ok: true,
-            path: args.file.clone(),
-            start_line: start,
-            end_line: end,
-            total_lines,
-            content: selected_content,
-        };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    } else if !global.quiet {
-        print!("{selected_content}");
+    Ok(ReadOutput {
+        ok: true,
+        path: path.to_string(),
+        start_line: start,
+        end_line: end,
+        total_lines,
+        content: selected_content,
+    })
+}
+
+pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    std::env::set_current_dir(global.resolve_cwd()?)?;
+
+    let multi = args.files.len() > 1;
+    let mut outputs: Vec<ReadOutput> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+
+    for (i, path) in args.files.iter().enumerate() {
+        match read_one_file(path, &args.lines) {
+            Ok(output) => {
+                if global.jsonl {
+                    println!("{}", serde_json::to_string(&output)?);
+                } else if global.json {
+                    outputs.push(output);
+                } else if !global.quiet {
+                    if multi && i > 0 {
+                        println!();
+                    }
+                    if multi {
+                        println!("==> {} <==", path);
+                    }
+                    print!("{}", output.content);
+                }
+            }
+            Err(e) => {
+                if !global.quiet {
+                    eprintln!("error: {e}");
+                }
+                errors.push(e);
+            }
+        }
     }
 
-    Ok(exit::SUCCESS)
+    if global.json {
+        if outputs.len() == 1 {
+            println!("{}", serde_json::to_string_pretty(&outputs[0])?);
+        } else {
+            println!("{}", serde_json::to_string_pretty(&outputs)?);
+        }
+    }
+
+    if errors.len() == args.files.len() {
+        Ok(exit::FAILURE)
+    } else {
+        Ok(exit::SUCCESS)
+    }
 }
 
 #[cfg(test)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1090,6 +1090,108 @@ fn test_read_respects_cwd() {
         .stdout("content\n");
 }
 
+#[test]
+fn test_read_multiple_files() {
+    let dir = TempDir::new().unwrap();
+    let f1 = dir.path().join("a.txt");
+    let f2 = dir.path().join("b.txt");
+    fs::write(&f1, "alpha\n").unwrap();
+    fs::write(&f2, "beta\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("read")
+        .arg(f1.to_str().unwrap())
+        .arg(f2.to_str().unwrap())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("==> "))
+        .stdout(predicates::str::contains("alpha"))
+        .stdout(predicates::str::contains("beta"));
+}
+
+#[test]
+fn test_read_multiple_files_json() {
+    let dir = TempDir::new().unwrap();
+    let f1 = dir.path().join("x.txt");
+    let f2 = dir.path().join("y.txt");
+    fs::write(&f1, "one\n").unwrap();
+    fs::write(&f2, "two\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("read")
+        .arg(f1.to_str().unwrap())
+        .arg(f2.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json.is_array());
+    assert_eq!(json.as_array().unwrap().len(), 2);
+    assert!(json[0]["content"].as_str().unwrap().contains("one"));
+    assert!(json[1]["content"].as_str().unwrap().contains("two"));
+}
+
+#[test]
+fn test_read_multiple_files_jsonl() {
+    let dir = TempDir::new().unwrap();
+    let f1 = dir.path().join("p.txt");
+    let f2 = dir.path().join("q.txt");
+    fs::write(&f1, "first\n").unwrap();
+    fs::write(&f2, "second\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("read")
+        .arg(f1.to_str().unwrap())
+        .arg(f2.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let lines: Vec<&str> = std::str::from_utf8(&output.stdout)
+        .unwrap()
+        .trim()
+        .lines()
+        .collect();
+    assert_eq!(lines.len(), 2);
+    let j1: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let j2: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    assert!(j1["content"].as_str().unwrap().contains("first"));
+    assert!(j2["content"].as_str().unwrap().contains("second"));
+}
+
+#[test]
+fn test_read_partial_failure_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let f1 = dir.path().join("exists.txt");
+    fs::write(&f1, "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("read")
+        .arg(f1.to_str().unwrap())
+        .arg("/tmp/patchloom-no-such-file-xyz")
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("hello"));
+}
+
+#[test]
+fn test_read_all_fail_returns_failure() {
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("read")
+        .arg("/tmp/patchloom-no-1-xyz")
+        .arg("/tmp/patchloom-no-2-xyz")
+        .assert()
+        .code(1);
+}
+
 // ── status command ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

`patchloom read` now accepts multiple file paths in a single invocation.

## Problem

Agents frequently need to read 3-5 files at once before editing. With single-file `read`, this required 3-5 separate tool calls. In a 12-round improvement session, ~50 multi-file read batches used native `read_file` instead of patchloom because batch read was not supported.

## Change

- `ReadArgs.file` becomes `ReadArgs.files: Vec<String>` with `num_args = 1..`
- Plain text: `==> path <==` separators between files (matching `head` convention)
- JSON: array of `ReadOutput` objects (single file still emits a single object for backward compatibility)
- JSONL: one `ReadOutput` per line per file
- Partial failure: returns SUCCESS if at least one file read succeeds; FAILURE only if all fail

## Validation

`make check` passes: 166 unit + 244 integration tests, clippy clean. 5 new integration tests cover multi-file plain text, JSON array, JSONL, partial failure, and all-fail scenarios.

Closes #136