### PR TITLE
Tighten file-only contracts and honor jsonl across all commands

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -83,8 +83,8 @@ These flags affect how Patchloom reports results or chooses which files to touch
 <!-- ref:global-flag:jsonl -->
 ### `--jsonl`
 
-- **What it does:** Emits one JSON object per result line.
-- **Use when:** A read style command may produce many results and you want to stream them incrementally to another tool.
+- **What it does:** Emits one JSON value per result line (compact, no pretty-printing).
+- **Use when:** A read style command may produce many results and you want to stream them incrementally to another tool. Also works for single-result commands where compact output is preferred.
 - **Prefer instead:** Use `--json` when you want one aggregate document for the whole command.
 
 <!-- ref:global-flag:quiet -->
@@ -415,7 +415,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:tx-mode:plan-stdin -->
 ### `tx --plan -`
 
-- **What it does:** Reads the transaction plan JSON from stdin instead of a plan file.
+- **What it does:** Reads the transaction plan from stdin instead of a plan file. Defaults to JSON; use `--plan-format` for YAML or TOML.
 - **Use when:** The plan is generated on the fly or piped from another tool.
 - **Prefer instead:** Use `--plan <file>` when the plan should be stored, reviewed, or reused.
 

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -62,6 +62,10 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let path = cwd.join(&args.file);
 
+    if path.exists() && !path.is_file() {
+        bail!("target is not a file: {}", args.file);
+    }
+
     // For non-write modes, an early exists check is fine (no TOCTOU concern).
     // The --apply path below uses File::create_new for race-free creation.
     if !global.apply && !args.force && path.exists() {
@@ -226,6 +230,24 @@ mod tests {
 
         let content = fs::read_to_string(&file).unwrap();
         assert_eq!(content, "overwritten\n");
+    }
+
+    #[test]
+    fn create_rejects_directory_target_even_with_force() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("folder");
+        fs::create_dir(&target).unwrap();
+
+        let args = CreateArgs {
+            file: target.to_string_lossy().into_owned(),
+            content: Some("hello\n".to_string()),
+            stdin: false,
+            force: true,
+            write: Default::default(),
+        };
+
+        let err = run(args, &default_global()).unwrap_err();
+        assert!(err.to_string().contains("target is not a file"));
     }
 
     #[test]

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -78,13 +78,15 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 }
             }
         }
+        let output = CreateOutput {
+            ok: true,
+            path: args.file.clone(),
+            diff: None,
+        };
         if global.json {
-            let output = CreateOutput {
-                ok: true,
-                path: args.file.clone(),
-                diff: None,
-            };
             println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if global.jsonl {
+            println!("{}", serde_json::to_string(&output)?);
         } else if !global.quiet {
             println!("would create {}", args.file);
         }
@@ -108,18 +110,20 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             atomic_create_new(&path, &content, &policy)?;
         }
 
