### PR TITLE
Clarify tx lifecycle step fields

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -679,6 +679,8 @@ Use these when newline and whitespace correctness is the main concern.
 
 - **What it does:** Runs shell commands after writes are staged to disk but before validation.
 - **Use when:** Generated or edited files should be normalized by tools like `cargo fmt`, `prettier`, or `black` as part of the same workflow.
+- **Step fields:** Each entry accepts `cmd` (required shell command) and `timeout` (seconds, default `60`).
+- **Failure behavior:** Any non-zero exit or timeout fails the transaction. With `strict: true`, Patchloom rolls back the staged writes.
 - **Prefer instead:** Run formatting outside `tx` when it does not need to participate in the transaction's success criteria.
 
 <!-- ref:tx-field:validate -->
@@ -686,6 +688,8 @@ Use these when newline and whitespace correctness is the main concern.
 
 - **What it does:** Runs shell commands that decide whether the transaction should be reported as valid.
 - **Use when:** Build, test, or policy checks are part of the definition of success for the change.
+- **Step fields:** Each entry accepts `cmd` (required shell command), `required` (bool, default `false`), and `timeout` (seconds, default `60`).
+- **Failure behavior:** `required: true` makes the step gate transaction success. `required: false` still reports the validation problem to stderr, but the transaction keeps succeeding.
 - **Prefer instead:** Use standalone verification outside `tx` when the mutation and the validation lifecycle should stay separate.
 
 ### Transaction operations


### PR DESCRIPTION
## Summary
- document the per-step fields accepted by `tx.format`
- document the per-step fields accepted by `tx.validate`
- clarify the default timeout and validation gating behavior in the reference docs

## Testing
- `make check`