### PR TITLE
fix: add test coverage and update install instructions for v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,22 +159,20 @@ MCP mode wins overall (228.5s vs 233.8s native) because structured tool calls sk
 ## Install
 
 ```bash
-# Core CLI install (requires Rust 1.95+)
-git clone https://github.com/patchloom/patchloom.git
-cd patchloom
-cargo install --path .
+# Homebrew (macOS/Linux)
+brew install patchloom/tap/patchloom
 
-# Install with MCP support
-cargo install --path . --features mcp
+# crates.io (requires Rust 1.95+)
+cargo install patchloom
+
+# With MCP support
+cargo install patchloom --features mcp
 ```
 
-`cargo install --path .` gives you the core CLI commands. If you also want
-`patchloom mcp-server`, install with `--features mcp`.
-
-Other install channels are planned for public launch, including crates.io,
-GitHub Releases binaries, and Homebrew. See
-[Installation](./docs/getting-started/installation.md) for the current path and
-planned post-launch options.
+Pre-built binaries for Linux, macOS, and Windows are on the
+[Releases](https://github.com/patchloom/patchloom/releases/latest) page.
+See [Installation](./docs/getting-started/installation.md) for shell
+installer scripts, source builds, and shell completion setup.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1195%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1197%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -384,7 +384,7 @@ flowchart LR
 
 ## Status
 
-1195 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1197 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,31 +1,15 @@
 # Installation
 
-Patchloom is not yet published to crates.io or Homebrew. Install from source
-for now. The sections below describe the planned post-launch channels.
-
-## From source (current)
-
-Install the core CLI from source (requires Rust 1.95+):
+## From Homebrew (macOS and Linux)
 
 ```bash
-git clone https://github.com/patchloom/patchloom.git
-cd patchloom
-cargo install --path .
+brew install patchloom/tap/patchloom
 ```
 
-Install with MCP support:
+This installs the core CLI from a pre-built binary. If you need
+`mcp-server`, install from source with `--features mcp` (see below).
 
-```bash
-git clone https://github.com/patchloom/patchloom.git
-cd patchloom
-cargo install --path . --features mcp
-```
-
-The `mcp-server` command is feature-gated. If you only run `cargo install --path .`, you get the core CLI without MCP.
-
-If you're contributing from a source checkout, use `make check-fast` while iterating and `make check` before committing. `make check` is the full local CI gate.
-
-## From crates.io (after public launch)
+## From crates.io
 
 Core CLI:
 
@@ -33,29 +17,54 @@ Core CLI:
 cargo install patchloom
 ```
 
-MCP-capable install:
+With MCP support:
 
 ```bash
 cargo install patchloom --features mcp
 ```
 
-## From GitHub releases (after public launch)
+## From GitHub Releases
 
-Pre-built binaries for Linux, macOS, and Windows will be available on the
-[Releases](https://github.com/patchloom/patchloom/releases) page. Download
-the archive for your platform, extract, and place `patchloom` on your PATH.
+Pre-built binaries for Linux (x64, ARM64), macOS (x64, ARM64), and Windows
+(x64) are available on the
+[Releases](https://github.com/patchloom/patchloom/releases/latest) page.
+Download the archive for your platform, extract, and place `patchloom` on
+your PATH.
 
-The current planned release pipeline targets the core CLI build. If you need
-`mcp-server`, install from source with `--features mcp`.
-
-## From Homebrew (after public launch)
+Shell and PowerShell installer scripts are also available:
 
 ```bash
-brew install patchloom/tap/patchloom
+# Unix (Linux/macOS)
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/patchloom/patchloom/releases/latest/download/patchloom-installer.sh | sh
+
+# Windows (PowerShell)
+powershell -ExecutionPolicy ByPass -c "irm https://github.com/patchloom/patchloom/releases/latest/download/patchloom-installer.ps1 | iex"
 ```
 
-The planned Homebrew formula also targets the core CLI build. If you need
-`mcp-server`, install from source with `--features mcp`.
+Pre-built binaries include the core CLI only. If you need `mcp-server`,
+install from source with `--features mcp`.
+
+## From source
+
+Install from source (requires Rust 1.95+):
+
+```bash
+git clone https://github.com/patchloom/patchloom.git
+cd patchloom
+cargo install --path .
+```
+
+With MCP support:
+
+```bash
+cargo install --path . --features mcp
+```
+
+The `mcp-server` command is feature-gated. If you only run
+`cargo install --path .`, you get the core CLI without MCP.
+
+If you're contributing from a source checkout, use `make check-fast`
+while iterating and `make check` before committing.
 
 ## Shell completions
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,6 +266,24 @@ color = "always"
     }
 
     #[test]
+    fn apply_config_crlf_eol() {
+        let config = ProjectConfig {
+            write_policy: WritePolicy {
+                normalize_eol: Some("crlf".into()),
+                ..WritePolicy::default()
+            },
+            ..ProjectConfig::default()
+        };
+        let mut global = crate::cli::global::GlobalFlags::default();
+        apply_config(&mut global, &config);
+
+        assert!(matches!(
+            global.normalize_eol,
+            Some(crate::cli::global::EolMode::Crlf)
+        ));
+    }
+
+    #[test]
     fn apply_config_unknown_color_value_stays_auto() {
         let config = ProjectConfig {
             output: Output {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13913,16 +13913,20 @@ fn test_smoke_shell_completion_docs_include_elvish() {
 fn test_smoke_source_install_docs_use_cargo_install_path() {
     let source_install_flow = "git clone https://github.com/patchloom/patchloom.git\ncd patchloom\ncargo install --path .";
 
-    for (path, label) in [
-        (installation_path(), "installation guide"),
-        (readme_path(), "README"),
-    ] {
-        let content = fs::read_to_string(path).unwrap();
-        assert!(
-            content.contains(source_install_flow),
-            "{label} should document the first-run source install flow"
-        );
-    }
+    // Source install flow lives in the installation guide (not README,
+    // which leads with Homebrew/crates.io and links to the guide).
+    let content = fs::read_to_string(installation_path()).unwrap();
+    assert!(
+        content.contains(source_install_flow),
+        "installation guide should document the source install flow"
+    );
+
+    // README should reference the installation guide for details.
+    let readme = fs::read_to_string(readme_path()).unwrap();
+    assert!(
+        readme.contains("[Installation](./docs/getting-started/installation.md)"),
+        "README should link to the full installation guide"
+    );
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8618,6 +8618,28 @@ fn test_replace_insert_before_nth() {
 }
 
 #[test]
+fn test_replace_insert_after_nth() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "x a x a x\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("a")
+        .arg("--insert-after")
+        .arg("]")
+        .arg("--nth")
+        .arg("2")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "x a x a] x\n");
+}
+
+#[test]
 fn test_replace_insert_before_and_to_conflict() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("data.txt");


### PR DESCRIPTION
## Changes

Two commits from multi-perspective improvement Cycle 1:

### 1. Test coverage gaps (QA Engineer perspective)

- **test_replace_insert_after_nth**: verifies `--insert-after` combined with `--nth` (the parallel `--insert-before --nth` was already tested)
- **apply_config_crlf_eol**: verifies `normalize_eol = "crlf"` in project config (only the `"lf"` path was previously covered)

### 2. Installation docs update (End User perspective)

Now that v0.1.0 is published, the installation guide and README lead with the easiest install methods (Homebrew, crates.io, GitHub Releases with shell/powershell installers) instead of the pre-release "clone and build from source" flow.

- Removes all "planned for public launch" and "not yet published" language
- Updates the smoke test to check the installation guide (not README) for the source flow

Test count: 1197 (594 unit + 603 integration)