### PR TITLE
feat: op name aliases, doc_query consolidation, dynamic bench timeout

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -9,7 +9,7 @@
 
 | Task pattern | Tool to use |
 |---|---|
-| Set/get a key in JSON, YAML, or TOML | `doc_set`, `doc_get` |
+| Set/get a key in JSON, YAML, or TOML | `doc_set`, `doc_get`, `doc_query` |
 | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |
 | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |
 | Fix trailing whitespace or missing newlines | `fix_whitespace` (one call per file) |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1206%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1207%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -382,7 +382,7 @@ flowchart LR
 
 ## Status
 
-1206 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1207 passing tests across 18 core commands, plus the optional `mcp-server` command. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -97,11 +97,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `doc_update` | Update array elements matching a predicate |
 | `doc_move` | Move a value from one selector path to another |
 | `doc_get` | Read a value by selector (read-only) |
-| `doc_has` | Check whether a selector path exists (read-only) |
-| `doc_keys` | List object keys at a selector path (read-only) |
-| `doc_len` | Count items in an array or object (read-only) |
-| `doc_select` | Filter array items by selector (read-only) |
-| `doc_flatten` | List all leaf selector paths and values (read-only) |
+| `doc_query` | Query a structured file: has, keys, len, select, or flatten (read-only) |
 | `doc_diff` | Compare two structured files (read-only) |
 | `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes. Binary and invalid UTF-8 files are skipped (read-only) |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -310,18 +310,14 @@ pub struct SearchParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct DocSelectorParams {
+pub struct DocQueryParams {
+    /// Query action: "has" (check existence), "keys" (list keys), "len" (count),
+    /// "select" (filter array), or "flatten" (list all paths).
+    pub action: String,
     /// File path (relative to working directory).
     pub path: String,
-    /// Selector to query (e.g., "version", "db.pool", "items[*]").
-    pub selector: String,
-}
-
-#[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct DocFileParams {
-    /// File path (relative to working directory).
-    pub path: String,
+    /// Selector to query. Required for has/keys/len/select; ignored for flatten.
+    pub selector: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -808,80 +804,52 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Check whether a selector path exists in a JSON, YAML, or TOML file. Returns true/false. Example: {\"path\": \"config.json\", \"selector\": \"database.host\"}"
+        description = "Query a JSON, YAML, or TOML file. Actions: \"has\" (check if selector exists, returns true/false), \"keys\" (list object keys at selector), \"len\" (count items at selector), \"select\" (filter array by predicate selector), \"flatten\" (list all leaf paths and values). Example: {\"action\": \"has\", \"path\": \"config.json\", \"selector\": \"database.host\"}"
     )]
-    async fn doc_has(
+    async fn doc_query(
         &self,
-        Parameters(p): Parameters<DocSelectorParams>,
+        Parameters(p): Parameters<DocQueryParams>,
     ) -> Result<CallToolResult, McpError> {
         self.check_path(&p.path)?;
         let abs = self.cwd.join(&p.path);
-        let action = crate::cmd::doc::DocAction::Has {
-            file: abs.to_string_lossy().into_owned(),
-            selector: p.selector,
-        };
-        doc_readonly(&action)
-    }
-
-    #[tool(
-        description = "List object keys at a selector path in a JSON, YAML, or TOML file. Example: {\"path\": \"package.json\", \"selector\": \"scripts\"}"
-    )]
-    async fn doc_keys(
-        &self,
-        Parameters(p): Parameters<DocSelectorParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        let abs = self.cwd.join(&p.path);
-        let action = crate::cmd::doc::DocAction::Keys {
-            file: abs.to_string_lossy().into_owned(),
-            selector: p.selector,
-        };
-        doc_readonly(&action)
-    }
-
-    #[tool(
-        description = "Count items in an array or keys in an object in a JSON, YAML, or TOML file. Example: {\"path\": \"config.yaml\", \"selector\": \"servers\"}"
-    )]
-    async fn doc_len(
-        &self,
-        Parameters(p): Parameters<DocSelectorParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        let abs = self.cwd.join(&p.path);
-        let action = crate::cmd::doc::DocAction::Len {
-            file: abs.to_string_lossy().into_owned(),
-            selector: p.selector,
-        };
-        doc_readonly(&action)
-    }
-
-    #[tool(
-        description = "Filter array items by selector in a JSON, YAML, or TOML file. Example: {\"path\": \"config.yaml\", \"selector\": \"users[role=admin]\"}"
-    )]
-    async fn doc_select(
-        &self,
-        Parameters(p): Parameters<DocSelectorParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        let abs = self.cwd.join(&p.path);
-        let action = crate::cmd::doc::DocAction::Select {
-            file: abs.to_string_lossy().into_owned(),
-            selector: p.selector,
-        };
-        doc_readonly(&action)
-    }
-
-    #[tool(
-        description = "List all leaf selector paths and values in a JSON, YAML, or TOML file. Useful for exploring unknown file structure. Example: {\"path\": \"config.yaml\"}"
-    )]
-    async fn doc_flatten(
-        &self,
-        Parameters(p): Parameters<DocFileParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        let abs = self.cwd.join(&p.path);
-        let action = crate::cmd::doc::DocAction::Flatten {
-            file: abs.to_string_lossy().into_owned(),
+        let file = abs.to_string_lossy().into_owned();
+        let action = match p.action.as_str() {
+            "has" => {
+                let selector = p.selector.ok_or_else(|| {
+                    McpError::invalid_params("'has' action requires a selector".to_string(), None)
+                })?;
+                crate::cmd::doc::DocAction::Has { file, selector }
+            }
+            "keys" => {
+                let selector = p.selector.ok_or_else(|| {
+                    McpError::invalid_params("'keys' action requires a selector".to_string(), None)
+                })?;
+                crate::cmd::doc::DocAction::Keys { file, selector }
+            }
+            "len" => {
+                let selector = p.selector.ok_or_else(|| {
+                    McpError::invalid_params("'len' action requires a selector".to_string(), None)
+                })?;
+                crate::cmd::doc::DocAction::Len { file, selector }
+            }
+            "select" => {
+                let selector = p.selector.ok_or_else(|| {
+                    McpError::invalid_params(
+                        "'select' action requires a selector".to_string(),
+                        None,
+                    )
+                })?;
+                crate::cmd::doc::DocAction::Select { file, selector }
+            }
+            "flatten" => crate::cmd::doc::DocAction::Flatten { file },
+            other => {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "unknown action '{other}'; valid actions: has, keys, len, select, flatten"
+                    ),
+                    None,
+                ));
+            }
         };
         doc_readonly(&action)
     }
@@ -1548,11 +1516,7 @@ mod tests {
             .collect::<std::collections::BTreeMap<_, _>>();
         assert!(names.contains(&"doc_set"), "missing doc_set tool");
         assert!(names.contains(&"doc_get"), "missing doc_get tool");
-        assert!(names.contains(&"doc_has"), "missing doc_has tool");
-        assert!(names.contains(&"doc_keys"), "missing doc_keys tool");
-        assert!(names.contains(&"doc_len"), "missing doc_len tool");
-        assert!(names.contains(&"doc_select"), "missing doc_select tool");
-        assert!(names.contains(&"doc_flatten"), "missing doc_flatten tool");
+        assert!(names.contains(&"doc_query"), "missing doc_query tool");
         assert!(names.contains(&"doc_diff"), "missing doc_diff tool");
         assert!(names.contains(&"read_file"), "missing read_file tool");
         assert!(names.contains(&"search_files"), "missing search_files tool");
@@ -1597,7 +1561,7 @@ mod tests {
             "missing md_insert_before_heading tool"
         );
         assert!(names.contains(&"transaction"), "missing transaction tool");
-        assert_eq!(names.len(), 33, "expected 33 tools, got {}", names.len());
+        assert_eq!(names.len(), 29, "expected 29 tools, got {}", names.len());
         client.cancel().await.unwrap();
     }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -152,7 +152,7 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
             "## Tool selection guide\n\n\
              | Task pattern | Tool to use |\n\
              |---|---|\n\
-             | Set/get a key in JSON, YAML, or TOML | `doc_set`, `doc_get` |\n\
+             | Set/get a key in JSON, YAML, or TOML | `doc_set`, `doc_get`, `doc_query` |\n\
              | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |\n\
              | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |\n\
              | Fix trailing whitespace or missing newlines | `fix_whitespace` (one call per file) |\n\

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -40,7 +40,7 @@ pub struct PlanWritePolicy {
 #[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
 #[serde(tag = "op")]
 pub enum Operation {
-    #[serde(rename = "replace")]
+    #[serde(rename = "replace", alias = "replace_text")]
     Replace {
         glob: Option<String>,
         path: Option<String>,
@@ -57,103 +57,106 @@ pub enum Operation {
         #[serde(default)]
         if_exists: bool,
     },
-    #[serde(rename = "doc.set")]
+    #[serde(rename = "doc.set", alias = "doc_set")]
     DocSet {
         path: String,
         selector: String,
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.delete")]
+    #[serde(rename = "doc.delete", alias = "doc_delete")]
     DocDelete { path: String, selector: String },
-    #[serde(rename = "doc.merge")]
+    #[serde(rename = "doc.merge", alias = "doc_merge")]
     DocMerge {
         path: String,
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.append")]
+    #[serde(rename = "doc.append", alias = "doc_append")]
     DocAppend {
         path: String,
         selector: String,
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.prepend")]
+    #[serde(rename = "doc.prepend", alias = "doc_prepend")]
     DocPrepend {
         path: String,
         selector: String,
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.update")]
+    #[serde(rename = "doc.update", alias = "doc_update")]
     DocUpdate {
         path: String,
         selector: String,
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.move")]
+    #[serde(rename = "doc.move", alias = "doc_move")]
     DocMove {
         path: String,
         from: String,
         to: String,
     },
-    #[serde(rename = "doc.ensure")]
+    #[serde(rename = "doc.ensure", alias = "doc_ensure")]
     DocEnsure {
         path: String,
         selector: String,
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.delete_where")]
+    #[serde(rename = "doc.delete_where", alias = "doc_delete_where")]
     DocDeleteWhere {
         path: String,
         selector: String,
         predicate: String,
     },
-    #[serde(rename = "md.replace_section")]
+    #[serde(rename = "md.replace_section", alias = "md_replace_section")]
     MdReplaceSection {
         path: String,
         heading: String,
         content: String,
     },
-    #[serde(rename = "md.insert_after_heading")]
+    #[serde(rename = "md.insert_after_heading", alias = "md_insert_after_heading")]
     MdInsertAfterHeading {
         path: String,
         heading: String,
         content: String,
     },
-    #[serde(rename = "md.insert_before_heading")]
+    #[serde(
+        rename = "md.insert_before_heading",
+        alias = "md_insert_before_heading"
+    )]
     MdInsertBeforeHeading {
         path: String,
         heading: String,
         content: String,
     },
-    #[serde(rename = "md.upsert_bullet")]
+    #[serde(rename = "md.upsert_bullet", alias = "md_upsert_bullet")]
     MdUpsertBullet {
         path: String,
         heading: String,
         bullet: String,
     },
-    #[serde(rename = "md.table_append")]
+    #[serde(rename = "md.table_append", alias = "md_table_append")]
     MdTableAppend {
         path: String,
         heading: String,
         row: String,
     },
-    #[serde(rename = "md.dedupe_headings")]
+    #[serde(rename = "md.dedupe_headings", alias = "md_dedupe_headings")]
     MdDedupeHeadings { path: String },
-    #[serde(rename = "tidy.fix")]
+    #[serde(rename = "tidy.fix", alias = "fix_whitespace")]
     TidyFix {
         path: String,
         ensure_final_newline: Option<bool>,
         trim_trailing_whitespace: Option<bool>,
         normalize_eol: Option<String>,
     },
-    #[serde(rename = "file.create")]
+    #[serde(rename = "file.create", alias = "create_file")]
     FileCreate {
         path: String,
         content: String,
         force: Option<bool>,
     },
-    #[serde(rename = "file.delete")]
+    #[serde(rename = "file.delete", alias = "delete_file")]
     FileDelete { path: String },
-    #[serde(rename = "file.rename")]
+    #[serde(rename = "file.rename", alias = "move_file")]
     FileRename {
         from: String,
         to: String,
@@ -161,12 +164,12 @@ pub enum Operation {
         #[serde(default)]
         force: bool,
     },
-    #[serde(rename = "patch.apply")]
+    #[serde(rename = "patch.apply", alias = "apply_patch")]
     PatchApply {
         /// Inline diff text to apply.
         diff: String,
     },
-    #[serde(rename = "search")]
+    #[serde(rename = "search", alias = "search_files")]
     Search {
         path: String,
         pattern: String,
@@ -186,13 +189,13 @@ pub enum Operation {
         /// Assert that the total match count equals N. Fails the operation otherwise.
         assert_count: Option<usize>,
     },
-    #[serde(rename = "read")]
+    #[serde(rename = "read", alias = "read_file")]
     Read {
         path: String,
         /// Optional line range (e.g., "10:25").
         lines: Option<String>,
     },
-    #[serde(rename = "md.lint_agents")]
+    #[serde(rename = "md.lint_agents", alias = "md_lint")]
     MdLintAgents { path: String },
 }
 
@@ -340,6 +343,34 @@ mod tests {
         ]}"#;
         let plan = parse_plan(json).unwrap();
         assert_eq!(plan.operations.len(), 30);
+    }
+
+    #[test]
+    fn parse_op_aliases_match_mcp_tool_names() {
+        // MCP tools use underscores (doc_set, create_file). Plan ops use dots
+        // (doc.set, file.create). Both forms should parse via serde aliases.
+        let json = r#"{"version": "1", "operations": [
+            {"op": "replace_text", "from": "a", "to": "b"},
+            {"op": "doc_set", "path": "f.json", "selector": "k", "value": 1},
+            {"op": "doc_delete", "path": "f.json", "selector": "k"},
+            {"op": "doc_merge", "path": "f.json", "value": {}},
+            {"op": "doc_append", "path": "f.json", "selector": "arr", "value": 1},
+            {"op": "doc_ensure", "path": "f.json", "selector": "k", "value": 1},
+            {"op": "doc_delete_where", "path": "f.json", "selector": "arr", "predicate": "x=1"},
+            {"op": "md_replace_section", "path": "f.md", "heading": "H", "content": "c"},
+            {"op": "md_upsert_bullet", "path": "f.md", "heading": "H", "bullet": "- item"},
+            {"op": "md_table_append", "path": "f.md", "heading": "H", "row": "| a |"},
+            {"op": "fix_whitespace", "path": "f.txt"},
+            {"op": "create_file", "path": "f.txt", "content": "c"},
+            {"op": "delete_file", "path": "f.txt"},
+            {"op": "move_file", "from": "a.txt", "to": "b.txt"},
+            {"op": "apply_patch", "diff": "--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+b"},
+            {"op": "search_files", "path": ".", "pattern": "x"},
+            {"op": "read_file", "path": "f.txt"},
+            {"op": "md_lint", "path": "f.md"}
+        ]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert_eq!(plan.operations.len(), 18);
     }
 
     #[test]

--- a/tests/agent/test_bench.py
+++ b/tests/agent/test_bench.py
@@ -610,20 +610,34 @@ def test_dry_run_prompts(request):
     print(f"{'=' * 60}")
 
 
-@pytest.mark.timeout(1200)
+def _save_partial_results(request, n_runs):
+    """Save whatever benchmark results have been collected so far."""
+    all_runs = getattr(request.config, "_bench_runs", {})
+    if not all_runs:
+        return
+    modes = [m for m in ["patchloom", "mcp", "native"] if m in all_runs]
+    if modes:
+        results_dir = Path(__file__).resolve().parent.parent.parent / "benches" / "agent" / "results"
+        _save_results(all_runs, modes, results_dir, n_runs)
+
+
+@pytest.mark.timeout(0)  # dynamic: set below
 def test_multi_turn_patchloom(bench_agent, bench_patchloom_bin, tmp_path, n_runs, request):
     """Run tasks in one session WITH patchloom CLI AGENTS.md."""
+    request.node.timeout = max(1200, n_runs * 700)
     print(f"\n  === Multi-turn session: PATCHLOOM mode ({n_runs} run{'s' if n_runs > 1 else ''}) ===")
     runs = _run_n_sessions(bench_agent, bench_patchloom_bin, tmp_path, "patchloom", n_runs)
     if not hasattr(request.config, "_bench_runs"):
         request.config._bench_runs = {}
     request.config._bench_runs["patchloom"] = runs
+    _save_partial_results(request, n_runs)
     assert any(t.success for r in runs for t in r.tasks)
 
 
-@pytest.mark.timeout(1200)
+@pytest.mark.timeout(0)  # dynamic: set below
 def test_multi_turn_mcp(bench_agent, bench_patchloom_bin, tmp_path, n_runs, request):
     """Run tasks in one session WITH patchloom MCP tools."""
+    request.node.timeout = max(1200, n_runs * 700)
     if not _has_mcp_support(bench_patchloom_bin):
         pytest.skip("patchloom binary lacks MCP support (build with --features mcp)")
     print(f"\n  === Multi-turn session: MCP mode ({n_runs} run{'s' if n_runs > 1 else ''}) ===")
@@ -631,12 +645,14 @@ def test_multi_turn_mcp(bench_agent, bench_patchloom_bin, tmp_path, n_runs, requ
     if not hasattr(request.config, "_bench_runs"):
         request.config._bench_runs = {}
     request.config._bench_runs["mcp"] = runs
+    _save_partial_results(request, n_runs)
     assert any(t.success for r in runs for t in r.tasks)
 
 
-@pytest.mark.timeout(1200)
+@pytest.mark.timeout(0)  # dynamic: set below
 def test_multi_turn_native(bench_agent, bench_patchloom_bin, tmp_path, n_runs, request):
     """Run tasks in one session WITHOUT patchloom (native tools only)."""
+    request.node.timeout = max(1200, n_runs * 700)
     print(f"\n  === Multi-turn session: NATIVE mode ({n_runs} run{'s' if n_runs > 1 else ''}) ===")
     runs = _run_n_sessions(bench_agent, bench_patchloom_bin, tmp_path, "native", n_runs)
     if not hasattr(request.config, "_bench_runs"):

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15724,14 +15724,14 @@ async fn test_mcp_doc_has_existing_key() {
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, text) = call_tool_text(
         &client,
-        "doc_has",
-        serde_json::json!({"path": "data.json", "selector": "name"}),
+        "doc_query",
+        serde_json::json!({"action": "has", "path": "data.json", "selector": "name"}),
     )
     .await;
-    assert!(!is_error, "doc_has should succeed: {text}");
+    assert!(!is_error, "doc_query has should succeed: {text}");
     assert!(
         text.contains("true"),
-        "doc_has should return true for existing key: {text}"
+        "doc_query has should return true for existing key: {text}"
     );
     client.cancel().await.unwrap();
 }
@@ -16591,18 +16591,18 @@ async fn test_mcp_doc_keys_round_trip() {
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, text) = call_tool_text(
         &client,
-        "doc_keys",
-        serde_json::json!({"path": "config.json", "selector": "."}),
+        "doc_query",
+        serde_json::json!({"action": "keys", "path": "config.json", "selector": "."}),
     )
     .await;
-    assert!(!is_error, "doc_keys should succeed: {text}");
+    assert!(!is_error, "doc_query keys should succeed: {text}");
     assert!(
         text.contains("name"),
-        "doc_keys output should contain 'name': {text}"
+        "doc_query keys output should contain 'name': {text}"
     );
     assert!(
         text.contains("version"),
-        "doc_keys output should contain 'version': {text}"
+        "doc_query keys output should contain 'version': {text}"
     );
     client.cancel().await.unwrap();
 }
@@ -16618,12 +16618,12 @@ async fn test_mcp_doc_len_round_trip() {
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, text) = call_tool_text(
         &client,
-        "doc_len",
-        serde_json::json!({"path": "config.json", "selector": "tags"}),
+        "doc_query",
+        serde_json::json!({"action": "len", "path": "config.json", "selector": "tags"}),
     )
     .await;
-    assert!(!is_error, "doc_len should succeed: {text}");
-    assert!(text.contains('3'), "doc_len should return 3: {text}");
+    assert!(!is_error, "doc_query len should succeed: {text}");
+    assert!(text.contains('3'), "doc_query len should return 3: {text}");
     client.cancel().await.unwrap();
 }
 
@@ -16642,14 +16642,14 @@ async fn test_mcp_doc_select_round_trip() {
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, text) = call_tool_text(
         &client,
-        "doc_select",
-        serde_json::json!({"path": "config.json", "selector": "users[role=admin]"}),
+        "doc_query",
+        serde_json::json!({"action": "select", "path": "config.json", "selector": "users[role=admin]"}),
     )
     .await;
-    assert!(!is_error, "doc_select should succeed: {text}");
+    assert!(!is_error, "doc_query select should succeed: {text}");
     assert!(
         text.contains("alice"),
-        "doc_select should return matching item: {text}"
+        "doc_query select should return matching item: {text}"
     );
     client.cancel().await.unwrap();
 }
@@ -16669,18 +16669,18 @@ async fn test_mcp_doc_flatten_round_trip() {
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, text) = call_tool_text(
         &client,
-        "doc_flatten",
-        serde_json::json!({"path": "config.json"}),
+        "doc_query",
+        serde_json::json!({"action": "flatten", "path": "config.json"}),
     )
     .await;
-    assert!(!is_error, "doc_flatten should succeed: {text}");
+    assert!(!is_error, "doc_query flatten should succeed: {text}");
     assert!(
         text.contains("db.host"),
-        "doc_flatten should contain 'db.host': {text}"
+        "doc_query flatten should contain 'db.host': {text}"
     );
     assert!(
         text.contains("db.port"),
-        "doc_flatten should contain 'db.port': {text}"
+        "doc_query flatten should contain 'db.port': {text}"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Four improvements to MCP agent reliability and benchmark infrastructure:

### 1. Operation name aliases (agent-facing)

Batch and transaction operations now accept both naming conventions:
- Dot notation: `doc.set`, `file.create`, `tidy.fix` (canonical)
- Underscore notation: `doc_set`, `create_file`, `fix_whitespace` (matches MCP tool names)

When an agent uses the transaction tool and passes `{"op": "create_file"}` instead of `{"op": "file.create"}`, it now works instead of failing with a parse error. This eliminates a confusion source where MCP tool names and batch/tx op names used different conventions.

### 2. Consolidate doc read tools (33 to 29 tools)

Merged 5 rarely-used read-only doc tools into a single `doc_query` tool:
- `doc_has`, `doc_keys`, `doc_len`, `doc_select`, `doc_flatten` => `doc_query(action, path, selector)`

Fewer tools = less schema overhead = more room in the agent's context window. `doc_get` and `doc_diff` remain as standalone tools since they're commonly used.

### 3. Dynamic benchmark timeout

Pytest timeout now scales with `RUNS`: `max(1200, N * 700)` seconds. A 3-run benchmark needs ~2100s, which was hitting the old fixed 1200s limit.

### 4. Partial result saving

Each mode now saves benchmark results immediately after completing, so data is preserved even if a later mode times out or fails.

## Changes

| File | Change |
|------|--------|
| `src/plan.rs` | Added `#[serde(alias)]` to all 23 Operation variants; new alias test |
| `src/cmd/mcp.rs` | Replaced 5 doc tools with `doc_query`; updated tool count test (33 => 29) |
| `src/cmd/mod.rs` | Updated agent-rules tool selection table |
| `tests/agent/test_bench.py` | Dynamic timeout; partial result saving |
| `tests/integration.rs` | Updated 5 MCP integration tests for `doc_query` |
| `docs/getting-started/mcp-setup.md` | Updated tool table |
| `PATCHLOOM.md`, `README.md` | Regenerated |

## Verification

`make check` passes: 599 unit + 608 integration = 1207 tests