### PR TITLE
Print agent metadata in test session header

### DIFF
--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -120,6 +120,23 @@ def workspace(tmp_path, patchloom_bin):
     return tmp_path
 
 
+def pytest_report_header(config):
+    """Print agent and model metadata at the top of every test run."""
+    agent_name = config.getoption("--agent")
+    model = config.getoption("--model")
+    driver = create_driver(agent_name, model)
+    if not driver.is_available():
+        return [f"agent: {agent_name} (NOT AVAILABLE)"]
+    meta = driver.get_metadata()
+    # Stash for later use by fixtures
+    config._agent_metadata = meta
+    return [
+        f"agent: {meta.agent_name}  "
+        f"model: {meta.model_name} ({meta.model_alias})  "
+        f"cli: {meta.cli_version}",
+    ]
+
+
 @pytest.fixture
 def agent(request):
     """Create the agent driver from CLI flags."""

--- a/tests/agent/drivers/__init__.py
+++ b/tests/agent/drivers/__init__.py
@@ -1,1 +1,1 @@
-from .base import AgentDriver, AgentResult, create_driver
+from .base import AgentDriver, AgentMetadata, AgentResult, create_driver

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -20,6 +20,16 @@ class AgentResult:
     patchloom_calls: list[dict] = field(default_factory=list)
 
 
+@dataclass
+class AgentMetadata:
+    """Metadata about the agent and model used for a test run."""
+
+    agent_name: str       # e.g. "grok"
+    model_alias: str      # e.g. "grok-build"
+    model_name: str       # e.g. "Grok 4.3"
+    cli_version: str      # e.g. "grok 0.1.211 (2f2cd6d5c)"
+
+
 class AgentDriver(ABC):
     """Abstract interface for invoking an AI agent in headless mode."""
 
@@ -42,6 +52,10 @@ class AgentDriver(ABC):
     @abstractmethod
     def is_available(self) -> bool:
         """Check if this agent and model are configured and reachable."""
+
+    @abstractmethod
+    def get_metadata(self) -> AgentMetadata:
+        """Return metadata about the agent, model, and CLI version."""
 
 
 def create_driver(agent_name: str, model: str) -> AgentDriver:

--- a/tests/agent/drivers/grok.py
+++ b/tests/agent/drivers/grok.py
@@ -9,7 +9,7 @@ import subprocess
 import time
 from pathlib import Path
 
-from .base import AgentDriver, AgentResult, parse_shim_log
+from .base import AgentDriver, AgentMetadata, AgentResult, parse_shim_log
 
 
 class GrokDriver(AgentDriver):
@@ -76,6 +76,41 @@ class GrokDriver(AgentDriver):
 
     def is_available(self) -> bool:
         return shutil.which("grok") is not None
+
+    def get_metadata(self) -> AgentMetadata:
+        # CLI version
+        cli_version = "unknown"
+        try:
+            proc = subprocess.run(
+                ["grok", "--version"],
+                capture_output=True, text=True, timeout=5,
+            )
+            cli_version = proc.stdout.strip()
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+        # Model name (ask the model to self-identify)
+        model_name = "unknown"
+        try:
+            proc = subprocess.run(
+                ["grok", "-p",
+                 "Reply with ONLY your model name and version, nothing else.",
+                 "--output-format", "json", "-m", self.model,
+                 "--max-turns", "1"],
+                capture_output=True, text=True, timeout=30,
+            )
+            data = json.loads(proc.stdout)
+            model_name = data.get("text", "unknown").strip()
+        except (subprocess.TimeoutExpired, FileNotFoundError,
+                json.JSONDecodeError, KeyError):
+            pass
+
+        return AgentMetadata(
+            agent_name=self.name,
+            model_alias=self.model,
+            model_name=model_name,
+            cli_version=cli_version,
+        )
 
 
 def _try_parse_json(text: str) -> dict | None:


### PR DESCRIPTION
## Summary

Show agent name, model name, model alias, and CLI version in the pytest session header for every agent test run.

## Why

When reviewing test results, you need to know exactly which LLM and CLI version produced them. Previously this was not captured anywhere.

## Output

```
============================= test session starts ==============================
platform linux -- Python 3.14.4, pytest-9.0.3
agent: grok  model: Grok 4.3 (grok-build)  cli: grok 0.1.211 (2f2cd6d5c)
rootdir: /home/sebtardif/patchloom/tests/agent
```

## Changes

- **drivers/base.py**: Add `AgentMetadata` dataclass and abstract `get_metadata()` method
- **drivers/grok.py**: Implement `get_metadata()`: resolves CLI version via `grok --version`, model name via self-identification prompt
- **conftest.py**: Add `pytest_report_header` hook that prints metadata in the standard header

## Verification

- `make check` passes (421 Rust tests)
- Agent test header prints correctly with and without `-v`/`-s` flags

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I am contributing this work under the repository license (`MIT OR Apache-2.0`)