### PR TITLE
ci: use GitHub App token for release-please identity separation

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -22,7 +22,8 @@ jobs:
       pull-requests: write
     if: >
       github.actor == 'SebTardif' ||
-      github.actor == 'dependabot[bot]'
+      github.actor == 'dependabot[bot]' ||
+      github.actor == 'patchloom-release[bot]'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,15 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89f4291f2343e4b830e5d # v4
         id: rp
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## Summary

Switch release-please from `GITHUB_TOKEN` to the `patchloom-release` GitHub App token, fixing two problems:

1. **CI triggers on release PRs**: `GITHUB_TOKEN` events don't trigger workflows (GitHub security feature), so CI never ran on the release PR. The App token creates events that do trigger workflows.

2. **Auto-approve works**: `GITHUB_TOKEN` acts as `github-actions[bot]`, which can't approve its own PRs. The App creates PRs as `patchloom-release[bot]`, so the `github-actions[bot]` auto-approve is a different identity and can approve.

## Changes

- **`release.yml`**: Add `actions/create-github-app-token` step before release-please, pass the generated token to `release-please-action`
- **`auto-approve.yml`**: Add `patchloom-release[bot]` to the trusted actor list so release PRs get auto-approved and auto-merged

## Credentials

- `AUTO_APPROVE_CLIENT_ID` (repo variable): set to the App's Client ID
- `AUTO_APPROVE_PRIVATE_KEY` (repo secret): set to the App's private key PEM