### PR TITLE
Clamp empty read ranges past EOF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 857 tests (443 unit + 414 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 859 tests (443 unit + 416 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-857%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-859%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -338,7 +338,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-857 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+859 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -26,6 +26,25 @@ struct ReadOutput {
 
 type LineRange = (usize, Option<usize>);
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct SelectedLines {
+    pub content: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub total_lines: usize,
+}
+
+impl SelectedLines {
+    fn empty(total_lines: usize) -> Self {
+        Self {
+            content: String::new(),
+            start_line: 0,
+            end_line: 0,
+            total_lines,
+        }
+    }
+}
+
 pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
     if let Some((start_str, end_str)) = spec.split_once(':') {
         if start_str.is_empty() {
@@ -58,6 +77,33 @@ pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
     }
 }
 
+pub(crate) fn select_lines(content: &str, lines: LineRange) -> SelectedLines {
+    let all_lines: Vec<&str> = content.lines().collect();
+    let total_lines = all_lines.len();
+    if total_lines == 0 {
+        return SelectedLines::empty(total_lines);
+    }
+
+    let (start, end) = lines;
+    let start_idx = (start - 1).min(total_lines);
+    let end_idx = end.unwrap_or(total_lines).min(total_lines);
+    if start_idx == end_idx {
+        return SelectedLines::empty(total_lines);
+    }
+
+    let mut selected = all_lines[start_idx..end_idx].join("\n");
+    if content.ends_with('\n') && end_idx == total_lines {
+        selected.push('\n');
+    }
+
+    SelectedLines {
+        content: selected,
+        start_line: start_idx + 1,
+        end_line: end_idx,
+        total_lines,
+    }
+}
+
 fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, String> {
     let content = fs::read_to_string(path).map_err(|e| format!("{path}: {e}"))?;
 
@@ -75,38 +121,15 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Str
         });
     }
 
-    let all_lines: Vec<&str> = content.lines().collect();
-    let total_lines = all_lines.len();
-
-    let (start, end) = if let Some((start, end)) = lines {
-        (start, end.unwrap_or(total_lines).min(total_lines))
-    } else {
-        (1, total_lines)
-    };
-
-    let selected_content = if total_lines == 0 {
-        String::new()
-    } else {
-        let start_idx = (start - 1).min(total_lines);
-        let end_idx = end.min(total_lines);
-        if start_idx == end_idx {
-            String::new()
-        } else {
-            let mut s = all_lines[start_idx..end_idx].join("\n");
-            if content.ends_with('\n') && end >= total_lines {
-                s.push('\n');
-            }
-            s
-        }
-    };
+    let selected = select_lines(&content, lines.unwrap());
 
     Ok(ReadOutput {
         ok: true,
         path: path.to_string(),
-        start_line: start,
-        end_line: end,
-        total_lines,
-        content: selected_content,
+        start_line: selected.start_line,
+        end_line: selected.end_line,
+        total_lines: selected.total_lines,
+        content: selected.content,
     })
 }
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -575,33 +575,18 @@ fn execute_read_op(path: &str, lines: &Option<String>, tx: &mut TxState<'_>) -> 
         return Ok(());
     }
 
-    let all_lines: Vec<&str> = content.lines().collect();
-    let total_lines = all_lines.len();
-    let (start, end) = {
+    let selected = {
         let spec = lines.as_ref().unwrap();
-        let (s, e) = crate::cmd::read::parse_line_range(spec)?;
-        let end = e.unwrap_or(total_lines).min(total_lines);
-        (s, end)
-    };
-
-    let selected = if total_lines == 0 {
-        String::new()
-    } else {
-        let start_idx = (start - 1).min(total_lines);
-        let end_idx = end.min(total_lines);
-        let mut s = all_lines[start_idx..end_idx].join("\n");
-        if content.ends_with('\n') && end >= total_lines {
-            s.push('\n');
-        }
-        s
+        let range = crate::cmd::read::parse_line_range(spec)?;
+        crate::cmd::read::select_lines(content, range)
     };
 
     tx.tx_reads.push(TxReadResult {
         path: path.to_string(),
-        content: selected,
-        start_line: start,
-        end_line: end,
-        total_lines,
+        content: selected.content,
+        start_line: selected.start_line,
+        end_line: selected.end_line,
+        total_lines: selected.total_lines,
     });
     Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2170,6 +2170,30 @@ fn test_read_json_output() {
 }
 
 #[test]
+fn test_read_json_lines_start_past_eof_clamps_metadata() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("short.txt");
+    fs::write(&file, "a\nb\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("read")
+        .arg(file.to_str().unwrap())
+        .arg("--lines")
+        .arg("5:9")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["content"].as_str().unwrap(), "");
+    assert_eq!(json["total_lines"], 2);
+    assert_eq!(json["start_line"], 0);
+    assert_eq!(json["end_line"], 0);
+}
+
+#[test]
 fn test_read_respects_cwd() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("inner.txt"), "content\n").unwrap();
@@ -8212,6 +8236,35 @@ fn test_tx_read_with_lines_in_plan() {
     assert!(!content.contains("eee"));
     assert_eq!(json["reads"][0]["start_line"], 2);
     assert_eq!(json["reads"][0]["end_line"], 4);
+}
+
+#[test]
+fn test_tx_read_lines_start_past_eof_clamps_metadata() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("short.txt");
+    fs::write(&file, "a\nb\n").unwrap();
+
+    let plan = serde_json::json!({
+        "operations": [{"op": "read", "path": file.to_str().unwrap(), "lines": "5:9"}]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg("--plan")
+        .arg(plan_file.to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["reads"][0]["content"].as_str().unwrap(), "");
+    assert_eq!(json["reads"][0]["total_lines"], 2);
+    assert_eq!(json["reads"][0]["start_line"], 0);
+    assert_eq!(json["reads"][0]["end_line"], 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- clamp empty `read --lines` selections that start past EOF to `start_line=0` and `end_line=0` instead of returning impossible metadata
- reuse the same shared line-selection helper for `tx read` so transactional reads match top-level `read` behavior
- add regression coverage for both top-level `read` and `tx read`, and refresh generated test counts

## Testing
- cargo test --test integration --all-features start_past_eof_clamps_metadata
- cargo test --lib --all-features read_one_file
- make check
