### PR TITLE
Return structured batch output on empty input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 868 tests (443 unit + 425 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 870 tests (443 unit + 427 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-868%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-870%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -338,7 +338,7 @@ Two integration modes, same capabilities:
 
 ## Status
 
-868 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+870 passing tests across 15 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Security
 

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -315,7 +315,16 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if operations.is_empty() {
-        if !global.quiet {
+        if global.json || global.jsonl {
+            global.emit_json(&serde_json::json!({
+                "ok": true,
+                "status": "success",
+                "files_changed": 0,
+                "files_created": 0,
+                "files_deleted": 0,
+                "changes": []
+            }))?;
+        } else if !global.quiet {
             eprintln!("batch: no operations found in input");
         }
         return Ok(exit::SUCCESS);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10565,6 +10565,64 @@ fn test_batch_comment_only_input_succeeds() {
 }
 
 #[test]
+fn test_batch_json_empty_input_returns_structured_success() {
+    let dir = TempDir::new().unwrap();
+    let ops = dir.path().join("empty.txt");
+    fs::write(&ops, "").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("batch")
+        .arg("--input")
+        .arg(&ops)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["files_changed"], 0);
+    assert_eq!(json["files_created"], 0);
+    assert_eq!(json["files_deleted"], 0);
+    assert_eq!(json["changes"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn test_batch_jsonl_empty_input_returns_structured_success() {
+    let dir = TempDir::new().unwrap();
+    let ops = dir.path().join("empty.txt");
+    fs::write(&ops, "# only a comment\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("batch")
+        .arg("--input")
+        .arg(&ops)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "JSONL output should be a single line");
+    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["files_changed"], 0);
+}
+
+#[test]
 fn test_batch_malformed_line_fails() {
     let dir = TempDir::new().unwrap();
     let ops = dir.path().join("bad.txt");


### PR DESCRIPTION
## Summary
- return machine-readable JSON/JSONL output for `batch` with empty or comment-only input instead of leaking human stderr with no structured payload
- match the existing `tx` success shape with `files_changed: 0`
- keep text-mode and quiet-mode behavior unchanged
- add regression coverage for both `--json` and `--jsonl` empty-input cases, and refresh generated test counts

## Testing
- make check
