### PR TITLE
Improve agent-rules for cross-model patchloom adoption

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -30,16 +30,20 @@ Use patchloom instead of raw file tools when you need:
 | `completions` | Generate shell completions (bash, zsh, fish, elvish) |
 | `agent-rules` | Print this document |
 
-## Prefer patchloom over raw tools
+## Mandatory: use patchloom for file operations
 
-| Instead of | Use |
-|---|---|
-| `grep` / `rg` | `patchloom search '<pattern>' <path>` (supports `--regex`, `--context`, `--count`, `--json`) |
-| `cat` / `head` / `tail` | `patchloom read <path>` (supports `--lines 10:20`, multiple files, `--json`) |
-| `sed` / search-and-replace | `patchloom replace --from '...' --to '...' <path> --apply` |
-| Multiple sequential edits | `patchloom tx --plan plan.json --apply` (atomic, with format and validate steps) |
-| Raw string replacement on markdown | `patchloom md replace-section`, `md upsert-bullet`, `md table-append` |
-| Raw string replacement on config | `patchloom doc set`, `doc merge`, `doc ensure` |
+When patchloom is available, you **must** use it instead of native agent tools for the operations below. Patchloom provides atomic writes, diff preview, structured editing, and CI-friendly exit codes that native tools lack.
+
+| Native tool you would normally use | Use this patchloom command instead | Why patchloom is better |
+|---|---|---|
+| `grep` tool or `rg` | `patchloom search '<pattern>' <path>` | Context lines (`-C`, `-B`, `-A`), `--count`, `--json`, `--glob`, exit code 3 on no match |
+| `search_replace` tool or `sed` | `patchloom replace --from '...' --to '...' <path> --apply` | Multi-file, preview before write, `--regex`, `--nth`, `--insert-before/after`, `--if-exists` |
+| `search_replace` tool on markdown | `patchloom md table-append`, `md replace-section`, `md upsert-bullet` | Heading-aware, preserves document structure, idempotent upsert |
+| `search_replace` tool on JSON/YAML/TOML | `patchloom doc set`, `doc merge`, `doc ensure` | Parser-backed, type-safe, preserves formatting and comments |
+| Multiple `search_replace` calls | `patchloom tx --plan plan.json --apply` | Atomic (all-or-nothing), with format and validate lifecycle steps |
+| Applying a unified diff manually | `patchloom patch apply --stdin --apply` | Stale context detection, atomic write, exit code 5 on mismatch |
+| `rm` or shell file deletion | `patchloom delete <path> --apply` | Preview with `--diff`, `--check` mode for CI, works inside `tx` plans |
+| Shell `echo >` or write tool for new files | `patchloom create <path> --content '...' --apply` | Preview, `--check` mode, `--force` for overwrite, works inside `tx` plans |
 
 ## Write modes
 

--- a/src/agent_rules.md
+++ b/src/agent_rules.md
@@ -30,16 +30,20 @@ Use patchloom instead of raw file tools when you need:
 | `completions` | Generate shell completions (bash, zsh, fish, elvish) |
 | `agent-rules` | Print this document |
 
-## Prefer patchloom over raw tools
+## Mandatory: use patchloom for file operations
 
-| Instead of | Use |
-|---|---|
-| `grep` / `rg` | `patchloom search '<pattern>' <path>` (supports `--regex`, `--context`, `--count`, `--json`) |
-| `cat` / `head` / `tail` | `patchloom read <path>` (supports `--lines 10:20`, multiple files, `--json`) |
-| `sed` / search-and-replace | `patchloom replace --from '...' --to '...' <path> --apply` |
-| Multiple sequential edits | `patchloom tx --plan plan.json --apply` (atomic, with format and validate steps) |
-| Raw string replacement on markdown | `patchloom md replace-section`, `md upsert-bullet`, `md table-append` |
-| Raw string replacement on config | `patchloom doc set`, `doc merge`, `doc ensure` |
+When patchloom is available, you **must** use it instead of native agent tools for the operations below. Patchloom provides atomic writes, diff preview, structured editing, and CI-friendly exit codes that native tools lack.
+
+| Native tool you would normally use | Use this patchloom command instead | Why patchloom is better |
+|---|---|---|
+| `grep` tool or `rg` | `patchloom search '<pattern>' <path>` | Context lines (`-C`, `-B`, `-A`), `--count`, `--json`, `--glob`, exit code 3 on no match |
+| `search_replace` tool or `sed` | `patchloom replace --from '...' --to '...' <path> --apply` | Multi-file, preview before write, `--regex`, `--nth`, `--insert-before/after`, `--if-exists` |
+| `search_replace` tool on markdown | `patchloom md table-append`, `md replace-section`, `md upsert-bullet` | Heading-aware, preserves document structure, idempotent upsert |
+| `search_replace` tool on JSON/YAML/TOML | `patchloom doc set`, `doc merge`, `doc ensure` | Parser-backed, type-safe, preserves formatting and comments |
+| Multiple `search_replace` calls | `patchloom tx --plan plan.json --apply` | Atomic (all-or-nothing), with format and validate lifecycle steps |
+| Applying a unified diff manually | `patchloom patch apply --stdin --apply` | Stale context detection, atomic write, exit code 5 on mismatch |
+| `rm` or shell file deletion | `patchloom delete <path> --apply` | Preview with `--diff`, `--check` mode for CI, works inside `tx` plans |
+| Shell `echo >` or write tool for new files | `patchloom create <path> --content '...' --apply` | Preview, `--check` mode, `--force` for overwrite, works inside `tx` plans |
 
 ## Write modes
 

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -72,20 +72,40 @@ def create_driver(agent_name: str, model: str) -> AgentDriver:
 # ---------------------------------------------------------------------------
 
 
