### PR TITLE
ci: use App token for auto-merge to trigger release-please

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -29,9 +29,15 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
       - name: Auto-approve PR
         uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4
       - name: Enable auto-merge
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,6 +25,12 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
@@ -33,7 +39,7 @@ jobs:
       - name: Approve and enable auto-merge (patch/minor only)
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr review --approve "$PR_URL"


### PR DESCRIPTION
## Problem

Auto-merge workflows (`auto-approve.yml` and `dependabot-auto-merge.yml`) used `GITHUB_TOKEN` for `gh pr merge --auto`. When `GITHUB_TOKEN` merges a PR, the resulting push to main does **not** trigger downstream workflows (this is GitHub's intentional recursive trigger prevention).

This meant the Release workflow's `release-please` job never ran after any PR merge, so no release PR was ever created.

## Fix

Switch both workflows to use the GitHub App token (same App already used by release-please for identity separation) so the merge is attributed to the App identity and the push event triggers the Release workflow.

## Changes

| File | Change |
|------|--------|
| `auto-approve.yml` | Generate App token, use it for `gh pr merge` |
| `dependabot-auto-merge.yml` | Generate App token, use it for `gh pr merge` |

## Verification

After this PR merges (itself via the fixed auto-approve flow), subsequent PR merges should trigger the Release workflow on main, and release-please will create a release PR tracking conventional commits.