### PR TITLE
ci: enforce pip hash verification and auto-update PR branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install test dependencies
-        run: pip install -r tests/agent/requirements.txt
+        run: pip install --require-hashes -r tests/agent/requirements.txt
 
       - name: Agent benchmark dry run
         run: cd tests/agent && pytest test_bench.py::test_dry_run_prompts -v -s --dry-run-prompts

--- a/.github/workflows/update-branches.yml
+++ b/.github/workflows/update-branches.yml
@@ -1,0 +1,36 @@
+name: Update PR branches
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: update-branches-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  update-branches:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2
+        with:
+          egress-policy: audit
+      - name: Update open PR branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --state open --json number --jq '.[].number')
+          for pr in $prs; do
+            echo "Updating PR #$pr..."
+            gh api "repos/$GITHUB_REPOSITORY/pulls/$pr/update-branch" \
+              -X PUT -f update_method=merge 2>&1 || echo "  Skipped PR #$pr (conflicts or already up to date)"
+          done


### PR DESCRIPTION
Two CI improvements:

**1. Fix Scorecard Pinned-Dependencies alert (#37)**

Add `--require-hashes` to the `pip install` command in the agent-bench job. The `tests/agent/requirements.txt` already contains per-package SHA-256 hashes, but Scorecard requires the CLI flag to recognize the install as hash-pinned.

**2. Auto-update open PR branches**

Add a workflow that triggers on push to `main` and calls the GitHub `update-branch` API for every open PR. This removes the need to manually click "Update branch" on each PR when `strict_required_status_checks_policy` is enabled. PRs with merge conflicts are skipped gracefully.