### PR TITLE
fix: improvement cycle 3 (backup consistency, test coverage)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,7 @@ src/
   cmd/tx.rs            Transaction engine: execute a multi-operation plan atomically
   cmd/explain.rs       Parse a tx plan and print a human-readable summary
   cmd/undo.rs          Restore files from backup sessions created by --apply
+  cmd/init.rs          Project setup: shell completion install, AGENTS.md generation
   config.rs            Project config file (.patchloom.toml) loading and merging
   backup.rs            Backup session management for undo safety net
   selector/mod.rs      Re-exports selector parser and evaluator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1189 tests (588 unit + 601 integration)
+- 1191 tests (590 unit + 601 integration)
 - Added fuzz targets for batch tokenizer (`fuzz_batch_tokenize`) and selector evaluator (`fuzz_selector_eval`), bringing the total to 5 fuzz targets
 - CI: added Codecov upload to coverage job and coverage badge to README
 - CI: added benchmark summary table and 90-day artifact retention for regression tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing
 
-- 1187 tests (586 unit + 601 integration)
+- 1189 tests (588 unit + 601 integration)
 - Added fuzz targets for batch tokenizer (`fuzz_batch_tokenize`) and selector evaluator (`fuzz_selector_eval`), bringing the total to 5 fuzz targets
 - CI: added Codecov upload to coverage job and coverage badge to README
 - CI: added benchmark summary table and 90-day artifact retention for regression tracking

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1189%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1191%20passing-brightgreen)](#)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![codecov](https://codecov.io/gh/patchloom/patchloom/graph/badge.svg)](https://codecov.io/gh/patchloom/patchloom)
 
@@ -377,7 +377,7 @@ flowchart LR
 
 ## Status
 
-1189 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1191 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
-[![Tests](https://img.shields.io/badge/tests-1187%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1189%20passing-brightgreen)](#)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![codecov](https://codecov.io/gh/patchloom/patchloom/graph/badge.svg)](https://codecov.io/gh/patchloom/patchloom)
 
@@ -377,7 +377,7 @@ flowchart LR
 
 ## Status
 
-1187 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1189 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -1584,6 +1584,38 @@ mod tests {
     // -- flatten ------------------------------------------------------------
 
     #[test]
+    fn set_apply_creates_backup_session() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"version": "1.0"}"#);
+        let action = DocAction::Set {
+            file: path.clone(),
+            selector: "version".into(),
+            value: "\"2.0\"".into(),
+        };
+        let ctx = WriteContext {
+            apply: true,
+            ..WriteContext::default()
+        };
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let backup_dir = dir.path().join(".patchloom/backups");
+        assert!(
+            backup_dir.exists(),
+            "backup directory should exist after doc set --apply"
+        );
+        let sessions: Vec<_> = fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert!(
+            !sessions.is_empty(),
+            "at least one backup session should be created"
+        );
+    }
+
+    #[test]
     fn flatten_enumerates_leaf_paths() {
         let dir = TempDir::new().unwrap();
         let path = write_file(

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -464,12 +464,14 @@ struct WriteContext {
 ///
 /// `path` is the absolute (IO) path used for writing.
 /// `display_path` is the relative path shown in diff headers.
+/// `cwd` is the project root for backup session creation.
 fn write_result(
     path: &str,
     display_path: &str,
     original: &str,
     new_content: &str,
     ctx: &WriteContext,
+    cwd: &Path,
 ) -> anyhow::Result<(String, u8)> {
     if ctx.check {
         if original != new_content {
@@ -478,7 +480,9 @@ fn write_result(
         return Ok((String::new(), exit::SUCCESS));
     }
     if ctx.apply {
-        write::atomic_write(Path::new(path), new_content, &ctx.write_policy)?;
+        let p = Path::new(path);
+        let writes = [(p, new_content, &ctx.write_policy)];
+        crate::backup::backup_write_files(cwd, &writes)?;
         return Ok((String::new(), exit::SUCCESS));
     }
     // Default or explicit --diff: show unified diff.
@@ -491,7 +495,9 @@ fn write_result(
         let output = diff::format_diff_result_colored(&diff_result, ctx.color);
         // --confirm: show diff, prompt, then apply if confirmed.
         if ctx.confirm && crate::cli::global::confirm_prompt("Apply?") {
-            write::atomic_write(Path::new(path), new_content, &ctx.write_policy)?;
+            let p = Path::new(path);
+            let writes = [(p, new_content, &ctx.write_policy)];
+            crate::backup::backup_write_files(cwd, &writes)?;
         }
         Ok((output, exit::SUCCESS))
     } else {
@@ -527,7 +533,7 @@ where
     let display_path = crate::files::relative_display(std::path::Path::new(file), cwd)
         .to_string_lossy()
         .into_owned();
-    write_result(file, &display_path, &original, &new_content, ctx)
+    write_result(file, &display_path, &original, &new_content, ctx, cwd)
 }
 
 fn execute_write(
@@ -1134,7 +1140,7 @@ mod tests {
             value: "42".into(),
         };
         let ctx = WriteContext::default();
-        let (output, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (output, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         // Default: shows diff containing the new key.
         assert!(output.contains("+"));
@@ -1151,7 +1157,7 @@ mod tests {
             value: "world".into(),
         };
         let ctx = WriteContext::default();
-        let (output, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (output, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert!(output.contains("world"));
     }
@@ -1167,7 +1173,7 @@ mod tests {
             selector: "age".into(),
         };
         let ctx = WriteContext::default();
-        let (output, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (output, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert!(output.contains("-"));
         assert!(output.contains("age"));
@@ -1192,7 +1198,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let content = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1216,7 +1222,7 @@ mod tests {
             predicate: "name=nobody".into(),
         };
         let ctx = WriteContext::default();
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::NO_MATCHES);
     }
 
@@ -1237,7 +1243,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let content = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1255,7 +1261,7 @@ mod tests {
             selector: "nonexistent".into(),
         };
         let ctx = WriteContext::default();
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::NO_MATCHES);
     }
 
@@ -1274,7 +1280,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let content = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1294,7 +1300,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let content = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1344,7 +1350,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let content = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1368,7 +1374,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (output, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (output, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert!(output.is_empty());
         // File should be unchanged.
@@ -1389,7 +1395,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let content = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1412,7 +1418,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let content = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1435,7 +1441,7 @@ mod tests {
             apply: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let content = fs::read_to_string(&path).unwrap();
         let val: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1457,7 +1463,7 @@ mod tests {
             check: true,
             ..WriteContext::default()
         };
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::CHANGES_DETECTED);
     }
 
@@ -1557,7 +1563,7 @@ mod tests {
             value: "42".into(),
         };
         let ctx = WriteContext::default();
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::FAILURE);
     }
 
@@ -1571,7 +1577,7 @@ mod tests {
             value: "42".into(),
         };
         let ctx = WriteContext::default();
-        let (_, code) = execute_write(&action, &ctx, std::path::Path::new("")).unwrap();
+        let (_, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::FAILURE);
     }
 

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -379,6 +379,47 @@ mod tests {
         }
     }
 
+    // -- backup ------------------------------------------------------------
+
+    #[test]
+    fn replace_section_apply_creates_backup_session() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\nold content\n# Other\nkept\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::ReplaceSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Title".into(),
+                stdin: false,
+                content: Some("new content".into()),
+            },
+            write: Default::default(),
+        };
+        let global = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            apply: true,
+            ..GlobalFlags::default()
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let backup_dir = dir.path().join(".patchloom/backups");
+        assert!(
+            backup_dir.exists(),
+            "backup directory should exist after md replace-section --apply"
+        );
+        let sessions: Vec<_> = fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert!(
+            !sessions.is_empty(),
+            "at least one backup session should be created"
+        );
+    }
+
     // -- replace-section ----------------------------------------------------
 
     #[test]

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -5,7 +5,7 @@ use crate::ops::md::{
     dedupe_headings_in, find_section, insert_after_heading_in, insert_before_heading_in,
     non_fenced_lines, parse_headings, replace_section_in, table_append_in, upsert_bullet_in,
 };
-use crate::write::{atomic_write, policy_from_flags};
+use crate::write::policy_from_flags;
 use anyhow::Context;
 use clap::Args;
 use serde::Serialize;
@@ -112,6 +112,7 @@ fn apply_mutation(
     original: &str,
     new_content: &str,
     global: &GlobalFlags,
+    cwd: &Path,
 ) -> anyhow::Result<u8> {
     let policy = policy_from_flags(global, Some(path));
     let final_content = crate::write::apply_policy(new_content, &policy);
@@ -136,7 +137,8 @@ fn apply_mutation(
     }
 
     if global.apply || (global.confirm && has_changes && global.should_apply()) {
-        atomic_write(path, new_content, &policy)?;
+        let writes = [(path, new_content, &policy)];
+        crate::backup::backup_write_files(cwd, &writes)?;
     }
 
     Ok(exit::SUCCESS)
@@ -232,7 +234,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let read = |file: &str| read_markdown_file(&cwd.join(file), file);
     let apply = |file: &str, original: &str, new_content: &str| {
         let path = cwd.join(file);
-        apply_mutation(&path, file, original, new_content, global)
+        apply_mutation(&path, file, original, new_content, global, &cwd)
     };
 
     match args.action {

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -762,4 +762,52 @@ index abc1234..def5678 100644
         assert_eq!(h.old_count, 1);
         assert_eq!(h.new_count, 1);
     }
+
+    #[test]
+    fn apply_creates_backup_session() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("hello.txt");
+        std::fs::write(&file, "line1\nold line\nline3\n").unwrap();
+
+        let diff_path = tmp.path().join("change.patch");
+        std::fs::write(
+            &diff_path,
+            "\
+--- a/hello.txt
++++ b/hello.txt
+@@ -1,3 +1,3 @@
+ line1
+-old line
++new line
+ line3
+",
+        )
+        .unwrap();
+
+        let mut global = flags_for(tmp.path());
+        global.apply = true;
+        let args = PatchArgs {
+            action: PatchAction::Apply {
+                file: Some(diff_path.to_string_lossy().into_owned()),
+                stdin: false,
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let backup_dir = tmp.path().join(".patchloom").join("backups");
+        assert!(
+            backup_dir.exists(),
+            "backup directory should exist after patch --apply"
+        );
+        let sessions: Vec<_> = std::fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            !sessions.is_empty(),
+            "at least one backup session should be created"
+        );
+    }
 }

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -646,4 +646,38 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);
     }
+
+    #[test]
+    fn fix_apply_creates_backup_session() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("no_nl.txt");
+        std::fs::write(&file, b"hello").unwrap();
+
+        let mut global = flags_for(tmp.path());
+        global.ensure_final_newline = true;
+        global.apply = true;
+
+        let args = TidyArgs {
+            action: TidyAction::Fix {
+                paths: vec![".".to_string()],
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let backup_dir = tmp.path().join(".patchloom").join("backups");
+        assert!(
+            backup_dir.exists(),
+            "backup directory should exist after tidy fix --apply"
+        );
+        let sessions: Vec<_> = std::fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            !sessions.is_empty(),
+            "at least one backup session should be created"
+        );
+    }
 }


### PR DESCRIPTION
## Changes

Improvement cycle 3 focused on backup consistency across all write commands.

### Backup consistency (functional fix)
- **doc.rs**: replaced direct `atomic_write` with `backup_write_files` so `doc set --apply` (and all other doc write subcommands) create backup sessions for `patchloom undo`
- **md.rs**: same fix for `md replace-section --apply` and all other md write subcommands

### Test coverage
- Added backup session tests for `patch --apply` and `tidy --apply` (implementation existed but lacked tests)
- Added backup session tests for `doc set --apply` and `md replace-section --apply` (guards the new backup integration)

### Documentation
- Added `cmd/init.rs` to AGENTS.md project structure (was missing)
- Updated test counts: 1191 tests (590 unit + 601 integration)

### Impact
All write commands now uniformly create backup sessions when `--apply` is used, enabling `patchloom undo` for every write operation. Previously, `doc` and `md` commands silently skipped backup creation.