### PR TITLE
fix: make release host job idempotent for release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,14 +84,15 @@ jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
     needs: [release-please]
-    # Run when: release-please created a release, OR a tag was pushed
-    # manually, OR workflow_dispatch, OR pull_request.
-    # always() is required because release-please is skipped on non-main events,
-    # and GitHub Actions skips dependent jobs when any need is skipped.
+    # Run when: a tag was pushed (real release), workflow_dispatch, or
+    # pull_request (dry-run plan).  NOT on push-to-main: release-please
+    # creates the tag on that event, and the resulting tag-push triggers
+    # this job via the refs/tags path, avoiding a duplicate build.
+    # always() is required because release-please is skipped on non-main
+    # events, and GitHub Actions skips dependent jobs when any need is skipped.
     if: >-
       always() && !failure() && !cancelled() &&
-      (needs.release-please.outputs.release_created == 'true' ||
-       startsWith(github.ref, 'refs/tags/') ||
+      (startsWith(github.ref, 'refs/tags/') ||
        github.event_name == 'workflow_dispatch' ||
        github.event_name == 'pull_request')
     permissions:
@@ -345,7 +346,17 @@ jobs:
           # Remove manifests so only distributable files are uploaded to the release
           rm -f artifacts/*-dist-manifest.json
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          TAG="${{ needs.plan.outputs.tag }}"
+
+          # release-please may have already created the GitHub Release
+          # (it creates both the tag and the release when its PR merges).
+          # If the release exists, upload artifacts to it; otherwise create it.
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            echo "Release $TAG already exists (created by release-please). Uploading artifacts..."
+            gh release upload "$TAG" artifacts/* --clobber
+          else
+            gh release create "$TAG" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          fi
 
           # Output the slimmed manifest for downstream jobs (full manifest
           # exceeds GitHub Actions ~50KB step output limit)


### PR DESCRIPTION
## Problem

v0.1.2 release shipped with no binaries, no installers, no Homebrew formula, no provenance attestation. The only assets were benchmark markdown files (`small.md`, `medium.md`).

## Root Cause

release-please creates both the git tag AND the GitHub Release when its PR merges. Then cargo-dist's `host` job tries `gh release create` with the same tag and fails:

```
a release with the same tag name already exists: patchloom-v0.1.2
```

All downstream jobs (provenance, Homebrew, crates.io, announce) were skipped. The only reason `small.md` and `medium.md` appeared is that `bench.yml` triggers on `release: published` and uploaded benchmark results to the (otherwise empty) release.

Additionally, the push-to-main event AND the tag-push event both triggered the release workflow, creating two redundant runs that both failed the same way.

## Fix

1. **Idempotent host job**: Check if the release already exists (`gh release view`). If it does (created by release-please), upload artifacts with `gh release upload --clobber`. If not, create it with `gh release create`.

2. **Eliminate duplicate run**: Remove `release_created` from the plan job's trigger condition. On push-to-main, only the release-please step runs. The tag push (triggered by release-please via App token) handles the full build-and-host pipeline.

## v0.1.2 Recovery

After this PR merges, v0.1.2 will be repaired by deleting the broken release and re-dispatching the workflow on the tag ref.