### PR TITLE
Add agent integration tests for patchloom usage verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 # Logs and OS files
 *.log
 .DS_Store
+
+# Python virtual environments
+tests/agent/.venv/
+tests/agent/.pytest_cache/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Patchloom is a Rust CLI for agent-grade repo operations. It provides thirteen co
 | `make update-readme` | Update README.md and CHANGELOG.md test counts from actual `cargo test` output |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |
 | `make check-patchloom-md` | Verify PATCHLOOM.md matches `patchloom agent-rules` output (part of `check`) |
+| `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`) |
 
 Always run `make check` before committing. It is the full CI gate.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - JSON output mode for `tx` command via `--json` flag
 - JSON error output on all tx failure paths, with explicit `error_kind` values for parse_error, rollback, validation_failed, and format_failed while preserving backward-compatible legacy `error` prefixes
 - `PATCHLOOM.md` generated file containing CLI usage instructions for AI agents, kept in sync via `make sync-patchloom-md` and verified by `make check-patchloom-md`
+- Agent integration tests (`make agent-test`): 8 scenarios verifying AI agents use patchloom when given PATCHLOOM.md instructions. Uses a shim binary to capture every patchloom invocation. Supports pluggable agent drivers (Grok Build CLI first, extensible to Claude Code and others)
 - 421 tests (166 unit + 255 integration)
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test integration-test clippy check update-readme sync-patchloom-md check-patchloom-md
+.PHONY: help fmt fmt-check build test integration-test clippy check update-readme sync-patchloom-md check-patchloom-md agent-test
 
 .DEFAULT_GOAL := help
 
@@ -43,3 +43,9 @@ sync-patchloom-md: ## Regenerate PATCHLOOM.md from patchloom agent-rules
 check-patchloom-md: ## Verify PATCHLOOM.md matches patchloom agent-rules output
 	@cargo run --quiet -- agent-rules | diff -q - PATCHLOOM.md >/dev/null 2>&1 \
 		|| (echo "ERROR: PATCHLOOM.md is stale. Run 'make sync-patchloom-md' to update." && exit 1)
+
+agent-test: build ## Run agent integration tests (requires LLM API key)
+	@cd tests/agent && \
+		([ -d .venv ] || python3 -m venv .venv) && \
+		.venv/bin/pip install -q -r requirements.txt && \
+		.venv/bin/pytest -v --timeout 240

