### PR TITLE
Fix README docs gaps and flaky update-readme script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,9 @@ clippy: ## Run clippy linter
 check: fmt-check build test integration-test clippy ## Run all checks (full CI gate)
 
 update-readme: ## Update README.md and CHANGELOG.md test counts
-	@unit=$$(cargo test --lib 2>&1 | grep '^test result' | sed 's/.*ok\. \([0-9]*\) passed.*/\1/'); \
-	integ=$$(cargo test --test integration 2>&1 | grep '^test result' | sed 's/.*ok\. \([0-9]*\) passed.*/\1/'); \
+	@unit=$$(cargo test --lib 2>&1 | grep '^test result:.*passed' | tail -1 | sed 's/.*ok\. \([0-9]*\) passed.*/\1/'); \
+	integ=$$(cargo test --test integration 2>&1 | grep '^test result:.*passed' | tail -1 | sed 's/.*ok\. \([0-9]*\) passed.*/\1/'); \
+	if [ -z "$$unit" ] || [ -z "$$integ" ]; then echo "ERROR: failed to parse test counts (unit=$$unit integ=$$integ)"; exit 1; fi; \
 	total=$$((unit + integ)); \
 	cmds=$$(cargo run --quiet -- --help 2>/dev/null | sed -n '/^Commands:/,/^$$/p' | grep '^ ' | grep -cv '^ *help'); \
 	ver=$$(grep '^V[0-9]' README.md | head -1 | sed 's/^\(V[0-9]*\).*/\1/'); \

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ Case-insensitive search:
 patchloom search -i 'todo' src/
 ```
 
+Show 3 lines after each match (like grep -A):
+
+```
+patchloom search -A 3 'fn main' src/
+```
+
+Show 1 line before and 5 after:
+
+```
+patchloom search -B 1 -A 5 'TODO' src/
+```
+
 ### replace
 
 Replace text across files (preview diff by default, write with `--apply`):
@@ -468,7 +480,9 @@ The `tx` command accepts a JSON plan with an array of operations:
     { "op": "file.create", "path": "new.txt", "content": "hello" },
     { "op": "file.create", "path": "existing.txt", "content": "overwrite", "force": true },
     { "op": "file.delete", "path": "obsolete.txt" },
-    { "op": "patch.apply", "diff": "--- a/f.txt\n+++ b/f.txt\n@@ -1 +1 @@\n-old\n+new" }
+    { "op": "patch.apply", "diff": "--- a/f.txt\n+++ b/f.txt\n@@ -1 +1 @@\n-old\n+new" },
+    { "op": "read", "path": "src/main.rs", "lines": "1:10" },
+    { "op": "search", "path": "src/main.rs", "pattern": "TODO", "context": 2 }
   ],
   "format": [
     { "cmd": "cargo fmt --all", "timeout": 30 }


### PR DESCRIPTION
## Summary

Fixes 3 issues found by `/session-improve` after landing PRs #151-#153.

## Changes

| File | Fix |
|---|---|
| `README.md` | Add `-B`/`-A` examples to search section; add `read` and `search` ops to tx plan example |
| `Makefile` | Fix flaky `update-readme`: stricter grep pattern, `tail -1` for interleaved output, error guard |

## Problem

1. Search examples didn't show the new `-B`/`-A` flags from PR #151
2. Tx plan example still showed only the original operations, missing `read` and `search` from PRs #152/#153
3. `make update-readme` failed 3 times this session with "Illegal number" due to `cargo test` output interleaving

## Validation

`make check` passes: 166 unit + 255 integration tests (421 total), clippy clean. `make update-readme` runs cleanly.

Closes #154