### PR TITLE
feat: add --whole-line, --range, and --collapse-blanks to replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1361%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1381%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1361 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1381 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -76,6 +76,13 @@ These flags shape how written content is normalized before it reaches disk.
 - **Use when:** The repo already encodes formatting policy in `.editorconfig` and Patchloom should follow it automatically.
 - **Prefer instead:** Use explicit write flags, or `tx` `write_policy`, when the command should be self-contained and not depend on repo metadata.
 
+<!-- ref:write-flag:collapse-blanks -->
+### `--collapse-blanks`
+
+- **What it does:** Collapses consecutive blank lines into a single blank line after writing. Useful after line deletion to prevent double-blank gaps.
+- **Use when:** You are deleting lines (e.g. with `replace --whole-line --to ''`) and want to clean up the resulting blank line runs.
+- **Prefer instead:** Omit when consecutive blank lines are intentional (e.g. section separators in code).
+
 ### Output and scope flags
 
 These flags affect how Patchloom reports results or chooses which files to touch.
@@ -426,6 +433,20 @@ These are meaningful command-specific modes that change how a top-level command 
 - **What it does:** Matches regardless of case during replacement.
 - **Use when:** The target text appears with inconsistent capitalization and should still be updated uniformly.
 - **Prefer instead:** Use case-sensitive replace when exact spelling is part of the safety boundary.
+
+<!-- ref:replace-mode:whole-line -->
+### `replace --whole-line`
+
+- **What it does:** Replaces (or deletes) entire lines that contain a match, instead of replacing only the matched span. When combined with `--to ''`, removes matching lines entirely.
+- **Use when:** You need to delete lines matching a pattern (dead code, lint suppressions, debug statements) or replace full lines based on a partial match.
+- **Prefer instead:** Use regular replace when only the matched text should change while the rest of the line stays intact.
+
+<!-- ref:replace-mode:range -->
+### `replace --range`
+
+- **What it does:** Restricts `--whole-line` matching to a line range (e.g. `--range 10:50`). Lines outside the range are not considered for matching. Requires `--whole-line`.
+- **Use when:** The pattern matches lines you want to keep in other parts of the file (e.g. removing dead code from implementation but not from tests).
+- **Prefer instead:** Omit when the pattern is specific enough to avoid false positives.
 
 <!-- ref:create-mode:stdin -->
 ### `create --stdin`

--- a/src/api.rs
+++ b/src/api.rs
@@ -131,6 +131,7 @@ pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
             Some(EolNormalization::Crlf) => EolMode::Crlf,
         },
         trim_trailing_whitespace: opts.trim_trailing_whitespace,
+        collapse_blanks: false,
     }
 }
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -81,6 +81,8 @@ pub struct GlobalFlags {
     #[clap(skip)]
     pub respect_editorconfig: bool,
     #[clap(skip)]
+    pub collapse_blanks: bool,
+    #[clap(skip)]
     pub confirm: bool,
 }
 