--- a/tests/agent/README.md
+++ b/tests/agent/README.md
@@ -1,0 +1,61 @@
+# Agent Integration Tests
+
+Verify that AI agents, given patchloom's AGENTS.md instructions, actually use patchloom for file operations instead of raw tools.
+
+## Prerequisites
+
+- Python 3.10+
+- `patchloom` binary (run `cargo build` first)
+- `grok` CLI installed and configured (or another supported agent)
+- `jq` installed (used by the patchloom shim)
+- API key set: `export GROK_CODE_XAI_API_KEY="xai-..."`
+
+## Running tests
+
+```bash
+# Run all tests with default agent (grok) and model (grok-build)
+make agent-test
+
+# Or run directly with options
+cd tests/agent
+pip install -r requirements.txt
+pytest -v --agent grok --model grok-build
+
+# Run a specific test
+pytest -v -k test_search
+
+# Use a different model
+pytest -v --model gpt-5
+```
+
+## How it works
+
+1. Each test creates an isolated temp directory with an `AGENTS.md` generated from `patchloom agent-rules`
+2. Fixture files are written for the scenario
+3. A **patchloom shim** wraps the real binary and logs every invocation to a JSONL file
+4. The agent is invoked in headless mode with the shim on PATH
+5. After the agent completes, the test asserts:
+   - **Patchloom was used** for the expected command (primary, hard failure)
+   - **Correct file state** after the operation (secondary)
+
+## Adding a new scenario
+
+1. Pick the right test file (`test_basic.py`, `test_batch.py`, or `test_structured.py`)
+2. Write fixture files into the `workspace`
+3. Call `run_scenario(agent, workspace, patchloom_shim, prompt)`
+4. Assert with `assert_patchloom_used(result, "command")`
+5. Verify file state
+
+## Adding a new agent driver
+
+1. Create `drivers/myagent.py` implementing `AgentDriver`
+2. Register it in `drivers/base.py` `create_driver()`
+3. Run: `pytest -v --agent myagent --model my-model`
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `AGENT_TEST_AGENT` | Agent name (default: `grok`) |
+| `AGENT_TEST_MODEL` | Model name (default: `grok-build`) |
+| `GROK_CODE_XAI_API_KEY` | API key for Grok Build CLI |

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -1,0 +1,156 @@
+"""Pytest configuration and shared fixtures for agent integration tests."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from drivers import AgentResult, create_driver
+from drivers.base import parse_shim_log
+
+# ---------------------------------------------------------------------------
+# pytest CLI options
+# ---------------------------------------------------------------------------
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--agent",
+        default=os.environ.get("AGENT_TEST_AGENT", "grok"),
+        help="Agent to test (default: grok)",
+    )
+    parser.addoption(
+        "--model",
+        default=os.environ.get("AGENT_TEST_MODEL", "grok-build"),
+        help="Model to use (default: grok-build)",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SHIM_TEMPLATE = (Path(__file__).parent / "shim.sh").read_text()
+
+
+def _find_patchloom_binary() -> str:
+    """Locate the patchloom binary: prefer cargo target, fall back to PATH."""
+    # Check for cargo-built binary in the repo
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    cargo_bin = repo_root / "target" / "debug" / "patchloom"
+    if cargo_bin.exists():
+        return str(cargo_bin)
+    cargo_bin_release = repo_root / "target" / "release" / "patchloom"
+    if cargo_bin_release.exists():
+        return str(cargo_bin_release)
+    # Fall back to PATH
+    found = shutil.which("patchloom")
+    if found:
+        return found
+    pytest.skip("patchloom binary not found; run 'cargo build' first")
+
+
+@pytest.fixture
+def patchloom_bin() -> str:
+    """Return the path to the real patchloom binary."""
+    return _find_patchloom_binary()
+
+
+@pytest.fixture
+def patchloom_shim(tmp_path, patchloom_bin):
+    """Set up a patchloom shim that logs invocations, return (env_dict, log_path)."""
+    shim_dir = tmp_path / "shim_bin"
+    shim_dir.mkdir()
+    log_file = tmp_path / "patchloom_calls.jsonl"
+
+    shim_script = SHIM_TEMPLATE.replace("__REAL_PATH__", patchloom_bin)
+    shim_script = shim_script.replace("__LOG_PATH__", str(log_file))
+    shim_path = shim_dir / "patchloom"
+    shim_path.write_text(shim_script)
+    shim_path.chmod(shim_path.stat().st_mode | stat.S_IEXEC)
+
+    env = {
+        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
+        "PATCHLOOM_SHIM_LOG": str(log_file),
+    }
+    return env, log_file
+
+
+@pytest.fixture
+def workspace(tmp_path, patchloom_bin):
+    """Create an isolated workspace with AGENTS.md from patchloom agent-rules.
+
+    The workspace is a git repo so agents discover AGENTS.md via the standard
+    project-rules mechanism.
+    """
+    # Generate AGENTS.md from patchloom agent-rules
+    result = subprocess.run(
+        [patchloom_bin, "agent-rules"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    (tmp_path / "AGENTS.md").write_text(result.stdout)
+
+    # Initialize a git repo so the agent discovers AGENTS.md
+    subprocess.run(
+        ["git", "init"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "add", "."],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.name=test", "-c", "user.email=test@test.com",
+         "commit", "-m", "init"],
+        cwd=tmp_path,
+        capture_output=True,
+        check=True,
+    )
+    return tmp_path
+
+
+@pytest.fixture
+def agent(request):
+    """Create the agent driver from CLI flags."""
+    agent_name = request.config.getoption("--agent")
+    model = request.config.getoption("--model")
+    driver = create_driver(agent_name, model)
+    if not driver.is_available():
+        pytest.skip(f"Agent {agent_name!r} is not available on this system")
+    return driver
+
+
+def run_scenario(
+    agent,
+    workspace: Path,
+    patchloom_shim: tuple,
+    prompt: str,
+    *,
+    max_turns: int = 15,
+    timeout_secs: int = 180,
+) -> AgentResult:
+    """Run a prompt through the agent with patchloom shim capture."""
+    shim_env, log_path = patchloom_shim
+
+    result = agent.run_prompt(
+        prompt,
+        workspace,
+        max_turns=max_turns,
+        timeout_secs=timeout_secs,
+        extra_env=shim_env,
+    )
+    # Re-parse shim log in case the driver didn't pick it up
+    if not result.patchloom_calls:
+        result.patchloom_calls = parse_shim_log(log_path)
+    return result

--- a/tests/agent/drivers/__init__.py
+++ b/tests/agent/drivers/__init__.py
@@ -1,0 +1,1 @@
+from .base import AgentDriver, AgentResult, create_driver

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -1,0 +1,112 @@
+"""Base agent driver abstraction for patchloom agent integration tests."""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class AgentResult:
+    """Result of running an agent prompt."""
+
+    stdout: str
+    stderr: str
+    exit_code: int
+    output_json: dict | None
+    duration_secs: float
+    patchloom_calls: list[dict] = field(default_factory=list)
+
+
+class AgentDriver(ABC):
+    """Abstract interface for invoking an AI agent in headless mode."""
+
+    def __init__(self, name: str, model: str):
+        self.name = name
+        self.model = model
+
+    @abstractmethod
+    def run_prompt(
+        self,
+        prompt: str,
+        cwd: Path,
+        *,
+        max_turns: int = 10,
+        timeout_secs: int = 120,
+        extra_env: dict | None = None,
+    ) -> AgentResult:
+        """Run a single prompt and return the result."""
+
+    @abstractmethod
+    def is_available(self) -> bool:
+        """Check if this agent and model are configured and reachable."""
+
+
+def create_driver(agent_name: str, model: str) -> AgentDriver:
+    """Factory: create the right driver for the given agent name."""
+    if agent_name == "grok":
+        from .grok import GrokDriver
+
+        return GrokDriver(model=model)
+    raise ValueError(f"Unknown agent: {agent_name!r}. Available: grok")
+
+
+# ---------------------------------------------------------------------------
+# Assertion helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_patchloom_used(result: AgentResult, expected_command: str) -> None:
+    """Assert patchloom was invoked with the expected subcommand."""
+    matching = [
+        c
+        for c in result.patchloom_calls
+        if c.get("args") and c["args"][0] == expected_command
+    ]
+    all_commands = [
+        c["args"][0] for c in result.patchloom_calls if c.get("args")
+    ]
+    assert matching, (
+        f"Expected patchloom {expected_command} to be invoked, but "
+        f"patchloom was called {len(result.patchloom_calls)} time(s) "
+        f"with commands: {all_commands or 'none'}"
+    )
+
+
+def assert_patchloom_used_any(
+    result: AgentResult, commands: list[str]
+) -> None:
+    """Assert patchloom was invoked with any of the expected subcommands."""
+    used = {c["args"][0] for c in result.patchloom_calls if c.get("args")}
+    overlap = used & set(commands)
+    assert overlap, (
+        f"Expected patchloom to use one of {commands}, "
+        f"but only saw: {sorted(used) or 'no patchloom calls'}"
+    )
+
+
+def report_raw_tool_usage(result: AgentResult) -> list[str]:
+    """Return names of raw agent tools spotted in the response text."""
+    raw_tools = []
+    text = (result.stdout or "") + (result.output_json or {}).get("text", "")
+    for tool in ["search_replace", "read_file", "grep", "list_dir"]:
+        if tool in text:
+            raw_tools.append(tool)
+    return raw_tools
+
+
+def parse_shim_log(path: Path) -> list[dict]:
+    """Parse the JSONL log written by the patchloom shim."""
+    if not path.exists():
+        return []
+    entries = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if line:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return entries

--- a/tests/agent/drivers/grok.py
+++ b/tests/agent/drivers/grok.py
@@ -1,0 +1,94 @@
+"""Grok Build CLI agent driver."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from .base import AgentDriver, AgentResult, parse_shim_log
+
+
+class GrokDriver(AgentDriver):
+    """Invokes Grok Build CLI in headless mode."""
+
+    def __init__(self, model: str = "grok-build"):
+        super().__init__(name="grok", model=model)
+
+    def run_prompt(
+        self,
+        prompt: str,
+        cwd: Path,
+        *,
+        max_turns: int = 10,
+        timeout_secs: int = 120,
+        extra_env: dict | None = None,
+    ) -> AgentResult:
+        env = {**os.environ, **(extra_env or {})}
+        cmd = [
+            "grok",
+            "-p",
+            prompt,
+            "--yolo",
+            "--output-format",
+            "json",
+            "--max-turns",
+            str(max_turns),
+            "--cwd",
+            str(cwd),
+            "-m",
+            self.model,
+        ]
+
+        start = time.monotonic()
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout_secs,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            return AgentResult(
+                stdout=exc.stdout or "",
+                stderr=exc.stderr or "",
+                exit_code=-1,
+                output_json=None,
+                duration_secs=time.monotonic() - start,
+                patchloom_calls=_load_calls(extra_env),
+            )
+        duration = time.monotonic() - start
+
+        output_json = _try_parse_json(proc.stdout)
+
+        return AgentResult(
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            exit_code=proc.returncode,
+            output_json=output_json,
+            duration_secs=duration,
+            patchloom_calls=_load_calls(extra_env),
+        )
+
+    def is_available(self) -> bool:
+        return shutil.which("grok") is not None
+
+
+def _try_parse_json(text: str) -> dict | None:
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+def _load_calls(extra_env: dict | None) -> list[dict]:
+    if not extra_env:
+        return []
+    log_path = extra_env.get("PATCHLOOM_SHIM_LOG", "")
+    if not log_path:
+        return []
+    return parse_shim_log(Path(log_path))

