### PR TITLE
Expand agent tests to cover full patchloom command surface

### DIFF
--- a/tests/agent/test_basic.py
+++ b/tests/agent/test_basic.py
@@ -101,3 +101,72 @@ def test_read(agent, workspace, patchloom_shim):
     # Assert: agent saw the file content
     response_text = (result.output_json or {}).get("text", result.stdout)
     assert "MyApp" in response_text, "Agent should report the app_name value"
+
+
+@pytest.mark.timeout(180)
+def test_replace_regex(agent, workspace, patchloom_shim):
+    """Agent should use patchloom replace --regex for pattern-based renames."""
+    (workspace / "src").mkdir()
+    (workspace / "src" / "utils.py").write_text(
+        "def get_user_name():\n"
+        "    pass\n"
+        "\n"
+        "def get_user_email():\n"
+        "    pass\n"
+        "\n"
+        "def set_user_role():\n"
+        "    pass\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "In src/utils.py, rename all functions that start with 'get_user_' "
+        "to start with 'fetch_user_' instead. Use a regex replacement so you "
+        "don't have to replace each one individually.",
+    )
+
+    # Primary: patchloom replace was used
+    assert_patchloom_used(result, "replace")
+
+    # Secondary: functions renamed
+    content = (workspace / "src" / "utils.py").read_text()
+    assert "fetch_user_name" in content, "get_user_name should become fetch_user_name"
+    assert "fetch_user_email" in content, "get_user_email should become fetch_user_email"
+    assert "set_user_role" in content, "set_user_role should NOT be renamed"
+    assert "get_user_" not in content, "No get_user_ prefixes should remain"
+
+
+@pytest.mark.timeout(180)
+def test_replace_insert(agent, workspace, patchloom_shim):
+    """Agent should use patchloom replace --insert-before to add a header."""
+    (workspace / "src").mkdir()
+    (workspace / "src" / "main.py").write_text(
+        "import sys\n\ndef main():\n    print('Hello')\n"
+    )
+    (workspace / "src" / "utils.py").write_text(
+        "import os\n\ndef helper():\n    return 42\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Add this copyright header as the very first line of every .py "
+        "file under src/:\n"
+        "# Copyright 2025 Example Corp. All rights reserved.\n"
+        "Insert it before the existing first line, don't replace anything.",
+    )
+
+    # Primary: patchloom replace was used
+    assert_patchloom_used(result, "replace")
+
+    # Secondary: header added as first line
+    for fname in ["main.py", "utils.py"]:
+        content = (workspace / "src" / fname).read_text()
+        assert content.startswith("# Copyright 2025 Example Corp"), (
+            f"{fname} should start with copyright header"
+        )
+        # Original content preserved
+        assert "import" in content, f"{fname} should still have imports"

--- a/tests/agent/test_batch.py
+++ b/tests/agent/test_batch.py
@@ -145,3 +145,45 @@ def test_tx_read_then_edit(agent, workspace, patchloom_shim):
     readme = (workspace / "README.md").read_text()
     assert "2.0.0" in readme, "README.md should contain 2.0.0"
     assert "1.0.0" not in readme, "README.md should not contain old version"
+
+
+@pytest.mark.timeout(240)
+def test_tx_format_validate(agent, workspace, patchloom_shim):
+    """Agent should use patchloom tx with format and validate lifecycle steps."""
+    (workspace / "src").mkdir()
+    (workspace / "src" / "config.json").write_text(
+        json.dumps({"version": "1.0.0", "env": "dev"}, indent=2) + "\n"
+    )
+    (workspace / "src" / "settings.json").write_text(
+        json.dumps({"version": "1.0.0", "debug": True}, indent=2) + "\n"
+    )
+    # Create a simple validation script
+    (workspace / "check.sh").write_text(
+        '#!/bin/bash\n'
+        'grep -q "2.0.0" src/config.json && grep -q "2.0.0" src/settings.json\n'
+    )
+    import stat
+    (workspace / "check.sh").chmod(
+        (workspace / "check.sh").stat().st_mode | stat.S_IEXEC
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Update the version from '1.0.0' to '2.0.0' in both "
+        "src/config.json and src/settings.json using a patchloom "
+        "transaction plan. Include a validate step that runs "
+        "'./check.sh' to verify both files were updated correctly.",
+        max_turns=20,
+    )
+
+    # Primary: patchloom tx was used
+    assert_patchloom_used(result, "tx")
+
+    # Secondary: both files updated
+    config = json.loads((workspace / "src" / "config.json").read_text())
+    assert config["version"] == "2.0.0", "config.json version should be 2.0.0"
+
+    settings = json.loads((workspace / "src" / "settings.json").read_text())
+    assert settings["version"] == "2.0.0", "settings.json version should be 2.0.0"

