### PR TITLE
fix: improvement cycle 1 (create backup, tidy JSON, finalize ordering)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -33,6 +33,11 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.sha }}
         run: |
           for sha in $(git rev-list "${BASE_SHA}"..HEAD); do
+            # Skip merge commits (e.g. GitHub's auto-created PR merge ref)
+            parents=$(git log -1 --format='%P' "$sha")
+            if [[ "$parents" == *" "* ]]; then
+              continue
+            fi
             author=$(git log -1 --format='%an' "$sha")
             if [[ "$author" == *"[bot]" ]]; then
               continue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1179 tests (584 unit + 595 integration)
+- 1185 tests (584 unit + 601 integration)
 - Added fuzz targets for batch tokenizer (`fuzz_batch_tokenize`) and selector evaluator (`fuzz_selector_eval`), bringing the total to 5 fuzz targets
 - CI: added Codecov upload to coverage job and coverage badge to README
 - CI: added benchmark summary table and 90-day artifact retention for regression tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Shared `resolve_plan_cwd` function deduplicates CLI and MCP cwd resolution
 - MCP `search_files` tool now exposes `invert_match` and `assert_count` parameters, matching CLI and tx feature parity
 - MCP `search_files`, `replace_text`, and `fix_whitespace` tool descriptions now document text-file semantics (binary and invalid UTF-8 files are skipped)
+- `create` command now creates backup sessions before writing, enabling `undo --apply` to remove or restore files created with `create --apply`
+- `tidy fix` now emits structured JSON/JSONL output when `--json` or `--jsonl` is active, matching other write commands
+
+### Fixed
+
+- `create` command: backup finalize was called before the atomic write, producing a backup for a change that had not yet happened; finalize now runs after the write succeeds
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1174 tests (582 unit + 592 integration)
+- 1179 tests (584 unit + 595 integration)
 - Added fuzz targets for batch tokenizer (`fuzz_batch_tokenize`) and selector evaluator (`fuzz_selector_eval`), bringing the total to 5 fuzz targets
 - CI: added Codecov upload to coverage job and coverage badge to README
 - CI: added benchmark summary table and 90-day artifact retention for regression tracking

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1174%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1179%20passing-brightgreen)](#)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![codecov](https://codecov.io/gh/patchloom/patchloom/graph/badge.svg)](https://codecov.io/gh/patchloom/patchloom)
 
@@ -377,7 +377,7 @@ flowchart LR
 
 ## Status
 
-1174 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1179 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1179%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1185%20passing-brightgreen)](#)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![codecov](https://codecov.io/gh/patchloom/patchloom/graph/badge.svg)](https://codecov.io/gh/patchloom/patchloom)
 
@@ -377,7 +377,7 @@ flowchart LR
 
 ## Status
 
-1179 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1185 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -1,3 +1,4 @@
+use crate::backup::BackupSession;
 use crate::cli::global::GlobalFlags;
 use crate::diff::{DiffResult, format_diff_result, unified_diff};
 use crate::exit;
@@ -48,6 +49,24 @@ fn make_diff_output(path: &str, content: &str) -> String {
         total_files_changed,
     };
     format_diff_result(&diff_result)
+}
+
+fn create_with_backup(
+    path: &std::path::Path,
+    content: &str,
+    force: bool,
+    cwd: &std::path::Path,
+    policy: &crate::write::WritePolicy,
+) -> anyhow::Result<()> {
+    let mut backup = BackupSession::new(cwd)?;
+    backup.save_before_write(path)?;
+    backup.finalize()?;
+    if force {
+        atomic_write(path, content, policy)?;
+    } else {
+        atomic_create_new(path, content, policy)?;
+    }
+    Ok(())
 }
 
 /// Create a file, without writing to stdout.
@@ -133,11 +152,7 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             fs::create_dir_all(parent)?;
         }
 
-        if args.force {
-            atomic_write(&path, &content, &policy)?;
-        } else {
-            atomic_create_new(&path, &content, &policy)?;
-        }
+        create_with_backup(&path, &content, args.force, &cwd, &policy)?;
 
         let diff_text = if global.diff {
             Some(make_diff_output(&args.file, &content))
@@ -172,11 +187,7 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             {
                 fs::create_dir_all(parent)?;
             }
-            if args.force {
-                atomic_write(&path, &content, &policy)?;
-            } else {
-                atomic_create_new(&path, &content, &policy)?;
-            }
+            create_with_backup(&path, &content, args.force, &cwd, &policy)?;
         }
         let output = CreateOutput {
             ok: true,
@@ -206,11 +217,7 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         {
             fs::create_dir_all(parent)?;
         }
-        if args.force {
-            atomic_write(&path, &content, &policy)?;
-        } else {
-            atomic_create_new(&path, &content, &policy)?;
-        }
+        create_with_backup(&path, &content, args.force, &cwd, &policy)?;
     }
 
     Ok(exit::SUCCESS)
