### PR TITLE
chore: release prep for v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,55 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-06-04
+
 ### Security
 
 - Fixed external path traversal bypass in `undo --apply` restore logic: crafted `__external__/../..` manifest entries could overwrite files outside the project root
-
-### Changed
-
-- MCP server: cached canonicalized cwd at startup, eliminating redundant `realpath` syscall per tool invocation
-- MCP server: consolidated `validate_path_contained` + `validate_path_resolved` into single `check_path` method, preventing partial validation
-- Extracted shared tx execution core (`execute_and_collect`, `run_lifecycle`) eliminating ~190 lines of duplication
-- Extracted `backup_write_files` helper, refactored 5 call sites across replace, patch, and tidy commands
-- Extracted `apply_replacements` helper in replace command, deduplicating backup+write block
-- Extracted `with_doc_mutation` helper in doc command, eliminating 9x load/clone/serialize/write boilerplate
-- Fixed `read_file_content` double-join bug when transaction cwd is relative
 - Added syntactic path traversal validation to undo restore paths
 - Added `validate_path_resolved` symlink check to all 16 MCP write handlers
-- Extracted `compile_replace_regex` shared helper
-- Improved doc command error messages to list supported file extensions
-- CLI `tx` validates plan `cwd` is a directory, returning PARSE_ERROR instead of confusing OS errors
-- Lifecycle shell commands (format/validate) now capture first 512 bytes of stderr in error output
-- Relative plan `cwd` values resolve from invocation root, matching MCP behavior
-- Lifecycle failure messages include the working directory (`cwd: .` or `cwd: nested`)
-- MCP `transaction` validates relative `cwd` resolves to a directory, not a file
-- Shared `resolve_plan_cwd` function deduplicates CLI and MCP cwd resolution
-- MCP `search_files` tool now exposes `invert_match` and `assert_count` parameters, matching CLI and tx feature parity
-- MCP `search_files`, `replace_text`, and `fix_whitespace` tool descriptions now document text-file semantics (binary and invalid UTF-8 files are skipped)
-- `create` command now creates backup sessions before writing, enabling `undo --apply` to remove or restore files created with `create --apply`
-- `tidy fix` now emits structured JSON/JSONL output when `--json` or `--jsonl` is active, matching other write commands
-
-### Fixed
-
-- `create` command: backup finalize was called before the atomic write, producing a backup for a change that had not yet happened; finalize now runs after the write succeeds
-
-### Documentation
-
-- Documented column offset semantics in search JSON output
-- Added `init` command to README Commands table
-- Documented stderr capture and cwd context in lifecycle failure output (reference docs, quickstart)
-- Added `cargo check --all-targets` to CONTRIBUTING.md for default-feature build verification
-- Added launch announcement blog post command count freshness guard
-
-### Testing
-
-- 1195 tests (593 unit + 602 integration)
-- Added fuzz targets for batch tokenizer (`fuzz_batch_tokenize`) and selector evaluator (`fuzz_selector_eval`), bringing the total to 5 fuzz targets
-- CI: added Codecov upload to coverage job and coverage badge to README
-- CI: added benchmark summary table and 90-day artifact retention for regression tracking
-- CI: added cross-run benchmark comparison that detects gradual regressions by comparing against the latest main baseline (20% threshold with 2ms minimum absolute change)
-
-## [0.1.0] - 2025-05-23
 
 ### Commands
 
@@ -86,6 +44,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `read` and `search` operations in tx plans for inspect-then-edit workflows in a single call
 - `batch` provides simpler line-oriented syntax covering 20 operation types
 - Operation ordering is well-defined: last write wins, delete-then-create works, each op sees prior results
+- CLI `tx` validates plan `cwd` is a directory, returning PARSE_ERROR instead of confusing OS errors
+- Relative plan `cwd` values resolve from invocation root, matching MCP behavior
+- Lifecycle shell commands (format/validate) now capture first 512 bytes of stderr in error output
+- Lifecycle failure messages include the working directory (`cwd: .` or `cwd: nested`)
 
 ### Correctness fixes
 
@@ -97,6 +59,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - tx glob replace no longer buffers non-matching files into pending state
 - `create --check` verifies parent directory exists (non-force mode)
 - Race-free file creation via `File::create_new` for `create --apply` and tx `file.create`
+- Fixed `read_file_content` double-join bug when transaction cwd is relative
+- `create` command: backup finalize was called before the atomic write, producing a backup for a change that had not yet happened; finalize now runs after the write succeeds
+- `create` command now creates backup sessions before writing, enabling `undo --apply` to remove or restore files created with `create --apply`
 
 ### Output and diagnostics
 
