### PR TITLE
Add read operation to tx plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - 12 commands: `search`, `replace`, `patch`, `md`, `doc`, `hygiene`, `create`, `delete`, `read`, `status`, `tx`, `completions`
-- 22 transaction plan operation types for atomic multi-file changes
+- 23 transaction plan operation types for atomic multi-file changes
 - `format` and `validate` lifecycle arrays in tx plans with configurable timeout
 - `--nth N` flag for replace (standalone and tx) to target a specific occurrence
 - `--case-insensitive` / `-i` for search and replace
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `delete --json` structured output for consistency with other write commands
 - `agent-rules` command that prints an end-user AGENTS.md teaching AI agents how to use patchloom
 - `search --before-context` (`-B`) and `--after-context` (`-A`) for asymmetric context around matches
+- `read` operation in `tx` plans for inspect-then-edit workflows in a single call
 - Stderr diagnostics for silently skipped files in search, replace, and tx glob replace
 - Documentation for tx operation ordering semantics
 - Documentation for `write_policy` in tx plans (applies to all operations including `file.create`)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -790,6 +790,13 @@ The operations below are the building blocks inside `operations`.
 - **Use when:** File removal should roll back if later format or validation steps fail.
 - **Related:** top level `delete`
 
+<!-- ref:tx-op:read -->
+### `read`
+
+- **What it does:** Reads a file inside a transaction and includes its content in the JSON output without writing anything.
+- **Use when:** An agent needs to inspect file content before or after other operations in the same plan, enabling "understand then edit" in a single call.
+- **Related:** top level `read`
+
 <!-- ref:tx-op:patch.apply -->
 ### `patch.apply`
 

--- a/src/agent_rules.md
+++ b/src/agent_rules.md
@@ -104,7 +104,7 @@ The `tx` command runs multiple operations atomically. If any operation fails, al
 
 **Lifecycle:** operations run in order, then format steps (code formatters), then validate steps (build/test). With `"strict": true`, a format or validation failure reverts all file writes (exit 7).
 
-**22 operation types:** `replace`, `doc.set`, `doc.delete`, `doc.merge`, `doc.append`, `doc.prepend`, `doc.update`, `doc.move`, `doc.ensure`, `doc.delete_where`, `md.replace_section`, `md.insert_after_heading`, `md.insert_before_heading`, `md.upsert_bullet`, `md.table_append`, `md.dedupe_headings`, `hygiene.fix`, `file.create`, `file.delete`, `patch.apply`.
+**23 operation types:** `read`, `replace`, `doc.set`, `doc.delete`, `doc.merge`, `doc.append`, `doc.prepend`, `doc.update`, `doc.move`, `doc.ensure`, `doc.delete_where`, `md.replace_section`, `md.insert_after_heading`, `md.insert_before_heading`, `md.upsert_bullet`, `md.table_append`, `md.dedupe_headings`, `hygiene.fix`, `file.create`, `file.delete`, `patch.apply`.
 
 Plans also accept YAML and TOML formats (auto-detected from file extension, or `--plan-format yaml`).
 

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -24,7 +24,7 @@ struct ReadOutput {
     content: String,
 }
 
-fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usize>)> {
+pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usize>)> {
     if let Some((start_str, end_str)) = spec.split_once(':') {
         let start: usize = start_str
             .parse()

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -35,6 +35,8 @@ struct TxOutput {
     files_created: usize,
     files_deleted: usize,
     changes: Vec<TxChange>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    reads: Vec<TxReadResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error_kind: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -46,6 +48,16 @@ struct TxOutput {
 struct TxChange {
     path: String,
     action: &'static str,
+}
+
+/// A file read result in the tx output.
+#[derive(Serialize)]
+struct TxReadResult {
+    path: String,
+    content: String,
+    start_line: usize,
+    end_line: usize,
+    total_lines: usize,
 }
 
 #[derive(Debug, Args)]
@@ -129,6 +141,7 @@ fn op_label(op: &Operation) -> &'static str {
         Operation::FileCreate { .. } => "file.create",
         Operation::FileDelete { .. } => "file.delete",
         Operation::PatchApply { .. } => "patch.apply",
+        Operation::Read { .. } => "read",
     }
 }
 
@@ -245,6 +258,7 @@ fn execute_operation(
     op: &Operation,
     pending: &mut HashMap<PathBuf, (String, String)>,
     deletions: &mut HashSet<PathBuf>,
+    tx_reads: &mut Vec<TxReadResult>,
 ) -> anyhow::Result<usize> {
     match op {
         Operation::Replace {
@@ -693,6 +707,42 @@ fn execute_operation(
             }
         }
 
+        Operation::Read { path, lines } => {
+            let file_path = PathBuf::from(path);
+            let content = read_file_content(pending, &file_path)?.to_string();
+            let all_lines: Vec<&str> = content.lines().collect();
+            let total_lines = all_lines.len();
+
+            let (start, end) = if let Some(spec) = lines {
+                let (s, e) = crate::cmd::read::parse_line_range(spec)?;
+                let end = e.unwrap_or(total_lines).min(total_lines);
+                (s, end)
+            } else {
+                (1, total_lines)
+            };
+
+            let selected = if total_lines == 0 {
+                String::new()
+            } else {
+                let start_idx = (start - 1).min(total_lines);
+                let end_idx = end.min(total_lines);
+                let mut s = all_lines[start_idx..end_idx].join("\n");
+                if content.ends_with('\n') && end >= total_lines {
+                    s.push('\n');
+                }
+                s
+            };
+
+            tx_reads.push(TxReadResult {
+                path: path.clone(),
+                content: selected,
+                start_line: start,
+                end_line: end,
+                total_lines,
+            });
+            // Read operations don't modify pending state
+        }
+
         Operation::FileDelete { path } => {
             let file_path = PathBuf::from(path);
             let created_in_tx = match pending.get(&file_path) {
@@ -763,6 +813,7 @@ fn build_tx_output(
     changes: &[(PathBuf, String, String)],
     deletions: &HashSet<PathBuf>,
     existed_before: &HashSet<PathBuf>,
+    reads: Vec<TxReadResult>,
 ) -> TxOutput {
     let mut tx_changes = Vec::new();
     let mut created = 0usize;
@@ -809,6 +860,7 @@ fn build_tx_output(
         files_created: created,
         files_deleted: deleted_count,
         changes: tx_changes,
+        reads,
         error_kind: None,
         error: None,
     }
@@ -826,6 +878,7 @@ fn emit_error_json_with_prefix(
         files_created: 0,
         files_deleted: 0,
         changes: Vec::new(),
+        reads: Vec::new(),
         error_kind: Some(error_kind),
         error: Some(format!("{legacy_error_prefix}: {error}")),
     };
@@ -918,6 +971,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let mut deletions: HashSet<PathBuf> = HashSet::new();
     let mut has_non_idempotent_replace = false;
     let mut total_replace_matches = 0usize;
+    let mut tx_reads: Vec<TxReadResult> = Vec::new();
 
     for (i, op) in plan.operations.iter().enumerate() {
         if let Operation::Replace { if_exists, .. } = op {
@@ -925,7 +979,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 has_non_idempotent_replace = true;
             }
         }
-        match execute_operation(op, &mut pending, &mut deletions) {
+        match execute_operation(op, &mut pending, &mut deletions, &mut tx_reads) {
             Ok(match_count) => {
                 total_replace_matches += match_count;
             }
@@ -975,20 +1029,29 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 return Ok(exit::NO_MATCHES);
             }
             if global.json {
-                let output =
-                    build_tx_output("success", true, &changes, &deletions, &existed_before);
+                let mut output = build_tx_output(
+                    "success",
+                    true,
+                    &changes,
+                    &deletions,
+                    &existed_before,
+                    Vec::new(),
+                );
+                output.reads = std::mem::take(&mut tx_reads);
                 println!("{}", serde_json::to_string_pretty(&output)?);
             }
             return Ok(exit::SUCCESS);
         }
         if global.json {
-            let output = build_tx_output(
+            let mut output = build_tx_output(
                 "changes_detected",
                 true,
                 &changes,
                 &deletions,
                 &existed_before,
+                Vec::new(),
             );
+            output.reads = std::mem::take(&mut tx_reads);
             println!("{}", serde_json::to_string_pretty(&output)?);
         } else if !global.quiet {
             println!("{} file(s) would change", changes.len() + pending_deletions);
@@ -1137,7 +1200,15 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::NO_MATCHES);
         }
         if global.json {
-            let output = build_tx_output("success", true, &changes, &deletions, &existed_before);
+            let mut output = build_tx_output(
+                "success",
+                true,
+                &changes,
+                &deletions,
+                &existed_before,
+                Vec::new(),
+            );
+            output.reads = std::mem::take(&mut tx_reads);
             println!("{}", serde_json::to_string_pretty(&output)?);
         }
         return Ok(exit::SUCCESS);
@@ -1149,7 +1220,15 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // Default / --diff mode: show unified diffs.
     if global.json {
-        let output = build_tx_output("success", true, &changes, &deletions, &existed_before);
+        let mut output = build_tx_output(
+            "success",
+            true,
+            &changes,
+            &deletions,
+            &existed_before,
+            Vec::new(),
+        );
+        output.reads = std::mem::take(&mut tx_reads);
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else if !changes.is_empty() {
         print_diffs(&changes);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -160,6 +160,12 @@ pub enum Operation {
         /// Inline diff text to apply.
         diff: String,
     },
+    #[serde(rename = "read")]
+    Read {
+        path: String,
+        /// Optional line range (e.g., "10:25").
+        lines: Option<String>,
+    },
 }
 
 /// A validation step to run after applying operations.
@@ -324,10 +330,12 @@ mod tests {
             {"op": "file.create", "path": "f.txt", "content": "c"},
             {"op": "file.create", "path": "g.txt", "content": "c", "force": true},
             {"op": "file.delete", "path": "f.txt"},
-            {"op": "patch.apply", "diff": "--- a/f.txt\n+++ b/f.txt\n@@ -1 +1 @@\n-a\n+b"}
+            {"op": "patch.apply", "diff": "--- a/f.txt\n+++ b/f.txt\n@@ -1 +1 @@\n-a\n+b"},
+            {"op": "read", "path": "f.txt"},
+            {"op": "read", "path": "f.txt", "lines": "1:10"}
         ]}"#;
         let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 22);
+        assert_eq!(plan.operations.len(), 24);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1244,9 +1244,9 @@ fn test_read_multiple_files_with_lines() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("b\nc\nd"));
     assert!(stdout.contains("y"));
-    // d should appear from the first file, y from the second
-    assert!(!stdout.contains("a"));
-    assert!(!stdout.contains("e"));
+    // "aaa" and "eee" should not appear (outside the range for the first file)
+    assert!(!stdout.contains("aaa"));
+    assert!(!stdout.contains("eee"));
 }
 
 // ── status command ─────────────────────────────────────────────────
@@ -4974,6 +4974,106 @@ fn test_tx_format_timeout_kills_hanging_command() {
         .timeout(std::time::Duration::from_secs(10))
         .assert()
         .code(6); // VALIDATION_FAILED
+}
+
+#[test]
+fn test_tx_read_operation_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "line1\nline2\nline3\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{"op": "read", "path": file.to_str().unwrap()}]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["reads"].as_array().unwrap().len(), 1);
+    assert!(json["reads"][0]["content"]
+        .as_str()
+        .unwrap()
+        .contains("line1"));
+    assert_eq!(json["reads"][0]["total_lines"], 3);
+}
+
+#[test]
+fn test_tx_read_with_lines_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "aaa\nbbb\nccc\nddd\neee\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{"op": "read", "path": file.to_str().unwrap(), "lines": "2:4"}]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let content = json["reads"][0]["content"].as_str().unwrap();
+    assert!(content.contains("bbb"));
+    assert!(content.contains("ccc"));
+    assert!(content.contains("ddd"));
+    assert!(!content.contains("aaa"));
+    assert!(!content.contains("eee"));
+    assert_eq!(json["reads"][0]["start_line"], 2);
+    assert_eq!(json["reads"][0]["end_line"], 4);
+}
+
+#[test]
+fn test_tx_read_sees_in_plan_state() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello world\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "read", "path": file.to_str().unwrap()},
+            {"op": "replace", "path": file.to_str().unwrap(), "from": "hello", "to": "goodbye"},
+            {"op": "read", "path": file.to_str().unwrap()}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let reads = json["reads"].as_array().unwrap();
+    assert_eq!(reads.len(), 2);
+    // First read sees original content
+    assert!(reads[0]["content"].as_str().unwrap().contains("hello"));
+    // Second read sees post-replace content
+    assert!(reads[1]["content"].as_str().unwrap().contains("goodbye"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

New tx operation `{"op": "read"}` that includes file content in JSON output without writing, enabling inspect-then-edit workflows in a single call.

## Problem

Agent workflows follow a pattern: read 3-5 files to understand, then edit atomically. This required separate `patchloom read` calls before `patchloom tx`. Now both can be in one plan.

## Change

- `Operation::Read { path, lines }` added to plan.rs (23 ops total)
- Reads see in-plan state (a read after a replace sees the post-replace content)
- Results populate a `reads` array in TxOutput JSON
- Reuses `parse_line_range` from read.rs (made `pub(crate)`)

## Example

```json
{"operations": [
  {"op": "read", "path": "src/main.rs"},
  {"op": "replace", "path": "src/main.rs", "from": "old", "to": "new"},
  {"op": "read", "path": "src/main.rs"}
]}
```

The first read shows the original, the second shows the post-replace state.

## Validation

`make check` passes: 166 unit + 250 integration tests (416 total), clippy clean. 3 new integration tests.

Closes #148