### PR TITLE
Document tx write policy fields

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -658,6 +658,8 @@ Use these when newline and whitespace correctness is the main concern.
 
 - **What it does:** Applies newline, EOL, and whitespace normalization across all pending writes in the plan.
 - **Use when:** Every write in the transaction should share the same normalization policy.
+- **Fields:** Supports `ensure_final_newline` (bool), `normalize_eol` (`keep`, `lf`, or `crlf`), and `trim_trailing_whitespace` (bool).
+- **Precedence:** Patchloom starts from the invocation's per-file write policy, including CLI flags and any `--respect-editorconfig` values, then overrides only the keys set here.
 - **Prefer instead:** Use CLI write flags when one invocation needs defaults, but the plan itself should stay generic.
 
 <!-- ref:tx-field:strict -->


### PR DESCRIPTION
## Summary
- document the supported `tx.write_policy` subfields in the reference docs
- document how plan-level `write_policy` interacts with CLI flags and editorconfig-derived defaults

## Testing
- `cargo test --all-features --test integration test_reference_doc_covers_meaningful_feature_inventory -- --exact --nocapture`
- `cargo test --all-features --test integration test_reference_doc_requires_use_when_stanza -- --exact --nocapture`
- `make check`