### PR TITLE
feat: structured JSON APIs for batch and transaction MCP tools

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -93,25 +93,29 @@ fix_whitespace({"path": "src/main.py"})
 
 ### Batching (the main speed win)
 
-Use `batch` to make multiple edits in one call. Each operation is a string in patchloom's line-oriented format:
+Use `batch` to make multiple edits in one call. Pass structured objects with an `op` field (no quoting needed):
 
 ```json
 batch({"operations": [
-"doc.set config.json version \"2.0.0\"",
-"doc.set config.yaml app.version \"2.0.0\"",
-"replace README.md \"1.0.0\" \"2.0.0\"",
-"file.create hello.txt \"Hello, World!\"",
-"file.rename old.txt new.txt",
-"md.upsert_bullet CHANGELOG.md \"## Changes\" \"- Bumped to 2.0.0\""
+{"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
+{"op": "doc.set", "path": "config.yaml", "selector": "app.version", "value": "2.0.0"},
+{"op": "replace", "path": "README.md", "from": "1.0.0", "to": "2.0.0"},
+{"op": "file.create", "path": "hello.txt", "content": "Hello, World!"},
+{"op": "file.rename", "from": "old.txt", "to": "new.txt"},
+{"op": "md.upsert_bullet", "path": "CHANGELOG.md", "heading": "## Changes", "bullet": "- Bumped to 2.0.0"}
 ]})
 ```
 
 ### Transactions (atomic multi-file edits)
 
-Use `transaction` for atomic operations that roll back on failure. The `plan` parameter is a JSON string:
+Use `transaction` when all operations must succeed or all roll back. Pass an `operations` array directly (no plan string needed):
 
 ```json
-transaction({"plan": "{\"version\": \"1\", \"operations\": [{\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"}, {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}, {\"op\": \"file.create\", \"path\": \"hello.txt\", \"content\": \"Hello!\"}]}"})
+transaction({"operations": [
+{"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
+{"op": "replace", "path": "README.md", "from": "1.0.0", "to": "2.0.0"},
+{"op": "file.create", "path": "hello.txt", "content": "Hello!"}
+]})
 ```
 
 All operations succeed together or roll back.
@@ -120,14 +124,42 @@ All operations succeed together or roll back.
 
 ```json
 batch({"operations": [
-"doc.set package.json version \"2.0.0\"",
-"doc.set config.yaml app.version \"2.0.0\"",
-"doc.set config.json version \"2.0.0\"",
-"doc.set pyproject.toml project.version \"2.0.0\"",
-"replace version.txt \"1.0.0\" \"2.0.0\"",
-"replace README.md \"1.0.0\" \"2.0.0\""
+{"op": "doc.set", "path": "package.json", "selector": "version", "value": "2.0.0"},
+{"op": "doc.set", "path": "config.yaml", "selector": "app.version", "value": "2.0.0"},
+{"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
+{"op": "doc.set", "path": "pyproject.toml", "selector": "project.version", "value": "2.0.0"},
+{"op": "replace", "path": "version.txt", "from": "1.0.0", "to": "2.0.0"},
+{"op": "replace", "path": "README.md", "from": "1.0.0", "to": "2.0.0"}
 ]})
 ```
+
+### Tidy: fix whitespace in all files
+
+```json
+batch({"operations": [
+{"op": "tidy.fix", "path": "dirty1.txt"},
+{"op": "tidy.fix", "path": "dirty2.txt"}
+]})
+```
+
+Available operation types for batch and transaction:
+
+| op | Required fields | Description |
+|---|---|---|
+| `doc.set` | path, selector, value | Set a key in JSON/YAML/TOML |
+| `doc.delete` | path, selector | Delete a key |
+| `doc.merge` | path, value | Deep-merge an object |
+| `doc.append` | path, selector, value | Append to an array |
+| `replace` | path, from, to | Replace text in a file |
+| `file.create` | path, content | Create a file |
+| `file.delete` | path | Delete a file |
+| `file.rename` | from, to | Rename/move a file |
+| `tidy.fix` | path | Fix whitespace (trim trailing, ensure newline) |
+| `md.upsert_bullet` | path, heading, bullet | Add/update bullet under heading |
+| `md.table_append` | path, heading, row | Append row to table |
+| `md.replace_section` | path, heading, content | Replace section content |
+| `md.insert_after_heading` | path, heading, content | Insert after heading |
+| `patch.apply` | diff | Apply a unified diff |
 
 ## Batching (the main speed win)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1201%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1206%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -382,7 +382,7 @@ flowchart LR
 
 ## Status
 
