### PR TITLE
fix: address AI code quality findings in GrokDriver

### DIFF
--- a/tests/agent/drivers/grok.py
+++ b/tests/agent/drivers/grok.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import subprocess
 import time
 from pathlib import Path
 
-from .base import AgentDriver, AgentMetadata, AgentResult, load_shim_calls, try_parse_json
+from .base import AgentDriver, AgentMetadata, AgentResult, load_shim_calls, parse_last_json_line, try_parse_json
 
 
 class GrokDriver(AgentDriver):
@@ -51,6 +50,7 @@ class GrokDriver(AgentDriver):
                 text=True,
                 timeout=timeout_secs,
                 env=env,
+                cwd=str(cwd),
             )
         except subprocess.TimeoutExpired as exc:
             return AgentResult(
@@ -99,10 +99,9 @@ class GrokDriver(AgentDriver):
                  "--max-turns", "1"],
                 capture_output=True, text=True, timeout=30,
             )
-            data = json.loads(proc.stdout)
+            data = parse_last_json_line(proc.stdout) or {}
             model_name = data.get("text", "unknown").strip()
-        except (subprocess.TimeoutExpired, FileNotFoundError,
-                json.JSONDecodeError, KeyError):
+        except (subprocess.TimeoutExpired, FileNotFoundError):
             pass  # model query failed; use default
 
         return AgentMetadata(


### PR DESCRIPTION
Fixes all 3 AI code quality findings flagged on `tests/agent/drivers/grok.py`.

## Changes

- **Add `cwd=str(cwd)` to `subprocess.run`** in `run_prompt`: the grok CLI `--cwd` flag was already passed, but setting `cwd` on the subprocess itself provides belt-and-suspenders consistency with `ClaudeDriver`.
- **Use `parse_last_json_line` instead of `json.loads`** in `get_metadata`: more robust when the CLI emits JSONL or prefixes non-JSON output. The helper was already available in `base.py`.
- **Remove dead `KeyError` catch**: `data.get("text", "unknown")` uses a default and can never raise `KeyError`. Also removed `json.JSONDecodeError` from the except clause since `parse_last_json_line` handles decode errors internally.
- **Remove unused `import json`** (no longer needed after the above changes).

All changes verified with `make check` (593 unit + 602 integration tests pass).