### PR TITLE
fix(bench): use neutral tidy prompt so agents discover batch_tidy

### DIFF
--- a/tests/agent/test_bench.py
+++ b/tests/agent/test_bench.py
@@ -257,8 +257,8 @@ TASKS = [
             "Report which files have issues, then fix all the issues."
         ),
         "prompt_mcp": (
-            "Fix whitespace in dirty1.txt then dirty2.txt then clean.txt. "
-            "Call fix_whitespace once for each file."
+            "Fix whitespace issues (trailing whitespace, missing final newlines) "
+            "in dirty1.txt, dirty2.txt, and clean.txt."
         ),
         "setup": lambda ws: [
             (ws / "clean.txt").write_text("This file is clean\n"),
@@ -408,8 +408,9 @@ def _run_session(agent, real_bin, tmp_path, mode):
                     mcp_calls_this_task += 1
                     try:
                         entry = json.loads(line)
-                        tool = entry.get("tool", "?")
-                        mcp_tool_counts[tool] = mcp_tool_counts.get(tool, 0) + 1
+                        if isinstance(entry, dict):
+                            tool = entry.get("tool", "?")
+                            mcp_tool_counts[tool] = mcp_tool_counts.get(tool, 0) + 1
                     except (json.JSONDecodeError, TypeError):
                         pass
             _run_session._prev_mcp_count = len(mcp_lines)


### PR DESCRIPTION
## What

The MCP tidy benchmark prompt previously told the agent to "call fix_whitespace once for each file", which prevented discovery of batch_tidy. This replaces it with a neutral prompt that describes the task without naming any specific tool.

Also fixes the MCP log parser to handle non-dict JSON values that can appear in the JSONL log file (previously caused an AttributeError crash).

## Results

With the neutral prompt, agents now naturally select batch_tidy:

| Task | CLI (s) | MCP (s) | Native (s) | Winner | MCP Tools |
|------|---------|---------|------------|--------|-----------|
| tidy (before) | 72.8 | 34.7 | 81.1 | MCP | fix_whitespace x3 |
| tidy (after) | 62.0 | **21.3** | 70.4 | **MCP** | **batch_tidy x1** |

MCP total dropped from 261s to 208s, now 32% faster than both CLI and native.

## Changes

- Neutral tidy prompt: describes the task without tool name hints
- Defensive type check in MCP log parser for non-dict JSON values