### PR TITLE
fix(ci): exclude securityscorecards.dev from lychee link checks

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -16,6 +16,8 @@ exclude = [
   "github\\.com/patchloom/patchloom-vscode",
   # FOSSA badge SVG may 404 briefly between analysis runs
   "app\\.fossa\\.com/api/projects/.*\\.svg",
+  # Scorecard viewer is slow and times out intermittently in CI
+  "securityscorecards\\.dev",
 ]
 
 accept = [200, 429]


### PR DESCRIPTION
## Problem

The Links workflow has been failing on main since PR #463 (badges) was merged. The root cause is that the OpenSSF Scorecard viewer URL (`securityscorecards.dev/viewer`) times out intermittently in CI.

Worse, the PR was merged **despite the failing check** because `Check Links` was not a required status check in the branch ruleset.

## Fix

1. **lychee.toml**: Add `securityscorecards.dev` to the exclude list (the viewer is slow and unreliable for automated checks; the badge API URL is also covered since both share the same domain)
2. **Branch ruleset** (applied via API, not in this diff): Added `Check Links` as a required status check so a failing Links job blocks merge going forward

## Verification

- The lychee exclusion prevents the timeout from causing a failure
- The ruleset update ensures no PR can merge with a broken Links check again