### PR TITLE
Clarify example template guidance

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,8 +3,8 @@
 Sample transaction plans and batch scripts demonstrating Patchloom's capabilities.
 
 These examples are **illustrative templates**, not guaranteed to run unchanged in
-this repo. Read the target paths in each file first, then adapt them to your
-project before applying.
+this repo. Read the target paths and any embedded `format` or `validate`
+commands in each file first, then adapt them to your project before applying.
 
 ```
 # Transaction plans (JSON)


### PR DESCRIPTION
## Summary
- clarify that example plans are templates that may need lifecycle command changes as well as path changes
- explicitly call out embedded `format` and `validate` commands in `examples/README.md`

## Testing
- `make check`