### PR TITLE
fix: use .intoto.jsonl extension for attestation bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -351,17 +351,17 @@ jobs:
               --repo "${{ github.repository }}" 2>/dev/null; then
               for bundle in *.jsonl; do
                 [ -f "$bundle" ] || continue
-                cp "$bundle" "$OLDPWD/attestation-bundles/${name}.sigstore.jsonl"
+                cp "$bundle" "$OLDPWD/attestation-bundles/${name}.intoto.jsonl"
                 break
               done
             fi
             popd > /dev/null
             rm -rf "$tmpdir"
           done
-          # Upload all bundle files to the release (Scorecard recognizes .sigstore files)
-          if ls attestation-bundles/*.sigstore.jsonl 1>/dev/null 2>&1; then
+          # Upload all bundle files to the release (Scorecard recognizes .intoto.jsonl)
+          if ls attestation-bundles/*.intoto.jsonl 1>/dev/null 2>&1; then
             gh release upload "${{ needs.plan.outputs.tag }}" \
-              attestation-bundles/*.sigstore.jsonl \
+              attestation-bundles/*.intoto.jsonl \
               --clobber
           fi
       - name: Install cargo-cyclonedx


### PR DESCRIPTION
Scorecard Signed-Releases check recognizes `.intoto.jsonl` but not `.sigstore.jsonl`. The release workflow was uploading attestation bundles with the wrong extension, causing Scorecard to score 0/10 on Signed-Releases despite valid attestations being present.

**Changes:**
- Rename attestation bundle output from `*.sigstore.jsonl` to `*.intoto.jsonl` in the provenance job
- Retroactively renamed 9 bundles on the v0.1.0 release (done outside this PR)

**Scorecard extensions recognized:**
| Extension | Score |
|-----------|-------|
| \*.intoto.jsonl | 10/10 (SLSA provenance) |
| \*.sigstore.json | 8/10 |
| \*.sig, \*.asc | 8/10 |
| \*.sigstore.jsonl | not recognized |