### PR TITLE
feat: md.move-section -- move a heading section between files

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -12,6 +12,7 @@
 | Set/get a key in JSON, YAML, or TOML | `doc_set`, `doc_get`, `doc_query` |
 | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |
 | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |
+| Move a heading section (same file or cross-file) | `md_move_section` |
 | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |
 | Create, rename, or delete a file | `create_file`, `move_file`, `delete_file` |
 | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1325%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1344%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1325 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1344 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -100,6 +100,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `md_replace_section` | Replace a markdown section by heading |
 | `md_insert_after_heading` | Insert content after a markdown heading |
 | `md_insert_before_heading` | Insert content before a markdown heading |
+| `md_move_section` | Move a heading section (same file reorder or cross-file) |
 | `md_lint` | Lint an AGENTS.md file for common issues |
 | `fix_whitespace` | Fix whitespace and line endings in a text file. Binary and invalid UTF-8 files are skipped |
 | `create_file` | Create a new file with content |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -228,7 +228,7 @@ These are the main entry points. If you are deciding between commands, start her
 ## `batch`
 
 - **What it does:** Executes multiple operations from a simple line-oriented format. Each line is one operation with positional arguments (e.g., `doc.set config.json version "2.0.0"`). Internally builds a tx plan and delegates to the tx engine.
-- **Use when:** Editing multiple files and the JSON tx plan format is too verbose. The line format covers 21 operations (doc.set, doc.delete, doc.merge, doc.ensure, doc.append, doc.prepend, doc.update, doc.move, doc.delete_where, replace, file.create, file.delete, file.rename, md.upsert_bullet, md.table_append, md.replace_section, md.insert_after_heading, md.insert_before_heading, md.dedupe_headings, md.lint_agents, tidy.fix) with minimal syntax. For AI agents, this is faster to generate than a full JSON plan.
+- **Use when:** Editing multiple files and the JSON tx plan format is too verbose. The line format covers 22 operations (doc.set, doc.delete, doc.merge, doc.ensure, doc.append, doc.prepend, doc.update, doc.move, doc.delete_where, replace, file.create, file.delete, file.rename, md.upsert_bullet, md.table_append, md.replace_section, md.insert_after_heading, md.insert_before_heading, md.move_section, md.dedupe_headings, md.lint_agents, tidy.fix) with minimal syntax. For AI agents, this is faster to generate than a full JSON plan.
 - **Prefer instead:** Use `tx` when you need format/validate lifecycle steps, strict mode, or operations not supported by the line format (patch.apply, replace with regex/nth, search, read).
 - **Related:** `tx`
 
@@ -660,6 +660,13 @@ Use these when markdown structure matters more than raw text matching.
 - **What it does:** Appends a row to the markdown table under a heading.
 - **Use when:** A docs table should grow without manually rebuilding its existing rows.
 - **Prefer instead:** Use `md replace-section` when the whole table should be regenerated from source data.
+
+<!-- ref:md-action:move-section -->
+### `md move-section`
+
+- **What it does:** Moves a heading section to a new position, either within the same file (reorder) or to a different file. The section (heading plus body) is extracted from the source and inserted at the target location. Both files are updated atomically.
+- **Use when:** Reorganizing documentation structure by moving sections between files or reordering sections within a file.
+- **Prefer instead:** Use `md replace-section` for rewriting content in place, or manual cut and paste when the move involves non-contiguous content.
 
 ## `patch` actions
 

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -30,6 +30,8 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
 /// md.replace_section <path> <heading> <content>
 /// md.insert_after_heading <path> <heading> <content>
 /// md.insert_before_heading <path> <heading> <content>
+/// md.move_section <path> <heading> before|after <target_heading>
+/// md.move_section <path> <heading> <to> before|after <target_heading>
 /// md.dedupe_headings <path>
 /// md.lint_agents <path>
 /// tidy.fix <path>
@@ -43,7 +45,7 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
   doc.update, doc.move, doc.delete_where, replace, file.create,
   file.delete, file.rename, md.upsert_bullet, md.table_append,
   md.replace_section, md.insert_after_heading, md.insert_before_heading,
-  md.dedupe_headings, md.lint_agents, tidy.fix
+  md.move_section, md.dedupe_headings, md.lint_agents, tidy.fix
 
 EXAMPLES:
   printf 'doc.set config.json version "2.0"\nreplace README.md v1 v2\n' | patchloom batch
