### PR TITLE
Narrow release workflow token scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@
 
 name: Release
 permissions:
-  "contents": "write"
+  "contents": "read"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -52,6 +52,8 @@ concurrency:
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
+    permissions:
+      "contents": "write"
     runs-on: "ubuntu-22.04"
     timeout-minutes: 10
     outputs:
@@ -222,6 +224,8 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
+    permissions:
+      "contents": "write"
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:


### PR DESCRIPTION
## Summary
- reduce the default `release.yml` token scope from `contents: write` to `contents: read`
- keep `contents: write` only on the `plan` and `host` jobs that create or mutate GitHub release state
- leave external publish paths unchanged and still gated off while the repo stays private

## Testing
- `make check`
- parsed `.github/workflows/release.yml` locally with PyYAML