### PR TITLE
chore: add supply chain provenance, SBOM, and metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,45 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  provenance:
+    needs:
+      - plan
+      - host
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - name: Download release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: artifacts-*
+          path: artifacts
+          merge-multiple: true
+      - name: Clean non-distributable files
+        run: rm -f artifacts/*-dist-manifest.json artifacts/plan-dist-manifest.json
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: artifacts/*
+      - name: Install cargo-cyclonedx
+        run: cargo install cargo-cyclonedx --locked
+      - name: Generate SBOM
+        run: cargo cyclonedx --format json --all
+      - name: Upload SBOM to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ needs.plan.outputs.tag }}" \
+            patchloom/bom.json#patchloom-sbom.cdx.json \
+            --clobber
+
   publish-homebrew-formula:
     needs:
       - plan

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 keywords = ["cli", "agents", "patch", "markdown", "config"]
 categories = ["command-line-utilities", "development-tools", "config"]
 documentation = "https://docs.rs/patchloom"
+authors = ["Sebastien Tardif"]
 exclude = [
   "benches/",
   "tests/agent/",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"


### PR DESCRIPTION
## Summary

Add supply chain transparency and contributor convenience for public launch.

### Changes

**Supply chain (Scorecard compliance)**
- Add SLSA provenance attestation job to `release.yml` using `actions/attest-build-provenance@v2` (SHA-pinned). Attests all release artifacts after the GitHub Release is created.
- Add CycloneDX SBOM generation via `cargo-cyclonedx`. The SBOM is uploaded to each release as `patchloom-sbom.cdx.json`.

**Contributor convenience**
- Add `rust-toolchain.toml` (`channel = "stable"`) so `rustup` auto-installs the right toolchain on clone.
- Add `authors` field to `Cargo.toml` (shown on crates.io page).

### Verification

- `make check` passes (590 unit + 602 integration tests)
- `Cargo.lock` unchanged (no dependency changes)
- Provenance and SBOM jobs will only run on tag pushes (gated on `publishing == 'true'`)
- New job has proper `permissions` block (`id-token: write`, `attestations: write`, `contents: write`)