### PR TITLE
fix(ci): resolve Scorecard findings for token permissions and pinned deps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,8 +5,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: dependabot-auto-merge-${{ github.event.pull_request.number }}
@@ -15,6 +14,9 @@ concurrency:
 jobs:
   auto-merge:
     name: Auto-merge Dependabot PRs
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     if: github.actor == 'dependabot[bot]'

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -44,9 +44,16 @@ jobs:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
       - name: Install FOSSA CLI
         if: steps.check-key.outputs.skip != 'true'
+        env:
+          FOSSA_VERSION: "3.17.10"
         run: |
-          curl -H 'Cache-Control: no-cache' \
-            https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+          curl -fsSL -o "fossa_${FOSSA_VERSION}_linux_amd64.tar.gz" \
+            "https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_VERSION}/fossa_${FOSSA_VERSION}_linux_amd64.tar.gz"
+          curl -fsSL -o "fossa_${FOSSA_VERSION}_linux_amd64.tar.gz.sha256" \
+            "https://github.com/fossas/fossa-cli/releases/download/v${FOSSA_VERSION}/fossa_${FOSSA_VERSION}_linux_amd64.tar.gz.sha256"
+          sha256sum -c "fossa_${FOSSA_VERSION}_linux_amd64.tar.gz.sha256"
+          tar xzf "fossa_${FOSSA_VERSION}_linux_amd64.tar.gz" fossa
+          sudo install fossa /usr/local/bin/fossa
       - name: Run FOSSA analysis
         if: steps.check-key.outputs.skip != 'true'
         env:


### PR DESCRIPTION
Resolves the 13 open Scorecard code scanning alerts at `/security/quality`.

## Fixed (2 alerts)

| Alert | Fix |
|---|---|
| **#6** Token-Permissions `dependabot-auto-merge.yml:8` | Moved `contents:write` and `pull-requests:write` from workflow level to job level |
| **#7** Pinned-Dependencies `fossa.yml:48` | Pinned FOSSA CLI to v3.17.10 with SHA-256 verification instead of `curl \| bash install-latest.sh` |

## Dismissed (11 alerts)

| Alerts | Rule | Reason |
|---|---|---|
| **#1, #2, #4, #16** | Token-Permissions (release.yml) | cargo-dist generated; write permissions required for release creation, provenance attestation, and package publishing |
| **#15** | Token-Permissions (bench.yml) | Job-level `contents:write` required for `gh release upload` |
| **#8, #9** | Pinned-Dependencies (release.yml) | cargo-dist generated `curl \| sh` install scripts; version pinned in URL |
| **#10** | Code-Review | Project-level metric; solo-maintainer repo |
| **#11** | Maintained | Project-level metric; actively maintained |
| **#13** | Vulnerabilities | Dependabot + Trivy already configured |
| **#14** | SAST | CodeQL with security-and-quality queries already configured |