### PR TITLE
test: cover parse_line_range error paths and reduce batch visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1357%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1361%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1357 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1361 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -63,7 +63,7 @@ pub struct BatchArgs {
 }
 
 /// Parse a single line into an Operation.
-pub fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
+fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
     let tokens = tokenize(line).map_err(|e| anyhow::anyhow!("line {line_num}: {e}"))?;
     if tokens.is_empty() {
         anyhow::bail!("line {line_num}: empty operation");

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -277,6 +277,42 @@ mod tests {
     }
 
     #[test]
+    fn parse_range_non_numeric_single_fails() {
+        let err = parse_line_range("abc").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid line number"),
+            "expected 'invalid line number', got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_range_single_zero_fails() {
+        let err = parse_line_range("0").unwrap_err();
+        assert!(
+            err.to_string().contains("1-based"),
+            "expected '1-based', got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_range_non_numeric_start_fails() {
+        let err = parse_line_range("abc:10").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid start line"),
+            "expected 'invalid start line', got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_range_non_numeric_end_fails() {
+        let err = parse_line_range("5:xyz").unwrap_err();
+        assert!(
+            err.to_string().contains("invalid end line"),
+            "expected 'invalid end line', got: {err}"
+        );
+    }
+
+    #[test]
     fn read_one_file_empty_file() {
         let dir = tempfile::TempDir::new().unwrap();
         let file = dir.path().join("empty.txt");


### PR DESCRIPTION
## What

Two small improvements from multi-perspective cycle 11:

1. **Test coverage**: Add 4 unit tests for untested error paths in `parse_line_range()` (`src/cmd/read.rs`):
   - Non-numeric single value ("abc")
   - Single zero ("0")
   - Non-numeric start in range ("abc:10")
   - Non-numeric end in range ("5:xyz")

2. **Code hygiene**: Reduce `batch::parse_line` from `pub` to `fn` since it has no external callers.

## Testing

All 1361 tests pass (`make check` clean).

## Test count

1357 -> 1361 (+4 tests)