@@ -119,6 +121,10 @@ pub struct WriteFlags {
     #[arg(long, global = true)]
     pub respect_editorconfig: bool,
 
+    /// Collapse consecutive blank lines into a single blank line after writing.
+    #[arg(long, global = true)]
+    pub collapse_blanks: bool,
+
     /// Show diff then prompt before applying. Implies --apply on confirmation.
     #[arg(long, global = true, conflicts_with_all = ["apply", "check"])]
     pub confirm: bool,
@@ -150,6 +156,7 @@ impl GlobalFlags {
         self.normalize_eol = w.normalize_eol;
         self.trim_trailing_whitespace = w.trim_trailing_whitespace;
         self.respect_editorconfig = w.respect_editorconfig;
+        self.collapse_blanks = w.collapse_blanks;
     }
 
     /// Whether to proceed with the write after optional confirmation.

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -137,6 +137,8 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
                 case_insensitive: false,
                 multiline: false,
                 if_exists: false,
+                whole_line: false,
+                range: None,
             })
         }
         "file.create" => {

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -122,6 +122,8 @@ fn describe_operation(op: &Operation) -> String {
             case_insensitive,
             insert_before,
             insert_after,
+            whole_line,
+            range,
             ..
         } => {
             let target = path.as_deref().or(glob.as_deref()).unwrap_or("(all files)");
@@ -144,8 +146,13 @@ fn describe_operation(op: &Operation) -> String {
             } else {
                 ""
             };
+            let wl_str = if *whole_line { ", whole-line" } else { "" };
+            let range_str = range
+                .as_deref()
+                .map(|r| format!(", lines {r}"))
+                .unwrap_or_default();
             format!(
-                "Replace \"{from}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str})"
+                "Replace \"{from}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{range_str})"
             )
         }
         Operation::DocSet {
@@ -322,6 +329,8 @@ mod tests {
             case_insensitive: false,
             multiline: false,
             if_exists: false,
+            whole_line: false,
+            range: None,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Replace "v1" with "v2" in README.md (literal)"#);
@@ -341,6 +350,8 @@ mod tests {
             case_insensitive: true,
             multiline: false,
             if_exists: false,
+            whole_line: false,
+            range: None,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -454,6 +465,8 @@ mod tests {
             case_insensitive: false,
             multiline: false,
             if_exists: false,
+            whole_line: false,
+            range: None,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -477,6 +490,8 @@ mod tests {
             case_insensitive: false,
             multiline: false,
             if_exists: false,
+            whole_line: false,
+            range: None,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Insert "// added" after "use crate" in lib.rs"#);

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -137,6 +137,12 @@ pub struct ReplaceParams {
     /// Return success even if no matches found (idempotent mode).
     #[serde(default)]
     pub if_exists: bool,
+    /// Replace the entire line containing each match, not just the matched span.
+    /// When combined with to="" this deletes matching lines.
+    #[serde(default)]
+    pub whole_line: bool,
+    /// Restrict matching to a line range (e.g. "10:50"). Requires whole_line=true.
+    pub range: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1142,7 +1148,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists. Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
+        description = "Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range. Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
     )]
     async fn replace_text(
         &self,
@@ -1177,6 +1183,8 @@ impl PatchloomService {
                 case_insensitive: p.case_insensitive,
                 multiline: p.multiline,
                 if_exists: p.if_exists,
+                whole_line: p.whole_line,
+                range: p.range,
             }]),
             &self.cwd,
         )
@@ -1468,6 +1476,8 @@ impl PatchloomService {
                 case_insensitive: p.case_insensitive,
                 multiline: p.multiline,
                 if_exists: false,
+                whole_line: false,
+                range: None,
             })
             .collect();
         execute_plan_validated(make_plan(ops), &self.cwd)
@@ -1626,7 +1636,7 @@ mod tests {
         assert_eq!(
             descriptions.get("replace_text"),
             Some(
-                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists. Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
+                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range. Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
             ),
             "replace_text description drifted"
         );

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -2,8 +2,8 @@ use crate::cli::global::GlobalFlags;
 use crate::diff::{self, DiffResult, unified_diff};
 use crate::exit;
 use crate::ops::replace::{
-    ReplaceModeError, compile_replace_regex, replace_content, replacement_text,
-    validate_replace_mode,
+    ReplaceModeError, compile_replace_regex, replace_content, replace_whole_lines,
+    replacement_text, validate_replace_mode,
 };
 use crate::write::policy_from_flags;
 use clap::Args;
@@ -55,6 +55,15 @@ pub struct ReplaceArgs {
     /// Case-insensitive matching.
     #[arg(long, short = 'i')]
     pub case_insensitive: bool,
+    // ref:replace-mode:whole-line
+    /// Replace the entire line containing each match, not just the matched span.
+    /// Useful for deleting lines (--whole-line --to '') or replacing full lines.
+    #[arg(long, short = 'L')]
+    pub whole_line: bool,
+    // ref:replace-mode:range
+    /// Restrict matching to a line range (e.g. '10:50'). 1-based, inclusive.
+    #[arg(long, short = 'R')]
+    pub range: Option<String>,
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,
 }
@@ -103,6 +112,18 @@ fn apply_replacements(
     crate::backup::backup_write_files(cwd, &writes)
 }
 
+/// Parse `--range` argument into (start, optional_end). Reuses the line-range
+/// parser from the read command.
+fn parse_range_arg(spec: Option<&str>) -> anyhow::Result<Option<(usize, Option<usize>)>> {
+    match spec {
+        None => Ok(None),
+        Some(s) => {
+            let (start, end) = crate::cmd::read::parse_line_range(s)?;
+            Ok(Some((start, end)))
+        }
+    }
+}
+
 fn build_replacement(args: &ReplaceArgs) -> String {
     replacement_text(
         &args.from,
@@ -134,13 +155,25 @@ fn collect_replacements(
 
     let from = &args.from;
     let nth = args.nth;
+    let whole_line = args.whole_line;
+    let range = parse_range_arg(args.range.as_deref())?;
 
     let cwd_ref = &cwd;
     let mut replacements: Vec<FileReplacement> =
         crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let content = crate::read_text_file(path, "replace", quiet)?;
-            let (replaced, count) =
-                replace_content(&content, from, &replacement, compiled_re.as_ref(), nth);
+            let (replaced, count) = if whole_line {
+                replace_whole_lines(
+                    &content,
+                    from,
+                    &replacement,
+                    compiled_re.as_ref(),
+                    nth,
+                    range,
+                )
+            } else {
+                replace_content(&content, from, &replacement, compiled_re.as_ref(), nth)
+            };
             if count > 0 {
                 let replaced = replaced.into_owned();
                 let display_path = crate::files::relative_display(path, cwd_ref)
@@ -202,6 +235,12 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
     if args.nth == Some(0) {
         anyhow::bail!("--nth is 1-based; use --nth 1 for the first occurrence");
+    }
+    if args.range.is_some() && !args.whole_line {
+        anyhow::bail!("--range requires --whole-line");
+    }
+    if args.whole_line && args.multiline {
+        anyhow::bail!("--whole-line and --multiline cannot be combined");
     }
 
     match validate_replace_mode(
@@ -373,6 +412,8 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            whole_line: false,
+            range: None,
             write: Default::default(),
         }
     }
@@ -413,6 +454,8 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            whole_line: false,
+            range: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &default_global()).unwrap();
@@ -440,6 +483,8 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            whole_line: false,
+            range: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &default_global()).unwrap();
@@ -542,6 +587,8 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            whole_line: false,
+            range: None,
             write: Default::default(),
         };
         let code = run(args, &default_global()).unwrap();
@@ -566,6 +613,8 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            whole_line: false,
+            range: None,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -638,6 +687,8 @@ mod tests {
             multiline: true,
             nth: None,
             case_insensitive: false,
+            whole_line: false,
+            range: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &default_global()).unwrap();
@@ -665,6 +716,8 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            whole_line: false,
+            range: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &default_global()).unwrap();
@@ -756,9 +809,227 @@ mod tests {
             multiline: false,
             nth: Some(0),
             case_insensitive: false,
+            whole_line: false,
+            range: None,
             write: Default::default(),
         };
         let err = run(args, &default_global()).unwrap_err();
         assert!(err.to_string().contains("1-based"), "{err}");
+    }
+
+    #[test]
+    fn whole_line_deletes_matching_lines() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        fs::write(
+            &file,
+            "fn main() {\n    let _x = foo();\n    let y = bar();\n    let _z = baz();\n}\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            from: "let _".to_string(),
+            to: Some(String::new()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &default_global()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 2);
+        assert_eq!(
+            replacements[0].replaced,
+            "fn main() {\n    let y = bar();\n}\n"
+        );
+    }
+
+    #[test]
+    fn whole_line_regex_deletes_matching_lines() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        fs::write(
+            &file,
+            "use std::io;\nuse std::fmt;\nuse crate::foo;\nuse crate::bar;\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            from: r"use crate::".to_string(),
+            to: Some(String::new()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: false,
+            regex: true,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &default_global()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 2);
+        assert_eq!(replacements[0].replaced, "use std::io;\nuse std::fmt;\n");
+    }
+
+    #[test]
+    fn whole_line_replaces_entire_line() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "alpha\nbeta match\ngamma\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "match".to_string(),
+            to: Some("replaced line".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &default_global()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].replaced, "alpha\nreplaced line\ngamma\n");
+    }
+
+    #[test]
+    fn whole_line_with_range_restricts_matches() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "aaa\nbbb\nccc\nbbb\neee\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "bbb".to_string(),
+            to: Some(String::new()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            whole_line: true,
+            range: Some("1:3".to_string()),
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &default_global()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        // Only the bbb on line 2 should be deleted; the one on line 4 is outside range.
+        assert_eq!(replacements[0].match_count, 1);
+        assert_eq!(replacements[0].replaced, "aaa\nccc\nbbb\neee\n");
+    }
+
+    #[test]
+    fn whole_line_nth_only_removes_nth_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "aaa\nbbb\nccc\nbbb\neee\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "bbb".to_string(),
+            to: Some(String::new()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: Some(2),
+            case_insensitive: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &default_global()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 1);
+        // Second occurrence of bbb (line 4) is deleted.
+        assert_eq!(replacements[0].replaced, "aaa\nbbb\nccc\neee\n");
+    }
+
+    #[test]
+    fn range_requires_whole_line() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "hello".to_string(),
+            to: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            whole_line: false,
+            range: Some("1:5".to_string()),
+            write: Default::default(),
+        };
+        let err = run(args, &default_global()).unwrap_err();
+        assert!(
+            err.to_string().contains("--range requires --whole-line"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn whole_line_and_multiline_conflict() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "hello".to_string(),
+            to: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: false,
+            regex: true,
+            if_exists: false,
+            multiline: true,
+            nth: None,
+            case_insensitive: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let err = run(args, &default_global()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("--whole-line and --multiline cannot be combined"),
+            "{err}"
+        );
     }
 }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -11,8 +11,8 @@ use crate::ops::md::{
 };
 use crate::ops::patch::apply_patch_with_loader;
 use crate::ops::replace::{
-    ReplaceModeError, compile_replace_regex, replace_content, replacement_text,
-    validate_replace_mode,
+    ReplaceModeError, compile_replace_regex, replace_content, replace_whole_lines,
+    replacement_text, validate_replace_mode,
 };
 use crate::plan::{self, Operation, Plan};
 use crate::selector;
