### PR TITLE
docs: add 'Removing an MCP tool' checklist to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -244,6 +244,28 @@ async fn new_tool(
 
 6. Run `make sync-patchloom-md && make update-readme && make check`.
 
+## Removing an MCP tool
+
+1. **Remove the handler method and params struct** from `src/cmd/mcp.rs`.
+
+2. **Remove the tool name** from the `mcp_lists_expected_tools` test and update the expected count.
+
+3. **Remove integration tests** for the tool from `tests/integration.rs`.
+
+4. **Remove references** from all documentation that lists MCP tools:
+   - `src/cmd/mod.rs` (agent-rules generator)
+   - `docs/getting-started/mcp-setup.md`
+   - `examples/README.md` (example descriptions)
+   - `benches/README.md` (MCP benchmark table)
+
+5. Grep for the tool name across the repo to catch remaining references:
+
+```bash
+grep -ri "tool_name" --include="*.md" --include="*.rs" --include="*.json" .
+```
+
+6. Run `make sync-patchloom-md && make update-readme && make check`.
+
 ## Coding conventions
 
 - Run `cargo fmt` before every commit.


### PR DESCRIPTION
## Problem

AGENTS.md has an 'Adding a new MCP tool' checklist (6 steps, specific files) but no removal counterpart. PR #481 removed batch/transaction MCP tools but missed stale references in `examples/README.md` and `benches/README.md` (fixed in #484).

## Fix

Add a parallel 'Removing an MCP tool' section that covers:
1. Remove handler and params from `mcp.rs`
2. Update expected tools test
3. Remove integration tests
4. Remove references from all doc files (mod.rs, mcp-setup.md, examples/README.md, benches/README.md)
5. Grep for remaining references
6. Run `make sync-patchloom-md && make update-readme && make check`