### PR TITLE
Add MODEL= flag to make agent-test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Patchloom is a Rust CLI for agent-grade repo operations. It provides thirteen co
 | `make update-readme` | Update README.md and CHANGELOG.md test counts from actual `cargo test` output |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |
 | `make check-patchloom-md` | Verify PATCHLOOM.md matches `patchloom agent-rules` output (part of `check`) |
-| `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`) |
+| `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
 
 Always run `make check` before committing. It is the full CI gate.
 

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ check-patchloom-md: ## Verify PATCHLOOM.md matches patchloom agent-rules output
 	@cargo run --quiet -- agent-rules | diff -q - PATCHLOOM.md >/dev/null 2>&1 \
 		|| (echo "ERROR: PATCHLOOM.md is stale. Run 'make sync-patchloom-md' to update." && exit 1)
 
-agent-test: build ## Run agent integration tests (requires LLM API key)
+agent-test: build ## Run agent integration tests (requires LLM API key). Use MODEL=X to switch LLM.
 	@cd tests/agent && \
 		([ -d .venv ] || python3 -m venv .venv) && \
 		.venv/bin/pip install -q -r requirements.txt && \
-		.venv/bin/pytest -v --timeout 240
+		.venv/bin/pytest -v --timeout 240 $(if $(MODEL),--model $(MODEL),)


### PR DESCRIPTION
## Summary

Support `MODEL=X make agent-test` for switching the LLM model without navigating to the test directory.

## Why

Previously, testing with a different model required `cd tests/agent && .venv/bin/pytest --model X`. This adds the convenience of staying at repo root.

## Usage

```bash
make agent-test                           # default (grok-build)
make agent-test MODEL=sxs-gpt-5-4        # GPT-5.4
make agent-test MODEL=sxs-claude-opus-4-6 # Claude Opus 4.6
```

## Verification

- `make check` passes (421 tests)

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I am contributing this work under the repository license (`MIT OR Apache-2.0`)