### PR TITLE
Validate read --lines before execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 845 tests (440 unit + 405 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 847 tests (440 unit + 407 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-845%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-847%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -334,7 +334,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-845 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+847 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -115,6 +115,18 @@ fn read_one_file(path: &str, lines_spec: &Option<String>) -> Result<ReadOutput, 
 pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
 
+    if let Some(spec) = &args.lines
+        && let Err(err) = parse_line_range(spec)
+    {
+        if global.json || global.jsonl {
+            anyhow::bail!("invalid --lines value '{spec}': {err}");
+        }
+        if !global.quiet {
+            eprintln!("read: {err}");
+        }
+        return Ok(exit::FAILURE);
+    }
+
     let multi = args.files.len() > 1;
     let mut outputs: Vec<ReadOutput> = Vec::new();
     let mut errors: Vec<String> = Vec::new();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2068,6 +2068,47 @@ fn test_read_nonexistent_file_fails() {
 }
 
 #[test]
+fn test_read_invalid_lines_returns_failure() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\nworld\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("read")
+        .arg(file.to_str().unwrap())
+        .arg("--lines")
+        .arg("0:1")
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("line numbers are 1-based"));
+}
+
+#[test]
+fn test_read_json_invalid_lines_returns_error_object() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\nworld\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("read")
+        .arg(file.to_str().unwrap())
+        .arg("--lines")
+        .arg("0:1")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("invalid --lines value '0:1'"));
+    assert!(error.contains("line numbers are 1-based"));
+}
+
+#[test]
 fn test_read_json_output() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("data.txt");


### PR DESCRIPTION
## Summary
- validate `read --lines` once before per-file execution
- return the structured top-level error envelope in `--json` mode instead of serializing `[]` for invalid line ranges
- add plain and structured regression coverage, then refresh generated test counts

## Testing
- `make check`