### PR TITLE
Fix status parsing for filenames with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 841 tests (439 unit + 402 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 843 tests (440 unit + 403 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-841%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-843%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -334,7 +334,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-841 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+843 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -26,13 +26,13 @@ enum FileCategory {
     Modified,
 }
 
-/// Parse one line of `git status --porcelain=v1` into a category and file path.
-fn parse_porcelain_line(line: &str) -> Option<(FileCategory, String)> {
-    if line.len() < 4 {
+/// Parse one NUL-delimited `git status --porcelain=v1 -z` record.
+fn parse_porcelain_record(record: &[u8]) -> Option<(FileCategory, String)> {
+    if record.len() < 4 {
         return None;
     }
-    let xy = &line[..2];
-    let file = line[3..].to_string();
+    let xy = std::str::from_utf8(&record[..2]).ok()?;
+    let file = String::from_utf8_lossy(&record[3..]).into_owned();
     let category = match xy.trim() {
         "??" | "A" | "AM" => FileCategory::Created,
         "D" => FileCategory::Deleted,
@@ -48,7 +48,8 @@ pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     cmd.current_dir(&cwd)
         .arg("status")
         .arg("--porcelain=v1")
-        .arg("--no-renames");
+        .arg("--no-renames")
+        .arg("-z");
     for path in &args.paths {
         cmd.arg("--").arg(path);
     }
@@ -58,15 +59,18 @@ pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         anyhow::bail!("git status failed: {stderr}");
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
     let glob_matcher = crate::build_glob_matcher(global)?;
 
     let mut modified = Vec::new();
     let mut created = Vec::new();
     let mut deleted = Vec::new();
 
-    for line in stdout.lines() {
-        let (category, file) = match parse_porcelain_line(line) {
+    for record in output
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|record| !record.is_empty())
+    {
+        let (category, file) = match parse_porcelain_record(record) {
             Some(v) => v,
             None => continue,
         };
@@ -121,43 +125,50 @@ mod tests {
 
     #[test]
     fn parse_untracked_file() {
-        let (cat, file) = parse_porcelain_line("?? new.txt").unwrap();
+        let (cat, file) = parse_porcelain_record(b"?? new.txt").unwrap();
         assert_eq!(cat, FileCategory::Created);
         assert_eq!(file, "new.txt");
     }
 
     #[test]
     fn parse_staged_new_file() {
-        let (cat, file) = parse_porcelain_line("A  staged.txt").unwrap();
+        let (cat, file) = parse_porcelain_record(b"A  staged.txt").unwrap();
         assert_eq!(cat, FileCategory::Created);
         assert_eq!(file, "staged.txt");
     }
 
     #[test]
     fn parse_staged_and_modified() {
-        let (cat, file) = parse_porcelain_line("AM both.txt").unwrap();
+        let (cat, file) = parse_porcelain_record(b"AM both.txt").unwrap();
         assert_eq!(cat, FileCategory::Created);
         assert_eq!(file, "both.txt");
     }
 
     #[test]
     fn parse_deleted_file() {
-        let (cat, file) = parse_porcelain_line("D  gone.txt").unwrap();
+        let (cat, file) = parse_porcelain_record(b"D  gone.txt").unwrap();
         assert_eq!(cat, FileCategory::Deleted);
         assert_eq!(file, "gone.txt");
     }
 
     #[test]
     fn parse_modified_file() {
-        let (cat, file) = parse_porcelain_line(" M changed.txt").unwrap();
+        let (cat, file) = parse_porcelain_record(b" M changed.txt").unwrap();
         assert_eq!(cat, FileCategory::Modified);
         assert_eq!(file, "changed.txt");
     }
 
     #[test]
     fn parse_short_line_returns_none() {
-        assert!(parse_porcelain_line("??").is_none());
-        assert!(parse_porcelain_line("A").is_none());
-        assert!(parse_porcelain_line("").is_none());
+        assert!(parse_porcelain_record(b"??").is_none());
+        assert!(parse_porcelain_record(b"A").is_none());
+        assert!(parse_porcelain_record(b"").is_none());
+    }
+
+    #[test]
+    fn parse_filename_with_spaces() {
+        let (cat, file) = parse_porcelain_record(b"?? file name.txt").unwrap();
+        assert_eq!(cat, FileCategory::Created);
+        assert_eq!(file, "file name.txt");
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2459,6 +2459,58 @@ fn test_status_deleted_file() {
     );
 }
 
+#[test]
+fn test_status_glob_matches_filename_with_spaces() {
+    let dir = TempDir::new().unwrap();
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "a.txt"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    fs::write(dir.path().join("file name.txt"), "new\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--glob")
+        .arg("*.txt")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("status")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let created = json["created"].as_array().unwrap();
+    assert!(
+        created.iter().any(|v| v.as_str() == Some("file name.txt")),
+        "glob-filtered status should report the unquoted filename, got: {json}"
+    );
+}
+
 // ── create command ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- parse `git status` with `--porcelain=v1 -z` in `status`
- preserve filenames with spaces when applying `--glob` filters
- add regression coverage and refresh recorded test counts

## Testing
- `make check`