@@ -586,6 +586,8 @@ fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<us
         insert_after,
         case_insensitive,
         multiline,
+        whole_line,
+        range,
         ..
     } = op
     else {
@@ -595,12 +597,26 @@ fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<us
     let use_regex = regex_mode || *case_insensitive;
     let replacement = replacement_text(from, to, insert_before, insert_after, use_regex);
     let compiled_re = compile_replace_regex(from, regex_mode, *case_insensitive, *multiline)?;
+    let parsed_range = range
+        .as_deref()
+        .map(crate::cmd::read::parse_line_range)
+        .transpose()?;
 
     if let Some(p) = path {
         let file_path = tx.cwd.join(p);
         let content = read_file_content(tx.pending, &file_path)?;
-        let (replaced, match_count) =
-            replace_content(content, from, &replacement, compiled_re.as_ref(), *nth);
+        let (replaced, match_count) = if *whole_line {
+            replace_whole_lines(
+                content,
+                from,
+                &replacement,
+                compiled_re.as_ref(),
+                *nth,
+                parsed_range,
+            )
+        } else {
+            replace_content(content, from, &replacement, compiled_re.as_ref(), *nth)
+        };
         if match_count > 0 {
             let owned = replaced.into_owned();
             update_file_content(tx.pending, tx.deletions, &file_path, owned);
@@ -674,8 +690,18 @@ fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<us
                     }
                 }
             };