+        let diff_text = if global.diff {
+            Some(make_diff_output(&args.file, &content))
+        } else {
+            None
+        };
+        let output = CreateOutput {
+            ok: true,
+            path: args.file.clone(),
+            diff: diff_text,
+        };
         if global.json {
-            let diff_text = if global.diff {
-                Some(make_diff_output(&args.file, &content))
-            } else {
-                None
-            };
-            let output = CreateOutput {
-                ok: true,
-                path: args.file.clone(),
-                diff: diff_text,
-            };
             println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if global.jsonl {
+            println!("{}", serde_json::to_string(&output)?);
         } else if global.diff {
             print!("{}", make_diff_output(&args.file, &content));
         } else if !global.quiet {
@@ -129,13 +133,15 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // Default / --diff mode: show unified diff of changes.
+    let output = CreateOutput {
+        ok: true,
+        path: args.file.clone(),
+        diff: Some(make_diff_output(&args.file, &content)),
+    };
     if global.json {
-        let output = CreateOutput {
-            ok: true,
-            path: args.file.clone(),
-            diff: Some(make_diff_output(&args.file, &content)),
-        };
         println!("{}", serde_json::to_string_pretty(&output)?);
+    } else if global.jsonl {
+        println!("{}", serde_json::to_string(&output)?);
     } else {
         print!("{}", make_diff_output(&args.file, &content));
     }

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -26,6 +26,9 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if !path.exists() {
         anyhow::bail!("file not found: {}", args.file);
     }
+    if !path.is_file() {
+        anyhow::bail!("target is not a file: {}", args.file);
+    }
 
     if global.check {
         let output = DeleteOutput {
@@ -127,6 +130,23 @@ mod tests {
         let code = run(make_args(&file.to_string_lossy()), &global).unwrap();
         assert_eq!(code, exit::CHANGES_DETECTED);
         assert!(file.exists(), "--check should not delete the file");
+    }
+
+    #[test]
+    fn directory_target_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("folder");
+        std::fs::create_dir(&target).unwrap();
+
+        let result = run(
+            make_args(&target.to_string_lossy()),
+            &GlobalFlags::default(),
+        );
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("target is not a file"));
     }
 
     #[test]

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -28,13 +28,15 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if global.check {
+        let output = DeleteOutput {
+            ok: true,
+            path: args.file.clone(),
+            applied: false,
+        };
         if global.json {
-            let output = DeleteOutput {
-                ok: true,
-                path: args.file.clone(),
-                applied: false,
-            };
             println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if global.jsonl {
+            println!("{}", serde_json::to_string(&output)?);
         } else if !global.quiet {
             println!("would delete {}", args.file);
         }
@@ -43,13 +45,15 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if global.apply {
         std::fs::remove_file(path)?;
+        let output = DeleteOutput {
+            ok: true,
+            path: args.file.clone(),
+            applied: true,
+        };
         if global.json {
-            let output = DeleteOutput {
-                ok: true,
-                path: args.file.clone(),
-                applied: true,
-            };
             println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if global.jsonl {
+            println!("{}", serde_json::to_string(&output)?);
         } else if !global.quiet {
             println!("deleted {}", args.file);
         }
@@ -57,13 +61,15 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // Default: dry-run.
+    let output = DeleteOutput {
+        ok: true,
+        path: args.file.clone(),
+        applied: false,
+    };
     if global.json {
-        let output = DeleteOutput {
-            ok: true,
-            path: args.file.clone(),
-            applied: false,
-        };
         println!("{}", serde_json::to_string_pretty(&output)?);
+    } else if global.jsonl {
+        println!("{}", serde_json::to_string(&output)?);
     } else if !global.quiet {
         println!("would delete {}", args.file);
     }

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -866,7 +866,7 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
 
     let (output, code) = execute_with_mode(&args.action, output_mode)?;
-    if !output.is_empty() {
+    if !output.is_empty() && (global.json || global.jsonl || !global.quiet) {
         println!("{output}");
     }
     Ok(code)

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -252,18 +252,47 @@ fn diff_values(
     }
 }
 
-fn format_value(value: &serde_json::Value, json_mode: bool) -> String {
-    if json_mode {
-        serde_json::to_string_pretty(value).unwrap_or_default()
-    } else {
-        match value {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OutputMode {
+    Text,
+    Json,
+    Jsonl,
+}
+
+fn format_value(value: &serde_json::Value, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Json => serde_json::to_string_pretty(value).unwrap_or_default(),
+        OutputMode::Jsonl => serde_json::to_string(value).unwrap_or_default(),
+        OutputMode::Text => match value {
             serde_json::Value::String(s) => s.clone(),
             serde_json::Value::Number(n) => n.to_string(),
             serde_json::Value::Bool(b) => b.to_string(),
             serde_json::Value::Null => "null".to_string(),
             // Compound values (arrays, objects) always render as JSON.
             _ => serde_json::to_string_pretty(value).unwrap_or_default(),
+        },
+    }
+}
+
+fn format_values(values: &[&serde_json::Value], mode: OutputMode) -> anyhow::Result<String> {
+    match mode {
+        OutputMode::Text => Ok(values
+            .iter()
+            .map(|value| format_value(value, mode))
+            .collect::<Vec<_>>()
+            .join("\n")),
+        OutputMode::Json => {
+            if values.len() == 1 {
+                Ok(serde_json::to_string_pretty(values[0])?)
+            } else {
+                Ok(serde_json::to_string_pretty(values)?)
+            }
         }
+        OutputMode::Jsonl => Ok(values
+            .iter()
+            .map(serde_json::to_string)
+            .collect::<Result<Vec<_>, _>>()?
+            .join("\n")),
     }
 }
 
@@ -559,7 +588,7 @@ fn execute_write(action: &DocAction, ctx: &WriteContext) -> anyhow::Result<(Stri
             write_result(file, &original, &new_content, ctx)
         }
 
-        // Read-only actions are handled by execute().
+        // Read-only actions are handled by execute_with_mode().
         _ => anyhow::bail!("not a write action"),
     }
 }
@@ -568,7 +597,7 @@ fn execute_write(action: &DocAction, ctx: &WriteContext) -> anyhow::Result<(Stri
 // Core execution (returns output text + exit code for testability)
 // ---------------------------------------------------------------------------
 
-fn execute(action: &DocAction, json_mode: bool) -> anyhow::Result<(String, u8)> {
+fn execute_with_mode(action: &DocAction, output_mode: OutputMode) -> anyhow::Result<(String, u8)> {
     match action {
         DocAction::Get { file, selector } => {
             let root = load_file(file)?;
@@ -578,8 +607,7 @@ fn execute(action: &DocAction, json_mode: bool) -> anyhow::Result<(String, u8)> 
             if results.is_empty() {
                 return Ok((String::new(), exit::NO_MATCHES));
             }
-            let lines: Vec<String> = results.iter().map(|v| format_value(v, json_mode)).collect();
-            Ok((lines.join("\n"), exit::SUCCESS))
+            Ok((format_values(&results, output_mode)?, exit::SUCCESS))
         }
 
         DocAction::Has { file, selector } => {
@@ -588,7 +616,12 @@ fn execute(action: &DocAction, json_mode: bool) -> anyhow::Result<(String, u8)> 
                 selector::parse(selector).map_err(|e| anyhow::anyhow!("selector error: {e}"))?;
             let results = selector::eval(&root, &sel);
             let found = !results.is_empty();
-            Ok((found.to_string(), exit::SUCCESS))
+            let output = match output_mode {
+                OutputMode::Text => found.to_string(),
+                OutputMode::Json => serde_json::to_string_pretty(&found)?,
+                OutputMode::Jsonl => serde_json::to_string(&found)?,
+            };
+            Ok((output, exit::SUCCESS))
         }
 
         DocAction::Keys { file, selector } => {
@@ -602,7 +635,16 @@ fn execute(action: &DocAction, json_mode: bool) -> anyhow::Result<(String, u8)> 
             match results[0].as_object() {
                 Some(obj) => {
                     let keys: Vec<&str> = obj.keys().map(std::string::String::as_str).collect();
-                    Ok((keys.join("\n"), exit::SUCCESS))
+                    let output = match output_mode {
+                        OutputMode::Text => keys.join("\n"),
+                        OutputMode::Json => serde_json::to_string_pretty(&keys)?,
+                        OutputMode::Jsonl => keys
+                            .iter()
+                            .map(serde_json::to_string)
+                            .collect::<Result<Vec<_>, _>>()?
+                            .join("\n"),
+                    };
+                    Ok((output, exit::SUCCESS))
                 }
                 None => Ok((
                     format!("doc keys: target at '{selector}' is not an object"),
@@ -621,9 +663,21 @@ fn execute(action: &DocAction, json_mode: bool) -> anyhow::Result<(String, u8)> 
             }
             let target = results[0];
             if let Some(arr) = target.as_array() {
-                Ok((arr.len().to_string(), exit::SUCCESS))
+                let len = arr.len();
+                let output = match output_mode {
+                    OutputMode::Text => len.to_string(),
+                    OutputMode::Json => serde_json::to_string_pretty(&len)?,
+                    OutputMode::Jsonl => serde_json::to_string(&len)?,
+                };
+                Ok((output, exit::SUCCESS))
             } else if let Some(obj) = target.as_object() {
-                Ok((obj.len().to_string(), exit::SUCCESS))
+                let len = obj.len();
+                let output = match output_mode {
+                    OutputMode::Text => len.to_string(),
+                    OutputMode::Json => serde_json::to_string_pretty(&len)?,
+                    OutputMode::Jsonl => serde_json::to_string(&len)?,
+                };
+                Ok((output, exit::SUCCESS))
             } else {
                 Ok((
                     format!("doc len: target at '{selector}' is not an array or object"),
@@ -641,8 +695,7 @@ fn execute(action: &DocAction, json_mode: bool) -> anyhow::Result<(String, u8)> 
             if results.is_empty() {
                 return Ok((String::new(), exit::NO_MATCHES));
             }
-            let lines: Vec<String> = results.iter().map(|v| format_value(v, json_mode)).collect();
-            Ok((lines.join("\n"), exit::SUCCESS))
+            Ok((format_values(&results, output_mode)?, exit::SUCCESS))
         }
 
         DocAction::Flatten { file } => {
@@ -652,16 +705,32 @@ fn execute(action: &DocAction, json_mode: bool) -> anyhow::Result<(String, u8)> 
             if entries.is_empty() {
                 return Ok((String::new(), exit::NO_MATCHES));
             }
-            if json_mode {
-                let obj: serde_json::Map<String, serde_json::Value> =
-                    entries.into_iter().map(|(k, v)| (k, v.clone())).collect();
-                Ok((serde_json::to_string_pretty(&obj)?, exit::SUCCESS))
-            } else {
-                let lines: Vec<String> = entries
-                    .iter()
-                    .map(|(k, v)| format!("{k} = {}", format_value(v, false)))
-                    .collect();
-                Ok((lines.join("\n"), exit::SUCCESS))
+            match output_mode {
+                OutputMode::Json => {
+                    let obj: serde_json::Map<String, serde_json::Value> =
+                        entries.into_iter().map(|(k, v)| (k, v.clone())).collect();
+                    Ok((serde_json::to_string_pretty(&obj)?, exit::SUCCESS))
+                }
+                OutputMode::Jsonl => {
+                    let lines = entries
+                        .iter()
+                        .map(|(k, v)| {
+                            serde_json::to_string(&serde_json::json!({
+                                "path": k,
+                                "value": v,
+                            }))
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                        .join("\n");
+                    Ok((lines, exit::SUCCESS))
+                }
+                OutputMode::Text => {
+                    let lines: Vec<String> = entries
+                        .iter()
+                        .map(|(k, v)| format!("{k} = {}", format_value(v, OutputMode::Text)))
+                        .collect();
+                    Ok((lines.join("\n"), exit::SUCCESS))
+                }
             }
         }
 
@@ -673,46 +742,55 @@ fn execute(action: &DocAction, json_mode: bool) -> anyhow::Result<(String, u8)> 
             if entries.is_empty() {
                 return Ok(("identical\n".to_string(), exit::SUCCESS));
             }
-            if json_mode {
-                Ok((serde_json::to_string_pretty(&entries)?, exit::SUCCESS))
-            } else {
-                let mut out = String::new();
-                for e in &entries {
-                    match e.kind.as_str() {
-                        "added" => {
-                            if let Some(v) = e.new_value.as_ref() {
-                                out.push_str(&format!(
-                                    "+ {} = {}\n",
-                                    e.path,
-                                    format_value(v, false)
-                                ));
+            match output_mode {
+                OutputMode::Json => Ok((serde_json::to_string_pretty(&entries)?, exit::SUCCESS)),
+                OutputMode::Jsonl => Ok((
+                    entries
+                        .iter()
+                        .map(serde_json::to_string)
+                        .collect::<Result<Vec<_>, _>>()?
+                        .join("\n"),
+                    exit::SUCCESS,
+                )),
+                OutputMode::Text => {
+                    let mut out = String::new();
+                    for e in &entries {
+                        match e.kind.as_str() {
+                            "added" => {
+                                if let Some(v) = e.new_value.as_ref() {
+                                    out.push_str(&format!(
+                                        "+ {} = {}\n",
+                                        e.path,
+                                        format_value(v, OutputMode::Text)
+                                    ));
+                                }
                             }
-                        }
-                        "removed" => {
-                            if let Some(v) = e.old_value.as_ref() {
-                                out.push_str(&format!(
-                                    "- {} = {}\n",
-                                    e.path,
-                                    format_value(v, false)
-                                ));
+                            "removed" => {
+                                if let Some(v) = e.old_value.as_ref() {
+                                    out.push_str(&format!(
+                                        "- {} = {}\n",
+                                        e.path,
+                                        format_value(v, OutputMode::Text)
+                                    ));
+                                }
                             }
-                        }
-                        "changed" => {
-                            if let (Some(old), Some(new)) =
-                                (e.old_value.as_ref(), e.new_value.as_ref())
-                            {
-                                out.push_str(&format!(
-                                    "~ {} = {} -> {}\n",
-                                    e.path,
-                                    format_value(old, false),
-                                    format_value(new, false)
-                                ));
+                            "changed" => {
+                                if let (Some(old), Some(new)) =
+                                    (e.old_value.as_ref(), e.new_value.as_ref())
+                                {
+                                    out.push_str(&format!(
+                                        "~ {} = {} -> {}\n",
+                                        e.path,
+                                        format_value(old, OutputMode::Text),
+                                        format_value(new, OutputMode::Text)
+                                    ));
+                                }
                             }
+                            _ => {}
                         }
-                        _ => {}
                     }
+                    Ok((out, exit::SUCCESS))
                 }
-                Ok((out, exit::SUCCESS))
             }
         }
 
@@ -779,7 +857,15 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(code);
     }
 
-    let (output, code) = execute(&args.action, global.json)?;
+    let output_mode = if global.json {
+        OutputMode::Json
+    } else if global.jsonl {
+        OutputMode::Jsonl
+    } else {
+        OutputMode::Text
+    };
+
+    let (output, code) = execute_with_mode(&args.action, output_mode)?;
     if !output.is_empty() {
         println!("{output}");
     }
@@ -813,7 +899,7 @@ mod tests {
             file: path,
             selector: "name".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(output, "hello");
     }
@@ -826,7 +912,7 @@ mod tests {
             file: path,
             selector: "name".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(output, "hello");
     }
@@ -839,7 +925,7 @@ mod tests {
             file: path,
             selector: "name".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(output, "hello");
     }
@@ -854,7 +940,7 @@ mod tests {
             file: path,
             selector: "name".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(output, "true");
     }
@@ -867,7 +953,7 @@ mod tests {
             file: path,
             selector: "missing".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(output, "false");
     }
@@ -886,7 +972,7 @@ mod tests {
             file: path,
             selector: "scripts".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let keys: Vec<&str> = output.split('\n').collect();
         assert_eq!(keys.len(), 3);
@@ -905,7 +991,7 @@ mod tests {
             file: path,
             selector: "items".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(output, "5");
     }
@@ -920,7 +1006,7 @@ mod tests {
             file: path,
             selector: "nonexistent".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::NO_MATCHES);
         assert!(output.is_empty());
     }
@@ -1309,7 +1395,7 @@ mod tests {
             file_a: a,
             file_b: b,
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert!(output.contains("~ name"), "should show changed: {output}");
         assert!(
@@ -1332,7 +1418,7 @@ mod tests {
             file_a: a,
             file_b: b,
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(output, "identical\n");
     }
@@ -1347,7 +1433,7 @@ mod tests {
             file: path,
             selector: "name".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::FAILURE);
         assert!(output.contains("not an object"));
     }
@@ -1360,7 +1446,7 @@ mod tests {
             file: path,
             selector: "name".into(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::FAILURE);
         assert!(output.contains("not an array or object"));
     }
@@ -1373,7 +1459,7 @@ mod tests {
             file: path,
             selector: String::new(),
         };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(output, "3");
     }
@@ -1403,7 +1489,7 @@ mod tests {
             r#"{"a":1,"b":{"c":2,"d":3},"e":[10,20]}"#,
         );
         let action = DocAction::Flatten { file: path };
-        let (output, code) = execute(&action, false).unwrap();
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert!(output.contains("a = 1"), "missing a: {output}");
         assert!(output.contains("b.c = 2"), "missing b.c: {output}");

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -299,6 +299,10 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             if !removed.is_empty() {
                 if global.json {
                     println!("{}", serde_json::to_string_pretty(&removed)?);
+                } else if global.jsonl {
+                    for h in &removed {
+                        println!("{}", serde_json::to_string(h)?);
+                    }
                 } else if !global.quiet {
                     for h in &removed {
                         eprintln!("md: removed duplicate: {h}");

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -323,7 +323,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 for issue in &issues {
                     println!("{}", serde_json::to_string(issue)?);
                 }
-            } else {
+            } else if !global.quiet {
                 for issue in &issues {
                     match (issue.line, &issue.heading) {
                         (Some(ln), Some(h)) => {

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -128,7 +128,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 let file_path = root.join(&pf.path);
                 let original = match std::fs::read_to_string(&file_path) {
                     Ok(s) => s,
-                    Err(_) => {
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                         let msg = format!("file not found: {}", file_path.display());
                         results.push(PatchCheckResult {
                             path: pf.path.clone(),
@@ -137,6 +137,19 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         });
                         if !global.json && !global.jsonl && !global.quiet {
                             eprintln!("patch check: {} -- MISSING: {}", pf.path, msg);
+                        }
+                        all_clean = false;
+                        continue;
+                    }
+                    Err(e) => {
+                        let msg = format!("failed to read {}: {}", file_path.display(), e);
+                        results.push(PatchCheckResult {
+                            path: pf.path.clone(),
+                            status: "error".to_string(),
+                            error: Some(msg.clone()),
+                        });
+                        if !global.json && !global.jsonl && !global.quiet {
+                            eprintln!("patch check: {} -- READ ERROR: {}", pf.path, msg);
                         }
                         all_clean = false;
                         continue;

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -44,6 +44,10 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         anyhow::bail!("source is not a file: {}", args.from);
     }
 
+    if dst.exists() && !dst.is_file() {
+        anyhow::bail!("destination is not a file: {}", args.to);
+    }
+
     // Validate destination does not exist (unless --force).
     if !args.force && dst.exists() {
         anyhow::bail!("destination already exists: {}", args.to);
@@ -270,6 +274,25 @@ mod tests {
 
         let err = run(args, &global).unwrap_err();
         assert!(err.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn rename_force_rejects_directory_destination() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("old.txt");
+        let dst = dir.path().join("folder");
+        fs::write(&src, "hello\n").unwrap();
+        fs::create_dir(&dst).unwrap();
+
+        let args = RenameArgs {
+            from: src.to_string_lossy().into_owned(),
+            to: dst.to_string_lossy().into_owned(),
+            force: true,
+            write: Default::default(),
+        };
+
+        let err = run(args, &default_global()).unwrap_err();
+        assert!(err.to_string().contains("destination is not a file"));
     }
 
     #[test]

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -51,14 +51,16 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // If source and destination resolve to the same path, it's a no-op.
     if src == dst {
+        let output = RenameOutput {
+            ok: true,
+            from: args.from.clone(),
+            to: args.to.clone(),
+            diff: None,
+        };
         if global.json {
-            let output = RenameOutput {
-                ok: true,
-                from: args.from.clone(),
-                to: args.to.clone(),
-                diff: None,
-            };
             println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if global.jsonl {
+            println!("{}", serde_json::to_string(&output)?);
         } else if !global.quiet {
             println!("source and destination are the same: {}", args.from);
         }
@@ -67,14 +69,16 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // --check mode: report that rename would happen (no file read needed).
     if global.check {
+        let output = RenameOutput {
+            ok: true,
+            from: args.from.clone(),
+            to: args.to.clone(),
+            diff: None,
+        };
         if global.json {
-            let output = RenameOutput {
-                ok: true,
-                from: args.from.clone(),
-                to: args.to.clone(),
-                diff: None,
-            };
             println!("{}", serde_json::to_string_pretty(&output)?);
+        } else if global.jsonl {
+            println!("{}", serde_json::to_string(&output)?);
         } else if !global.quiet {
             println!("would rename {} -> {}", args.from, args.to);
         }
@@ -113,17 +117,19 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             fs::remove_file(&src)?;
         }
 
-        if global.json || global.diff {
+        if global.json || global.jsonl || global.diff {
             // After --apply, source is gone; read from destination.
             let diff_text = try_diff(&dst, &args.from, &args.to);
+            let output = RenameOutput {
+                ok: true,
+                from: args.from.clone(),
+                to: args.to.clone(),
+                diff: if global.diff { diff_text.clone() } else { None },
+            };
             if global.json {
-                let output = RenameOutput {
-                    ok: true,
-                    from: args.from.clone(),
-                    to: args.to.clone(),
-                    diff: if global.diff { diff_text } else { None },
-                };
                 println!("{}", serde_json::to_string_pretty(&output)?);
+            } else if global.jsonl {
+                println!("{}", serde_json::to_string(&output)?);
             } else if let Some(d) = diff_text {
                 print!("{d}");
             } else if !global.quiet {
@@ -137,14 +143,16 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // Default / --diff mode: show what would happen (source still exists).
     let diff_text = try_diff(&src, &args.from, &args.to);
+    let output = RenameOutput {
+        ok: true,
+        from: args.from.clone(),
+        to: args.to.clone(),
+        diff: diff_text.clone(),
+    };
     if global.json {
-        let output = RenameOutput {
-            ok: true,
-            from: args.from.clone(),
-            to: args.to.clone(),
-            diff: diff_text,
-        };
         println!("{}", serde_json::to_string_pretty(&output)?);
+    } else if global.jsonl {
+        println!("{}", serde_json::to_string(&output)?);
     } else if let Some(d) = diff_text {
         print!("{d}");
     } else if !global.quiet {

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -36,9 +36,12 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let src = cwd.join(&args.from);
     let dst = cwd.join(&args.to);
 
-    // Validate source exists.
+    // Validate source exists and is a file.
     if !src.exists() {
         anyhow::bail!("source file not found: {}", args.from);
+    }
+    if !src.is_file() {
+        anyhow::bail!("source is not a file: {}", args.from);
     }
 
     // Validate destination does not exist (unless --force).

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -86,15 +86,17 @@ pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let total_changes = modified.len() + created.len() + deleted.len();
 
+    let out = StatusOutput {
+        ok: true,
+        modified: modified.clone(),
+        created: created.clone(),
+        deleted: deleted.clone(),
+        total_changes,
+    };
     if global.json {
-        let out = StatusOutput {
-            ok: true,
-            modified: modified.clone(),
-            created: created.clone(),
-            deleted: deleted.clone(),
-            total_changes,
-        };
         println!("{}", serde_json::to_string_pretty(&out)?);
+    } else if global.jsonl {
+        println!("{}", serde_json::to_string(&out)?);
     } else if !global.quiet {
         for f in &modified {
             println!("M  {f}");

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1066,10 +1066,22 @@ fn build_tx_output(
     }
 }
 
+fn emit_output_json(output: &TxOutput, compact: bool) {
+    let result = if compact {
+        serde_json::to_string(output)
+    } else {
+        serde_json::to_string_pretty(output)
+    };
+    if let Ok(json) = result {
+        println!("{json}");
+    }
+}
+
 fn emit_error_json_with_prefix(
     error_kind: &'static str,
     legacy_error_prefix: &'static str,
     error: &str,
+    compact: bool,
 ) {
     let output = TxOutput {
         ok: false,
@@ -1083,19 +1095,16 @@ fn emit_error_json_with_prefix(
         error_kind: Some(error_kind),
         error: Some(format!("{legacy_error_prefix}: {error}")),
     };
-    // Best-effort: if serialization fails, we can't do much.
-    if let Ok(json) = serde_json::to_string_pretty(&output) {
-        println!("{json}");
-    }
+    emit_output_json(&output, compact);
 }
 
-fn emit_error_json(error_kind: &'static str, error: &str) {
+fn emit_error_json(error_kind: &'static str, error: &str, compact: bool) {
     let legacy_error_prefix = if error_kind == "format_failed" {
         "validation_failed"
     } else {
         error_kind
     };
-    emit_error_json_with_prefix(error_kind, legacy_error_prefix, error);
+    emit_error_json_with_prefix(error_kind, legacy_error_prefix, error, compact);
 }
 
 fn describe_exit_status(status: std::process::ExitStatus) -> String {
@@ -1231,6 +1240,9 @@ fn rollback_strict(
 // ---------------------------------------------------------------------------
 
 pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let structured = global.json || global.jsonl;
+    let compact = global.jsonl;
+
     // 1. Read plan from file or stdin.
     let plan_text = if args.plan == "-" {
         let mut buf = String::new();
@@ -1250,8 +1262,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let plan = match plan::parse_plan_auto(&plan_text, plan_path, args.plan_format.as_deref()) {
         Ok(p) => p,
         Err(e) => {
-            if global.json {
-                emit_error_json("parse_error", &e.to_string());
+            if structured {
+                emit_error_json("parse_error", &e.to_string(), compact);
             } else {
                 eprintln!("tx: plan parse error: {e}");
             }
@@ -1265,8 +1277,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 "unsupported plan version '{v}' (this build supports version {})",
                 crate::plan::SCHEMA_VERSION
             );
-            if global.json {
-                emit_error_json("parse_error", &msg);
+            if structured {
+                emit_error_json("parse_error", &msg, compact);
             } else {
                 eprintln!("tx: {msg}");
             }
@@ -1275,8 +1287,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if let Err(e) = validate_plan_operations(&plan) {
-        if global.json {
-            emit_error_json("parse_error", &e.to_string());
+        if structured {
+            emit_error_json("parse_error", &e.to_string(), compact);
         } else {
             eprintln!("tx: plan parse error: {e}");
         }
@@ -1325,8 +1337,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
             Err(e) => {
                 let msg = format!("operation {} ({}) failed: {e}", i + 1, op_label(op));
-                if global.json {
-                    emit_error_json("rollback", &msg);
+                if structured {
+                    emit_error_json("rollback", &msg, compact);
                 } else {
                     eprintln!("tx: {msg}");
                 }
@@ -1371,16 +1383,16 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             if replace_no_matches {
                 return Ok(exit::NO_MATCHES);
             }
-            if global.json {
+            if structured {
                 let mut output =
                     build_tx_output("success", true, &changes, &deletions, &existed_before, &cwd);
                 output.reads = std::mem::take(&mut tx_reads);
                 output.searches = std::mem::take(&mut tx_searches);
-                println!("{}", serde_json::to_string_pretty(&output)?);
+                emit_output_json(&output, compact);
             }
             return Ok(exit::SUCCESS);
         }
-        if global.json {
+        if structured {
             let mut output = build_tx_output(
                 "changes_detected",
                 true,
@@ -1391,7 +1403,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             );
             output.reads = std::mem::take(&mut tx_reads);
             output.searches = std::mem::take(&mut tx_searches);
-            println!("{}", serde_json::to_string_pretty(&output)?);
+            emit_output_json(&output, compact);
         } else if !global.quiet {
             println!("{} file(s) would change", changes.len() + pending_deletions);
         }
@@ -1450,15 +1462,15 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             if plan.strict {
                 rollback_strict(&changes, &pending, &deletions, &existed_before);
                 let rollback_msg = format!("strict mode -- all changes reverted ({})", err.message);
-                if global.json {
-                    emit_error_json_with_prefix(err.kind, "rollback", &rollback_msg);
+                if structured {
+                    emit_error_json_with_prefix(err.kind, "rollback", &rollback_msg, compact);
                 } else {
                     eprintln!("tx: {rollback_msg}");
                 }
                 return Ok(exit::ROLLBACK);
             }
-            if global.json {
-                emit_error_json(err.kind, &err.message);
+            if structured {
+                emit_error_json(err.kind, &err.message, compact);
             }
             return Ok(exit::VALIDATION_FAILED);
         }
@@ -1466,12 +1478,12 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         if replace_no_matches {
             return Ok(exit::NO_MATCHES);
         }
-        if global.json {
+        if structured {
             let mut output =
                 build_tx_output("success", true, &changes, &deletions, &existed_before, &cwd);
             output.reads = std::mem::take(&mut tx_reads);
             output.searches = std::mem::take(&mut tx_searches);
-            println!("{}", serde_json::to_string_pretty(&output)?);
+            emit_output_json(&output, compact);
         }
         return Ok(exit::SUCCESS);
     }
@@ -1481,12 +1493,12 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // Default / --diff mode: show unified diffs.
-    if global.json {
+    if structured {
         let mut output =
             build_tx_output("success", true, &changes, &deletions, &existed_before, &cwd);
         output.reads = std::mem::take(&mut tx_reads);
         output.searches = std::mem::take(&mut tx_searches);
-        println!("{}", serde_json::to_string_pretty(&output)?);
+        emit_output_json(&output, compact);
     } else if !changes.is_empty() {
         print_diffs(&changes, &cwd);
     }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -902,6 +902,10 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
             let src_path = tx.cwd.join(from);
             let dst_path = tx.cwd.join(to);
 
+            if dst_path.exists() && !dst_path.is_file() {
+                anyhow::bail!("destination is not a file: {to}");
+            }
+
             // If source and destination are the same path, no-op.
             if src_path == dst_path {
                 return Ok(0);

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -847,6 +847,9 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
             force,
         } => {
             let file_path = tx.cwd.join(path);
+            if file_path.exists() && !file_path.is_file() {
+                anyhow::bail!("target is not a file: {path}");
+            }
             if force.unwrap_or(false) {
                 if tx.pending.contains_key(&file_path) || file_path.exists() {
                     let _ = read_file_content(tx.pending, &file_path, tx.cwd)?;
@@ -881,6 +884,9 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
 
         Operation::FileDelete { path } => {
             let file_path = tx.cwd.join(path);
+            if file_path.exists() && !file_path.is_file() {
+                anyhow::bail!("target is not a file: {path}");
+            }
             let created_in_tx = match tx.pending.get(&file_path) {
                 Some((original, _)) => original.is_empty() && !file_path.exists(),
                 None => {
@@ -902,6 +908,9 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
             let src_path = tx.cwd.join(from);
             let dst_path = tx.cwd.join(to);
 
+            if src_path.exists() && !src_path.is_file() {
+                anyhow::bail!("source is not a file: {from}");
+            }
             if dst_path.exists() && !dst_path.is_file() {
                 anyhow::bail!("destination is not a file: {to}");
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,18 +18,21 @@ use cli::Cli;
 /// Run the patchloom CLI. Returns the exit code as a u8.
 pub fn run() -> anyhow::Result<u8> {
     let cli = Cli::parse();
-    let json_mode = cli.global.json;
+    let structured = cli.global.json || cli.global.jsonl;
+    let compact = cli.global.jsonl;
     match cmd::dispatch(cli) {
         Ok(code) => Ok(code),
-        Err(e) if json_mode => {
+        Err(e) if structured => {
             let output = serde_json::json!({
                 "ok": false,
                 "error": format!("{e:#}")
             });
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&output).unwrap_or_default()
-            );
+            let serialized = if compact {
+                serde_json::to_string(&output)
+            } else {
+                serde_json::to_string_pretty(&output)
+            };
+            println!("{}", serialized.unwrap_or_default());
             Ok(exit::FAILURE)
         }
         Err(e) => Err(e),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4240,6 +4240,31 @@ fn test_md_dedupe_headings_removes_duplicate() {
 }
 
 #[test]
+fn test_md_dedupe_headings_jsonl_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.md");
+    fs::write(&file, "# Title\n\n## Dup\n\nFirst\n\n## Dup\n\nSecond\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("md")
+        .arg("dedupe-headings")
+        .arg("--file")
+        .arg(&file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1);
+    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(json.as_str().unwrap(), "## Dup");
+}
+
+#[test]
 fn test_md_dedupe_headings_json_output() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.md");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8130,6 +8130,40 @@ fn test_tx_json_output_on_modified_empty_file_reports_modified_in_check_mode() {
 }
 
 #[test]
+fn test_tx_jsonl_output_on_check() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "replace", "path": file.to_str().unwrap(), "from": "hello", "to": "world"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "JSONL should be a single line");
+    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["status"], "changes_detected");
+    assert_eq!(json["files_changed"], 1);
+}
+
+#[test]
 fn test_tx_json_output_on_check() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2956,6 +2956,70 @@ fn test_patch_check_exits_5_when_stale() {
 }
 
 #[test]
+fn test_patch_check_exits_5_on_directory_read_error() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("test.txt");
+    fs::create_dir(&target).unwrap();
+
+    let patch_file = dir.path().join("change.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -0,0 +1 @@\n+new line\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("check")
+        .arg("--file")
+        .arg(&patch_file)
+        .assert()
+        .code(5)
+        .stderr(predicate::str::contains(
+            "patch check: test.txt -- READ ERROR: failed to read",
+        ));
+}
+
+#[test]
+fn test_patch_check_json_reports_directory_read_error() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("test.txt");
+    fs::create_dir(&target).unwrap();
+
+    let patch_file = dir.path().join("change.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -0,0 +1 @@\n+new line\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("check")
+        .arg("--file")
+        .arg(&patch_file)
+        .arg("--json")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(5));
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["files"][0]["status"], "error");
+    assert!(json["files"][0]["error"]
+        .as_str()
+        .unwrap()
+        .contains("failed to read"));
+}
+
+#[test]
 fn test_patch_apply_check_quiet_suppresses_output() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -825,6 +825,29 @@ fn test_doc_get_jsonl_compound_value_is_single_line_json() {
 }
 
 #[test]
+fn test_doc_get_quiet_suppresses_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"name":"patchloom"}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--quiet")
+        .arg("doc")
+        .arg("get")
+        .arg(&file)
+        .arg("name")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        output.stdout.is_empty(),
+        "quiet should suppress doc get output"
+    );
+}
+
+#[test]
 fn test_doc_get_json() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.json");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5254,6 +5254,95 @@ fn test_tx_file_rename_force_overwrites() {
 }
 
 #[test]
+fn test_tx_file_rename_force_directory_destination_fails_in_dry_run() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.txt"), "hello\n").unwrap();
+    fs::create_dir(dir.path().join("folder")).unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "file.rename", "from": "old.txt", "to": "folder", "force": true}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .assert()
+        .code(7)
+        .stderr(predicate::str::contains("destination is not a file"));
+
+    assert!(dir.path().join("old.txt").is_file());
+    assert!(dir.path().join("folder").is_dir());
+}
+
+#[test]
+fn test_tx_file_rename_force_directory_destination_fails_in_check_mode() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.txt"), "hello\n").unwrap();
+    fs::create_dir(dir.path().join("folder")).unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "file.rename", "from": "old.txt", "to": "folder", "force": true}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .arg("--check")
+        .assert()
+        .code(7)
+        .stderr(predicate::str::contains("destination is not a file"));
+
+    assert!(dir.path().join("old.txt").is_file());
+    assert!(dir.path().join("folder").is_dir());
+}
+
+#[test]
+fn test_tx_file_rename_force_directory_destination_fails_in_apply_mode() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.txt"), "hello\n").unwrap();
+    fs::create_dir(dir.path().join("folder")).unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "file.rename", "from": "old.txt", "to": "folder", "force": true}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .arg("--apply")
+        .assert()
+        .code(7)
+        .stderr(predicate::str::contains("destination is not a file"));
+
+    assert!(dir.path().join("old.txt").is_file());
+    assert!(dir.path().join("folder").is_dir());
+}
+
+#[test]
 fn test_tx_file_rename_same_path_is_noop() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("same.txt"), "keep me\n").unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10847,6 +10847,28 @@ fn test_json_error_envelope_on_doc_get_nonexistent_file() {
 }
 
 #[test]
+fn test_jsonl_error_envelope_on_delete_nonexistent_file() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("delete")
+        .arg("--file")
+        .arg(nonexistent_path("jsonl-error-del.txt"))
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "JSONL error should be a single line");
+    let json: serde_json::Value = serde_json::from_str(lines[0])
+        .unwrap_or_else(|_| panic!("expected JSON line, got: {}", lines[0]));
+    assert_eq!(json["ok"], false);
+    assert!(json["error"].as_str().unwrap().contains("file not found"));
+}
+
+#[test]
 fn test_json_error_envelope_on_delete_nonexistent_file() {
     let output = Command::cargo_bin("patchloom")
         .unwrap()

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3319,6 +3319,80 @@ fn test_rename_check_directory_source_fails() {
 }
 
 #[test]
+fn test_rename_force_directory_destination_fails_in_dry_run() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("old.txt");
+    let dst = dir.path().join("folder");
+    fs::write(&src, "hello\n").unwrap();
+    fs::create_dir(&dst).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("rename")
+        .arg("--from")
+        .arg(&src)
+        .arg("--to")
+        .arg(&dst)
+        .arg("--force")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("destination is not a file"));
+
+    assert!(src.is_file(), "source file should remain in place");
+    assert!(dst.is_dir(), "destination directory should remain in place");
+}
+
+#[test]
+fn test_rename_force_directory_destination_fails_in_check_mode() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("old.txt");
+    let dst = dir.path().join("folder");
+    fs::write(&src, "hello\n").unwrap();
+    fs::create_dir(&dst).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("rename")
+        .arg("--from")
+        .arg(&src)
+        .arg("--to")
+        .arg(&dst)
+        .arg("--force")
+        .arg("--check")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("destination is not a file"));
+
+    assert!(src.is_file(), "source file should remain in place");
+    assert!(dst.is_dir(), "destination directory should remain in place");
+}
+
+#[test]
+fn test_rename_force_directory_destination_fails_in_apply_mode() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("old.txt");
+    let dst = dir.path().join("folder");
+    fs::write(&src, "hello\n").unwrap();
+    fs::create_dir(&dst).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("rename")
+        .arg("--from")
+        .arg(&src)
+        .arg("--to")
+        .arg(&dst)
+        .arg("--force")
+        .arg("--apply")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("destination is not a file"));
+
+    assert!(src.is_file(), "source file should remain in place");
+    assert!(dst.is_dir(), "destination directory should remain in place");
+}
+
+#[test]
 fn test_rename_directory_source_fails() {
     let dir = TempDir::new().unwrap();
     let src = dir.path().join("folder");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3219,6 +3219,52 @@ fn test_rename_missing_source_fails() {
 }
 
 #[test]
+fn test_rename_check_directory_source_fails() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("folder");
+    let dst = dir.path().join("moved-folder");
+    fs::create_dir(&src).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("rename")
+        .arg("--from")
+        .arg(&src)
+        .arg("--to")
+        .arg(&dst)
+        .arg("--check")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("source is not a file"));
+
+    assert!(src.is_dir(), "source directory should remain in place");
+    assert!(!dst.exists(), "destination should not be created");
+}
+
+#[test]
+fn test_rename_directory_source_fails() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("folder");
+    let dst = dir.path().join("moved-folder");
+    fs::create_dir(&src).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("rename")
+        .arg("--from")
+        .arg(&src)
+        .arg("--to")
+        .arg(&dst)
+        .arg("--apply")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("source is not a file"));
+
+    assert!(src.is_dir(), "source directory should remain in place");
+    assert!(!dst.exists(), "destination should not be created");
+}
+
+#[test]
 fn test_rename_binary_file() {
     let dir = TempDir::new().unwrap();
     let src = dir.path().join("image.bin");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -800,6 +800,31 @@ fn test_replace_multiline_regex() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_doc_get_jsonl_compound_value_is_single_line_json() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"obj":{"name":"patchloom","version":1}}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("get")
+        .arg(&file)
+        .arg("obj")
+        .arg("--jsonl")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1);
+    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(json["name"], "patchloom");
+    assert_eq!(json["version"], 1);
+}
+
+#[test]
 fn test_doc_get_json() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.json");
@@ -847,6 +872,34 @@ fn test_doc_has_missing_key() {
         .assert()
         .success()
         .stdout(predicate::str::contains("false"));
+}
+
+#[test]
+fn test_doc_keys_jsonl_outputs_one_key_per_line() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"scripts":{"build":"tsc","lint":"eslint"}}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("keys")
+        .arg(&file)
+        .arg("scripts")
+        .arg("--jsonl")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+    assert_eq!(lines.len(), 2);
+    assert!(lines.iter().any(|v| v == "build"));
+    assert!(lines.iter().any(|v| v == "lint"));
 }
 
 #[test]
@@ -2831,6 +2884,70 @@ fn test_hygiene_check_json_output() {
     assert_eq!(json["ok"], false);
     assert!(json["issue_count"].as_u64().unwrap() >= 2);
     assert!(json["issues"].is_array());
+}
+
+#[test]
+fn test_doc_flatten_jsonl_outputs_path_value_objects() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"a":1,"b":{"c":2}}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("flatten")
+        .arg(&file)
+        .arg("--jsonl")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+
+    assert!(lines.iter().any(|v| v["path"] == "a" && v["value"] == 1));
+    assert!(lines.iter().any(|v| v["path"] == "b.c" && v["value"] == 2));
+}
+
+#[test]
+fn test_doc_diff_jsonl_outputs_one_entry_per_line() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.json");
+    let b = dir.path().join("b.json");
+    fs::write(&a, r#"{"name":"old","removed":true}"#).unwrap();
+    fs::write(&b, r#"{"name":"new","added":"yes"}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("diff")
+        .arg(&a)
+        .arg(&b)
+        .arg("--jsonl")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<serde_json::Value> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect();
+
+    assert!(lines
+        .iter()
+        .any(|v| v["kind"] == "changed" && v["path"] == "name"));
+    assert!(lines
+        .iter()
+        .any(|v| v["kind"] == "removed" && v["path"] == "removed"));
+    assert!(lines
+        .iter()
+        .any(|v| v["kind"] == "added" && v["path"] == "added"));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4357,6 +4357,71 @@ fn test_search_literal_flag() {
 // ---------------------------------------------------------------------------
 
 #[test]
+fn test_create_force_directory_target_fails_in_dry_run() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("folder");
+    fs::create_dir(&target).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("create")
+        .arg("--file")
+        .arg(&target)
+        .arg("--content")
+        .arg("hello\n")
+        .arg("--force")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("target is not a file"));
+
+    assert!(target.is_dir(), "directory should remain in place");
+}
+
+#[test]
+fn test_create_force_directory_target_fails_in_check_mode() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("folder");
+    fs::create_dir(&target).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("create")
+        .arg("--file")
+        .arg(&target)
+        .arg("--content")
+        .arg("hello\n")
+        .arg("--force")
+        .arg("--check")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("target is not a file"));
+
+    assert!(target.is_dir(), "directory should remain in place");
+}
+
+#[test]
+fn test_create_force_directory_target_fails_in_apply_mode() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("folder");
+    fs::create_dir(&target).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("create")
+        .arg("--file")
+        .arg(&target)
+        .arg("--content")
+        .arg("hello\n")
+        .arg("--force")
+        .arg("--apply")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("target is not a file"));
+
+    assert!(target.is_dir(), "directory should remain in place");
+}
+
+#[test]
 fn test_create_force_overwrites_existing() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("existing.txt");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2152,6 +2152,58 @@ fn test_status_modified_file() {
 }
 
 #[test]
+fn test_status_jsonl_output() {
+    let dir = TempDir::new().unwrap();
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "a.txt"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    fs::write(dir.path().join("new.txt"), "new\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("status")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["total_changes"], 1);
+    assert!(json["created"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|v| v == "new.txt"));
+}
+
+#[test]
 fn test_status_json_output() {
     let dir = TempDir::new().unwrap();
     std::process::Command::new("git")
@@ -3072,6 +3124,31 @@ fn test_create_check_exits_2() {
 }
 
 #[test]
+fn test_create_check_jsonl_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("new.txt");
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("create")
+        .arg("--file")
+        .arg(&file)
+        .arg("--content")
+        .arg("hello\n")
+        .arg("--check")
+        .arg("--jsonl")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["path"], file.to_str().unwrap());
+    assert!(json["diff"].is_null());
+}
+
+#[test]
 fn test_create_check_json_output() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("new.txt");
@@ -3285,6 +3362,32 @@ fn test_rename_binary_file() {
 
     assert!(!src.exists());
     assert_eq!(fs::read(&dst).unwrap(), b"\x00\x01\x02\xff\xfe");
+}
+
+#[test]
+fn test_rename_check_jsonl_output() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("old.txt");
+    fs::write(&src, "content\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("rename")
+        .arg("--from")
+        .arg(&src)
+        .arg("--to")
+        .arg(dir.path().join("new.txt"))
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["from"], src.to_str().unwrap());
+    assert_eq!(json["to"], dir.path().join("new.txt").to_str().unwrap());
+    assert!(json["diff"].is_null());
 }
 
 #[test]
@@ -5934,6 +6037,29 @@ fn test_delete_removes_file() {
         .success();
 
     assert!(!file.exists());
+}
+
+#[test]
+fn test_delete_jsonl_check_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("safe.txt");
+    fs::write(&file, "keep\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("delete")
+        .arg("--file")
+        .arg(file.to_str().unwrap())
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["applied"], false);
+    assert!(json["path"].as_str().unwrap().contains("safe.txt"));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4312,6 +4312,29 @@ fn test_md_dedupe_headings_json_output() {
 }
 
 #[test]
+fn test_md_lint_agents_quiet_suppresses_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("AGENTS.md");
+    fs::write(&file, "# T\n\nUse git add .\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--quiet")
+        .arg("md")
+        .arg("lint-agents")
+        .arg("--file")
+        .arg(&file)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        output.stdout.is_empty(),
+        "quiet should suppress lint-agents output"
+    );
+}
+
+#[test]
 fn test_md_lint_agents_clean_file_exits_0() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("AGENTS.md");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4655,6 +4655,34 @@ fn test_tx_json_output_create_then_delete_is_noop() {
 }
 
 #[test]
+fn test_tx_file_delete_directory_target_fails() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("folder");
+    fs::create_dir(&target).unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "file.delete", "path": "folder"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .assert()
+        .code(7)
+        .stderr(predicate::str::contains("target is not a file"));
+
+    assert!(target.is_dir(), "directory should remain in place");
+}
+
+#[test]
 fn test_tx_file_delete_existing() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("doomed.txt");
@@ -5149,6 +5177,36 @@ fn test_tx_file_delete_empty_file() {
         .success();
 
     assert!(!file.exists(), "empty file should be deleted");
+}
+
+#[test]
+fn test_tx_file_rename_directory_source_fails() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("folder");
+    let dst = dir.path().join("new-name");
+    fs::create_dir(&src).unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "file.rename", "from": "folder", "to": "new-name"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .assert()
+        .code(7)
+        .stderr(predicate::str::contains("source is not a file"));
+
+    assert!(src.is_dir(), "source directory should remain in place");
+    assert!(!dst.exists(), "destination should not be created");
 }
 
 #[test]
@@ -6467,6 +6525,35 @@ fn test_tx_file_create_new_file_writes_content() {
         "created via tx\n",
         "file.create via tx should write correct content through File::create_new"
     );
+}
+
+#[test]
+fn test_tx_file_create_force_directory_target_fails() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("folder");
+    fs::create_dir(&target).unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "file.create",
+            "path": target.to_str().unwrap(),
+            "content": "hello\n",
+            "force": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .assert()
+        .code(7)
+        .stderr(predicate::str::contains("target is not a file"));
+
+    assert!(target.is_dir(), "directory should remain in place");
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6131,6 +6131,43 @@ fn test_delete_check_mode_does_not_remove() {
 }
 
 #[test]
+fn test_delete_directory_target_fails_in_dry_run() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("folder");
+    fs::create_dir(&target).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("delete")
+        .arg("--file")
+        .arg(target.to_str().unwrap())
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("target is not a file"));
+
+    assert!(target.is_dir(), "directory should remain in place");
+}
+
+#[test]
+fn test_delete_directory_target_fails_in_check_mode() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("folder");
+    fs::create_dir(&target).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("delete")
+        .arg("--file")
+        .arg(target.to_str().unwrap())
+        .arg("--check")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("target is not a file"));
+
+    assert!(target.is_dir(), "directory should remain in place");
+}
+
+#[test]
 fn test_delete_nonexistent_file_fails() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("ghost.txt");


### PR DESCRIPTION
This PR fixes two classes of user-visible bugs found through iterative multi-perspective auditing:

**File-only contract enforcement:**
- Standalone `rename`, `delete`, and `create` now reject directory paths consistently across preview, `--check`, and `--apply` modes instead of only failing on apply
- `tx file.rename`, `tx file.create`, and `tx file.delete` now use the same explicit file-only error messages as standalone commands
- `patch check` now distinguishes directory read errors from missing files

**JSONL output contract:**
- `create`, `delete`, `rename`, and `status` now honor `--jsonl` instead of emitting human text
- `doc` read actions (`get`, `has`, `keys`, `len`, `select`, `flatten`, `diff`) now honor `--jsonl` with action-appropriate compact output
- `tx` and `batch` now honor `--jsonl` with compact single-line JSON envelopes

All changes include focused regression tests. Full gate (`make check`) passes.