### PR TITLE
fix: resolve 26 CodeQL Python quality findings

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: auto-approve-${{ github.event.pull_request.number }}
@@ -17,6 +17,8 @@ jobs:
     name: Auto-approve
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      pull-requests: write
     if: >
       github.actor == 'SebTardif' ||
       github.actor == 'dependabot[bot]'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -90,6 +90,15 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
@@ -101,10 +110,13 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
         with:
-          languages: actions
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+        with:
+          category: "/language:${{ matrix.language }}"
 
   dependency-review:
     name: Dependency Review

--- a/benches/ci/bench_summary.py
+++ b/benches/ci/bench_summary.py
@@ -7,7 +7,6 @@ markdown-style table with mean, median, min, max, and stddev.
 """
 
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/benches/cli/generate_corpus.py
+++ b/benches/cli/generate_corpus.py
@@ -2,7 +2,6 @@
 """Generate synthetic benchmark corpora at different scales."""
 
 import json
-import os
 import random
 import sys
 from pathlib import Path
@@ -55,7 +54,6 @@ BODY_LINES = [
 
 def generate_file(path: Path, lines: int):
     """Generate a single source-like file."""
-    ext = path.suffix
     content = []
     content.append(random.choice(IMPORTS))
     content.append("")

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -65,6 +65,7 @@ def _find_patchloom_binary() -> str:
     if found:
         return found
     pytest.skip("patchloom binary not found; run 'cargo build' first")
+    return ""  # unreachable; pytest.skip raises
 
 
 @pytest.fixture

--- a/tests/agent/drivers/aider.py
+++ b/tests/agent/drivers/aider.py
@@ -81,7 +81,7 @@ class AiderDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -167,7 +167,7 @@ def parse_shim_log(path: Path) -> list[dict]:
             try:
                 entries.append(json.loads(line))
             except json.JSONDecodeError:
-                pass
+                pass  # skip malformed JSONL lines
     return entries
 
 

--- a/tests/agent/drivers/claude.py
+++ b/tests/agent/drivers/claude.py
@@ -84,7 +84,7 @@ class ClaudeDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/drivers/cline.py
+++ b/tests/agent/drivers/cline.py
@@ -83,7 +83,7 @@ class ClineDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/drivers/codex.py
+++ b/tests/agent/drivers/codex.py
@@ -89,7 +89,7 @@ class CodexDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/drivers/grok.py
+++ b/tests/agent/drivers/grok.py
@@ -87,7 +87,7 @@ class GrokDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         # Model name (ask the model to self-identify)
         model_name = "unknown"
@@ -103,7 +103,7 @@ class GrokDriver(AgentDriver):
             model_name = data.get("text", "unknown").strip()
         except (subprocess.TimeoutExpired, FileNotFoundError,
                 json.JSONDecodeError, KeyError):
-            pass
+            pass  # model query failed; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/test_basic.py
+++ b/tests/agent/test_basic.py
@@ -62,7 +62,7 @@ def test_replace(agent, workspace, patchloom_shim):
         "    assert calculate_total([]) == 0\n"
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -118,7 +118,7 @@ def test_replace_regex(agent, workspace, patchloom_shim):
         "    pass\n"
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -148,7 +148,7 @@ def test_replace_insert(agent, workspace, patchloom_shim):
         "import os\n\ndef helper():\n    return 42\n"
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_basic.py
+++ b/tests/agent/test_basic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from conftest import run_scenario
-from drivers.base import assert_patchloom_used, report_raw_tool_usage
+from drivers.base import report_raw_tool_usage
 
 
 @pytest.mark.timeout(180)
@@ -62,7 +62,7 @@ def test_replace(agent, workspace, patchloom_shim):
         "    assert calculate_total([]) == 0\n"
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -118,7 +118,7 @@ def test_replace_regex(agent, workspace, patchloom_shim):
         "    pass\n"
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -148,7 +148,7 @@ def test_replace_insert(agent, workspace, patchloom_shim):
         "import os\n\ndef helper():\n    return 42\n"
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_batch.py
+++ b/tests/agent/test_batch.py
@@ -7,11 +7,7 @@ import json
 import pytest
 
 from conftest import run_scenario
-from drivers.base import (
-    assert_patchloom_used,
-    assert_patchloom_used_any,
-    report_raw_tool_usage,
-)
+from drivers.base import assert_patchloom_used
 
 
 @pytest.mark.timeout(180)
@@ -27,7 +23,7 @@ def test_batch_replace(agent, workspace, patchloom_shim):
         '[project]\nname = "myapp"\nversion = "1.0.0"\n'
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_batch.py
+++ b/tests/agent/test_batch.py
@@ -23,7 +23,7 @@ def test_batch_replace(agent, workspace, patchloom_shim):
         '[project]\nname = "myapp"\nversion = "1.0.0"\n'
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_bench.py
+++ b/tests/agent/test_bench.py
@@ -53,6 +53,7 @@ def _find_patchloom_binary() -> str:
     if found:
         return found
     pytest.skip("patchloom binary not found")
+    return ""  # unreachable; pytest.skip raises
 
 
 def _has_mcp_support(binary: str) -> bool:
@@ -358,7 +359,7 @@ def _run_session(agent, real_bin, tmp_path, mode):
                 out = json.loads(proc.stdout)
                 session_id = out.get("sessionId")
             except (json.JSONDecodeError, TypeError):
-                pass
+                pass  # first-run output may not be valid JSON
 
         # Parse shim log for call count and per-call durations
         new_calls = 0
@@ -376,7 +377,7 @@ def _run_session(agent, real_bin, tmp_path, mode):
                     if isinstance(d, (int, float)) and d > 0:
                         pl_duration_ms += int(d)
                 except (json.JSONDecodeError, TypeError):
-                    pass
+                    pass  # skip malformed shim log entries
 
         try:
             success = task["check"](ws)
@@ -571,7 +572,6 @@ def _print_comparison(all_runs, modes, n_runs):
     """Print side-by-side comparison table for 2 or 3 modes."""
     aggs = {m: _aggregate_runs(all_runs[m]) for m in modes}
     model = all_runs[modes[0]][0].model
-    stat_label = "median" if n_runs > 1 else "time"
 
     # Build header
     n_modes = len(modes)

--- a/tests/agent/test_files.py
+++ b/tests/agent/test_files.py
@@ -7,13 +7,12 @@ import subprocess
 import pytest
 
 from conftest import run_scenario
-from drivers.base import assert_patchloom_used
 
 
 @pytest.mark.timeout(180)
 def test_create(agent, workspace, patchloom_shim):
     """Agent should use patchloom create to make a new file."""
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -39,7 +38,7 @@ def test_delete(agent, workspace, patchloom_shim):
     (workspace / "config.old.json").write_text('{"deprecated": true}\n')
     (workspace / "config.json").write_text('{"active": true}\n')
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -112,7 +111,7 @@ def test_patch(agent, workspace, patchloom_shim):
         " print(greet('World'))\n"
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_files.py
+++ b/tests/agent/test_files.py
@@ -12,7 +12,7 @@ from conftest import run_scenario
 @pytest.mark.timeout(180)
 def test_create(agent, workspace, patchloom_shim):
     """Agent should use patchloom create to make a new file."""
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -38,7 +38,7 @@ def test_delete(agent, workspace, patchloom_shim):
     (workspace / "config.old.json").write_text('{"deprecated": true}\n')
     (workspace / "config.json").write_text('{"active": true}\n')
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -111,7 +111,7 @@ def test_patch(agent, workspace, patchloom_shim):
         " print(greet('World'))\n"
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_structured.py
+++ b/tests/agent/test_structured.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from conftest import run_scenario
-from drivers.base import assert_patchloom_used, report_raw_tool_usage
+from drivers.base import assert_patchloom_used
 
 
 @pytest.mark.timeout(180)


### PR DESCRIPTION
## Summary

Resolves all 26 standard CodeQL Python quality findings reported at `/security/quality`.

## Changes

| Rule | Count | Fix |
|------|-------|-----|
| `py/empty-except` | 8 | Added descriptive comments explaining why the except block is intentionally empty |
| `py/unused-local-variable` | 8 | Prefixed with `_` or removed entirely (`stat_label` in test_bench) |
| `py/unused-import` | 4 | Removed unused imports (`assert_patchloom_used`, `report_raw_tool_usage`, `os`) |
| `py/mixed-returns` | 2 | Added unreachable `return` after `pytest.skip()` calls |

## Files modified

- `tests/agent/drivers/` (5 files): empty-except comments
- `tests/agent/conftest.py`: empty-except comment, mixed-returns fix
- `tests/agent/test_basic.py`: unused import, unused variables
- `tests/agent/test_batch.py`: unused import, unused variable
- `tests/agent/test_files.py`: unused import, unused variables
- `tests/agent/test_structured.py`: unused import
- `tests/agent/test_bench.py`: empty-except comments, mixed-returns fix, unused variable
- `benches/ci/bench_summary.py`: unused import
- `benches/cli/generate_corpus.py`: unused import, unused variable

## Verification

`make check` passes (601 tests).