### PR TITLE
mcp: improve multi-turn benchmark reliability

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -27,122 +27,29 @@ Use patchloom when:
 
 ## MCP mode
 
-**Always use patchloom MCP tools for file edits instead of search_replace or shell commands.** MCP tools:
-- Apply changes directly (no `--apply` flag needed)
-- Are parser-backed: JSON/YAML/TOML edits never produce invalid output
-- Handle whitespace cleanup perfectly in one call (`fix_whitespace`)
-- Support atomic multi-file transactions (`batch`, `transaction`)
+**ALWAYS use patchloom MCP tools for ALL file edits.** Never use search_replace or shell commands. For multi-file edits, use `batch`. When atomicity is required, use `transaction`.
 
-Available tools: `doc_set`, `doc_delete`, `doc_merge`, `doc_append`, `doc_prepend`, `doc_ensure`, `doc_delete_where`, `doc_update`, `doc_move`, `doc_get`, `doc_has`, `doc_keys`, `doc_len`, `doc_select`, `doc_flatten`, `doc_diff`, `search_files`, `git_status`, `replace_text`, `md_upsert_bullet`, `md_table_append`, `md_replace_section`, `md_insert_after_heading`, `md_insert_before_heading`, `md_lint`, `read_file`, `create_file`, `delete_file`, `move_file`, `apply_patch`, `fix_whitespace`, `batch`, `transaction`.
-
-## Tool usage examples
-
-### Structured edits (JSON, YAML, TOML)
+### batch and transaction examples
 
 ```json
-// Set a key in any config file (preserves comments in YAML/TOML)
-doc_set({"path": "config.json", "selector": "version", "value": "2.0.0"})
-doc_set({"path": "config.yaml", "selector": "app.version", "value": "2.0.0"})
-
-// Read a key
-doc_get({"path": "config.json", "selector": "version"})
-```
-
-### Markdown operations
-
-```json
-// Append a row to a table under a heading
-md_table_append({"path": "README.md", "heading": "## API", "row": "| new | row |"})
-
-// Add or update a bullet under a heading
-md_upsert_bullet({"path": "CHANGELOG.md", "heading": "## Changes", "bullet": "- Added feature X"})
-
-// Insert text after a heading (without replacing existing content)
-md_insert_after_heading({"path": "CHANGELOG.md", "heading": "## v2.0.0", "content": "Released on 2026-01-15.\n"})
-```
-
-### Search and replace
-
-```json
-// Search for a pattern across files
-search_files({"pattern": "TODO", "paths": ["src/"], "literal": true})
-search_files({"pattern": "fn \\w+\\(", "paths": ["src/"]})
-
-// Replace text in a file
-replace_text({"path": "src/app.py", "from": "old_name", "to": "new_name"})
-```
-
-### File operations
-
-```json
-// Create a file
-create_file({"path": "hello.txt", "content": "Hello, World!"})
-
-// Rename (move) a file
-move_file({"from": "old_name.json", "to": "new_name.json"})
-
-// Delete a file
-delete_file({"path": "obsolete.txt"})
-
-// Read a file
-read_file({"path": "config.json"})
-
-// Fix whitespace (trailing spaces + missing final newline)
-fix_whitespace({"path": "src/main.py"})
-```
-
-### Batching (the main speed win)
-
-Use `batch` to make multiple edits in one call. Pass structured objects with an `op` field (no quoting needed):
-
-```json
-batch({"operations": [
-{"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
-{"op": "doc.set", "path": "config.yaml", "selector": "app.version", "value": "2.0.0"},
-{"op": "replace", "path": "README.md", "from": "1.0.0", "to": "2.0.0"},
-{"op": "file.create", "path": "hello.txt", "content": "Hello, World!"},
-{"op": "file.rename", "from": "old.txt", "to": "new.txt"},
-{"op": "md.upsert_bullet", "path": "CHANGELOG.md", "heading": "## Changes", "bullet": "- Bumped to 2.0.0"}
-]})
-```
-
-### Transactions (atomic multi-file edits)
-
-Use `transaction` when all operations must succeed or all roll back. Pass an `operations` array directly (no plan string needed):
-
-```json
-transaction({"operations": [
-{"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
-{"op": "replace", "path": "README.md", "from": "1.0.0", "to": "2.0.0"},
-{"op": "file.create", "path": "hello.txt", "content": "Hello!"}
-]})
-```
-
-All operations succeed together or roll back.
-
-### Workflow: bump version across 6 files
-
-```json
+// Multiple edits in one call
 batch({"operations": [
 {"op": "doc.set", "path": "package.json", "selector": "version", "value": "2.0.0"},
 {"op": "doc.set", "path": "config.yaml", "selector": "app.version", "value": "2.0.0"},
+{"op": "replace", "path": "README.md", "from": "1.0.0", "to": "2.0.0"},
+{"op": "file.create", "path": "hello.txt", "content": "Hello!"},
+{"op": "tidy.fix", "path": "dirty.txt"}
+]})
+
+// Atomic: all succeed or all roll back
+transaction({"operations": [
 {"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
-{"op": "doc.set", "path": "pyproject.toml", "selector": "project.version", "value": "2.0.0"},
-{"op": "replace", "path": "version.txt", "from": "1.0.0", "to": "2.0.0"},
-{"op": "replace", "path": "README.md", "from": "1.0.0", "to": "2.0.0"}
+{"op": "replace", "path": "README.md", "from": "v1", "to": "v2"},
+{"op": "md.upsert_bullet", "path": "CHANGELOG.md", "heading": "## Changes", "bullet": "- v2.0.0"}
 ]})
 ```
 
