### PR TITLE
fix(ci): add checkout step to release host job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,6 +318,9 @@ jobs:
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       # Download all build artifacts and the plan manifest from scratch storage
       - name: "Download GitHub Artifacts"
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
The host job needs a git repository context for `gh release create` to resolve the repository. The checkout step was accidentally removed in PR #494 when cleaning up the host job to remove `dist host` usage.

Without it, `gh release create` fails with:
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>