### PR TITLE
fix: md silent default mode, search empty-pattern guard, strengthen assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1318%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1320%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -413,7 +413,7 @@ flowchart LR
 
 ## Status
 
-1318 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1320 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -270,7 +270,11 @@ pub fn doc_get(path: &Path, selector: &str) -> anyhow::Result<serde_json::Value>
     let result = selector::eval(&doc, &segments);
     match result.len() {
         0 => bail!("selector '{}' matched nothing", selector),
-        1 => Ok(result.into_iter().next().unwrap().clone()),
+        1 => Ok(result
+            .into_iter()
+            .next()
+            .expect("len==1 guarantees element")
+            .clone()),
         _ => Ok(serde_json::Value::Array(
             result.into_iter().cloned().collect(),
         )),

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -322,9 +322,10 @@ mod tests {
             if_exists: false,
         };
         let desc = describe_operation(&op);
-        assert!(desc.contains("regex"));
-        assert!(desc.contains("#1"));
-        assert!(desc.contains("case-insensitive"));
+        assert_eq!(
+            desc,
+            r#"Replace "fn\s+main" with "fn entry" in src/lib.rs (regex, occurrence #1, case-insensitive)"#
+        );
     }
 
     #[test]

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -1658,38 +1658,59 @@ mod tests {
 
     #[test]
     fn path_rejects_absolute() {
-        assert!(validate_path_contained("/etc/passwd").is_err());
+        assert!(
+            validate_path_contained("/etc/passwd").is_err(),
+            "absolute path should be rejected"
+        );
     }
 
     #[test]
     fn path_rejects_traversal() {
-        assert!(validate_path_contained("../../etc/passwd").is_err());
+        assert!(
+            validate_path_contained("../../etc/passwd").is_err(),
+            "parent traversal should be rejected"
+        );
     }
 
     #[test]
     fn path_rejects_deep_traversal() {
-        assert!(validate_path_contained("a/b/../../../escape").is_err());
+        assert!(
+            validate_path_contained("a/b/../../../escape").is_err(),
+            "deep traversal escaping cwd should be rejected"
+        );
     }
 
     #[test]
     fn path_allows_relative() {
-        assert!(validate_path_contained("src/main.rs").is_ok());
+        assert!(
+            validate_path_contained("src/main.rs").is_ok(),
+            "simple relative path should be allowed"
+        );
     }
 
     #[test]
     fn path_allows_dot_relative() {
-        assert!(validate_path_contained("./foo/bar.json").is_ok());
+        assert!(
+            validate_path_contained("./foo/bar.json").is_ok(),
+            "dot-relative path should be allowed"
+        );
     }
 
     #[test]
     fn path_allows_safe_parent() {
         // a/../b resolves within cwd
-        assert!(validate_path_contained("a/../b").is_ok());
+        assert!(
+            validate_path_contained("a/../b").is_ok(),
+            "parent that resolves within cwd should be allowed"
+        );
     }
 
     #[test]
     fn path_rejects_single_parent() {
-        assert!(validate_path_contained("..").is_err());
+        assert!(
+            validate_path_contained("..").is_err(),
+            "bare parent directory should be rejected"
+        );
     }
 
     #[test]
@@ -1697,7 +1718,10 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         std::fs::write(dir.path().join("safe.txt"), "ok").unwrap();
         let canon = dir.path().canonicalize().unwrap();
-        assert!(validate_path_resolved("safe.txt", dir.path(), &canon).is_ok());
+        assert!(
+            validate_path_resolved("safe.txt", dir.path(), &canon).is_ok(),
+            "existing file inside cwd should be allowed"
+        );
     }
 
     #[test]
@@ -1705,7 +1729,10 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         // Non-existent files with safe ancestors are allowed.
         let canon = dir.path().canonicalize().unwrap();
