### PR TITLE
Clarify MCP text-file tool semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1136 tests (555 unit + 581 integration)
+- 1137 tests (555 unit + 582 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1136%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1137%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1136 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1137 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -103,17 +103,17 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `doc_select` | Filter array items by selector (read-only) |
 | `doc_flatten` | List all leaf selector paths and values (read-only) |
 | `doc_diff` | Compare two structured files (read-only) |
-| `search_files` | Search files for a pattern, including literal, case-insensitive, count, file-only, and multiline modes (read-only) |
+| `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, and multiline modes. Binary and invalid UTF-8 files are skipped (read-only) |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
 | `read_file` | Read file contents with optional line range |
-| `replace_text` | Replace text in a file (literal or regex) |
+| `replace_text` | Replace text in a text file (literal or regex). Binary and invalid UTF-8 files are skipped |
 | `md_upsert_bullet` | Add a bullet under a markdown heading |
 | `md_table_append` | Append a row to a markdown table |
 | `md_replace_section` | Replace a markdown section by heading |
 | `md_insert_after_heading` | Insert content after a markdown heading |
 | `md_insert_before_heading` | Insert content before a markdown heading |
 | `md_lint` | Lint an AGENTS.md file for common issues |
-| `fix_whitespace` | Fix whitespace and line endings |
+| `fix_whitespace` | Fix whitespace and line endings in a text file. Binary and invalid UTF-8 files are skipped |
 | `create_file` | Create a new file with content |
 | `delete_file` | Delete a file |
 | `move_file` | Move or rename a file (binary-safe) |

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -868,7 +868,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Search files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts, case_insensitive=true to ignore case, or multiline=true to let '.' span newlines."
+        description = "Search text files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts, case_insensitive=true to ignore case, or multiline=true to let '.' span newlines. Binary and invalid UTF-8 files are skipped."
     )]
     async fn search_files(
         &self,
@@ -960,7 +960,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace text in a file. Literal by default; set regex=true for regex patterns. Use nth=N to replace only the Nth match. Use insert_before/insert_after instead of 'to' to insert around matches."
+        description = "Replace text in a text file. Literal by default; set regex=true for regex patterns. Use nth=N to replace only the Nth match. Use insert_before/insert_after instead of 'to' to insert around matches. Binary and invalid UTF-8 files are skipped."
     )]
     async fn replace_text(
         &self,
@@ -1174,7 +1174,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Fix whitespace: ensures file ends with a newline and trims trailing spaces from all lines."
+        description = "Fix whitespace in a text file: ensures the file ends with a newline and trims trailing spaces from all lines. Binary and invalid UTF-8 files are skipped."
     )]
     async fn fix_whitespace(
         &self,
@@ -1388,6 +1388,10 @@ mod tests {
         let client = spawn_test_client(dir.path().to_path_buf()).await;
         let tools = client.peer().list_all_tools().await.unwrap();
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        let descriptions = tools
+            .iter()
+            .map(|t| (t.name.as_ref(), t.description.as_deref().unwrap_or("")))
+            .collect::<std::collections::BTreeMap<_, _>>();
         assert!(names.contains(&"doc_set"), "missing doc_set tool");
         assert!(names.contains(&"doc_get"), "missing doc_get tool");
         assert!(names.contains(&"doc_has"), "missing doc_has tool");
@@ -1398,12 +1402,33 @@ mod tests {
         assert!(names.contains(&"doc_diff"), "missing doc_diff tool");
         assert!(names.contains(&"read_file"), "missing read_file tool");
         assert!(names.contains(&"search_files"), "missing search_files tool");
+        assert_eq!(
+            descriptions.get("search_files"),
+            Some(
+                &"Search text files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts, case_insensitive=true to ignore case, or multiline=true to let '.' span newlines. Binary and invalid UTF-8 files are skipped."
+            ),
+            "search_files description drifted"
+        );
         assert!(names.contains(&"git_status"), "missing git_status tool");
         assert!(names.contains(&"replace_text"), "missing replace_text tool");
+        assert_eq!(
+            descriptions.get("replace_text"),
+            Some(
+                &"Replace text in a text file. Literal by default; set regex=true for regex patterns. Use nth=N to replace only the Nth match. Use insert_before/insert_after instead of 'to' to insert around matches. Binary and invalid UTF-8 files are skipped."
+            ),
+            "replace_text description drifted"
+        );
         assert!(names.contains(&"batch"), "missing batch tool");
         assert!(
             names.contains(&"fix_whitespace"),
             "missing fix_whitespace tool"
+        );
+        assert_eq!(
+            descriptions.get("fix_whitespace"),
+            Some(
+                &"Fix whitespace in a text file: ensures the file ends with a newline and trims trailing spaces from all lines. Binary and invalid UTF-8 files are skipped."
+            ),
+            "fix_whitespace description drifted"
         );
         assert!(names.contains(&"move_file"), "missing move_file tool");
         assert!(names.contains(&"create_file"), "missing create_file tool");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13551,6 +13551,12 @@ fn test_mcp_setup_documents_search_files_modes() {
 }
 
 #[test]
+fn test_mcp_setup_documents_text_file_skip_semantics() {
+    let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
+    assert!(doc.contains("Binary and invalid UTF-8 files are skipped"));
+}
+
+#[test]
 fn test_ci_workflow_routes_macos_fork_prs_to_github_hosted_runners() {
     let ci = fs::read_to_string(ci_workflow_path()).unwrap();
     let fork_safe_macos_runs_on = r#"runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) && 'macos-latest' || fromJson('["self-hosted","macOS","ARM64"]') }}"#;


### PR DESCRIPTION
## Summary
- document that MCP search, replace, and whitespace tools operate on text files
- mention binary and invalid UTF-8 skip semantics in MCP docs and tool descriptions
- add regression checks for MCP docs and tool description drift

## Testing
- cargo check --all-targets
- make check

Refs #399