### PR TITLE
Return structured doc errors for non-array targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 860 tests (443 unit + 417 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 862 tests (443 unit + 419 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-860%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-862%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -338,7 +338,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-860 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+862 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -390,7 +390,6 @@ fn load_file_with_content(path: &str) -> anyhow::Result<(String, serde_json::Val
 struct WriteContext {
     check: bool,
     apply: bool,
-    quiet: bool,
     write_policy: write::WritePolicy,
 }
 
@@ -512,10 +511,10 @@ fn execute_write(action: &DocAction, ctx: &WriteContext) -> anyhow::Result<(Stri
             match target.as_array_mut() {
                 Some(arr) => arr.push(parsed),
                 None => {
-                    if !ctx.quiet {
-                        eprintln!("doc append: target at '{selector}' is not an array in {file}");
-                    }
-                    return Ok((String::new(), exit::FAILURE));
+                    return Ok((
+                        format!("doc append: target at '{selector}' is not an array in {file}"),
+                        exit::FAILURE,
+                    ));
                 }
             }
 
@@ -537,10 +536,10 @@ fn execute_write(action: &DocAction, ctx: &WriteContext) -> anyhow::Result<(Stri
             match target.as_array_mut() {
                 Some(arr) => arr.insert(0, parsed),
                 None => {
-                    if !ctx.quiet {
-                        eprintln!("doc prepend: target at '{selector}' is not an array in {file}");
-                    }
-                    return Ok((String::new(), exit::FAILURE));
+                    return Ok((
+                        format!("doc prepend: target at '{selector}' is not an array in {file}"),
+                        exit::FAILURE,
+                    ));
                 }
             }
 
@@ -861,10 +860,18 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let ctx = WriteContext {
             check: global.check,
             apply: global.apply,
-            quiet: global.quiet,
             write_policy: policy_from_flags(global, doc_file_path.map(std::path::Path::new)),
         };
         let (output, code) = execute_write(&args.action, &ctx)?;
+        if code == exit::FAILURE && !output.is_empty() {
+            if global.json || global.jsonl {
+                anyhow::bail!(output);
+            }
+            if !global.quiet {
+                eprintln!("{output}");
+            }
+            return Ok(code);
+        }
         if !output.is_empty() {
             println!("{output}");
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11573,6 +11573,70 @@ fn test_json_error_envelope_on_delete_nonexistent_file() {
     assert_eq!(json["ok"], false);
 }
 
+#[test]
+fn test_json_error_envelope_on_doc_append_non_array_target() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"name":"patchloom"}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("doc")
+        .arg("append")
+        .arg(&file)
+        .arg("name")
+        .arg("\"x\"")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|_| panic!("expected JSON output, got: {stdout}"));
+    assert_eq!(json["ok"], false);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("doc append: target at 'name' is not an array")
+    );
+}
+
+#[test]
+fn test_jsonl_error_envelope_on_doc_prepend_non_array_target() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"name":"patchloom"}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("doc")
+        .arg("prepend")
+        .arg(&file)
+        .arg("name")
+        .arg("\"x\"")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "JSONL error should be a single line");
+    let json: serde_json::Value = serde_json::from_str(lines[0])
+        .unwrap_or_else(|_| panic!("expected JSON line, got: {}", lines[0]));
+    assert_eq!(json["ok"], false);
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("doc prepend: target at 'name' is not an array")
+    );
+}
+
 // ---------------------------------------------------------------------------
 // MCP server integration tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- return machine-readable error envelopes for structured `doc append` and `doc prepend` when the target selector is not an array
- preserve the existing human-readable error text for non-structured runs
- add regression coverage for both `--json` and `--jsonl`, and refresh generated test counts

## Testing
- cargo test --test integration --all-features json_error_envelope_on_doc_append_non_array_target
- cargo test --test integration --all-features jsonl_error_envelope_on_doc_prepend_non_array_target
- make update-readme
- make check
