### PR TITLE
Fix self-hosted Linux workflow tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,12 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Generate coverage
-        run: cargo llvm-cov --all-features --lib --test integration --lcov --output-path lcov.info
+        run: |
+          if [[ -x /home/linuxbrew/.linuxbrew/bin/llvm-profdata && -x /home/linuxbrew/.linuxbrew/bin/llvm-cov ]]; then
+            export LLVM_PROFDATA=/home/linuxbrew/.linuxbrew/bin/llvm-profdata
+            export LLVM_COV=/home/linuxbrew/.linuxbrew/bin/llvm-cov
+          fi
+          cargo llvm-cov --all-features --lib --test integration --lcov --output-path lcov.info
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -53,8 +53,11 @@ jobs:
           GITLEAKS_VERSION: 8.30.1
         run: |
           archive="${RUNNER_TEMP}/gitleaks.tar.gz"
+          bindir="${RUNNER_TEMP}/gitleaks-bin"
+          mkdir -p "$bindir"
           curl --retry 5 --retry-all-errors --retry-delay 2 -sSfL \
             -o "$archive" \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          tar -xzf "$archive" -C /usr/local/bin gitleaks
+          tar -xzf "$archive" -C "$bindir" gitleaks
+          printf '%s\n' "$bindir" >> "$GITHUB_PATH"
       - run: gitleaks detect --source . --exit-code 1


### PR DESCRIPTION
## Summary
- install `gitleaks` into a writable temp bin directory on the self-hosted Linux runner instead of extracting into `/usr/local/bin`
- point the self-hosted coverage job at the available Linux LLVM tools before running `cargo llvm-cov`
- keep the earlier trusted-event self-hosted runner routing intact

## Testing
- parsed `.github/workflows/ci.yml` and `.github/workflows/security.yml` locally with PyYAML
- `make check`
- extracted and ran `gitleaks` locally from a temp bin dir
- ran `cargo llvm-cov` locally with explicit `LLVM_PROFDATA` and `LLVM_COV` paths