### PR TITLE
Add file path context to doc parse and read errors

### DIFF
--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -4,6 +4,7 @@ use crate::exit;
 use crate::selector;
 use crate::write;
 use crate::write::policy_from_flags;
+use anyhow::Context;
 use clap::Args;
 use serde::Serialize;
 use std::path::Path;
@@ -111,17 +112,22 @@ pub(crate) fn detect_format(path: &str) -> anyhow::Result<FileFormat> {
 }
 
 fn load_file(path: &str) -> anyhow::Result<serde_json::Value> {
-    let content = std::fs::read_to_string(path)?;
+    let content = std::fs::read_to_string(path).with_context(|| format!("reading {path}"))?;
     let format = detect_format(path)?;
     match format {
-        FileFormat::Json => Ok(serde_json::from_str(&content)?),
-        FileFormat::Yaml => Ok(serde_yaml_ng::from_str(&content)?),
+        FileFormat::Json => {
+            Ok(serde_json::from_str(&content).with_context(|| format!("parsing {path}"))?)
+        }
+        FileFormat::Yaml => {
+            Ok(serde_yaml_ng::from_str(&content).with_context(|| format!("parsing {path}"))?)
+        }
         FileFormat::Toml => {
             // Parse with DocumentMut, then deserialize to serde_json::Value.
             let _doc: toml_edit::DocumentMut = content
                 .parse()
-                .map_err(|e: toml_edit::TomlError| anyhow::anyhow!("{e}"))?;
-            let value: serde_json::Value = toml_edit::de::from_str(&content)?;
+                .map_err(|e: toml_edit::TomlError| anyhow::anyhow!("parsing {path}: {e}"))?;
+            let value: serde_json::Value =
+                toml_edit::de::from_str(&content).with_context(|| format!("parsing {path}"))?;
             Ok(value)
         }
     }
@@ -331,12 +337,18 @@ pub(crate) fn serialize_value(
 
 /// Load a file, returning original content, parsed value, and detected format.
 fn load_file_with_content(path: &str) -> anyhow::Result<(String, serde_json::Value, FileFormat)> {
-    let content = std::fs::read_to_string(path)?;
+    let content = std::fs::read_to_string(path).with_context(|| format!("reading {path}"))?;
     let format = detect_format(path)?;
     let value = match &format {
-        FileFormat::Json => serde_json::from_str(&content)?,
-        FileFormat::Yaml => serde_yaml_ng::from_str(&content)?,
-        FileFormat::Toml => toml_edit::de::from_str(&content)?,
+        FileFormat::Json => {
+            serde_json::from_str(&content).with_context(|| format!("parsing {path}"))?
+        }
+        FileFormat::Yaml => {
+            serde_yaml_ng::from_str(&content).with_context(|| format!("parsing {path}"))?
+        }
+        FileFormat::Toml => {
+            toml_edit::de::from_str(&content).with_context(|| format!("parsing {path}"))?
+        }
     };
     Ok((content, value, format))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ fn main() -> ExitCode {
     match patchloom::run() {
         Ok(code) => ExitCode::from(code),
         Err(e) => {
-            eprintln!("patchloom: {e}");
+            eprintln!("patchloom: {e:#}");
             ExitCode::from(1)
         }
     }


### PR DESCRIPTION
## Summary

Wrap doc command parse and read errors with file path context using `anyhow::Context`, and display the full error chain in the CLI output.

## Why

When `doc get` or `doc set` encounters a malformed file, the error message showed only the parser error (e.g., "expected ident at line 1 column 2") without identifying which file was involved. This is especially confusing in `tx` plans that process multiple files.

**Before:** `patchloom: expected ident at line 1 column 2`
**After:** `patchloom: parsing /tmp/bad.json: expected ident at line 1 column 2`

## Verification

- `make check` passes (436 tests: 178 unit + 258 integration)
- Manually tested with malformed JSON, nonexistent file, and valid file
- Error chain displays correctly with `{e:#}` format

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I updated docs or examples if CLI behavior, flags, or output changed