### PR TITLE
fix(ci): remove duplicate release creation in cargo-dist workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -329,8 +329,8 @@ jobs:
       - id: host
         shell: bash
         run: |
-          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --steps=release --output-format=json > dist-manifest.json
-          echo "artifacts uploaded and released successfully"
+          dist host ${{ needs.plan.outputs.tag-flag }} --steps=upload --output-format=json > dist-manifest.json
+          echo "artifacts uploaded successfully"
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"


### PR DESCRIPTION
## Problem

The release workflow has a bug where `dist host --steps=upload --steps=release` creates a GitHub Release, then the explicit `gh release create` step tries to create another one with the same tag. This causes the release to fail with:

```
a release with the same tag name already exists: patchloom-v0.1.1
```

This prevented v0.1.1 from being published despite the release PR (#488) merging successfully.

## Fix

Remove `--steps=release` from the `dist host` command so it only uploads artifacts to scratch storage. The explicit `gh release create` step then handles the actual GitHub Release creation with proper artifacts, title, and release notes.

## Verification

- The `gh release create` step at line 363 already handles release creation with all artifacts from the `artifacts/` directory
- `dist host --steps=upload` only uploads to scratch storage without creating a release
- No other steps depend on `dist host` creating the release

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>