### PR TITLE
Update reference and concepts docs for multi-file read

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -10,7 +10,7 @@ Patchloom has 12 commands, each targeting a different kind of repo operation:
 - **doc** -- parser-backed JSON, YAML, and TOML mutations
 - **hygiene** -- whitespace and line-ending normalization
 - **create** / **delete** -- file lifecycle
-- **read** -- file content inspection with optional line range
+- **read** -- file content inspection with optional line range (supports multiple files)
 - **status** -- uncommitted change summary from git
 - **tx** -- atomic multi-operation transactions
 - **completions** -- shell completion generation

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -196,8 +196,8 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:read -->
 ## `read`
 
-- **What it does:** Prints the contents of a file, optionally restricted to a line range.
-- **Use when:** An agent needs to inspect a file or file section before deciding on an edit.
+- **What it does:** Prints the contents of one or more files, optionally restricted to a line range. Multiple files get `==> path <==` separators in text mode, a JSON array in `--json` mode, and one object per line in `--jsonl` mode.
+- **Use when:** An agent needs to inspect one or several files before deciding on an edit.
 - **Prefer instead:** Use `search` when you need pattern matching, or `doc get` when the file is structured and you want a single value.
 - **Related:** `search`, `doc get`
 


### PR DESCRIPTION
## Summary

Updates reference docs and concepts to reflect multi-file support in `read` (added in PR #140).

## Problem

The reference docs for `read` still said "a file" (singular) and didn't mention separators, JSON array output, or JSONL streaming for multiple files.

## Change

| File | Change |
|---|---|
| `docs/reference/README.md` | Updated "What it does" and "Use when" for `read` to describe multi-file behavior |
| `docs/getting-started/concepts.md` | Added "(supports multiple files)" to the read command description |

## Validation

`make check` passes: 166 unit + 244 integration tests, clippy clean.