### PR TITLE
Emit structured patch apply errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 847 tests (440 unit + 407 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 850 tests (440 unit + 410 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-847%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-850%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -334,7 +334,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-847 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+850 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -79,6 +79,18 @@ struct PatchCheckOutput {
     files: Vec<PatchCheckResult>,
 }
 
+fn emit_error(global: &GlobalFlags, error: &str) -> anyhow::Result<()> {
+    if global.emit_json(&serde_json::json!({
+        "ok": false,
+        "error": error,
+    }))? {
+        return Ok(());
+    }
+
+    eprintln!("{error}");
+    Ok(())
+}
+
 // ── Public entry point ──────────────────────────────────────────────
 
 pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
@@ -91,15 +103,17 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let diff_text = match read_diff_input(&file, stdin_flag) {
         Ok(text) => text,
         Err(DiffReadError::NoSource) => {
-            eprintln!("patch: must specify --file <path> or --stdin");
+            emit_error(global, "patch: must specify --file <path> or --stdin")?;
             return Ok(exit::PARSE_ERROR);
         }
         Err(DiffReadError::IoError(path, e)) => {
-            eprintln!("patch: failed to read '{}': {}", path, e);
+            let msg = format!("patch: failed to read '{path}': {e}");
+            emit_error(global, &msg)?;
             return Ok(exit::PARSE_ERROR);
         }
         Err(DiffReadError::StdinError(e)) => {
-            eprintln!("patch: failed to read stdin: {}", e);
+            let msg = format!("patch: failed to read stdin: {e}");
+            emit_error(global, &msg)?;
             return Ok(exit::PARSE_ERROR);
         }
     };
@@ -108,7 +122,8 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let patch_files = match parse_patch(&diff_text) {
         Ok(pf) => pf,
         Err(msg) => {
-            eprintln!("patch: parse error: {msg}");
+            let msg = format!("patch: parse error: {msg}");
+            emit_error(global, &msg)?;
             return Ok(exit::PARSE_ERROR);
         }
     };
@@ -201,19 +216,21 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     Ok(s) => s,
                     Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
                     Err(e) => {
-                        eprintln!(
+                        let msg = format!(
                             "patch apply: {} -- READ ERROR: failed to read {}: {}",
                             pf.path,
                             file_path.display(),
                             e
                         );
+                        emit_error(global, &msg)?;
                         return Ok(exit::AMBIGUOUS);
                     }
                 };
                 let patched = match apply_hunks(&original, &pf.hunks) {
                     Ok(p) => p,
                     Err(msg) => {
-                        eprintln!("patch apply: {} -- STALE: {}", pf.path, msg);
+                        let msg = format!("patch apply: {} -- STALE: {}", pf.path, msg);
+                        emit_error(global, &msg)?;
                         return Ok(exit::AMBIGUOUS);
                     }
                 };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -96,6 +96,24 @@ fn shell_test_exists(path: &Path) -> String {
     }
 }
 
+fn assert_patch_apply_error_object(
+    output: &std::process::Output,
+    expected_exit_code: i32,
+    expected_error_substring: &str,
+) {
+    assert_eq!(output.status.code(), Some(expected_exit_code));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains(expected_error_substring)
+    );
+}
+
 fn git_ok(dir: &Path, args: &[&str]) {
     let output = std::process::Command::new("git")
         .args(args)
@@ -3069,6 +3087,54 @@ fn test_hygiene_check_exits_0_when_clean() {
 }
 
 #[test]
+fn test_patch_apply_json_parse_error_returns_error_object() {
+    let dir = TempDir::new().unwrap();
+    let patch_file = dir.path().join("bad.patch");
+    fs::write(&patch_file, "not a patch\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("patch")
+        .arg("apply")
+        .arg("--file")
+        .arg(&patch_file)
+        .output()
+        .unwrap();
+
+    assert_patch_apply_error_object(&output, 4, "patch: parse error:");
+}
+
+#[test]
+fn test_patch_apply_json_stale_error_returns_error_object() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let patch_file = dir.path().join("stale.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1 +1 @@\n-old\n+new\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("apply")
+        .arg("--file")
+        .arg(&patch_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_patch_apply_error_object(&output, 5, "patch apply: test.txt -- STALE:");
+}
+
+#[test]
 fn test_patch_check_exits_0_when_clean() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -3124,6 +3190,25 @@ fn test_patch_check_json_output_clean() {
     assert_eq!(json["ok"], true);
     assert!(json["files"].is_array());
     assert_eq!(json["files"][0]["status"], "clean");
+}
+
+#[test]
+fn test_patch_apply_jsonl_parse_error_returns_error_object() {
+    let dir = TempDir::new().unwrap();
+    let patch_file = dir.path().join("bad.patch");
+    fs::write(&patch_file, "not a patch\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("patch")
+        .arg("apply")
+        .arg("--file")
+        .arg(&patch_file)
+        .output()
+        .unwrap();
+
+    assert_patch_apply_error_object(&output, 4, "patch: parse error:");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- emit machine-readable error objects for `patch apply` parse and stale/read failures in structured mode
- keep the existing `patch check` JSON schema and preserve the existing patch exit codes
- add regression coverage for JSON and JSONL patch-apply error cases, then refresh generated test counts

## Testing
- `make check`