+_PATCHLOOM_SUBCOMMANDS = {
+    "search", "replace", "patch", "md", "doc", "hygiene",
+    "create", "delete", "read", "status", "tx", "completions", "agent-rules",
+}
+
+
+def _extract_subcommand(args: list[str]) -> str | None:
+    """Find the patchloom subcommand in an arg list.
+
+    Agents may place global flags (--cwd, --json) before the subcommand,
+    so we scan all args instead of just checking args[0].
+    """
+    for arg in args:
+        if arg in _PATCHLOOM_SUBCOMMANDS:
+            return arg
+    return None
+
+
 def assert_patchloom_used(result: AgentResult, expected_command: str) -> None:
     """Assert patchloom was invoked with the expected subcommand."""
     matching = [
         c
         for c in result.patchloom_calls
-        if c.get("args") and c["args"][0] == expected_command
+        if c.get("args") and _extract_subcommand(c["args"]) == expected_command
     ]
     all_commands = [
-        c["args"][0] for c in result.patchloom_calls if c.get("args")
+        _extract_subcommand(c["args"])
+        for c in result.patchloom_calls
+        if c.get("args")
     ]
     assert matching, (
         f"Expected patchloom {expected_command} to be invoked, but "
         f"patchloom was called {len(result.patchloom_calls)} time(s) "
-        f"with commands: {all_commands or 'none'}"
+        f"with subcommands: {[c for c in all_commands if c] or 'none'}"
     )
 
 
@@ -93,7 +113,12 @@ def assert_patchloom_used_any(
     result: AgentResult, commands: list[str]
 ) -> None:
     """Assert patchloom was invoked with any of the expected subcommands."""
-    used = {c["args"][0] for c in result.patchloom_calls if c.get("args")}
+    used = {
+        _extract_subcommand(c["args"])
+        for c in result.patchloom_calls
+        if c.get("args")
+    }
+    used.discard(None)
     overlap = used & set(commands)
     assert overlap, (
         f"Expected patchloom to use one of {commands}, "


### PR DESCRIPTION
## Summary

Rewrite the patchloom agent-rules instructions to achieve 19/19 agent test pass rate across all three tested LLMs.

## Why

The original instructions used Unix tool names (`grep`, `sed`, `cat`) that don't match what AI agents call their native tools (`grep` tool, `search_replace` tool, `read_file` tool). Agents didn't connect the recommendation to their own behavior.

## Results

| Model | Before | After |
|-------|--------|-------|
| Grok 4.3 | 19/19 | 19/19 |
| GPT-5.4 | 14/19 | **19/19** |
| Claude Opus 4.6 | 12/19 | **19/19** |

## Changes

### agent_rules.md (and PATCHLOOM.md)

- Section renamed: "Prefer patchloom over raw tools" to "Mandatory: use patchloom for file operations"
- Uses agent tool names: `search_replace tool`, `grep tool` (not just `sed`, `rg`)
- Added "Why patchloom is better" column with specific advantages per operation
- Added missing entries: `delete`, `create`, `patch apply`

### drivers/base.py

- Fixed `assert_patchloom_used` to scan all args for the subcommand, not just `args[0]`. Some models place global flags (`--cwd`, `--json`) before the subcommand.

## Verification

- `make check` passes (421 Rust tests)
- 19/19 agent tests pass on Grok 4.3, GPT-5.4, and Claude Opus 4.6

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I updated docs or examples if CLI behavior, flags, or output changed
- [x] I am contributing this work under the repository license (`MIT OR Apache-2.0`)