### PR TITLE
Preserve tx read raw file content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 844 tests (440 unit + 404 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 845 tests (440 unit + 405 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-844%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-845%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -334,7 +334,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-844 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+845 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -532,17 +532,28 @@ fn execute_read_op(path: &str, lines: &Option<String>, tx: &mut TxState<'_>) -> 
     read_file_content(tx.pending, &file_path, tx.cwd)?;
     // Re-borrow immutably to avoid cloning the entire file content.
     let content = &tx.pending[&file_path].1;
+    // Fast path: no line range requested, preserve raw content exactly and avoid
+    // rebuilding lines. This matches the standalone `read` command contract.
+    if lines.is_none() {
+        let total_lines = content.lines().count();
+        let start_line = if total_lines == 0 { 0 } else { 1 };
+        tx.tx_reads.push(TxReadResult {
+            path: path.to_string(),
+            content: content.clone(),
+            start_line,
+            end_line: total_lines,
+            total_lines,
+        });
+        return Ok(());
+    }
+
     let all_lines: Vec<&str> = content.lines().collect();
     let total_lines = all_lines.len();
-
-    let (start, end) = if let Some(spec) = lines {
+    let (start, end) = {
+        let spec = lines.as_ref().unwrap();
         let (s, e) = crate::cmd::read::parse_line_range(spec)?;
         let end = e.unwrap_or(total_lines).min(total_lines);
         (s, end)
-    } else if total_lines == 0 {
-        (0, 0)
-    } else {
-        (1, total_lines)
     };
 
     let selected = if total_lines == 0 {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7915,6 +7915,35 @@ fn test_tx_read_empty_file_without_lines_matches_read_contract() {
 }
 
 #[test]
+fn test_tx_read_without_lines_preserves_crlf_content() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("crlf.txt");
+    fs::write(&file, "a\r\nb\r\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{"op": "read", "path": file.to_str().unwrap()}]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["reads"][0]["content"].as_str().unwrap(), "a\r\nb\r\n");
+    assert_eq!(json["reads"][0]["start_line"], 1);
+    assert_eq!(json["reads"][0]["end_line"], 2);
+    assert_eq!(json["reads"][0]["total_lines"], 2);
+}
+
+#[test]
 fn test_tx_read_with_lines_in_plan() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("data.txt");


### PR DESCRIPTION
## Summary
- preserve raw file content for no-range `tx` reads so they match standalone `read`, including CRLF line endings
- skip the unnecessary split-and-join path for no-range `tx` reads
- add regression coverage and refresh generated test-count docs

## Testing
- `make check`