### PR TITLE
readme: remove MSRV badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 [![Tests](https://img.shields.io/badge/tests-1195%20passing-brightgreen)](#)
-[![MSRV](https://img.shields.io/badge/MSRV-1.95-blue)](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14009,11 +14009,6 @@ fn test_smoke_rust_version_docs_and_ci_match_cargo_metadata() {
         ci.contains(&format!("toolchain: \"{rust_version}\"")),
         "ci.yml should pin the MSRV job to the same Rust version as Cargo.toml"
     );
-
-    assert!(
-        readme.contains(&format!("MSRV-{rust_version}-")),
-        "README MSRV badge should use the same Rust version as Cargo.toml"
-    );
 }
 
 #[test]


### PR DESCRIPTION
Remove the MSRV badge from README.md. Most users do not know what MSRV means, and the Rust version requirement is already documented in CONTRIBUTING.md and CHANGELOG.md.

Also removes the corresponding integration test assertion.