### PR TITLE
docs: update stale MCP tool count (29 to 30)

### DIFF
--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -99,7 +99,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 ## By the numbers
 
 - **1,318 tests**, zero unsafe code
-- **20 commands** including MCP server with 29 structured tool calls
+- **20 commands** including MCP server with 30 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14860,7 +14860,7 @@ fn test_smoke_readme_command_examples() {
         "launch announcement CLI command count drifted"
     );
     assert!(
-        launch.contains("29 structured tool calls"),
+        launch.contains("30 structured tool calls"),
         "launch announcement MCP tool count drifted"
     );
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
The `md_move_section` tool added in PR #554 brought the MCP tool count from 29 to 30, but the launch announcement and its integration test assertion were not updated.

**Changes:**
- `docs/blog/launch-announcement.md`: 29 -> 30 structured tool calls
- `tests/integration.rs`: assertion updated to match

Discovered during improvement cycle 12 (Spec/Contract Compliance perspective).