### PR TITLE
ci: add parallel fuzz testing to PR and main pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,41 @@ jobs:
         if: always() && steps.baseline.outputs.found == 'true'
         run: python3 benches/ci/bench_compare.py "$RUNNER_TEMP/baseline" "$RUNNER_TEMP" | tee -a "$GITHUB_STEP_SUMMARY"
 
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - fuzz_selector_parse
+          - fuzz_patch_parse
+          - fuzz_patch_apply
+          - fuzz_batch_tokenize
+          - fuzz_selector_eval
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: ./.github/actions/setup-rust
+        with:
+          toolchain: nightly
+
+      - name: Install cargo-fuzz
+        uses: taiki-e/install-action@25435dc8dd3baed7417e0c96d3fe89013a5b2e09 # v2
+        with:
+          tool: cargo-fuzz
+
+      - name: Fuzz ${{ matrix.target }}
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60
+
   audit:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,6 +348,8 @@ jobs:
           tool: cargo-fuzz
 
       - name: Fuzz ${{ matrix.target }}
+        env:
+          RUSTUP_TOOLCHAIN: nightly
         run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60
 
   agent-dry-run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
       - name: Fuzz ${{ matrix.target }}
         env:
           RUSTUP_TOOLCHAIN: nightly
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60
+        run: cargo fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=60
 
   agent-dry-run:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,6 +350,30 @@ jobs:
       - name: Fuzz ${{ matrix.target }}
         run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60
 
+  agent-dry-run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: pip install -r tests/agent/requirements.txt
+
+      - name: Agent benchmark dry run
+        run: cd tests/agent && pytest test_bench.py::test_dry_run_prompts -v -s --dry-run-prompts
+
   audit:
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
Run all 5 fuzz targets as a matrix of parallel CI jobs (60s each), so they execute within the existing pipeline wall-clock time.

## What changed

Added a `fuzz` job to `ci.yml` with a 5-target matrix:
- `fuzz_selector_parse`
- `fuzz_patch_parse`
- `fuzz_patch_apply`
- `fuzz_batch_tokenize`
- `fuzz_selector_eval`

Each target runs for 60 seconds using `cargo fuzz` on nightly. All 5 jobs run concurrently, so the total wall-clock cost is ~60s of fuzzing plus setup, well within the existing `ci-windows` bottleneck (~2m42s).

## Why

Fuzz tests were previously manual-only (`make fuzz`). Running them on every PR and push to main catches parser and evaluator panics before they reach users.