### PR TITLE
Relax example plan format timeouts

### DIFF
--- a/examples/02-multi-file-batch.json
+++ b/examples/02-multi-file-batch.json
@@ -6,7 +6,7 @@
     { "op": "replace", "glob": "*.md", "from": "v0.1.0", "to": "v0.2.0" }
   ],
   "format": [
-    { "cmd": "cargo fmt --all", "timeout": 30 }
+    { "cmd": "cargo fmt --all" }
   ],
   "validate": [
     { "cmd": "cargo build", "required": true, "timeout": 120 }

--- a/examples/05-strict-mode.json
+++ b/examples/05-strict-mode.json
@@ -10,7 +10,7 @@
     { "op": "md.insert_after_heading", "path": "CHANGELOG.md", "heading": "## Unreleased", "content": "- Added new_module" }
   ],
   "format": [
-    { "cmd": "cargo fmt --all", "timeout": 30 }
+    { "cmd": "cargo fmt --all" }
   ],
   "validate": [
     { "cmd": "cargo build", "required": true, "timeout": 120 },


### PR DESCRIPTION
## Summary
- remove brittle explicit 30s `cargo fmt --all` timeouts from the two tx example plans
- let those example lifecycle steps use the command default timeout instead
- keep the examples unchanged otherwise while avoiding flaky Windows smoke failures

## Testing
- `cargo test --all-features --test integration test_smoke_example_02_multi_file_batch_plan -- --exact --nocapture`
- `cargo test --all-features --test integration test_smoke_example_05_strict_mode_plan -- --exact --nocapture`
- `make check`