--- a/tests/agent/requirements.txt
+++ b/tests/agent/requirements.txt
@@ -1,0 +1,2 @@
+pytest>=8.0
+pytest-timeout>=2.3

--- a/tests/agent/shim.sh
+++ b/tests/agent/shim.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Patchloom invocation-capture shim.
+# Logs every call to a JSONL file, then delegates to the real binary.
+# Placeholders __REAL_PATH__ and __LOG_PATH__ are replaced at runtime by conftest.py.
+
+REAL_PATCHLOOM="__REAL_PATH__"
+LOG_FILE="__LOG_PATH__"
+
+# Build a JSON array of args using jq
+args_json=$(printf '%s\n' "$@" | jq -R . | jq -sc .)
+
+# Run the real binary, capture exit code
+"$REAL_PATCHLOOM" "$@"
+exit_code=$?
+
+# Append one JSONL record with timestamp, args, and exit code
+echo "{\"ts\":$(date +%s),\"args\":${args_json},\"exit_code\":${exit_code}}" >> "$LOG_FILE"
+
+exit $exit_code

--- a/tests/agent/test_basic.py
+++ b/tests/agent/test_basic.py
@@ -1,0 +1,108 @@
+"""Basic agent scenarios: search, replace, read."""
+
+from __future__ import annotations
+
+import pytest
+
+from conftest import run_scenario
+from drivers.base import assert_patchloom_used, report_raw_tool_usage
+
+
+@pytest.mark.timeout(180)
+def test_search(agent, workspace, patchloom_shim):
+    """Agent should use patchloom search to find lines matching a pattern."""
+    # Setup: create files with TODO markers
+    (workspace / "src").mkdir()
+    (workspace / "src" / "main.py").write_text(
+        "# TODO: implement auth\ndef main():\n    pass\n"
+    )
+    (workspace / "src" / "utils.py").write_text(
+        "def helper():\n    # TODO: add logging\n    return 42\n"
+    )
+    (workspace / "README.md").write_text(
+        "# Project\n\nA sample project.\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Find all lines containing 'TODO' across all source files in this "
+        "project. Report which files and line numbers contain TODO comments.",
+    )
+
+    # Primary: patchloom search was used
+    assert_patchloom_used(result, "search")
+
+    # Secondary: output mentions both files
+    response_text = (result.output_json or {}).get("text", result.stdout)
+    assert "main.py" in response_text, "Agent should mention main.py"
+    assert "utils.py" in response_text, "Agent should mention utils.py"
+
+    raw = report_raw_tool_usage(result)
+    if raw:
+        print(f"WARNING: Agent also used raw tools: {raw}")
+
+
+@pytest.mark.timeout(180)
+def test_replace(agent, workspace, patchloom_shim):
+    """Agent should use patchloom replace to rename a function across files."""
+    (workspace / "src").mkdir()
+    (workspace / "src" / "app.py").write_text(
+        "def calculate_total(items):\n"
+        "    return sum(i.price for i in items)\n"
+        "\n"
+        "result = calculate_total(order_items)\n"
+    )
+    (workspace / "src" / "test_app.py").write_text(
+        "from app import calculate_total\n"
+        "\n"
+        "def test_it():\n"
+        "    assert calculate_total([]) == 0\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Rename the function 'calculate_total' to 'compute_sum' in all "
+        "files under src/. Make sure every reference is updated.",
+    )
+
+    # Primary: patchloom replace (or tx with replace op) was used
+    assert_patchloom_used(result, "replace")
+
+    # Secondary: files are updated
+    app_content = (workspace / "src" / "app.py").read_text()
+    test_content = (workspace / "src" / "test_app.py").read_text()
+    assert "compute_sum" in app_content, "app.py should have new name"
+    assert "calculate_total" not in app_content, "app.py should not have old name"
+    assert "compute_sum" in test_content, "test_app.py should have new name"
+    assert "calculate_total" not in test_content, "test_app.py should not have old name"
+
+
+@pytest.mark.timeout(180)
+@pytest.mark.xfail(
+    reason="Agents prefer their native read_file tool over patchloom read. "
+    "Tracked as a PATCHLOOM.md instruction effectiveness issue.",
+    strict=False,
+)
+def test_read(agent, workspace, patchloom_shim):
+    """Agent should use patchloom read to inspect a file."""
+    (workspace / "config.json").write_text(
+        '{\n  "app_name": "MyApp",\n  "version": "1.0.0",\n  "debug": false\n}\n'
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Show me the contents of config.json. Report what you see.",
+    )
+
+    # Primary: patchloom read was used
+    assert_patchloom_used(result, "read")
+
+    # Secondary: agent saw the file content
+    response_text = (result.output_json or {}).get("text", result.stdout)
+    assert "MyApp" in response_text, "Agent should report the app_name value"

