### PR TITLE
test: strengthen weak test assertions and add PartialEq to EolMode

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1195,11 +1195,10 @@ mod tests {
         let policy = make_write_policy(&opts);
         assert!(policy.ensure_final_newline);
         assert!(policy.trim_trailing_whitespace);
-        // normalize_eol should be Lf, verify by checking it's not Keep.
-        assert_ne!(
-            format!("{:?}", policy.normalize_eol),
-            "Keep",
-            "should map Lf, not Keep"
+        assert_eq!(
+            policy.normalize_eol,
+            crate::cli::global::EolMode::Lf,
+            "should map EolNormalization::Lf to EolMode::Lf"
         );
 
         // Default options should produce default policy.

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -14,7 +14,7 @@ pub enum ColorMode {
 }
 
 /// Write policy for EOL normalization.
-#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
 pub enum EolMode {
     /// Keep existing line endings.
     #[default]

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -2389,8 +2389,8 @@ mod tests {
             let new = json!(["a", "b"]);
 
             let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
-            assert!(result.contains("a"), "array item missing: {result}");
-            assert!(result.contains("b"), "array item missing: {result}");
+            assert!(result.contains("- a"), "array item '- a' missing: {result}");
+            assert!(result.contains("- b"), "array item '- b' missing: {result}");
         }
 
         #[test]


### PR DESCRIPTION
## Changes

Fix two weak test assertions found during multi-perspective audit:

1. **`make_write_policy_maps_options`** (api.rs): Replaced `format!("{:?}") != "Keep"` Debug-string comparison with direct `assert_eq!(policy.normalize_eol, EolMode::Lf)`. Required adding `PartialEq, Eq` derives to `EolMode`.

2. **`yaml_mapping_to_array_root_type_change_not_lost`** (ops.rs): Replaced `contains("a")` single-character match with `contains("- a")` to actually match the YAML array item syntax instead of any occurrence of the letter 'a'.

## Why

Both assertions would pass even if the code produced wrong output that happened to contain the matched substring. The strengthened assertions are specific to the expected format.

## Verification

`make check-fast` passes (1318 tests, 0 failures)

Signed-off-by: Sebastien Tardif <seb@tardif.ca>