### PR TITLE
fix: correct pinned action SHAs in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Install mdBook
-        uses: peaceiris/actions-mdbook@ee69d230fe19ce30e291c8b4aae45ef23fdce116 # v2.0.0
+        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2.0.0
         with:
           mdbook-version: "0.4.44"
 
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac590b76de0 # v4.0.5
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
The Docs workflow failed on main because two action commit SHAs had incorrect suffixes (partially matching the real hash but diverging after the first ~12 characters):

| Action | Wrong SHA | Correct SHA (tag) |
|--------|-----------|-------------------|
| `peaceiris/actions-mdbook` | `ee69d230fe19ce30e291...` | `ee69d230fe19748b7abf...` (v2.0.0) |
| `actions/deploy-pages` | `d6db90164ac5ed86f2b6aed7e0febac590b76de0` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` (v4.0.5) |

Verified all SHAs against their respective tags via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>`.