@@ -224,6 +226,33 @@ pub fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
                 content: args[2].clone(),
             })
         }
+        "md.move_section" => {
+            // 4 args: md.move_section <path> <heading> before|after <target_heading>
+            // 5 args: md.move_section <path> <heading> <to> before|after <target_heading>
+            if args.len() == 4 {
+                let (before, after) = parse_position_keyword(&args[2], line_num)?;
+                Ok(Operation::MdMoveSection {
+                    path: args[0].clone(),
+                    heading: args[1].clone(),
+                    to: None,
+                    before: before.map(|_| args[3].clone()),
+                    after: after.map(|_| args[3].clone()),
+                })
+            } else if args.len() == 5 {
+                let (before, after) = parse_position_keyword(&args[3], line_num)?;
+                Ok(Operation::MdMoveSection {
+                    path: args[0].clone(),
+                    heading: args[1].clone(),
+                    to: Some(args[2].clone()),
+                    before: before.map(|_| args[4].clone()),
+                    after: after.map(|_| args[4].clone()),
+                })
+            } else {
+                anyhow::bail!(
+                    "line {line_num}: md.move_section requires 4 args (same-file) or 5 args (cross-file)"
+                )
+            }
+        }
         "md.dedupe_headings" => {
             require_args(op, args, 1, line_num)?;
             Ok(Operation::MdDedupeHeadings {
@@ -250,6 +279,18 @@ pub fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
 }
 
 /// Check that the exact number of arguments were provided.
+/// Parse a position keyword ("before" or "after") and return which one was given.
+fn parse_position_keyword(
+    keyword: &str,
+    line_num: usize,
+) -> anyhow::Result<(Option<()>, Option<()>)> {
+    match keyword {
+        "before" => Ok((Some(()), None)),
+        "after" => Ok((None, Some(()))),
+        _ => anyhow::bail!("line {line_num}: expected 'before' or 'after', got '{keyword}'"),
+    }
+}
+
 fn require_args(op: &str, args: &[String], expected: usize, line_num: usize) -> anyhow::Result<()> {
     if args.len() != expected {
         anyhow::bail!(
@@ -782,5 +823,45 @@ file.create hello.txt "Hello, World!"
             operations.push(parse_line(trimmed, i + 1).unwrap());
         }
         assert_eq!(operations.len(), 4);
+    }
+
+    #[test]
+    fn parse_line_md_move_section_same_file() {
+        let op = parse_line("md.move_section README.md \"FAQ\" before \"License\"", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdMoveSection { path, heading, to, before, after }
+            if path == "README.md" && heading == "FAQ" && to.is_none()
+               && before.as_deref() == Some("License") && after.is_none()
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_move_section_cross_file() {
+        let op = parse_line(
+            "md.move_section spec.md \"Appendix\" dest.md after \"Layer 4\"",
+            1,
+        )
+        .unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdMoveSection { path, heading, to, before, after }
+            if path == "spec.md" && heading == "Appendix"
+               && to.as_deref() == Some("dest.md")
+               && before.is_none() && after.as_deref() == Some("Layer 4")
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_move_section_bad_keyword() {
+        let err =
+            parse_line("md.move_section README.md \"FAQ\" between \"License\"", 1).unwrap_err();
+        assert!(err.to_string().contains("expected 'before' or 'after'"));
+    }
+
+    #[test]
+    fn parse_line_md_move_section_wrong_arg_count() {
+        let err = parse_line("md.move_section README.md", 1).unwrap_err();
+        assert!(err.to_string().contains("requires 4 args"));
     }
 }

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -218,6 +218,27 @@ fn describe_operation(op: &Operation) -> String {
         Operation::MdTableAppend { path, heading, .. } => {
             format!("Append row to table under \"{heading}\" in {path}")
         }
+        Operation::MdMoveSection {
+            path,
+            heading,
+            to,
+            before,
+            after,
+        } => {
+            let dest = to.as_deref().unwrap_or(path.as_str());
+            let pos = if let Some(b) = before {
+                format!("before \"{b}\"")
+            } else if let Some(a) = after {
+                format!("after \"{a}\"")
+            } else {
+                "(no position)".to_string()
+            };
+            if to.is_some() {
+                format!("Move section \"{heading}\" from {path} to {dest} {pos}")
+            } else {
+                format!("Move section \"{heading}\" {pos} in {path}")
+            }
+        }
         Operation::MdDedupeHeadings { path } => {
             format!("Deduplicate headings in {path}")
         }
@@ -511,6 +532,36 @@ mod tests {
         assert_eq!(
             describe_operation(&op),
             "Lint AGENTS.md for AGENTS.md issues"
+        );
+    }
+
+    #[test]
+    fn describe_md_move_section_same_file() {
+        let op = Operation::MdMoveSection {
+            path: "README.md".into(),
+            heading: "FAQ".into(),
+            to: None,
+            before: Some("License".into()),
+            after: None,
+        };
+        assert_eq!(
+            describe_operation(&op),
+            r#"Move section "FAQ" before "License" in README.md"#
+        );
+    }
+
+    #[test]
+    fn describe_md_move_section_cross_file() {
+        let op = Operation::MdMoveSection {
+            path: "spec.md".into(),
+            heading: "Appendix".into(),
+            to: Some("notes.md".into()),
+            before: None,
+            after: Some("Body".into()),
+        };
+        assert_eq!(
+            describe_operation(&op),
+            r#"Move section "Appendix" from spec.md to notes.md after "Body""#
         );
     }
 }

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -210,6 +210,24 @@ pub struct MdInsertParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
+pub struct MdMoveSectionParams {
+    /// Source file path containing the section to move.
+    pub path: String,
+    /// Heading of the section to move (e.g., "## FAQ").
+    pub heading: String,
+    /// Destination file path. Omit for same-file reorder.
+    #[serde(default)]
+    pub to: Option<String>,
+    /// Insert before this heading at the destination.
+    #[serde(default)]
+    pub before: Option<String>,
+    /// Insert after this heading at the destination.
+    #[serde(default)]
+    pub after: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct TidyParams {
     /// File path to normalize.
     pub path: String,
@@ -532,12 +550,19 @@ fn validate_operation_paths(
             | Operation::MdUpsertBullet { path, .. }
             | Operation::MdTableAppend { path, .. }
             | Operation::MdDedupeHeadings { path, .. }
+            | Operation::MdLintAgents { path, .. }
             | Operation::TidyFix { path, .. }
             | Operation::FileCreate { path, .. }
             | Operation::FileDelete { path, .. }
             | Operation::Read { path, .. }
-            | Operation::Search { path, .. }
-            | Operation::MdLintAgents { path, .. } => vec![path.as_str()],
+            | Operation::Search { path, .. } => vec![path.as_str()],
+            Operation::MdMoveSection { path, to, .. } => {
+                let mut p = vec![path.as_str()];
+                if let Some(to) = to {
+                    p.push(to.as_str());
+                }
+                p
+            }
             Operation::DocMerge { path, .. } => vec![path.as_str()],
             Operation::Replace { path, glob, .. } => {
                 let mut p = Vec::new();
@@ -1253,6 +1278,41 @@ impl PatchloomService {
     }
 
     #[tool(
+        description = "Move a markdown heading section to a new position (same file reorder or cross-file). Exactly one of before or after is required. Omit to for same-file reorder. Example: {\"path\": \"spec.md\", \"heading\": \"## Appendix\", \"to\": \"notes.md\", \"before\": \"## References\"}"
+    )]
+    async fn md_move_section(
+        &self,
+        Parameters(p): Parameters<MdMoveSectionParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.check_path(&p.path)?;
+        if let Some(ref to) = p.to {
+            self.check_path(to)?;
+        }
+        if p.before.is_none() && p.after.is_none() {
+            return Err(McpError::invalid_params(
+                "exactly one of 'before' or 'after' must be provided",
+                None,
+            ));
+        }
+        if p.before.is_some() && p.after.is_some() {
+            return Err(McpError::invalid_params(
+                "'before' and 'after' cannot both be set",
+                None,
+            ));
+        }
+        execute_plan_validated(
+            make_plan(vec![Operation::MdMoveSection {
+                path: p.path,
+                heading: p.heading,
+                to: p.to,
+                before: p.before,
+                after: p.after,
+            }]),
+            &self.cwd,
+        )
+    }
+
+    #[tool(
         description = "Lint a markdown rules file for duplicate headings, dangerous git commands, and missing final newline. Example: {\"path\": \"AGENTS.md\"}"
     )]
     async fn md_lint(
@@ -1598,7 +1658,11 @@ mod tests {
             names.contains(&"md_insert_before_heading"),
             "missing md_insert_before_heading tool"
         );
-        assert_eq!(names.len(), 29, "expected 29 tools, got {}", names.len());
+        assert!(
+            names.contains(&"md_move_section"),
+            "missing md_move_section tool"
+        );
+        assert_eq!(names.len(), 30, "expected 30 tools, got {}", names.len());
         client.cancel().await.unwrap();
     }
 

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -3,7 +3,8 @@ use crate::diff::{self, DiffResult, unified_diff};
 use crate::exit;
 use crate::ops::md::{
     dedupe_headings_in, find_section, insert_after_heading_in, insert_before_heading_in,
-    non_fenced_lines, parse_headings, replace_section_in, table_append_in, upsert_bullet_in,
+    move_section_in, non_fenced_lines, parse_headings, replace_section_in, table_append_in,
+    upsert_bullet_in,
 };
 use crate::write::policy_from_flags;
 use anyhow::Context;
@@ -84,6 +85,23 @@ pub enum MdAction {
         /// The row to append, in markdown table format (e.g., "| col1 | col2 | col3 |").
         #[arg(long)]
         row: String,
+    },
+    /// Move a heading section to a new location (same file or different file).
+    MoveSection {
+        /// Source file containing the section to move.
+        file: String,
+        /// Heading of the section to move (e.g., "## FAQ").
+        #[arg(long)]
+        heading: String,
+        /// Destination file. Omit for same-file reorder.
+        #[arg(long)]
+        to: Option<String>,
+        /// Insert before this heading at the destination.
+        #[arg(long, conflicts_with = "after")]
+        before: Option<String>,
+        /// Insert after this heading at the destination.
+        #[arg(long, conflicts_with = "before")]
+        after: Option<String>,
     },
 }
 
@@ -372,6 +390,51 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         }
                     }
                 }
+            }
+        }
+
+        MdAction::MoveSection {
+            file,
+            heading,
+            to,
+            before,
+            after,
+        } => {
+            let position = match (&before, &after) {
+                (Some(b), None) => ("before", b.as_str()),
+                (None, Some(a)) => ("after", a.as_str()),
+                _ => anyhow::bail!("exactly one of --before or --after must be provided"),
+            };
+
+            let same_file = to.is_none();
+            let dest_file = to.as_deref().unwrap_or(&file);
+            let source_original = read(&file)?;
+            let dest_original = if same_file {
+                source_original.clone()
+            } else {
+                read(dest_file)?
+            };
+
+            match move_section_in(
+                &source_original,
+                &heading,
+                &dest_original,
+                position,
+                same_file,
+            ) {
+                Some((new_source, new_dest)) => {
+                    if same_file {
+                        apply(&file, &source_original, &new_source)
+                    } else {
+                        // Apply both files. If either fails, the caller sees the error.
+                        let code = apply(&file, &source_original, &new_source)?;
+                        if code != exit::SUCCESS {
+                            return Ok(code);
+                        }
+                        apply(dest_file, &dest_original, &new_dest)
+                    }
+                }
+                None => Ok(exit::NO_MATCHES),
             }
         }
     }