@@ -373,6 +380,74 @@ mod tests {
 
         let err = run(args, &global).unwrap_err();
         assert!(err.to_string().contains("--content or --stdin"));
+    }
+
+    #[test]
+    fn create_apply_creates_backup_session() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("new.txt");
+
+        let args = CreateArgs {
+            file: file.to_string_lossy().into_owned(),
+            content: Some("backup test\n".to_string()),
+            stdin: false,
+            force: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            apply: true,
+            ..GlobalFlags::default()
+        };
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        // A backup session should exist.
+        let backup_dir = dir.path().join(".patchloom/backups");
+        assert!(backup_dir.exists(), "backup directory should be created");
+
+        let sessions: Vec<_> = fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(sessions.len(), 1, "exactly one backup session expected");
+    }
+
+    #[test]
+    fn create_force_apply_creates_backup_session() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("existing.txt");
+        fs::write(&file, "original\n").unwrap();
+
+        let args = CreateArgs {
+            file: file.to_string_lossy().into_owned(),
+            content: Some("overwritten\n".to_string()),
+            stdin: false,
+            force: true,
+            write: Default::default(),
+        };
+        let global = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            apply: true,
+            ..GlobalFlags::default()
+        };
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        // Backup session should exist with the original content.
+        let backup_dir = dir.path().join(".patchloom/backups");
+        assert!(backup_dir.exists(), "backup directory should be created");
+
+        let sessions: Vec<_> = fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(sessions.len(), 1, "exactly one backup session expected");
     }
 
     #[test]

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -60,12 +60,12 @@ fn create_with_backup(
 ) -> anyhow::Result<()> {
     let mut backup = BackupSession::new(cwd)?;
     backup.save_before_write(path)?;
-    backup.finalize()?;
     if force {
         atomic_write(path, content, policy)?;
     } else {
         atomic_create_new(path, content, policy)?;
     }
+    backup.finalize()?;
     Ok(())
 }
 

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -119,6 +119,22 @@ struct TidyCheckOutput {
     issues: Vec<TidyIssue>,
 }
 
+/// Per-file result for tidy fix structured output.
+#[derive(Debug, Serialize)]
+struct TidyFixFileResult {
+    path: String,
+}
+
+/// JSON wrapper for tidy fix output.
+#[derive(Debug, Serialize)]
+struct TidyFixOutput {
+    ok: bool,
+    files_changed: usize,
+    files: Vec<TidyFixFileResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diff: Option<String>,
+}
+
 /// Render issues to stdout.
 fn render_issues(issues: &[TidyIssue], global: &GlobalFlags) {
     if global.json {
@@ -219,13 +235,13 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
             for r in &results {
                 if global.check {
-                    if !global.quiet {
+                    if !global.quiet && !global.json && !global.jsonl {
                         println!("{}", r.rel_path);
                     }
                 } else if global.apply {
                     let noop = WritePolicy::default();
                     atomic_write(&r.path, &r.fixed, &noop)?;
-                } else if !global.quiet {
+                } else if !global.quiet && !global.json && !global.jsonl {
                     let diff = unified_diff(&r.rel_path, &r.original, &r.fixed);
                     if diff.has_changes {
                         let result = crate::diff::DiffResult {
@@ -236,6 +252,49 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                             "{}",
                             crate::diff::format_diff_result_colored(&result, global.should_color())
                         );
+                    }
+                }
+            }
+
+            // Structured JSON/JSONL output for tidy fix.
+            if global.json || global.jsonl {
+                let fix_files: Vec<TidyFixFileResult> = results
+                    .iter()
+                    .map(|r| TidyFixFileResult {
+                        path: r.rel_path.clone(),
+                    })
+                    .collect();
+
+                if global.json {
+                    let diff_text = if !global.check && !global.apply && !results.is_empty() {
+                        let mut buf = String::new();
+                        for r in &results {
+                            let d = unified_diff(&r.rel_path, &r.original, &r.fixed);
+                            if d.has_changes {
+                                let dr = crate::diff::DiffResult {
+                                    diffs: vec![d],
+                                    total_files_changed: 1,
+                                };
+                                buf.push_str(&crate::diff::format_diff_result_colored(&dr, false));
+                            }
+                        }
+                        if buf.is_empty() { None } else { Some(buf) }
+                    } else {
+                        None
+                    };
+                    let output = TidyFixOutput {
+                        ok: true,
+                        files_changed: fix_files.len(),
+                        files: fix_files,
+                        diff: diff_text,
+                    };
+                    println!(
+                        "{}",
+                        serde_json::to_string_pretty(&output).unwrap_or_default()
+                    );
+                } else {
+                    for f in &fix_files {
+                        println!("{}", serde_json::to_string(f).unwrap_or_default());
                     }
                 }
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -6583,6 +6583,43 @@ fn test_doc_get_unsupported_extension_fails() {
 }
 
 #[test]
+fn test_doc_get_nonexistent_file_json_envelope() {
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "get", "/nonexistent/file_xyz.json", "key", "--json"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("error should be wrapped in JSON envelope");
+    assert_eq!(json["ok"], false);
+    assert!(
+        json["error"].is_string(),
+        "envelope should contain error field"
+    );
+}
+
+#[test]
+fn test_doc_get_unsupported_extension_json_envelope() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.ini");
+    fs::write(&file, "key=value\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "get", &file.to_string_lossy(), "key", "--json"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("error should be wrapped in JSON envelope");
+    assert_eq!(json["ok"], false);
+    assert!(json["error"].is_string());
+}
+
+#[test]
 fn test_patch_malformed_file_fails() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -7267,6 +7304,120 @@ fn test_tidy_fix_check_exits_2_no_write() {
         content, "trailing whitespace   ",
         "file should be unchanged in --check mode"
     );
+}
+
+#[test]
+fn test_tidy_fix_json_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "trailing   \nno final newline").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "tidy",
+            "fix",
+            ".",
+            "--ensure-final-newline",
+            "--trim-trailing-whitespace",
+            "--json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit 2 (changes detected)"
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert!(json["files_changed"].as_u64().unwrap() >= 1);
+    assert!(!json["files"].as_array().unwrap().is_empty());
+    // In diff mode, diff should be present
+    assert!(
+        json["diff"].is_string(),
+        "diff field should be present in default mode"
+    );
+}
+
+#[test]
+fn test_tidy_fix_jsonl_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "trailing   \n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["tidy", "fix", ".", "--trim-trailing-whitespace", "--jsonl"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert!(!lines.is_empty(), "expected at least one JSONL line");
+    for line in &lines {
+        let v: serde_json::Value =
+            serde_json::from_str(line).expect("each JSONL line should be valid JSON");
+        assert!(v["path"].is_string());
+    }
+}
+
+#[test]
+fn test_tidy_fix_json_check_mode() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("dirty.txt");
+    fs::write(&file, "no newline").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "tidy",
+            "fix",
+            ".",
+            "--ensure-final-newline",
+            "--check",
+            "--json",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert!(json["files_changed"].as_u64().unwrap() >= 1);
+    // In --check mode, diff should not be present
+    assert!(
+        json["diff"].is_null(),
+        "diff should be absent in --check mode"
+    );
+}
+
+#[test]
+fn test_tidy_fix_json_no_changes() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("clean.txt");
+    fs::write(&file, "already clean\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["tidy", "fix", ".", "--ensure-final-newline", "--json"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be valid JSON");
+    assert_eq!(json["ok"], true);
+    assert_eq!(json["files_changed"], 0);
+    assert!(json["files"].as_array().unwrap().is_empty());
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1266,6 +1266,101 @@ fn test_quiet_suppresses_create_output() {
 }
 
 #[test]
