### PR TITLE
Add integration test for multi-file read with --lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 410 tests (166 unit + 244 integration)
+- 411 tests (166 unit + 245 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 12 commands and 410 passing tests.
+V2 with 12 commands and 411 passing tests.
 
 ## Install
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1192,6 +1192,34 @@ fn test_read_all_fail_returns_failure() {
         .code(1);
 }
 
+#[test]
+fn test_read_multiple_files_with_lines() {
+    let dir = TempDir::new().unwrap();
+    let f1 = dir.path().join("long.txt");
+    let f2 = dir.path().join("short.txt");
+    fs::write(&f1, "a\nb\nc\nd\ne\n").unwrap();
+    fs::write(&f2, "x\ny\n").unwrap();
+
+    // --lines 2:4 on a 5-line file gives lines 2-4; on a 2-line file gives line 2 only
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("read")
+        .arg(f1.to_str().unwrap())
+        .arg(f2.to_str().unwrap())
+        .arg("--lines")
+        .arg("2:4")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("b\nc\nd"));
+    assert!(stdout.contains("y"));
+    // d should appear from the first file, y from the second
+    assert!(!stdout.contains("a"));
+    assert!(!stdout.contains("e"));
+}
+
 // ── status command ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Adds a regression test for `patchloom read` with `--lines` applied across multiple files with different line counts.

## Problem

QA audit found no test for the interaction between `--lines` and multi-file read. The range is clamped per-file, but this behavior was untested.

## Change

New `test_read_multiple_files_with_lines` test: reads a 5-line file and a 2-line file with `--lines 2:4`. Verifies the 5-line file returns lines 2-4 and the 2-line file returns only line 2.

## Validation

`make check` passes: 166 unit + 245 integration tests, clippy clean.