### PR TITLE
test: strengthen doc_merge and file_rename assertions in API tests

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -816,7 +816,13 @@ mod tests {
 
         assert!(result.changed);
         let on_disk = fs::read_to_string(&file).unwrap();
-        assert!(on_disk.contains("\"b\""));
+        let parsed: serde_json::Value = serde_json::from_str(&on_disk).unwrap();
+        assert_eq!(
+            parsed["a"],
+            serde_json::json!(1),
+            "merge must preserve existing keys"
+        );
+        assert_eq!(parsed["b"], serde_json::json!(2), "merge must add new keys");
     }
 
     #[test]
@@ -917,6 +923,11 @@ mod tests {
         assert!(result.applied);
         assert!(!src.exists());
         assert!(dst.exists());
+        let dst_content = fs::read_to_string(&dst).unwrap();
+        assert_eq!(
+            dst_content, "content\n",
+            "rename must preserve file content"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Improvement cycle 2: strengthen existing test assertions.

## Changes

- `doc_merge_merges_values`: verify both existing key preservation and new key addition on disk (was only checking `changed` flag)
- `file_rename_works`: verify renamed file content matches original (was only checking existence)

## Verification

`make check` passes locally (695 unit + 616 integration tests).