### PR TITLE
test: stderr truncation guard, CHANGELOG update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1120 tests (545 unit + 575 integration)
+- 1121 tests (545 unit + 576 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added `validate_path_resolved` symlink check to all 16 MCP write handlers
 - Extracted `compile_replace_regex` shared helper
 - Improved doc command error messages to list supported file extensions
+- CLI `tx` validates plan `cwd` is a directory, returning PARSE_ERROR instead of confusing OS errors
+- Lifecycle shell commands (format/validate) now capture first 512 bytes of stderr in error output
+- Relative plan `cwd` values resolve from invocation root, matching MCP behavior
+- Lifecycle failure messages include the working directory (`cwd: .` or `cwd: nested`)
+- MCP `transaction` validates relative `cwd` resolves to a directory, not a file
+- Shared `resolve_plan_cwd` function deduplicates CLI and MCP cwd resolution
 
 ### Documentation
 
 - Documented column offset semantics in search JSON output
 - Added `init` command to README Commands table
+- Documented stderr capture and cwd context in lifecycle failure output (reference docs, quickstart)
+- Added `cargo check --all-targets` to CONTRIBUTING.md for default-feature build verification
+- Added launch announcement blog post command count freshness guard
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1120%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1121%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1120 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1121 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -728,7 +728,7 @@ Use these when newline and whitespace correctness is the main concern.
 - **What it does:** Runs shell commands after writes are staged to disk but before validation.
 - **Use when:** Generated or edited files should be normalized by tools like `cargo fmt`, `prettier`, or `black` as part of the same workflow.
 - **Step fields:** Each entry accepts `cmd` (required shell command) and `timeout` (seconds, default `60`).
-- **Failure behavior:** Any non-zero exit or timeout fails the transaction. Error output reports the failing step number, exit status, and the lifecycle working directory (`cwd`). With `strict: true`, Patchloom rolls back the staged writes.
+- **Failure behavior:** Any non-zero exit or timeout fails the transaction. Error output reports the failing step number, exit status, the lifecycle working directory (`cwd`), and a truncated snippet of the command's stderr when available. With `strict: true`, Patchloom rolls back the staged writes.
 - **Prefer instead:** Run formatting outside `tx` when it does not need to participate in the transaction's success criteria.
 
 <!-- ref:tx-field:validate -->
@@ -737,7 +737,7 @@ Use these when newline and whitespace correctness is the main concern.
 - **What it does:** Runs shell commands that decide whether the transaction should be reported as valid.
 - **Use when:** Build, test, or policy checks are part of the definition of success for the change.
 - **Step fields:** Each entry accepts `cmd` (required shell command), `required` (bool, default `false`), and `timeout` (seconds, default `60`).
-- **Failure behavior:** `required: true` makes the step gate transaction success. `required: false` still reports the validation problem to stderr. Error output reports the failing step number, exit status, and the lifecycle working directory (`cwd`).
+- **Failure behavior:** `required: true` makes the step gate transaction success. `required: false` still reports the validation problem to stderr. Error output reports the failing step number, exit status, the lifecycle working directory (`cwd`), and a truncated snippet of the command's stderr when available.
 - **Prefer instead:** Use standalone verification outside `tx` when the mutation and the validation lifecycle should stay separate.
 
 ### Transaction operations

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13044,6 +13044,54 @@ fn test_tx_lifecycle_stderr_captured_in_format_error() {
 }
 
 #[test]
+fn test_tx_lifecycle_stderr_truncated_when_exceeding_limit() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    // Generate >512 bytes of stderr output. Each line is ~80 chars;
+    // 10 lines = ~800 bytes, well over the 512-byte capture limit.
+    let stderr_cmd = "for i in 1 2 3 4 5 6 7 8 9 10; do echo \"LONGLINE_${i}_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\" >&2; done && exit 1";
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "hello",
+            "to": "world"
+        }],
+        "validate": [{
+            "cmd": stderr_cmd,
+            "required": true,
+            "timeout": 5
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(6));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let error = json["error"].as_str().unwrap();
+    assert!(
+        error.contains("LONGLINE_1_"),
+        "truncated stderr should include the beginning: {error}"
+    );
+    assert!(
+        error.contains("(truncated)"),
+        "long stderr should be marked as truncated: {error}"
+    );
+}
+
+#[test]
 fn test_smoke_quickstart_command_flow() {
     let quickstart = fs::read_to_string(quickstart_path()).unwrap();
     assert!(quickstart.contains("patchloom search 'TODO' src/"));
@@ -14011,7 +14059,7 @@ fn test_reference_doc_describes_confirm_json_applied_contract_for_file_lifecycle
 fn test_reference_doc_describes_tx_lifecycle_failure_context() {
     let reference = fs::read_to_string(reference_path()).unwrap();
     assert!(reference.contains(
-        "Error output reports the failing step number, exit status, and the lifecycle working directory (`cwd`)."
+        "Error output reports the failing step number, exit status, the lifecycle working directory (`cwd`), and a truncated snippet of the command's stderr when available."
     ));
 }
 


### PR DESCRIPTION
Two commits from the multi-perspective improvement cycle:

1. **test: stderr truncation regression test** (31cd5a8)
   - Verifies lifecycle stderr exceeding 512 bytes is truncated with `(truncated)` marker
   - Updated reference docs to mention stderr capture in lifecycle failure output
   - Updated doc freshness test to match new wording

2. **docs: CHANGELOG unreleased section** (c415c98)
   - Added entries for plan cwd validation, lifecycle stderr capture, cwd context in errors, resolve_plan_cwd deduplication, and documentation updates from PRs #396 and #397

Test count: 1121 (545 unit + 576 integration). `make check` passes.