### PR TITLE
Clarify tx plan trust model in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,8 @@ Or use a JSON plan with format and validate lifecycle:
 patchloom tx --plan plan.json --apply
 ```
 
+`tx` plans are trusted input. `format` and `validate` run their `cmd` fields through the host shell (`sh -c` on Unix, `cmd /C` on Windows), so only run plans you trust.
+
 ### 4. Or use MCP for structured tool calls (no shell syntax)
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify in the README that `tx` plans are trusted input
- explain that `format` and `validate` run their `cmd` fields through the host shell
- warn users to run only plans they trust

## Testing
- make check-readme
- make check-patchloom-md