@@ -933,5 +996,158 @@ mod tests {
             "next section damaged"
         );
         assert!(result.contains("| B |"), "new row missing");
+    }
+
+    // -- move-section -------------------------------------------------------
+
+    #[test]
+    fn move_section_same_file_reorder_before() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\na-content\n# B\nb-content\n# C\nc-content\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "C".into(),
+                to: None,
+                before: Some("B".into()),
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &default_global()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        let a_pos = result.find("# A").unwrap();
+        let c_pos = result.find("# C").unwrap();
+        let b_pos = result.find("# B").unwrap();
+        assert!(a_pos < c_pos, "A should come before C");
+        assert!(c_pos < b_pos, "C should come before B after move");
+        assert!(result.contains("a-content"), "A content lost");
+        assert!(result.contains("b-content"), "B content lost");
+        assert!(result.contains("c-content"), "C content lost");
+    }
+
+    #[test]
+    fn move_section_same_file_reorder_after() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\na-content\n# B\nb-content\n# C\nc-content\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "A".into(),
+                to: None,
+                before: None,
+                after: Some("B".into()),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &default_global()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        let b_pos = result.find("# B").unwrap();
+        let a_pos = result.find("# A").unwrap();
+        let c_pos = result.find("# C").unwrap();
+        assert!(b_pos < a_pos, "B should come before A after move");
+        assert!(a_pos < c_pos, "A should come before C");
+    }
+
+    #[test]
+    fn move_section_cross_file() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("source.md");
+        let dst = dir.path().join("dest.md");
+        fs::write(
+            &src,
+            "# Keep\nkept\n# Move Me\nmoved content\n# Also Keep\nalso\n",
+        )
+        .unwrap();
+        fs::write(&dst, "# Intro\nintro text\n# End\nend text\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: src.to_str().unwrap().to_string(),
+                heading: "Move Me".into(),
+                to: Some(dst.to_str().unwrap().to_string()),
+                before: Some("End".into()),
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &default_global()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let src_result = fs::read_to_string(&src).unwrap();
+        assert!(
+            !src_result.contains("# Move Me"),
+            "section not removed from source"
+        );
+        assert!(
+            !src_result.contains("moved content"),
+            "section body not removed from source"
+        );
+        assert!(src_result.contains("# Keep"), "kept section lost");
+        assert!(src_result.contains("# Also Keep"), "other section lost");
+
+        let dst_result = fs::read_to_string(&dst).unwrap();
+        assert!(
+            dst_result.contains("# Move Me"),
+            "section not added to dest"
+        );
+        assert!(
+            dst_result.contains("moved content"),
+            "section body not in dest"
+        );
+        let move_pos = dst_result.find("# Move Me").unwrap();
+        let end_pos = dst_result.find("# End").unwrap();
+        assert!(move_pos < end_pos, "section not inserted before End");
+    }
+
+    #[test]
+    fn move_section_missing_heading_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\ncontent\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Missing".into(),
+                to: None,
+                before: Some("A".into()),
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &default_global()).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn move_section_no_before_or_after_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\ncontent\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "A".into(),
+                to: None,
+                before: None,
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let result = run(args, &default_global());
+        assert!(
+            result.is_err(),
+            "expected error when neither --before nor --after is provided"
+        );
     }
 }

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -161,6 +161,7 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Set/get a key in JSON, YAML, or TOML | `doc_set`, `doc_get`, `doc_query` |\n\
              | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |\n\
              | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |\n\
