### PR TITLE
docs: update stale test count (1,318 to 1,361) in launch announcement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,7 +85,7 @@ src/
                        patch (parse, apply hunks with fuzz, loader). Each is a pub(crate) submodule.
   write.rs             Atomic file writes via tempfile; WritePolicy applies trim, EOL, final newline
   plan.rs              Transaction plan format: Plan, Operation, FormatStep, ValidationStep;
-                       23 operation types including all doc/md/replace/tidy/file/patch/read/search ops
+                       25 operation types including all doc/md/replace/tidy/file/patch/read/search ops
 tests/
   integration.rs       Rust integration tests (cargo test --test integration)
   agent/               Python (pytest) agent integration tests verifying AI agents use patchloom

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,318 tests**, zero unsafe code
+- **1,361 tests**, zero unsafe code
 - **20 commands** including MCP server with 30 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14854,7 +14854,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,318 tests"));
+    assert!(launch.contains("1,361 tests"));
     assert!(
         launch.contains("20 commands"),
         "launch announcement CLI command count drifted"
@@ -15273,7 +15273,7 @@ fn test_agents_doc_project_inventory_matches_repo_state() {
     );
     assert!(
         agents.contains(
-            "23 operation types including all doc/md/replace/tidy/file/patch/read/search ops"
+            "25 operation types including all doc/md/replace/tidy/file/patch/read/search ops"
         ),
         "AGENTS.md should describe the current tx operation count"
     );


### PR DESCRIPTION
The launch announcement's test count was set at launch (1,318) and never updated as improvement cycles added tests. Current count is 1,361 (728 unit + 633 integration).

Also includes the AGENTS.md operation count fix from #560 to avoid merge conflict.

**Changes:**
- `docs/blog/launch-announcement.md`: 1,318 -> 1,361 tests
- `AGENTS.md`: 23 -> 25 operation types (same as #560)
- `tests/integration.rs`: assertions updated to match

Discovered during improvement cycle 14.