### PR TITLE
fix: parse release-please pr output as JSON

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,11 +107,9 @@ jobs:
       - name: Get PR branch
         id: pr-branch
         env:
-          GH_TOKEN: ${{ github.token }}
+          PR_JSON: ${{ needs.release-please.outputs.pr }}
         run: |
-          branch=$(gh pr view "${{ needs.release-please.outputs.pr }}" \
-            --repo "${{ github.repository }}" \
-            --json headRefName --jq .headRefName)
+          branch=$(echo "$PR_JSON" | jq -r .headBranchName)
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:


### PR DESCRIPTION
The `sync-generated-files` job from PR #513 failed because release-please's `pr` output is a full JSON object (with `headBranchName`, `number`, `title`, `body`, etc.), not a plain PR number.

Passing the raw JSON to `gh pr view` caused a bash syntax error from parentheses in the JSON body field.

**Fix**: Extract `headBranchName` directly from the JSON via `jq` instead of calling the GitHub API. This is also faster (no API call needed).