### PR TITLE
test: improvement cycle 10 — whole-line integration and write_policy

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -92,6 +92,16 @@ patchloom search --count "old_function_name" src/
 patchloom replace "old_function_name" --to "new_function_name" src/ --apply
 ```
 
+### Delete lines matching a pattern
+
+```bash
+# Delete entire lines containing a pattern; collapse consecutive blanks
+patchloom replace 'dbg!' --whole-line --to '' src/ --collapse-blanks --apply
+
+# Restrict to a line range (e.g. implementation only, skip tests)
+patchloom replace 'TODO' --whole-line --range 10:200 --to '' notes.md --apply
+```
+
 ### Edit a CI workflow
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1381%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1389%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1381 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1389 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -751,7 +751,7 @@ Use these when newline and whitespace correctness is the main concern.
 
 - **What it does:** Applies newline, EOL, and whitespace normalization across all pending writes in the plan.
 - **Use when:** Every write in the transaction should share the same normalization policy.
-- **Fields:** Supports `ensure_final_newline` (bool), `normalize_eol` (`keep`, `lf`, or `crlf`), and `trim_trailing_whitespace` (bool).
+- **Fields:** Supports `ensure_final_newline` (bool), `normalize_eol` (`keep`, `lf`, or `crlf`), `trim_trailing_whitespace` (bool), and `collapse_blanks` (bool).
 - **Precedence:** Patchloom starts from the invocation's per-file write policy, including CLI flags and any `--respect-editorconfig` values, then overrides only the keys set here.
 - **Prefer instead:** Use CLI write flags when one invocation needs defaults, but the plan itself should stay generic.
 

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -498,6 +498,29 @@ mod tests {
     }
 
     #[test]
+    fn describe_replace_whole_line_with_range() {
+        let op = Operation::Replace {
+            path: Some("src/lib.rs".into()),
+            glob: None,
+            mode: None,
+            from: "dbg!".into(),
+            to: Some(String::new()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: true,
+            range: Some("10:50".into()),
+        };
+        let desc = describe_operation(&op);
+        assert!(desc.contains("whole-line"), "{desc}");
+        assert!(desc.contains("lines 10:50"), "{desc}");
+        assert!(desc.contains(r#"with """#), "{desc}");
+    }
+
+    #[test]
     fn describe_file_rename() {
         let op = Operation::FileRename {
             from: "old.rs".into(),

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -292,6 +292,16 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
         );
 
         out.push_str(
+            "### Delete lines matching a pattern\n\n\
+             ```bash\n\
+             # Delete entire lines containing a pattern; collapse consecutive blanks\n\
+             patchloom replace 'dbg!' --whole-line --to '' src/ --collapse-blanks --apply\n\n\
+             # Restrict to a line range (e.g. implementation only, skip tests)\n\
+             patchloom replace 'TODO' --whole-line --range 10:200 --to '' notes.md --apply\n\
+             ```\n\n",
+        );
+
+        out.push_str(
             "### Edit a CI workflow\n\n\
              ```bash\n\
              # Set a value in a YAML workflow by selector (preserves comments and formatting)\n\
@@ -577,6 +587,13 @@ mod tests {
         // MCP-only mode must NOT have exit codes
         let out = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));
         assert!(!out.contains("## Exit codes"));
