### PR TITLE
ci: CodeQL quality improvements and native coverage

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 permissions:
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: auto-approve-${{ github.event.pull_request.number }}
@@ -17,6 +17,8 @@ jobs:
     name: Auto-approve
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      pull-requests: write
     if: >
       github.actor == 'SebTardif' ||
       github.actor == 'dependabot[bot]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      code-quality: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
@@ -153,6 +156,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -165,22 +169,24 @@ jobs:
           tool: cargo-llvm-cov
 
       - name: Generate coverage
-        run: cargo llvm-cov --all-features --lib --test integration --lcov --output-path lcov.info
+        run: cargo llvm-cov --all-features --lib --test integration --cobertura --output-path coverage.xml
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: coverage-report
-          path: lcov.info
+          path: coverage.xml
 
-      - name: Upload to Codecov
-        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
+      - name: Upload coverage
+        if: >-
+          always() &&
+          (github.event_name != 'pull_request' ||
+           github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
         with:
-          files: lcov.info
-          fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          file: coverage.xml
+          language: Rust
+          label: code-coverage/rust
 
   bench:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -90,6 +90,15 @@ jobs:
       actions: read
       contents: read
       security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+        include:
+          - language: actions
+            build-mode: none
+          - language: python
+            build-mode: none
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
@@ -101,10 +110,13 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
         with:
-          languages: actions
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4
+        with:
+          category: "/language:${{ matrix.language }}"
 
   dependency-review:
     name: Dependency Review

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE-MIT)
 [![Tests](https://img.shields.io/badge/tests-1191%20passing-brightgreen)](#)
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
-[![codecov](https://codecov.io/gh/patchloom/patchloom/graph/badge.svg)](https://codecov.io/gh/patchloom/patchloom)
+[![Coverage](https://img.shields.io/badge/coverage-GitHub%20native-brightgreen)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 
 **One binary. Every platform. Structured file edits for AI agents.**

--- a/benches/ci/bench_summary.py
+++ b/benches/ci/bench_summary.py
@@ -7,7 +7,6 @@ markdown-style table with mean, median, min, max, and stddev.
 """
 
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/benches/cli/generate_corpus.py
+++ b/benches/cli/generate_corpus.py
@@ -2,7 +2,6 @@
 """Generate synthetic benchmark corpora at different scales."""
 
 import json
-import os
 import random
 import sys
 from pathlib import Path
@@ -55,7 +54,6 @@ BODY_LINES = [
 
 def generate_file(path: Path, lines: int):
     """Generate a single source-like file."""
-    ext = path.suffix
     content = []
     content.append(random.choice(IMPORTS))
     content.append("")

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -65,6 +65,7 @@ def _find_patchloom_binary() -> str:
     if found:
         return found
     pytest.skip("patchloom binary not found; run 'cargo build' first")
+    return ""  # unreachable; pytest.skip raises
 
 
 @pytest.fixture

--- a/tests/agent/drivers/aider.py
+++ b/tests/agent/drivers/aider.py
@@ -81,7 +81,7 @@ class AiderDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -167,7 +167,7 @@ def parse_shim_log(path: Path) -> list[dict]:
             try:
                 entries.append(json.loads(line))
             except json.JSONDecodeError:
-                pass
+                pass  # skip malformed JSONL lines
     return entries
 
 

--- a/tests/agent/drivers/claude.py
+++ b/tests/agent/drivers/claude.py
@@ -84,7 +84,7 @@ class ClaudeDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/drivers/cline.py
+++ b/tests/agent/drivers/cline.py
@@ -83,7 +83,7 @@ class ClineDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/drivers/codex.py
+++ b/tests/agent/drivers/codex.py
@@ -89,7 +89,7 @@ class CodexDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/drivers/grok.py
+++ b/tests/agent/drivers/grok.py
@@ -87,7 +87,7 @@ class GrokDriver(AgentDriver):
             )
             cli_version = proc.stdout.strip()
         except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+            pass  # CLI not installed or too slow; use default
 
         # Model name (ask the model to self-identify)
         model_name = "unknown"
@@ -103,7 +103,7 @@ class GrokDriver(AgentDriver):
             model_name = data.get("text", "unknown").strip()
         except (subprocess.TimeoutExpired, FileNotFoundError,
                 json.JSONDecodeError, KeyError):
-            pass
+            pass  # model query failed; use default
 
         return AgentMetadata(
             agent_name=self.name,

--- a/tests/agent/test_basic.py
+++ b/tests/agent/test_basic.py
@@ -62,7 +62,7 @@ def test_replace(agent, workspace, patchloom_shim):
         "    assert calculate_total([]) == 0\n"
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -118,7 +118,7 @@ def test_replace_regex(agent, workspace, patchloom_shim):
         "    pass\n"
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -148,7 +148,7 @@ def test_replace_insert(agent, workspace, patchloom_shim):
         "import os\n\ndef helper():\n    return 42\n"
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_basic.py
+++ b/tests/agent/test_basic.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from conftest import run_scenario
-from drivers.base import assert_patchloom_used, report_raw_tool_usage
+from drivers.base import report_raw_tool_usage
 
 
 @pytest.mark.timeout(180)
@@ -62,7 +62,7 @@ def test_replace(agent, workspace, patchloom_shim):
         "    assert calculate_total([]) == 0\n"
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -118,7 +118,7 @@ def test_replace_regex(agent, workspace, patchloom_shim):
         "    pass\n"
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -148,7 +148,7 @@ def test_replace_insert(agent, workspace, patchloom_shim):
         "import os\n\ndef helper():\n    return 42\n"
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_batch.py
+++ b/tests/agent/test_batch.py
@@ -7,11 +7,7 @@ import json
 import pytest
 
 from conftest import run_scenario
-from drivers.base import (
-    assert_patchloom_used,
-    assert_patchloom_used_any,
-    report_raw_tool_usage,
-)
+from drivers.base import assert_patchloom_used
 
 
 @pytest.mark.timeout(180)
@@ -27,7 +23,7 @@ def test_batch_replace(agent, workspace, patchloom_shim):
         '[project]\nname = "myapp"\nversion = "1.0.0"\n'
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_batch.py
+++ b/tests/agent/test_batch.py
@@ -23,7 +23,7 @@ def test_batch_replace(agent, workspace, patchloom_shim):
         '[project]\nname = "myapp"\nversion = "1.0.0"\n'
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_bench.py
+++ b/tests/agent/test_bench.py
@@ -53,6 +53,7 @@ def _find_patchloom_binary() -> str:
     if found:
         return found
     pytest.skip("patchloom binary not found")
+    return ""  # unreachable; pytest.skip raises
 
 
 def _has_mcp_support(binary: str) -> bool:
@@ -358,7 +359,7 @@ def _run_session(agent, real_bin, tmp_path, mode):
                 out = json.loads(proc.stdout)
                 session_id = out.get("sessionId")
             except (json.JSONDecodeError, TypeError):
-                pass
+                pass  # first-run output may not be valid JSON
 
         # Parse shim log for call count and per-call durations
         new_calls = 0
@@ -376,7 +377,7 @@ def _run_session(agent, real_bin, tmp_path, mode):
                     if isinstance(d, (int, float)) and d > 0:
                         pl_duration_ms += int(d)
                 except (json.JSONDecodeError, TypeError):
-                    pass
+                    pass  # skip malformed shim log entries
 
         try:
             success = task["check"](ws)
@@ -571,7 +572,6 @@ def _print_comparison(all_runs, modes, n_runs):
     """Print side-by-side comparison table for 2 or 3 modes."""
     aggs = {m: _aggregate_runs(all_runs[m]) for m in modes}
     model = all_runs[modes[0]][0].model
-    stat_label = "median" if n_runs > 1 else "time"
 
     # Build header
     n_modes = len(modes)

--- a/tests/agent/test_files.py
+++ b/tests/agent/test_files.py
@@ -7,13 +7,12 @@ import subprocess
 import pytest
 
 from conftest import run_scenario
-from drivers.base import assert_patchloom_used
 
 
 @pytest.mark.timeout(180)
 def test_create(agent, workspace, patchloom_shim):
     """Agent should use patchloom create to make a new file."""
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -39,7 +38,7 @@ def test_delete(agent, workspace, patchloom_shim):
     (workspace / "config.old.json").write_text('{"deprecated": true}\n')
     (workspace / "config.json").write_text('{"active": true}\n')
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -112,7 +111,7 @@ def test_patch(agent, workspace, patchloom_shim):
         " print(greet('World'))\n"
     )
 
-    result = run_scenario(
+    _result = run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_files.py
+++ b/tests/agent/test_files.py
@@ -12,7 +12,7 @@ from conftest import run_scenario
 @pytest.mark.timeout(180)
 def test_create(agent, workspace, patchloom_shim):
     """Agent should use patchloom create to make a new file."""
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -38,7 +38,7 @@ def test_delete(agent, workspace, patchloom_shim):
     (workspace / "config.old.json").write_text('{"deprecated": true}\n')
     (workspace / "config.json").write_text('{"active": true}\n')
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,
@@ -111,7 +111,7 @@ def test_patch(agent, workspace, patchloom_shim):
         " print(greet('World'))\n"
     )
 
-    _result = run_scenario(
+    run_scenario(
         agent,
         workspace,
         patchloom_shim,

--- a/tests/agent/test_structured.py
+++ b/tests/agent/test_structured.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 from conftest import run_scenario
-from drivers.base import assert_patchloom_used, report_raw_tool_usage
+from drivers.base import assert_patchloom_used
 
 
 @pytest.mark.timeout(180)


### PR DESCRIPTION
## Changes

- **CodeQL Python quality findings**: Resolve 26 findings (unused assignments, redundant operations, unreachable code) across agent test drivers and conftest
- **CodeQL matrix strategy**: Split single-language CodeQL into per-language matrix (actions, python) with dedicated categories
- **Auto-approve permissions**: Move `pull-requests: write` from workflow-level to job-level for Scorecard TokenPermissions compliance
- **GitHub native coverage**: Replace Codecov/LCOV with `actions/upload-code-coverage` and `cargo-llvm-cov --cobertura` for line-level coverage on PR diffs without external dependencies
- **DCO app removal**: Uninstalled probot DCO app (replaced by GitHub Actions workflow in prior work)
- **Stale analysis cleanup**: Deleted 18 stale CodeQL analyses from old single-language configuration

Signed-off-by: Sebastien Tardif <seb@tardif.ca>