### PR TITLE
refactor: remove dead else-if branch in json_to_toml_value

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -256,10 +256,8 @@ pub mod doc {
             serde_json::Value::Number(n) => {
                 if let Some(i) = n.as_i64() {
                     toml_edit::Value::from(i)
-                } else if let Some(f) = n.as_f64() {
-                    toml_edit::Value::from(f)
                 } else {
-                    // u64 that doesn't fit in i64; store as float.
+                    // Covers u64 > i64::MAX and float values.
                     toml_edit::Value::from(n.as_f64().unwrap_or(0.0))
                 }
             }


### PR DESCRIPTION
Remove unreachable code in `json_to_toml_value` (`src/ops.rs`).

With default serde_json features, `as_f64()` always succeeds for any `Number` after `as_i64()` returns `None`. The intermediate `else if let Some(f) = n.as_f64()` branch was unreachable dead code. Collapsed the three-way match into a two-way match.

No behavior change. All 1318 tests pass.