### PR TITLE
fix: resolve GitHub AI code quality findings

### DIFF
--- a/scripts/fossa-filter.py
+++ b/scripts/fossa-filter.py
@@ -41,7 +41,7 @@ LLVM_EXCEPTION_LICENSES = {
 def is_false_positive(pkg: str, license_id: str, issue_type: str = "") -> bool:
     """Return True if the (package, license, type) tuple is a documented false positive."""
     # Rust compiler infrastructure: apache-2.0 WITH llvm-exception
-    if license_id in LLVM_EXCEPTION_LICENSES:
+    if pkg in LLVM_EXCEPTION_CRATES and license_id in LLVM_EXCEPTION_LICENSES:
         return True
 
     # r-efi: pure type definitions, transitively pulled by std

--- a/scripts/test_fossa_filter.py
+++ b/scripts/test_fossa_filter.py
@@ -47,6 +47,16 @@ def test_r_efi_filtered():
     assert rc == 0, f"Expected 0, got {rc}: {out}"
 
 
+def test_unknown_crate_llvm_exception_not_filtered():
+    """An unknown crate with llvm-exception license should NOT be filtered."""
+    issues = [
+        {"revisionId": "cargo+mystery-crate$0.1.0", "license": "apache-2.0 WITH llvm-exception", "type": "policy_conflict"},
+    ]
+    rc, out = run_filter(issues)
+    assert rc == 1, f"Expected 1, got {rc}: {out}"
+    assert "mystery-crate" in out
+
+
 def test_genuine_issue_not_filtered():
     issues = [
         {"revisionId": "cargo+shady-crate$0.1.0", "license": "GPL-3.0", "type": "policy_conflict"},

--- a/tests/agent/drivers/grok.py
+++ b/tests/agent/drivers/grok.py
@@ -26,7 +26,8 @@ class GrokDriver(AgentDriver):
         timeout_secs: int = 120,
         extra_env: dict | None = None,
     ) -> AgentResult:
-        env = {**os.environ, **(extra_env or {})}
+        shim_env = extra_env or {}
+        env = {**os.environ, **shim_env}
         cmd = [
             "grok",
             "-p",
@@ -59,7 +60,7 @@ class GrokDriver(AgentDriver):
                 exit_code=-1,
                 output_json=None,
                 duration_secs=time.monotonic() - start,
-                patchloom_calls=load_shim_calls(extra_env),
+                patchloom_calls=load_shim_calls(shim_env),
             )
         duration = time.monotonic() - start
 
@@ -71,7 +72,7 @@ class GrokDriver(AgentDriver):
             exit_code=proc.returncode,
             output_json=output_json,
             duration_secs=duration,
-            patchloom_calls=load_shim_calls(extra_env),
+            patchloom_calls=load_shim_calls(shim_env),
         )
 
     def is_available(self) -> bool:
@@ -110,7 +111,4 @@ class GrokDriver(AgentDriver):
             model_name=model_name,
             cli_version=cli_version,
         )
-
-
-
 


### PR DESCRIPTION
## Summary

Fixes both GitHub AI code quality findings.

### fossa-filter.py: tighten LLVM exception check

The `is_false_positive` function checked only the license string
(`apache-2.0 WITH llvm-exception`) without verifying the package name
against `LLVM_EXCEPTION_CRATES`. Any package with that license would
be silently filtered, not just known compiler infrastructure crates
like `cc` and `compiler_builtins`.

Fix: require both `pkg in LLVM_EXCEPTION_CRATES` and
`license_id in LLVM_EXCEPTION_LICENSES`.

Added regression test: `test_unknown_crate_llvm_exception_not_filtered`.

### grok.py: compute shim_env once

The `extra_env or {}` expression was evaluated inline for `env`
construction, but the raw `extra_env` (which could be `None`) was
passed to `load_shim_calls` in both the timeout and success paths.
While `load_shim_calls` handles `None` gracefully, computing
`shim_env = extra_env or {}` once and reusing it is clearer.

## Verification

- `python3 scripts/test_fossa_filter.py`: 8/8 pass (including new test)
- `make check-fast`: 603 tests pass