### PR TITLE
test: add API tests for md_insert_after_heading, apply_patch_file, make_write_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1315%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1318%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -413,7 +413,7 @@ flowchart LR
 
 ## Status
 
-1315 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1318 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,315 tests**, zero unsafe code
+- **1,318 tests**, zero unsafe code
 - **20 commands** including MCP server with 29 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)

--- a/src/api.rs
+++ b/src/api.rs
@@ -1135,6 +1135,79 @@ mod tests {
         assert!(result.new_content.contains("Inserted before second."));
     }
 
+    #[test]
+    fn md_insert_after_heading_works() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("doc.md");
+        fs::write(&file, "# First\n\nBody 1.\n\n# Second\n\nBody 2.\n").unwrap();
+
+        let result = md_insert_after_heading(
+            &file,
+            "First",
+            "Inserted after first.\n\n",
+            ApplyMode::Preview,
+        )
+        .unwrap();
+
+        assert!(result.changed);
+        assert!(!result.applied);
+        assert!(result.new_content.contains("Inserted after first."));
+        // Verify insertion is after the heading, not before.
+        let pos_heading = result.new_content.find("# First").unwrap();
+        let pos_insertion = result.new_content.find("Inserted after first.").unwrap();
+        assert!(pos_insertion > pos_heading);
+    }
+
+    #[test]
+    fn apply_patch_file_applies_multi_file_patch() {
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "aaa\n").unwrap();
+        fs::write(&b, "bbb\n").unwrap();
+
+        let patch = "\
+--- a/a.txt\n\
++++ b/a.txt\n\
+@@ -1 +1 @@\n\
+-aaa\n\
++AAA\n\
+--- a/b.txt\n\
++++ b/b.txt\n\
+@@ -1 +1 @@\n\
+-bbb\n\
++BBB\n";
+
+        let results = apply_patch_file(patch, dir.path(), ApplyMode::Apply).unwrap();
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().all(|r| r.changed && r.applied));
+        assert_eq!(fs::read_to_string(&a).unwrap(), "AAA\n");
+        assert_eq!(fs::read_to_string(&b).unwrap(), "BBB\n");
+    }
+
+    #[test]
+    fn make_write_policy_maps_options() {
+        let opts = WritePolicyOptions {
+            ensure_final_newline: true,
+            normalize_eol: Some(EolNormalization::Lf),
+            trim_trailing_whitespace: true,
+        };
+        let policy = make_write_policy(&opts);
+        assert!(policy.ensure_final_newline);
+        assert!(policy.trim_trailing_whitespace);
+        // normalize_eol should be Lf, verify by checking it's not Keep.
+        assert_ne!(
+            format!("{:?}", policy.normalize_eol),
+            "Keep",
+            "should map Lf, not Keep"
+        );
+
+        // Default options should produce default policy.
+        let default_policy = make_write_policy(&WritePolicyOptions::default());
+        assert!(!default_policy.ensure_final_newline);
+        assert!(!default_policy.trim_trailing_whitespace);
+    }
+
     // Static assertions: all public API types must be Send + Sync.
     const _: () = {
         fn _assert<T: Send + Sync>() {}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14377,7 +14377,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,315 tests"));
+    assert!(launch.contains("1,318 tests"));
     assert!(
         launch.contains("20 commands"),
         "launch announcement CLI command count drifted"


### PR DESCRIPTION
## Changes

Complete public API test coverage by adding tests for the last 3 untested functions:

- `md_insert_after_heading`: Verifies content is inserted after the correct heading in preview mode
- `apply_patch_file`: Verifies multi-file unified diff application in apply mode
- `make_write_policy`: Verifies WritePolicyOptions to WritePolicy mapping (both custom and default)

All 21 public API functions now have unit tests (31 total in api.rs, up from 28).

Updates blog post test count (1315 -> 1318) and README badge.

## Verification

`make check` passes (1318 tests, 0 failures)

Signed-off-by: Sebastien Tardif <seb@tardif.ca>