+    }
+
+    #[test]
+    fn workflow_includes_whole_line_delete_example() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(out.contains("--whole-line"));
+        assert!(out.contains("--collapse-blanks"));
     }
 
     #[test]

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1323,6 +1323,9 @@ fn build_write_policy(
     if let Some(trim_trailing_whitespace) = plan_write_policy.trim_trailing_whitespace {
         write_policy.trim_trailing_whitespace = trim_trailing_whitespace;
     }
+    if let Some(collapse_blanks) = plan_write_policy.collapse_blanks {
+        write_policy.collapse_blanks = collapse_blanks;
+    }
 
     Ok(write_policy)
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -33,6 +33,7 @@ pub struct PlanWritePolicy {
     pub ensure_final_newline: Option<bool>,
     pub normalize_eol: Option<String>,
     pub trim_trailing_whitespace: Option<bool>,
+    pub collapse_blanks: Option<bool>,
 }
 
 /// A single operation within a plan.
@@ -460,7 +461,8 @@ mod tests {
             "write_policy": {
                 "ensure_final_newline": true,
                 "normalize_eol": "crlf",
-                "trim_trailing_whitespace": true
+                "trim_trailing_whitespace": true,
+                "collapse_blanks": true
             },
             "operations": [],
             "format": [{"cmd": "fmt", "timeout": 30}],
@@ -472,6 +474,7 @@ mod tests {
         assert_eq!(wp.ensure_final_newline, Some(true));
         assert_eq!(wp.normalize_eol.as_deref(), Some("crlf"));
         assert_eq!(wp.trim_trailing_whitespace, Some(true));
+        assert_eq!(wp.collapse_blanks, Some(true));
         let fmt = &plan.format.unwrap()[0];
         assert_eq!(fmt.timeout, Some(30));
         let val = &plan.validate.unwrap()[0];

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1687,6 +1687,139 @@ fn test_replace_multiline_regex() {
 }
 
 // ---------------------------------------------------------------------------
+// replace --whole-line, --range, --collapse-blanks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_replace_whole_line_deletes_matching_lines() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(
+        &file,
+        "fn main() {\n    let _x = foo();\n    let y = bar();\n    let _z = baz();\n}\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("let _")
+        .arg("--whole-line")
+        .arg("--to")
+        .arg("")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn main() {\n    let y = bar();\n}\n"
+    );
+}
+
+#[test]
+fn test_replace_whole_line_with_range() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "aaa\nbbb\nccc\nbbb\neee\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("bbb")
+        .arg("--whole-line")
+        .arg("--range")
+        .arg("1:3")
+        .arg("--to")
+        .arg("")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "aaa\nccc\nbbb\neee\n");
+}
+
+#[test]
+fn test_replace_collapse_blanks_after_whole_line_delete() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    // Two blank lines surround "remove"; deleting it leaves consecutive blanks.
+    fs::write(&file, "keep\n\nremove\n\nalso keep\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("remove")
+        .arg("--whole-line")
+        .arg("--to")
+        .arg("")
+        .arg("--collapse-blanks")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "keep\n\nalso keep\n");
+}
+
+#[test]
+fn test_replace_range_requires_whole_line() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("hello")
+        .arg("--range")
+        .arg("1:5")
+        .arg("--to")
+        .arg("hi")
+        .arg(file.to_str().unwrap())
+        .assert()
+        .failure();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn test_tx_replace_whole_line_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "alpha\nbeta match\ngamma\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "match",
+            "to": "replaced line",
+            "whole_line": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "alpha\nreplaced line\ngamma\n"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // doc
 // ---------------------------------------------------------------------------
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7012,6 +7012,41 @@ fn test_tx_write_policy_ensure_final_newline() {
     );
 }
 
+#[test]
+fn test_tx_write_policy_collapse_blanks() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "keep\n\nremove\n\nalso keep\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "write_policy": {
+            "collapse_blanks": true
+        },
+        "operations": [{
+            "op": "replace",
+            "path": "test.txt",
+            "from": "remove",
+            "to": "",
+            "whole_line": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "keep\n\nalso keep\n");
+}
+
 // ---------------------------------------------------------------------------
 // doc/patch error paths
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add integration tests for `replace --whole-line`, `--range`, and `--collapse-blanks` (CLI and tx plan paths)
- Add `collapse_blanks` to tx plan `write_policy` so agents can collapse blank lines without CLI flags
- Document line-deletion workflow in agent-rules/PATCHLOOM.md and reference guide

## Context

Cycle 10 rotation after PR #564 landed. QA found unit tests but no integration coverage for the new replace flags. Spec review found `write_policy` missing `collapse_blanks` despite the CLI flag existing.

## Test plan

- [x] `make check` (1389 tests)