### PR TITLE
fix: remove documentation field so crates.io auto-links to docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/patchloom/patchloom"
 readme = "README.md"
 keywords = ["cli", "agents", "patch", "markdown", "config"]
 categories = ["command-line-utilities", "development-tools", "config"]
-documentation = "https://github.com/patchloom/patchloom"
 authors = ["Sebastien Tardif"]
 exclude = [
   "benches/",


### PR DESCRIPTION
The `documentation` field in `Cargo.toml` pointed to the GitHub repo, which overrode crates.io's automatic docs.rs link. Users browsing crates.io were sent to the GitHub repo instead of seeing the docs.rs API documentation.

Removing the field lets crates.io display the `https://docs.rs/patchloom` link prominently.

This is a metadata-only change with no code impact.