### PR TITLE
Remove dead error.rs placeholder module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,6 @@ src/
   selector/parser.rs   Path selector parser (key, index, wildcard, predicate segments)
   selector/eval.rs     Evaluate parsed selectors against serde_json::Value trees
   agent_rules.md       End-user AGENTS.md template, embedded at compile time by agent-rules command
-  error.rs             Reserved for future structured error types (currently a placeholder)
   exit.rs              Exit code constants: SUCCESS=0, FAILURE=1, CHANGES_DETECTED=2,
                        NO_MATCHES=3, PARSE_ERROR=4, AMBIGUOUS=5, VALIDATION_FAILED=6, ROLLBACK=7
   diff.rs              Unified diff generation using similar::TextDiff; FileDiff and DiffResult types

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,2 +1,0 @@
-// Reserved for future structured error types.
-// Exit codes are currently returned directly via `exit::*` constants.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 pub mod cli;
 pub mod cmd;
 pub mod diff;
-pub mod error;
 pub mod exit;
 pub(crate) mod files;
 pub(crate) mod ops;


### PR DESCRIPTION
## Summary

Remove the empty `src/error.rs` placeholder module and its `pub mod error` declaration in `lib.rs`.

## Why

The module contained only a comment ("Reserved for future structured error types") and was not imported anywhere in the codebase. Exit codes via `exit.rs` constants are the actual error mechanism. Dead modules add noise to the project structure listing.

## Verification

- `make check` passes (436 tests: 178 unit + 258 integration)
- `grep -r 'error::' src/` confirms no imports existed
- Updated AGENTS.md project structure to remove the entry

## Checklist

- [x] All commits in this pull request are signed off with `git commit -s`
- [x] I ran the relevant test, lint, and format steps for the files I changed
- [x] I updated docs or examples if CLI behavior, flags, or output changed