### PR TITLE
fix: improvement cycle (UTF-8 truncate, doc_set double-parse, docs freshness)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1307%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1311%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -379,7 +379,7 @@ flowchart LR
 
 ## Status
 
-1307 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1311 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,39 @@ patchloom mcp-server --allow-shell
 
 See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent configuration and the full security model.
 
+### As a Rust library
+
+Add patchloom as a dependency (omit the MCP server with `default-features = false`):
+
+```toml
+[dependencies]
+patchloom = { version = "0.1", default-features = false }
+```
+
+```rust
+use patchloom::api::{self, ApplyMode};
+use std::path::Path;
+
+// Replace text (preview only, no disk write)
+let result = api::replace_text(
+    Path::new("src/config.rs"),
+    "old_value", "new_value",
+    &api::ReplaceOptions::default(),
+    ApplyMode::Preview,
+)?;
+println!("{}", result.diff);
+
+// Set a value in a JSON file
+api::doc_set(
+    Path::new("config.json"),
+    "version",
+    serde_json::json!("2.0"),
+    ApplyMode::Apply,
+)?;
+```
+
+All API types are `Send + Sync`. See the `patchloom::api` module docs for the full surface.
+
 ## Getting started
 
 | Resource | What you'll learn |
@@ -291,6 +324,7 @@ See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent con
 | `undo` | Restore files from a backup created by `--apply` |
 | `completions` | Generate shell completions (bash, zsh, fish, elvish) |
 | `init` | Set up patchloom in a project (agent rules, completions, MCP) |
+| `schema` | Export operation schemas with tier filtering and system prompts |
 | `agent-rules` | Generate agent instructions for your project |
 
 ## How patchloom compares

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,8 +98,8 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,195 tests**, zero unsafe code
-- **19 commands** including MCP server with 29 structured tool calls
+- **1,311 tests**, zero unsafe code
+- **20 commands** including MCP server with 29 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -2,7 +2,7 @@
 
 ## Commands
 
-Patchloom has 19 commands:
+Patchloom has 20 commands:
 
 - **search** / **replace** -- text-level find and replace across files
 - **patch** -- apply unified diffs
@@ -16,6 +16,7 @@ Patchloom has 19 commands:
 - **batch** -- line-oriented multi-operation format (delegates to tx engine)
 - **completions** -- shell completion generation
 - **agent-rules** -- print end-user agent documentation for patchloom
+- **schema** -- export operation schemas with tier filtering and system prompts
 - **explain** -- summarize a tx plan in plain English before applying
 - **undo** -- restore files from a backup created by `--apply`
 - **init** -- set up patchloom in a project (agent rules, completions, MCP)

