### PR TITLE
Reuse parsed read line ranges

### DIFF
--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -24,7 +24,9 @@ struct ReadOutput {
     content: String,
 }
 
-pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usize>)> {
+type LineRange = (usize, Option<usize>);
+
+pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
     if let Some((start_str, end_str)) = spec.split_once(':') {
         if start_str.is_empty() {
             anyhow::bail!("missing start line in range '{spec}' (expected START:END)");
@@ -56,11 +58,11 @@ pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usiz
     }
 }
 
-fn read_one_file(path: &str, lines_spec: &Option<String>) -> Result<ReadOutput, String> {
+fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, String> {
     let content = fs::read_to_string(path).map_err(|e| format!("{path}: {e}"))?;
 
     // Fast path: no line range requested, skip split/join (#169).
-    if lines_spec.is_none() {
+    if lines.is_none() {
         let total_lines = content.lines().count();
         let start_line = if total_lines == 0 { 0 } else { 1 };
         return Ok(ReadOutput {
@@ -76,30 +78,26 @@ fn read_one_file(path: &str, lines_spec: &Option<String>) -> Result<ReadOutput, 
     let all_lines: Vec<&str> = content.lines().collect();
     let total_lines = all_lines.len();
 
-    let (start, end) = if let Some(spec) = &lines_spec {
-        let (s, e) = parse_line_range(spec).map_err(|e| e.to_string())?;
-        let end = e.unwrap_or(total_lines).min(total_lines);
-        (s, end)
+    let (start, end) = if let Some((start, end)) = lines {
+        (start, end.unwrap_or(total_lines).min(total_lines))
     } else {
         (1, total_lines)
     };
 
-    let selected: Vec<&str> = if total_lines == 0 {
-        Vec::new()
+    let selected_content = if total_lines == 0 {
+        String::new()
     } else {
         let start_idx = (start - 1).min(total_lines);
         let end_idx = end.min(total_lines);
-        all_lines[start_idx..end_idx].to_vec()
-    };
-
-    let selected_content = if selected.is_empty() {
-        String::new()
-    } else {
-        let mut s = selected.join("\n");
-        if content.ends_with('\n') && end >= total_lines {
-            s.push('\n');
+        if start_idx == end_idx {
+            String::new()
+        } else {
+            let mut s = all_lines[start_idx..end_idx].join("\n");
+            if content.ends_with('\n') && end >= total_lines {
+                s.push('\n');
+            }
+            s
         }
-        s
     };
 
     Ok(ReadOutput {
@@ -115,17 +113,22 @@ fn read_one_file(path: &str, lines_spec: &Option<String>) -> Result<ReadOutput, 
 pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
 
-    if let Some(spec) = &args.lines
-        && let Err(err) = parse_line_range(spec)
-    {
-        if global.json || global.jsonl {
-            anyhow::bail!("invalid --lines value '{spec}': {err}");
+    let parsed_lines = if let Some(spec) = &args.lines {
+        match parse_line_range(spec) {
+            Ok(range) => Some(range),
+            Err(err) => {
+                if global.json || global.jsonl {
+                    anyhow::bail!("invalid --lines value '{spec}': {err}");
+                }
+                if !global.quiet {
+                    eprintln!("read: {err}");
+                }
+                return Ok(exit::FAILURE);
+            }
         }
-        if !global.quiet {
-            eprintln!("read: {err}");
-        }
-        return Ok(exit::FAILURE);
-    }
+    } else {
+        None
+    };
 
     let multi = args.files.len() > 1;
     let mut outputs: Vec<ReadOutput> = Vec::new();
@@ -134,7 +137,7 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     for (i, path) in args.files.iter().enumerate() {
         let resolved = cwd.join(path);
         let resolved_str = resolved.to_string_lossy();
-        match read_one_file(&resolved_str, &args.lines) {
+        match read_one_file(&resolved_str, parsed_lines) {
             Ok(output) => {
                 if global.jsonl {
                     println!("{}", serde_json::to_string(&output)?);
@@ -221,7 +224,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let file = dir.path().join("empty.txt");
         fs::write(&file, "").unwrap();
-        let result = read_one_file(file.to_str().unwrap(), &None).unwrap();
+        let result = read_one_file(file.to_str().unwrap(), None).unwrap();
         assert_eq!(result.content, "");
         assert_eq!(result.total_lines, 0);
         assert_eq!(result.start_line, 0);
@@ -233,8 +236,8 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let file = dir.path().join("short.txt");
         fs::write(&file, "line1\nline2\nline3\n").unwrap();
-        let spec = Some("2:100".to_string());
-        let result = read_one_file(file.to_str().unwrap(), &spec).unwrap();
+        let lines = Some((2, Some(100)));
+        let result = read_one_file(file.to_str().unwrap(), lines).unwrap();
         assert_eq!(result.content, "line2\nline3\n");
         assert_eq!(result.start_line, 2);
         assert_eq!(result.end_line, 3);
@@ -246,7 +249,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let file = dir.path().join("trail.txt");
         fs::write(&file, "hello\n").unwrap();
-        let result = read_one_file(file.to_str().unwrap(), &None).unwrap();
+        let result = read_one_file(file.to_str().unwrap(), None).unwrap();
         assert_eq!(result.content, "hello\n");
         assert_eq!(result.total_lines, 1);
     }
@@ -256,7 +259,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let file = dir.path().join("notrail.txt");
         fs::write(&file, "hello").unwrap();
-        let result = read_one_file(file.to_str().unwrap(), &None).unwrap();
+        let result = read_one_file(file.to_str().unwrap(), None).unwrap();
         assert_eq!(result.content, "hello");
         assert_eq!(result.total_lines, 1);
     }
@@ -267,8 +270,8 @@ mod tests {
         let file = dir.path().join("trail.txt");
         fs::write(&file, "a\nb\nc\n").unwrap();
         // Request to end of file: trailing newline should be preserved.
-        let spec = Some("2:3".to_string());
-        let result = read_one_file(file.to_str().unwrap(), &spec).unwrap();
+        let lines = Some((2, Some(3)));
+        let result = read_one_file(file.to_str().unwrap(), lines).unwrap();
         assert_eq!(result.content, "b\nc\n");
     }
 
@@ -278,8 +281,8 @@ mod tests {
         let file = dir.path().join("mid.txt");
         fs::write(&file, "a\nb\nc\nd\n").unwrap();
         // Request lines 2:3 (not end of file): no trailing newline added.
-        let spec = Some("2:3".to_string());
-        let result = read_one_file(file.to_str().unwrap(), &spec).unwrap();
+        let lines = Some((2, Some(3)));
+        let result = read_one_file(file.to_str().unwrap(), lines).unwrap();
         assert_eq!(result.content, "b\nc");
     }
 
@@ -288,15 +291,15 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let file = dir.path().join("empty.txt");
         fs::write(&file, "").unwrap();
-        let spec = Some("1:5".to_string());
-        let result = read_one_file(file.to_str().unwrap(), &spec).unwrap();
+        let lines = Some((1, Some(5)));
+        let result = read_one_file(file.to_str().unwrap(), lines).unwrap();
         assert_eq!(result.content, "");
         assert_eq!(result.total_lines, 0);
     }
 
     #[test]
     fn read_one_file_nonexistent_returns_error() {
-        let result = read_one_file("/tmp/does-not-exist-patchloom-test.txt", &None);
+        let result = read_one_file("/tmp/does-not-exist-patchloom-test.txt", None);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary
- parse `read --lines` once in `run()` instead of reparsing the same range for every requested file
- pass the parsed line range into `read_one_file()` and name the tuple with a small type alias for clarity
- remove the extra temporary Vec allocation before joining selected lines

## Testing
- cargo test read_one_file --lib --all-features
- make check
