### PR TITLE
test: strengthen weak assertion in test_doc_merge_check_exits_2

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15143,8 +15143,8 @@ fn test_doc_merge_check_exits_2() {
         .code(2);
 
     let content = fs::read_to_string(&file).unwrap();
-    assert!(
-        !content.contains("b"),
+    assert_eq!(
+        content, r#"{"a":1}"#,
         "file should be unchanged in --check mode"
     );
 }


### PR DESCRIPTION
Replace `!content.contains("b")` with `assert_eq!(content, r#"{"a":1}"#)` in `test_doc_merge_check_exits_2`.

The previous assertion only verified a single character was absent, which would pass even if the file were corrupted. The new assertion checks the exact file content matches the original, properly verifying that `--check` mode does not modify the file.

All 1318 tests pass.