### PR TITLE
feat: add MCP benchmark suite (make bench-mcp)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Patchloom is a Rust CLI for agent-grade repo operations. The default build provi
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
 | `make fuzz` | Run fuzz tests (5 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |
+| `make bench-mcp` | Run MCP benchmarks: per-call latency vs CLI process spawn (not part of `check`) |
 | `make bench-agent` | Run LLM agent A/B benchmarks (requires API key, not part of `check`). Use `MODEL=X RUNS=N` to configure runs |
 | `make bench-agent-dry-run` | Preview agent benchmark prompts without calling the LLM API |
 | `make bench-agent-report` | Generate comparison report from saved agent benchmark results. Use `FILE=path` for specific file |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test integration-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit bench-cli bench-agent bench-agent-dry-run bench-agent-report fuzz
+.PHONY: help fmt fmt-check build test integration-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz
 
 .DEFAULT_GOAL := help
 
@@ -74,6 +74,9 @@ agent-test: build ## Run agent integration tests (requires LLM API key). Use MOD
 
 bench-cli: build ## Run CLI benchmarks vs native tools (requires hyperfine)
 	cd benches/cli && bash run.sh
+
+bench-mcp: ## Run MCP benchmarks: per-call latency vs CLI (no extra tools needed)
+	cd benches/mcp && bash run.sh
 
 bench-agent: build ## Run LLM agent A/B benchmarks (requires API key). Use MODEL=X RUNS=N to configure.
 	@cd tests/agent && \

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,14 +1,17 @@
 # Benchmarks
 
-Patchloom ships two benchmark suites: **CLI benchmarks** (patchloom vs native
-tools) and **agent benchmarks** (AI agent task completion with and without
-patchloom).
+Patchloom ships three benchmark suites: **CLI benchmarks** (patchloom vs native
+tools), **MCP benchmarks** (MCP per-call latency vs CLI process spawn), and
+**agent benchmarks** (AI agent task completion with and without patchloom).
 
 ## Quick start
 
 ```bash
 # CLI benchmarks (requires hyperfine, jq, yq)
 make bench-cli
+
+# MCP benchmarks (no extra tools needed)
+make bench-mcp
 
 # Agent benchmarks (requires grok CLI + API key)
 make bench-agent MODEL=sxs-claude-opus-4-6
@@ -100,6 +103,69 @@ C program doing one thing). The value proposition is:
 2. **Batched operations**: patchloom wins dramatically (6-7x) because one
    process invocation replaces N tool spawns. For AI agents, this means one
    tool call instead of N round-trips.
+
+---
+
+## MCP benchmarks
+
+**Location:** `benches/mcp/` + `tests/bench_mcp.rs`
+
+Measures the per-call latency advantage of MCP (JSON-RPC over stdio) compared
+to spawning a new CLI process for each operation. MCP amortizes process startup:
+one long-running server handles all tool calls, eliminating the cost of process
+spawn + arg parse + exit for every operation.
+
+### What is measured
+
+| Dimension | Description |
+|-----------|-------------|
+| Server startup | Time from process spawn to first tool call ready |
+| Per-call latency | Same operation via MCP (server running) vs CLI (new process) |
+| Burst throughput | 50 sequential doc_set calls: MCP vs 50 CLI process spawns |
+
+### Benchmark list
+
+- search_files (literal): `patchloom search` (MCP) vs CLI
+- search_files (regex): `patchloom search --regex` (MCP) vs CLI
+- doc_set (JSON): single key mutation (MCP) vs CLI
+- doc_set (YAML): comment-preserving edit (MCP) vs CLI
+- replace_text: string replacement (MCP) vs CLI
+- read_file: file read (MCP) vs CLI
+- fix_whitespace: tidy single file (MCP) vs CLI
+- batch (6 ops): 6-file version bump (MCP) vs CLI
+- transaction (4 ops): atomic multi-file edit (MCP) vs CLI
+
+### Prerequisites
+
+- patchloom built with MCP support (done automatically by `make bench-mcp`)
+- No extra tools needed (pure Rust benchmark using the `rmcp` client library)
+
+### Running
+
+```bash
+make bench-mcp
+```
+
+Results are printed to stdout and saved to `benches/mcp/results/`.
+
+### Methodology
+
+- Each operation runs 50 iterations after 3 warmup iterations.
+- MCP calls go through a single server instance (amortized startup).
+- CLI calls spawn a new `patchloom` process each time (full startup cost).
+- Both use the release binary for fair comparison.
+- Timing uses `std::time::Instant` for sub-microsecond precision.
+- File state is reset between iterations for write operations.
+
+### Interpreting results
+
+MCP should win on every operation because it eliminates process startup
+(~3-5ms per call on macOS). The advantage is largest for fast operations
+(read_file, doc_set) where startup dominates execution time, and smallest
+for expensive operations (multi-file search) where execution dominates.
+
+The **burst test** shows the cumulative advantage: 50 MCP calls should
+complete in roughly the time of 5-10 CLI invocations.
 
 ---
 

--- a/benches/mcp/run.sh
+++ b/benches/mcp/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# MCP benchmark runner: measures MCP JSON-RPC per-call latency vs CLI process spawn.
+# Usage: bash run.sh [ITERATIONS]
+#
+# Starts a patchloom MCP server once, sends tool calls over JSON-RPC, and
+# compares per-call latency against spawning a new CLI process for each
+# operation. Shows the amortized startup advantage of MCP for AI agents.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RESULTS_DIR="$SCRIPT_DIR/results"
+CORPUS_DIR="$SCRIPT_DIR/../cli/corpus"
+
+# Build release binary with MCP support
+echo "Building patchloom (release, all features)..."
+cargo build --release --all-features --manifest-path "$REPO_ROOT/Cargo.toml" --quiet
+
+# Generate corpus if needed (reuse CLI benchmark corpus)
+if [ ! -d "$CORPUS_DIR/small" ]; then
+    echo "Generating benchmark corpus..."
+    python3 "$SCRIPT_DIR/../cli/generate_corpus.py" small
+fi
+
+mkdir -p "$RESULTS_DIR"
+
+ITERS="${1:-50}"
+echo ""
+echo "Running MCP benchmarks (${ITERS} iterations per operation)..."
+echo ""
+
+# Run the Rust benchmark binary
+# --test-threads=1 ensures sequential execution (no interleaving output)
+cargo test --test bench_mcp --all-features --release -- \
+    --nocapture --test-threads=1 \
+    2>&1 | tee "$RESULTS_DIR/latest.log"
+
+# Extract just the markdown table from the output
+sed -n '/^# MCP Benchmark/,$ p' "$RESULTS_DIR/latest.log" > "$RESULTS_DIR/latest.md" 2>/dev/null || true
+
+echo ""
+echo "Results saved to $RESULTS_DIR/"

--- a/tests/bench_mcp.rs
+++ b/tests/bench_mcp.rs
@@ -1,0 +1,817 @@
+//! MCP benchmark: measures per-call JSON-RPC latency vs CLI process-spawn overhead.
+//!
+//! Run via `make bench-mcp` or directly:
+//! ```bash
+//! cargo test --test bench_mcp --all-features --release -- --nocapture
+//! ```
+//!
+//! This is NOT part of `make check`. It measures performance, not correctness.
+
+#[cfg(feature = "mcp")]
+mod bench {
+    use rmcp::ServiceExt;
+    use rmcp::transport::TokioChildProcess;
+    use std::path::{Path, PathBuf};
+    use std::time::{Duration, Instant};
+    use tempfile::TempDir;
+
+    const WARMUP: usize = 3;
+    const ITERATIONS: usize = 50;
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    async fn spawn_mcp_client(cwd: &Path) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
+        let bin = patchloom_bin();
+        let mut cmd = tokio::process::Command::new(bin);
+        cmd.arg("mcp-server").current_dir(cwd);
+        let transport = TokioChildProcess::new(cmd).expect("failed to spawn patchloom mcp-server");
+        ().serve(transport)
+            .await
+            .expect("failed to connect MCP client")
+    }
+
+    async fn call_tool(
+        client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
+        tool: &str,
+        args: serde_json::Value,
+    ) -> bool {
+        let params = rmcp::model::CallToolRequestParams::new(tool.to_string())
+            .with_arguments(serde_json::from_value(args).unwrap());
+        let result = client.peer().call_tool(params).await.unwrap();
+        result.is_error.unwrap_or(false)
+    }
+
+    fn patchloom_bin() -> PathBuf {
+        // Prefer release binary if it exists (bench should be run in release mode)
+        let release = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target/release/patchloom");
+        if release.exists() {
+            return release;
+        }
+        assert_cmd::cargo::cargo_bin("patchloom")
+    }
+
+    fn run_cli(bin: &Path, args: &[&str], cwd: &Path) -> Duration {
+        let start = Instant::now();
+        let output = std::process::Command::new(bin)
+            .args(args)
+            .current_dir(cwd)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .output()
+            .expect("failed to run patchloom CLI");
+        let elapsed = start.elapsed();
+        // Allow exit codes 0 (success), 2 (changes detected), 3 (no matches)
+        assert!(
+            [0, 2, 3].contains(&output.status.code().unwrap_or(-1)),
+            "CLI failed with exit code {:?} for args {:?}",
+            output.status.code(),
+            args
+        );
+        elapsed
+    }
+
+    /// Run N iterations, discard warmup, return sorted durations.
+    fn stats(durations: &[Duration]) -> (Duration, Duration, Duration) {
+        let mut sorted: Vec<Duration> = durations.to_vec();
+        sorted.sort();
+        let sum: Duration = sorted.iter().sum();
+        let mean = sum / sorted.len() as u32;
+        let min = sorted[0];
+        let max = sorted[sorted.len() - 1];
+        (mean, min, max)
+    }
+
+    fn format_us(d: Duration) -> String {
+        let us = d.as_micros();
+        if us >= 1_000_000 {
+            format!("{:.1}s", d.as_secs_f64())
+        } else if us >= 1_000 {
+            format!("{:.2}ms", us as f64 / 1_000.0)
+        } else {
+            format!("{}us", us)
+        }
+    }
+
+    /// Create a temp workspace with files needed for benchmarks.
+    fn create_workspace() -> TempDir {
+        let dir = TempDir::new().unwrap();
+        let p = dir.path();
+
+        // JSON config
+        std::fs::write(
+            p.join("config.json"),
+            r#"{"name":"bench","version":"v1.0.0","debug":false}"#,
+        )
+        .unwrap();
+
+        // YAML config with comments
+        std::fs::write(
+            p.join("config.yaml"),
+            "# Application configuration\n\
+             app:\n\
+             \x20 name: bench  # project name\n\
+             \x20 version: 'v1.0.0'  # current release\n\
+             \x20 debug: false\n",
+        )
+        .unwrap();
+
+        // TOML config
+        std::fs::write(
+            p.join("config.toml"),
+            "# Application configuration\n\
+             [app]\n\
+             name = \"bench\"  # project name\n\
+             version = \"v1.0.0\"  # current release\n\
+             debug = false\n",
+        )
+        .unwrap();
+
+        // package.json
+        std::fs::write(
+            p.join("package.json"),
+            r#"{"name":"bench","version":"v1.0.0","main":"index.js"}"#,
+        )
+        .unwrap();
+
+        // VERSION file
+        std::fs::write(p.join("VERSION"), "v1.0.0\n").unwrap();
+
+        // README with table and changelog
+        std::fs::write(
+            p.join("README.md"),
+            "# Bench Project\n\n\
+             ## Commands\n\n\
+             | Command | Description |\n\
+             |---------|-------------|\n\
+             | build | Build the project |\n\
+             | test | Run tests |\n\n\
+             ## Changelog\n\n\
+             - v1.0.0 initial release\n",
+        )
+        .unwrap();
+
+        // Source files for search benchmarks
+        let src = p.join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        for i in 0..20 {
+            let content = format!(
+                "// TODO: implement feature {i}\n\
+                 fn process_{i}(data: &str) -> String {{\n\
+                 \x20   data.to_uppercase()\n\
+                 }}\n\n\
+                 // v1.0.0 release code\n\
+                 fn helper_{i}() {{}}\n"
+            );
+            std::fs::write(src.join(format!("file_{i:03}.rs")), content).unwrap();
+        }
+
+        // Files with tidy issues
+        let tidy = p.join("tidy_test");
+        std::fs::create_dir_all(&tidy).unwrap();
+        for i in 0..10 {
+            std::fs::write(
+                tidy.join(format!("dirty_{i}.txt")),
+                "line one   \nline two\nno final newline",
+            )
+            .unwrap();
+        }
+
+        dir
+    }
+
+    fn reset_config_files(dir: &Path) {
+        std::fs::write(
+            dir.join("config.json"),
+            r#"{"name":"bench","version":"v1.0.0","debug":false}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("config.yaml"),
+            "# Application configuration\n\
+             app:\n\
+             \x20 name: bench  # project name\n\
+             \x20 version: 'v1.0.0'  # current release\n\
+             \x20 debug: false\n",
+        )
+        .unwrap();
+    }
+
+    struct BenchResult {
+        name: String,
+        mcp_mean: Duration,
+        mcp_min: Duration,
+        mcp_max: Duration,
+        cli_mean: Duration,
+        cli_min: Duration,
+        cli_max: Duration,
+    }
+
+    impl BenchResult {
+        fn speedup(&self) -> f64 {
+            self.cli_mean.as_secs_f64() / self.mcp_mean.as_secs_f64()
+        }
+
+        fn winner(&self) -> &str {
+            let ratio = self.speedup();
+            if ratio > 1.2 {
+                "MCP"
+            } else if ratio < 0.83 {
+                "CLI"
+            } else {
+                "~tied"
+            }
+        }
+    }
+
+    // ── Main benchmark ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn bench_mcp_vs_cli() {
+        let dir = create_workspace();
+        let cwd = dir.path();
+        let bin = patchloom_bin();
+
+        // 1. Measure server startup
+        let startup_start = Instant::now();
+        let client = spawn_mcp_client(cwd).await;
+        let startup_time = startup_start.elapsed();
+
+        let mut results: Vec<BenchResult> = Vec::new();
+
+        // ── search_files (literal) ──────────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "search_files",
+                    serde_json::json!({"pattern": "TODO", "paths": ["src"], "literal": true}),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                let elapsed = run_cli(&bin, &["search", "TODO", "src"], cwd);
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "search (literal)".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── search_files (regex) ────────────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "search_files",
+                    serde_json::json!({"pattern": "fn \\w+\\(", "paths": ["src"]}),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                let elapsed = run_cli(&bin, &["search", "--regex", r"fn \w+\(", "src"], cwd);
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "search (regex)".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── doc_set (JSON) ──────────────────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_config_files(cwd);
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "doc_set",
+                    serde_json::json!({"path": "config.json", "selector": "version", "value": "v2.0.0"}),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_config_files(cwd);
+                let elapsed = run_cli(
+                    &bin,
+                    &["doc", "set", "config.json", "version", "v2.0.0", "--apply"],
+                    cwd,
+                );
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "doc_set (JSON)".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── doc_set (YAML) ──────────────────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_config_files(cwd);
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "doc_set",
+                    serde_json::json!({"path": "config.yaml", "selector": "app.version", "value": "v2.0.0"}),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_config_files(cwd);
+                let elapsed = run_cli(
+                    &bin,
+                    &[
+                        "doc",
+                        "set",
+                        "config.yaml",
+                        "app.version",
+                        "v2.0.0",
+                        "--apply",
+                    ],
+                    cwd,
+                );
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "doc_set (YAML)".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── replace_text ────────────────────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                // Reset: write v1.0.0 back into VERSION
+                std::fs::write(cwd.join("VERSION"), "v1.0.0\n").unwrap();
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "replace_text",
+                    serde_json::json!({
+                        "path": "VERSION",
+                        "from": "v1.0.0",
+                        "to": "v2.0.0"
+                    }),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                std::fs::write(cwd.join("VERSION"), "v1.0.0\n").unwrap();
+                let elapsed = run_cli(
+                    &bin,
+                    &["replace", "v1.0.0", "--to", "v2.0.0", "VERSION", "--apply"],
+                    cwd,
+                );
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "replace_text".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── read_file ───────────────────────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "read_file",
+                    serde_json::json!({"path": "config.json"}),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                let elapsed = run_cli(&bin, &["read", "config.json"], cwd);
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "read_file".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── fix_whitespace (tidy) ───────────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+            let tidy_file = "tidy_test/dirty_0.txt";
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_tidy_files(cwd);
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "fix_whitespace",
+                    serde_json::json!({"path": tidy_file}),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_tidy_files(cwd);
+                let elapsed = run_cli(&bin, &["tidy", "--apply", tidy_file], cwd);
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "fix_whitespace".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── batch (6-file version bump) ─────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+
+            let batch_ops = vec![
+                r#"doc.set config.json version "v2.0.0""#,
+                r#"doc.set config.yaml app.version "v2.0.0""#,
+                r#"doc.set config.toml app.version "v2.0.0""#,
+                r#"doc.set package.json version "v2.0.0""#,
+                r#"replace VERSION "v1.0.0" "v2.0.0""#,
+                r#"replace README.md "v1.0.0" "v2.0.0""#,
+            ];
+
+            let batch_file = cwd.join("_bench_batch.txt");
+            std::fs::write(&batch_file, batch_ops.join("\n")).unwrap();
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_all_files(cwd);
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "batch",
+                    serde_json::json!({"operations": batch_ops}),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            let batch_path_str = batch_file.to_str().unwrap().to_string();
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_all_files(cwd);
+                let elapsed = run_cli(&bin, &["batch", &batch_path_str, "--apply"], cwd);
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            std::fs::remove_file(&batch_file).ok();
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "batch (6 ops)".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── transaction (4-file atomic) ─────────────────────────────
+        {
+            let mut mcp_times = Vec::new();
+            let mut cli_times = Vec::new();
+
+            let tx_plan_str = serde_json::json!({
+                "version": "1",
+                "operations": [
+                    {"op": "doc.set", "path": "config.json", "selector": "version", "value": "v2.0.0"},
+                    {"op": "doc.set", "path": "config.yaml", "selector": "app.version", "value": "v2.0.0"},
+                    {"op": "replace", "path": "VERSION", "from": "v1.0.0", "to": "v2.0.0"},
+                    {"op": "md.upsert_bullet", "path": "README.md", "heading": "Changelog", "bullet": "- v2.0.0 release"}
+                ]
+            }).to_string();
+
+            let tx_file = cwd.join("_bench_tx.json");
+            std::fs::write(&tx_file, &tx_plan_str).unwrap();
+
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_all_files(cwd);
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "transaction",
+                    serde_json::json!({"plan": tx_plan_str}),
+                )
+                .await;
+                let elapsed = start.elapsed();
+                if i >= WARMUP {
+                    mcp_times.push(elapsed);
+                }
+            }
+
+            let tx_path_str = tx_file.to_str().unwrap().to_string();
+            for i in 0..(WARMUP + ITERATIONS) {
+                reset_all_files(cwd);
+                let elapsed = run_cli(&bin, &["tx", &tx_path_str, "--apply"], cwd);
+                if i >= WARMUP {
+                    cli_times.push(elapsed);
+                }
+            }
+
+            std::fs::remove_file(&tx_file).ok();
+
+            let (mcp_mean, mcp_min, mcp_max) = stats(&mcp_times);
+            let (cli_mean, cli_min, cli_max) = stats(&cli_times);
+            results.push(BenchResult {
+                name: "transaction (4 ops)".to_string(),
+                mcp_mean,
+                mcp_min,
+                mcp_max,
+                cli_mean,
+                cli_min,
+                cli_max,
+            });
+        }
+
+        // ── Burst: 50 sequential doc_set via MCP vs 50 CLI spawns ──
+        let burst_n = 50;
+        let mut burst_mcp_total = Duration::ZERO;
+        let mut burst_cli_total = Duration::ZERO;
+        {
+            // MCP burst
+            for j in 0..burst_n {
+                reset_config_files(cwd);
+                let val = format!("v{}.0.0", j + 2);
+                let start = Instant::now();
+                call_tool(
+                    &client,
+                    "doc_set",
+                    serde_json::json!({"path": "config.json", "selector": "version", "value": val}),
+                )
+                .await;
+                burst_mcp_total += start.elapsed();
+            }
+
+            // CLI burst
+            for j in 0..burst_n {
+                reset_config_files(cwd);
+                let val = format!("v{}.0.0", j + 2);
+                let start = Instant::now();
+                let output = std::process::Command::new(&bin)
+                    .args(["doc", "set", "config.json", "version", &val, "--apply"])
+                    .current_dir(cwd)
+                    .stdout(std::process::Stdio::null())
+                    .stderr(std::process::Stdio::null())
+                    .output()
+                    .unwrap();
+                burst_cli_total += start.elapsed();
+                assert!(output.status.success());
+            }
+        }
+
+        // Shut down server gracefully
+        drop(client);
+
+        // ── Print results ───────────────────────────────────────────
+
+        println!();
+        println!("# MCP Benchmark Results");
+        println!();
+        println!("Server startup: {}", format_us(startup_time));
+        println!(
+            "Iterations per operation: {} (+ {} warmup)",
+            ITERATIONS, WARMUP
+        );
+        println!();
+        println!(
+            "| Operation | MCP mean | MCP min | MCP max | CLI mean | CLI min | CLI max | Speedup | Winner |"
+        );
+        println!(
+            "|:----------|:---------|:--------|:--------|:---------|:--------|:--------|--------:|:-------|"
+        );
+
+        for r in &results {
+            println!(
+                "| {} | {} | {} | {} | {} | {} | {} | {:.1}x | {} |",
+                r.name,
+                format_us(r.mcp_mean),
+                format_us(r.mcp_min),
+                format_us(r.mcp_max),
+                format_us(r.cli_mean),
+                format_us(r.cli_min),
+                format_us(r.cli_max),
+                r.speedup(),
+                r.winner(),
+            );
+        }
+
+        println!();
+        println!("## Burst test: {} sequential doc_set calls", burst_n);
+        println!();
+        println!("| Mode | Total | Per-call avg | Speedup |");
+        println!("|:-----|:------|:-------------|--------:|");
+        let burst_speedup = burst_cli_total.as_secs_f64() / burst_mcp_total.as_secs_f64();
+        println!(
+            "| MCP | {} | {} | |",
+            format_us(burst_mcp_total),
+            format_us(burst_mcp_total / burst_n as u32),
+        );
+        println!(
+            "| CLI | {} | {} | {:.1}x slower |",
+            format_us(burst_cli_total),
+            format_us(burst_cli_total / burst_n as u32),
+            burst_speedup,
+        );
+        println!();
+        println!(
+            "MCP amortizes process startup: {} saved over {} calls.",
+            format_us(burst_cli_total.saturating_sub(burst_mcp_total)),
+            burst_n,
+        );
+    }
+
+    fn reset_tidy_files(dir: &Path) {
+        let tidy = dir.join("tidy_test");
+        for i in 0..10 {
+            std::fs::write(
+                tidy.join(format!("dirty_{i}.txt")),
+                "line one   \nline two\nno final newline",
+            )
+            .unwrap();
+        }
+    }
+
+    fn reset_all_files(dir: &Path) {
+        std::fs::write(
+            dir.join("config.json"),
+            r#"{"name":"bench","version":"v1.0.0","debug":false}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("config.yaml"),
+            "# Application configuration\n\
+             app:\n\
+             \x20 name: bench  # project name\n\
+             \x20 version: 'v1.0.0'  # current release\n\
+             \x20 debug: false\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("config.toml"),
+            "# Application configuration\n\
+             [app]\n\
+             name = \"bench\"  # project name\n\
+             version = \"v1.0.0\"  # current release\n\
+             debug = false\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.join("package.json"),
+            r#"{"name":"bench","version":"v1.0.0","main":"index.js"}"#,
+        )
+        .unwrap();
+        std::fs::write(dir.join("VERSION"), "v1.0.0\n").unwrap();
+        std::fs::write(
+            dir.join("README.md"),
+            "# Bench Project\n\n\
+             ## Commands\n\n\
+             | Command | Description |\n\
+             |---------|-------------|\n\
+             | build | Build the project |\n\
+             | test | Run tests |\n\n\
+             ## Changelog\n\n\
+             - v1.0.0 initial release\n",
+        )
+        .unwrap();
+    }
+}
+
+#[cfg(not(feature = "mcp"))]
+#[test]
+fn bench_mcp_requires_mcp_feature() {
+    eprintln!("MCP benchmarks require --all-features. Skipping.");
+}