+             | Move a heading section (same file or cross-file) | `md_move_section` |\n\
              | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |\n\
              | Create, rename, or delete a file | `create_file`, `move_file`, `delete_file` |\n\
              | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |\n\

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -6,8 +6,8 @@ use crate::ops::doc::{
     navigate_mut, parse_doc, serialize_value_preserving, set_at_path, update_matching,
 };
 use crate::ops::md::{
-    dedupe_headings_in, insert_after_heading_in, insert_before_heading_in, replace_section_in,
-    table_append_for_tx, upsert_bullet_in,
+    dedupe_headings_in, insert_after_heading_in, insert_before_heading_in, move_section_in,
+    replace_section_in, table_append_for_tx, upsert_bullet_in,
 };
 use crate::ops::patch::apply_patch_with_loader;
 use crate::ops::replace::{
@@ -269,6 +269,7 @@ fn op_label(op: &Operation) -> &'static str {
         Operation::MdInsertBeforeHeading { .. } => "md.insert_before_heading",
         Operation::MdUpsertBullet { .. } => "md.upsert_bullet",
         Operation::MdTableAppend { .. } => "md.table_append",
+        Operation::MdMoveSection { .. } => "md.move_section",
         Operation::MdDedupeHeadings { .. } => "md.dedupe_headings",
         Operation::TidyFix { .. } => "tidy.fix",
         Operation::FileCreate { .. } => "file.create",
@@ -340,6 +341,15 @@ fn validate_operation(op: &Operation) -> anyhow::Result<()> {
         | Operation::Read { .. }
         | Operation::MdLintAgents { .. }
         | Operation::PatchApply { .. } => Ok(()),
+        Operation::MdMoveSection { before, after, .. } => {
+            if before.is_none() && after.is_none() {
+                anyhow::bail!("md.move_section requires either 'before' or 'after'");
+            }
+            if before.is_some() && after.is_some() {
+                anyhow::bail!("md.move_section: 'before' and 'after' cannot both be set");
+            }
+            Ok(())
+        }
         Operation::Search {
             invert_match,
             multiline,
@@ -884,6 +894,7 @@ fn op_needs_doc_flush(op: &Operation) -> bool {
             | Operation::MdInsertBeforeHeading { .. }
             | Operation::MdUpsertBullet { .. }
             | Operation::MdTableAppend { .. }
+            | Operation::MdMoveSection { .. }
             | Operation::MdDedupeHeadings { .. }
             | Operation::PatchApply { .. }
             | Operation::Read { .. }
@@ -1048,6 +1059,39 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
 
         Operation::MdTableAppend { path, heading, row } => {
             apply_md_heading_op(tx, path, heading, row, table_append_for_tx, "heading/table")?;
+        }
+
+        Operation::MdMoveSection {
+            path,
+            heading,
+            to,
+            before,
+            after,
+        } => {
+            let position = match (before.as_deref(), after.as_deref()) {
+                (Some(b), None) => ("before", b),
+                (None, Some(a)) => ("after", a),
+                _ => anyhow::bail!("md.move_section requires exactly one of 'before' or 'after'"),
+            };
+            let same_file = to.is_none();
+            let dest_path_str = to.as_deref().unwrap_or(path.as_str());
+            let source_path = tx.cwd.join(path);
+            let dest_path = tx.cwd.join(dest_path_str);
+            let source_content = read_file_content(tx.pending, &source_path)?.to_owned();
+            let dest_content = if same_file {
+                source_content.clone()
+            } else {
+                read_file_content(tx.pending, &dest_path)?.to_owned()
+            };
+            let (new_source, new_dest) =
+                move_section_in(&source_content, heading, &dest_content, position, same_file)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("md.move_section: heading or target not found")
+                    })?;
+            update_file_content(tx.pending, tx.deletions, &source_path, new_source);
+            if !same_file {
+                update_file_content(tx.pending, tx.deletions, &dest_path, new_dest);
+            }
         }
 
         Operation::MdDedupeHeadings { path } => {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1544,6 +1544,77 @@ pub mod md {
         None
     }
 
+    /// Return the full byte range of a section INCLUDING its heading line.
+    ///
+    /// Unlike `find_section` which returns only the body range (after the
+    /// heading), this returns `(section_start, section_end)` where
+    /// `section_start` is the first byte of the heading line itself.
+    pub fn section_range(content: &str, heading: &str) -> Option<(usize, usize)> {
+        let headings = parse_headings(content);
+        let offsets = line_byte_starts(content);
+        let query = normalize_heading_query(heading);
+
+        for h in &headings {
+            if h.text.trim() == query {
+                let section_start = offsets[h.line_start];
+                let section_end = if h.line_end < offsets.len() {
+                    offsets[h.line_end]
+                } else {
+                    content.len()
+                };
+                return Some((section_start, section_end));
+            }
+        }
+        None
+    }
+
+    /// Move a heading section to a new location, either within the same file
+    /// or from one file to another.
+    ///
+    /// Returns `(new_source, new_dest)`. For same-file moves the caller
+    /// should use only `new_source` (both values are identical).
+    ///
+    /// `position` is `("before", heading)` or `("after", heading)`.
+    pub fn move_section_in(
+        source_content: &str,
+        heading: &str,
+        dest_content: &str,
+        position: (&str, &str),
+        same_file: bool,
+    ) -> Option<(String, String)> {
+        let (section_start, section_end) = section_range(source_content, heading)?;
+        let section_text = &source_content[section_start..section_end];
+
+        if same_file {
+            // Same-file reorder: remove the section first, then insert into
+            // the resulting content. This avoids complex offset adjustment.
+            let without_section = format!(
+                "{}{}",
+                &source_content[..section_start],
+                &source_content[section_end..]
+            );
+            let result = match position.0 {
+                "before" => insert_before_heading_in(&without_section, position.1, section_text)?,
+                "after" => insert_after_heading_in(&without_section, position.1, section_text)?,
+                _ => return None,
+            };
+            Some((result.clone(), result))
+        } else {
+            // Cross-file move: remove from source, insert into dest.
+            let new_source = format!(
+                "{}{}",
+                &source_content[..section_start],
+                &source_content[section_end..]
+            );
+            let new_dest = match position.0 {
+                "before" => insert_before_heading_in(dest_content, position.1, section_text)?,
+                "after" => insert_after_heading_in(dest_content, position.1, section_text)?,
+                _ => return None,
+            };
+            Some((new_source, new_dest))
+        }
+    }
+
     pub fn replace_section_in(content: &str, heading: &str, replacement: &str) -> Option<String> {
         let (body_start, body_end) = find_section(content, heading)?;
         let mut out = String::with_capacity(content.len());
@@ -3205,6 +3276,80 @@ mod tests {
             let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n";
             let result = table_append_for_tx(content, "API", "| b | 2 |").unwrap();
             assert!(result.contains("| a | 1 |\n| b | 2 |\n"));
+        }
+
+        #[test]
+        fn section_range_includes_heading() {
+            let content = "# A\nbody a\n# B\nbody b\n";
+            let (start, end) = section_range(content, "A").unwrap();
+            assert_eq!(&content[start..end], "# A\nbody a\n");
+        }
+
+        #[test]
+        fn section_range_last_section() {
+            let content = "# A\nbody a\n# B\nbody b\n";
+            let (start, end) = section_range(content, "B").unwrap();
+            assert_eq!(&content[start..end], "# B\nbody b\n");
+        }
+
+        #[test]
+        fn section_range_missing() {
+            let content = "# A\nbody\n";
+            assert!(section_range(content, "Missing").is_none());
+        }
+
+        #[test]
+        fn move_section_same_file_before() {
+            let content = "# A\na body\n# B\nb body\n# C\nc body\n";
+            let (result, _) =
+                move_section_in(content, "C", content, ("before", "B"), true).unwrap();
+            let a_pos = result.find("# A").unwrap();
+            let c_pos = result.find("# C").unwrap();
+            let b_pos = result.find("# B").unwrap();
+            assert!(a_pos < c_pos);
+            assert!(c_pos < b_pos);
+            assert!(result.contains("a body"));
+            assert!(result.contains("b body"));
+            assert!(result.contains("c body"));
+        }
+
+        #[test]
+        fn move_section_same_file_after() {
+            let content = "# A\na body\n# B\nb body\n# C\nc body\n";
+            let (result, _) = move_section_in(content, "A", content, ("after", "B"), true).unwrap();
+            let b_pos = result.find("# B").unwrap();
+            let a_pos = result.find("# A").unwrap();
+            let c_pos = result.find("# C").unwrap();
+            assert!(b_pos < a_pos);
+            assert!(a_pos < c_pos);
+        }
+
+        #[test]
+        fn move_section_cross_file() {
+            let source = "# Keep\nkept\n# Move\nmoved\n# Stay\nstayed\n";
+            let dest = "# Intro\nintro\n# End\nend\n";
+            let (new_src, new_dst) =
+                move_section_in(source, "Move", dest, ("before", "End"), false).unwrap();
+            assert!(!new_src.contains("# Move"));
+            assert!(!new_src.contains("moved"));
+            assert!(new_src.contains("# Keep"));
+            assert!(new_src.contains("# Stay"));
+            assert!(new_dst.contains("# Move\nmoved"));
+            let move_pos = new_dst.find("# Move").unwrap();
+            let end_pos = new_dst.find("# End").unwrap();
+            assert!(move_pos < end_pos);
+        }
+
+        #[test]
+        fn move_section_missing_source_heading() {
+            let content = "# A\nbody\n";
+            assert!(move_section_in(content, "Missing", content, ("before", "A"), true).is_none());
+        }
+
+        #[test]
+        fn move_section_missing_target_heading() {
+            let content = "# A\nbody\n# B\nbody\n";
+            assert!(move_section_in(content, "A", content, ("before", "Missing"), true).is_none());
         }
     }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -139,6 +139,17 @@ pub enum Operation {
         heading: String,
         row: String,
     },
+    #[serde(rename = "md.move_section", alias = "md_move_section")]
+    MdMoveSection {
+        path: String,
+        heading: String,
+        /// Destination file. When omitted, reorder within the same file.
+        to: Option<String>,
+        /// Insert before this heading at the destination.
+        before: Option<String>,
+        /// Insert after this heading at the destination.
+        after: Option<String>,
+    },
     #[serde(rename = "md.dedupe_headings", alias = "md_dedupe_headings")]
     MdDedupeHeadings { path: String },
     #[serde(rename = "tidy.fix", alias = "fix_whitespace")]
@@ -326,6 +337,8 @@ mod tests {
             {"op": "md.insert_before_heading", "path": "f.md", "heading": "H", "content": "c"},
             {"op": "md.upsert_bullet", "path": "f.md", "heading": "H", "bullet": "- item"},
             {"op": "md.table_append", "path": "f.md", "heading": "H", "row": "| a | b |"},
+            {"op": "md.move_section", "path": "src.md", "heading": "FAQ", "before": "License"},
+            {"op": "md.move_section", "path": "src.md", "heading": "Appendix", "to": "dest.md", "after": "Body"},
             {"op": "md.dedupe_headings", "path": "f.md"},
             {"op": "tidy.fix", "path": "f.txt"},
             {"op": "tidy.fix", "path": "f.txt", "trim_trailing_whitespace": true, "normalize_eol": "lf"},
@@ -342,7 +355,7 @@ mod tests {
             {"op": "search", "path": "f.txt", "pattern": "TODO", "invert_match": true, "assert_count": 5}
         ]}"#;
         let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 30);
+        assert_eq!(plan.operations.len(), 32);
     }
 
     #[test]
@@ -357,6 +370,7 @@ mod tests {
             {"op": "doc_append", "path": "f.json", "selector": "arr", "value": 1},
             {"op": "doc_ensure", "path": "f.json", "selector": "k", "value": 1},
             {"op": "doc_delete_where", "path": "f.json", "selector": "arr", "predicate": "x=1"},
+            {"op": "md_move_section", "path": "f.md", "heading": "H", "before": "X"},
             {"op": "md_replace_section", "path": "f.md", "heading": "H", "content": "c"},
             {"op": "md_upsert_bullet", "path": "f.md", "heading": "H", "bullet": "- item"},
             {"op": "md_table_append", "path": "f.md", "heading": "H", "row": "| a |"},
@@ -370,7 +384,7 @@ mod tests {
             {"op": "md_lint", "path": "f.md"}
         ]}"#;
         let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 18);
