### PR TITLE
Return structured read errors on all-fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 860 tests (443 unit + 417 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 862 tests (443 unit + 419 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-860%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-862%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -338,7 +338,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-860 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+862 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -135,12 +135,13 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Str
 
 pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
+    let structured = global.json || global.jsonl;
 
     let parsed_lines = if let Some(spec) = &args.lines {
         match parse_line_range(spec) {
             Ok(range) => Some(range),
             Err(err) => {
-                if global.json || global.jsonl {
+                if structured {
                     anyhow::bail!("invalid --lines value '{spec}': {err}");
                 }
                 if !global.quiet {
@@ -177,12 +178,19 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 }
             }
             Err(e) => {
-                if !global.quiet {
+                if !structured && !global.quiet {
                     eprintln!("read: {e}");
                 }
                 errors.push(e);
             }
         }
+    }
+
+    if errors.len() == args.files.len() {
+        if structured {
+            anyhow::bail!(errors.join("\n"));
+        }
+        return Ok(exit::FAILURE);
     }
 
     if global.json {
@@ -193,11 +201,13 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     }
 
-    if errors.len() == args.files.len() {
-        Ok(exit::FAILURE)
-    } else {
-        Ok(exit::SUCCESS)
+    if structured && !global.quiet {
+        for error in &errors {
+            eprintln!("read: {error}");
+        }
     }
+
+    Ok(exit::SUCCESS)
 }
 
 #[cfg(test)]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2335,6 +2335,52 @@ fn test_read_all_fail_returns_failure() {
 }
 
 #[test]
+fn test_read_json_all_fail_returns_error_object() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("read")
+        .arg(nonexistent_path("no-1-json-read-fail"))
+        .arg(nonexistent_path("no-2-json-read-fail"))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|_| panic!("expected JSON output, got: {stdout}"));
+    assert_eq!(json["ok"], false);
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("no-1-json-read-fail"));
+    assert!(error.contains("no-2-json-read-fail"));
+}
+
+#[test]
+fn test_read_jsonl_all_fail_returns_error_object() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("read")
+        .arg(nonexistent_path("no-1-jsonl-read-fail"))
+        .arg(nonexistent_path("no-2-jsonl-read-fail"))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "JSONL error should be a single line");
+    let json: serde_json::Value = serde_json::from_str(lines[0])
+        .unwrap_or_else(|_| panic!("expected JSON line, got: {}", lines[0]));
+    assert_eq!(json["ok"], false);
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("no-1-jsonl-read-fail"));
+    assert!(error.contains("no-2-jsonl-read-fail"));
+}
+
+#[test]
 fn test_read_multiple_files_with_lines() {
     let dir = TempDir::new().unwrap();
     let f1 = dir.path().join("long.txt");


### PR DESCRIPTION
## Summary
- return a structured top-level error object when `read --json` or `read --jsonl` fails for every requested file
- suppress human stderr for structured all-fail `read` runs so stdout remains machine-readable
- add regression coverage for both `--json` and `--jsonl` all-fail cases

## Testing
- cargo test --test integration --all-features all_fail_returns_error_object
- cargo test --test integration --all-features test_read_json_invalid_lines_returns_error_object
- cargo test --test integration --all-features test_read_multiple_files_json_partial_failure_keeps_array
- make update-readme
- make check
