### PR TITLE
Adapt workflows for hosted runner billing limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
         run: make check
 
   ci-windows:
+    # GitHub-hosted Windows runners are unavailable while this repo stays
+    # private and hosted-runner billing is blocked.
+    if: ${{ !github.event.repository.private }}
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
@@ -77,6 +80,9 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   ci-macos:
+    # GitHub-hosted macOS runners are unavailable while this repo stays
+    # private and hosted-runner billing is blocked.
+    if: ${{ !github.event.repository.private }}
     runs-on: macos-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,10 @@ jobs:
   plan:
     permissions:
       "contents": "write"
-    runs-on: "ubuntu-22.04"
+    # Use the self-hosted runner for trusted events. Fork PRs fall back to
+    # GitHub-hosted so untrusted workflow changes never run on the self-hosted
+    # machine.
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'ubuntu-22.04' || fromJson('["self-hosted","Linux","X64"]') }}
     timeout-minutes: 10
     outputs:
       val: ${{ steps.plan.outputs.manifest }}


### PR DESCRIPTION
## Summary
- route the Release plan job to the self-hosted Linux runner for trusted events
- skip the hosted Windows and macOS CI jobs while the private repo billing block prevents them from starting
- keep fork PRs on GitHub-hosted runners where self-hosted execution would be unsafe

## Testing
- python3 YAML parse for .github/workflows/ci.yml and .github/workflows/release.yml
- make check
