### PR TITLE
tx: validate plan cwd, capture lifecycle stderr, blog freshness guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1114 tests (545 unit + 569 integration)
+- 1120 tests (545 unit + 575 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1114%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1120%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1114 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1120 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -131,27 +131,69 @@ fn host_shell_command(cmd: &str, cwd: &Path) -> std::process::Command {
     }
 }
 
-/// Run a shell command with a timeout. Returns the exit status,
-/// or an error if the command times out or fails to start.
-fn run_shell_with_timeout(
-    cmd: &str,
-    timeout_secs: u64,
-    cwd: &Path,
-) -> anyhow::Result<std::process::ExitStatus> {
+/// Result of a shell command execution with captured stderr.
+struct ShellResult {
+    status: std::process::ExitStatus,
+    /// First N bytes of stderr output (truncated for safety).
+    stderr_head: String,
+}
+
+/// Maximum bytes of stderr to capture from lifecycle commands.
+const LIFECYCLE_STDERR_MAX: usize = 512;
+
+/// Run a shell command with a timeout. Returns the exit status and
+/// a truncated snippet of stderr, or an error if the command times out
+/// or fails to start.
+fn run_shell_with_timeout(cmd: &str, timeout_secs: u64, cwd: &Path) -> anyhow::Result<ShellResult> {
     let mut child = host_shell_command(cmd, cwd)
         .stdout(std::process::Stdio::null())
-        // Discard stderr so verbose lifecycle steps cannot block on a full pipe.
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .spawn()?;
+
+    // Read stderr in a background thread to avoid blocking if the pipe fills.
+    let stderr_handle = child.stderr.take().unwrap();
+    let reader_thread = std::thread::spawn(move || {
+        use std::io::Read;
+        let mut buf = vec![0u8; LIFECYCLE_STDERR_MAX + 1];
+        let mut reader = stderr_handle;
+        let mut total = 0;
+        loop {
+            match reader.read(&mut buf[total..]) {
+                Ok(0) => break,
+                Ok(n) => {
+                    total += n;
+                    if total > LIFECYCLE_STDERR_MAX {
+                        // Drain remaining stderr so the child is not blocked.
+                        let mut discard = [0u8; 4096];
+                        while reader.read(&mut discard).unwrap_or(0) > 0 {}
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        let cap = total.min(LIFECYCLE_STDERR_MAX);
+        let text = String::from_utf8_lossy(&buf[..cap]).to_string();
+        if total > LIFECYCLE_STDERR_MAX {
+            format!("{text}... (truncated)")
+        } else {
+            text
+        }
+    });
 
     let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
     loop {
         if let Some(status) = child.try_wait()? {
-            return Ok(status);
+            let stderr_head = reader_thread.join().unwrap_or_default();
+            return Ok(ShellResult {
+                status,
+                stderr_head,
+            });
         }
         if std::time::Instant::now() >= deadline {
             kill_process_tree(&mut child);
-            anyhow::bail!("timed out after {timeout_secs}s");
+            let stderr_head = reader_thread.join().unwrap_or_default();
+            anyhow::bail!("timed out after {timeout_secs}s: {stderr_head}");
         }
         std::thread::sleep(SHELL_POLL_INTERVAL);
     }
@@ -1286,6 +1328,16 @@ struct LifecycleError {
     kind: &'static str,
 }
 
+/// Format a lifecycle step failure message, appending stderr output if available.
+fn lifecycle_failure_msg(header: &str, stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        header.to_string()
+    } else {
+        format!("{header}: {trimmed}")
+    }
+}
+
 fn run_format_steps(
     steps: &[plan::FormatStep],
     base_cwd: &Path,
@@ -1296,13 +1348,17 @@ fn run_format_steps(
         let timeout_secs = step.timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
         let result = run_shell_with_timeout(&step.cmd, timeout_secs, cwd);
         match result {
-            Ok(status) if !status.success() => {
-                let msg = format!(
+            Ok(ShellResult {
+                status,
+                stderr_head,
+            }) if !status.success() => {
+                let header = format!(
                     "format step failed (step {}, {}, cwd: {})",
                     index + 1,
                     describe_exit_status(status),
                     lifecycle_cwd
                 );
+                let msg = lifecycle_failure_msg(&header, &stderr_head);
                 eprintln!("tx: {msg}");
                 return Err(LifecycleError {
                     message: msg,
@@ -1337,14 +1393,23 @@ fn run_validate_steps(
         let timeout_secs = step.timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
         let result = run_shell_with_timeout(&step.cmd, timeout_secs, cwd);
         match result {
-            Ok(status) if status.success() => {}
-            Ok(status) => {
-                let msg = format!(
+            Ok(ShellResult {
+                status,
+                stderr_head,
+            }) if status.success() => {
+                let _ = stderr_head; // Discard stderr on success.
+            }
+            Ok(ShellResult {
+                status,
+                stderr_head,
+            }) => {
+                let header = format!(
                     "required validation failed (step {}, {}, cwd: {})",
                     index + 1,
                     describe_exit_status(status),
                     lifecycle_cwd
                 );
+                let msg = lifecycle_failure_msg(&header, &stderr_head);
                 eprintln!("tx: {msg}");
                 if step.required.unwrap_or(false) {
                     return Err(LifecycleError {
@@ -1793,6 +1858,19 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // 3. Resolve working directory (plan.cwd overrides global --cwd).
     let base_cwd = global.resolve_cwd()?;
     let cwd = resolve_plan_cwd(&base_cwd, plan.cwd.as_deref());
+
+    if plan.cwd.is_some() && !cwd.is_dir() {
+        let msg = format!(
+            "plan cwd is not a directory: {}",
+            plan.cwd.as_deref().unwrap()
+        );
+        if structured {
+            emit_error_json("parse_error", &msg, compact);
+        } else {
+            eprintln!("tx: {msg}");
+        }
+        return Ok(exit::PARSE_ERROR);
+    }
 
     // 4. Execute all operations, collecting changes in memory (no writes).
     let mut result = match execute_and_collect(&plan, &cwd, global, global.quiet, structured) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12875,6 +12875,175 @@ fn test_tx_json_output_reports_lifecycle_cwd_for_relative_plan_cwd() {
 }
 
 #[test]
+fn test_tx_cli_rejects_plan_cwd_that_is_a_file() {
+    let dir = TempDir::new().unwrap();
+    let not_a_dir = dir.path().join("not-a-dir");
+    fs::write(&not_a_dir, "nope\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": "not-a-dir",
+        "operations": [{
+            "op": "replace",
+            "path": "anything.txt",
+            "from": "a",
+            "to": "b"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .assert()
+        .code(4) // PARSE_ERROR
+        .stderr(predicate::str::contains("plan cwd is not a directory"));
+}
+
+#[test]
+fn test_tx_cli_rejects_plan_cwd_that_is_a_file_json_output() {
+    let dir = TempDir::new().unwrap();
+    let not_a_dir = dir.path().join("not-a-dir");
+    fs::write(&not_a_dir, "nope\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": "not-a-dir",
+        "operations": [{
+            "op": "replace",
+            "path": "anything.txt",
+            "from": "a",
+            "to": "b"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = patchloom_in(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg(&plan_file)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(4));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "parse_error");
+    let error = json["error"].as_str().unwrap();
+    assert!(error.contains("plan cwd is not a directory"));
+}
+
+#[test]
+fn test_tx_cli_rejects_plan_cwd_nonexistent() {
+    let dir = TempDir::new().unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": "does-not-exist",
+        "operations": [{
+            "op": "replace",
+            "path": "anything.txt",
+            "from": "a",
+            "to": "b"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .assert()
+        .code(4) // PARSE_ERROR
+        .stderr(predicate::str::contains("plan cwd is not a directory"));
+}
+
+#[test]
+fn test_tx_lifecycle_stderr_captured_in_validation_error() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    // Use a command that writes to stderr before failing.
+    let stderr_cmd = "echo 'CUSTOM_ERROR: something went wrong' >&2 && exit 1";
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "hello",
+            "to": "world"
+        }],
+        "validate": [{
+            "cmd": stderr_cmd,
+            "required": true,
+            "timeout": 5
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    let error = json["error"].as_str().unwrap();
+    assert!(
+        error.contains("CUSTOM_ERROR: something went wrong"),
+        "lifecycle error should include captured stderr: {error}"
+    );
+}
+
+#[test]
+fn test_tx_lifecycle_stderr_captured_in_format_error() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    let stderr_cmd = "echo 'FMT_FAIL: bad formatting' >&2 && exit 1";
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "original",
+            "to": "changed"
+        }],
+        "format": [{
+            "cmd": stderr_cmd,
+            "timeout": 5
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(
+        stderr.contains("FMT_FAIL: bad formatting"),
+        "format step stderr should include captured output: {stderr}"
+    );
+}
+
+#[test]
 fn test_smoke_quickstart_command_flow() {
     let quickstart = fs::read_to_string(quickstart_path()).unwrap();
     assert!(quickstart.contains("patchloom search 'TODO' src/"));
@@ -13194,6 +13363,32 @@ fn test_smoke_installation_docs_cover_contributor_verification_loop() {
     assert!(
         content.contains("make check"),
         "installation guide should mention the full contributor verification gate"
+    );
+}
+
+#[test]
+fn test_launch_announcement_command_count_matches_readme() {
+    let readme = fs::read_to_string(readme_path()).unwrap();
+    let launch = fs::read_to_string(launch_announcement_path()).unwrap();
+
+    // Extract core command count from README (e.g., "across 18 core commands").
+    let readme_count: usize = readme
+        .lines()
+        .find(|l| l.contains("core commands"))
+        .and_then(|l| {
+            let idx = l.find("core commands")?;
+            l[..idx]
+                .split_whitespace()
+                .next_back()?
+                .parse::<usize>()
+                .ok()
+        })
+        .expect("README should state the core command count");
+
+    // Launch announcement says "N commands cover".
+    assert!(
+        launch.contains(&format!("{readme_count} commands cover")),
+        "launch announcement command count should match README ({readme_count} core commands)"
     );
 }
 


### PR DESCRIPTION
Three fixes in one commit:

**#393: CLI tx validates plan cwd is a directory**
The MCP transaction handler already rejects plan `cwd` values that resolve to a file (not a directory). The CLI `tx` command now performs the same check after `resolve_plan_cwd()`, returning PARSE_ERROR with `plan cwd is not a directory: <path>` instead of falling through to confusing OS errors.

**#395: Lifecycle steps capture stderr in error output**
`run_shell_with_timeout` now pipes stderr instead of discarding it (`Stdio::null()`). The first 512 bytes are captured in a background thread and appended to the error message. Example:
```
format step failed (step 1, exit code 1, cwd: .): error[E0308]: mismatched types ...
```
The background reader drains any excess output to prevent pipe deadlocks. Existing redaction tests still pass (the `shell_fail_with_secret` helper runs `false` which produces no stderr).

**#394: Blog post command count freshness guard**
New integration test `test_launch_announcement_command_count_matches_readme` extracts the core command count from README.md and verifies the launch announcement blog post uses the same number. Prevents silent drift.

Closes #393, closes #394, closes #395

Test count: 1120 (545 unit + 575 integration). `make check` passes.