### PR TITLE
fix: rename same-file detection via path canonicalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1354%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1357%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1354 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1357 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -57,7 +57,12 @@ fn validate_rename_paths(
     if dst.exists() && !dst.is_file() {
         anyhow::bail!("destination is not a file: {dst_label}");
     }
-    if src == dst {
+    if src == dst
+        || matches!(
+            (src.canonicalize(), dst.canonicalize()),
+            (Ok(ref s), Ok(ref d)) if s == d
+        )
+    {
         return Ok(RenameValidation::NoOp);
     }
     if !force && dst.exists() {
@@ -497,6 +502,29 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert!(file.exists(), "file should still exist");
+        assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+    }
+
+    #[test]
+    fn rename_same_file_via_different_path_is_noop() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("same.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let mut global = global_for(&dir);
+        global.apply = true;
+
+        // Use "./same.txt" as destination - different string, same file.
+        let args = RenameArgs {
+            from: file.to_string_lossy().into_owned(),
+            to: dir.path().join("./same.txt").to_string_lossy().into_owned(),
+            force: true,
+            write: Default::default(),
+        };
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(file.exists(), "file must not be deleted");
         assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
     }
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1215,8 +1215,13 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
                 anyhow::bail!("destination is not a file: {to}");
             }
 
-            // If source and destination are the same path, no-op.
-            if src_path == dst_path {
+            // If source and destination resolve to the same file, no-op.
+            if src_path == dst_path
+                || matches!(
+                    (src_path.canonicalize(), dst_path.canonicalize()),
+                    (Ok(ref s), Ok(ref d)) if s == d
+                )
+            {
                 return Ok(0);
             }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4692,6 +4692,29 @@ fn test_rename_same_path_without_force_is_noop() {
 }
 
 #[test]
+fn test_rename_same_file_via_different_path_is_noop() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("same.txt");
+    fs::write(&file, "content\n").unwrap();
+
+    // Use ./same.txt as destination - different string, same file.
+    let alt_path = dir.path().join("./same.txt");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("rename")
+        .arg(&file)
+        .arg(&alt_path)
+        .arg("--apply")
+        .arg("--force")
+        .assert()
+        .success();
+
+    assert!(file.exists(), "file must not be deleted");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "content\n");
+}
+
+#[test]
 fn test_rename_force_overwrites() {
     let dir = TempDir::new().unwrap();
     let src = dir.path().join("old.txt");
@@ -7490,6 +7513,40 @@ fn test_tx_file_rename_same_path_is_noop() {
         .assert()
         .success();
 
+    assert_eq!(
+        fs::read_to_string(dir.path().join("same.txt")).unwrap(),
+        "keep me\n"
+    );
+}
+
+#[test]
+fn test_tx_file_rename_same_file_via_different_path_is_noop() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("same.txt"), "keep me\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [
+            {"op": "file.rename", "from": "same.txt", "to": "./same.txt", "force": true}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert!(
+        dir.path().join("same.txt").exists(),
+        "file must not be deleted"
+    );
     assert_eq!(
         fs::read_to_string(dir.path().join("same.txt")).unwrap(),
         "keep me\n"


### PR DESCRIPTION
## What

Fix a bug where `patchloom rename file.md ./file.md --apply --force --ensure-final-newline` would destroy the file instead of treating it as a no-op.

The `rename` command and the tx engine's `file.rename` operation used raw `PathBuf` comparison (`src == dst`) to detect same-file renames. Paths like `file.md` and `./file.md` produce different `PathBuf` values but resolve to the same file. Without canonicalization, a rename with write policy transforms active would:

1. Read the file as UTF-8
2. Write transformed content to the "destination" (same file)
3. Delete the "source" (same file), destroying it

Now compares canonicalized paths, matching the fix applied to `md move-section` in PR #556.

## Changes

- `src/cmd/rename.rs`: Use canonicalized path comparison in `validate_rename_paths()`
- `src/cmd/tx.rs`: Use canonicalized path comparison in `FileRename` handler

## Testing

- 1 new unit test: `rename_same_file_via_different_path_is_noop`
- 2 new integration tests: CLI and tx engine paths
- All 1357 tests pass (`make check` clean)

## Test count

1354 -> 1357 (+3 tests)