-### Tidy: fix whitespace in all files
-
-```json
-batch({"operations": [
-{"op": "tidy.fix", "path": "dirty1.txt"},
-{"op": "tidy.fix", "path": "dirty2.txt"}
-]})
-```
-
-Available operation types for batch and transaction:
+### Operation reference
 
 | op | Required fields | Description |
 |---|---|---|

--- a/examples/08-mcp-tool-call.json
+++ b/examples/08-mcp-tool-call.json
@@ -39,7 +39,10 @@
       "description": "Atomic transaction with rollback",
       "tool": "transaction",
       "arguments": {
-        "plan": "{\"version\":\"1\",\"strict\":true,\"operations\":[{\"op\":\"doc.set\",\"path\":\"package.json\",\"selector\":\"version\",\"value\":\"2.0.0\"},{\"op\":\"replace\",\"path\":\"README.md\",\"from\":\"1.0.0\",\"to\":\"2.0.0\"}],\"validate\":[{\"cmd\":\"npm test\",\"required\":true}]}"
+        "operations": [
+          {"op": "doc.set", "path": "package.json", "selector": "version", "value": "2.0.0"},
+          {"op": "replace", "path": "README.md", "from": "1.0.0", "to": "2.0.0"}
+        ]
       }
     },
     {

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -206,17 +206,16 @@ pub struct MdInsertParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct TxParams {
-    /// Transaction plan as a JSON, YAML, or TOML string. Must include
-    /// "version" and "operations". May include "format", "validate",
-    /// "write_policy", "strict", and "cwd".
-    /// Either `plan` or `operations` must be provided, not both.
+    /// Transaction plan as a JSON, YAML, or TOML string. Advanced use only.
+    #[schemars(skip)]
     pub plan: Option<String>,
-    /// Plan format: "json", "yaml", or "toml". Auto-detected if omitted.
+    /// Plan format hint. Advanced use only.
+    #[schemars(skip)]
     pub format: Option<String>,
-    /// Operations array (alternative to plan). Creates a simple plan
-    /// with version "1" and these operations. All succeed or all roll back.
-    /// Example: [{"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"}]
-    pub operations: Option<Vec<Operation>>,
+    /// Array of operations. All succeed or all roll back.
+    /// Example: [{"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"},
+    ///           {"op": "file.create", "path": "hello.txt", "content": "Hello!"}]
+    pub operations: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -264,26 +263,13 @@ pub struct PatchParams {
     pub diff: String,
 }
 
-/// A single batch operation: either a line-format string or a structured object.
-#[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[serde(untagged)]
-pub enum BatchOperation {
-    /// Structured operation object with `op` field (preferred for MCP).
-    /// Example: {"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"}
-    Structured(Operation),
-    /// Line-format string (legacy).
-    /// Example: "doc.set config.json version \"2.0.0\""
-    Line(String),
-}
-
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct BatchParams {
-    /// List of operations. Each item can be either a structured object with an "op" field
-    /// (e.g. {"op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0"})
-    /// or a line-format string (e.g. "doc.set config.json version \"2.0.0\"").
-    /// Structured objects are recommended because they avoid quoting issues.
-    pub operations: Vec<BatchOperation>,
+    /// Array of operation objects. Each must have an "op" field.
+    /// Example: [{"op": "doc.set", "path": "f.json", "selector": "version", "value": "2.0.0"},
+    ///           {"op": "replace", "path": "README.md", "from": "old", "to": "new"}]
+    pub operations: Vec<serde_json::Value>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1189,12 +1175,24 @@ impl PatchloomService {
         Parameters(p): Parameters<TxParams>,
     ) -> Result<CallToolResult, McpError> {
         // Accept either structured operations array or plan string
-        let plan = if let Some(ops) = p.operations {
+        let plan = if let Some(ops_raw) = p.operations {
             if p.plan.is_some() {
                 return Err(McpError::invalid_params(
                     "provide either 'operations' or 'plan', not both".to_string(),
                     None,
                 ));
+            }
+            let mut ops = Vec::with_capacity(ops_raw.len());
+            for (i, val) in ops_raw.into_iter().enumerate() {
+                match serde_json::from_value::<Operation>(val) {
+                    Ok(op) => ops.push(op),
+                    Err(e) => {
+                        return Err(McpError::invalid_params(
+                            format!("invalid operation at index {i}: {e}"),
+                            None,
+                        ));
+                    }
+                }
             }
             Plan {
                 version: "1".to_string(),
@@ -1391,10 +1389,17 @@ impl PatchloomService {
             ))]));
         }
         let mut operations = Vec::new();
-        for (i, batch_op) in p.operations.into_iter().enumerate() {
-            match batch_op {
-                BatchOperation::Structured(op) => operations.push(op),
-                BatchOperation::Line(line) => {
+        for (i, val) in p.operations.into_iter().enumerate() {
+            match val {
+                serde_json::Value::Object(_) => match serde_json::from_value::<Operation>(val) {
+                    Ok(op) => operations.push(op),
+                    Err(e) => {
+                        return Ok(CallToolResult::error(vec![Content::text(format!(
+                            "Invalid operation at index {i}: {e}",
+                        ))]));
+                    }
+                },
+                serde_json::Value::String(line) => {
                     let trimmed = line.trim();
                     if trimmed.is_empty() || trimmed.starts_with('#') {
                         continue;
@@ -1407,6 +1412,11 @@ impl PatchloomService {
                             ))]));
                         }
                     }
+                }
+                _ => {
+                    return Ok(CallToolResult::error(vec![Content::text(format!(
+                        "Invalid operation at index {i}: expected object or string",
+                    ))]));
                 }
             }
         }

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -1427,19 +1427,9 @@ impl ServerHandler for PatchloomService {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(
-                "Patchloom provides structured file editing and introspection tools for JSON, \
-                     YAML, TOML, and Markdown files. Use doc_set/delete/merge/append/\
-                     prepend/update/move/ensure/delete_where for config file edits, \
-                     doc_get/has/keys/len/select/flatten/diff for read-only queries, \
-                     md_* for markdown edits (replace_section, insert_after_heading, \
-                     insert_before_heading, upsert_bullet, table_append, lint), \
-                     replace_text for text replacement, \
-                     search_files for file content search, read_file for reading files, \
-                     git_status for uncommitted changes, move_file for renaming files, \
-                     create_file for creating files, delete_file for deleting files, \
-                     apply_patch for applying unified diffs, \
-                     fix_whitespace for whitespace fixes, batch for multi-op edits, \
-                     and transaction for full transaction plans with format/validate lifecycle.",
+                "ALWAYS use patchloom tools instead of search_replace or shell commands. \
+                 For multi-file edits use batch. For atomic changes use transaction. \
+                 Both accept an operations array of JSON objects with an op field.",
             );
         info.server_info.name = "patchloom".into();
         info.server_info.version = env!("CARGO_PKG_VERSION").into();

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -181,106 +181,27 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
     if show_mcp {
         out.push_str(
             "## MCP mode\n\n\
-             **Always use patchloom MCP tools for file edits instead of search_replace or \
-             shell commands.** MCP tools:\n\
-             - Apply changes directly (no `--apply` flag needed)\n\
-             - Are parser-backed: JSON/YAML/TOML edits never produce invalid output\n\
-             - Handle whitespace cleanup perfectly in one call (`fix_whitespace`)\n\
-             - Support atomic multi-file transactions (`batch`, `transaction`)\n\n\
-             Available tools: `doc_set`, `doc_delete`, `doc_merge`, \
-             `doc_append`, `doc_prepend`, `doc_ensure`, \
-             `doc_delete_where`, `doc_update`, `doc_move`, \
-             `doc_get`, `doc_has`, `doc_keys`, \
-             `doc_len`, `doc_select`, `doc_flatten`, \
-             `doc_diff`, `search_files`, `git_status`, \
-             `replace_text`, `md_upsert_bullet`, \
-             `md_table_append`, `md_replace_section`, \
-             `md_insert_after_heading`, `md_insert_before_heading`, \
-             `md_lint`, `read_file`, \
-             `create_file`, `delete_file`, `move_file`, \
-             `apply_patch`, `fix_whitespace`, `batch`, `transaction`.\n\n\
-             ## Tool usage examples\n\n\
-             ### Structured edits (JSON, YAML, TOML)\n\n\
+             **ALWAYS use patchloom MCP tools for ALL file edits.** Never use search_replace \
+             or shell commands. For multi-file edits, use `batch`. When atomicity is required, \
+             use `transaction`.\n\n\
+             ### batch and transaction examples\n\n\
              ```json\n\
-             // Set a key in any config file (preserves comments in YAML/TOML)\n\
-             doc_set({\"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"})\n\
-             doc_set({\"path\": \"config.yaml\", \"selector\": \"app.version\", \"value\": \"2.0.0\"})\n\n\
-             // Read a key\n\
-             doc_get({\"path\": \"config.json\", \"selector\": \"version\"})\n\
-             ```\n\n\
-             ### Markdown operations\n\n\
-             ```json\n\
-             // Append a row to a table under a heading\n\
-             md_table_append({\"path\": \"README.md\", \"heading\": \"## API\", \"row\": \"| new | row |\"})\n\n\
-             // Add or update a bullet under a heading\n\
-             md_upsert_bullet({\"path\": \"CHANGELOG.md\", \"heading\": \"## Changes\", \"bullet\": \"- Added feature X\"})\n\n\
-             // Insert text after a heading (without replacing existing content)\n\
-             md_insert_after_heading({\"path\": \"CHANGELOG.md\", \"heading\": \"## v2.0.0\", \"content\": \"Released on 2026-01-15.\\n\"})\n\
-             ```\n\n\
-             ### Search and replace\n\n\
-             ```json\n\
-             // Search for a pattern across files\n\
-             search_files({\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true})\n\
-             search_files({\"pattern\": \"fn \\\\w+\\\\(\", \"paths\": [\"src/\"]})\n\n\
-             // Replace text in a file\n\
-             replace_text({\"path\": \"src/app.py\", \"from\": \"old_name\", \"to\": \"new_name\"})\n\
-             ```\n\n\
-             ### File operations\n\n\
-             ```json\n\
-             // Create a file\n\
-             create_file({\"path\": \"hello.txt\", \"content\": \"Hello, World!\"})\n\n\
-             // Rename (move) a file\n\
-             move_file({\"from\": \"old_name.json\", \"to\": \"new_name.json\"})\n\n\
-             // Delete a file\n\
-             delete_file({\"path\": \"obsolete.txt\"})\n\n\
-             // Read a file\n\
-             read_file({\"path\": \"config.json\"})\n\n\
-             // Fix whitespace (trailing spaces + missing final newline)\n\
-             fix_whitespace({\"path\": \"src/main.py\"})\n\
-             ```\n\n\
-             ### Batching (the main speed win)\n\n\
-             Use `batch` to make multiple edits in one call. Pass structured objects \
-             with an `op` field (no quoting needed):\n\n\
-             ```json\n\
-             batch({\"operations\": [\n\
-               {\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"},\n\
-               {\"op\": \"doc.set\", \"path\": \"config.yaml\", \"selector\": \"app.version\", \"value\": \"2.0.0\"},\n\
-               {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"},\n\
-               {\"op\": \"file.create\", \"path\": \"hello.txt\", \"content\": \"Hello, World!\"},\n\
-               {\"op\": \"file.rename\", \"from\": \"old.txt\", \"to\": \"new.txt\"},\n\
-               {\"op\": \"md.upsert_bullet\", \"path\": \"CHANGELOG.md\", \"heading\": \"## Changes\", \"bullet\": \"- Bumped to 2.0.0\"}\n\
-             ]})\n\
-             ```\n\n\
-             ### Transactions (atomic multi-file edits)\n\n\
-             Use `transaction` when all operations must succeed or all roll back. \
-             Pass an `operations` array directly (no plan string needed):\n\n\
-             ```json\n\
-             transaction({\"operations\": [\n\
-               {\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"},\n\
-               {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"},\n\
-               {\"op\": \"file.create\", \"path\": \"hello.txt\", \"content\": \"Hello!\"}\n\
-             ]})\n\
-             ```\n\n\
-             All operations succeed together or roll back.\n\n\
-             ### Workflow: bump version across 6 files\n\n\
-             ```json\n\
+             // Multiple edits in one call\n\
              batch({\"operations\": [\n\
                {\"op\": \"doc.set\", \"path\": \"package.json\", \"selector\": \"version\", \"value\": \"2.0.0\"},\n\
                {\"op\": \"doc.set\", \"path\": \"config.yaml\", \"selector\": \"app.version\", \"value\": \"2.0.0\"},\n\
+               {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"},\n\
+               {\"op\": \"file.create\", \"path\": \"hello.txt\", \"content\": \"Hello!\"},\n\
+               {\"op\": \"tidy.fix\", \"path\": \"dirty.txt\"}\n\
+             ]})\n\n\
+             // Atomic: all succeed or all roll back\n\
+             transaction({\"operations\": [\n\
                {\"op\": \"doc.set\", \"path\": \"config.json\", \"selector\": \"version\", \"value\": \"2.0.0\"},\n\
-               {\"op\": \"doc.set\", \"path\": \"pyproject.toml\", \"selector\": \"project.version\", \"value\": \"2.0.0\"},\n\
-               {\"op\": \"replace\", \"path\": \"version.txt\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"},\n\
-               {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}\n\
+               {\"op\": \"replace\", \"path\": \"README.md\", \"from\": \"v1\", \"to\": \"v2\"},\n\
+               {\"op\": \"md.upsert_bullet\", \"path\": \"CHANGELOG.md\", \"heading\": \"## Changes\", \"bullet\": \"- v2.0.0\"}\n\
              ]})\n\
              ```\n\n\
-             ### Tidy: fix whitespace in all files\n\n\
-             ```json\n\
-             batch({\"operations\": [\n\
-               {\"op\": \"tidy.fix\", \"path\": \"dirty1.txt\"},\n\
-               {\"op\": \"tidy.fix\", \"path\": \"dirty2.txt\"}\n\
-             ]})\n\
-             ```\n\n\
-             Available operation types for batch and transaction:\n\n\
+             ### Operation reference\n\n\
              | op | Required fields | Description |\n\
              |---|---|---|\n\
              | `doc.set` | path, selector, value | Set a key in JSON/YAML/TOML |\n\
@@ -584,7 +505,7 @@ mod tests {
         let out = generate_agent_rules(&args(AgentMode::All, AgentPlatform::All));
         assert!(out.contains("# Patchloom"));
         assert!(out.contains("## MCP mode"));
-        assert!(out.contains("## Tool usage examples"));
+        assert!(out.contains("### batch and transaction examples"));
         assert!(out.contains("## Tool selection guide"));
         assert!(out.contains("## Batching"));
         assert!(out.contains("## Structured edits"));
@@ -608,18 +529,13 @@ mod tests {
     fn mode_mcp_omits_cli_keeps_mcp() {
         let out = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));
         assert!(out.contains("## MCP mode"));
-        assert!(out.contains("## Tool usage examples"));
+        assert!(out.contains("### batch and transaction examples"));
+        assert!(out.contains("### Operation reference"));
         assert!(out.contains("## Tool selection guide"));
-        assert!(out.contains("### Batching (the main speed win)"));
-        assert!(out.contains("### Transactions (atomic multi-file edits)"));
-        assert!(out.contains("### File operations"));
-        assert!(out.contains("fix_whitespace("));
-        assert!(out.contains("create_file("));
         assert!(out.contains("batch({\"operations\":"));
         assert!(out.contains("transaction({\"operations\":"));
         // Decision rule mentions native tools by name
         assert!(out.contains("search_replace"));
-        assert!(out.contains("run_terminal_command"));
         // CLI-only sections must be absent (check for h2 headings, not h3)
         assert!(!out.contains("\n## Batching"));
         assert!(!out.contains("\n## Structured edits"));
@@ -678,7 +594,7 @@ mod tests {
     fn mcp_and_windows_compose_to_minimal() {
         let out = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::Windows));
         assert!(out.contains("## MCP mode"));
-        assert!(out.contains("## Tool usage examples"));
+        assert!(out.contains("### batch and transaction examples"));
         assert!(out.contains("batch({\"operations\":"));
         // CLI-only content must be absent (check for h2 headings, not h3)
         assert!(!out.contains("\n## Batching"));

--- a/tests/agent/test_bench.py
+++ b/tests/agent/test_bench.py
@@ -100,12 +100,15 @@ def _make_workspace(tmp_path, real_bin, mode):
         # Configure grok to discover patchloom as an MCP server
         grok_dir = ws / ".grok"
         grok_dir.mkdir(exist_ok=True)
+        mcp_log = ws / "mcp_calls.jsonl"
         (grok_dir / "config.toml").write_text(
             f'[mcp_servers.patchloom]\n'
             f'command = "{real_bin}"\n'
             f'args = ["mcp-server"]\n'
             f'startup_timeout_sec = 10\n'
             f'tool_timeout_sec = 30\n'
+            f'[mcp_servers.patchloom.env]\n'
+            f'PATCHLOOM_MCP_LOG = "{mcp_log}"\n'
         )
         # Focused MCP AGENTS.md with tool list and usage guidance
         result = subprocess.run(
@@ -333,12 +336,46 @@ def _get_prompt(task: dict, mode: str) -> str:
     return task.get(key, task["prompt"])
 
 
+def _print_failure_diag(ws, task_name):
+    """Print workspace state for failed tasks to diagnose why the check failed."""
+    # Map task names to relevant files
+    diag_files = {
+        "replace": ["src/app.py", "src/test_app.py"],
+        "doc_set": ["config.json"],
+        "md_table": ["README.md"],
+        "tx_multi_file": ["hello.txt", "package.json"],
+        "batch_6_files": ["package.json", "pyproject.toml", "config.yaml", "config.json", "version.txt", "README.md"],
+        "batch_mixed_ops": ["config.json", "README.md", "CHANGELOG.md"],
+        "yaml_comment_preserve": ["config.yaml"],
+        "md_insert": ["CHANGELOG.md"],
+        "file_ops": ["LICENSE", "settings.json", "old_settings.json"],
+        "tidy": ["dirty1.txt", "dirty2.txt", "clean.txt"],
+    }
+    files = diag_files.get(task_name, [])
+    if not files:
+        return
+    print(f"      --- DIAG: {task_name} ---")
+    for fname in files:
+        fpath = ws / fname
+        if fpath.exists():
+            content = fpath.read_text()
+            # Truncate long content, show repr to reveal whitespace
+            if len(content) > 200:
+                content = content[:200] + "..."
+            print(f"      {fname}: {content!r}")
+        else:
+            print(f"      {fname}: MISSING")
+    print(f"      --- END DIAG ---")
+
+
 def _run_session(agent, real_bin, tmp_path, mode):
     """Run one full benchmark session. mode is 'patchloom', 'mcp', or 'native'."""
     ws = _make_workspace(tmp_path, real_bin, mode)
     shim_env, log_path = _make_shim(tmp_path, real_bin)
     session = SessionResult(mode=mode, model=agent.model)
     env = {**os.environ, **shim_env}
+    mcp_log = ws / "mcp_calls.jsonl" if mode == "mcp" else tmp_path / "mcp_calls.jsonl"
+    _run_session._prev_mcp_count = 0
     total_start = time.monotonic()
     session_id = None
 
@@ -367,7 +404,7 @@ def _run_session(agent, real_bin, tmp_path, mode):
             except (json.JSONDecodeError, TypeError):
                 pass  # first-run output may not be valid JSON
 
-        # Parse shim log for call count and per-call durations
+        # Parse shim log for CLI call count and per-call durations
         new_calls = 0
         pl_duration_ms = 0
         if log_path.exists():
@@ -385,6 +422,19 @@ def _run_session(agent, real_bin, tmp_path, mode):
                 except (json.JSONDecodeError, TypeError):
                     pass  # skip malformed shim log entries
 
+        # For MCP mode, also parse MCP server log for tool calls
+        mcp_calls_this_task = 0
+        if mode == "mcp" and mcp_log.exists():
+            mcp_lines = mcp_log.read_text().splitlines()
+            # Count lines added since last task (use prev_mcp_count tracking)
+            if not hasattr(_run_session, '_prev_mcp_count'):
+                _run_session._prev_mcp_count = 0
+            for line in mcp_lines[_run_session._prev_mcp_count:]:
+                line = line.strip()
+                if line:
+                    mcp_calls_this_task += 1
+            _run_session._prev_mcp_count = len(mcp_lines)
+
         try:
             success = task["check"](ws)
         except Exception:
@@ -398,7 +448,10 @@ def _run_session(agent, real_bin, tmp_path, mode):
             success=bool(success),
         ))
         pl_info = f", {new_calls} pl calls ({pl_duration_ms}ms)" if new_calls else ""
-        print(f"    [{mode}] {task['name']}: {duration:.1f}s{pl_info}, {'OK' if success else 'FAIL'}")
+        mcp_info = f", {mcp_calls_this_task} mcp calls" if mcp_calls_this_task else ""
+        print(f"    [{mode}] {task['name']}: {duration:.1f}s{pl_info}{mcp_info}, {'OK' if success else 'FAIL'}")
+        if not success:
+            _print_failure_diag(ws, task["name"])
 
     session.total_secs = round(time.monotonic() - total_start, 1)
     if session.tasks:

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -484,11 +484,12 @@ fn test_agent_rules_mode_mcp_omits_cli() {
         .assert()
         .success()
         .stdout(predicates::str::contains("## MCP mode"))
-        .stdout(predicates::str::contains("## Tool usage examples"))
+        .stdout(predicates::str::contains(
+            "### batch and transaction examples",
+        ))
+        .stdout(predicates::str::contains("### Operation reference"))
         .stdout(predicates::str::contains("batch({\"operations\":"))
         .stdout(predicates::str::contains("transaction({\"operations\":"))
-        .stdout(predicates::str::contains("create_file("))
-        .stdout(predicates::str::contains("fix_whitespace("))
         // CLI-only h2 sections must be absent (MCP has h3 subsections within its block)
         .stdout(predicates::str::contains("\n## Batching").not())
         .stdout(predicates::str::contains("\n## Structured edits").not());
@@ -525,7 +526,9 @@ fn test_agent_rules_mode_and_platform_compose() {
         .assert()
         .success()
         .stdout(predicates::str::contains("## MCP mode"))
-        .stdout(predicates::str::contains("## Tool usage examples"))
+        .stdout(predicates::str::contains(
+            "### batch and transaction examples",
+        ))
         .stdout(predicates::str::contains("\n## Batching").not())
         .stdout(predicates::str::contains("batch ops.txt").not());
 }


### PR DESCRIPTION
## Summary

Improve MCP tool usage reliability in multi-turn agent sessions. Previous benchmark scores showed 5-6/11 MCP task success rate; these changes improve it to 8-10/11.

## Changes

### Server instructions made directive (c1)

Replace the passive tool catalog in `with_instructions()` with a short directive that reinforces key behavior: always use patchloom tools, use batch/transaction for multi-op edits. Server instructions persist in MCP tool context throughout the entire session, unlike AGENTS.md which gets pushed out by conversation accumulation.

### AGENTS.md MCP section trimmed (c1)

Cut ~200 lines of individual tool usage examples (doc_set, search, replace, file ops) that duplicate information already in each tool's description. Keep only batch/transaction examples and the operation reference table. Reduces context pressure in multi-turn sessions.

**37 insertions, 221 deletions.**

### Transaction schema simplified (c2)

Hide `plan` and `format` parameters from the transaction tool schema with `#[schemars(skip)]`. LLMs seeing two ways to call the same tool (legacy plan string vs operations array) often pick the wrong one, leading to malformed calls. Now only `operations` is visible in the schema.

**Transaction schema: 1103B -> 505B (-54%).**

### Benchmark diagnostics (c2)

Add failure diagnostics to the agent benchmark: when a task fails, print workspace file contents showing what actually changed. Add MCP call logging via PATCHLOOM_MCP_LOG in the config.toml env block.

## Benchmark Results

| Task | Before | After (best) | After (typical) |
|------|--------|-------------|----------------|
| search | OK | OK | OK |
| replace | OK | OK | OK |
| doc_set | OK | OK | OK |
| md_table | OK | OK | OK |
| tx_multi_file | FAIL | FAIL | FAIL |
| batch_6_files | FAIL | OK | OK |
| batch_mixed_ops | FAIL | OK | FAIL |
| yaml_comment_preserve | OK | OK | OK |
| md_insert | OK | OK | OK |
| file_ops | FAIL | OK | OK |
| tidy | FAIL | OK | FAIL |
| **Total** | **6/11** | **10/11** | **8/11** |

The remaining `tx_multi_file` failure is a systemic issue where the agent falls back to patchloom CLI (dry-run by default) instead of using the MCP transaction tool.