-            let (replaced, match_count) =
-                replace_content(&content, from, &replacement, compiled_re.as_ref(), *nth);
+            let (replaced, match_count) = if *whole_line {
+                replace_whole_lines(
+                    &content,
+                    from,
+                    &replacement,
+                    compiled_re.as_ref(),
+                    *nth,
+                    parsed_range,
+                )
+            } else {
+                replace_content(&content, from, &replacement, compiled_re.as_ref(), *nth)
+            };
             total_matches += match_count;
             if match_count > 0 {
                 update_file_content(tx.pending, tx.deletions, &file_path, replaced.into_owned());
@@ -1121,6 +1147,7 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
                 } else {
                     EolMode::Keep
                 },
+                collapse_blanks: false,
             };
             let new = crate::write::apply_policy(&content, &policy);
             if content != *new {

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1416,6 +1416,121 @@ pub mod replace {
             }
         }
     }
+
+    /// Whole-line replacement: when a line matches the pattern, the entire line
+    /// (including its newline) is replaced with `to`. When `to` is empty, the
+    /// line is deleted. Supports optional line-range restriction and nth match.
+    ///
+    /// For regex patterns, capture groups in `to` are expanded using the match
+    /// found on each line.
+    pub fn replace_whole_lines<'a>(
+        content: &'a str,
+        from: &str,
+        to: &str,
+        compiled_re: Option<&Regex>,
+        nth: Option<usize>,
+        range: Option<(usize, Option<usize>)>,
+    ) -> (std::borrow::Cow<'a, str>, usize) {
+        use std::borrow::Cow;
+
+        let mut result = String::with_capacity(content.len());
+        let mut match_count = 0usize;
+        let mut rest = content;
+        let mut line_num = 0usize; // 1-based
+
+        while !rest.is_empty() {
+            line_num += 1;
+
+            // Find line boundary.
+            let (line_content, line_with_ending, advance) = if let Some(pos) = rest.find('\n') {
+                (&rest[..pos], &rest[..=pos], pos + 1)
+            } else {
+                (rest, rest, rest.len())
+            };
+
+            // Check range restriction.
+            let in_range = match range {
+                Some((start, Some(end))) => line_num >= start && line_num <= end,
+                Some((start, None)) => line_num >= start,
+                None => true,
+            };
+
+            if !in_range {
+                result.push_str(line_with_ending);
+                rest = &rest[advance..];
+                continue;
+            }
+
+            // Check if this line matches the pattern.
+            let line_match = if let Some(re) = compiled_re {
+                re.captures(line_content)
+            } else if line_content.contains(from) {
+                None // Sentinel: literal match found, no captures.
+            } else {
+                // Use a special marker to distinguish "no match" from
+                // "literal match with no captures".
+                rest = &rest[advance..];
+                result.push_str(line_with_ending);
+                continue;
+            };
+
+            // For literal matches, we set a flag and handle below.
+            let is_literal_match = compiled_re.is_none() && line_content.contains(from);
+            let has_match = line_match.is_some() || is_literal_match;
+
+            if !has_match {
+                result.push_str(line_with_ending);
+                rest = &rest[advance..];
+                continue;
+            }
+
+            match_count += 1;
+
+            // Handle --nth: only act on the Nth occurrence.
+            if let Some(n) = nth
+                && match_count != n
+            {
+                result.push_str(line_with_ending);
+                rest = &rest[advance..];
+                continue;
+            }
+
+            // Replace the line.
+            if to.is_empty() {
+                // Delete the line entirely (don't append anything).
+            } else if let Some(ref caps) = line_match {
+                // Regex with captures: expand replacement text.
+                let mut expanded = String::new();
+                caps.expand(to, &mut expanded);
+                result.push_str(&expanded);
+                // Preserve the original line ending.
+                if line_with_ending.len() > line_content.len() {
+                    result.push('\n');
+                }
+            } else {
+                // Literal match: replacement is used as-is.
+                result.push_str(to);
+                if line_with_ending.len() > line_content.len() {
+                    result.push('\n');
+                }
+            }
+
+            rest = &rest[advance..];
+        }
+
+        // Determine actual match count for nth mode.
+        let effective_count = if let Some(n) = nth {
+            if match_count >= n { 1 } else { 0 }
+        } else {
+            match_count
+        };
+
+        if effective_count == 0 {
+            return (Cow::Borrowed(content), 0);
+        }
+
+        (Cow::Owned(result), effective_count)
+    }
 }
 
 pub mod md {
@@ -3027,6 +3142,82 @@ mod tests {
         fn compile_plain_literal_returns_none() {
             let re = compile_replace_regex("hello", false, false, false).unwrap();
             assert!(re.is_none());
+        }
+
+        // ── replace_whole_lines tests ─────────────────────────────────
+
+        #[test]
+        fn whole_lines_delete_literal() {
+            let content = "aaa\nbbb\nccc\nbbb\neee\n";
+            let (result, count) = replace_whole_lines(content, "bbb", "", None, None, None);
+            assert_eq!(count, 2);
+            assert_eq!(&*result, "aaa\nccc\neee\n");
+        }
+
+        #[test]
+        fn whole_lines_delete_regex() {
+            let re = compile_replace_regex(r"let _\w+", true, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "fn main() {\n    let _x = foo();\n    let y = bar();\n}\n";
+            let (result, count) = replace_whole_lines(content, "", "", Some(&re), None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "fn main() {\n    let y = bar();\n}\n");
+        }
+
+        #[test]
+        fn whole_lines_replace_with_text() {
+            let content = "alpha\nbeta\ngamma\n";
+            let (result, count) =
+                replace_whole_lines(content, "beta", "REPLACED", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "alpha\nREPLACED\ngamma\n");
+        }
+
+        #[test]
+        fn whole_lines_range_restriction() {
+            let content = "aaa\nbbb\nccc\nbbb\neee\n";
+            // Range 1:3 means lines 1-3 only. Second bbb is on line 4.
+            let (result, count) =
+                replace_whole_lines(content, "bbb", "", None, None, Some((1, Some(3))));
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\nccc\nbbb\neee\n");
+        }
+
+        #[test]
+        fn whole_lines_nth() {
+            let content = "aaa\nbbb\nccc\nbbb\neee\n";
+            let (result, count) = replace_whole_lines(content, "bbb", "", None, Some(2), None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\nbbb\nccc\neee\n");
+        }
+
+        #[test]
+        fn whole_lines_no_match_returns_borrowed() {
+            let content = "aaa\nbbb\nccc\n";
+            let (result, count) = replace_whole_lines(content, "zzz", "", None, None, None);
+            assert_eq!(count, 0);
+            assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+        }
+
+        #[test]
+        fn whole_lines_regex_capture_groups() {
+            let re = compile_replace_regex(r"version = (\d+)", true, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "name = foo\nversion = 3\nrelease = true\n";
+            let (result, count) =
+                replace_whole_lines(content, "", "version = ${1}00", Some(&re), None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "name = foo\nversion = 300\nrelease = true\n");
+        }
+
+        #[test]
+        fn whole_lines_last_line_no_newline() {
+            let content = "aaa\nbbb\nccc";
+            let (result, count) = replace_whole_lines(content, "ccc", "", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\nbbb\n");
         }
     }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -56,6 +56,10 @@ pub enum Operation {
         multiline: bool,
         #[serde(default)]
         if_exists: bool,
+        #[serde(default)]
+        whole_line: bool,
+        /// Line range restriction (e.g. "10:50"). Only valid with whole_line.
+        range: Option<String>,
     },
     #[serde(rename = "doc.set", alias = "doc_set")]
     DocSet {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -114,7 +114,9 @@ pub fn operation_schemas() -> Vec<OperationSchema> {
                     "nth": {"type": "integer", "minimum": 1, "description": "Replace only the Nth match (1-based)."},
                     "case_insensitive": {"type": "boolean", "default": false},
                     "multiline": {"type": "boolean", "default": false},
-                    "if_exists": {"type": "boolean", "default": false, "description": "Do not error if no matches found."}
+                    "if_exists": {"type": "boolean", "default": false, "description": "Do not error if no matches found."},
+                    "whole_line": {"type": "boolean", "default": false, "description": "Replace the entire line containing each match."},
+                    "range": {"type": "string", "description": "Restrict matching to a line range (e.g. '10:50'). Requires whole_line."}
                 }
             }),
             min_tier: Tier::Weak,

--- a/src/write.rs
+++ b/src/write.rs
@@ -12,6 +12,7 @@ pub struct WritePolicy {
     pub ensure_final_newline: bool,
     pub normalize_eol: EolMode,
     pub trim_trailing_whitespace: bool,
+    pub collapse_blanks: bool,
 }
 
 impl WritePolicy {
@@ -21,6 +22,7 @@ impl WritePolicy {
         !self.ensure_final_newline
             && matches!(self.normalize_eol, EolMode::Keep)
             && !self.trim_trailing_whitespace
+            && !self.collapse_blanks
     }
 }
 
@@ -30,6 +32,7 @@ impl Default for WritePolicy {
             ensure_final_newline: false,
             normalize_eol: EolMode::Keep,
             trim_trailing_whitespace: false,
+            collapse_blanks: false,
         }
     }
 }
@@ -148,6 +151,64 @@ pub fn trim_trailing_whitespace(content: &str) -> std::borrow::Cow<'_, str> {
     Cow::Owned(result)
 }
 
+/// Collapse consecutive blank lines into a single blank line.
+///
+/// A blank line is one that contains only whitespace. Two or more consecutive
+/// blank lines are reduced to one. Returns `Cow::Borrowed` when no collapsing
+/// is needed, avoiding allocation.
+pub fn collapse_blanks(content: &str) -> std::borrow::Cow<'_, str> {
+    use std::borrow::Cow;
+
+    let bytes = content.as_bytes();
+    // Quick scan: look for two consecutive line endings with only whitespace between.
+    let mut prev_blank = false;
+    let mut needs_collapse = false;
+    for line in content.lines() {
+        let is_blank = line.trim().is_empty();
+        if is_blank && prev_blank {
+            needs_collapse = true;
+            break;
+        }
+        prev_blank = is_blank;
+    }
+
+    if !needs_collapse {
+        return Cow::Borrowed(content);
+    }
+
+    let mut result = String::with_capacity(bytes.len());
+    let mut prev_blank = false;
+    let mut rest = content;
+
+    while !rest.is_empty() {
+        if let Some(pos) = rest.find('\n') {
+            let line_with_ending = &rest[..=pos];
+            let line_content = if pos > 0 && rest.as_bytes()[pos - 1] == b'\r' {
+                &rest[..pos - 1]
+            } else {
+                &rest[..pos]
+            };
+            let is_blank = line_content.trim().is_empty();
+            if is_blank && prev_blank {
+                // Skip this consecutive blank line.
+            } else {
+                result.push_str(line_with_ending);
+            }
+            prev_blank = is_blank;
+            rest = &rest[pos + 1..];
+        } else {
+            // Last line without trailing newline.
+            let is_blank = rest.trim().is_empty();
+            if !(is_blank && prev_blank) {
+                result.push_str(rest);
+            }
+            break;
+        }
+    }
+
+    Cow::Owned(result)
+}
+
 /// Apply a [`WritePolicy`] to `content`: trim, then EOL normalise, then final newline.
 ///
 /// Returns `Cow::Borrowed` when the policy is a no-op, avoiding allocation.
