### PR TITLE
Multi-perspective improvement: tx cwd resolution and lifecycle diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1106 tests (544 unit + 562 integration)
+- 1108 tests (544 unit + 564 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1108 tests (544 unit + 564 integration)
+- 1110 tests (545 unit + 565 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1111 tests (545 unit + 566 integration)
+- 1114 tests (545 unit + 569 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1110 tests (545 unit + 565 integration)
+- 1111 tests (545 unit + 566 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,10 @@ make check          # must pass before every commit
 2. Make your changes. Run `make check-fast` during development for rapid feedback.
 3. Run `make check` before committing. This is the full CI gate: formatting,
    clippy, unit tests, integration tests, and doc verification.
-4. Commit with a [DCO sign-off](#dco-sign-off).
+4. If you touched `#[cfg(...)]` attributes or MCP-only code, also run
+   `cargo check --all-targets`. `make check` uses `--all-features`, so it
+   does not exercise the default-feature build.
+5. Commit with a [DCO sign-off](#dco-sign-off).
 5. Open a pull request against `main`.
 
 ### Useful make targets
@@ -38,6 +41,7 @@ make check          # must pass before every commit
 | `make update-readme` | Refresh generated test counts in README.md and CHANGELOG.md |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` |
 | `make audit` | Run `cargo audit` for known vulnerabilities |
+| `cargo check --all-targets` | Catch default-feature build regressions after `#[cfg(...)]` or MCP edits |
 
 ## Writing tests
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1110%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1111%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1110 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1111 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1106%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1108%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1106 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1108 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1111%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1114%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1111 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1114 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1108%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1110%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1108 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1110 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -147,6 +147,6 @@ What this means in practice:
 
 - **Plans can execute arbitrary shell commands.** The `format` and `validate` lifecycle steps pass their `cmd` field to `sh -c` (or `cmd /C` on Windows) with the user's full privileges. Only load plans you trust.
 - **File operations are unrestricted.** `create`, `delete`, `read`, `replace`, `patch`, and all `tx` operations accept any path the invoking user can access. There is no sandbox, chroot, or path restriction.
-- **Plan `cwd` overrides the working directory.** A plan's `cwd` field changes the process working directory for all subsequent operations and lifecycle steps. This is intentional for self-contained plans, but means a malicious plan can resolve relative paths from any directory.
+- **Plan `cwd` overrides the working directory.** A plan's `cwd` field changes the working directory for all subsequent operations and lifecycle steps. Relative values resolve from the invocation root, not from the plan file location. In normal CLI use this still runs with the invoking user's filesystem access; in MCP mode the resolved directory must stay under the server root.
 
 **For AI agent authors:** Do not construct plans from untrusted conversational input without validation. A plan is equivalent to a shell script. Treat plan files with the same care you would treat a Makefile or a bash script from an unknown source.

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -135,7 +135,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 
 The MCP server enforces path containment: all file paths must resolve within the working directory where `patchloom mcp-server` was started. Absolute paths, `../` traversal, and symlinks escaping the working directory are rejected. This prevents an agent from accidentally (or maliciously) editing files outside the project.
 
-The `batch` tool parses its operations line by line and validates every path before execution. The `transaction` tool accepts full transaction plans. All operation paths and plan-level `cwd` fields are validated for containment before execution.
+The `batch` tool parses its operations line by line and validates every path before execution. The `transaction` tool accepts full transaction plans. All operation paths and plan-level `cwd` fields are validated for containment before execution. A relative transaction `cwd` still resolves from the server invocation root, then must remain inside that root.
 
 ### Shell execution gate
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -124,7 +124,8 @@ patchloom tx bump.json --apply
 
 If an operation fails, nothing is written. Format and validate lifecycle steps run
 after writes, so use `"strict": true` in the plan if you want those failures to
-roll back all changes too.
+roll back all changes too. Lifecycle failure output includes the failing step
+number, exit status, and the `cwd` used for that step.
 
 ## Step 6: Inspect and undo changes
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -728,7 +728,7 @@ Use these when newline and whitespace correctness is the main concern.
 - **What it does:** Runs shell commands after writes are staged to disk but before validation.
 - **Use when:** Generated or edited files should be normalized by tools like `cargo fmt`, `prettier`, or `black` as part of the same workflow.
 - **Step fields:** Each entry accepts `cmd` (required shell command) and `timeout` (seconds, default `60`).
-- **Failure behavior:** Any non-zero exit or timeout fails the transaction. With `strict: true`, Patchloom rolls back the staged writes.
+- **Failure behavior:** Any non-zero exit or timeout fails the transaction. Error output reports the failing step number, exit status, and the lifecycle working directory (`cwd`). With `strict: true`, Patchloom rolls back the staged writes.
 - **Prefer instead:** Run formatting outside `tx` when it does not need to participate in the transaction's success criteria.
 
 <!-- ref:tx-field:validate -->
@@ -737,7 +737,7 @@ Use these when newline and whitespace correctness is the main concern.
 - **What it does:** Runs shell commands that decide whether the transaction should be reported as valid.
 - **Use when:** Build, test, or policy checks are part of the definition of success for the change.
 - **Step fields:** Each entry accepts `cmd` (required shell command), `required` (bool, default `false`), and `timeout` (seconds, default `60`).
-- **Failure behavior:** `required: true` makes the step gate transaction success. `required: false` still reports the validation problem to stderr, but the transaction keeps succeeding.
+- **Failure behavior:** `required: true` makes the step gate transaction success. `required: false` still reports the validation problem to stderr. Error output reports the failing step number, exit status, and the lifecycle working directory (`cwd`).
 - **Prefer instead:** Use standalone verification outside `tx` when the mutation and the validation lifecycle should stay separate.
 
 ### Transaction operations

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -106,7 +106,7 @@ These flags affect how Patchloom reports results or chooses which files to touch
 
 - **What it does:** Sets the working directory used to resolve relative paths.
 - **Use when:** You are invoking Patchloom from outside the target repo, or you want scripts to behave predictably regardless of the caller's current directory.
-- **Prefer instead:** Use a plan level `cwd` in `tx` when the directory choice should travel with the plan itself.
+- **Prefer instead:** Use a plan level `cwd` in `tx` when the directory choice should travel with the plan itself, but keep it inside the invocation root. Relative plan `cwd` values resolve from the caller's working directory (`--cwd` or the process cwd), not from the plan file location.
 
 <!-- ref:global-flag:glob -->
 ### `--glob`
@@ -695,7 +695,8 @@ Use these when newline and whitespace correctness is the main concern.
 ### `cwd`
 
 - **What it does:** Sets the base directory used to resolve relative paths inside the plan.
-- **Use when:** The plan should behave the same no matter where it is invoked from.
+- **Use when:** You need plan operations and lifecycle steps to run from a specific subdirectory under the invocation root.
+- **Important:** Relative values resolve from the invocation working directory (`--cwd` or the process cwd), not from the plan file's directory. In MCP mode, the resolved directory must stay inside the server root.
 - **Prefer instead:** Use the CLI `--cwd` flag when the directory choice is a caller concern rather than part of the plan itself.
 
 <!-- ref:tx-field:write_policy -->

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use std::path::PathBuf;
 
 use crate::cli::global::GlobalFlags;
+use crate::cmd::tx::resolve_plan_cwd;
 use crate::exit;
 use crate::plan::{Operation, Plan};
 
@@ -1129,6 +1130,7 @@ impl PatchloomService {
         // Validate plan-level cwd for containment.
         if let Some(ref plan_cwd) = plan.cwd {
             let cwd_path = std::path::Path::new(plan_cwd);
+            let resolved_plan_cwd = resolve_plan_cwd(&self.cwd, Some(plan_cwd));
             if cwd_path.is_absolute() {
                 // Absolute cwd must be inside the server's working directory.
                 let canon_plan_cwd = cwd_path.canonicalize().map_err(|e| {
@@ -1144,18 +1146,19 @@ impl PatchloomService {
                     ));
                 }
             } else {
-                self.check_path(plan_cwd)?;
+                validate_path_resolved(plan_cwd, &self.cwd, &self.canon_cwd)?;
+                if !resolved_plan_cwd.is_dir() {
+                    return Err(McpError::invalid_params(
+                        format!("plan cwd is not a directory: {plan_cwd}"),
+                        None,
+                    ));
+                }
             }
         }
 
         // Resolve effective cwd for path validation.
         let (effective_cwd, effective_canon_cwd) = if let Some(ref plan_cwd) = plan.cwd {
-            let p = std::path::Path::new(plan_cwd);
-            let eff = if p.is_absolute() {
-                p.to_path_buf()
-            } else {
-                self.cwd.join(p)
-            };
+            let eff = resolve_plan_cwd(&self.cwd, Some(plan_cwd));
             let canon = eff.canonicalize().map_err(|e| {
                 McpError::internal_error(format!("failed to canonicalize effective cwd: {e}"), None)
             })?;
@@ -1508,6 +1511,13 @@ mod tests {
     #[test]
     fn path_rejects_single_parent() {
         assert!(validate_path_contained("..").is_err());
+    }
+
+    #[test]
+    fn path_resolution_matches_tx_relative_cwd_rules() {
+        let base = std::path::Path::new("/workspace");
+        assert_eq!(resolve_plan_cwd(base, Some("nested")), base.join("nested"));
+        assert_eq!(resolve_plan_cwd(base, Some("a/../b")), base.join("a/../b"));
     }
 
     #[test]

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1251,6 +1251,16 @@ fn describe_exit_status(status: std::process::ExitStatus) -> String {
     }
 }
 
+fn describe_lifecycle_cwd(base_cwd: &Path, cwd: &Path) -> String {
+    if cwd == base_cwd {
+        ".".to_string()
+    } else {
+        crate::files::relative_display(cwd, base_cwd)
+            .display()
+            .to_string()
+    }
+}
+
 fn print_diffs(changes: &[(PathBuf, String, String)], cwd: &Path, color: bool) {
     let diffs: Vec<_> = changes
         .iter()
@@ -1276,16 +1286,22 @@ struct LifecycleError {
     kind: &'static str,
 }
 
-fn run_format_steps(steps: &[plan::FormatStep], cwd: &Path) -> Result<(), LifecycleError> {
+fn run_format_steps(
+    steps: &[plan::FormatStep],
+    base_cwd: &Path,
+    cwd: &Path,
+) -> Result<(), LifecycleError> {
+    let lifecycle_cwd = describe_lifecycle_cwd(base_cwd, cwd);
     for (index, step) in steps.iter().enumerate() {
         let timeout_secs = step.timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
         let result = run_shell_with_timeout(&step.cmd, timeout_secs, cwd);
         match result {
             Ok(status) if !status.success() => {
                 let msg = format!(
-                    "format step failed (step {}, {})",
+                    "format step failed (step {}, {}, cwd: {})",
                     index + 1,
-                    describe_exit_status(status)
+                    describe_exit_status(status),
+                    lifecycle_cwd
                 );
                 eprintln!("tx: {msg}");
                 return Err(LifecycleError {
@@ -1294,7 +1310,11 @@ fn run_format_steps(steps: &[plan::FormatStep], cwd: &Path) -> Result<(), Lifecy
                 });
             }
             Err(e) => {
-                let msg = format!("format step error (step {}): {e}", index + 1);
+                let msg = format!(
+                    "format step error (step {}, cwd: {}): {e}",
+                    index + 1,
+                    lifecycle_cwd
+                );
                 eprintln!("tx: {msg}");
                 return Err(LifecycleError {
                     message: msg,
@@ -1307,7 +1327,12 @@ fn run_format_steps(steps: &[plan::FormatStep], cwd: &Path) -> Result<(), Lifecy
     Ok(())
 }
 
-fn run_validate_steps(steps: &[plan::ValidationStep], cwd: &Path) -> Result<(), LifecycleError> {
+fn run_validate_steps(
+    steps: &[plan::ValidationStep],
+    base_cwd: &Path,
+    cwd: &Path,
+) -> Result<(), LifecycleError> {
+    let lifecycle_cwd = describe_lifecycle_cwd(base_cwd, cwd);
     for (index, step) in steps.iter().enumerate() {
         let timeout_secs = step.timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
         let result = run_shell_with_timeout(&step.cmd, timeout_secs, cwd);
@@ -1315,9 +1340,10 @@ fn run_validate_steps(steps: &[plan::ValidationStep], cwd: &Path) -> Result<(), 
             Ok(status) if status.success() => {}
             Ok(status) => {
                 let msg = format!(
-                    "required validation failed (step {}, {})",
+                    "required validation failed (step {}, {}, cwd: {})",
                     index + 1,
-                    describe_exit_status(status)
+                    describe_exit_status(status),
+                    lifecycle_cwd
                 );
                 eprintln!("tx: {msg}");
                 if step.required.unwrap_or(false) {
@@ -1328,7 +1354,11 @@ fn run_validate_steps(steps: &[plan::ValidationStep], cwd: &Path) -> Result<(), 
                 }
             }
             Err(e) => {
-                let msg = format!("validation error (step {}): {e}", index + 1);
+                let msg = format!(
+                    "validation error (step {}, cwd: {}): {e}",
+                    index + 1,
+                    lifecycle_cwd
+                );
                 eprintln!("tx: {msg}");
                 if step.required.unwrap_or(false) {
                     return Err(LifecycleError {
@@ -1476,16 +1506,16 @@ fn execute_and_collect(
 }
 
 /// Run format and validation lifecycle steps. Returns `None` on success.
-fn run_lifecycle(plan: &Plan, cwd: &Path) -> Option<LifecycleError> {
+fn run_lifecycle(plan: &Plan, base_cwd: &Path, cwd: &Path) -> Option<LifecycleError> {
     plan.format
         .as_deref()
-        .map(|steps| run_format_steps(steps, cwd))
+        .map(|steps| run_format_steps(steps, base_cwd, cwd))
         .unwrap_or(Ok(()))
         .err()
         .or_else(|| {
             plan.validate
                 .as_deref()
-                .and_then(|steps| run_validate_steps(steps, cwd).err())
+                .and_then(|steps| run_validate_steps(steps, base_cwd, cwd).err())
         })
 }
 
@@ -1659,7 +1689,7 @@ pub(crate) fn execute_plan_direct(plan: Plan, cwd: &Path) -> anyhow::Result<(u8,
     )?;
 
     // Run format steps, then validation steps.
-    if let Some(err) = run_lifecycle(&plan, &effective_cwd) {
+    if let Some(err) = run_lifecycle(&plan, cwd, &effective_cwd) {
         if plan.strict {
             rollback_strict(
                 &result.changes,
@@ -1842,7 +1872,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
 
         // 6. Run format steps, then validation steps.
-        if let Some(err) = run_lifecycle(&plan, &cwd) {
+        if let Some(err) = run_lifecycle(&plan, &base_cwd, &cwd) {
             if plan.strict {
                 rollback_strict(
                     &result.changes,

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1489,7 +1489,7 @@ fn run_lifecycle(plan: &Plan, cwd: &Path) -> Option<LifecycleError> {
         })
 }
 
-fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathBuf {
+pub(crate) fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathBuf {
     match plan_cwd {
         Some(plan_cwd) => {
             let path = Path::new(plan_cwd);

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1489,6 +1489,20 @@ fn run_lifecycle(plan: &Plan, cwd: &Path) -> Option<LifecycleError> {
         })
 }
 
+fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathBuf {
+    match plan_cwd {
+        Some(plan_cwd) => {
+            let path = Path::new(plan_cwd);
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                base_cwd.join(path)
+            }
+        }
+        None => base_cwd.to_path_buf(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Direct execution (MCP / in-process callers)
 // ---------------------------------------------------------------------------
@@ -1598,11 +1612,7 @@ pub(crate) fn execute_plan_direct(plan: Plan, cwd: &Path) -> anyhow::Result<(u8,
     }
 
     // Resolve working directory (plan.cwd overrides argument).
-    let effective_cwd: PathBuf = if let Some(ref c) = plan.cwd {
-        PathBuf::from(c)
-    } else {
-        cwd.to_path_buf()
-    };
+    let effective_cwd = resolve_plan_cwd(cwd, plan.cwd.as_deref());
 
     // Load project config so write_policy picks up .patchloom.toml settings.
     let mut global = GlobalFlags {
@@ -1751,11 +1761,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // 3. Resolve working directory (plan.cwd overrides global --cwd).
-    let cwd: PathBuf = if let Some(ref c) = plan.cwd {
-        PathBuf::from(c)
-    } else {
-        global.resolve_cwd()?
-    };
+    let base_cwd = global.resolve_cwd()?;
+    let cwd = resolve_plan_cwd(&base_cwd, plan.cwd.as_deref());
 
     // 4. Execute all operations, collecting changes in memory (no writes).
     let mut result = match execute_and_collect(&plan, &cwd, global, global.quiet, structured) {

--- a/tests/agent/README.md
+++ b/tests/agent/README.md
@@ -18,6 +18,8 @@ make agent-test
 
 # Or run directly with options
 cd tests/agent
+python3 -m venv .venv
+. .venv/bin/activate
 pip install -r requirements.txt
 pytest -v --agent grok --model grok-build
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12801,6 +12801,32 @@ fn test_tx_honors_cwd_for_relative_plan_path() {
 }
 
 #[test]
+fn test_tx_relative_plan_cwd_resolves_from_invocation_root() {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path().join("repo");
+    let nested = repo.join("nested");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(
+        repo.join("plan.toml"),
+        "version = \"1\"\ncwd = \"nested\"\n\n[[operations]]\nop = \"file.create\"\npath = \"out.txt\"\ncontent = \"hello\\n\"\n",
+    )
+    .unwrap();
+
+    patchloom_in(&repo)
+        .arg("tx")
+        .arg("plan.toml")
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(nested.join("out.txt")).unwrap(),
+        "hello\n"
+    );
+    assert!(!repo.join("out.txt").exists());
+}
+
+#[test]
 fn test_smoke_quickstart_command_flow() {
     let quickstart = fs::read_to_string(quickstart_path()).unwrap();
     assert!(quickstart.contains("patchloom search 'TODO' src/"));
@@ -14199,6 +14225,27 @@ async fn spawn_mcp_client_opts(
         .expect("failed to connect MCP client")
 }
 
+#[cfg(feature = "mcp")]
+async fn spawn_mcp_client_process_and_cwd(
+    process_dir: &Path,
+    server_cwd: &Path,
+) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
+    use rmcp::ServiceExt;
+    use rmcp::transport::TokioChildProcess;
+
+    let bin = assert_cmd::cargo::cargo_bin("patchloom");
+    let mut cmd = tokio::process::Command::new(bin);
+    cmd.arg("mcp-server")
+        .arg("--cwd")
+        .arg(server_cwd)
+        .current_dir(process_dir);
+
+    let transport = TokioChildProcess::new(cmd).expect("failed to spawn patchloom mcp-server");
+    ().serve(transport)
+        .await
+        .expect("failed to connect MCP client")
+}
+
 /// Helper: call a tool and return the text content from the first Content item.
 async fn call_tool_text(
     client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
@@ -14758,6 +14805,44 @@ async fn test_mcp_tx_rejects_escaping_cwd() {
     assert!(
         result.is_err(),
         "tx with escaping cwd should be rejected as a path containment violation"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_tx_rejects_relative_cwd_that_escapes_server_root() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let process_dir = dir.path().join("sandbox");
+    let repo_dir = dir.path().join("repo");
+    fs::create_dir_all(&process_dir).unwrap();
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::write(repo_dir.join("inside.txt"), "inside\n").unwrap();
+    fs::write(dir.path().join("outside.txt"), "outside\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": "..",
+        "operations": [
+            {"op": "replace", "path": "outside.txt", "from": "outside", "to": "pwned"}
+        ]
+    });
+
+    let client = spawn_mcp_client_process_and_cwd(&process_dir, &repo_dir).await;
+    let params = rmcp::model::CallToolRequestParams::new("transaction".to_string()).with_arguments(
+        serde_json::from_value(serde_json::json!({"plan": plan.to_string()})).unwrap(),
+    );
+    let result = client.peer().call_tool(params).await;
+    assert!(
+        result.is_err(),
+        "tx with relative escaping cwd should be rejected"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("outside.txt")).unwrap(),
+        "outside\n"
     );
     client.cancel().await.unwrap();
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10927,7 +10927,7 @@ fn test_tx_validation_failure_redacts_shell_command_in_stderr() {
 
     assert_eq!(output.status.code(), Some(6));
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("required validation failed (step 1, exit code 1)"));
+    assert!(stderr.contains("required validation failed (step 1, exit code 1, cwd: .)"));
     assert!(!stderr.contains(secret));
 }
 
@@ -10970,7 +10970,7 @@ fn test_tx_json_output_on_validation_failure_redacts_shell_command() {
     assert_eq!(json["error_kind"], "validation_failed");
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("validation_failed"));
-    assert!(error.contains("required validation failed (step 1, exit code 1)"));
+    assert!(error.contains("required validation failed (step 1, exit code 1, cwd: .)"));
     assert!(!error.contains(secret));
 }
 
@@ -11012,7 +11012,8 @@ fn test_tx_json_output_on_validation_failure() {
     assert_eq!(json["error_kind"], "validation_failed");
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("validation_failed"));
-    assert!(error.contains("required validation failed (step 1, exit code 1)"));
+    assert!(error.contains("required validation failed (step 1, exit code 1, cwd: .)"));
+    assert!(error.contains("cwd: ."));
     assert!(error.contains("exit code 1"));
 }
 
@@ -11056,7 +11057,7 @@ fn test_tx_json_output_on_strict_validation_failure_preserves_reason() {
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("rollback"));
     assert!(error.contains("strict mode -- all changes reverted"));
-    assert!(error.contains("required validation failed (step 1, exit code 1)"));
+    assert!(error.contains("required validation failed (step 1, exit code 1, cwd: .)"));
     assert!(error.contains("exit code 1"));
 }
 
@@ -11192,7 +11193,7 @@ fn test_tx_format_failure_redacts_shell_command_in_stderr() {
 
     assert_eq!(output.status.code(), Some(6));
     let stderr = String::from_utf8(output.stderr).unwrap();
-    assert!(stderr.contains("format step failed (step 1, exit code 1)"));
+    assert!(stderr.contains("format step failed (step 1, exit code 1, cwd: .)"));
     assert!(!stderr.contains(secret));
 }
 
@@ -11234,7 +11235,7 @@ fn test_tx_json_output_on_format_failure_redacts_shell_command() {
     assert_eq!(json["error_kind"], "format_failed");
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("validation_failed"));
-    assert!(error.contains("format step failed (step 1, exit code 1)"));
+    assert!(error.contains("format step failed (step 1, exit code 1, cwd: .)"));
     assert!(!error.contains(secret));
 }
 
@@ -11277,7 +11278,7 @@ fn test_tx_json_output_on_strict_format_failure_preserves_error_kind() {
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("rollback"));
     assert!(error.contains("strict mode -- all changes reverted"));
-    assert!(error.contains("format step failed (step 1, exit code 1)"));
+    assert!(error.contains("format step failed (step 1, exit code 1, cwd: .)"));
     assert!(error.contains("exit code 1"));
 }
 
@@ -12831,6 +12832,49 @@ fn test_tx_relative_plan_cwd_resolves_from_invocation_root() {
 }
 
 #[test]
+fn test_tx_json_output_reports_lifecycle_cwd_for_relative_plan_cwd() {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path().join("repo");
+    let nested = repo.join("nested");
+    fs::create_dir_all(&nested).unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": "nested",
+        "operations": [{
+            "op": "file.create",
+            "path": "out.txt",
+            "content": "hello\n"
+        }],
+        "validate": [{
+            "cmd": shell_false(),
+            "required": true,
+            "timeout": 5
+        }]
+    });
+    let plan_file = repo.join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = patchloom_in(&repo)
+        .arg("--json")
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "validation_failed");
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("required validation failed (step 1, exit code 1, cwd: nested)"));
+    assert_eq!(
+        fs::read_to_string(nested.join("out.txt")).unwrap(),
+        "hello\n"
+    );
+}
+
+#[test]
 fn test_smoke_quickstart_command_flow() {
     let quickstart = fs::read_to_string(quickstart_path()).unwrap();
     assert!(quickstart.contains("patchloom search 'TODO' src/"));
@@ -13766,6 +13810,21 @@ fn test_reference_doc_describes_confirm_json_applied_contract_for_file_lifecycle
     let reference = fs::read_to_string(reference_path()).unwrap();
     let contract = "When combined with `--confirm` and `--json` or `--jsonl`, the structured output includes `applied: true|false` so callers can tell whether the prompt was accepted.";
     assert_eq!(reference.matches(contract).count(), 3);
+}
+
+#[test]
+fn test_reference_doc_describes_tx_lifecycle_failure_context() {
+    let reference = fs::read_to_string(reference_path()).unwrap();
+    assert!(reference.contains(
+        "Error output reports the failing step number, exit status, and the lifecycle working directory (`cwd`)."
+    ));
+}
+
+#[test]
+fn test_quickstart_doc_describes_tx_lifecycle_failure_context() {
+    let quickstart = fs::read_to_string(quickstart_path()).unwrap();
+    assert!(quickstart.contains("Lifecycle failure output includes the failing step"));
+    assert!(quickstart.contains("status, and the `cwd` used for that step."));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14849,6 +14849,37 @@ async fn test_mcp_tx_rejects_relative_cwd_that_escapes_server_root() {
 
 #[cfg(feature = "mcp")]
 #[tokio::test]
+async fn test_mcp_tx_rejects_relative_cwd_that_is_a_file() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let repo_dir = dir.path().join("repo");
+    fs::create_dir_all(&repo_dir).unwrap();
+    fs::write(repo_dir.join("not-a-dir"), "nope\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": "not-a-dir",
+        "operations": [
+            {"op": "replace", "path": "anything.txt", "from": "a", "to": "b"}
+        ]
+    });
+
+    let client = spawn_mcp_client(&repo_dir).await;
+    let params = rmcp::model::CallToolRequestParams::new("transaction".to_string()).with_arguments(
+        serde_json::from_value(serde_json::json!({"plan": plan.to_string()})).unwrap(),
+    );
+    let result = client.peer().call_tool(params).await;
+    assert!(
+        result.is_err(),
+        "tx with a file-valued relative cwd should be rejected"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
 async fn test_mcp_tx_yaml_format() {
     if !has_mcp_support() {
         return;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11975,6 +11975,10 @@ fn installation_path() -> PathBuf {
         .join("installation.md")
 }
 
+fn agent_test_readme_path() -> PathBuf {
+    repo_root().join("tests").join("agent").join("README.md")
+}
+
 fn concepts_path() -> PathBuf {
     repo_root()
         .join("docs")
@@ -13150,6 +13154,19 @@ fn test_smoke_installation_docs_cover_contributor_verification_loop() {
 }
 
 #[test]
+fn test_agent_test_readme_uses_virtualenv_for_direct_install() {
+    let content = fs::read_to_string(agent_test_readme_path()).unwrap();
+    assert!(
+        content.contains("python3 -m venv .venv"),
+        "agent test readme should create a virtualenv before pip install"
+    );
+    assert!(
+        content.contains(". .venv/bin/activate"),
+        "agent test readme should show how to activate the virtualenv"
+    );
+}
+
+#[test]
 fn test_smoke_rust_version_docs_and_ci_match_cargo_metadata() {
     let cargo = fs::read_to_string(repo_root().join("Cargo.toml")).unwrap();
     let rust_version_line = cargo
@@ -13204,6 +13221,7 @@ fn test_contributing_make_targets_table_covers_key_targets() {
         "make integration-test",
         "make clippy",
         "make update-readme",
+        "cargo check --all-targets",
     ] {
         assert!(
             contributing.contains(&format!("| `{target}`")),


### PR DESCRIPTION
Four improvements from the multi-perspective improvement rotation:

1. **tx: resolve relative plan cwd from invocation root** (commit 4924771)
   - Relative `cwd` values in tx plans now resolve from the CLI invocation working directory, not treated as absolute paths
   - MCP mode already had this behavior; CLI mode now matches
   - Added 3 integration tests covering relative cwd resolution

2. **mcp: share tx cwd resolution rules** (commit 72333f9)
   - Deduplicated cwd resolution between CLI and MCP into `resolve_plan_cwd()`
   - MCP transaction handler now validates relative cwd resolves to a directory (not a file)
   - Added 2 MCP integration tests for relative cwd escaping and file-valued cwd rejection

3. **docs: clarify contributor verification loops** (commit 7854e89)
   - Added `cargo check --all-targets` to CONTRIBUTING.md make-targets table
   - Documented virtualenv-first install flow in agent test README
   - Added doc smoke tests for both

4. **tx: include cwd in lifecycle failure messages** (commit c9d244a)
   - Format step and validation step errors now report the lifecycle working directory
   - Helps debug failures when plan `cwd` differs from invocation root
   - Added regression tests and doc freshness tests

Test count: 1114 (545 unit + 569 integration). `make check` passes.