-1201 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1206 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -118,8 +118,8 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `delete_file` | Delete a file |
 | `move_file` | Move or rename a file (binary-safe) |
 | `apply_patch` | Apply a unified diff |
-| `batch` | Run multiple operations in one call |
-| `transaction` | Execute a full transaction plan with format/validate lifecycle |
+| `batch` | Run multiple operations in one call (structured objects or line-format strings) |
+| `transaction` | Execute atomic multi-file edits with optional format/validate lifecycle |
 
 ## How MCP mode differs from CLI mode
 
@@ -135,7 +135,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 
 The MCP server enforces path containment: all file paths must resolve within the working directory where `patchloom mcp-server` was started. Absolute paths, `../` traversal, and symlinks escaping the working directory are rejected. This prevents an agent from accidentally (or maliciously) editing files outside the project.
 
-The `batch` tool parses its operations line by line and validates every path before execution. The `transaction` tool accepts full transaction plans. All operation paths and plan-level `cwd` fields are validated for containment before execution. A relative transaction `cwd` still resolves from the server invocation root, then must remain inside that root.
+The `batch` tool accepts operations as structured JSON objects (with an `op` field) or as line-format strings, and validates every path before execution. The `transaction` tool accepts either an `operations` array directly or a full plan string. All operation paths and plan-level `cwd` fields are validated for containment before execution. A relative transaction `cwd` still resolves from the server invocation root, then must remain inside that root.
 
 ### Shell execution gate
 
@@ -167,7 +167,7 @@ An MCP-capable agent sends:
 
 Patchloom parses the YAML, changes `database.port` to `5432`, preserves all comments and formatting, and writes the file. The agent receives a success response with no further action needed.
 
