### PR TITLE
Add read and status usage examples to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dual license: MIT OR Apache-2.0
 - CONTRIBUTING.md, SECURITY.md, AGENTS.md
 - CI with fmt, clippy, tests, MSRV check, and dependency audit
-- `read` command for file content inspection with optional line range
+- `read` command for file content inspection with optional line range and multi-file batch support
 - `status` command showing uncommitted changes vs git HEAD
 - `replace --insert-before` and `--insert-after` modes for inserting text around matches
 - `replace --if-exists` flag for idempotent replacements that succeed on no match

--- a/README.md
+++ b/README.md
@@ -314,6 +314,46 @@ Delete a file:
 patchloom delete --file obsolete.txt --apply
 ```
 
+### read
+
+Read a file:
+
+```
+patchloom read src/main.rs
+```
+
+Read a specific line range:
+
+```
+patchloom read src/main.rs --lines 10:25
+```
+
+Read multiple files at once:
+
+```
+patchloom read src/main.rs src/lib.rs Cargo.toml
+```
+
+Get structured JSON output for multiple files:
+
+```
+patchloom --json read src/main.rs src/lib.rs
+```
+
+### status
+
+Show which files have uncommitted changes:
+
+```
+patchloom status
+```
+
+Get structured JSON output:
+
+```
+patchloom --json status
+```
+
 ### patch
 
 Apply a unified diff:


### PR DESCRIPTION
## Summary

Adds usage examples for `read` and `status` commands to the README.

## Problem

The README Usage section had examples for every command except `read` and `status`, which were added in PR #103 without corresponding examples.

## Change

Adds examples for:
- Single-file read
- Line range (`--lines 10:25`)
- Multi-file batch read (new in PR #140)
- JSON output for multi-file read
- `status` and `--json status`

Also updates CHANGELOG to note batch support for read.

## Validation

`make check` passes: 166 unit + 244 integration tests, clippy clean.

Closes #141