--- a/tests/agent/test_batch.py
+++ b/tests/agent/test_batch.py
@@ -1,0 +1,102 @@
+"""Batch and transaction agent scenarios."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from conftest import run_scenario
+from drivers.base import (
+    assert_patchloom_used,
+    assert_patchloom_used_any,
+    report_raw_tool_usage,
+)
+
+
+@pytest.mark.timeout(180)
+def test_batch_replace(agent, workspace, patchloom_shim):
+    """Agent should use patchloom to update a version string across multiple config files."""
+    (workspace / "package.json").write_text(
+        json.dumps({"name": "myapp", "version": "1.0.0"}, indent=2) + "\n"
+    )
+    (workspace / "config.yaml").write_text(
+        "app:\n  name: myapp\n  version: '1.0.0'\n"
+    )
+    (workspace / "pyproject.toml").write_text(
+        '[project]\nname = "myapp"\nversion = "1.0.0"\n'
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Update the version from '1.0.0' to '2.0.0' in all config files "
+        "(package.json, config.yaml, pyproject.toml).",
+    )
+
+    # Primary: patchloom was used (replace, tx, or doc)
+    assert_patchloom_used_any(result, ["replace", "tx", "doc"])
+
+    # Secondary: all files updated
+    pkg = json.loads((workspace / "package.json").read_text())
+    assert pkg["version"] == "2.0.0", "package.json version should be 2.0.0"
+
+    yaml_content = (workspace / "config.yaml").read_text()
+    assert "2.0.0" in yaml_content, "config.yaml should contain 2.0.0"
+    assert "1.0.0" not in yaml_content, "config.yaml should not contain 1.0.0"
+
+    toml_content = (workspace / "pyproject.toml").read_text()
+    assert "2.0.0" in toml_content, "pyproject.toml should contain 2.0.0"
+
+
+@pytest.mark.timeout(240)
+def test_tx_multi_file(agent, workspace, patchloom_shim):
+    """Agent should use patchloom tx for atomic multi-file operations."""
+    (workspace / "package.json").write_text(
+        json.dumps({"name": "myapp", "version": "1.0.0"}, indent=2) + "\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Do both of these atomically using a patchloom transaction:\n"
+        "1. Create a new file called hello.txt containing 'Hello, World!'\n"
+        "2. Update the version in package.json from '1.0.0' to '3.0.0'\n"
+        "Use a single patchloom tx plan so both changes happen atomically.",
+        max_turns=20,
+    )
+
+    # Primary: patchloom tx was used
+    assert_patchloom_used(result, "tx")
+
+    # Secondary: both changes applied
+    hello = workspace / "hello.txt"
+    assert hello.exists(), "hello.txt should exist"
+    assert "Hello" in hello.read_text(), "hello.txt should contain Hello"
+
+    pkg = json.loads((workspace / "package.json").read_text())
+    assert pkg["version"] == "3.0.0", "package.json version should be 3.0.0"
+
+
+@pytest.mark.timeout(180)
+def test_hygiene(agent, workspace, patchloom_shim):
+    """Agent should use patchloom hygiene to fix trailing whitespace."""
+    (workspace / "dirty.txt").write_text("line one   \nline two\t\nline three  \n")
+    (workspace / "clean.txt").write_text("already clean\n")
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Fix trailing whitespace in all text files in this project.",
+    )
+
+    # Primary: patchloom hygiene was used
+    assert_patchloom_used(result, "hygiene")
+
+    # Secondary: trailing whitespace removed
+    content = (workspace / "dirty.txt").read_text()
+    for line in content.splitlines():
+        assert line == line.rstrip(), f"Line still has trailing whitespace: {line!r}"

--- a/tests/agent/test_structured.py
+++ b/tests/agent/test_structured.py
@@ -1,0 +1,79 @@
+"""Structured editing agent scenarios: doc and md commands."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from conftest import run_scenario
+from drivers.base import assert_patchloom_used, report_raw_tool_usage
+
+
+@pytest.mark.timeout(180)
+def test_doc_set(agent, workspace, patchloom_shim):
+    """Agent should use patchloom doc to set a key in a JSON file."""
+    (workspace / "config.json").write_text(
+        json.dumps(
+            {"app_name": "MyApp", "debug": False, "log_level": "info"},
+            indent=2,
+        )
+        + "\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Set the 'debug' key to true in config.json.",
+    )
+
+    # Primary: patchloom doc was used
+    assert_patchloom_used(result, "doc")
+
+    # Secondary: config.json updated
+    config = json.loads((workspace / "config.json").read_text())
+    assert config["debug"] is True, "debug should be true"
+    # Other keys should be preserved
+    assert config["app_name"] == "MyApp", "app_name should be preserved"
+    assert config["log_level"] == "info", "log_level should be preserved"
+
+
+@pytest.mark.timeout(180)
+def test_md_table(agent, workspace, patchloom_shim):
+    """Agent should use patchloom md to append a row to a markdown table."""
+    (workspace / "README.md").write_text(
+        "# My Project\n"
+        "\n"
+        "A sample project.\n"
+        "\n"
+        "## Commands\n"
+        "\n"
+        "| Command | Description |\n"
+        "|---------|-------------|\n"
+        "| `build` | Build the project |\n"
+        "| `test` | Run tests |\n"
+        "\n"
+        "## License\n"
+        "\n"
+        "MIT\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Add a new row to the Commands table in README.md: "
+        "command is `lint` and description is `Run the linter`.",
+    )
+
+    # Primary: patchloom md was used
+    assert_patchloom_used(result, "md")
+
+    # Secondary: table has the new row
+    content = (workspace / "README.md").read_text()
+    assert "lint" in content, "README should contain 'lint'"
+    assert "Run the linter" in content, "README should contain 'Run the linter'"
+    # Existing rows preserved
+    assert "build" in content, "Existing 'build' row should be preserved"
+    assert "test" in content, "Existing 'test' row should be preserved"