-For multi-file edits with post-write formatting and validation, use `transaction`:
+For multi-file atomic edits, use `transaction` with a structured `operations` array:
 
 ```json
 {
@@ -175,10 +175,27 @@ For multi-file edits with post-write formatting and validation, use `transaction
   "params": {
     "name": "transaction",
     "arguments": {
-      "plan": "{\"version\":\"1\",\"operations\":[{\"op\":\"replace\",\"path\":\"src/main.rs\",\"from\":\"v1\",\"to\":\"v2\"},{\"op\":\"doc.set\",\"path\":\"Cargo.toml\",\"selector\":\"package.version\",\"value\":\"2.0.0\"}],\"format\":[{\"cmd\":\"cargo fmt\"}],\"validate\":[{\"cmd\":\"cargo test\",\"required\":true}]}"
+      "operations": [
+        {"op": "replace", "path": "src/main.rs", "from": "v1", "to": "v2"},
+        {"op": "doc.set", "path": "Cargo.toml", "selector": "package.version", "value": "2.0.0"}
+      ]
     }
   }
 }
 ```
 
-This replaces text in `src/main.rs`, updates the version in `Cargo.toml`, runs `cargo fmt`, and verifies with `cargo test`. If any step fails, the transaction reports the error. With `"strict": true`, writes are rolled back on format or validate failure.
+All operations succeed together or roll back. For advanced use with post-write formatting and validation, use the `plan` string parameter instead:
+
+```json
+{
+  "method": "tools/call",
+  "params": {
+    "name": "transaction",
+    "arguments": {
+      "plan": "{\"version\":\"1\",\"operations\":[{\"op\":\"replace\",\"path\":\"src/main.rs\",\"from\":\"v1\",\"to\":\"v2\"}],\"format\":[{\"cmd\":\"cargo fmt\"}],\"validate\":[{\"cmd\":\"cargo test\",\"required\":true}]}"
+    }
+  }
+}
+```
+
+The `plan` string supports `format` and `validate` lifecycle steps (requires `--allow-shell`). With `"strict": true`, writes are rolled back on format or validate failure.

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -205,14 +205,18 @@ pub struct MdInsertParams {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[serde(deny_unknown_fields)]
 pub struct TxParams {
     /// Transaction plan as a JSON, YAML, or TOML string. Must include
     /// "version" and "operations". May include "format", "validate",
     /// "write_policy", "strict", and "cwd".
-    pub plan: String,
+    /// Either `plan` or `operations` must be provided, not both.
+    pub plan: Option<String>,
     /// Plan format: "json", "yaml", or "toml". Auto-detected if omitted.
     pub format: Option<String>,
+    /// Operations array (alternative to plan). Creates a simple plan
+    /// with version "1" and these operations. All succeed or all roll back.
+    /// Example: [{"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"}]
+    pub operations: Option<Vec<Operation>>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -260,12 +264,26 @@ pub struct PatchParams {
     pub diff: String,
 }
 
+/// A single batch operation: either a line-format string or a structured object.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum BatchOperation {
+    /// Structured operation object with `op` field (preferred for MCP).
+    /// Example: {"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"}
+    Structured(Operation),
+    /// Line-format string (legacy).
+    /// Example: "doc.set config.json version \"2.0.0\""
+    Line(String),
+}
+
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BatchParams {
-    /// List of operations, one per string, in line-oriented batch format.
-    /// Example: ["doc.set config.json version \"2.0.0\"", "replace README.md \"old\" \"new\""]
-    pub operations: Vec<String>,
+    /// List of operations. Each item can be either a structured object with an "op" field
+    /// (e.g. {"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"})
+    /// or a line-format string (e.g. "doc.set config.json version \"2.0.0\"").
+    /// Structured objects are recommended because they avoid quoting issues.
+    pub operations: Vec<BatchOperation>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -500,6 +518,8 @@ pub struct PatchloomService {
     /// Whether tx plans may include format/validate lifecycle steps that
     /// execute shell commands. Controlled by `--allow-shell` on startup.
     allow_shell: bool,
+    /// Optional path for logging MCP tool calls (set via `PATCHLOOM_MCP_LOG`).
+    call_log: Option<PathBuf>,
 }
 
 impl PatchloomService {
@@ -507,12 +527,38 @@ impl PatchloomService {
         let canon_cwd = cwd
             .canonicalize()
             .with_context(|| format!("failed to canonicalize cwd: {}", cwd.display()))?;
+        let call_log = std::env::var_os("PATCHLOOM_MCP_LOG").map(PathBuf::from);
         Ok(Self {
             tool_router: Self::tool_router(),
             cwd,
             canon_cwd,
             allow_shell,
+            call_log,
         })
+    }
+
+    /// Log a tool call if `PATCHLOOM_MCP_LOG` is set.
+    #[expect(dead_code)] // Will be wired up incrementally.
+    fn log_call(&self, tool: &str, params: &impl serde::Serialize, success: bool) {
+        if let Some(ref log_path) = self.call_log {
+            let entry = serde_json::json!({
+                "tool": tool,
+                "params": params,
+                "success": success,
+                "timestamp": std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis())
+                    .unwrap_or(0),
+            });
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(log_path)
+            {
+                use std::io::Write;
+                let _ = writeln!(f, "{entry}");
+            }
+        }
     }
 
     /// Validate a path for both syntactic containment and symlink resolution.
@@ -1136,16 +1182,39 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Execute a full transaction plan. Accepts a JSON/YAML/TOML plan string with operations, optional format/validate lifecycle steps, strict mode, and write_policy. This is the most powerful tool: use it when you need atomic multi-file edits with post-write formatting (cargo fmt, prettier), validation (tests, lints), and rollback on failure."
+        description = "Execute a transaction: all operations succeed or all roll back. Pass operations as a JSON array (recommended) or as a plan string. Example: {\"operations\": [{\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"}, {\"op\": \"file.create\", \"path\": \"hello.txt\", \"content\": \"Hello!\"}]}"
     )]
     async fn transaction(
         &self,
         Parameters(p): Parameters<TxParams>,
     ) -> Result<CallToolResult, McpError> {
-        let plan =
-            crate::plan::parse_plan_auto(&p.plan, None, p.format.as_deref()).map_err(|e| {
+        // Accept either structured operations array or plan string
+        let plan = if let Some(ops) = p.operations {
+            if p.plan.is_some() {
+                return Err(McpError::invalid_params(
+                    "provide either 'operations' or 'plan', not both".to_string(),
+                    None,
+                ));
+            }
+            Plan {
+                version: "1".to_string(),
+                cwd: None,
+                write_policy: None,
+                strict: false,
+                operations: ops,
+                format: None,
+                validate: None,
+            }
+        } else if let Some(ref plan_str) = p.plan {
+            crate::plan::parse_plan_auto(plan_str, None, p.format.as_deref()).map_err(|e| {
                 McpError::invalid_params(format!("failed to parse transaction plan: {e}"), None)
-            })?;
+            })?
+        } else {
+            return Err(McpError::invalid_params(
+                "either 'operations' or 'plan' must be provided".to_string(),
+                None,
+            ));
+        };
 
         // Gate: format/validate lifecycle steps execute shell commands.
         // Require --allow-shell on the MCP server to permit them.
@@ -1308,7 +1377,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Execute multiple operations atomically. Each string is one line in batch format: 'doc.set config.json version \"2.0\"'"
+        description = "Execute multiple operations in one call. Accepts structured objects (recommended) or line-format strings. Example: [{\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"}, {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"old\", \"to\": \"new\"}]"
     )]
     async fn batch(
         &self,
@@ -1322,17 +1391,22 @@ impl PatchloomService {
             ))]));
         }
         let mut operations = Vec::new();
-        for (i, line) in p.operations.iter().enumerate() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() || trimmed.starts_with('#') {
-                continue;
-            }
-            match crate::cmd::batch::parse_line(trimmed, i + 1) {
-                Ok(op) => operations.push(op),
-                Err(e) => {
-                    return Ok(CallToolResult::error(vec![Content::text(format!(
-                        "Parse error: {e}",
-                    ))]));
+        for (i, batch_op) in p.operations.into_iter().enumerate() {
+            match batch_op {
+                BatchOperation::Structured(op) => operations.push(op),
+                BatchOperation::Line(line) => {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() || trimmed.starts_with('#') {
+                        continue;
+                    }
+                    match crate::cmd::batch::parse_line(trimmed, i + 1) {
+                        Ok(op) => operations.push(op),
+                        Err(e) => {
+                            return Ok(CallToolResult::error(vec![Content::text(format!(
+                                "Parse error: {e}",
+                            ))]));
+                        }
+                    }
                 }
             }
         }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -239,40 +239,64 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              fix_whitespace({\"path\": \"src/main.py\"})\n\
              ```\n\n\
              ### Batching (the main speed win)\n\n\
