### PR TITLE
chore: require manual merge for release-please PRs

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Auto-approve PR
         uses: hmarr/auto-approve-action@f0939ea97e9205ef24d872e76833fa908a770363 # v4
       - name: Enable auto-merge
+        # Skip auto-merge for release-please PRs so the user controls
+        # release cadence.  The PR is still approved (satisfies branch
+        # protection) but waits for a manual merge click.
+        if: "!contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"


### PR DESCRIPTION
## Problem

release-please PRs were auto-approved AND auto-merged, causing unintended releases. v0.1.3 and v0.1.4 both shipped with only CI workflow changes (no user-facing fixes) because the release PRs merged without user approval.

## Fix

Add a label check to the auto-merge step in `auto-approve.yml`: skip `gh pr merge --auto` when the PR has the `autorelease: pending` label (which release-please adds to every release PR).

**What changes:**
- Release-please PRs are still **auto-approved** (satisfies branch protection's 1-approval requirement)
- Release-please PRs are **NOT auto-merged** (user clicks merge when ready to release)
- Dependabot PRs and user PRs continue to auto-merge as before

**What the ci-build-release skill says:** Use GitHub environment required reviewers to gate releases. This is the PR-level equivalent: the approval is automatic, but the merge requires human intent.