-        assert!(validate_path_resolved("new_file.txt", dir.path(), &canon).is_ok());
+        assert!(
+            validate_path_resolved("new_file.txt", dir.path(), &canon).is_ok(),
+            "nonexistent file with safe ancestor should be allowed"
+        );
     }
 
     #[cfg(unix)]

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -118,7 +118,9 @@ fn apply_mutation(
     let final_content = crate::write::apply_policy(new_content, &policy);
     let has_changes = original != final_content;
 
-    if global.diff || global.confirm {
+    // Show diff in default mode (no write flags), explicit --diff, or --confirm.
+    // Skip when --apply or --check is set without --diff.
+    if (!global.apply && !global.check) || global.diff || global.confirm {
         let d = unified_diff(display_path, original, &final_content);
         if d.has_changes {
             let result = DiffResult {

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -497,6 +497,9 @@ pub(crate) fn format_results(
 }
 
 pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    if args.pattern.is_empty() {
+        bail!("search pattern must not be empty");
+    }
     if args.invert_match && args.multiline {
         bail!("--invert-match and --multiline cannot be combined");
     }
@@ -622,6 +625,19 @@ mod tests {
             case_insensitive: false,
             assert_count: None,
         }
+    }
+
+    #[test]
+    fn empty_pattern_rejected() {
+        let dir = make_test_dir();
+        let args = make_args("", vec![dir.path().to_string_lossy().into_owned()]);
+        let result = run(args, &default_global());
+        assert!(result.is_err(), "empty pattern should be rejected");
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("must not be empty"),
+            "error should mention empty pattern: {msg}"
+        );
     }
 
     #[test]
@@ -874,14 +890,26 @@ mod tests {
         assert_eq!(v["file_count"], serde_json::json!(1));
         let matches = v["matches"].as_array().expect("matches is array");
         assert_eq!(matches.len(), 2);
+        // Matches are ordered by line within the file.
         for m in matches {
             let path = m["path"].as_str().unwrap();
             assert!(path.ends_with("hello.txt"), "unexpected path: {path}");
-            assert!(m["line"].as_u64().unwrap() > 0);
-            assert!(m["column"].as_u64().unwrap() > 0);
             let text = m["text"].as_str().unwrap();
             assert!(text.contains("Hello"), "match text missing 'Hello': {text}");
         }
+        // "Hello" appears at column 1 on lines 1 ("Hello, world!") and 3 ("Hello again!").
+        assert_eq!(matches[0]["line"].as_u64().unwrap(), 1, "first match line");
+        assert_eq!(
+            matches[0]["column"].as_u64().unwrap(),
+            1,
+            "first match column"
+        );
+        assert_eq!(matches[1]["line"].as_u64().unwrap(), 3, "second match line");
+        assert_eq!(
+            matches[1]["column"].as_u64().unwrap(),
+            1,
+            "second match column"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1063,7 +1063,7 @@ fn test_search_multiline_spans_lines() {
         .assert()
         .success()
         .stdout(predicate::str::contains("fn main()"))
-        .stdout(predicate::str::contains("}"));
+        .stdout(predicate::str::contains("println!"));
 }
 
 #[test]
@@ -2687,6 +2687,52 @@ fn test_md_replace_section() {
     assert!(
         content.contains("kept"),
         "Other section content should be intact"
+    );
+}
+
+#[test]
+fn test_md_default_mode_shows_diff() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.md");
+    fs::write(
+        &file,
+        "# Title\n\n## Section\n\nold content\n\n## Other\n\nkept\n",
+    )
+    .unwrap();
+
+    // Default mode (no --apply/--check/--diff) should show a unified diff preview.
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("md")
+        .arg("replace-section")
+        .arg(&file)
+        .arg("--heading")
+        .arg("## Section")
+        .arg("--content")
+        .arg("new content")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--- a/"),
+        "default mode should show diff header: {stdout}"
+    );
+    assert!(
+        stdout.contains("-old content"),
+        "default mode should show removed line: {stdout}"
+    );
+    assert!(
+        stdout.contains("+new content"),
+        "default mode should show added line: {stdout}"
+    );
+
+    // File should NOT be modified in default mode.
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("old content"),
+        "default mode should not modify the file"
     );
 }
 


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 2: QA Engineer, Developer, End User, and Adversarial Tester perspectives produced fixes.

## Changes

### Bug fix (End User)
- **`md` command silent in default mode** (`src/cmd/md.rs`): The `md` command produced no output when run without write flags (`--apply`, `--check`, `--diff`). Every other write command shows a unified diff preview by default, but `md` only showed the diff when `--diff` was explicitly passed. Fixed the condition to include default mode. Added integration test.

### Validation (Adversarial Tester)
- **Empty search pattern** (`src/cmd/search.rs`): `patchloom search ""` would match at every byte position, producing enormous output. Added the same `pattern must not be empty` guard that `replace` already has. Added unit test.

### Production code (Developer)
- **`api.rs:273`**: Replaced banned `.unwrap()` with `.expect("len==1 guarantees element")` to comply with the project convention.

### Test improvements (QA Engineer)
- **`explain.rs`**: Replaced 3 weak `contains()` calls with a single `assert_eq!` on the full expected output string.
- **`mcp.rs`**: Added descriptive assertion messages to 9 path-validation tests.
- **`search.rs`**: Replaced weak `> 0` bounds on line/column with exact expected values (line 1 col 1, line 3 col 1).
- **`integration.rs`**: Replaced weak `contains("}")" with `contains("println!")" in multiline search test.

## Verification

`make check` passes (1320 tests: 703 unit + 617 integration, 0 clippy warnings, 0 fmt issues).

Signed-off-by: Sebastien Tardif <seb@tardif.com>