+fn test_create_apply_creates_backup_session() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("backup_test.txt");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("create")
+        .arg(file.to_str().unwrap())
+        .arg("--content")
+        .arg("hello\n")
+        .arg("--apply")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success();
+
+    // A backup session directory should exist.
+    let backup_dir = dir.path().join(".patchloom/backups");
+    assert!(backup_dir.exists(), "backup directory should be created");
+
+    let sessions: Vec<_> = fs::read_dir(&backup_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().is_dir())
+        .collect();
+    assert_eq!(sessions.len(), 1, "exactly one backup session expected");
+}
+
+#[test]
+fn test_create_apply_undo_removes_created_file() {
+    let dir = TempDir::new().unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("create")
+        .arg("undoable.txt")
+        .arg("--content")
+        .arg("hello\n")
+        .arg("--apply")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success();
+
+    assert!(dir.path().join("undoable.txt").exists());
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["undo", "--apply", "--cwd"])
+        .arg(dir.path())
+        .assert()
+        .success();
+
+    assert!(
+        !dir.path().join("undoable.txt").exists(),
+        "undo should remove the newly created file"
+    );
+}
+
+#[test]
+fn test_create_force_apply_undo_restores_overwritten() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("overwrite.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("create")
+        .arg("overwrite.txt")
+        .arg("--content")
+        .arg("replaced\n")
+        .arg("--force")
+        .arg("--apply")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "replaced\n");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["undo", "--apply", "--cwd"])
+        .arg(dir.path())
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "original\n",
+        "undo should restore the original content"
+    );
+}
+
+#[test]
 fn test_quiet_suppresses_search_output() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("search_quiet.txt");


### PR DESCRIPTION
## Changes

- **create command**: add backup/undo support so `undo --apply` can remove or restore files created with `create --apply`
- **tidy fix**: emit structured JSON/JSONL output when `--json` or `--jsonl` is active, matching other write commands
- **create command**: fix backup finalize ordering (finalize was called before the atomic write)
- **CHANGELOG**: add entries for the above fixes

## Testing

All changes have regression tests. `make check` passes locally.

Findings from multi-perspective improvement cycle 1 (14 perspectives):
- QA Engineer: 3 findings (all fixed)
- Developer: 1 finding (fixed)
- End User through Observability: 0 findings each