@@ -166,6 +227,12 @@ pub fn apply_policy<'a>(content: &'a str, policy: &WritePolicy) -> std::borrow::
 
     if !matches!(policy.normalize_eol, EolMode::Keep)
         && let Cow::Owned(new) = normalize_eol(&s, policy.normalize_eol)
+    {
+        s = Cow::Owned(new);
+    }
+
+    if policy.collapse_blanks
+        && let Cow::Owned(new) = collapse_blanks(&s)
     {
         s = Cow::Owned(new);
     }
@@ -233,6 +300,7 @@ pub fn policy_from_flags(
         ensure_final_newline: efn,
         normalize_eol: eol.unwrap_or(EolMode::Keep),
         trim_trailing_whitespace: ttw,
+        collapse_blanks: global.collapse_blanks,
     }
 }
 
@@ -392,6 +460,7 @@ mod tests {
             trim_trailing_whitespace: true,
             normalize_eol: EolMode::Lf,
             ensure_final_newline: true,
+            ..Default::default()
         };
         // Trailing whitespace, CRLF endings, no final newline.
         let input = "hello  \r\nworld\t\r\n";
@@ -411,6 +480,7 @@ mod tests {
             ensure_final_newline: true,
             normalize_eol: EolMode::Lf,
             trim_trailing_whitespace: true,
+            ..Default::default()
         };
 
         atomic_write(&target, "foo  \r\nbar", &policy).unwrap();
