### PR TITLE
fix: add error context to backup restore and rename cross-device paths

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -159,9 +159,11 @@ impl BackupSession {
         if file_path.exists() {
             let backup_path = self.session_dir.join(&rel_str);
             if let Some(parent) = backup_path.parent() {
-                std::fs::create_dir_all(parent)?;
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating backup dir for {rel_str}"))?;
             }
-            std::fs::copy(file_path, &backup_path)?;
+            std::fs::copy(file_path, &backup_path)
+                .with_context(|| format!("backing up {rel_str} before delete"))?;
         }
 
         self.entries.push(ManifestEntry {
@@ -253,7 +255,8 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
 
     let content = std::fs::read_to_string(&manifest_path)
         .with_context(|| format!("no backup session found for {timestamp}"))?;
-    let manifest: Manifest = serde_json::from_str(&content)?;
+    let manifest: Manifest = serde_json::from_str(&content)
+        .with_context(|| format!("parsing backup manifest for session {timestamp}"))?;
 
     let mut restored = 0;
     for entry in &manifest.entries {
@@ -270,16 +273,21 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
                 let backup = session_dir.join(&entry.path);
                 if backup.exists() {
                     if let Some(parent) = target.parent() {
-                        std::fs::create_dir_all(parent)?;
+                        std::fs::create_dir_all(parent).with_context(|| {
+                            format!("creating parent dir for restore target {}", entry.path)
+                        })?;
                     }
-                    std::fs::copy(&backup, &target)?;
+                    std::fs::copy(&backup, &target)
+                        .with_context(|| format!("restoring modified file {}", entry.path))?;
                     restored += 1;
                 }
             }
             FileAction::Created => {
                 // File was newly created by the apply; remove it.
                 if target.exists() {
-                    std::fs::remove_file(&target)?;
+                    std::fs::remove_file(&target).with_context(|| {
+                        format!("removing created file {} during undo", entry.path)
+                    })?;
                     restored += 1;
                 }
             }
@@ -287,9 +295,12 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
                 let backup = session_dir.join(&entry.path);
                 if backup.exists() {
                     if let Some(parent) = target.parent() {
-                        std::fs::create_dir_all(parent)?;
+                        std::fs::create_dir_all(parent).with_context(|| {
+                            format!("creating parent dir for restore target {}", entry.path)
+                        })?;
                     }
-                    std::fs::copy(&backup, &target)?;
+                    std::fs::copy(&backup, &target)
+                        .with_context(|| format!("restoring deleted file {}", entry.path))?;
                     restored += 1;
                 }
             }

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -261,7 +261,7 @@ fn do_rename(
         } else {
             atomic_create_new(dst, &content, policy)?;
         }
-        fs::remove_file(src)?;
+        fs::remove_file(src).with_context(|| format!("removing source file {}", src.display()))?;
     }
     Ok(())
 }
@@ -284,8 +284,12 @@ fn rename_or_copy(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Resul
     match fs::rename(src, dst) {
         Ok(()) => Ok(()),
         Err(e) if is_cross_device(&e) => {
-            fs::copy(src, dst)?;
-            fs::remove_file(src)?;
+            fs::copy(src, dst).with_context(|| {
+                format!("cross-device copy {} -> {}", src.display(), dst.display())
+            })?;
+            fs::remove_file(src).with_context(|| {
+                format!("removing source after cross-device copy: {}", src.display())
+            })?;
             Ok(())
         }
         Err(e) => Err(e.into()),


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 3: Observability/Error Detective perspective produced error handling improvements.

## Changes

### Error context improvements
- **`backup.rs` restore path** (`restore_session()`): Added `.with_context()` to all 5 filesystem operations (create_dir_all, copy, remove_file) in the restore loop. Previously, a restore failure would produce a bare OS error (e.g., "Permission denied") without indicating which file or action failed. Now each error includes the entry path and operation type ("restoring modified file config.yaml", "removing created file temp.txt during undo").
- **`backup.rs` save_before_delete()**: Added context to create_dir_all and copy operations, matching the pattern already used in the sibling `save_before_write()` method.
- **`backup.rs` manifest parsing**: Added context to `serde_json::from_str()` so JSON parse errors include the session timestamp.
- **`rename.rs` rename_or_copy()**: Added context to the cross-device copy and source removal operations so failures include source and destination paths.
- **`rename.rs` do_rename()**: Added context to the post-rename source file removal.

## Motivation

The backup restore path is the most critical place for diagnostics. When restore fails, the user has already lost their original files via `--apply` and needs to know exactly which file failed and why. The rename cross-device fallback operates on two different filesystems, where the most common failures (disk full, permissions) need both paths reported.

## Verification

`make check` passes (all unit and integration tests, clippy, fmt).

Signed-off-by: Sebastien Tardif <seb@tardif.com>