### PR TITLE
Route Linux CI jobs to self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
         run: cargo check --all-targets --all-features
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'ubuntu-latest' || fromJson('["self-hosted","Linux","X64"]') }}
     timeout-minutes: 15
     steps:
       - name: Harden Runner
@@ -146,7 +146,8 @@ jobs:
         with:
           components: llvm-tools-preview
 
-      - name: Cache Rust dependencies
+      - name: Cache Rust dependencies (fork PRs on GitHub-hosted runners)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   trivy:
     name: Trivy
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'ubuntu-latest' || fromJson('["self-hosted","Linux","X64"]') }}
     timeout-minutes: 10
     steps:
       - name: Harden Runner
@@ -38,7 +38,7 @@ jobs:
 
   gitleaks:
     name: Gitleaks
-    runs-on: ubuntu-latest
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'ubuntu-latest' || fromJson('["self-hosted","Linux","X64"]') }}
     timeout-minutes: 5
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Summary
- route Linux-only `coverage`, `trivy`, and `gitleaks` jobs to the existing self-hosted Linux runner for trusted events
- keep fork PRs on GitHub-hosted Linux runners using the same fallback pattern already used elsewhere in CI
- leave Windows and macOS jobs on GitHub-hosted runners as requested

## Testing
- parsed `.github/workflows/ci.yml` and `.github/workflows/security.yml` locally with PyYAML
- `make check`