### PR TITLE
fix(ci): move FOSSA secret check from job-level to step-level

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -22,8 +22,7 @@ jobs:
     # Skips private repos (set up FOSSA after going public).
     if: >-
       github.event.pull_request.user.login != 'dependabot[bot]' &&
-      !github.event.repository.private &&
-      secrets.FOSSA_API_KEY != ''
+      !github.event.repository.private
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -34,16 +33,27 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+      - name: Check FOSSA API key
+        id: check-key
+        run: |
+          if [ -z "$FOSSA_API_KEY" ]; then
+            echo "FOSSA_API_KEY not configured, skipping"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       - name: Install FOSSA CLI
+        if: steps.check-key.outputs.skip != 'true'
         run: |
           curl -H 'Cache-Control: no-cache' \
             https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
       - name: Run FOSSA analysis
+        if: steps.check-key.outputs.skip != 'true'
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: fossa analyze
       - name: Check FOSSA status
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.check-key.outputs.skip != 'true'
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: fossa test


### PR DESCRIPTION
GitHub Actions does not allow the `secrets` context in job-level `if:` expressions. This was introduced in PR #435 and causes the FOSSA workflow to fail on every push to main with:

```
Unrecognized named-value: 'secrets'. Located at position 98 within expression
```

**Fix:** Move the API key check to a step-level guard. A "Check FOSSA API key" step sets `skip=true` via `GITHUB_OUTPUT` when `FOSSA_API_KEY` is empty, and all subsequent steps condition on that output. The job-level `if:` retains the Dependabot and private-repo guards (which use `github` context, not `secrets`).