### PR TITLE
Fix relative glob matching across commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 851 tests (440 unit + 411 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 857 tests (443 unit + 414 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-851%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-857%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -334,7 +334,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-851 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+857 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/hygiene.rs
+++ b/src/cmd/hygiene.rs
@@ -94,15 +94,15 @@ fn collect_issues(paths: &[String], global: &GlobalFlags) -> anyhow::Result<Vec<
     let root = global.resolve_cwd()?;
     let glob_matcher = crate::build_glob_matcher(global)?;
     let file_paths = crate::collect_file_paths_opts(paths, global, true, Some(&root))?;
+    let glob_roots = crate::collect_glob_roots(paths, global, Some(&root))?;
 
-    let file_issues: Vec<Vec<HygieneIssue>> = crate::par_process_files(
-        &file_paths,
-        glob_matcher.as_ref(),
-        |path| match check_file(path) {
-            Ok(issues) if !issues.is_empty() => Some(issues),
-            _ => None,
-        },
-    );
+    let file_issues: Vec<Vec<HygieneIssue>> =
+        crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
+            match check_file(path) {
+                Ok(issues) if !issues.is_empty() => Some(issues),
+                _ => None,
+            }
+        });
 
     Ok(file_issues.into_iter().flatten().collect())
 }
@@ -159,6 +159,7 @@ pub fn run(args: HygieneArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let root = global.resolve_cwd()?;
             let glob_matcher = crate::build_glob_matcher(global)?;
             let fix_file_paths = crate::collect_file_paths_opts(&paths, global, true, Some(&root))?;
+            let glob_roots = crate::collect_glob_roots(&paths, global, Some(&root))?;
 
             // Parallel read+compute phase: each file is read, checked for
             // binary content, and has the write policy applied concurrently.
@@ -169,8 +170,11 @@ pub fn run(args: HygieneArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 fixed: String,
             }
 
-            let results: Vec<FixResult> =
-                crate::par_process_files(&fix_file_paths, glob_matcher.as_ref(), |file_path| {
+            let results: Vec<FixResult> = crate::par_process_files(
+                &fix_file_paths,
+                glob_matcher.as_ref(),
+                &glob_roots,
+                |file_path| {
                     let data = std::fs::read(file_path).ok()?;
                     if data.is_empty() || is_binary(&data) {
                         return None;
@@ -194,7 +198,8 @@ pub fn run(args: HygieneArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         original: original.into_owned(),
                         fixed,
                     })
-                });
+                },
+            );
 
             // Serial output/write phase for ordered, crash-safe writes.
             let any_changed = !results.is_empty();

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -97,6 +97,7 @@ fn collect_replacements(
     let cwd = global.resolve_cwd()?;
     let glob_matcher = crate::build_glob_matcher(global)?;
     let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+    let glob_roots = crate::collect_glob_roots(&args.paths, global, Some(&cwd))?;
     let replacement = build_replacement(args);
     let quiet = global.quiet;
 
@@ -121,7 +122,7 @@ fn collect_replacements(
     let nth = args.nth;
 
     let mut replacements: Vec<FileReplacement> =
-        crate::par_process_files(&file_paths, glob_matcher.as_ref(), |path| {
+        crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let content = crate::read_text_file(path, "replace", quiet)?;
             let (replaced, count) =
                 replace_content(&content, from, &replacement, compiled_re.as_ref(), nth);

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -269,11 +269,12 @@ fn collect_matches(args: &SearchArgs, global: &GlobalFlags) -> anyhow::Result<Se
     let glob_matcher = crate::build_glob_matcher(global)?;
     let matcher = build_matcher(args)?;
     let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+    let glob_roots = crate::collect_glob_roots(&args.paths, global, Some(&cwd))?;
     let count_only = args.count || args.files_with_matches;
 
     // Process files in parallel (#167).
     let file_results: Vec<FileResult> =
-        crate::par_process_files(&file_paths, glob_matcher.as_ref(), |path| {
+        crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
             search_one_file(path, &matcher, args, global.quiet)
         });
 

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -49,6 +49,7 @@ pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         .arg("status")
         .arg("--porcelain=v1")
         .arg("--no-renames")
+        .arg("--untracked-files=all")
         .arg("-z");
     for path in &args.paths {
         cmd.arg("--").arg(path);
@@ -60,6 +61,7 @@ pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     let glob_matcher = crate::build_glob_matcher(global)?;
+    let glob_roots = crate::collect_glob_roots(&args.paths, global, Some(&cwd))?;
 
     let mut modified = Vec::new();
     let mut created = Vec::new();
@@ -75,8 +77,9 @@ pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             None => continue,
         };
 
+        let file_path = cwd.join(&file);
         if let Some(ref matcher) = glob_matcher
-            && !crate::matches_glob(std::path::Path::new(&file), Some(matcher))
+            && !crate::matches_glob_with_roots(&file_path, Some(matcher), &glob_roots)
         {
             continue;
         }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -479,7 +479,15 @@ fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<us
     } else if let Some(pattern) = glob {
         let matcher = Glob::new(pattern)?.compile_matcher();
         let matches_pattern = |path: &Path| {
-            matcher.is_match(path) || path.file_name().is_some_and(|name| matcher.is_match(name))
+            matcher.is_match(path)
+                || path.file_name().is_some_and(|name| matcher.is_match(name))
+                || path.strip_prefix(tx.cwd).ok().is_some_and(|relative| {
+                    !relative.as_os_str().is_empty()
+                        && (matcher.is_match(relative)
+                            || relative
+                                .file_name()
+                                .is_some_and(|name| matcher.is_match(name)))
+                })
         };
         let mut total_matches = 0usize;
         let mut candidate_paths = Vec::new();

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,7 +1,7 @@
 use crate::cli::global::GlobalFlags;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::{WalkBuilder, WalkState};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
 
 /// Returns `true` if the buffer looks like binary content (contains a NUL byte
@@ -99,11 +99,91 @@ pub(crate) fn build_glob_matcher(global: &GlobalFlags) -> anyhow::Result<Option<
     Ok(Some(builder.build()?))
 }
 
+/// Collect roots used for matching `--glob` patterns against walked files.
+pub(crate) fn collect_glob_roots(
+    paths: &[String],
+    global: &GlobalFlags,
+    root: Option<&Path>,
+) -> anyhow::Result<Vec<PathBuf>> {
+    if global.files_from.is_some() {
+        return Ok(root.map(|r| vec![r.to_path_buf()]).unwrap_or_default());
+    }
+
+    let defaults;
+    let effective: &[String] = if paths.is_empty() {
+        defaults = [".".to_string()];
+        &defaults
+    } else {
+        paths
+    };
+
+    let mut roots = Vec::new();
+    for path in effective {
+        let resolved = match root {
+            Some(r) => r.join(path),
+            None => PathBuf::from(path),
+        };
+        let glob_root = if resolved.is_file() {
+            resolved
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| resolved.clone())
+        } else {
+            resolved.clone()
+        };
+        let glob_root = normalize_glob_root(glob_root);
+        if !roots.contains(&glob_root) {
+            roots.push(glob_root);
+        }
+    }
+
+    Ok(roots)
+}
+
+fn normalize_glob_root(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    if normalized.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        normalized
+    }
+}
+
+fn glob_matches_path(path: &Path, matcher: &GlobSet) -> bool {
+    matcher.is_match(path) || path.file_name().is_some_and(|name| matcher.is_match(name))
+}
+
+/// Check whether `path` matches any of the globs, either directly or relative
+/// to one of the provided roots (always true if no globs).
+pub(crate) fn matches_glob_with_roots(
+    path: &Path,
+    matcher: Option<&GlobSet>,
+    roots: &[PathBuf],
+) -> bool {
+    match matcher {
+        None => true,
+        Some(m) => {
+            matches_glob(path, Some(m))
+                || roots.iter().any(|root| {
+                    path.strip_prefix(root).ok().is_some_and(|relative| {
+                        !relative.as_os_str().is_empty() && matches_glob(relative, Some(m))
+                    })
+                })
+        }
+    }
+}
+
 /// Check whether `path` matches any of the globs (always true if no globs).
 pub(crate) fn matches_glob(path: &Path, matcher: Option<&GlobSet>) -> bool {
     match matcher {
         None => true,
-        Some(m) => m.is_match(path) || path.file_name().is_some_and(|n| m.is_match(n)),
+        Some(m) => glob_matches_path(path, m),
     }
 }
 
@@ -175,20 +255,26 @@ pub(crate) fn read_text_file(path: &Path, cmd: &str, quiet: bool) -> Option<Stri
 pub(crate) fn par_process_files<T, F>(
     paths: &[PathBuf],
     glob_matcher: Option<&GlobSet>,
+    glob_roots: &[PathBuf],
     f: F,
 ) -> Vec<T>
 where
     T: Send,
     F: Fn(&Path) -> Option<T> + Sync,
 {
-    fn process_slice<T, F>(paths: &[PathBuf], glob_matcher: Option<&GlobSet>, f: &F) -> Vec<T>
+    fn process_slice<T, F>(
+        paths: &[PathBuf],
+        glob_matcher: Option<&GlobSet>,
+        glob_roots: &[PathBuf],
+        f: &F,
+    ) -> Vec<T>
     where
         T: Send,
         F: Fn(&Path) -> Option<T> + Sync,
     {
         paths
             .iter()
-            .filter(|p| matches_glob(p, glob_matcher))
+            .filter(|p| matches_glob_with_roots(p, glob_matcher, glob_roots))
             .filter_map(|p| f(p.as_path()))
             .collect()
     }
@@ -199,7 +285,7 @@ where
         .min(paths.len());
 
     if num_splits <= 1 {
-        return process_slice(paths, glob_matcher, &f);
+        return process_slice(paths, glob_matcher, glob_roots, &f);
     }
 
     let chunk_size = paths.len().div_ceil(num_splits);
@@ -209,11 +295,11 @@ where
         // Spawn threads for all chunks except the first.
         let handles: Vec<_> = chunks[1..]
             .iter()
-            .map(|chunk| s.spawn(|| process_slice(chunk, glob_matcher, &f)))
+            .map(|chunk| s.spawn(|| process_slice(chunk, glob_matcher, glob_roots, &f)))
             .collect();
 
         // Process the first chunk on the calling thread immediately.
-        let mut results = process_slice(chunks[0], glob_matcher, &f);
+        let mut results = process_slice(chunks[0], glob_matcher, glob_roots, &f);
 
         // Collect results from spawned threads.
         for handle in handles {
@@ -282,12 +368,41 @@ mod tests {
         assert!(!matches_glob(Path::new("src/main.py"), Some(&matcher)));
     }
 
+    #[test]
+    fn glob_matches_nested_relative_pattern_with_root() {
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("sub/*.txt").unwrap());
+        let matcher = builder.build().unwrap();
+        let roots = vec![PathBuf::from("/tmp/project")];
+
+        assert!(matches_glob_with_roots(
+            Path::new("/tmp/project/sub/file.txt"),
+            Some(&matcher),
+            &roots,
+        ));
+        assert!(!matches_glob_with_roots(
+            Path::new("/tmp/project/other.txt"),
+            Some(&matcher),
+            &roots,
+        ));
+    }
+
+    #[test]
+    fn collect_glob_roots_normalizes_current_directory_segments() {
+        let global = GlobalFlags::default();
+        let roots = collect_glob_roots(&[], &global, Some(Path::new("/tmp/project"))).unwrap();
+
+        assert_eq!(roots, vec![PathBuf::from("/tmp/project")]);
+    }
+
     // ── par_process_files ─────────────────────────────────────────────
 
     #[test]
     fn par_process_single_file() {
         let paths = vec![PathBuf::from("a.txt")];
-        let results = par_process_files(&paths, None, |p| Some(p.to_string_lossy().into_owned()));
+        let results = par_process_files(&paths, None, &[], |p| {
+            Some(p.to_string_lossy().into_owned())
+        });
         assert_eq!(results, vec!["a.txt"]);
     }
 
@@ -301,7 +416,7 @@ mod tests {
         let mut builder = GlobSetBuilder::new();
         builder.add(Glob::new("*.rs").unwrap());
         let matcher = builder.build().unwrap();
-        let results = par_process_files(&paths, Some(&matcher), |p| {
+        let results = par_process_files(&paths, Some(&matcher), &[], |p| {
             Some(p.to_string_lossy().into_owned())
         });
         assert_eq!(results.len(), 2);
@@ -310,17 +425,34 @@ mod tests {
     }
 
     #[test]
+    fn par_process_filters_with_relative_glob_root() {
+        let paths = vec![
+            PathBuf::from("/tmp/project/sub/a.txt"),
+            PathBuf::from("/tmp/project/other.txt"),
+        ];
+        let mut builder = GlobSetBuilder::new();
+        builder.add(Glob::new("sub/*.txt").unwrap());
+        let matcher = builder.build().unwrap();
+        let roots = vec![PathBuf::from("/tmp/project")];
+        let results = par_process_files(&paths, Some(&matcher), &roots, |p| {
+            Some(p.to_string_lossy().into_owned())
+        });
+        assert_eq!(results, vec!["/tmp/project/sub/a.txt".to_string()]);
+    }
+
+    #[test]
     fn par_process_empty_paths() {
         let paths: Vec<PathBuf> = vec![];
-        let results: Vec<String> =
-            par_process_files(&paths, None, |p| Some(p.to_string_lossy().into_owned()));
+        let results: Vec<String> = par_process_files(&paths, None, &[], |p| {
+            Some(p.to_string_lossy().into_owned())
+        });
         assert!(results.is_empty());
     }
 
     #[test]
     fn par_process_closure_can_filter() {
         let paths = vec![PathBuf::from("a.txt"), PathBuf::from("b.txt")];
-        let results = par_process_files(&paths, None, |p| {
+        let results = par_process_files(&paths, None, &[], |p| {
             if p.to_string_lossy().contains('a') {
                 Some(1)
             } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -373,6 +373,26 @@ fn test_glob_filters_by_pattern() {
         .stdout(predicate::str::contains("skip.txt").not());
 }
 
+#[test]
+fn test_glob_filters_nested_relative_pattern() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("sub/keep.txt"), "hello\n").unwrap();
+    fs::write(dir.path().join("other.txt"), "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--glob")
+        .arg("sub/*.txt")
+        .arg("search")
+        .arg("hello")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("sub/keep.txt"))
+        .stdout(predicate::str::contains("other.txt").not());
+}
+
 // ---------------------------------------------------------------------------
 // --cwd flag
 // ---------------------------------------------------------------------------
@@ -2437,6 +2457,32 @@ fn test_status_glob_matches_filename_with_spaces() {
         created.iter().any(|v| v.as_str() == Some("file name.txt")),
         "glob-filtered status should report the unquoted filename, got: {json}"
     );
+}
+
+#[test]
+fn test_status_glob_matches_nested_relative_pattern() {
+    let dir = TempDir::new().unwrap();
+    init_git_repo_with_committed_file(dir.path(), "a.txt", "hello\n");
+    fs::create_dir_all(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("sub/keep.txt"), "new\n").unwrap();
+    fs::write(dir.path().join("other.txt"), "new\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--glob")
+        .arg("sub/*.txt")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("status")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let created = json["created"].as_array().unwrap();
+    assert!(created.iter().any(|v| v.as_str() == Some("sub/keep.txt")));
+    assert!(!created.iter().any(|v| v.as_str() == Some("other.txt")));
 }
 
 // ── create command ─────────────────────────────────────────────────
@@ -6019,6 +6065,42 @@ fn test_tx_glob_replace_matches_file_created_earlier_in_transaction() {
     assert_eq!(
         fs::read_to_string(dir.path().join("new.txt")).unwrap(),
         "bye\n"
+    );
+}
+
+#[test]
+fn test_tx_glob_replace_matches_nested_relative_pattern() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("sub")).unwrap();
+    fs::write(dir.path().join("sub/keep.txt"), "hello\n").unwrap();
+    fs::write(dir.path().join("other.txt"), "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [
+            {"op": "replace", "glob": "sub/*.txt", "from": "hello", "to": "bye"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("--plan")
+        .arg(&plan_file)
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("sub/keep.txt")).unwrap(),
+        "bye\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("other.txt")).unwrap(),
+        "hello\n"
     );
 }
 


### PR DESCRIPTION
## Summary
- make shared `--glob` filtering match nested relative patterns like `sub/*.txt`
- make `tx replace` with `glob` honor the same nested relative matching model
- make `status` enumerate nested untracked files individually so relative glob filters can see them
- refresh generated test-count docs after the new regression coverage

## Testing
- cargo test --lib glob_matches_nested_relative_pattern_with_root
- cargo test --lib collect_glob_roots_normalizes_current_directory_segments
- cargo test --lib par_process_filters_with_relative_glob_root
- cargo test --test integration nested_relative_pattern
- cargo test --test integration test_status_glob_matches_filename_with_spaces
- make check
