### PR TITLE
ci: re-enable fossa test with false-positive filter, switch to Actions badge

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -59,7 +59,21 @@ jobs:
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
         run: fossa analyze
-      # fossa test disabled: default policy flags apache-2.0 WITH
-      # llvm-exception (7 crates) and LGPL-2.1-or-later on r-efi.
-      # All are false positives. Re-enable with a filter script when
-      # the free tier supports persistent ignore rules or policy edits.
+      - name: Run FOSSA license check
+        if: steps.check-key.outputs.skip != 'true'
+        env:
+          FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+        run: |
+          set +e
+          fossa test --format json > fossa-results.json 2>fossa-stderr.txt
+          TEST_EXIT=$?
+          set -e
+
+          if [ "$TEST_EXIT" -eq 0 ]; then
+            echo "FOSSA test passed with no issues."
+            exit 0
+          fi
+
+          echo "FOSSA test found issues. Filtering known false positives..."
+          head -c 2000 fossa-stderr.txt
+          python3 scripts/fossa-filter.py fossa-results.json

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
-[![FOSSA Status](https://app.fossa.com/api/projects/custom%2B62499%2Fgithub.com%2Fpatchloom%2Fpatchloom.svg?type=shield&issueType=license)](https://app.fossa.com/projects/custom%2B62499%2Fgithub.com%2Fpatchloom%2Fpatchloom?ref=badge_shield&issueType=license)
+[![FOSSA Status](https://github.com/patchloom/patchloom/actions/workflows/fossa.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/fossa.yml)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 

--- a/scripts/fossa-filter.py
+++ b/scripts/fossa-filter.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Filter known false positives from FOSSA test JSON output.
+
+Exit 0 if all issues are documented false positives.
+Exit 1 if any genuine issues remain after filtering.
+
+Documented false positives
+--------------------------
+1. cc, compiler_builtins (and other Rust compiler infrastructure)
+   apache-2.0 WITH llvm-exception
+   The LLVM exception explicitly permits compiling code with these
+   crates without the Apache-2.0 license applying to the compiled
+   output. Standard Rust compiler infrastructure; affects every Rust
+   project. FOSSA flags the "WITH llvm-exception" clause as an
+   unrecognized license modifier.
+
+2. r-efi  LGPL-2.1-or-later
+   Pure UEFI type definitions (data structures, no executable code).
+   Pulled in transitively via std on some targets; not linked into the
+   user binary in any meaningful way.
+"""
+
+import json
+import sys
+
+
+# Crates with "apache-2.0 WITH llvm-exception" that FOSSA cannot parse.
+# The LLVM exception permits compilation without license propagation.
+LLVM_EXCEPTION_CRATES = {
+    "cc",
+    "compiler_builtins",
+}
+
+# License IDs that FOSSA uses for the LLVM exception variant.
+LLVM_EXCEPTION_LICENSES = {
+    "apache-2.0 WITH llvm-exception",
+    "Apache-2.0 WITH LLVM-exception",
+}
+
+
+def is_false_positive(pkg: str, license_id: str, issue_type: str = "") -> bool:
+    """Return True if the (package, license, type) tuple is a documented false positive."""
+    # Rust compiler infrastructure: apache-2.0 WITH llvm-exception
+    if license_id in LLVM_EXCEPTION_LICENSES:
+        return True
+
+    # r-efi: pure type definitions, transitively pulled by std
+    if pkg == "r-efi" and license_id in ("LGPL-2.1-or-later", "LGPL-2.1+"):
+        return True
+
+    return False
+
+
+def extract_package(issue: dict) -> str:
+    """Extract the package name from a FOSSA issue.
+
+    FOSSA uses 'revisionId' with format 'cargo+cc$1.0.106'.
+    Strip the ecosystem prefix and version suffix to get the crate name.
+    Falls back to 'package' or 'name' fields if revisionId is missing.
+    """
+    rev = issue.get("revisionId", "")
+    if rev:
+        # Strip ecosystem prefix (e.g., "cargo+", "go+")
+        if "+" in rev:
+            rev = rev.split("+", 1)[1]
+        # Strip version suffix (e.g., "$1.0.106")
+        if "$" in rev:
+            rev = rev.rsplit("$", 1)[0]
+        return rev
+    return issue.get("package", "") or issue.get("name", "") or ""
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("Usage: fossa-filter.py <fossa-results.json>", file=sys.stderr)
+        return 2
+
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+
+    # fossa test --format json may return a list or an object with an issues key
+    if isinstance(data, list):
+        issues = data
+    else:
+        issues = data.get("issues", data.get("issue", []))
+    if not isinstance(issues, list):
+        issues = []
+
+    real_issues = []
+    filtered_count = 0
+
+    for issue in issues:
+        pkg = extract_package(issue)
+        lic = issue.get("license", "") or issue.get("licenseId", "") or ""
+        itype = issue.get("type", "") or issue.get("issueType", "") or ""
+
+        if is_false_positive(pkg, lic, itype):
+            filtered_count += 1
+            continue
+
+        real_issues.append(issue)
+
+    if real_issues:
+        print(f"FAIL: {len(real_issues)} genuine issue(s) after filtering "
+              f"{filtered_count} known false positives:")
+        for r in real_issues:
+            pkg = extract_package(r)
+            lic = r.get("license", "") or r.get("licenseId", "?")
+            itype = r.get("type", "") or r.get("issueType", "?")
+            print(f"  - {pkg}  {lic}  ({itype})")
+        return 1
+
+    print(f"OK: All {filtered_count} issue(s) are documented false positives.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_fossa_filter.py
+++ b/scripts/test_fossa_filter.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Tests for scripts/fossa-filter.py."""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+FILTER = os.path.join(os.path.dirname(__file__), "fossa-filter.py")
+
+
+def run_filter(issues):
+    """Run the filter on a list of FOSSA issues and return (exit_code, stdout)."""
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(issues, f)
+        f.flush()
+        result = subprocess.run(
+            [sys.executable, FILTER, f.name],
+            capture_output=True, text=True,
+        )
+    os.unlink(f.name)
+    return result.returncode, result.stdout
+
+
+def test_empty_issues():
+    rc, out = run_filter([])
+    assert rc == 0, f"Expected 0, got {rc}: {out}"
+    assert "0 issue(s)" in out
+
+
+def test_llvm_exception_filtered():
+    issues = [
+        {"revisionId": "cargo+cc$1.0.106", "license": "apache-2.0 WITH llvm-exception", "type": "policy_conflict"},
+        {"revisionId": "cargo+compiler_builtins$0.1.139", "license": "apache-2.0 WITH llvm-exception", "type": "policy_conflict"},
+    ]
+    rc, out = run_filter(issues)
+    assert rc == 0, f"Expected 0, got {rc}: {out}"
+    assert "2 issue(s)" in out
+
+
+def test_r_efi_filtered():
+    issues = [
+        {"revisionId": "cargo+r-efi$4.5.0", "license": "LGPL-2.1-or-later", "type": "policy_flag"},
+    ]
+    rc, out = run_filter(issues)
+    assert rc == 0, f"Expected 0, got {rc}: {out}"
+
+
+def test_genuine_issue_not_filtered():
+    issues = [
+        {"revisionId": "cargo+shady-crate$0.1.0", "license": "GPL-3.0", "type": "policy_conflict"},
+    ]
+    rc, out = run_filter(issues)
+    assert rc == 1, f"Expected 1, got {rc}: {out}"
+    assert "1 genuine" in out
+
+
+def test_mixed_issues():
+    issues = [
+        {"revisionId": "cargo+cc$1.0.106", "license": "apache-2.0 WITH llvm-exception", "type": "policy_conflict"},
+        {"revisionId": "cargo+r-efi$4.5.0", "license": "LGPL-2.1-or-later", "type": "policy_flag"},
+        {"revisionId": "cargo+bad-crate$1.0.0", "license": "AGPL-3.0", "type": "policy_conflict"},
+    ]
+    rc, out = run_filter(issues)
+    assert rc == 1, f"Expected 1, got {rc}: {out}"
+    assert "1 genuine" in out
+    assert "bad-crate" in out
+
+
+def test_object_wrapper():
+    """FOSSA may wrap issues in an object."""
+    issues_obj = {"issues": [
+        {"revisionId": "cargo+cc$1.0.106", "license": "apache-2.0 WITH llvm-exception", "type": "policy_conflict"},
+    ]}
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(issues_obj, f)
+        f.flush()
+        result = subprocess.run(
+            [sys.executable, FILTER, f.name],
+            capture_output=True, text=True,
+        )
+    os.unlink(f.name)
+    assert result.returncode == 0
+
+
+def test_case_insensitive_license():
+    """FOSSA may use different casing for the license ID."""
+    issues = [
+        {"revisionId": "cargo+cc$1.0.106", "license": "Apache-2.0 WITH LLVM-exception", "type": "policy_conflict"},
+    ]
+    rc, out = run_filter(issues)
+    assert rc == 0, f"Expected 0, got {rc}: {out}"
+
+
+if __name__ == "__main__":
+    tests = [f for f in dir() if f.startswith("test_")]
+    passed = 0
+    failed = 0
+    for t in sorted(tests):
+        try:
+            globals()[t]()
+            print(f"  PASS  {t}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  FAIL  {t}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)


### PR DESCRIPTION
Switches the FOSSA badge from the FOSSA API badge to a GitHub Actions workflow badge and re-enables `fossa test` with a false-positive filter script.

**Problem:** The FOSSA API badge queried the dashboard, which showed "failing" due to unresolved Rust false positives (apache-2.0 WITH llvm-exception on compiler crates, LGPL-2.1-or-later on r-efi). The `fossa test` step was disabled in CI because of these false positives.

**Fix:**
- Switch badge to GitHub Actions workflow badge (reflects CI result, not raw dashboard status)
- Add `scripts/fossa-filter.py` that strips documented Rust false positives
- Re-enable `fossa test` in the workflow, piped through the filter
- Add `scripts/test_fossa_filter.py` with 7 test cases

The filter exits 0 when only known false positives remain, and exits 1 for genuine new license issues. This matches the pattern used in coolify-terraform/terraform-provider-coolify for Go false positives.