-             Use `batch` to make multiple edits in one call. Each operation is a string \
-             in patchloom's line-oriented format:\n\n\
+             Use `batch` to make multiple edits in one call. Pass structured objects \
+             with an `op` field (no quoting needed):\n\n\
              ```json\n\
              batch({\"operations\": [\n\
-               \"doc.set config.json version \\\"2.0.0\\\"\",\n\
-               \"doc.set config.yaml app.version \\\"2.0.0\\\"\",\n\
-               \"replace README.md \\\"1.0.0\\\" \\\"2.0.0\\\"\",\n\
-               \"file.create hello.txt \\\"Hello, World!\\\"\",\n\
-               \"file.rename old.txt new.txt\",\n\
-               \"md.upsert_bullet CHANGELOG.md \\\"## Changes\\\" \\\"- Bumped to 2.0.0\\\"\"\n\
+               {\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"},\n\
+               {\"op\": \"doc.set\", \"path\": \"config.yaml\", \"selector\": \"app.version\", \"value\": \"2.0.0\"},\n\
+               {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"},\n\
+               {\"op\": \"file.create\", \"path\": \"hello.txt\", \"content\": \"Hello, World!\"},\n\
+               {\"op\": \"file.rename\", \"from\": \"old.txt\", \"to\": \"new.txt\"},\n\
+               {\"op\": \"md.upsert_bullet\", \"path\": \"CHANGELOG.md\", \"heading\": \"## Changes\", \"bullet\": \"- Bumped to 2.0.0\"}\n\
              ]})\n\
              ```\n\n\
              ### Transactions (atomic multi-file edits)\n\n\
-             Use `transaction` for atomic operations that roll back on failure. \
-             The `plan` parameter is a JSON string:\n\n\
+             Use `transaction` when all operations must succeed or all roll back. \
+             Pass an `operations` array directly (no plan string needed):\n\n\
              ```json\n\
-             transaction({\"plan\": \"{\\\"version\\\": \\\"1\\\", \\\"operations\\\": [\
-             {\\\"op\\\": \\\"doc.set\\\", \\\"path\\\": \\\"config.json\\\", \\\"selector\\\": \\\"version\\\", \\\"value\\\": \\\"2.0.0\\\"}, \
-             {\\\"op\\\": \\\"replace\\\", \\\"path\\\": \\\"README.md\\\", \\\"from\\\": \\\"1.0.0\\\", \\\"to\\\": \\\"2.0.0\\\"}, \
-             {\\\"op\\\": \\\"file.create\\\", \\\"path\\\": \\\"hello.txt\\\", \\\"content\\\": \\\"Hello!\\\"}\
-             ]}\"})\n\
+             transaction({\"operations\": [\n\
+               {\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"},\n\
+               {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"},\n\
+               {\"op\": \"file.create\", \"path\": \"hello.txt\", \"content\": \"Hello!\"}\n\
+             ]})\n\
              ```\n\n\
              All operations succeed together or roll back.\n\n\
              ### Workflow: bump version across 6 files\n\n\
              ```json\n\
              batch({\"operations\": [\n\
-               \"doc.set package.json version \\\"2.0.0\\\"\",\n\
-               \"doc.set config.yaml app.version \\\"2.0.0\\\"\",\n\
-               \"doc.set config.json version \\\"2.0.0\\\"\",\n\
-               \"doc.set pyproject.toml project.version \\\"2.0.0\\\"\",\n\
-               \"replace version.txt \\\"1.0.0\\\" \\\"2.0.0\\\"\",\n\
-               \"replace README.md \\\"1.0.0\\\" \\\"2.0.0\\\"\"\n\
+               {\"op\": \"doc.set\", \"path\": \"package.json\", \"selector\": \"version\", \"value\": \"2.0.0\"},\n\
+               {\"op\": \"doc.set\", \"path\": \"config.yaml\", \"selector\": \"app.version\", \"value\": \"2.0.0\"},\n\
+               {\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"},\n\
+               {\"op\": \"doc.set\", \"path\": \"pyproject.toml\", \"selector\": \"project.version\", \"value\": \"2.0.0\"},\n\
+               {\"op\": \"replace\", \"path\": \"version.txt\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"},\n\
+               {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}\n\
              ]})\n\
-             ```\n\n",
+             ```\n\n\
+             ### Tidy: fix whitespace in all files\n\n\
+             ```json\n\
+             batch({\"operations\": [\n\
+               {\"op\": \"tidy.fix\", \"path\": \"dirty1.txt\"},\n\
+               {\"op\": \"tidy.fix\", \"path\": \"dirty2.txt\"}\n\
+             ]})\n\
+             ```\n\n\
+             Available operation types for batch and transaction:\n\n\
+             | op | Required fields | Description |\n\
+             |---|---|---|\n\
+             | `doc.set` | path, selector, value | Set a key in JSON/YAML/TOML |\n\
+             | `doc.delete` | path, selector | Delete a key |\n\
+             | `doc.merge` | path, value | Deep-merge an object |\n\
+             | `doc.append` | path, selector, value | Append to an array |\n\
+             | `replace` | path, from, to | Replace text in a file |\n\
+             | `file.create` | path, content | Create a file |\n\
+             | `file.delete` | path | Delete a file |\n\
+             | `file.rename` | from, to | Rename/move a file |\n\
+             | `tidy.fix` | path | Fix whitespace (trim trailing, ensure newline) |\n\
+             | `md.upsert_bullet` | path, heading, bullet | Add/update bullet under heading |\n\
+             | `md.table_append` | path, heading, row | Append row to table |\n\
+             | `md.replace_section` | path, heading, content | Replace section content |\n\
+             | `md.insert_after_heading` | path, heading, content | Insert after heading |\n\
+             | `patch.apply` | diff | Apply a unified diff |\n\n",
         );
     }
 
