### PR TITLE
Document agent tests in project structure and README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,16 @@ src/
   write.rs             Atomic file writes via tempfile; WritePolicy applies trim, EOL, final newline
   plan.rs              Transaction plan format: Plan, Operation, FormatStep, ValidationStep;
                        22 operation types including all doc/md/replace/hygiene/file/patch ops
+tests/
+  integration.rs       Rust integration tests (cargo test --test integration)
+  agent/               Python (pytest) agent integration tests verifying AI agents use patchloom
+    conftest.py        Fixtures: workspace with AGENTS.md, patchloom shim for invocation capture
+    drivers/           Pluggable agent drivers (GrokDriver first, extensible)
+    test_basic.py      Search, replace, read scenarios
+    test_batch.py      Batch replace, tx multi-file, hygiene scenarios
+    test_structured.py Doc set, md table-append scenarios
+    shim.sh            Patchloom invocation-capture shim template
+PATCHLOOM.md           Generated CLI usage guide for AI agents (from patchloom agent-rules)
 ```
 
 ## Architecture conventions

--- a/README.md
+++ b/README.md
@@ -570,6 +570,10 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 All commits must be signed off with `git commit -s`.
 
+### Agent integration tests
+
+`make agent-test` runs pytest-based scenarios that verify AI agents use patchloom (not raw tools) when given PATCHLOOM.md instructions. Requires an LLM API key (`GROK_CODE_XAI_API_KEY`). Not part of `make check`. See [tests/agent/README.md](./tests/agent/README.md) for details.
+
 ## Security
 
 For current security reporting guidance, see [SECURITY.md](./SECURITY.md).


### PR DESCRIPTION
## Summary

Add documentation for the agent integration test suite added in PR #157.

## Why

The AGENTS.md project structure section was missing `tests/agent/` and `PATCHLOOM.md`. The README had no mention of `make agent-test`.

## Changes

- **AGENTS.md**: Added `tests/agent/` directory tree and `PATCHLOOM.md` to project structure
- **README.md**: Added "Agent integration tests" subsection under Contributing

## Verification

- `make check` passes (421 tests)

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I am contributing this work under the repository license (`MIT OR Apache-2.0`)