### PR TITLE
Add search operation to tx plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - 12 commands: `search`, `replace`, `patch`, `md`, `doc`, `hygiene`, `create`, `delete`, `read`, `status`, `tx`, `completions`
-- 23 transaction plan operation types for atomic multi-file changes
+- 24 transaction plan operation types for atomic multi-file changes
 - `format` and `validate` lifecycle arrays in tx plans with configurable timeout
 - `--nth N` flag for replace (standalone and tx) to target a specific occurrence
 - `--case-insensitive` / `-i` for search and replace
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `agent-rules` command that prints an end-user AGENTS.md teaching AI agents how to use patchloom
 - `search --before-context` (`-B`) and `--after-context` (`-A`) for asymmetric context around matches
 - `read` operation in `tx` plans for inspect-then-edit workflows in a single call
+- `search` operation in `tx` plans for locate-then-edit workflows in a single call
 - Stderr diagnostics for silently skipped files in search, replace, and tx glob replace
 - Documentation for tx operation ordering semantics
 - Documentation for `write_policy` in tx plans (applies to all operations including `file.create`)
@@ -45,7 +46,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Thread-based timeout for format/validate steps (replaces polling loop)
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
-- 416 tests (166 unit + 250 integration)
+- 421 tests (166 unit + 255 integration)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent-grade repo operations in one binary.
 
 ## Status
 
-V2 with 13 commands and 416 passing tests.
+V2 with 13 commands and 421 passing tests.
 
 ## Install
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -790,6 +790,13 @@ The operations below are the building blocks inside `operations`.
 - **Use when:** File removal should roll back if later format or validation steps fail.
 - **Related:** top level `delete`
 
+<!-- ref:tx-op:search -->
+### `search`
+
+- **What it does:** Searches a file for a pattern inside a transaction and includes match results in the JSON output without writing anything.
+- **Use when:** An agent needs to locate patterns before replacing them in the same plan, enabling locate-then-edit in a single call.
+- **Related:** top level `search`
+
 <!-- ref:tx-op:read -->
 ### `read`
 

--- a/src/agent_rules.md
+++ b/src/agent_rules.md
@@ -104,7 +104,7 @@ The `tx` command runs multiple operations atomically. If any operation fails, al
 
 **Lifecycle:** operations run in order, then format steps (code formatters), then validate steps (build/test). With `"strict": true`, a format or validation failure reverts all file writes (exit 7).
 
-**23 operation types:** `read`, `replace`, `doc.set`, `doc.delete`, `doc.merge`, `doc.append`, `doc.prepend`, `doc.update`, `doc.move`, `doc.ensure`, `doc.delete_where`, `md.replace_section`, `md.insert_after_heading`, `md.insert_before_heading`, `md.upsert_bullet`, `md.table_append`, `md.dedupe_headings`, `hygiene.fix`, `file.create`, `file.delete`, `patch.apply`.
+**24 operation types:** `read`, `search`, `replace`, `doc.set`, `doc.delete`, `doc.merge`, `doc.append`, `doc.prepend`, `doc.update`, `doc.move`, `doc.ensure`, `doc.delete_where`, `md.replace_section`, `md.insert_after_heading`, `md.insert_before_heading`, `md.upsert_bullet`, `md.table_append`, `md.dedupe_headings`, `hygiene.fix`, `file.create`, `file.delete`, `patch.apply`.
 
 Plans also accept YAML and TOML formats (auto-detected from file extension, or `--plan-format yaml`).
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -37,6 +37,8 @@ struct TxOutput {
     changes: Vec<TxChange>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     reads: Vec<TxReadResult>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    searches: Vec<TxSearchResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error_kind: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -48,6 +50,27 @@ struct TxOutput {
 struct TxChange {
     path: String,
     action: &'static str,
+}
+
+/// A search match in the tx output.
+#[derive(Serialize)]
+struct TxSearchMatch {
+    line: usize,
+    column: usize,
+    text: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    context_before: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    context_after: Vec<String>,
+}
+
+/// A search result in the tx output.
+#[derive(Serialize)]
+struct TxSearchResult {
+    path: String,
+    pattern: String,
+    match_count: usize,
+    matches: Vec<TxSearchMatch>,
 }
 
 /// A file read result in the tx output.
@@ -142,6 +165,7 @@ fn op_label(op: &Operation) -> &'static str {
         Operation::FileDelete { .. } => "file.delete",
         Operation::PatchApply { .. } => "patch.apply",
         Operation::Read { .. } => "read",
+        Operation::Search { .. } => "search",
     }
 }
 
