### PR TITLE
fix: md/doc --check produce stdout output and doc --json errors use structured JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1320%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1325%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -413,7 +413,7 @@ flowchart LR
 
 ## Status
 
-1320 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1325 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -475,7 +475,10 @@ fn write_result(
 ) -> anyhow::Result<(String, u8)> {
     if ctx.check {
         if original != new_content {
-            return Ok((String::new(), exit::CHANGES_DETECTED));
+            return Ok((
+                format!("would modify {display_path}"),
+                exit::CHANGES_DETECTED,
+            ));
         }
         return Ok((String::new(), exit::SUCCESS));
     }
@@ -921,10 +924,28 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let (output, code) = execute_write(&args.action, &ctx, &cwd)?;
         if code == exit::FAILURE && !output.is_empty() {
             if global.json || global.jsonl {
-                anyhow::bail!(output);
-            }
-            if !global.quiet {
+                let err_obj = serde_json::json!({"ok": false, "error": &output});
+                if global.json {
+                    println!("{}", serde_json::to_string_pretty(&err_obj)?);
+                } else {
+                    println!("{}", serde_json::to_string(&err_obj)?);
+                }
+            } else if !global.quiet {
                 eprintln!("{output}");
+            }
+            return Ok(code);
+        }
+        if code == exit::CHANGES_DETECTED && !output.is_empty() {
+            if global.json || global.jsonl {
+                let check_obj =
+                    serde_json::json!({"ok": true, "has_changes": true, "message": &output});
+                if global.json {
+                    println!("{}", serde_json::to_string_pretty(&check_obj)?);
+                } else {
+                    println!("{}", serde_json::to_string(&check_obj)?);
+                }
+            } else if !global.quiet {
+                println!("{output}");
             }
             return Ok(code);
         }

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -135,6 +135,20 @@ fn apply_mutation(
     }
 
     if global.check && has_changes {
+        #[derive(Serialize)]
+        struct CheckOutput<'a> {
+            ok: bool,
+            path: &'a str,
+            has_changes: bool,
+        }
+        let output = CheckOutput {
+            ok: true,
+            path: display_path,
+            has_changes: true,
+        };
+        if !global.emit_json(&output)? && !global.quiet {
+            println!("would modify {display_path}");
+        }
         return Ok(exit::CHANGES_DETECTED);
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17425,3 +17425,168 @@ fn test_schema_invalid_tier_fails() {
         .assert()
         .failure();
 }
+
+// ---------------------------------------------------------------------------
+// md --check produces stdout output (#544)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_md_check_produces_stdout() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.md");
+    fs::write(
+        &file,
+        "# Title\n\n## Section\n\nold content\n\n## Other\n\nkept\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("md")
+        .arg("replace-section")
+        .arg(&file)
+        .arg("--heading")
+        .arg("## Section")
+        .arg("--content")
+        .arg("new content")
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("would modify"),
+        "md --check should produce stdout, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_md_check_json_produces_structured_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.md");
+    fs::write(
+        &file,
+        "# Title\n\n## Section\n\nold content\n\n## Other\n\nkept\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("md")
+        .arg("replace-section")
+        .arg(&file)
+        .arg("--heading")
+        .arg("## Section")
+        .arg("--content")
+        .arg("new content")
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|_| panic!("expected JSON output, got: {stdout}"));
+    assert_eq!(json["ok"], true, "check output should have ok=true");
+    assert_eq!(
+        json["has_changes"], true,
+        "check output should have has_changes=true"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// doc --check produces stdout output (#544)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_doc_check_produces_stdout() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"version":"1.0"}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("version")
+        .arg("\"2.0\"")
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("would modify"),
+        "doc --check should produce stdout, got: {stdout}"
+    );
+}
+
+#[test]
+fn test_doc_check_json_produces_structured_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"version":"1.0"}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("version")
+        .arg("\"2.0\"")
+        .arg("--check")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|_| panic!("expected JSON output, got: {stdout}"));
+    assert_eq!(json["ok"], true, "check output should have ok=true");
+    assert_eq!(
+        json["has_changes"], true,
+        "check output should have has_changes=true"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// doc --json failure produces structured error on stdout (#545)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_doc_json_failure_structured_on_stdout() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"name":"patchloom"}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("doc")
+        .arg("append")
+        .arg(&file)
+        .arg("name")
+        .arg("\"x\"")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    // Stderr should be empty; error goes to stdout as JSON.
+    assert!(
+        String::from_utf8_lossy(&output.stderr).trim().is_empty(),
+        "stderr should be empty in --json mode"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|_| panic!("expected JSON output, got: {stdout}"));
+    assert_eq!(json["ok"], false);
+    assert!(
+        json["error"].as_str().unwrap().contains("not an array"),
+        "error should mention 'not an array'"
+    );
+}


### PR DESCRIPTION
## Summary

Two write commands (`md` and `doc`) had gaps in their `--check` and `--json` output handling:

1. **`md --check` and `doc --check` produced no stdout** (issue #544): the commands returned exit code 2 correctly but emitted nothing, making it impossible for callers to know *which* file would change without parsing the exit code alone.

2. **`doc` FAILURE errors bypassed `--json` structured output** (issue #545): when a doc write operation failed (e.g., `append` on a non-array target), the error went through `anyhow::bail!()` and the global error handler instead of emitting structured JSON directly. While the global handler did wrap it in JSON, this was indirect and inconsistent with how other commands handle errors.

## Changes

### `src/cmd/md.rs`
- `apply_mutation()` now emits `"would modify <path>"` in plain mode or `{"ok": true, "path": "...", "has_changes": true}` in JSON mode when `--check` detects changes.

### `src/cmd/doc.rs`
- `write_result()` now returns `"would modify <path>"` instead of an empty string when `--check` detects changes.
- `run()` now handles `CHANGES_DETECTED` exit code with proper JSON output (`{"ok": true, "has_changes": true, "message": "..."}`).
- `run()` now handles `FAILURE` exit code with structured JSON (`{"ok": false, "error": "..."}`) directly on stdout instead of using `bail!()`.

### `tests/integration.rs`
- 5 new integration tests:
  - `test_md_check_produces_stdout`: verifies `md --check` emits text
  - `test_md_check_json_produces_structured_output`: verifies `md --check --json` emits structured JSON
  - `test_doc_check_produces_stdout`: verifies `doc --check` emits text
  - `test_doc_check_json_produces_structured_output`: verifies `doc --check --json` emits structured JSON
  - `test_doc_json_failure_structured_on_stdout`: verifies doc failures in `--json` mode emit `{"ok": false}` on stdout with empty stderr

Closes #544
Closes #545