### PR TITLE
Clarify text-file semantics for search, replace, and tidy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ async fn new_tool(
 
 - Run `cargo fmt` before every commit.
 - `cargo clippy --all-targets --all-features -- -D warnings` must produce zero warnings.
-- `make check` is the full gate: formatting, build, test, clippy. Nothing merges unless it passes.
+- `make check` is the full gate. Nothing merges unless it passes.
 - All commits require a `Signed-off-by` line (DCO). Use `git commit -s`.
 - Keep `main.rs` thin. No business logic in `main.rs` or `lib.rs`.
 - Prefer returning exit codes over panicking. Never use `unwrap()` in non-test code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1131 tests (554 unit + 577 integration)
+- 1132 tests (554 unit + 578 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1132 tests (554 unit + 578 integration)
+- 1136 tests (555 unit + 581 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1130 tests (554 unit + 576 integration)
+- 1131 tests (554 unit + 577 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ make check          # must pass before every commit
    `cargo check --all-targets`. `make check` uses `--all-features`, so it
    does not exercise the default-feature build.
 5. Commit with a [DCO sign-off](#dco-sign-off).
-5. Open a pull request against `main`.
+6. Open a pull request against `main`.
 
 ### Useful make targets
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1132%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1136%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -269,15 +269,15 @@ See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent con
 | `doc` | Parser-backed JSON/YAML/TOML edits | Changing config values without breaking syntax |
 | `md` | Heading-aware markdown edits | Updating tables, sections, bullets in docs |
 | `patch` | Apply unified diffs with stale detection | Replaying patches safely |
-| `tidy` | Whitespace and newline normalization | CI checks for text tidiness |
+| `tidy` | Text-file whitespace and newline normalization | CI checks for text tidiness |
 | `mcp-server` | MCP protocol server (requires `--features mcp`) | MCP-capable agents (no shell syntax) |
 
 ### General-purpose (also useful in scripts and CI)
 
 | Command | Description |
 |---|---|
-| `search` | Fast literal or regex search across a repo |
-| `replace` | Mechanical string replacement with diff preview |
+| `search` | Fast literal or regex search across text files |
+| `replace` | Mechanical string replacement across text files with diff preview |
 | `create` | Create a new file with content |
 | `delete` | Delete a file |
 | `rename` | Move (rename) a file |
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1132 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1136 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1131%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1132%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1131 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1132 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1130%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1131%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1130 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1131 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -103,7 +103,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `doc_select` | Filter array items by selector (read-only) |
 | `doc_flatten` | List all leaf selector paths and values (read-only) |
 | `doc_diff` | Compare two structured files (read-only) |
-| `search_files` | Search files for a pattern, including literal, count, file-only, and multiline modes (read-only) |
+| `search_files` | Search files for a pattern, including literal, case-insensitive, count, file-only, and multiline modes (read-only) |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
 | `read_file` | Read file contents with optional line range |
 | `replace_text` | Replace text in a file (literal or regex) |

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -103,7 +103,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `doc_select` | Filter array items by selector (read-only) |
 | `doc_flatten` | List all leaf selector paths and values (read-only) |
 | `doc_diff` | Compare two structured files (read-only) |
-| `search_files` | Search files for a pattern with context (read-only) |
+| `search_files` | Search files for a pattern, including literal, count, file-only, and multiline modes (read-only) |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
 | `read_file` | Read file contents with optional line range |
 | `replace_text` | Replace text in a file (literal or regex) |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -140,7 +140,7 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:search -->
 ## `search`
 
-- **What it does:** Searches files with literal or regex matching, optional context, counts, and file only results.
+- **What it does:** Searches text files with literal or regex matching, optional context, counts, and file only results. Binary and invalid UTF-8 files are skipped.
 - **Use when:** You need to locate candidate edits, audit repo state, or narrow inputs before changing files. For AI agents, native search/grep tools are typically faster for simple pattern matching.
 - **Prefer instead:** Use `replace` for actual text mutation, or `doc`, `md`, or `patch` when you already know the structured change you want.
 - **Related:** `--glob`, `--files-from`, `replace`
@@ -148,7 +148,7 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:replace -->
 ## `replace`
 
-- **What it does:** Performs mechanical string replacement across one or many files, with literal or regex matching.
+- **What it does:** Performs mechanical string replacement across one or many text files, with literal or regex matching. Binary and invalid UTF-8 files are skipped.
 - **Use when:** You are doing a rename, version bump, boilerplate rewrite, or another string level change where plain text semantics are enough. For AI agents doing single-file replacements, native search_replace tools are typically faster; use patchloom `replace` inside `tx` plans when batching multiple file edits.
 - **Prefer instead:** Use `doc` for structured data, `md` for heading aware markdown, or `patch` when you already have a unified diff.
 - **Related:** `search`, `tx`
@@ -180,7 +180,7 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:tidy -->
 ## `tidy`
 
-- **What it does:** Checks or fixes trailing whitespace, line endings, and final newlines.
+- **What it does:** Checks or fixes trailing whitespace, line endings, and final newlines in text files. Binary and invalid UTF-8 files are skipped.
 - **Use when:** You need repo text normalization, or a CI guard for basic text tidiness.
 - **Prefer instead:** Use write policy flags when the cleanup should only apply to files already being touched by another command.
 - **Related:** `tidy check`, `tidy fix`, `tx tidy.fix`
@@ -667,14 +667,14 @@ Use these when newline and whitespace correctness is the main concern.
 <!-- ref:tidy-action:check -->
 ### `tidy check`
 
-- **What it does:** Reports missing final newlines, mixed line endings, and trailing whitespace.
+- **What it does:** Reports missing final newlines, mixed line endings, and trailing whitespace in text files. Binary and invalid UTF-8 files are skipped.
 - **Use when:** You want a non mutating tidy audit for CI or local review.
 - **Prefer instead:** Use `tidy fix` when the goal is to normalize the files immediately.
 
 <!-- ref:tidy-action:fix -->
 ### `tidy fix`
 
-- **What it does:** Applies newline and whitespace normalization.
+- **What it does:** Applies newline and whitespace normalization to text files. Binary and invalid UTF-8 files are skipped.
 - **Use when:** Existing files already need cleanup and the cleanup itself is the task.
 - **Prefer instead:** Use write policy flags when normalization should only apply to files already being touched by another write command.
 

--- a/examples/08-mcp-tool-call.json
+++ b/examples/08-mcp-tool-call.json
@@ -15,11 +15,13 @@
       }
     },
     {
-      "description": "Search for a pattern across the repo",
+      "description": "Search for a multi-line function signature",
       "tool": "search_files",
       "arguments": {
-        "paths": ["src"],
-        "pattern": "TODO|FIXME"
+        "paths": ["src/cmd"],
+        "pattern": "async fn search_files\\(.*?\\{",
+        "multiline": true,
+        "context": 1
       }
     },
     {

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -868,7 +868,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Search files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts."
+        description = "Search files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts, case_insensitive=true to ignore case, or multiline=true to let '.' span newlines."
     )]
     async fn search_files(
         &self,

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -26,9 +26,9 @@ pub enum Command {
     Create(create::CreateArgs),
     /// Delete a file.
     Delete(delete::DeleteArgs),
-    /// Fast literal or regex search across a repo.
+    /// Fast literal or regex search across text files.
     Search(search::SearchArgs),
-    /// Mechanical string replacement with diff preview.
+    /// Mechanical string replacement across text files with diff preview.
     Replace(replace::ReplaceArgs),
     /// Show which files have uncommitted changes.
     Status(status::StatusArgs),
@@ -42,7 +42,7 @@ pub enum Command {
     Md(md::MdArgs),
     /// Parser-backed JSON, YAML, and TOML operations.
     Doc(doc::DocArgs),
-    /// Final newline, line ending, and whitespace normalization.
+    /// Text-file newline, line ending, and whitespace normalization.
     Tidy(tidy::TidyArgs),
     /// Execute a multi-operation plan atomically.
     Tx(tx::TxArgs),

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -21,9 +21,9 @@ pub struct TidyArgs {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum TidyAction {
-    /// Report newline, EOL, and whitespace issues.
+    /// Report newline, EOL, and whitespace issues in text files.
     Check { paths: Vec<String> },
-    /// Apply normalization fixes.
+    /// Apply normalization fixes to text files.
     Fix { paths: Vec<String> },
 }
 
@@ -36,15 +36,11 @@ pub struct TidyIssue {
     pub line: Option<usize>,
 }
 
-use crate::is_binary;
-
-/// Check a single file for tidy issues.
-fn check_file(path: &Path) -> anyhow::Result<Vec<TidyIssue>> {
-    let data = std::fs::read(path)?;
-
-    if data.is_empty() || is_binary(&data) {
-        return Ok(Vec::new());
-    }
+fn check_file(path: &Path, quiet: bool) -> Vec<TidyIssue> {
+    let Some(text) = crate::read_text_file(path, "tidy", quiet) else {
+        return Vec::new();
+    };
+    let data = text.as_bytes();
 
     let path_str = path.to_string_lossy().into_owned();
     let mut issues = Vec::new();
@@ -59,9 +55,9 @@ fn check_file(path: &Path) -> anyhow::Result<Vec<TidyIssue>> {
     }
 
     // Check mixed line endings: file has both \r\n and bare \n.
-    let has_crlf = memchr::memmem::find(&data, b"\r\n").is_some();
+    let has_crlf = memchr::memmem::find(data, b"\r\n").is_some();
     // A bare \n is any \n not preceded by \r.
-    let has_bare_lf = memchr::memchr_iter(b'\n', &data).any(|i| i == 0 || data[i - 1] != b'\r');
+    let has_bare_lf = memchr::memchr_iter(b'\n', data).any(|i| i == 0 || data[i - 1] != b'\r');
     if has_crlf && has_bare_lf {
         issues.push(TidyIssue {
             path: path_str.clone(),
@@ -89,7 +85,7 @@ fn check_file(path: &Path) -> anyhow::Result<Vec<TidyIssue>> {
         }
     }
 
-    Ok(issues)
+    issues
 }
 
 /// Collect all issues from the given paths, honouring .gitignore and optional
@@ -104,15 +100,11 @@ fn collect_issues(paths: &[String], global: &GlobalFlags) -> anyhow::Result<Vec<
     let quiet = global.quiet;
     let file_issues: Vec<Vec<TidyIssue>> =
         crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
-            match check_file(path) {
-                Ok(issues) if !issues.is_empty() => Some(issues),
-                Ok(_) => None,
-                Err(e) => {
-                    if !quiet {
-                        eprintln!("tidy: skipping {}: {e}", path.display());
-                    }
-                    None
-                }
+            let issues = check_file(path, quiet);
+            if issues.is_empty() {
+                None
+            } else {
+                Some(issues)
             }
         });
 
@@ -188,19 +180,10 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 glob_matcher.as_ref(),
                 &glob_roots,
                 |file_path| {
-                    let data = match std::fs::read(file_path) {
-                        Ok(d) => d,
-                        Err(e) => {
-                            if !quiet {
-                                eprintln!("tidy: skipping {}: {e}", file_path.display());
-                            }
-                            return None;
-                        }
+                    let original = match crate::read_text_file(file_path, "tidy", quiet) {
+                        Some(text) => text,
+                        None => return None,
                     };
-                    if data.is_empty() || is_binary(&data) {
-                        return None;
-                    }
-                    let original = String::from_utf8_lossy(&data);
                     let policy = policy_from_flags(global, Some(file_path));
                     let fixed = apply_policy(&original, &policy);
                     if fixed == *original {
@@ -216,7 +199,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     Some(FixResult {
                         path: file_path.to_owned(),
                         rel_path,
-                        original: original.into_owned(),
+                        original,
                         fixed,
                     })
                 },
@@ -304,7 +287,7 @@ mod tests {
         let file = tmp.path().join("no_newline.txt");
         std::fs::write(&file, b"hello").unwrap();
 
-        let issues = check_file(&file).unwrap();
+        let issues = check_file(&file, true);
         assert!(
             issues.iter().any(|i| i.issue == "missing final newline"),
             "expected missing final newline issue, got: {issues:?}"
@@ -318,7 +301,7 @@ mod tests {
         // First line uses CRLF, second uses bare LF.
         std::fs::write(&file, b"line1\r\nline2\nline3\n").unwrap();
 
-        let issues = check_file(&file).unwrap();
+        let issues = check_file(&file, true);
         assert!(
             issues.iter().any(|i| i.issue == "mixed line endings"),
             "expected mixed line endings issue, got: {issues:?}"
@@ -331,7 +314,7 @@ mod tests {
         let file = tmp.path().join("trailing.txt");
         std::fs::write(&file, b"hello   \nworld\n").unwrap();
 
-        let issues = check_file(&file).unwrap();
+        let issues = check_file(&file, true);
         let trailing: Vec<_> = issues
             .iter()
             .filter(|i| i.issue == "trailing whitespace")
@@ -346,7 +329,7 @@ mod tests {
         let file = tmp.path().join("clean.txt");
         std::fs::write(&file, b"hello\nworld\n").unwrap();
 
-        let issues = check_file(&file).unwrap();
+        let issues = check_file(&file, true);
         assert!(issues.is_empty(), "expected no issues for clean file");
 
         let global = flags_for(tmp.path());
@@ -367,7 +350,7 @@ mod tests {
         // Missing final newline + trailing whitespace on line 1 + mixed endings.
         std::fs::write(&file, b"hello \r\nworld\nfoo").unwrap();
 
-        let issues = check_file(&file).unwrap();
+        let issues = check_file(&file, true);
         let issue_types: Vec<&str> = issues.iter().map(|i| i.issue).collect();
         assert!(
             issue_types.contains(&"missing final newline"),
@@ -392,10 +375,25 @@ mod tests {
         data.insert(3, 0x00);
         std::fs::write(&file, &data).unwrap();
 
-        let issues = check_file(&file).unwrap();
+        let issues = check_file(&file, true);
         assert!(
             issues.is_empty(),
             "expected no issues for binary file, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn large_binary_files_are_skipped_via_header_probe() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("large.bin");
+        let mut data = vec![b'a'; 10_000];
+        data[4096] = 0;
+        std::fs::write(&file, &data).unwrap();
+
+        let issues = check_file(&file, true);
+        assert!(
+            issues.is_empty(),
+            "expected no issues for large binary file, got: {issues:?}"
         );
     }
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -619,17 +619,14 @@ mod tests {
     fn read_text_file_binary_past_8k_still_read_as_text() {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("mostly_text.txt");
-        // 8 KiB of text, then a NUL byte. The binary check only inspects
-        // the first 8 KiB, so this file should be treated as text but
-        // fail UTF-8 validation (NUL is valid UTF-8 but is_binary only
-        // checks the first 8 KiB). Actually NUL IS valid UTF-8, so this
-        // will succeed as text. The real check: is_binary only looks at
-        // the first 8 KiB probe, and the rest is read unconditionally.
+        // 8 KiB of text, then a NUL byte and newline. The binary check only
+        // inspects the first 8 KiB, so the file is still treated as text.
         let mut data = vec![b'a'; 8192];
+        data.push(0);
         data.push(b'\n');
         std::fs::write(&file, &data).unwrap();
         let result = read_text_file(&file, "test", false);
         assert!(result.is_some());
-        assert_eq!(result.unwrap().len(), 8193);
+        assert_eq!(result.unwrap().len(), 8194);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13547,7 +13547,7 @@ fn test_mcp_setup_documents_allow_shell_flag() {
 #[test]
 fn test_mcp_setup_documents_search_files_modes() {
     let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
-    assert!(doc.contains("literal, count, file-only, and multiline modes"));
+    assert!(doc.contains("literal, case-insensitive, count, file-only, and multiline modes"));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13545,6 +13545,12 @@ fn test_mcp_setup_documents_allow_shell_flag() {
 }
 
 #[test]
+fn test_mcp_setup_documents_search_files_modes() {
+    let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
+    assert!(doc.contains("literal, count, file-only, and multiline modes"));
+}
+
+#[test]
 fn test_ci_workflow_routes_macos_fork_prs_to_github_hosted_runners() {
     let ci = fs::read_to_string(ci_workflow_path()).unwrap();
     let fork_safe_macos_runs_on = r#"runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'macos-latest' || fromJson('["self-hosted","macOS","ARM64"]') }}"#;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14741,6 +14741,37 @@ async fn test_mcp_search_finds_pattern() {
 }
 
 #[tokio::test]
+async fn test_mcp_search_multiline_returns_json_matches() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("multi.txt"), "hello\nworld\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "search_files",
+        serde_json::json!({
+            "pattern": "hello.*world",
+            "paths": ["multi.txt"],
+            "multiline": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "multiline search should succeed: {text}");
+
+    let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(json["match_count"], 1);
+    assert_eq!(json["file_count"], 1);
+    assert_eq!(json["matches"][0]["path"], "multi.txt");
+    assert_eq!(json["matches"][0]["line"], 1);
+    assert_eq!(json["matches"][0]["column"], 1);
+    assert_eq!(json["matches"][0]["text"], "hello\nworld");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_doc_has_existing_key() {
     if !has_mcp_support() {
         return;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14174,6 +14174,42 @@ fn test_search_skips_binary_files() {
 }
 
 #[test]
+fn test_search_skips_invalid_utf8_files() {
+    let dir = TempDir::new().unwrap();
+    let text_file = dir.path().join("text.txt");
+    fs::write(&text_file, "needle in text\n").unwrap();
+
+    let invalid_file = dir.path().join("invalid.txt");
+    fs::write(&invalid_file, b"needle\xffin invalid").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("needle")
+        .arg(dir.path().to_str().unwrap())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("text.txt"),
+        "should find match in text file"
+    );
+    assert!(
+        !stdout.contains("invalid.txt"),
+        "should skip invalid UTF-8 file, got: {stdout}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid.txt (invalid UTF-8)"),
+        "expected search invalid UTF-8 warning, got: {stderr}"
+    );
+}
+
+#[test]
 fn test_replace_skips_binary_files() {
     let dir = TempDir::new().unwrap();
     let text_file = dir.path().join("text.txt");
@@ -14205,6 +14241,45 @@ fn test_replace_skips_binary_files() {
 }
 
 #[test]
+fn test_replace_skips_invalid_utf8_files() {
+    let dir = TempDir::new().unwrap();
+    let text_file = dir.path().join("text.txt");
+    fs::write(&text_file, "old value\n").unwrap();
+
+    let invalid_file = dir.path().join("invalid.txt");
+    let invalid_content = b"old value\xff trailing".to_vec();
+    fs::write(&invalid_file, &invalid_content).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("old value")
+        .arg("--to")
+        .arg("new value")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let text_content = fs::read_to_string(&text_file).unwrap();
+    assert_eq!(text_content, "new value\n");
+
+    let invalid_after = fs::read(&invalid_file).unwrap();
+    assert_eq!(
+        invalid_after, invalid_content,
+        "invalid UTF-8 file should not be modified"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid.txt (invalid UTF-8)"),
+        "expected replace invalid UTF-8 warning, got: {stderr}"
+    );
+}
+
+#[test]
 fn test_tidy_skips_binary_files() {
     let dir = TempDir::new().unwrap();
     // Text file with trailing whitespace.
@@ -14231,6 +14306,45 @@ fn test_tidy_skips_binary_files() {
 
     let bin_after = fs::read(&bin_file).unwrap();
     assert_eq!(bin_after, bin_content, "binary file should not be modified");
+}
+
+#[test]
+fn test_tidy_skips_invalid_utf8_files() {
+    let dir = TempDir::new().unwrap();
+    let text_file = dir.path().join("text.txt");
+    fs::write(&text_file, "hello   \n").unwrap();
+
+    let invalid_file = dir.path().join("invalid.txt");
+    let invalid_content = b"hello\xff   ".to_vec();
+    fs::write(&invalid_file, &invalid_content).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tidy")
+        .arg("fix")
+        .arg(dir.path().to_str().unwrap())
+        .arg("--trim-trailing-whitespace")
+        .arg("--ensure-final-newline")
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+
+    let text_content = fs::read_to_string(&text_file).unwrap();
+    assert_eq!(text_content, "hello\n");
+
+    let invalid_after = fs::read(&invalid_file).unwrap();
+    assert_eq!(
+        invalid_after, invalid_content,
+        "invalid UTF-8 file should not be modified"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid.txt (invalid UTF-8)"),
+        "expected tidy invalid UTF-8 warning, got: {stderr}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make `tidy` use the shared text-file loader so binary and invalid UTF-8 files are skipped consistently
- add regression coverage for invalid UTF-8 behavior in `search`, `replace`, and `tidy`
- clarify command docs and refresh test counts in README and CHANGELOG

## Testing
- cargo check --all-targets
- make check