### PR TITLE
Align tx read empty-file metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 843 tests (440 unit + 403 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 844 tests (440 unit + 404 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-843%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-844%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -334,7 +334,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-843 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+844 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -539,6 +539,8 @@ fn execute_read_op(path: &str, lines: &Option<String>, tx: &mut TxState<'_>) -> 
         let (s, e) = crate::cmd::read::parse_line_range(spec)?;
         let end = e.unwrap_or(total_lines).min(total_lines);
         (s, end)
+    } else if total_lines == 0 {
+        (0, 0)
     } else {
         (1, total_lines)
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7886,6 +7886,35 @@ fn test_tx_read_operation_in_plan() {
 }
 
 #[test]
+fn test_tx_read_empty_file_without_lines_matches_read_contract() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.txt");
+    fs::write(&file, "").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{"op": "read", "path": file.to_str().unwrap()}]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["reads"][0]["content"].as_str().unwrap(), "");
+    assert_eq!(json["reads"][0]["total_lines"], 0);
+    assert_eq!(json["reads"][0]["start_line"], 0);
+    assert_eq!(json["reads"][0]["end_line"], 0);
+}
+
+#[test]
 fn test_tx_read_with_lines_in_plan() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("data.txt");


### PR DESCRIPTION
## Summary
- align `tx` read results with the standalone `read` contract for empty files without a line range
- add an integration regression test for the empty-file `tx` read case
- refresh generated test-count docs after adding the new regression test

## Testing
- `make check`