### PR TITLE
Clarify local verification in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ at your option.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
+For local verification before opening a pull request, run `make check`. It matches the main Linux CI gate: formatting, clippy, unit tests, integration tests, and generated-doc freshness checks. While iterating locally, `make check-fast` runs the Rust formatting, lint, and test path without the generated-doc freshness checks.
+
 All commits must be signed off with `git commit -s`.
 
 ### Agent integration tests


### PR DESCRIPTION
## Summary
- document the local verification path directly in the README contributing section
- explain that `make check` matches the main Linux CI gate
- point contributors to `make check-fast` for quicker local iteration

## Testing
- make check-readme
- make check-patchloom-md
