### PR TITLE
test: add API tests and fix stale blog test count

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1312%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1315%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -413,7 +413,7 @@ flowchart LR
 
 ## Status
 
-1312 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1315 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,311 tests**, zero unsafe code
+- **1,315 tests**, zero unsafe code
 - **20 commands** including MCP server with 29 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)

--- a/src/api.rs
+++ b/src/api.rs
@@ -1076,6 +1076,65 @@ mod tests {
         assert!(on_disk.contains("goodbye"));
     }
 
+    #[test]
+    fn apply_patch_works() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("code.rs");
+        fs::write(&file, "fn hello() {\n    println!(\"hi\");\n}\n").unwrap();
+
+        let patch = format!(
+            "--- a/{f}\n+++ b/{f}\n@@ -1,3 +1,3 @@\n fn hello() {{\n-    println!(\"hi\");\n+    println!(\"hello world\");\n }}\n",
+            f = "code.rs"
+        );
+
+        let result = apply_patch(&file, &patch, ApplyMode::Preview).unwrap();
+        assert!(result.changed);
+        assert!(!result.applied);
+        assert!(result.new_content.contains("hello world"));
+
+        // File should be unchanged on disk.
+        let on_disk = fs::read_to_string(&file).unwrap();
+        assert!(on_disk.contains("\"hi\""));
+    }
+
+    #[test]
+    fn md_table_append_adds_row() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("table.md");
+        fs::write(
+            &file,
+            "# Data\n\n| Name | Value |\n|------|-------|\n| a    | 1     |\n",
+        )
+        .unwrap();
+
+        let result =
+            md_table_append(&file, "# Data", "| b    | 2     |", ApplyMode::Apply).unwrap();
+
+        assert!(result.changed);
+        assert!(result.applied);
+        let on_disk = fs::read_to_string(&file).unwrap();
+        assert!(on_disk.contains("| b    | 2     |"));
+    }
+
+    #[test]
+    fn md_insert_before_heading_works() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# First\n\nBody 1.\n\n# Second\n\nBody 2.\n").unwrap();
+
+        let result = md_insert_before_heading(
+            &file,
+            "Second",
+            "Inserted before second.\n\n",
+            ApplyMode::Preview,
+        )
+        .unwrap();
+
+        assert!(result.changed);
+        assert!(!result.applied);
+        assert!(result.new_content.contains("Inserted before second."));
+    }
+
     // Static assertions: all public API types must be Send + Sync.
     const _: () = {
         fn _assert<T: Send + Sync>() {}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14377,7 +14377,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,311 tests"));
+    assert!(launch.contains("1,315 tests"));
     assert!(
         launch.contains("20 commands"),
         "launch announcement CLI command count drifted"


### PR DESCRIPTION
## Changes

- Add unit tests for `apply_patch`, `md_table_append`, and `md_insert_before_heading` public API functions
- Update stale test count in launch announcement blog post (1311 -> 1315)
- Update integration test assertion to match current test count

## Verification

`make check` passes (1315 tests, 0 failures)

Signed-off-by: Sebastien Tardif <seb@tardif.ca>