### PR TITLE
refactor: extract rename_with_backup helper to remove 3x duplication

### DIFF
--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -106,11 +106,7 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // --apply mode: perform the rename.
     if global.apply {
-        let mut backup = crate::backup::BackupSession::new(&cwd)?;
-        backup.save_before_delete(&src)?;
-        backup.save_before_write(&dst)?;
-        do_rename(&src, &dst, &args, &policy)?;
-        backup.finalize()?;
+        rename_with_backup(&src, &dst, &args, &policy, &cwd)?;
 
         if global.json || global.jsonl || global.diff {
             // After --apply, source is gone; read from destination.
@@ -141,11 +137,7 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if global.confirm && (global.json || global.jsonl) {
         let applied = global.should_apply();
         if applied {
-            let mut backup = crate::backup::BackupSession::new(&cwd)?;
-            backup.save_before_delete(&src)?;
-            backup.save_before_write(&dst)?;
-            do_rename(&src, &dst, &args, &policy)?;
-            backup.finalize()?;
+            rename_with_backup(&src, &dst, &args, &policy, &cwd)?;
         }
         let output = RenameOutput {
             ok: true,
@@ -175,17 +167,28 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // --confirm: prompt after showing preview, then rename if confirmed.
     if global.should_apply() {
-        let mut backup = crate::backup::BackupSession::new(&cwd)?;
-        backup.save_before_delete(&src)?;
-        backup.save_before_write(&dst)?;
-        do_rename(&src, &dst, &args, &policy)?;
-        backup.finalize()?;
+        rename_with_backup(&src, &dst, &args, &policy, &cwd)?;
         if global.show_status() {
             eprintln!("renamed {} -> {}", args.from, args.to);
         }
     }
 
     Ok(exit::SUCCESS)
+}
+
+fn rename_with_backup(
+    src: &std::path::Path,
+    dst: &std::path::Path,
+    args: &RenameArgs,
+    policy: &crate::write::WritePolicy,
+    cwd: &std::path::Path,
+) -> anyhow::Result<()> {
+    let mut backup = crate::backup::BackupSession::new(cwd)?;
+    backup.save_before_delete(src)?;
+    backup.save_before_write(dst)?;
+    do_rename(src, dst, args, policy)?;
+    backup.finalize()?;
+    Ok(())
 }
 
 /// Perform a rename with backup, without writing to stdout.


### PR DESCRIPTION
Extract the repeated backup+rename+finalize pattern into a `rename_with_backup()` helper function. This mirrors the existing `delete_with_backup()` and `create_with_backup()` helpers in their respective modules.

Three call sites in `rename::run()` that each created a `BackupSession`, saved before-delete and before-write, called `do_rename`, and finalized are now single-line calls to the new helper.

**Verification:** `make check` passes (601 tests, 0 failures).