### PR TITLE
MCP search_files: add invert_match and assert_count; bump deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Lifecycle failure messages include the working directory (`cwd: .` or `cwd: nested`)
 - MCP `transaction` validates relative `cwd` resolves to a directory, not a file
 - Shared `resolve_plan_cwd` function deduplicates CLI and MCP cwd resolution
+- MCP `search_files` tool now exposes `invert_match` and `assert_count` parameters, matching CLI and tx feature parity
+- MCP `search_files`, `replace_text`, and `fix_whitespace` tool descriptions now document text-file semantics (binary and invalid UTF-8 files are skipped)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1137 tests (555 unit + 582 integration)
+- 1141 tests (555 unit + 586 integration)
 
 ## [0.1.0] - 2025-05-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -655,15 +655,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mio"
@@ -1382,9 +1382,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -1516,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1529,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1539,9 +1539,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1552,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -1836,18 +1836,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1137%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1141%20passing-brightgreen)](#)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -375,7 +375,7 @@ flowchart LR
 
 ## Status
 
-1137 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1141 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -103,7 +103,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `doc_select` | Filter array items by selector (read-only) |
 | `doc_flatten` | List all leaf selector paths and values (read-only) |
 | `doc_diff` | Compare two structured files (read-only) |
-| `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, and multiline modes. Binary and invalid UTF-8 files are skipped (read-only) |
+| `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes. Binary and invalid UTF-8 files are skipped (read-only) |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
 | `read_file` | Read file contents with optional line range |
 | `replace_text` | Replace text in a text file (literal or regex). Binary and invalid UTF-8 files are skipped |

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -297,6 +297,11 @@ pub struct SearchParams {
     /// Enable multiline matching (dot matches newlines in regex mode).
     #[serde(default)]
     pub multiline: bool,
+    /// Show lines that do NOT match the pattern.
+    #[serde(default)]
+    pub invert_match: bool,
+    /// Assert that the total match count equals N. Returns exit code 0 if exact, 2 otherwise.
+    pub assert_count: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -868,7 +873,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Search text files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts, case_insensitive=true to ignore case, or multiline=true to let '.' span newlines. Binary and invalid UTF-8 files are skipped."
+        description = "Search text files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts, case_insensitive=true to ignore case, multiline=true to let '.' span newlines, invert_match=true to show non-matching lines, or assert_count=N to verify exact match count. Binary and invalid UTF-8 files are skipped."
     )]
     async fn search_files(
         &self,
@@ -877,6 +882,12 @@ impl PatchloomService {
         if p.files_with_matches && p.count {
             return Err(McpError::invalid_params(
                 "files_with_matches and count cannot be combined",
+                None,
+            ));
+        }
+        if p.invert_match && p.multiline {
+            return Err(McpError::invalid_params(
+                "invert_match and multiline cannot be combined",
                 None,
             ));
         }
@@ -897,10 +908,10 @@ impl PatchloomService {
             after_context: p.after_context,
             files_with_matches: p.files_with_matches,
             count: p.count,
-            invert_match: false,
+            invert_match: p.invert_match,
             multiline: p.multiline,
             case_insensitive: p.case_insensitive,
-            assert_count: None,
+            assert_count: p.assert_count,
         };
         let global = GlobalFlags {
             json: true,
@@ -909,6 +920,32 @@ impl PatchloomService {
         };
         let results = crate::cmd::search::collect_matches(&search_args, &global)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        // --assert-count mode: return count comparison instead of matches.
+        if let Some(expected) = p.assert_count {
+            let actual: usize = results.file_match_counts.values().sum();
+            let matched = actual == expected;
+            let status = if matched {
+                "success"
+            } else {
+                "changes_detected"
+            };
+            let code = if matched {
+                exit::SUCCESS
+            } else {
+                exit::CHANGES_DETECTED
+            };
+            let output = serde_json::json!({
+                "ok": true,
+                "status": status,
+                "assert_count": {
+                    "expected": expected,
+                    "actual": actual,
+                    "matched": matched,
+                }
+            });
+            return exit_code_to_result(code, &output.to_string(), "");
+        }
 
         let has_matches = if search_args.count || search_args.files_with_matches {
             !results.file_match_counts.is_empty()
@@ -1405,7 +1442,7 @@ mod tests {
         assert_eq!(
             descriptions.get("search_files"),
             Some(
-                &"Search text files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts, case_insensitive=true to ignore case, or multiline=true to let '.' span newlines. Binary and invalid UTF-8 files are skipped."
+                &"Search text files for a pattern (regex by default, use literal=true for exact match). Returns matches with line numbers and context. Set files_with_matches=true for file paths only, count=true for counts, case_insensitive=true to ignore case, multiline=true to let '.' span newlines, invert_match=true to show non-matching lines, or assert_count=N to verify exact match count. Binary and invalid UTF-8 files are skipped."
             ),
             "search_files description drifted"
         );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7272,6 +7272,43 @@ fn test_tx_glob_replace_matches_nested_relative_pattern() {
     );
 }
 
+#[test]
+fn test_tx_glob_replace_no_matching_files_exits_3() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("only.rs"), "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [
+            {"op": "replace", "glob": "*.nonexistent", "from": "hello", "to": "bye"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "glob matching zero files should exit 3 (NO_MATCHES)"
+    );
+
+    // Source file should be untouched.
+    assert_eq!(
+        fs::read_to_string(dir.path().join("only.rs")).unwrap(),
+        "hello\n"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // tx: md operations in plan
 // ---------------------------------------------------------------------------
@@ -13547,7 +13584,7 @@ fn test_mcp_setup_documents_allow_shell_flag() {
 #[test]
 fn test_mcp_setup_documents_search_files_modes() {
     let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
-    assert!(doc.contains("literal, case-insensitive, count, file-only, and multiline modes"));
+    assert!(doc.contains("literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes"));
 }
 
 #[test]
@@ -14894,6 +14931,94 @@ async fn test_mcp_search_multiline_returns_json_matches() {
     assert_eq!(json["matches"][0]["line"], 1);
     assert_eq!(json["matches"][0]["column"], 1);
     assert_eq!(json["matches"][0]["text"], "hello\nworld");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_search_invert_match_returns_non_matching_lines() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lines.txt"), "alpha\nbeta\ngamma\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "search_files",
+        serde_json::json!({
+            "pattern": "beta",
+            "paths": ["lines.txt"],
+            "invert_match": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "invert_match search should succeed: {text}");
+
+    let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(json["match_count"], 2);
+    assert_eq!(json["matches"][0]["text"], "alpha");
+    assert_eq!(json["matches"][1]["text"], "gamma");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_search_assert_count_match() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("rep.txt"), "foo\nfoo\nbar\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "search_files",
+        serde_json::json!({
+            "pattern": "foo",
+            "paths": ["rep.txt"],
+            "assert_count": 2
+        }),
+    )
+    .await;
+    assert!(!is_error, "assert_count=2 should succeed: {text}");
+
+    let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(json["assert_count"]["expected"], 2);
+    assert_eq!(json["assert_count"]["actual"], 2);
+    assert_eq!(json["assert_count"]["matched"], true);
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_search_assert_count_mismatch() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("rep.txt"), "foo\nfoo\nbar\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "search_files",
+        serde_json::json!({
+            "pattern": "foo",
+            "paths": ["rep.txt"],
+            "assert_count": 5
+        }),
+    )
+    .await;
+    // assert_count mismatch is a "changes_detected" result, reported as is_error=true
+    assert!(
+        is_error,
+        "assert_count mismatch should signal error: {text}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+    assert_eq!(json["assert_count"]["expected"], 5);
+    assert_eq!(json["assert_count"]["actual"], 2);
+    assert_eq!(json["assert_count"]["matched"], false);
     client.cancel().await.unwrap();
 }
 


### PR DESCRIPTION
## Changes

- **MCP feature parity**: Add `invert_match` and `assert_count` parameters to the `search_files` MCP tool, matching the CLI `search` command flags (`--invert-match`, `--assert-count`)
- **Tests**: 4 new integration tests (MCP invert_match, assert_count match, assert_count mismatch, tx glob zero-match exit code)
- **Dependencies**: Update memchr 2.8.1, log 0.4.30, toml_edit 0.25.12, zerocopy 0.8.49
- **Docs**: CHANGELOG updated with MCP feature parity notes

Test count: 555 unit + 586 integration = 1141 total

`make check` passes locally. CI green on branch.