### PR TITLE
test: strengthen weak assertion in find_section_with_hashes_in_query

### DIFF
--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3089,8 +3089,8 @@ mod tests {
         #[test]
         fn find_section_with_hashes_in_query() {
             let content = "## API\nsome text\n";
-            let result = find_section(content, "## API");
-            assert!(result.is_some());
+            let (start, end) = find_section(content, "## API").unwrap();
+            assert_eq!(&content[start..end], "some text\n");
         }
 
         #[test]


### PR DESCRIPTION
Strengthen the `find_section_with_hashes_in_query` test in `src/ops.rs`.

Previously the test only checked `assert!(result.is_some())`, confirming the section was found but not verifying the body content. Now uses `unwrap()` + `assert_eq!` to verify the actual section body is `"some text\n"`, ensuring the hash-prefix stripping logic works correctly.

All 1318 tests pass.