### PR TITLE
fix: improvement cycle 6 (doc_query validation, troubleshooting docs)

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -155,3 +155,15 @@ dependencies[name=react].version # predicate filter
 | 5 | Ambiguous (replacement matched multiple locations without `--nth`, or stale/missing patch context) |
 | 6 | Validation failed (tx plan validation step returned non-zero) |
 | 7 | Rollback (tx apply failed partway; changes were rolled back) |
+
+## Troubleshooting
+
+If a command produces unexpected results, enable verbose logging to see what patchloom is doing internally:
+
+```bash
+patchloom --verbose <command> [args]
+# or via environment variable:
+PATCHLOOM_LOG=1 patchloom <command> [args]
+```
+
+Diagnostic messages are printed to stderr prefixed with `[patchloom]`.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1224%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1225%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -379,7 +379,7 @@ flowchart LR
 
 ## Status
 
-1224 passing tests across 19 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1225 passing tests across 19 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -927,6 +927,9 @@ impl PatchloomService {
         Parameters(p): Parameters<DocQueryParams>,
     ) -> Result<CallToolResult, McpError> {
         self.check_path(&p.path)?;
+        if let Some(ref sel) = p.selector {
+            validate_param_size("selector", sel)?;
+        }
         let abs = self.cwd.join(&p.path);
         let file = abs.to_string_lossy().into_owned();
         let action = match p.action.as_str() {
@@ -1965,6 +1968,25 @@ mod tests {
         );
         let result = client.peer().call_tool(params).await;
         assert!(result.is_err(), "oversized batch should be rejected");
+        client.cancel().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn mcp_rejects_oversized_doc_query_selector() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("data.json"), r#"{"a":1}"#).unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let big_selector = "x".repeat(MAX_PARAM_BYTES + 1);
+        let params = rmcp::model::CallToolRequestParams::new("doc_query").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "action": "has",
+                "path": "data.json",
+                "selector": big_selector,
+            }))
+            .unwrap(),
+        );
+        let result = client.peer().call_tool(params).await;
+        assert!(result.is_err(), "oversized selector should be rejected");
         client.cancel().await.unwrap();
     }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -356,9 +356,22 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 4 | Parse error (malformed input file or plan) |\n\
              | 5 | Ambiguous (replacement matched multiple locations without `--nth`, or stale/missing patch context) |\n\
              | 6 | Validation failed (tx plan validation step returned non-zero) |\n\
-             | 7 | Rollback (tx apply failed partway; changes were rolled back) |\n",
+             | 7 | Rollback (tx apply failed partway; changes were rolled back) |\n\n",
         );
     }
+
+    // Troubleshooting (always shown)
+    out.push_str(
+        "## Troubleshooting\n\n\
+         If a command produces unexpected results, enable verbose logging to see \
+         what patchloom is doing internally:\n\n\
+         ```bash\n\
+         patchloom --verbose <command> [args]\n\
+         # or via environment variable:\n\
+         PATCHLOOM_LOG=1 patchloom <command> [args]\n\
+         ```\n\n\
+         Diagnostic messages are printed to stderr prefixed with `[patchloom]`.\n",
+    );
 
     out
 }


### PR DESCRIPTION
## Changes

- Add missing `validate_param_size` check on `doc_query` selector parameter.
  All other doc MCP handlers already validated their selector; `doc_query`
  was the only one that accepted arbitrarily large selectors.
- Add integration test for the `doc_query` oversized selector rejection.
- Add Troubleshooting section to generated agent rules (PATCHLOOM.md)
  documenting `--verbose` flag and `PATCHLOOM_LOG` environment variable.

## How found

Multi-perspective improvement rotation (14 perspectives). Two findings:
1. **QA Engineer** (iteration 1): systematic comparison of all doc MCP handlers revealed `doc_query` was missing the selector size validation that all 9 other doc handlers had.
2. **End User** (iteration 3): checked whether `--verbose` and `PATCHLOOM_LOG` were documented in the generated PATCHLOOM.md agent rules. They were not.

Iterations 2, 4-14 produced no findings (security, performance, architecture, adversarial testing, observability all clean).

## Testing

- `make check` passes (610 integration + unit tests, including the new `mcp_doc_query_rejects_oversized_selector` test)
- Test count updated in README.md (1224 -> 1225)