### PR TITLE
ci: enable auto-merge in auto-approve workflow

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
+      contents: write
       pull-requests: write
     if: >
       github.actor == 'SebTardif' ||
@@ -29,3 +30,7 @@ jobs:
           egress-policy: audit
       - name: Auto-approve PR
         uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
## Problem

The auto-approve workflow approves PRs by the owner but never enables auto-merge. This means every PR still shows an "Enable auto-merge (squash)" button that must be clicked manually, defeating the purpose of the auto-approve.

The dependabot-auto-merge workflow already does both (`gh pr review --approve` + `gh pr merge --auto --squash`), but the general auto-approve workflow was missing the second step.

## Fix

Add an "Enable auto-merge" step that calls `gh pr merge --auto --squash` after the approval. Also add `contents: write` permission (required by `gh pr merge --auto`).

After this change, PRs by the owner will be approved and queued for auto-merge as soon as the workflow fires. Once all required status checks pass, GitHub merges automatically.