### PR TITLE
fix(ci): prevent transitive skip of release build jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,10 +162,12 @@ jobs:
   build-local-artifacts:
     timeout-minutes: 30
     name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
-    # Let the initial task tell us to not run (currently very blunt)
+    # Let the initial task tell us to not run (currently very blunt).
+    # always() prevents transitive skip: release-please is skipped on tag
+    # pushes, which transitively skips plan's dependents unless they opt out.
     needs:
       - plan
-    if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
+    if: ${{ always() && !failure() && !cancelled() && fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
     strategy:
       fail-fast: false
       # Target platforms/runners are computed by dist in create-release.
@@ -246,6 +248,9 @@ jobs:
     needs:
       - plan
       - build-local-artifacts
+    # always() prevents transitive skip from release-please -> plan chain.
+    # Still requires plan success and build-local success.
+    if: ${{ always() && !cancelled() && needs.plan.result == 'success' && needs.build-local-artifacts.result == 'success' }}
     runs-on: "ubuntu-22.04"
     timeout-minutes: 20
     env:
@@ -301,7 +306,7 @@ jobs:
     permissions:
       "contents": "write"
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"
@@ -347,7 +352,7 @@ jobs:
     needs:
       - plan
       - host
-    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    if: ${{ always() && !cancelled() && needs.host.result == 'success' && needs.plan.outputs.publishing == 'true' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     permissions:
@@ -426,8 +431,9 @@ jobs:
       PLAN: ${{ needs.plan.outputs.val }}
       GITHUB_USER: "axo bot"
       GITHUB_EMAIL: "admin+bot@axo.dev"
+    # always() prevents transitive skip from release-please chain.
     # Do not publish outside the repo while the repository is private.
-    if: ${{ !github.event.repository.private && (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) }}
+    if: ${{ always() && !cancelled() && needs.host.result == 'success' && !github.event.repository.private && (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -471,8 +477,9 @@ jobs:
     needs:
       - plan
       - host
+    # always() prevents transitive skip from release-please chain.
     # Do not publish outside the repo while the repository is private.
-    if: ${{ !github.event.repository.private && (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) }}
+    if: ${{ always() && !cancelled() && needs.host.result == 'success' && !github.event.repository.private && (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) }}
     uses: ./.github/workflows/publish-crates.yml
     with:
       plan: ${{ needs.plan.outputs.val }}


### PR DESCRIPTION
## Problem

When `release-please` is skipped (tag push events), GitHub Actions transitively skips all downstream jobs in the dependency chain, even when intermediate jobs use `always()` and succeed.

The `plan` job uses `always()` to run despite `release-please` being skipped, but `build-local-artifacts`, `build-global-artifacts`, `provenance`, `publish-homebrew-formula`, and `custom-publish-crates` did not use `always()`, causing them to be transitively skipped.

**This is the root cause of v0.1.1 shipping with zero binaries**: plan ran successfully and produced a valid 5-target build matrix (3.3KB, well under the 50KB limit), but all build jobs were skipped before their `if` conditions were even evaluated.

## Root Cause

GitHub Actions dependency chain on tag push:
```
release-please (SKIPPED, tag push not main push)
  -> plan (needs: [release-please], uses always() -> SUCCESS)
       -> build-local-artifacts (needs: [plan], NO always() -> TRANSITIVELY SKIPPED)
            -> build-global-artifacts (TRANSITIVELY SKIPPED)
                 -> host (uses always(), runs but finds no artifacts -> FAILURE)
```

## Fix

Add `always() && !cancelled()` to all jobs in the `release-please -> plan` dependency chain that previously lacked it:

| Job | Before | After |
|-----|--------|-------|
| build-local-artifacts | `if: fromJson(...).include != null && ...` | `if: always() && !failure() && !cancelled() && fromJson(...).include != null && ...` |
| build-global-artifacts | (no if) | `if: always() && !cancelled() && needs.plan.result == 'success' && needs.build-local-artifacts.result == 'success'` |
| host | `always() && ...` (already had it) | Added `!cancelled()` guard |
| provenance | `if: publishing == 'true'` | `if: always() && !cancelled() && needs.host.result == 'success' && publishing == 'true'` |
| publish-homebrew-formula | `if: !private && ...` | `if: always() && !cancelled() && needs.host.result == 'success' && !private && ...` |
| custom-publish-crates | `if: !private && ...` | `if: always() && !cancelled() && needs.host.result == 'success' && !private && ...` |
| announce | (already had always()) | No change needed |

Each job still validates its own prerequisites (plan success, build success, etc.) to prevent running when upstream jobs genuinely fail.

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>