### PR TITLE
fix(ci): disable fossa test until false positives are filtered

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -52,8 +52,7 @@ jobs:
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: fossa analyze
-      - name: Check FOSSA status
-        if: github.event_name == 'pull_request' && steps.check-key.outputs.skip != 'true'
-        env:
-          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
-        run: fossa test
+      # fossa test disabled: default policy flags apache-2.0 WITH
+      # llvm-exception (7 crates) and LGPL-2.1-or-later on r-efi.
+      # All are false positives. Re-enable with a filter script when
+      # the free tier supports persistent ignore rules or policy edits.


### PR DESCRIPTION
The default FOSSA policy flags 9 Rust dependencies as compliance issues, all false positives:

| License | Crates | Why false positive |
|---|---|---|
| `apache-2.0 WITH llvm-exception` | linux-raw-sys, rustix, wasip2, wit-bindgen (x4), wit-bindgen-core, wit-bindgen-rust, wit-bindgen-rust-macro | The LLVM exception makes Apache-2.0 *more* permissive, not less |
| `LGPL-2.1-or-later` | r-efi | UEFI interface crate, not linked into the patchloom binary |

Free-tier FOSSA does not support persistent ignore rules or policy editing (API returns 403; UI ignoring resets per commit). This PR disables `fossa test` until a filter script is in place.

`fossa analyze` (dependency graph upload) continues to run on every push to main, keeping the badge and project dashboard active.