--- a/src/api.rs
+++ b/src/api.rs
@@ -202,17 +202,13 @@ pub fn doc_set(
     let format = ops::doc::detect_format(&path_str)?;
     let original = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
-    let mut doc = ops::doc::parse_doc(&original, &format)?;
+    let old_value = ops::doc::parse_doc(&original, &format)?;
+    let mut doc = old_value.clone();
 
     let segments = selector::parse_anyhow(selector)?;
     ops::doc::set_at_path(&mut doc, &segments, value)?;
 
-    let new_content = ops::doc::serialize_value_preserving(
-        &original,
-        &{ ops::doc::parse_doc(&original, &format)? },
-        &doc,
-        &format,
-    )?;
+    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
 
     let policy = WritePolicy::default();
     let applied = write_if_apply(path, &new_content, mode, &policy)?;

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -439,8 +439,20 @@ fn extract_identifiers(line: &str) -> Vec<String> {
 }
 
 /// Truncate a string for display in error messages.
+///
+/// Truncates at the last char boundary at or before `max_len` bytes,
+/// so this is safe for multi-byte UTF-8 input.
 fn truncate(s: &str, max_len: usize) -> &str {
-    if s.len() <= max_len { s } else { &s[..max_len] }
+    if s.len() <= max_len {
+        s
+    } else {
+        // Find the last char boundary at or before max_len.
+        let mut end = max_len;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
 }
 
 #[cfg(test)]
@@ -699,6 +711,65 @@ mod tests {
         let deserialized: ValidationResult = serde_json::from_str(&json).unwrap();
         assert!(deserialized.valid);
         assert_eq!(deserialized.warnings.len(), 1);
+    }
+
+    #[test]
+    fn truncate_safe_on_multibyte_utf8() {
+        // "café" has bytes: c(1) a(1) f(1) é(2) = 5 bytes, 4 chars.
+        let s = "café";
+        assert_eq!(s.len(), 5);
+        // Truncate at 4 would land in the middle of 'é' (bytes 3-4).
+        // Must not panic; should truncate before the multi-byte char.
+        let t = truncate(s, 4);
+        assert_eq!(t, "caf");
+        // Truncate at 5 returns the whole string.
+        assert_eq!(truncate(s, 5), "café");
+        // Truncate at 3 is a clean boundary.
+        assert_eq!(truncate(s, 3), "caf");
+        // Truncate at 0.
+        assert_eq!(truncate(s, 0), "");
+    }
+
+    #[test]
+    fn validate_edit_toml_syntax_check() {
+        let toml = "[database]\nhost = \"localhost\"\n";
+        // Valid replacement.
+        let result = validate_edit(toml, "localhost", "remotehost", Some("config.toml"));
+        assert!(result.valid);
+
+        // Invalid replacement (breaks TOML).
+        let result = validate_edit(
+            toml,
+            "[database]",
+            "not valid toml {{{{",
+            Some("config.toml"),
+        );
+        assert!(!result.valid);
+        assert!(result.errors[0].contains("invalid TOML"));
+    }
+
+    #[test]
+    fn find_similar_targets_multi_word_pattern() {
+        let content = "fn process_all_requests(data: &str) -> bool {\n    true\n}\n";
+        // Multi-word pattern triggers whole-line matching path.
+        let similar = find_similar_targets(content, "fn process_all_reqests(data: &str)", 3);
+        assert!(
+            !similar.is_empty(),
+            "should find similar multi-word targets"
+        );
+    }
+
+    #[test]
+    fn resolve_fallback_multi_line_no_similarity() {
+        // Multi-line targets skip the similarity path and go to error.
+        let content = "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n";
+        let result = resolve_with_fallback(content, "fn alphax() {}\nfn betax() {}", None, None);
+        assert!(
+            result.is_err(),
+            "multi-line targets without context should not match via similarity"
+        );
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, EditErrorKind::NoMatch);
     }
 
     // Static assertions: types must be Send + Sync.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14377,9 +14377,9 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,195 tests"));
+    assert!(launch.contains("1,311 tests"));
     assert!(
-        launch.contains("19 commands"),
+        launch.contains("20 commands"),
         "launch announcement CLI command count drifted"
     );
     assert!(


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle covering QA, Developer, End User, and documentation audit perspectives.

## Changes

### Bug fixes
- **UTF-8 truncate panic** (`src/fallback.rs`): The `truncate()` helper used byte slicing which panics on multi-byte UTF-8 boundaries. Changed to char-boundary-safe truncation that walks backwards to the nearest valid boundary.
- **doc_set double-parse** (`src/api.rs`): The `doc_set` function parsed the document twice (once for old_value, once for mutation). Changed to clone-before-mutate to eliminate the redundant parse.

### Documentation
- **Library API section** (`README.md`): Added "As a Rust library" section with dependency and usage examples.
- **Schema command** (`README.md`): Added `schema` to the command table.
- **Command count drift** (`docs/getting-started/concepts.md`, `docs/blog/launch-announcement.md`): Updated from 19 to 20 commands, added `schema` to the command list.
- **Stale test count** (`docs/blog/launch-announcement.md`): Updated from 1,195 to 1,311 tests.
- **Integration test sync** (`tests/integration.rs`): Updated smoke test assertions to match new doc values.

### Tests
- 4 new unit tests in `src/fallback.rs`: multi-byte UTF-8 truncation, TOML syntax validation, multi-word fuzzy matching, multi-line no-similarity error.

## Verification

`make check` passes (1,311 tests, 0 clippy warnings, 0 fmt issues).

Signed-off-by: Sebastien Tardif <seb@tardif.com>