### PR TITLE
fix: propagate read errors in file_create and extract inline conditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1311%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1312%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -413,7 +413,7 @@ flowchart LR
 
 ## Status
 
-1311 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1312 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -373,13 +373,14 @@ pub fn replace_text(
         opts.multiline,
     )?;
 
+    let direct_to = if opts.insert_before.is_none() && opts.insert_after.is_none() {
+        Some(to.to_string())
+    } else {
+        None
+    };
     let replacement = ops::replace::replacement_text(
         from,
-        &if opts.insert_before.is_none() && opts.insert_after.is_none() {
-            Some(to.to_string())
-        } else {
-            None
-        },
+        &direct_to,
         &opts.insert_before,
         &opts.insert_after,
         compiled_re.is_some(),
@@ -520,7 +521,8 @@ pub fn file_create(
     }
 
     let original = if path.exists() {
-        std::fs::read_to_string(path).unwrap_or_default()
+        std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read existing file: {}", path.display()))?
     } else {
         String::new()
     };
@@ -910,6 +912,25 @@ mod tests {
         let result = file_delete(&file, ApplyMode::Apply).unwrap();
         assert!(result.applied);
         assert!(!file.exists());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn file_create_force_propagates_read_error() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("unreadable.txt");
+        fs::write(&file, "original").unwrap();
+        fs::set_permissions(&file, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let err = file_create(&file, "new", true, ApplyMode::Apply).unwrap_err();
+        // Restore permissions so TempDir cleanup succeeds.
+        fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(
+            err.to_string().contains("failed to read existing file"),
+            "expected read error, got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix two issues identified by GitHub AI Code Quality findings:

### 1. Bug fix: `file_create` silently swallows read errors

`unwrap_or_default()` on `std::fs::read_to_string()` silently converted read errors (e.g. permission denied) into empty strings. When `force=true`, this means an unreadable existing file would be overwritten without any error, risking data loss.

**Fix:** Replace with `.with_context(|| ...)?` to propagate the error with a clear message.

### 2. Readability: extract inline `&if` in `replace_text`

The inline `&if expr { ... } else { ... }` passed directly as a function argument was valid Rust but hard to scan. Extracted into a named `direct_to` variable.

### Tests

- Added `file_create_force_propagates_read_error` regression test (unix-only, uses permission bits)
- All 1312 tests pass (`make check` clean)