### PR TITLE
fix(ci): correct SBOM upload path for cargo-cyclonedx

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,7 +344,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release upload "${{ needs.plan.outputs.tag }}" \
-            patchloom/bom.json#patchloom-sbom.cdx.json \
+            patchloom.cdx.json#patchloom-sbom.cdx.json \
             --clobber
 
   publish-homebrew-formula:


### PR DESCRIPTION
cargo cyclonedx --format json --all produces `patchloom.cdx.json` at the repo root, not `patchloom/bom.json`. The upload step referenced the wrong path, causing the SBOM upload to fail on the v0.1.0 release.

The SBOM was uploaded manually for v0.1.0. This fix prevents the same failure on future releases.