@@ -592,7 +616,7 @@ mod tests {
         assert!(out.contains("fix_whitespace("));
         assert!(out.contains("create_file("));
         assert!(out.contains("batch({\"operations\":"));
-        assert!(out.contains("transaction({\"plan\":"));
+        assert!(out.contains("transaction({\"operations\":"));
         // Decision rule mentions native tools by name
         assert!(out.contains("search_replace"));
         assert!(out.contains("run_terminal_command"));

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -37,6 +37,7 @@ pub struct PlanWritePolicy {
 
 /// A single operation within a plan.
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[serde(tag = "op")]
 pub enum Operation {
     #[serde(rename = "replace")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -486,7 +486,7 @@ fn test_agent_rules_mode_mcp_omits_cli() {
         .stdout(predicates::str::contains("## MCP mode"))
         .stdout(predicates::str::contains("## Tool usage examples"))
         .stdout(predicates::str::contains("batch({\"operations\":"))
-        .stdout(predicates::str::contains("transaction({\"plan\":"))
+        .stdout(predicates::str::contains("transaction({\"operations\":"))
         .stdout(predicates::str::contains("create_file("))
         .stdout(predicates::str::contains("fix_whitespace("))
         // CLI-only h2 sections must be absent (MCP has h3 subsections within its block)
@@ -15375,6 +15375,167 @@ async fn test_mcp_batch_round_trip() {
     assert_eq!(a["version"], "2.0.0", "batch doc.set failed");
     let b = fs::read_to_string(dir.path().join("b.txt")).unwrap();
     assert_eq!(b, "new text\n", "batch replace failed");
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_batch_structured_operations() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("config.json"), r#"{"version":"1.0.0"}"#).unwrap();
+    fs::write(dir.path().join("readme.md"), "version 1.0.0\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "batch",
+        serde_json::json!({
+            "operations": [
+                {"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
+                {"op": "replace", "path": "readme.md", "from": "1.0.0", "to": "2.0.0"},
+                {"op": "file.create", "path": "hello.txt", "content": "Hello, World!"}
+            ]
+        }),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "batch with structured ops should succeed: {text}"
+    );
+
+    let cfg: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("config.json")).unwrap()).unwrap();
+    assert_eq!(cfg["version"], "2.0.0", "doc.set failed");
+    assert!(
+        fs::read_to_string(dir.path().join("readme.md"))
+            .unwrap()
+            .contains("2.0.0"),
+        "replace failed"
+    );
+    assert!(dir.path().join("hello.txt").exists(), "file.create failed");
+    assert!(
+        fs::read_to_string(dir.path().join("hello.txt"))
+            .unwrap()
+            .contains("Hello, World!"),
+        "file.create content mismatch"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_batch_mixed_structured_and_line_format() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.json"), r#"{"k":"v1"}"#).unwrap();
+    fs::write(dir.path().join("b.txt"), "old\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "batch",
+        serde_json::json!({
+            "operations": [
+                {"op": "doc.set", "path": "a.json", "selector": "k", "value": "v2"},
+                "replace b.txt \"old\" \"new\""
+            ]
+        }),
+    )
+    .await;
+    assert!(!is_error, "batch with mixed formats should succeed: {text}");
+
+    let a: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("a.json")).unwrap()).unwrap();
+    assert_eq!(a["k"], "v2");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("b.txt")).unwrap(),
+        "new\n"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_transaction_structured_operations() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("pkg.json"),
+        r#"{"name":"app","version":"1.0.0"}"#,
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "transaction",
+        serde_json::json!({
+            "operations": [
+                {"op": "doc.set", "path": "pkg.json", "selector": "version", "value": "3.0.0"},
+                {"op": "file.create", "path": "hello.txt", "content": "Hello, World!"}
+            ]
+        }),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "tx with structured operations should succeed: {text}"
+    );
+
+    let pkg: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("pkg.json")).unwrap()).unwrap();
+    assert_eq!(pkg["version"], "3.0.0", "doc.set failed");
+    assert!(dir.path().join("hello.txt").exists(), "file.create failed");
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_transaction_rejects_both_plan_and_operations() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let params = rmcp::model::CallToolRequestParams::new("transaction").with_arguments(
+        serde_json::from_value(serde_json::json!({
+            "plan": "{\"version\":\"1\",\"operations\":[]}",
+            "operations": [{"op": "file.create", "path": "x.txt", "content": "y"}]
+        }))
+        .unwrap(),
+    );
+    let result = client.peer().call_tool(params).await;
+    assert!(
+        result.is_err(),
+        "tx with both plan and operations should be rejected"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_transaction_rejects_neither_plan_nor_operations() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let params = rmcp::model::CallToolRequestParams::new("transaction")
+        .with_arguments(serde_json::from_value(serde_json::json!({})).unwrap());
+    let result = client.peer().call_tool(params).await;
+    assert!(
+        result.is_err(),
+        "tx with neither plan nor operations should be rejected"
+    );
     client.cancel().await.unwrap();
 }
 


