### PR TITLE
fix(ci): use App token in update-branches to trigger CI on updated PRs

### DIFF
--- a/.github/workflows/update-branches.yml
+++ b/.github/workflows/update-branches.yml
@@ -17,16 +17,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+      # Use a GitHub App token instead of GITHUB_TOKEN so that the merge
+      # commit triggers pull_request workflows (CI, DCO, etc.) on the
+      # updated HEAD.  GITHUB_TOKEN pushes are silently ignored by GitHub
+      # to prevent infinite loops, which leaves required checks stale and
+      # blocks auto-merge.
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
       - name: Update open PR branches
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --base main --state open --json number --jq '.[].number')
           for pr in $prs; do


### PR DESCRIPTION
## Problem

The `update-branches` workflow used `GITHUB_TOKEN` to merge `main` into open PR branches. Pushes from `GITHUB_TOKEN` do not fire `pull_request` events (GitHub's infinite-loop protection), so CI never re-triggered on the new HEAD commit.

Combined with `strict_required_status_checks_policy: true`, this left PRs permanently stuck: required checks existed only on the old commit, not on the updated HEAD.

This caused the release-please PR #521 (v0.1.5) to require manual intervention (close/reopen) before auto-merge could proceed.

## Fix

Switch to the GitHub App token (`AUTO_APPROVE`) so that branch updates trigger `pull_request: synchronize` events, which re-run CI, DCO, CodeQL, and all other required checks on the updated HEAD.

Also narrow job-level permissions from `contents: write` to `contents: read` since the App token handles write operations via the API.

## Testing

- `make check` passes (1,232 tests: 622 unit + 610 integration)
- The fix mirrors the same App token pattern already used by `auto-approve.yml`, `dependabot-auto-merge.yml`, and `release.yml`