@@ -259,6 +283,7 @@ fn execute_operation(
     pending: &mut HashMap<PathBuf, (String, String)>,
     deletions: &mut HashSet<PathBuf>,
     tx_reads: &mut Vec<TxReadResult>,
+    tx_searches: &mut Vec<TxSearchResult>,
 ) -> anyhow::Result<usize> {
     match op {
         Operation::Replace {
@@ -743,6 +768,61 @@ fn execute_operation(
             // Read operations don't modify pending state
         }
 
+        Operation::Search {
+            path,
+            pattern,
+            regex,
+            case_insensitive,
+            context,
+            before_context,
+            after_context,
+        } => {
+            let file_path = PathBuf::from(path);
+            let content = read_file_content(pending, &file_path)?.to_string();
+
+            let re = if *regex {
+                let mut builder = regex::RegexBuilder::new(pattern);
+                if *case_insensitive {
+                    builder.case_insensitive(true);
+                }
+                builder.build()?
+            } else {
+                let escaped = regex::escape(pattern);
+                let mut builder = regex::RegexBuilder::new(&escaped);
+                if *case_insensitive {
+                    builder.case_insensitive(true);
+                }
+                builder.build()?
+            };
+
+            let ctx_before = before_context.or(*context).unwrap_or(0);
+            let ctx_after = after_context.or(*context).unwrap_or(0);
+            let lines: Vec<&str> = content.lines().collect();
+            let mut matches = Vec::new();
+
+            for (i, line) in lines.iter().enumerate() {
+                if let Some(m) = re.find(line) {
+                    let start = i.saturating_sub(ctx_before);
+                    let end = (i + 1 + ctx_after).min(lines.len());
+                    matches.push(TxSearchMatch {
+                        line: i + 1,
+                        column: m.start() + 1,
+                        text: line.to_string(),
+                        context_before: lines[start..i].iter().map(|s| s.to_string()).collect(),
+                        context_after: lines[i + 1..end].iter().map(|s| s.to_string()).collect(),
+                    });
+                }
+            }
+
+            tx_searches.push(TxSearchResult {
+                path: path.clone(),
+                pattern: pattern.clone(),
+                match_count: matches.len(),
+                matches,
+            });
+            // Search operations don't modify pending state
+        }
+
         Operation::FileDelete { path } => {
             let file_path = PathBuf::from(path);
             let created_in_tx = match pending.get(&file_path) {
@@ -861,6 +941,7 @@ fn build_tx_output(
         files_deleted: deleted_count,
         changes: tx_changes,
         reads,
+        searches: Vec::new(),
         error_kind: None,
         error: None,
     }
@@ -879,6 +960,7 @@ fn emit_error_json_with_prefix(
         files_deleted: 0,
         changes: Vec::new(),
         reads: Vec::new(),
+        searches: Vec::new(),
         error_kind: Some(error_kind),
         error: Some(format!("{legacy_error_prefix}: {error}")),
     };
@@ -972,6 +1054,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let mut has_non_idempotent_replace = false;
     let mut total_replace_matches = 0usize;
     let mut tx_reads: Vec<TxReadResult> = Vec::new();
+    let mut tx_searches: Vec<TxSearchResult> = Vec::new();
 
     for (i, op) in plan.operations.iter().enumerate() {
         if let Operation::Replace { if_exists, .. } = op {
@@ -979,7 +1062,13 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 has_non_idempotent_replace = true;
             }
         }
-        match execute_operation(op, &mut pending, &mut deletions, &mut tx_reads) {
+        match execute_operation(
+            op,
+            &mut pending,
+            &mut deletions,
+            &mut tx_reads,
+            &mut tx_searches,
+        ) {
             Ok(match_count) => {
                 total_replace_matches += match_count;
             }
@@ -1038,6 +1127,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     Vec::new(),
                 );
                 output.reads = std::mem::take(&mut tx_reads);
+                output.searches = std::mem::take(&mut tx_searches);
                 println!("{}", serde_json::to_string_pretty(&output)?);
             }
             return Ok(exit::SUCCESS);
@@ -1052,6 +1142,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 Vec::new(),
             );
             output.reads = std::mem::take(&mut tx_reads);
+            output.searches = std::mem::take(&mut tx_searches);
             println!("{}", serde_json::to_string_pretty(&output)?);
         } else if !global.quiet {
             println!("{} file(s) would change", changes.len() + pending_deletions);
@@ -1209,6 +1300,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 Vec::new(),
             );
             output.reads = std::mem::take(&mut tx_reads);
+            output.searches = std::mem::take(&mut tx_searches);
             println!("{}", serde_json::to_string_pretty(&output)?);
         }
         return Ok(exit::SUCCESS);
@@ -1229,6 +1321,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             Vec::new(),
         );
         output.reads = std::mem::take(&mut tx_reads);
+        output.searches = std::mem::take(&mut tx_searches);
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else if !changes.is_empty() {
         print_diffs(&changes);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -160,6 +160,18 @@ pub enum Operation {
         /// Inline diff text to apply.
         diff: String,
     },
+    #[serde(rename = "search")]
+    Search {
+        path: String,
+        pattern: String,
+        #[serde(default)]
+        regex: bool,
+        #[serde(default)]
+        case_insensitive: bool,
+        context: Option<usize>,
+        before_context: Option<usize>,
+        after_context: Option<usize>,
+    },
     #[serde(rename = "read")]
     Read {
         path: String,
@@ -332,10 +344,12 @@ mod tests {
             {"op": "file.delete", "path": "f.txt"},
             {"op": "patch.apply", "diff": "--- a/f.txt\n+++ b/f.txt\n@@ -1 +1 @@\n-a\n+b"},
             {"op": "read", "path": "f.txt"},
-            {"op": "read", "path": "f.txt", "lines": "1:10"}
+            {"op": "read", "path": "f.txt", "lines": "1:10"},
+            {"op": "search", "path": "f.txt", "pattern": "hello"},
+            {"op": "search", "path": "f.txt", "pattern": "he.*o", "regex": true, "case_insensitive": true}
         ]}"#;
         let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 24);
+        assert_eq!(plan.operations.len(), 26);
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5077,6 +5077,73 @@ fn test_tx_read_sees_in_plan_state() {
 }
 
 #[test]
+fn test_tx_search_operation_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "alpha\nbeta\ngamma\nalpha two\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{"op": "search", "path": file.to_str().unwrap(), "pattern": "alpha"}]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["searches"].as_array().unwrap().len(), 1);
+    assert_eq!(json["searches"][0]["match_count"], 2);
+    assert_eq!(json["searches"][0]["matches"][0]["line"], 1);
+    assert_eq!(json["searches"][0]["matches"][1]["line"], 4);
+}
+
+#[test]
+fn test_tx_search_then_replace_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello world\nfoo bar\nhello again\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "search", "path": file.to_str().unwrap(), "pattern": "hello"},
+            {"op": "replace", "path": file.to_str().unwrap(), "from": "hello", "to": "goodbye"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Search found 2 matches before replace
+    assert_eq!(json["searches"][0]["match_count"], 2);
+    // Replace changed the file
+    assert_eq!(json["files_changed"], 1);
+    // File on disk is replaced
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "goodbye world\nfoo bar\ngoodbye again\n"
+    );
+}
+
+#[test]
 fn test_tx_strict_mode_reverts_on_format_failure() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary

New tx operation `{"op": "search"}` that searches a file and includes match results in JSON output without writing, enabling locate-then-edit workflows in a single call.

## Problem

Agents frequently need to search for a pattern to locate it, then replace it. This required two separate patchloom calls. Now both can be in one plan.

## Change

- `Operation::Search` added to plan.rs (24 ops total)
- Supports `regex`, `case_insensitive`, `context`, `before_context`, `after_context`
- Results populate a `searches` array in TxOutput JSON (separate from `reads`)
- Searches see in-plan state (a search after a replace sees the post-replace content)

## Example

```json
{"operations": [
  {"op": "search", "path": "src/main.rs", "pattern": "old_name"},
  {"op": "replace", "path": "src/main.rs", "from": "old_name", "to": "new_name"}
]}
```

The search verifies what will be replaced; the replace makes the change.

## Validation

`make check` passes: 166 unit + 255 integration tests (421 total), clippy clean. 2 new integration tests.

Closes #150