@@ -540,6 +610,7 @@ mod tests {
             ensure_final_newline: true,
             normalize_eol: EolMode::Lf,
             trim_trailing_whitespace: false,
+            ..Default::default()
         };
 
         atomic_create_new(&target, "hello", &policy).unwrap();
@@ -569,5 +640,49 @@ mod tests {
         assert!(!policy.ensure_final_newline);
         assert!(matches!(policy.normalize_eol, EolMode::Keep));
         assert!(!policy.trim_trailing_whitespace);
+    }
+
+    #[test]
+    fn collapse_blanks_reduces_consecutive_blanks() {
+        let input = "line1\n\n\n\nline2\n\n\nline3\n";
+        let result = collapse_blanks(input);
+        assert_eq!(result, "line1\n\nline2\n\nline3\n");
+    }
+
+    #[test]
+    fn collapse_blanks_no_change_returns_borrowed() {
+        let input = "line1\n\nline2\nline3\n";
+        let result = collapse_blanks(input);
+        assert_eq!(result, input);
+        assert!(
+            matches!(result, std::borrow::Cow::Borrowed(_)),
+            "no-change should return Cow::Borrowed"
+        );
+    }
+
+    #[test]
+    fn collapse_blanks_whitespace_only_lines_are_blank() {
+        let input = "line1\n  \n\t\n\nline2\n";
+        let result = collapse_blanks(input);
+        // "  " and "\t" and "" are all blank; three consecutive blanks become one.
+        assert_eq!(result, "line1\n  \nline2\n");
+    }
+
+    #[test]
+    fn collapse_blanks_no_blanks() {
+        let input = "line1\nline2\nline3\n";
+        let result = collapse_blanks(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn apply_policy_collapse_blanks() {
+        let policy = WritePolicy {
+            collapse_blanks: true,
+            ..Default::default()
+        };
+        let input = "a\n\n\nb\n";
+        let result = apply_policy(input, &policy);
+        assert_eq!(result, "a\n\nb\n");
     }
 }


### PR DESCRIPTION
## Summary

Adds three new flags to the `replace` command that enable line-oriented replacements. This addresses the use cases from #563 with a more generic design than a standalone `delete-lines` command.

## New flags

| Flag | Short | Description |
|------|-------|-------------|
| `--whole-line` | `-L` | Replace/delete the entire line containing a match, not just the matched span |
| `--range START:END` | `-R` | Restrict `--whole-line` matching to a line range (1-based, inclusive) |
| `--collapse-blanks` | | Collapse consecutive blank lines after writing (available on all write commands) |

## Usage examples

```bash
# Delete dead code lines matching a regex
patchloom replace 'let _\w+ = checker\.' --to '' --regex --whole-line src/lib.rs --apply

# Scope to avoid test code (lines 1-7900 only)
patchloom replace 'let _\w+ =' --to '' --regex --whole-line --range 1:7900 src/lib.rs --apply

# Clean up resulting blank line gaps
patchloom replace '#\[allow(unused)\]' --to '' --regex --whole-line --collapse-blanks src/ --apply
```

## Design decisions

- **`--whole-line` on `replace` instead of a new `delete-lines` command**: more generic (covers delete, replace, and all existing replace modes like `--nth`, `--regex`, capture groups), fewer commands to learn.
- **`--collapse-blanks` as a write flag**: useful for any write command that might create blank lines, not just line deletion. Follows the same pattern as `--ensure-final-newline`.
- **`--range` requires `--whole-line`**: keeps the semantics clean; range filtering on span-based replace would be confusing.
- **`--whole-line` and `--multiline` conflict**: they have incompatible semantics (line-oriented vs span-oriented).

## Changes

- `src/ops.rs`: new `replace_whole_lines()` function with line-oriented replacement logic
- `src/write.rs`: new `collapse_blanks()` function and `WritePolicy` field
- `src/cmd/replace.rs`: new CLI flags, validation, wiring
- `src/cmd/tx.rs`: tx engine support for `whole_line` and `range` fields
- `src/cmd/mcp.rs`: MCP tool params and description updated
- `src/plan.rs`: `Operation::Replace` extended with new fields
- `src/schema.rs`: operation schema updated
- `docs/reference/README.md`: reference documentation for new flags

## Testing

20 new tests added (748 unit + 633 integration = 1381 total, all passing).

Closes #563