### PR TITLE
Add batch benchmark and improve tx batching instruction

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -24,7 +24,7 @@ For simple operations (read, search, string replace, create, delete), use your n
 | Append to a markdown table | `patchloom md table-append --file README.md --heading "## Commands" --row "\| cmd \| desc \|" --apply` | Heading-aware, finds the right table. `search_replace` on tables is fragile. |
 | Replace a markdown section | `patchloom md replace-section --file CHANGELOG.md --heading "## Unreleased" --content "new text" --apply` | Replaces only the section body, preserves everything else. |
 | Add a bullet idempotently | `patchloom md upsert-bullet --file AGENTS.md --heading "## Rules" --bullet "- New rule" --apply` | Skips if already present. |
-| Atomic multi-file edit | `patchloom tx --plan plan.json --apply` | All-or-nothing with rollback, format and validate lifecycle steps. |
+| Edit 3+ files at once | `patchloom tx --plan plan.json --apply` | **One tool call instead of N.** Batches doc/replace/create/md ops into a single plan. Also provides rollback and format/validate lifecycle. Always prefer `tx` over repeated individual calls when editing multiple files. |
 | Apply a unified diff | `patchloom patch apply --stdin --apply` | Stale context detection (exit 5 on mismatch). |
 | Check for whitespace drift | `patchloom hygiene check .` | Exit 2 when issues found. CI-friendly. |
 

--- a/src/agent_rules.md
+++ b/src/agent_rules.md
@@ -24,7 +24,7 @@ For simple operations (read, search, string replace, create, delete), use your n
 | Append to a markdown table | `patchloom md table-append --file README.md --heading "## Commands" --row "\| cmd \| desc \|" --apply` | Heading-aware, finds the right table. `search_replace` on tables is fragile. |
 | Replace a markdown section | `patchloom md replace-section --file CHANGELOG.md --heading "## Unreleased" --content "new text" --apply` | Replaces only the section body, preserves everything else. |
 | Add a bullet idempotently | `patchloom md upsert-bullet --file AGENTS.md --heading "## Rules" --bullet "- New rule" --apply` | Skips if already present. |
-| Atomic multi-file edit | `patchloom tx --plan plan.json --apply` | All-or-nothing with rollback, format and validate lifecycle steps. |
+| Edit 3+ files at once | `patchloom tx --plan plan.json --apply` | **One tool call instead of N.** Batches doc/replace/create/md ops into a single plan. Also provides rollback and format/validate lifecycle. Always prefer `tx` over repeated individual calls when editing multiple files. |
 | Apply a unified diff | `patchloom patch apply --stdin --apply` | Stale context detection (exit 5 on mismatch). |
 | Check for whitespace drift | `patchloom hygiene check .` | Exit 2 when issues found. CI-friendly. |
 

--- a/tests/agent/test_bench.py
+++ b/tests/agent/test_bench.py
@@ -106,6 +106,26 @@ TASKS = [
         "setup": lambda ws: (ws / "package.json").write_text(json.dumps({"name": "myapp", "version": "1.0.0"}, indent=2) + "\n"),
         "check": lambda ws: (ws / "hello.txt").exists() and json.loads((ws / "package.json").read_text()).get("version") == "3.0.0",
     },
+    {
+        "name": "batch_6_files",
+        "prompt": "Update the version from '1.0.0' to '2.0.0' in ALL of these files: package.json, pyproject.toml, config.yaml, config.json, version.txt, and the badge in README.md. Make sure every single file is updated.",
+        "setup": lambda ws: [
+            (ws / "package.json").write_text(json.dumps({"name": "myapp", "version": "1.0.0"}, indent=2) + "\n"),
+            (ws / "pyproject.toml").write_text('[project]\nname = "myapp"\nversion = "1.0.0"\n'),
+            (ws / "config.yaml").write_text("app:\n  name: myapp\n  version: '1.0.0'\n"),
+            (ws / "config.json").write_text(json.dumps({"app_name": "myapp", "version": "1.0.0"}, indent=2) + "\n"),
+            (ws / "version.txt").write_text("1.0.0\n"),
+            (ws / "README.md").write_text("# MyApp\n\n![version](https://img.shields.io/badge/version-1.0.0-blue)\n\nA sample app.\n"),
+        ],
+        "check": lambda ws: all([
+            json.loads((ws / "package.json").read_text()).get("version") == "2.0.0",
+            "2.0.0" in (ws / "pyproject.toml").read_text(),
+            "2.0.0" in (ws / "config.yaml").read_text(),
+            json.loads((ws / "config.json").read_text()).get("version") == "2.0.0",
+            (ws / "version.txt").read_text().strip() == "2.0.0",
+            "2.0.0" in (ws / "README.md").read_text(),
+        ]),
+    },
 ]
 
 


### PR DESCRIPTION
## Summary

Adds a batch_6_files benchmark task and improves the tx instruction to encourage batching for speed, not just atomicity.

## Why

The previous benchmarks only tested single-operation tasks where patchloom can't leverage its batching advantage. Patchloom's `tx` command can collapse N file operations into 1 tool call, eliminating N-1 LLM round-trips (~15-20s each). The instructions described tx as 'Atomic multi-file edit' which agents interpreted as 'for atomicity only,' missing the speed benefit.

## Changes

- Add `batch_6_files` task: update version in 6 config files (JSON, YAML, TOML, txt, md)
- Update agent_rules.md tx row: 'Edit 3+ files at once' with emphasis on batching speed
- Regenerate PATCHLOOM.md

## Results

The instruction change reduced patchloom calls from 28 to 6-8 (agents now batch via tx).

| Task | Grok delta | GPT-5.4 delta | Claude delta |
|---|---|---|---|
| tx_multi_file | **PL -10.3s** | **PL -18.6s** | native +6.0s |
| batch_6_files | native +8.3s | **PL -2.1s** | ~same |
| Simple tasks | ~same | native faster | native faster |

Patchloom's value shows in multi-file operations where batching eliminates LLM round-trips.

## Verification

- `make check` passes (421 tests)
- Benchmarks run on all three models

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I am contributing this work under the repository license (`MIT OR Apache-2.0`)