### PR TITLE
fix: improvement cycle 4 (MCP tests, doc dedup, error messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1199%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1205%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -379,7 +379,7 @@ flowchart LR
 
 ## Status
 
-1199 passing tests across 19 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1205 passing tests across 19 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -728,16 +728,11 @@ pub(crate) fn execute_with_mode(
                 return Ok((String::new(), exit::NO_MATCHES));
             }
             let target = results[0];
-            if let Some(arr) = target.as_array() {
-                let len = arr.len();
-                let output = match output_mode {
-                    OutputMode::Text => len.to_string(),
-                    OutputMode::Json => serde_json::to_string_pretty(&len)?,
-                    OutputMode::Jsonl => serde_json::to_string(&len)?,
-                };
-                Ok((output, exit::SUCCESS))
-            } else if let Some(obj) = target.as_object() {
-                let len = obj.len();
+            let len = target
+                .as_array()
+                .map(|a| a.len())
+                .or_else(|| target.as_object().map(|o| o.len()));
+            if let Some(len) = len {
                 let output = match output_mode {
                     OutputMode::Text => len.to_string(),
                     OutputMode::Json => serde_json::to_string_pretty(&len)?,

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -426,7 +426,10 @@ fn validate_path_resolved(
     })?;
     if !canon_path.starts_with(canon_cwd) {
         return Err(McpError::invalid_params(
-            format!("resolved path escapes working directory: {path}"),
+            format!(
+                "resolved path escapes working directory: {path} (cwd: {})",
+                cwd.display()
+            ),
             None,
         ));
     }
@@ -539,7 +542,15 @@ impl PatchloomService {
     /// Validate a path for both syntactic containment and symlink resolution.
     /// Combines the two checks that must always be called together.
     fn check_path(&self, path: &str) -> Result<(), McpError> {
-        validate_path_contained(path)?;
+        validate_path_contained(path).map_err(|_| {
+            McpError::invalid_params(
+                format!(
+                    "path rejected: {path}; use a relative path within the working directory ({})",
+                    self.cwd.display()
+                ),
+                None,
+            )
+        })?;
         validate_path_resolved(path, &self.cwd, &self.canon_cwd)
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -16545,6 +16545,173 @@ async fn test_mcp_batch_replace_path_traversal_rejected() {
     client.cancel().await.unwrap();
 }
 
+#[tokio::test]
+async fn test_mcp_rejects_unknown_fields() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("test.json"), r#"{"a":1}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    // Send a valid tool call but with an extra hallucinated parameter.
+    // deny_unknown_fields on the params struct must reject this.
+    let params = rmcp::model::CallToolRequestParams::new("doc_set").with_arguments(
+        serde_json::from_value(serde_json::json!({
+            "path": "test.json",
+            "selector": "a",
+            "value": 2,
+            "hallucinated_param": true
+        }))
+        .unwrap(),
+    );
+    let result = client.peer().call_tool(params).await;
+    assert!(
+        result.is_err(),
+        "unknown fields must be rejected by deny_unknown_fields"
+    );
+    // File must remain unchanged
+    let content = fs::read_to_string(dir.path().join("test.json")).unwrap();
+    assert_eq!(content, r#"{"a":1}"#);
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_replace_regex_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("ver.txt"),
+        "version = 1.2.3\nversion = 4.5.6\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, _text) = call_tool_text(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "ver.txt",
+            "from": r"version = (\d+)\.(\d+)\.(\d+)",
+            "to": "version = $1.$2.99",
+            "regex": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "regex replace should succeed");
+
+    let content = fs::read_to_string(dir.path().join("ver.txt")).unwrap();
+    assert_eq!(content, "version = 1.2.99\nversion = 4.5.99\n");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_replace_nth_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("rep.txt"), "foo bar foo baz foo\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, _text) = call_tool_text(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "rep.txt",
+            "from": "foo",
+            "to": "qux",
+            "nth": 2
+        }),
+    )
+    .await;
+    assert!(!is_error, "nth replace should succeed");
+
+    let content = fs::read_to_string(dir.path().join("rep.txt")).unwrap();
+    assert_eq!(content, "foo bar qux baz foo\n");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_replace_if_exists_no_match_succeeds() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("stable.txt"), "no match here\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, _text) = call_tool_text(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "stable.txt",
+            "from": "nonexistent",
+            "to": "replacement",
+            "if_exists": true
+        }),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "if_exists with no match should succeed (not error)"
+    );
+
+    let content = fs::read_to_string(dir.path().join("stable.txt")).unwrap();
+    assert_eq!(content, "no match here\n");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_doc_query_unknown_action_returns_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("data.json"), r#"{"x":1}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let params = rmcp::model::CallToolRequestParams::new("doc_query").with_arguments(
+        serde_json::from_value(serde_json::json!({
+            "path": "data.json",
+            "action": "nonexistent"
+        }))
+        .unwrap(),
+    );
+    let result = client.peer().call_tool(params).await;
+    assert!(
+        result.is_err(),
+        "unknown action should return McpError::invalid_params"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_doc_query_has_without_selector_returns_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("data.json"), r#"{"x":1}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let params = rmcp::model::CallToolRequestParams::new("doc_query").with_arguments(
+        serde_json::from_value(serde_json::json!({
+            "path": "data.json",
+            "action": "has"
+        }))
+        .unwrap(),
+    );
+    let result = client.peer().call_tool(params).await;
+    assert!(
+        result.is_err(),
+        "'has' without selector should return McpError::invalid_params"
+    );
+    client.cancel().await.unwrap();
+}
+
 // ---------------------------------------------------------------------------
 // Backup pruning integration tests (#371)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle covering QA, Developer, End User, and 11 additional perspectives (all no-op on this mature codebase).

## Changes

### QA Engineer: 6 new MCP protocol-level integration tests

- `test_mcp_rejects_unknown_fields`: verifies `deny_unknown_fields` rejects hallucinated parameters (security guard against LLM prompt injection)
- `test_mcp_replace_regex_round_trip`: validates regex mode mapping (`p.regex` to `mode: Some("regex")`)
- `test_mcp_replace_nth_round_trip`: validates nth-occurrence replace through MCP
- `test_mcp_replace_if_exists_no_match_succeeds`: validates if_exists returns success when no match
- `test_mcp_doc_query_unknown_action_returns_error`: validates unknown action rejection
- `test_mcp_doc_query_has_without_selector_returns_error`: validates selector requirement

### Developer: doc.rs Len deduplication

Merged two identical branches for array/object length counting into a single branch using Option chaining (-10 lines).

### End User: enriched MCP path validation errors

Path rejection errors now include the working directory so the caller knows what relative path to use:
- Before: `absolute paths are not allowed: /Users/me/project/config.yaml`
- After: `path rejected: /Users/me/project/config.yaml; use a relative path within the working directory (/tmp/workspace)`

## Filed issues

- #503: refactor tx.rs .map_err pattern (27 identical closures)
- #504: extract md operation helper in tx.rs
- #505: MCP input size limits (adversarial hardening)
- #506: --verbose / debug logging mode

## Verification

`make check` passes: 1205 tests (601 unit + 604 integration), 0 warnings.