### PR TITLE
fix: add benchmark result directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ fuzz/corpus/
 fuzz/artifacts/
 
 
+# Benchmark result files (local runs, not committed)
+benches/agent/results/
+benches/mcp/results/
+
 # Python virtual environments
 tests/agent/.venv/
 tests/agent/.pytest_cache/


### PR DESCRIPTION
Benchmark result files (`benches/agent/results/` and `benches/mcp/results/`) were not gitignored. This caused 35+ untracked files to appear in `git status`, creating noise and risk of accidental staging.

Signed-off-by: Sebastien Tardif <sebastien@tardif.ca>