### PR TITLE
Fix make update-readme for redesigned README format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Agent integration tests (`make agent-test`): 19 scenarios verifying AI agents use patchloom when given PATCHLOOM.md instructions. Uses a shim binary to capture every patchloom invocation. Supports pluggable agent drivers (Grok Build CLI first, extensible to Claude Code and others)
 - CLI benchmarks (`make bench-cli`): patchloom vs native tools (grep, sed, cat, jq) using hyperfine across small/medium/large synthetic corpora
 - Agent A/B benchmarks (`make bench-agent`): compares agent performance with and without patchloom AGENTS.md instructions, measuring duration, tool call count, and success rate
-- 255 integration tests and agent tests verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 421 tests (166 unit + 255 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ update-readme: ## Update README.md and CHANGELOG.md test counts
 	if [ -z "$$unit" ] || [ -z "$$integ" ]; then echo "ERROR: failed to parse test counts (unit=$$unit integ=$$integ)"; exit 1; fi; \
 	total=$$((unit + integ)); \
 	cmds=$$(cargo run --quiet -- --help 2>/dev/null | sed -n '/^Commands:/,/^$$/p' | grep '^ ' | grep -cv '^ *help'); \
-	ver=$$(grep '^V[0-9]' README.md | head -1 | sed 's/^\(V[0-9]*\).*/\1/'); \
-	sed -i "s/V[0-9]* with [0-9]* commands and [0-9]* passing tests\./$$ver with $$cmds commands and $$total passing tests./" README.md; \
+	sed -i "s/tests-[0-9]*%20passing/tests-$$total%20passing/" README.md; \
+	sed -i "s/[0-9]* passing tests across [0-9]* commands/$$total passing tests across $$cmds commands/" README.md; \
 	sed -i "/^## \[Unreleased\]/,/^## \[/ s/- [0-9]* tests ([0-9]* unit + [0-9]* integration)/- $$total tests ($$unit unit + $$integ integration)/" CHANGELOG.md; \
-	echo "README.md and CHANGELOG.md updated: $$ver, $$cmds commands, $$total tests ($$unit unit + $$integ integration)"
+	echo "README.md and CHANGELOG.md updated: $$cmds commands, $$total tests ($$unit unit + $$integ integration)"
 
 sync-patchloom-md: ## Regenerate PATCHLOOM.md from patchloom agent-rules
 	cargo run --quiet -- agent-rules > PATCHLOOM.md

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-255%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-421%20passing-brightgreen)](#)
 
 **Make your AI agent edit files faster.**
 
@@ -700,7 +700,7 @@ All commits must be signed off with `git commit -s`.
 
 ## Status
 
-255 passing tests across 13 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+421 passing tests across 13 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 


### PR DESCRIPTION
## Summary

PR #178 redesigned the README and CHANGELOG formats but did not update the Makefile `update-readme` target. The sed patterns no longer matched, so running `make update-readme` succeeded (exit 0) but changed nothing. Test counts were stuck at 255 instead of the correct 421 (166 unit + 255 integration).

## Why

The test badge and status line showed 255 (integration tests only) instead of the actual 421 total tests. Future test additions would never be reflected in the README.

## Verification

- `make check` passes (166 unit + 255 integration + clippy + fmt)
- `make update-readme` is now idempotent (running it twice produces no diff)
- Badge, status line, and CHANGELOG all show 421

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I updated docs or examples if CLI behavior, flags, or output changed