### PR TITLE
Fix tx glob replace for newly created files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 850 tests (440 unit + 410 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 851 tests (440 unit + 411 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-850%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-851%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -334,7 +334,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-850 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+851 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -478,8 +478,14 @@ fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<us
         Ok(match_count)
     } else if let Some(pattern) = glob {
         let matcher = Glob::new(pattern)?.compile_matcher();
-        let walker = WalkBuilder::new(tx.cwd).build();
+        let matches_pattern = |path: &Path| {
+            matcher.is_match(path) || path.file_name().is_some_and(|name| matcher.is_match(name))
+        };
         let mut total_matches = 0usize;
+        let mut candidate_paths = Vec::new();
+        let mut seen_paths = HashSet::new();
+
+        let walker = WalkBuilder::new(tx.cwd).build();
         for entry in walker {
             let entry = match entry {
                 Ok(e) => e,
@@ -489,11 +495,25 @@ fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<us
                 continue;
             }
             let file_path = entry.path().to_path_buf();
-            if !matcher.is_match(&file_path)
-                && !file_path.file_name().is_some_and(|n| matcher.is_match(n))
+            if matches_pattern(&file_path) && seen_paths.insert(file_path.clone()) {
+                candidate_paths.push(file_path);
+            }
+        }
+
+        for pending_path in tx.pending.keys() {
+            if !pending_path.starts_with(tx.cwd)
+                || pending_path.exists()
+                || tx.deletions.contains(pending_path)
+                || !matches_pattern(pending_path)
             {
                 continue;
             }
+            if seen_paths.insert(pending_path.clone()) {
+                candidate_paths.push(pending_path.clone());
+            }
+        }
+
+        for file_path in candidate_paths {
             let content = if tx.pending.contains_key(&file_path) {
                 let result = read_file_content(tx.pending, &file_path, tx.cwd);
                 match result {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5992,6 +5992,36 @@ fn test_tx_glob_replace_only_matches_pattern() {
     );
 }
 
+#[test]
+fn test_tx_glob_replace_matches_file_created_earlier_in_transaction() {
+    let dir = TempDir::new().unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "file.create", "path": "new.txt", "content": "hello\n"},
+            {"op": "replace", "glob": "*.txt", "from": "hello", "to": "bye"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new.txt")).unwrap(),
+        "bye\n"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // tx: md operations in plan
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make tx glob-based replace consider matching files created earlier in the same transaction
- add a regression test for file.create followed by replace with glob in one plan
- refresh README and CHANGELOG test counts after the new integration test

## Testing
- cargo test --test integration test_tx_glob_replace_matches_file_created_earlier_in_transaction
- make check