### PR DESCRIPTION
## Problem

The batch and transaction MCP tools required LLM-hostile formats:
- **batch**: line-oriented strings with manual quoting (`"doc.set config.json version \\"2.0.0\\""`)
- **transaction**: full JSON plan stringified inside another JSON parameter (double-escaped everything)

These caused persistent benchmark failures: 4/11 MCP tasks failed across three benchmark runs because LLMs struggle with nested escaping and custom DSL syntax.

## Solution

### Batch: structured objects (backward compatible)

Before (still works):
```json
batch({"operations": ["doc.set config.json version \\"2.0.0\\""]})
```

After (recommended):
```json
batch({"operations": [
  {"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
  {"op": "replace", "path": "README.md", "from": "old", "to": "new"},
  {"op": "tidy.fix", "path": "dirty.txt"}
]})
```

### Transaction: operations array (backward compatible)

Before (still works for advanced plans with format/validate):
```json
transaction({"plan": "{\\"version\\":\\"1\\",\\"operations\\":[...]}"})
```

After (recommended):
```json
transaction({"operations": [
  {"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
  {"op": "file.create", "path": "hello.txt", "content": "Hello!"}
]})
```

### How it works

The structured format uses patchloom's existing `Operation` enum (tagged with `#[serde(tag = "op")]`). Added `schemars::JsonSchema` derive so the MCP schema generator describes all operation variants to LLMs automatically.

`BatchOperation` is an `#[serde(untagged)]` enum that accepts either a structured `Operation` or a line-format `String`. Mixed arrays work too.

### Changes

- `BatchParams.operations`: `Vec<String>` -> `Vec<BatchOperation>` (structured or string)
- `TxParams.plan`: `String` -> `Option<String>`; added `TxParams.operations: Option<Vec<Operation>>`
- Agent-rules MCP examples rewritten with structured format
- Added operation types reference table to MCP instructions
- Added `tidy.fix` batch example
- Added `PATCHLOOM_MCP_LOG` env var for MCP call diagnostics
- 5 new integration tests, 608 total (was 603)
- Updated MCP setup docs

## Benchmark context

| Run | MCP Success | Change |
|-----|-------------|--------|
| Baseline | 6/11 | No examples |
| +Examples (PR #471) | 7/11 | +file_ops |
| +Guide (PR #472) | 7/11 | No change |
| +Structured APIs (this PR) | TBD | Running benchmark |