### PR TITLE
Clarify tx selector alias compatibility

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -713,6 +713,7 @@ The operations below are the building blocks inside `operations`.
 
 - **What it does:** Runs a targeted structured set inside a transaction.
 - **Use when:** A precise config update must be bundled atomically with other repo changes.
+- **Field naming:** Use `key` in new plans. For backward compatibility, existing plans that still use legacy `selector` are also accepted for `doc.set`, `doc.delete`, `doc.append`, `doc.prepend`, `doc.update`, `doc.ensure`, and `doc.delete_where`.
 - **Related:** top level `doc set`
 
 <!-- ref:tx-op:doc.delete -->


### PR DESCRIPTION
## Summary
- clarify in the tx reference that new plans should use `key` for structured doc operations
- document that legacy `selector` is still accepted for backward compatibility
- make the compatibility contract visible in the user-facing reference docs

## Testing
- make check-readme
- make check-patchloom-md
