### PR TITLE
chore: fix code quality findings from GitHub AI scanner

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -44,7 +44,7 @@ EOF
 
 One line per operation. Double-quote values with spaces.
 
-**Note:** Values are parsed as JSON. A quoted `"1.0"` produces the JSON number `1.0`, not the string `"1.0"`. To set a string that looks numeric, omit the outer quotes: `doc.set config.json version 1.0`.
+**Note:** Values are parsed as JSON first. An unquoted `1.0` is parsed as a number. To force a string, wrap in JSON quotes: `doc.set config.json version '"1.0"'`.
 
 On Windows (where heredocs are not available), write operations to a file and pass it:
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -211,7 +211,7 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  EOF\n\
                  ```\n\n\
                  One line per operation. Double-quote values with spaces.\n\n\
-                 **Note:** Values are parsed as JSON. A quoted `\"1.0\"` produces the JSON number `1.0`, not the string `\"1.0\"`. To set a string that looks numeric, omit the outer quotes: `doc.set config.json version 1.0`.\n\n",
+                 **Note:** Values are parsed as JSON first. An unquoted `1.0` is parsed as a number. To force a string, wrap in JSON quotes: `doc.set config.json version '\"1.0\"'`.\n\n",
             );
         }
 
@@ -229,7 +229,7 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
             if !show_linux {
                 out.push_str(
                     "One line per operation in the file. Double-quote values with spaces.\n\n\
-                     **Note:** Values are parsed as JSON. A quoted `\"1.0\"` produces the JSON number `1.0`, not the string `\"1.0\"`. To set a string that looks numeric, omit the outer quotes: `doc.set config.json version 1.0`.\n\n",
+                     **Note:** Values are parsed as JSON first. An unquoted `1.0` is parsed as a number. To force a string, wrap in JSON quotes: `doc.set config.json version '\"1.0\"'`.\n\n",
                 );
             }
         }

--- a/tests/agent/test_bench.py
+++ b/tests/agent/test_bench.py
@@ -357,6 +357,7 @@ def _run_session(agent, real_bin, tmp_path, mode):
         prev_count = len(prev_lines)
 
         prompt = _get_prompt(task, mode)
+        # --yolo runs non-interactively (auto-confirm/apply) so benchmarks are unattended.
         cmd = ["grok", "-p", prompt, "--yolo", "--output-format", "json",
                "--max-turns", "15", "--cwd", str(ws), "-m", agent.model]
         if session_id:
@@ -412,7 +413,7 @@ def _run_session(agent, real_bin, tmp_path, mode):
                             tool = entry.get("tool", "?")
                             mcp_tool_counts[tool] = mcp_tool_counts.get(tool, 0) + 1
                     except (json.JSONDecodeError, TypeError):
-                        pass
+                        pass  # Skip malformed MCP log lines
             _run_session._prev_mcp_count = len(mcp_lines)
 
         try:
@@ -582,7 +583,12 @@ def test_dry_run_prompts(request):
             for line in prompt.split("\n"):
                 print(f"    {line}")
         # Show check function source for transparency
-        print(f"\n  [check]: {task['check'].__code__.co_code!r:.60}...")
+        import inspect
+        try:
+            src = inspect.getsource(task["check"]).strip()
+            print(f"\n  [check]:\n    {src[:200]}")
+        except OSError:
+            print(f"\n  [check]: <source unavailable>")
     print(f"\n{'=' * 60}")
     print(f"Total: {len(TASKS)} tasks x {len(modes)} modes")
     print(f"{'=' * 60}")


### PR DESCRIPTION
Addresses findings from the [GitHub AI code quality scanner](https://github.com/patchloom/patchloom/security/quality/ai-findings) and one [CodeQL alert](https://github.com/patchloom/patchloom/security/code-scanning/38).

### Fixed (3 findings)

| File | Finding | Fix |
|------|---------|-----|
| `src/cmd/mod.rs` | Incorrect parse_value documentation (said quoted `"1.0"` produces a number; it actually produces a string) | Corrected: unquoted `1.0` is a number, quoted is a string |
| `tests/agent/test_bench.py` | `--yolo` flag undocumented | Added explanatory comment |
| `tests/agent/test_bench.py` | `co_code` bytecode dump not useful | Replaced with `inspect.getsource()` |

### Also fixed (CodeQL)

| Alert | Finding | Fix |
|-------|---------|-----|
| [#38](https://github.com/patchloom/patchloom/security/code-scanning/38) | `py/empty-except`: empty except with no comment | Added explanatory comment |

### Triaged as false positive / by-design (5 findings)

| File | Finding | Reason |
|------|---------|--------|
| `scripts/fossa-filter.py` | Missing error handling | Already has try/except with user-facing error message |
| `scripts/fossa-filter.py` | Unused `issue_type` param | Intentionally kept for API stability (has comment) |
| `src/selector/eval.rs` | Wildcard only matches arrays | By design: `[*]` is the array wildcard selector |
| `tests/agent/test_bench.py` | Function attribute state anti-pattern | Test harness only, not production code |