### PR TITLE
Clarify tx lifecycle rollback in quickstart

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -105,7 +105,9 @@ Apply all changes atomically:
 patchloom tx --plan bump.json --apply
 ```
 
-If any operation fails, nothing is written.
+If an operation fails, nothing is written. Format and validate lifecycle steps run
+after writes, so use `"strict": true` in the plan if you want those failures to
+roll back all changes too.
 
 ## Step 6: Use in CI
 


### PR DESCRIPTION
## Summary
- clarify that the quickstart transaction example only rolls back lifecycle failures when the plan uses `"strict": true`
- make the first-run quickstart wording align with the documented `tx` lifecycle semantics

## Testing
- `cargo test --test integration test_smoke_quickstart_command_flow -- --exact --nocapture`
- `cargo test --test integration test_smoke_quickstart_transaction_snippet -- --exact --nocapture`
- `make check`