### PR TITLE
fix: improvement cycle 11 — config, schema, MCP tests, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1389%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1394%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1389 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1394 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -107,7 +107,9 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## What comes next
 
-This is v0.1.0. We would love feedback on:
+Since launch, new capabilities have been added including line-oriented replace flags (`--whole-line`, `--range`, `--collapse-blanks`), project config defaults (`.patchloom.toml`), and expanded schema export. See the [reference guide](https://github.com/patchloom/patchloom/blob/main/docs/reference/README.md) for the full command reference and current feature set.
+
+We would love feedback on:
 
 - Which agent workflows hit friction that Patchloom could smooth
 - Missing operations or formats (`.env`? `.ini`? HCL?)

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -48,12 +48,13 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     match args.format {
         SchemaFormat::Json => {
-            let output = if args.examples {
-                serde_json::to_string_pretty(&ops)?
+            let ops_json: Vec<serde_json::Value> = if args.examples {
+                ops.iter()
+                    .map(|op| serde_json::to_value(op).unwrap_or_default())
+                    .collect()
             } else {
                 // Strip examples from the output.
-                let stripped: Vec<serde_json::Value> = ops
-                    .iter()
+                ops.iter()
                     .map(|op| {
                         let mut v = serde_json::to_value(op).unwrap_or_default();
                         if let Some(obj) = v.as_object_mut() {
@@ -61,9 +62,16 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         }
                         v
                     })
-                    .collect();
-                serde_json::to_string_pretty(&stripped)?
+                    .collect()
             };
+            let envelope = serde_json::json!({
+                "version": schema::INTENT_FORMAT_VERSION,
+                "operations": ops_json,
+                "plan_envelope": {
+                    "write_policy": schema::plan_write_policy_schema()
+                }
+            });
+            let output = serde_json::to_string_pretty(&envelope)?;
             if global.quiet {
                 return Ok(exit::SUCCESS);
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct WritePolicy {
     pub ensure_final_newline: Option<bool>,
     pub normalize_eol: Option<String>,
     pub trim_trailing_whitespace: Option<bool>,
+    pub collapse_blanks: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -88,6 +89,9 @@ pub fn apply_config(global: &mut crate::cli::global::GlobalFlags, config: &Proje
         && config.write_policy.trim_trailing_whitespace == Some(true)
     {
         global.trim_trailing_whitespace = true;
+    }
+    if !global.collapse_blanks && config.write_policy.collapse_blanks == Some(true) {
+        global.collapse_blanks = true;
     }
 
     // Exclude globs: prepend config globs before user globs.
@@ -181,6 +185,7 @@ mod tests {
 [write_policy]
 ensure_final_newline = true
 normalize_eol = "lf"
+collapse_blanks = true
 
 [exclude]
 globs = ["target/**"]
@@ -195,6 +200,7 @@ color = "always"
         assert_eq!(found_dir, dir.path());
         assert_eq!(config.write_policy.ensure_final_newline, Some(true));
         assert_eq!(config.write_policy.normalize_eol.as_deref(), Some("lf"));
+        assert_eq!(config.write_policy.collapse_blanks, Some(true));
         assert_eq!(config.exclude.globs, vec!["target/**"]);
         assert_eq!(config.output.color.as_deref(), Some("always"));
     }
@@ -229,6 +235,7 @@ color = "always"
                 ensure_final_newline: Some(true),
                 normalize_eol: Some("lf".into()),
                 trim_trailing_whitespace: Some(true),
+                collapse_blanks: Some(true),
             },
             exclude: Exclude {
                 globs: vec!["target/**".into()],
@@ -246,6 +253,7 @@ color = "always"
             Some(crate::cli::global::EolMode::Lf)
         ));
         assert!(global.trim_trailing_whitespace);
+        assert!(global.collapse_blanks);
         assert_eq!(global.glob, vec!["target/**"]);
         assert!(matches!(
             global.color,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -563,6 +563,37 @@ pub fn operation_schemas() -> Vec<OperationSchema> {
     ]
 }
 
+/// JSON Schema for plan-level `write_policy` envelope fields.
+///
+/// These fields are set at the plan level (not per-operation) and apply to all
+/// writes in a transaction. Agents using `patchloom schema` can discover these
+/// to build complete tx plans.
+pub fn plan_write_policy_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "description": "Write policy applied to all operations in the plan. Each field is optional; omitted fields inherit from CLI flags or project config.",
+        "properties": {
+            "ensure_final_newline": {
+                "type": "boolean",
+                "description": "Ensure every written file ends with a newline."
+            },
+            "normalize_eol": {
+                "type": "string",
+                "enum": ["keep", "lf", "crlf"],
+                "description": "Line ending normalization mode."
+            },
+            "trim_trailing_whitespace": {
+                "type": "boolean",
+                "description": "Remove trailing whitespace from every line."
+            },
+            "collapse_blanks": {
+                "type": "boolean",
+                "description": "Collapse consecutive blank lines into a single blank line."
+            }
+        }
+    })
+}
+
 /// Get operations available at a given capability tier (includes all lower tiers).
 pub fn operations_for_tier(tier: Tier) -> Vec<OperationSchema> {
     operation_schemas()
@@ -627,6 +658,29 @@ pub fn system_prompt_for_tier(tier: Tier) -> String {
             }
             out.push('\n');
         }
+    }
+
+    // Plan envelope: write_policy
+    out.push_str("## Plan Envelope: `write_policy`\n\n");
+    out.push_str("Set at the plan level (not per-operation) to apply write transformations to all operations.\n\n");
+    let wp_schema = plan_write_policy_schema();
+    if let Some(props) = wp_schema.get("properties")
+        && let Some(obj) = props.as_object()
+    {
+        out.push_str("**Fields:**\n\n");
+        for (key, schema) in obj {
+            let type_str = schema.get("type").and_then(|t| t.as_str()).unwrap_or("any");
+            let desc = schema
+                .get("description")
+                .and_then(|d| d.as_str())
+                .unwrap_or("");
+            out.push_str(&format!("- `{key}`: {type_str}"));
+            if !desc.is_empty() {
+                out.push_str(&format!(" -- {desc}"));
+            }
+            out.push('\n');
+        }
+        out.push('\n');
     }
 
     out
@@ -810,6 +864,24 @@ mod tests {
         assert!(prompt.contains("replace"));
         assert!(prompt.contains("doc.set"));
         assert!(prompt.contains("search"));
+    }
+
+    #[test]
+    fn plan_write_policy_schema_has_all_fields() {
+        let schema = plan_write_policy_schema();
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("ensure_final_newline"));
+        assert!(props.contains_key("normalize_eol"));
+        assert!(props.contains_key("trim_trailing_whitespace"));
+        assert!(props.contains_key("collapse_blanks"));
+    }
+
+    #[test]
+    fn system_prompt_includes_write_policy() {
+        let prompt = system_prompt_for_tier(Tier::Strong);
+        assert!(prompt.contains("write_policy"));
+        assert!(prompt.contains("collapse_blanks"));
+        assert!(prompt.contains("ensure_final_newline"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8381,6 +8381,44 @@ fn test_project_config_sets_write_policy_defaults() {
 }
 
 #[test]
+fn test_project_config_collapse_blanks() {
+    let dir = TempDir::new().unwrap();
+
+    // Create .patchloom.toml with collapse_blanks enabled.
+    fs::write(
+        dir.path().join(".patchloom.toml"),
+        "[write_policy]\ncollapse_blanks = true\n",
+    )
+    .unwrap();
+
+    // File where whole-line delete leaves consecutive blanks.
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "keep\n\nremove\n\nalso keep\n").unwrap();
+
+    // Run replace --whole-line without --collapse-blanks CLI flag.
+    // Config should supply the default.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("remove")
+        .arg("--whole-line")
+        .arg("--to")
+        .arg("")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "keep\n\nalso keep\n",
+        "config collapse_blanks should collapse consecutive blank lines"
+    );
+}
+
+#[test]
 fn test_project_config_exclude_globs() {
     let dir = TempDir::new().unwrap();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17439,6 +17439,70 @@ async fn test_mcp_replace_if_exists_no_match_succeeds() {
 }
 
 #[tokio::test]
+async fn test_mcp_replace_whole_line_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("code.rs"),
+        "fn main() {\n    dbg!(x);\n    let y = 1;\n    dbg!(y);\n}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, _text) = call_tool_text(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "code.rs",
+            "from": "dbg!",
+            "to": "",
+            "whole_line": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "whole_line replace should succeed");
+
+    let content = fs::read_to_string(dir.path().join("code.rs")).unwrap();
+    assert_eq!(content, "fn main() {\n    let y = 1;\n}\n");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_replace_whole_line_with_range_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("data.txt"),
+        "aaa\nbbb\nccc\nbbb\neee\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, _text) = call_tool_text(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "data.txt",
+            "from": "bbb",
+            "to": "",
+            "whole_line": true,
+            "range": "1:3"
+        }),
+    )
+    .await;
+    assert!(!is_error, "whole_line+range replace should succeed");
+
+    let content = fs::read_to_string(dir.path().join("data.txt")).unwrap();
+    // Only the first "bbb" (line 2, within range 1:3) should be deleted.
+    assert_eq!(content, "aaa\nccc\nbbb\neee\n");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_doc_query_unknown_action_returns_error() {
     if !has_mcp_support() {
         return;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17475,11 +17475,7 @@ async fn test_mcp_replace_whole_line_with_range_round_trip() {
         return;
     }
     let dir = TempDir::new().unwrap();
-    fs::write(
-        dir.path().join("data.txt"),
-        "aaa\nbbb\nccc\nbbb\neee\n",
-    )
-    .unwrap();
+    fs::write(dir.path().join("data.txt"), "aaa\nbbb\nccc\nbbb\neee\n").unwrap();
 
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, _text) = call_tool_text(
@@ -17981,7 +17977,10 @@ fn test_schema_json_output() {
         .get("operations")
         .and_then(|v| v.as_array())
         .expect("operations must be an array");
-    assert!(!ops.is_empty(), "schema should return at least one operation");
+    assert!(
+        !ops.is_empty(),
+        "schema should return at least one operation"
+    );
 
     // Every operation must have name, description, parameters, min_tier.
     for op in ops {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17973,13 +17973,18 @@ fn test_schema_json_output() {
         .success();
 
     let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
-    let parsed: Vec<serde_json::Value> = serde_json::from_str(&stdout).unwrap();
-    assert!(
-        !parsed.is_empty(),
-        "schema should return at least one operation"
-    );
-    // Every entry must have name, description, parameters, min_tier.
-    for op in &parsed {
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    // Envelope must contain version, operations, and plan_envelope.
+    assert!(parsed.get("version").is_some(), "missing version");
+    let ops = parsed
+        .get("operations")
+        .and_then(|v| v.as_array())
+        .expect("operations must be an array");
+    assert!(!ops.is_empty(), "schema should return at least one operation");
+
+    // Every operation must have name, description, parameters, min_tier.
+    for op in ops {
         assert!(op.get("name").is_some(), "missing name in schema entry");
         assert!(
             op.get("description").is_some(),
@@ -17994,6 +17999,15 @@ fn test_schema_json_output() {
             "missing min_tier in schema entry"
         );
     }
+
+    // Plan envelope must include write_policy with all fields.
+    let wp = parsed
+        .pointer("/plan_envelope/write_policy/properties")
+        .expect("plan_envelope.write_policy.properties must exist");
+    assert!(wp.get("ensure_final_newline").is_some());
+    assert!(wp.get("normalize_eol").is_some());
+    assert!(wp.get("trim_trailing_whitespace").is_some());
+    assert!(wp.get("collapse_blanks").is_some());
 }
 
 #[test]
@@ -18024,13 +18038,22 @@ fn test_schema_tier_filtering() {
         .assert()
         .success();
 
-    let weak: Vec<serde_json::Value> =
+    let weak_json: serde_json::Value =
         serde_json::from_str(&String::from_utf8(weak_output.get_output().stdout.clone()).unwrap())
             .unwrap();
-    let strong: Vec<serde_json::Value> = serde_json::from_str(
+    let strong_json: serde_json::Value = serde_json::from_str(
         &String::from_utf8(strong_output.get_output().stdout.clone()).unwrap(),
     )
     .unwrap();
+
+    let weak = weak_json
+        .get("operations")
+        .and_then(|v| v.as_array())
+        .expect("weak operations must be an array");
+    let strong = strong_json
+        .get("operations")
+        .and_then(|v| v.as_array())
+        .expect("strong operations must be an array");
 
     assert!(
         weak.len() < strong.len(),
@@ -18039,7 +18062,7 @@ fn test_schema_tier_filtering() {
         strong.len()
     );
     // All weak ops should have min_tier "weak".
-    for op in &weak {
+    for op in weak {
         assert_eq!(
             op.get("min_tier").and_then(|t| t.as_str()),
             Some("weak"),
@@ -18057,11 +18080,15 @@ fn test_schema_examples_flag() {
         .assert()
         .success();
 
-    let without: Vec<serde_json::Value> = serde_json::from_str(
+    let without_json: serde_json::Value = serde_json::from_str(
         &String::from_utf8(without_output.get_output().stdout.clone()).unwrap(),
     )
     .unwrap();
-    for op in &without {
+    let without = without_json
+        .get("operations")
+        .and_then(|v| v.as_array())
+        .expect("operations must be an array");
+    for op in without {
         assert!(
             op.get("examples").is_none(),
             "examples should be stripped without --examples flag"
@@ -18075,9 +18102,13 @@ fn test_schema_examples_flag() {
         .assert()
         .success();
 
-    let with: Vec<serde_json::Value> =
+    let with_json: serde_json::Value =
         serde_json::from_str(&String::from_utf8(with_output.get_output().stdout.clone()).unwrap())
             .unwrap();
+    let with = with_json
+        .get("operations")
+        .and_then(|v| v.as_array())
+        .expect("operations must be an array");
     assert!(
         with.iter().any(|op| op.get("examples").is_some()),
         "at least one op should have examples with --examples flag"


### PR DESCRIPTION
## Summary

Improvement cycle 11: resolves all open issues (#566, #567) before starting the rotation.

## Changes

### feat: add collapse_blanks to .patchloom.toml write_policy (Closes #566)

- Added `collapse_blanks` field to config `WritePolicy` struct
- Wired through `apply_config` merge (same pattern as other fields)
- Unit test and integration test verifying project config default

### test: MCP integration tests for whole_line and range (#567 item 1)

- `test_mcp_replace_whole_line_round_trip`: verifies line deletion via MCP
- `test_mcp_replace_whole_line_with_range_round_trip`: verifies range-restricted deletion

### feat: export plan-level write_policy in schema output (#567 item 2)

- `plan_write_policy_schema()` in `src/schema.rs` documents all 4 fields
- Schema JSON output now uses envelope: `{version, operations, plan_envelope}`
- System prompt includes write_policy section
- Updated all schema integration tests for new envelope structure

### docs: launch announcement post-launch note (#567 item 4)

- Added capabilities note with link to reference guide

### docs: update test count to 1394

- 752 unit + 642 integration tests

## Verification

`make check` passes (fmt, clippy, 752 unit tests, 642 integration tests, doc checks).

Closes #566
Closes #567
