### PR TITLE
Add --before-context and --after-context to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - tx replace `if_exists` field for idempotent replacements inside transactions
 - `delete --json` structured output for consistency with other write commands
 - `agent-rules` command that prints an end-user AGENTS.md teaching AI agents how to use patchloom
+- `search --before-context` (`-B`) and `--after-context` (`-A`) for asymmetric context around matches
 - Stderr diagnostics for silently skipped files in search, replace, and tx glob replace
 - Documentation for tx operation ordering semantics
 - Documentation for `write_policy` in tx plans (applies to all operations including `file.create`)
@@ -43,7 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 413 tests (166 unit + 247 integration)
+- 416 tests (166 unit + 250 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 13 commands and 413 passing tests.
+V2 with 13 commands and 416 passing tests.
 
 ## Install
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -257,6 +257,20 @@ These are meaningful command-specific modes that change how a top-level command 
 - **Use when:** The pattern you care about is inherently block-shaped, such as a function body or multi-line stanza.
 - **Prefer instead:** Use plain `search` for line-oriented patterns because it is simpler and easier to reason about.
 
+<!-- ref:search-mode:before-context -->
+### `search --before-context`
+
+- **What it does:** Shows N lines before each match but none after (unless combined with `-A`).
+- **Use when:** You need to see what precedes a match (function signature before a body, imports before usage) without cluttering output with lines after.
+- **Prefer instead:** Use `--context` (`-C`) when symmetric context is fine, or combine `-B` and `-A` for independent before/after counts.
+
+<!-- ref:search-mode:after-context -->
+### `search --after-context`
+
+- **What it does:** Shows N lines after each match but none before (unless combined with `-B`).
+- **Use when:** You need to see what follows a match (function body after signature, error handling after a call) without lines before.
+- **Prefer instead:** Use `--context` (`-C`) when symmetric context is fine, or combine `-B` and `-A` for independent before/after counts.
+
 <!-- ref:search-mode:case-insensitive -->
 ### `search --case-insensitive`
 

--- a/src/agent_rules.md
+++ b/src/agent_rules.md
@@ -16,7 +16,7 @@ Use patchloom instead of raw file tools when you need:
 
 | Command | What it does |
 |---|---|
-| `search` | Literal or regex search with context, counts, file-list, and multiline modes |
+| `search` | Literal or regex search with context (`-C`, `-B`, `-A`), counts, file-list, and multiline modes |
 | `replace` | Mechanical string replacement with diff preview, `--nth`, `--insert-before/after`, `--if-exists` |
 | `patch` | Preview or apply unified diffs with stale-context detection |
 | `md` | Markdown section-aware edits: replace-section, insert, upsert-bullet, table-append, dedupe, lint |

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -19,9 +19,15 @@ pub struct SearchArgs {
     /// Treat pattern as a regex (default).
     #[arg(long)]
     pub regex: bool,
-    /// Lines of context around matches.
+    /// Lines of context around matches (shorthand for -B N -A N).
     #[arg(long, short = 'C')]
     pub context: Option<usize>,
+    /// Lines of context before each match.
+    #[arg(long, short = 'B')]
+    pub before_context: Option<usize>,
+    /// Lines of context after each match.
+    #[arg(long, short = 'A')]
+    pub after_context: Option<usize>,
     // ref:search-mode:files-with-matches
     /// Only print file paths with matches.
     #[arg(long)]
@@ -142,7 +148,12 @@ fn collect_matches(args: &SearchArgs, global: &GlobalFlags) -> anyhow::Result<Se
                     context_after: None,
                 });
             }
-        } else if let Some(context) = args.context {
+        } else if args.context.is_some()
+            || args.before_context.is_some()
+            || args.after_context.is_some()
+        {
+            let ctx_before = args.before_context.or(args.context).unwrap_or(0);
+            let ctx_after = args.after_context.or(args.context).unwrap_or(0);
             let lines: Vec<&str> = content.lines().collect();
             for (i, line) in lines.iter().copied().enumerate() {
                 let found = re.find(line);
@@ -164,8 +175,8 @@ fn collect_matches(args: &SearchArgs, global: &GlobalFlags) -> anyhow::Result<Se
                     continue;
                 }
 
-                let start = i.saturating_sub(context);
-                let end = (i + 1 + context).min(lines.len());
+                let start = i.saturating_sub(ctx_before);
+                let end = (i + 1 + ctx_after).min(lines.len());
                 let column = found.map_or(1, |m| m.start() + 1);
                 let context_before = Some(lines[start..i].iter().map(|s| s.to_string()).collect());
                 let context_after = Some(lines[i + 1..end].iter().map(|s| s.to_string()).collect());
@@ -372,6 +383,8 @@ mod tests {
             literal: false,
             regex: false,
             context: None,
+            before_context: None,
+            after_context: None,
             files_with_matches: false,
             count: false,
             invert_match: false,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2454,6 +2454,76 @@ fn test_search_context_flag() {
 }
 
 #[test]
+fn test_search_before_context() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "aaa\nbbb\nccc\ntarget\nddd\neee\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("-B")
+        .arg("2")
+        .arg("target")
+        .arg(&file)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("bbb"))
+        .stdout(predicate::str::contains("ccc"))
+        .stdout(predicate::str::contains("target"))
+        // no after-context lines
+        .stdout(predicate::str::contains("ddd").not());
+}
+
+#[test]
+fn test_search_after_context() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "aaa\nbbb\ntarget\nccc\nddd\neee\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("-A")
+        .arg("2")
+        .arg("target")
+        .arg(&file)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("target"))
+        .stdout(predicate::str::contains("ccc"))
+        .stdout(predicate::str::contains("ddd"))
+        // no before-context lines
+        .stdout(predicate::str::contains("bbb").not());
+}
+
+#[test]
+fn test_search_asymmetric_context() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "aaa\nbbb\nccc\ntarget\nddd\neee\nfff\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("-B")
+        .arg("1")
+        .arg("-A")
+        .arg("3")
+        .arg("target")
+        .arg(&file)
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("ccc"))
+        .stdout(predicate::str::contains("target"))
+        .stdout(predicate::str::contains("ddd"))
+        .stdout(predicate::str::contains("eee"))
+        .stdout(predicate::str::contains("fff"))
+        // bbb is 2 lines before, should not appear with -B 1
+        .stdout(predicate::str::contains("bbb").not());
+}
+
+#[test]
 fn test_search_literal_flag() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary

Adds asymmetric context flags to `patchloom search`: `-B` (before only) and `-A` (after only).

## Problem

Agents frequently need asymmetric context (e.g., "show 6 lines after the match but none before"). Patchloom search only had symmetric `-C N`. In a session analysis, ~8 grep calls used `-A` or `-B` without `-C`.

## Change

- `-B N` / `--before-context N`: show N lines before each match
- `-A N` / `--after-context N`: show N lines after each match
- `-C N` remains as shorthand for `-B N -A N`
- When both `-B` and `-A` are given, they set independent counts
- Falls back to `-C` value when only one of `-B`/`-A` is specified

## Validation

`make check` passes: 166 unit + 250 integration tests (416 total), clippy clean. 3 new integration tests cover before-only, after-only, and asymmetric contexts.

Closes #149