### PR TITLE
Clarify relative glob matching in docs

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -89,6 +89,8 @@ Most commands accept `--glob <pattern>` (repeatable) to restrict which files are
 patchloom replace --from "old" --to "new" --glob "*.rs" --glob "*.toml" --apply
 ```
 
+Glob patterns match either the basename or the path relative to the input root. For example, if you search `src/`, then `--glob 'sub/*.txt'` matches `src/sub/file.txt`.
+
 In tx plans, individual operations can use `"glob"` instead of `"path"` to target multiple files.
 
 ## Security model

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -21,6 +21,12 @@ Count them:
 patchloom search 'TODO' --count src/
 ```
 
+Limit a search to a nested subtree with `--glob`:
+
+```bash
+patchloom search 'TODO' src/ --glob 'sub/*.rs'
+```
+
 ## Step 2: Replace text across files
 
 Preview a rename (no files changed yet):

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -104,7 +104,7 @@ These flags affect how Patchloom reports results or chooses which files to touch
 <!-- ref:global-flag:glob -->
 ### `--glob`
 
-- **What it does:** Restricts candidate files by one or more glob patterns.
+- **What it does:** Restricts candidate files by one or more glob patterns. Patterns match either the basename or the path relative to the input root, so `sub/*.txt` matches files under a searched `sub/` directory.
 - **Use when:** A command should only see a narrow file type or subtree, even if the input path is broader.
 - **Prefer instead:** Use `--files-from` when another tool has already determined the exact file list.
 


### PR DESCRIPTION
## Summary
- clarify that `--glob` matches basenames or paths relative to the input root
- add a quickstart example for nested patterns like `sub/*.rs`
- add the same behavior note to the concepts and reference docs

## Testing
- make check-readme
- make check-patchloom-md
