### PR TITLE
test: strengthen weak assertions and update transitive deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bstr"
@@ -182,9 +182,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "memchr"

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -1139,7 +1139,7 @@ mod tests {
         let (output, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
         // Default: shows diff containing the new key.
-        assert!(output.contains("+"));
+        assert!(output.contains("+ "), "diff should show an added line");
         assert!(output.contains("age"));
     }
 
@@ -1171,7 +1171,7 @@ mod tests {
         let ctx = WriteContext::default();
         let (output, code) = execute_write(&action, &ctx, dir.path()).unwrap();
         assert_eq!(code, exit::SUCCESS);
-        assert!(output.contains("-"));
+        assert!(output.contains("- "), "diff should show a removed line");
         assert!(output.contains("age"));
     }
 

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -642,7 +642,7 @@ mod tests {
         assert_eq!(results.matches.len(), 2);
         for m in &results.matches {
             assert!(m.text.contains("Hello"));
-            assert!(m.text.contains("!"));
+            assert!(m.text.ends_with('!'), "regex match should end with '!'");
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3168,8 +3168,8 @@ fn test_read_multiple_files_with_lines() {
     let dir = TempDir::new().unwrap();
     let f1 = dir.path().join("long.txt");
     let f2 = dir.path().join("short.txt");
-    fs::write(&f1, "a\nb\nc\nd\ne\n").unwrap();
-    fs::write(&f2, "x\ny\n").unwrap();
+    fs::write(&f1, "alpha\nbravo\ncharlie\ndelta\necho\n").unwrap();
+    fs::write(&f2, "xray\nyankee\n").unwrap();
 
     // --lines 2:4 on a 5-line file gives lines 2-4; on a 2-line file gives line 2 only
     let output = Command::cargo_bin("patchloom")
@@ -3184,11 +3184,35 @@ fn test_read_multiple_files_with_lines() {
 
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("b\nc\nd"));
-    assert!(stdout.contains("y"));
-    // "aaa" and "eee" should not appear (outside the range for the first file)
-    assert!(!stdout.contains("aaa"));
-    assert!(!stdout.contains("eee"));
+    assert!(
+        stdout.contains("bravo"),
+        "line 2 of first file should be present"
+    );
+    assert!(
+        stdout.contains("charlie"),
+        "line 3 of first file should be present"
+    );
+    assert!(
+        stdout.contains("delta"),
+        "line 4 of first file should be present"
+    );
+    assert!(
+        stdout.contains("yankee"),
+        "line 2 of second file should be present"
+    );
+    // Lines outside the range should not appear
+    assert!(
+        !stdout.contains("alpha"),
+        "line 1 of first file should be excluded"
+    );
+    assert!(
+        !stdout.contains("echo"),
+        "line 5 of first file should be excluded"
+    );
+    assert!(
+        !stdout.contains("xray"),
+        "line 1 of second file should be excluded"
+    );
 }
 
 // ── status command ─────────────────────────────────────────────────
@@ -3665,7 +3689,7 @@ fn test_doc_get_yaml_merge_key_resolved() {
         .arg("staging.retries")
         .assert()
         .success()
-        .stdout(predicate::str::contains("3"));
+        .stdout(predicate::str::starts_with("3"));
 }
 
 #[test]
@@ -3749,7 +3773,7 @@ fn test_doc_len_array() {
         .arg("items")
         .assert()
         .success()
-        .stdout(predicate::str::contains("5"));
+        .stdout(predicate::str::starts_with("5"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle: QA Engineer and Maintainer perspectives produced actionable fixes.

## Changes

### Test improvements (QA Engineer)
- **`test_read_multiple_files_with_lines`**: Replaced single-char file content (`a\nb\nc\nd\ne`) with distinctive words (`alpha\nbravo\ncharlie`). Old assertions like `contains("b")" would pass on any output containing the letter "b"; new assertions like `contains("bravo")" are specific to the expected line.
- **`test_doc_get_yaml_merge_key_resolved`**: Changed `contains("3")" to `starts_with("3")" so the assertion cannot pass on unrelated content.
- **`test_doc_len_array`**: Changed `contains("5")" to `starts_with("5")" for the same reason.
- **`set_creates_new_key`** (doc.rs): Changed `contains("+")" to `contains("+ ")" so the assertion matches diff added-line markers, not arbitrary plus signs.
- **`delete_removes_key`** (doc.rs): Changed `contains("-")" to `contains("- ")" for the same reason.
- **`regex_match_works`** (search.rs): Changed `contains("!")" to `ends_with('!')" to match the specific regex result.

### Dependency updates (Maintainer)
- bitflags 2.11.1 -> 2.13.0
- chrono 0.4.44 -> 0.4.45
- log 0.4.30 -> 0.4.32

## Verification

`make check` passes (all unit and integration tests, clippy, fmt).

Signed-off-by: Sebastien Tardif <seb@tardif.com>