### PR DESCRIPTION
Add benchmarks measuring MCP JSON-RPC per-call latency vs CLI process-spawn overhead. MCP amortizes startup: one long-running server handles all tool calls, eliminating process spawn + arg parse + exit cost for every operation.

## What it measures

| Dimension | Description |
|-----------|-------------|
| Server startup | Time from process spawn to first tool call ready |
| Per-call latency | Same operation via MCP (server running) vs CLI (new process) |
| Burst throughput | 50 sequential doc_set calls: MCP vs 50 CLI process spawns |

## Benchmark results (Apple Silicon)

| Operation | MCP mean | CLI mean | Speedup | Winner |
|:----------|:---------|:---------|--------:|:-------|
| search (literal) | 2.65ms | 4.70ms | 1.8x | MCP |
| search (regex) | 3.00ms | 5.03ms | 1.7x | MCP |
| doc_set (JSON) | 515us | 2.36ms | 4.6x | MCP |
| doc_set (YAML) | 636us | 2.56ms | 4.0x | MCP |
| replace_text | 696us | 5.40ms | 7.7x | MCP |
| read_file | 167us | 1.75ms | 10.5x | MCP |
| fix_whitespace | 834us | 1.72ms | 2.1x | MCP |
| batch (6 ops) | 2.05ms | 4.20ms | 2.0x | MCP |
| transaction (4 ops) | 1.71ms | 3.68ms | 2.2x | MCP |

Burst test (50 sequential doc_set): MCP 55ms total vs CLI 160ms total (2.9x faster).

## Files

- `tests/bench_mcp.rs`: Rust benchmark binary using rmcp client
- `benches/mcp/run.sh`: Shell wrapper
- `Makefile`: `bench-mcp` target
- `AGENTS.md`: Document new command
- `benches/README.md`: MCP benchmark section