### PR DESCRIPTION
## Summary

Add a pytest-based test harness that verifies AI agents actually use patchloom (not raw tools) when given PATCHLOOM.md instructions.

## Why

Patchloom ships an `agent-rules` command that generates instructions for AI agents. We need to verify those instructions actually work: that agents choose patchloom over their native tools for file operations.

## Architecture

- **Pluggable agent drivers**: `AgentDriver` ABC with `GrokDriver` as the first implementation
- **Patchloom shim**: A wrapper script that logs every patchloom invocation (args, exit code) to a JSONL file, enabling assertion on what the agent actually called
- **Isolated workspaces**: Each test creates a temp dir with `AGENTS.md` generated from `patchloom agent-rules`, plus scenario-specific fixture files
- **Dual assertions**: Every test checks (1) patchloom was used for the expected command, and (2) the files ended up in the correct state

## Test results (Grok Build CLI + Grok LLM)

| Test | Patchloom command | Result |
|------|------------------|--------|
| `test_search` | `patchloom search` | PASS |
| `test_replace` | `patchloom replace` | PASS |
| `test_read` | `patchloom read` | XFAIL (agent prefers native read_file) |
| `test_batch_replace` | `patchloom replace` or `tx` | PASS |
| `test_doc_set` | `patchloom doc` | PASS |
| `test_md_table` | `patchloom md` | PASS |
| `test_tx_multi_file` | `patchloom tx` | PASS |
| `test_hygiene` | `patchloom hygiene` | PASS |

`test_read` is marked `xfail` because agents consistently prefer their native `read_file` tool over `patchloom read` for simple file reads. This is a known PATCHLOOM.md instruction effectiveness issue, not a test bug.

## Verification

- `make check` passes (421 Rust tests: 166 unit + 255 integration)
- `make agent-test` runs 8 scenarios, 7 pass + 1 xfail
- Agent tests are NOT part of `make check` (too slow, requires API keys)

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I linked the issue or discussion first if this is non-trivial feature work
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I updated docs or examples if CLI behavior, flags, or output changed
- [x] I am contributing this work under the repository license (`MIT OR Apache-2.0`)
- [x] I linked any follow-up work that still needs tracking