### PR TITLE
Add unit tests for files.rs and binary file skip integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Agent integration tests (`make agent-test`): 19 scenarios verifying AI agents use patchloom when given PATCHLOOM.md instructions. Uses a shim binary to capture every patchloom invocation. Supports pluggable agent drivers (Grok Build CLI first, extensible to Claude Code and others)
 - CLI benchmarks (`make bench-cli`): patchloom vs native tools (grep, sed, cat, jq) using hyperfine across small/medium/large synthetic corpora
 - Agent A/B benchmarks (`make bench-agent`): compares agent performance with and without patchloom AGENTS.md instructions, measuring duration, tool call count, and success rate
-- 421 tests (166 unit + 255 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 436 tests (178 unit + 258 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-421%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-436%20passing-brightgreen)](#)
 
 **Make your AI agent edit files faster.**
 
@@ -700,7 +700,7 @@ All commits must be signed off with `git commit -s`.
 
 ## Status
 
-421 passing tests across 13 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+436 passing tests across 13 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -144,3 +144,110 @@ where
         results
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── is_binary ─────────────────────────────────────────────────────
+
+    #[test]
+    fn text_is_not_binary() {
+        assert!(!is_binary(b"hello world\n"));
+    }
+
+    #[test]
+    fn empty_is_not_binary() {
+        assert!(!is_binary(b""));
+    }
+
+    #[test]
+    fn nul_byte_makes_binary() {
+        assert!(is_binary(b"hello\x00world"));
+    }
+
+    #[test]
+    fn nul_at_8k_boundary_is_binary() {
+        let mut data = vec![b'a'; 8191];
+        data.push(0);
+        assert!(is_binary(&data));
+    }
+
+    #[test]
+    fn nul_past_8k_is_not_binary() {
+        let mut data = vec![b'a'; 8192];
+        data.push(0);
+        assert!(!is_binary(&data));
+    }
+
+    // ── matches_glob ──────────────────────────────────────────────────
+
+    #[test]
+    fn no_matcher_matches_everything() {
+        assert!(matches_glob(Path::new("any/file.rs"), None));
+    }
+
+    #[test]
+    fn glob_matches_extension() {
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("*.rs").unwrap());
+        let matcher = builder.build().unwrap();
+        assert!(matches_glob(Path::new("src/main.rs"), Some(&matcher)));
+    }
+
+    #[test]
+    fn glob_rejects_non_matching() {
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("*.rs").unwrap());
+        let matcher = builder.build().unwrap();
+        assert!(!matches_glob(Path::new("src/main.py"), Some(&matcher)));
+    }
+
+    // ── par_process_files ─────────────────────────────────────────────
+
+    #[test]
+    fn par_process_single_file() {
+        let paths = vec![PathBuf::from("a.txt")];
+        let results = par_process_files(&paths, None, |p| Some(p.to_string_lossy().to_string()));
+        assert_eq!(results, vec!["a.txt"]);
+    }
+
+    #[test]
+    fn par_process_filters_with_glob() {
+        let paths = vec![
+            PathBuf::from("a.rs"),
+            PathBuf::from("b.py"),
+            PathBuf::from("c.rs"),
+        ];
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("*.rs").unwrap());
+        let matcher = builder.build().unwrap();
+        let results = par_process_files(&paths, Some(&matcher), |p| {
+            Some(p.to_string_lossy().to_string())
+        });
+        assert_eq!(results.len(), 2);
+        assert!(results.contains(&"a.rs".to_string()));
+        assert!(results.contains(&"c.rs".to_string()));
+    }
+
+    #[test]
+    fn par_process_empty_paths() {
+        let paths: Vec<PathBuf> = vec![];
+        let results: Vec<String> =
+            par_process_files(&paths, None, |p| Some(p.to_string_lossy().to_string()));
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn par_process_closure_can_filter() {
+        let paths = vec![PathBuf::from("a.txt"), PathBuf::from("b.txt")];
+        let results = par_process_files(&paths, None, |p| {
+            if p.to_string_lossy().contains('a') {
+                Some(1)
+            } else {
+                None
+            }
+        });
+        assert_eq!(results, vec![1]);
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7303,3 +7303,94 @@ fn test_reference_doc_requires_use_when_stanza() {
         errors.join("\n\n")
     );
 }
+
+// ── binary file handling ─────────────────────────────────────────────
+
+#[test]
+fn test_search_skips_binary_files() {
+    let dir = TempDir::new().unwrap();
+    let text_file = dir.path().join("text.txt");
+    fs::write(&text_file, "needle in text\n").unwrap();
+    // Binary file: contains NUL byte.
+    let bin_file = dir.path().join("data.bin");
+    fs::write(&bin_file, b"needle\x00in binary").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("needle")
+        .arg(dir.path().to_str().unwrap())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("text.txt"),
+        "should find match in text file"
+    );
+    assert!(
+        !stdout.contains("data.bin"),
+        "should skip binary file, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_replace_skips_binary_files() {
+    let dir = TempDir::new().unwrap();
+    let text_file = dir.path().join("text.txt");
+    fs::write(&text_file, "old value\n").unwrap();
+    // Binary file with the same target text.
+    let bin_file = dir.path().join("data.bin");
+    let mut bin_content = b"old value".to_vec();
+    bin_content.push(0);
+    bin_content.extend_from_slice(b" more data");
+    fs::write(&bin_file, &bin_content).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("--from")
+        .arg("old value")
+        .arg("--to")
+        .arg("new value")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    let text_content = fs::read_to_string(&text_file).unwrap();
+    assert_eq!(text_content, "new value\n");
+
+    // Binary file should be untouched.
+    let bin_after = fs::read(&bin_file).unwrap();
+    assert_eq!(bin_after, bin_content, "binary file should not be modified");
+}
+
+#[test]
+fn test_hygiene_skips_binary_files() {
+    let dir = TempDir::new().unwrap();
+    // Text file with trailing whitespace.
+    let text_file = dir.path().join("text.txt");
+    fs::write(&text_file, "hello   \n").unwrap();
+    // Binary file with trailing spaces (should not be touched).
+    let bin_file = dir.path().join("data.bin");
+    let mut bin_content = b"hello   ".to_vec();
+    bin_content.push(0);
+    fs::write(&bin_file, &bin_content).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("hygiene")
+        .arg("fix")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--trim-trailing-whitespace")
+        .arg("--apply")
+        .assert()
+        .success();
+
+    let text_content = fs::read_to_string(&text_file).unwrap();
+    assert_eq!(text_content, "hello\n");
+
+    let bin_after = fs::read(&bin_file).unwrap();
+    assert_eq!(bin_after, bin_content, "binary file should not be modified");
+}


### PR DESCRIPTION
## Summary

Add 15 new tests covering previously untested code paths.

## Why

`files.rs` had zero tests despite containing critical functions (`is_binary`, `matches_glob`, `par_process_files`) used by search, replace, and hygiene. Binary file skipping was never tested at the integration level.

## Verification

- `make check` passes (436 tests: 178 unit + 258 integration)
- All 15 new tests pass
- Test count updated in README and CHANGELOG

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I updated docs or examples if CLI behavior, flags, or output changed