### PR TITLE
ci: fix release-please-action pin to valid v4 commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         with:
           client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
           private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
-      - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89f4291f2343e4b830e5d # v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: rp
         with:
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Problem

The release-please job fails on main with:

```
Unable to resolve action googleapis/release-please-action@a02a34c4d625f9be7cb89f4291f2343e4b830e5d, unable to find version
```

The commit hash `a02a34c4...` is not a valid commit in the `googleapis/release-please-action` repository.

## Fix

Update the pin to the correct v4 head commit (`5c625bfb...`).

## Context

This is the first time the release-please job ran on main (previously, push events to main were suppressed because GITHUB_TOKEN merges don't trigger workflows, fixed in #485). The invalid pin was never caught because the job never executed.