### PR TITLE
fix: add missing subcommands to agent driver subcommand set

### DIFF
--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -92,8 +92,9 @@ def create_driver(agent_name: str, model: str) -> AgentDriver:
 
 _PATCHLOOM_SUBCOMMANDS = {
     "search", "replace", "patch", "md", "doc", "tidy",
-    "create", "delete", "rename", "read", "status", "tx", "completions",
-    "agent-rules", "batch", "mcp-server",
+    "create", "delete", "rename", "read", "status", "tx",
+    "batch", "explain", "undo", "init", "completions",
+    "agent-rules", "mcp-server",
 }
 
 


### PR DESCRIPTION
## Summary

The `_PATCHLOOM_SUBCOMMANDS` set in `tests/agent/drivers/base.py` was missing three commands: `explain`, `undo`, and `init`. These commands were added to the CLI but the assertion helper set was not updated, meaning `assert_patchloom_used()` would produce false negatives if an agent test invoked any of these commands.

## What changed

| File | Change |
|------|--------|
| `tests/agent/drivers/base.py` | Added `explain`, `undo`, `init` to `_PATCHLOOM_SUBCOMMANDS` |

## Context

Found during loop 3 of a multi-perspective improvement rotation (QA Engineer perspective). Loops 1-2 had already converged with zero findings; this was the only actionable item in loop 3.

## Testing

`make check` passes: 1194 tests (593 unit + 601 integration)