@@ -105,20 +70,48 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Explicit `error_kind` values in tx JSON output (parse_error, rollback, validation_failed, format_failed)
 - Stderr diagnostics for silently skipped files in search, replace, and tx glob
 - File path context in doc operation error messages
+- Improved doc command error messages to list supported file extensions
+- `tidy fix` now emits structured JSON/JSONL output when `--json` or `--jsonl` is active, matching other write commands
+
+### MCP server
+
+- MCP `search_files` tool exposes `invert_match` and `assert_count` parameters, matching CLI and tx feature parity
+- MCP `search_files`, `replace_text`, and `fix_whitespace` tool descriptions document text-file semantics (binary and invalid UTF-8 files are skipped)
+- MCP `transaction` validates relative `cwd` resolves to a directory, not a file
+- Cached canonicalized cwd at startup, eliminating redundant `realpath` syscall per tool invocation
+- Consolidated `validate_path_contained` + `validate_path_resolved` into single `check_path` method, preventing partial validation
+- Shared `resolve_plan_cwd` function deduplicates CLI and MCP cwd resolution
 
 ### Testing and benchmarks
 
-- 1049 tests (505 unit + 544 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 1195 tests (593 unit + 602 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
+- 5 fuzz targets: selector parse, patch parse, patch apply, batch tokenize, selector eval
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine
 - Agent A/B benchmarks measuring duration, tool calls, and success rate
+
+### Internal improvements
+
+- Extracted shared tx execution core (`execute_and_collect`, `run_lifecycle`) eliminating ~190 lines of duplication
+- Extracted `backup_write_files` helper, refactored 5 call sites across replace, patch, and tidy commands
+- Extracted `apply_replacements` helper in replace command, deduplicating backup+write block
+- Extracted `with_doc_mutation` helper in doc command, eliminating 9x load/clone/serialize/write boilerplate
+- Extracted `compile_replace_regex` shared helper
 
 ### Infrastructure
 
 - MSRV: Rust 1.95+
 - License: MIT OR Apache-2.0
-- CI: fmt, clippy, tests, MSRV check, dependency audit, doc freshness checks, code coverage
+- CI: fmt, clippy, tests, MSRV check, dependency audit, doc freshness checks, code coverage, Codecov upload
+- CI: benchmark summary table with 90-day artifact retention and cross-run regression detection (20% threshold, 2ms minimum)
 - `make check` runs the full gate locally, including generated doc freshness
+
+### Documentation
+
+- Documented column offset semantics in search JSON output
+- Added `init` command to README Commands table
+- Documented stderr capture and cwd context in lifecycle failure output (reference docs, quickstart)
+- Added `cargo check --all-targets` to CONTRIBUTING.md for default-feature build verification
 
 [Unreleased]: https://github.com/patchloom/patchloom/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/patchloom/patchloom/releases/tag/v0.1.0

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,174 tests**, zero unsafe code
+- **1,195 tests**, zero unsafe code
 - **18 CLI commands** + MCP server with 33 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14248,7 +14248,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,174 tests"));
+    assert!(launch.contains("1,195 tests"));
     assert!(
         launch.contains("18 CLI commands"),
         "launch announcement CLI command count drifted"


### PR DESCRIPTION
Prepare for the first public release (v0.1.0).

## Changes

- **CHANGELOG**: Merged the `[Unreleased]` section into `[0.1.0]` since no release has ever been published. Updated release date to 2026-06-04. Organized changes into Security, Commands, MCP server, Internal improvements, and Documentation sections.
- **Launch announcement**: Updated stale test count from 1,174 to 1,195 (593 unit + 602 integration).
- **Integration test**: Updated the test count assertion to match.

## Release secrets (already configured)

| Secret | Status |
|--------|--------|
| `CARGO_REGISTRY_TOKEN` | Configured (crates.io, publish-new + publish-update scopes) |
| `HOMEBREW_TAP_TOKEN` | Configured (GitHub PAT, public_repo scope) |

## Remaining steps after merge

1. Tag `v0.1.0` on main: `git tag v0.1.0 && git push origin v0.1.0`
2. Monitor the release workflow
3. Verify GitHub Release artifacts, SLSA provenance, SBOM
4. Verify crates.io listing
5. Verify Homebrew formula in `patchloom/homebrew-tap`
6. Publish the launch announcement

Part of #434.