### PR TITLE
Keep read JSON multi-file output as array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 859 tests (443 unit + 416 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 860 tests (443 unit + 417 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-859%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-860%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -338,7 +338,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-859 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+860 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -186,7 +186,7 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if global.json {
-        if outputs.len() == 1 {
+        if !multi && outputs.len() == 1 {
             println!("{}", serde_json::to_string_pretty(&outputs[0])?);
         } else {
             println!("{}", serde_json::to_string_pretty(&outputs)?);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2255,6 +2255,29 @@ fn test_read_multiple_files_json() {
 }
 
 #[test]
+fn test_read_multiple_files_json_partial_failure_keeps_array() {
+    let dir = TempDir::new().unwrap();
+    let existing = dir.path().join("exists.txt");
+    fs::write(&existing, "hello\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("read")
+        .arg(existing.to_str().unwrap())
+        .arg(nonexistent_path("no-such-file-json-array-shape"))
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(json.is_array());
+    assert_eq!(json.as_array().unwrap().len(), 1);
+    assert_eq!(json[0]["path"], existing.to_str().unwrap());
+    assert_eq!(json[0]["content"], "hello\n");
+}
+
+#[test]
 fn test_read_multiple_files_jsonl() {
     let dir = TempDir::new().unwrap();
     let f1 = dir.path().join("p.txt");


### PR DESCRIPTION
## Summary
- keep `read --json` multi-file output in array form whenever multiple paths were requested, even if only one read succeeds
- align the implementation with the documented `read` contract for multi-file JSON output
- add regression coverage for the mixed-success case and refresh generated test counts

## Testing
- cargo test --test integration --all-features multiple_files_json
- make update-readme
- make check
