### PR TITLE
Emit structured search assert-count output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 864 tests (443 unit + 421 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 868 tests (443 unit + 425 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-864%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-868%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -338,7 +338,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-864 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+868 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -81,6 +81,20 @@ struct SearchOutput {
     file_count: usize,
 }
 
+#[derive(Debug, Serialize)]
+struct SearchAssertCount {
+    expected: usize,
+    actual: usize,
+    matched: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SearchAssertCountOutput {
+    ok: bool,
+    status: &'static str,
+    assert_count: SearchAssertCount,
+}
+
 struct SearchResults {
     matches: Vec<SearchMatch>,
     file_match_counts: BTreeMap<Arc<str>, usize>,
@@ -383,16 +397,36 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // --assert-count mode: succeed only if total count equals N.
     if let Some(expected) = args.assert_count {
         let actual: usize = results.file_match_counts.values().sum();
-        if actual == expected {
-            if !global.quiet {
-                eprintln!("assert-count: {actual} matches (expected {expected})");
-            }
-            return Ok(exit::SUCCESS);
+        let matches = actual == expected;
+        let status = if matches {
+            "success"
+        } else {
+            "changes_detected"
+        };
+        let code = if matches {
+            exit::SUCCESS
+        } else {
+            exit::CHANGES_DETECTED
+        };
+        if global.emit_json(&SearchAssertCountOutput {
+            ok: true,
+            status,
+            assert_count: SearchAssertCount {
+                expected,
+                actual,
+                matched: matches,
+            },
+        })? {
+            return Ok(code);
         }
         if !global.quiet {
-            eprintln!("assert-count: expected {expected} matches, found {actual}");
+            if matches {
+                eprintln!("assert-count: {actual} matches (expected {expected})");
+            } else {
+                eprintln!("assert-count: expected {expected} matches, found {actual}");
+            }
         }
-        return Ok(exit::CHANGES_DETECTED);
+        return Ok(code);
     }
 
     let has_matches = if args.count || args.files_with_matches {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -502,6 +502,122 @@ fn test_search_assert_count_zero_but_found() {
 }
 
 #[test]
+fn test_search_assert_count_json_success_returns_structured_output() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "foo\nbar\nfoo\n").unwrap();
+    fs::write(dir.path().join("b.txt"), "foo\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("search")
+        .arg("--literal")
+        .arg("--assert-count")
+        .arg("3")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["assert_count"]["expected"], 3);
+    assert_eq!(json["assert_count"]["actual"], 3);
+    assert_eq!(json["assert_count"]["matched"], true);
+}
+
+#[test]
+fn test_search_assert_count_json_mismatch_returns_structured_output() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "foo\nbar\nfoo\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("search")
+        .arg("--literal")
+        .arg("--assert-count")
+        .arg("5")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["status"], "changes_detected");
+    assert_eq!(json["assert_count"]["expected"], 5);
+    assert_eq!(json["assert_count"]["actual"], 2);
+    assert_eq!(json["assert_count"]["matched"], false);
+}
+
+#[test]
+fn test_search_assert_count_jsonl_success_returns_structured_output() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "foo\nbar\nfoo\n").unwrap();
+    fs::write(dir.path().join("b.txt"), "foo\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("search")
+        .arg("--literal")
+        .arg("--assert-count")
+        .arg("3")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "JSONL output should be a single line");
+    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["assert_count"]["expected"], 3);
+    assert_eq!(json["assert_count"]["actual"], 3);
+    assert_eq!(json["assert_count"]["matched"], true);
+}
+
+#[test]
+fn test_search_assert_count_jsonl_mismatch_returns_structured_output() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "foo\nbar\nfoo\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("search")
+        .arg("--literal")
+        .arg("--assert-count")
+        .arg("5")
+        .arg("foo")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "JSONL output should be a single line");
+    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["status"], "changes_detected");
+    assert_eq!(json["assert_count"]["expected"], 5);
+    assert_eq!(json["assert_count"]["actual"], 2);
+    assert_eq!(json["assert_count"]["matched"], false);
+}
+
+#[test]
 fn test_search_multiline_spans_lines() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("code.rs");


### PR DESCRIPTION
## Summary
- emit machine-readable `search --assert-count` results in `--json` and `--jsonl` while preserving exit code 0 on match and 2 on mismatch
- suppress human stderr for structured assert-count runs so machine-readable stdout stays clean
- add regression coverage for both success and mismatch in JSON and JSONL, and refresh generated test counts

## Testing
- make check
