### PR TITLE
fix: improvement cycle 2 (delete backup, tidy exit code tests)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1185 tests (584 unit + 601 integration)
+- 1187 tests (586 unit + 601 integration)
 - Added fuzz targets for batch tokenizer (`fuzz_batch_tokenize`) and selector evaluator (`fuzz_selector_eval`), bringing the total to 5 fuzz targets
 - CI: added Codecov upload to coverage job and coverage badge to README
 - CI: added benchmark summary table and 90-day artifact retention for regression tracking

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1185%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1187%20passing-brightgreen)](#)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![codecov](https://codecov.io/gh/patchloom/patchloom/graph/badge.svg)](https://codecov.io/gh/patchloom/patchloom)
 
@@ -377,7 +377,7 @@ flowchart LR
 
 ## Status
 
-1185 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1187 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -192,6 +192,33 @@ mod tests {
     }
 
     #[test]
+    fn apply_creates_backup_session() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("target.txt");
+        std::fs::write(&file, "content").unwrap();
+
+        let global = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            apply: true,
+            ..GlobalFlags::default()
+        };
+        let code = run(make_args(&file.to_string_lossy()), &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(!file.exists());
+
+        // A backup session should exist.
+        let backup_dir = dir.path().join(".patchloom/backups");
+        assert!(backup_dir.exists(), "backup directory should be created");
+
+        let sessions: Vec<_> = std::fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(sessions.len(), 1, "exactly one backup session expected");
+    }
+
+    #[test]
     fn nonexistent_file_returns_error() {
         let result = run(
             make_args("/tmp/nonexistent_patchloom_test_file_xyz.txt"),

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -487,6 +487,23 @@ mod tests {
     }
 
     #[test]
+    fn check_returns_changes_detected_for_dirty_file() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("no_newline.txt");
+        std::fs::write(&file, b"hello").unwrap();
+
+        let global = flags_for(tmp.path());
+        let args = TidyArgs {
+            action: TidyAction::Check {
+                paths: vec![".".to_string()],
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    #[test]
     fn fix_adds_missing_newline() {
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("no_nl.txt");


### PR DESCRIPTION
## Changes

- Add unit test verifying `delete --apply` creates a backup session (mirrors existing coverage for `create --apply`)
- Add unit test verifying `tidy --check` returns `CHANGES_DETECTED` exit code for dirty files
- Refresh test counts in README.md and CHANGELOG.md (1185 -> 1187)

## Testing

All 1187 tests pass (`make check` green locally).