+        assert_eq!(plan.operations.len(), 19);
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -414,6 +414,32 @@ pub fn operation_schemas() -> Vec<OperationSchema> {
             examples: vec![],
         },
         OperationSchema {
+            name: "md.move_section".into(),
+            description: "Move a heading section to a new position (same-file reorder or cross-file move). Exactly one of before or after is required.".into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "required": ["path", "heading"],
+                "properties": {
+                    "path": {"type": "string", "description": "Source file containing the section."},
+                    "heading": {"type": "string", "description": "Heading of the section to move."},
+                    "to": {"type": "string", "description": "Destination file (omit for same-file reorder)."},
+                    "before": {"type": "string", "description": "Insert before this heading."},
+                    "after": {"type": "string", "description": "Insert after this heading."}
+                }
+            }),
+            min_tier: Tier::Medium,
+            examples: vec![
+                OperationExample {
+                    description: "Reorder within same file".into(),
+                    args: serde_json::json!({"path": "README.md", "heading": "## FAQ", "before": "## License"}),
+                },
+                OperationExample {
+                    description: "Move section to another file".into(),
+                    args: serde_json::json!({"path": "spec.md", "heading": "## Appendix E", "to": "investigation.md", "after": "## Layer 4"}),
+                },
+            ],
+        },
+        OperationSchema {
             name: "patch.apply".into(),
             description: "Apply a unified diff patch to one or more files.".into(),
             parameters: serde_json::json!({


### PR DESCRIPTION
## Summary

Add `md.move-section` command that moves a heading section (heading line plus body) to a new position, either within the same file (reorder) or to a different file (cross-file move). Both source and destination are updated atomically via the tx engine's pending map.

## Interfaces

- **CLI:** `patchloom md move-section <file> --heading <h> [--to <dest>] --before|--after <target>`
- **MCP:** `md_move_section` tool (#30)
- **Batch:** `md.move_section <path> <heading> [<to>] before|after <target>`
- **Plan:** `{"op": "md.move_section", ...}`

## Integration points

- `src/ops.rs`: `section_range()` and `move_section_in()` helpers
- `src/plan.rs`: `MdMoveSection` variant on `Operation` enum
- `src/cmd/md.rs`: `MoveSection` CLI subcommand
- `src/cmd/tx.rs`: `op_label`, `validate_operation`, `op_needs_doc_flush`, `execute_operation`
- `src/cmd/batch.rs`: Line parser (4 args same-file, 5 args cross-file)
- `src/cmd/explain.rs`: Human-readable operation description
- `src/cmd/mcp.rs`: MCP tool with path validation for both `path` and `to`
- `src/schema.rs`: `OperationSchema` at Medium tier with examples
- `src/cmd/mod.rs`: Agent-rules tool selection guide
- `docs/reference/README.md`: Reference doc marker and description
- `docs/getting-started/mcp-setup.md`: MCP tool table

## Tests

- 19 new tests across ops, md, batch, explain, plan, and MCP
- `make check` passes: 722 unit + 622 integration = 1344 tests, 0 failures

Closes #553