### PR TITLE
docs: add OpenSSF Scorecard and FOSSA badges, remove stale text

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@
 [![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
+[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B62499%2Fgithub.com%2Fpatchloom%2Fpatchloom.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B62499%2Fgithub.com%2Fpatchloom%2Fpatchloom?ref=badge_shield&issueType=license)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 
@@ -408,5 +410,3 @@ All commits must be signed off with `git commit -s`.
 ## Security
 
 For current security reporting guidance, see [SECURITY.md](./SECURITY.md).
-
-GitHub private vulnerability reporting will be enabled after the repository becomes public.

--- a/lychee.toml
+++ b/lychee.toml
@@ -14,6 +14,8 @@ exclude = [
   "github\\.com/patchloom/patchloom/releases/tag/v",
   # Repos not yet created
   "github\\.com/patchloom/patchloom-vscode",
+  # FOSSA badge SVG may 404 briefly between analysis runs
+  "app\\.fossa\\.com/api/projects/.*\\.svg",
 ]
 
 accept = [200, 429]


### PR DESCRIPTION
## What

- Add **OpenSSF Scorecard** badge (score 7.9/10, live at [securityscorecards.dev](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom))
- Add **FOSSA license compliance** badge (uses `custom+62499` locator matching the CLI-based workflow)
- Remove stale text claiming the repo is not yet public (it is)
- Add FOSSA SVG exclusion to `lychee.toml` to prevent false link checker failures

## Why

The repo is public and both services have live data. The Scorecard API returns 200 with a 7.9/10 score. The FOSSA workflow (PR #437) has been running successfully since setup, but no badge was added because the `git+` locator format was tried instead of the correct `custom+62499` format.

The stale "after the repository becomes public" text in the Security section was misleading.

## Verification

All badge URLs verified before committing:

| Badge | SVG status | Link status |
|-------|-----------|-------------|
| OpenSSF Scorecard | 302 (redirect to SVG) | 200 |
| FOSSA License | 200 | 200 |

Relates to #450