--- a/tests/agent/test_files.py
+++ b/tests/agent/test_files.py
@@ -1,0 +1,131 @@
+"""File lifecycle agent scenarios: create, delete, status, patch."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from conftest import run_scenario
+from drivers.base import assert_patchloom_used
+
+
+@pytest.mark.timeout(180)
+def test_create(agent, workspace, patchloom_shim):
+    """Agent should use patchloom create to make a new file."""
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Create a new file called LICENSE containing the text:\n"
+        "MIT License\n\n"
+        "Copyright (c) 2025 Example Corp\n\n"
+        "Permission is hereby granted, free of charge, to any person.",
+    )
+
+    # Primary: patchloom create was used
+    assert_patchloom_used(result, "create")
+
+    # Secondary: file exists with correct content
+    license_file = workspace / "LICENSE"
+    assert license_file.exists(), "LICENSE should exist"
+    content = license_file.read_text()
+    assert "MIT License" in content, "LICENSE should contain MIT License"
+    assert "Example Corp" in content, "LICENSE should contain Example Corp"
+
+
+@pytest.mark.timeout(180)
+def test_delete(agent, workspace, patchloom_shim):
+    """Agent should use patchloom delete to remove a file."""
+    (workspace / "config.old.json").write_text('{"deprecated": true}\n')
+    (workspace / "config.json").write_text('{"active": true}\n')
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Delete the deprecated file config.old.json. "
+        "Do not touch config.json.",
+    )
+
+    # Primary: patchloom delete was used
+    assert_patchloom_used(result, "delete")
+
+    # Secondary: correct file removed, other preserved
+    assert not (workspace / "config.old.json").exists(), "config.old.json should be deleted"
+    assert (workspace / "config.json").exists(), "config.json should still exist"
+
+
+@pytest.mark.timeout(180)
+def test_status(agent, workspace, patchloom_shim):
+    """Agent checks uncommitted changes. Native git status is acceptable."""
+    # Create a tracked file, commit it, then modify it
+    tracked = workspace / "tracked.txt"
+    tracked.write_text("original\n")
+    subprocess.run(
+        ["git", "add", "tracked.txt"],
+        cwd=workspace, capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "-c", "user.name=test", "-c", "user.email=test@test.com",
+         "commit", "-m", "add tracked"],
+        cwd=workspace, capture_output=True, check=True,
+    )
+    # Now modify it so it shows as changed
+    tracked.write_text("modified\n")
+    # Also create an untracked file
+    (workspace / "untracked.txt").write_text("new\n")
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Which files have uncommitted changes in this project? "
+        "Report the filenames and whether they are modified or new.",
+    )
+
+    # No patchloom assertion: patchloom status is a thin wrapper around
+    # git status with no unique value. Native git status is fine.
+
+    # Assert: agent found the changed files
+    response_text = (result.output_json or {}).get("text", result.stdout)
+    assert "tracked.txt" in response_text, "Agent should mention tracked.txt"
+
+
+@pytest.mark.timeout(240)
+def test_patch(agent, workspace, patchloom_shim):
+    """Agent should use patchloom patch to apply a unified diff."""
+    (workspace / "greeting.py").write_text(
+        "def greet(name):\n"
+        "    return 'Hello, ' + name\n"
+        "\n"
+        "print(greet('World'))\n"
+    )
+
+    diff_text = (
+        "--- a/greeting.py\n"
+        "+++ b/greeting.py\n"
+        "@@ -1,4 +1,5 @@\n"
+        " def greet(name):\n"
+        "-    return 'Hello, ' + name\n"
+        "+    greeting = f'Hello, {name}!'\n"
+        "+    return greeting\n"
+        " \n"
+        " print(greet('World'))\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        f"Apply this unified diff to greeting.py:\n\n```diff\n{diff_text}```",
+        max_turns=20,
+    )
+
+    # Primary: patchloom patch was used
+    assert_patchloom_used(result, "patch")
+
+    # Secondary: file was patched correctly
+    content = (workspace / "greeting.py").read_text()
+    assert "greeting = f'Hello, {name}!'" in content, "Patch should be applied"
+    assert "return greeting" in content, "New return line should be present"

--- a/tests/agent/test_structured.py
+++ b/tests/agent/test_structured.py
@@ -77,3 +77,114 @@ def test_md_table(agent, workspace, patchloom_shim):
     # Existing rows preserved
     assert "build" in content, "Existing 'build' row should be preserved"
     assert "test" in content, "Existing 'test' row should be preserved"
+
+
+@pytest.mark.timeout(180)
+def test_doc_merge(agent, workspace, patchloom_shim):
+    """Agent should use patchloom doc merge to add a new section to a config."""
+    (workspace / "config.yaml").write_text(
+        "app:\n"
+        "  name: myapp\n"
+        "  port: 8080\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Add a 'database' section to config.yaml with these values: "
+        "host is 'localhost', port is 5432, and name is 'mydb'. "
+        "Keep the existing 'app' section intact.",
+    )
+
+    # Primary: patchloom doc was used
+    assert_patchloom_used(result, "doc")
+
+    # Secondary: database section added, app preserved
+    content = (workspace / "config.yaml").read_text()
+    assert "database" in content, "config.yaml should have database section"
+    assert "localhost" in content, "database host should be localhost"
+    assert "5432" in content, "database port should be 5432"
+    assert "mydb" in content, "database name should be mydb"
+    assert "myapp" in content, "app name should be preserved"
+    assert "8080" in content, "app port should be preserved"
+
+
+@pytest.mark.timeout(180)
+def test_md_replace_section(agent, workspace, patchloom_shim):
+    """Agent should use patchloom md replace-section to rewrite a section."""
+    (workspace / "README.md").write_text(
+        "# My Project\n"
+        "\n"
+        "A cool project.\n"
+        "\n"
+        "## Installation\n"
+        "\n"
+        "Run `make install` to install.\n"
+        "\n"
+        "## Usage\n"
+        "\n"
+        "Run `./app` to start.\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Replace the Installation section in README.md with these new "
+        "instructions:\n\n"
+        "```\n"
+        "pip install myproject\n"
+        "```\n\n"
+        "Keep all other sections unchanged.",
+    )
+
+    # Primary: patchloom md was used
+    assert_patchloom_used(result, "md")
+
+    # Secondary: Installation section replaced
+    content = (workspace / "README.md").read_text()
+    assert "pip install myproject" in content, "New installation instructions should be present"
+    assert "make install" not in content, "Old installation instructions should be gone"
+    # Other sections preserved
+    assert "## Usage" in content, "Usage section should be preserved"
+    assert "./app" in content, "Usage content should be preserved"
+
+
+@pytest.mark.timeout(180)
+def test_md_upsert_bullet(agent, workspace, patchloom_shim):
+    """Agent should use patchloom md upsert-bullet to add a rule idempotently."""
+    (workspace / "CONTRIBUTING.md").write_text(
+        "# Contributing\n"
+        "\n"
+        "## Coding Standards\n"
+        "\n"
+        "- Use 4-space indentation\n"
+        "- Write docstrings for all public functions\n"
+        "\n"
+        "## Testing\n"
+        "\n"
+        "Run `make test` before submitting.\n"
+    )
+
+    result = run_scenario(
+        agent,
+        workspace,
+        patchloom_shim,
+        "Add the following rule to the Coding Standards section in "
+        "CONTRIBUTING.md if it is not already there: "
+        "'All functions must have type annotations'. "
+        "Do not duplicate it if it already exists.",
+    )
+
+    # Primary: patchloom md was used
+    assert_patchloom_used(result, "md")
+
+    # Secondary: bullet added
+    content = (workspace / "CONTRIBUTING.md").read_text()
+    assert "type annotations" in content, "New rule should be present"
+    # Existing bullets preserved
+    assert "4-space indentation" in content, "Existing rule should be preserved"
+    assert "docstrings" in content, "Existing rule should be preserved"
+    # Other sections preserved
+    assert "## Testing" in content, "Testing section should be preserved"


### PR DESCRIPTION
## Summary

Add 10 new agent integration test scenarios, bringing the total from 9 to 19 and covering the full patchloom command surface.

## Why

The initial 9 tests covered search, replace, read, batch replace, tx, hygiene, doc set, and md table-append. This left create, delete, status, patch, regex replace, insert-before, doc merge, md replace-section, md upsert-bullet, and tx validate untested.

## New scenarios

| Test | Command | Asserts patchloom? | Result |
|------|---------|-------------------|--------|
| `test_create` | `create` | Yes | PASS |
| `test_delete` | `delete` | Yes | PASS |
| `test_status` | `status` | No (thin wrapper) | PASS |
| `test_patch` | `patch apply` | Yes | PASS |
| `test_replace_regex` | `replace --regex` | Yes | PASS |
| `test_replace_insert` | `replace --insert-before` | Yes | PASS |
| `test_doc_merge` | `doc merge` | Yes | PASS |
| `test_md_replace_section` | `md replace-section` | Yes | PASS |
| `test_md_upsert_bullet` | `md upsert-bullet` | Yes | PASS |
| `test_tx_format_validate` | `tx` with validate | Yes | PASS |

`test_status` follows the same pattern as `test_read`: `patchloom status` is a thin wrapper around `git status` with no unique value, so agents correctly use `git status` directly.

## Coverage summary

| Category | Tests | Patchloom commands covered |
|----------|-------|---------------------------|
| Search | 1 | `search` |
| Replace | 3 | `replace`, `replace --regex`, `replace --insert-before` |
| Read | 1 | native `read_file` (no patchloom assertion) |
| File lifecycle | 3 | `create`, `delete`, native `git status` |
| Patch | 1 | `patch apply` |
| Hygiene | 1 | `hygiene` |
| Doc | 2 | `doc set`, `doc merge` |
| Md | 3 | `md table-append`, `md replace-section`, `md upsert-bullet` |
| Tx | 3 | `tx` multi-file, `tx` read+replace, `tx` with validate |
| Batch | 1 | multi-file `replace` or `tx` |

## Verification

- `make check` passes (421 Rust tests)
- All 19 agent tests pass with Grok Build CLI + Grok LLM

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I am contributing this work under the repository license (`MIT OR Apache-2.0`)