### PR TITLE
fix: improvement cycle 11b - docs, CI hardening

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false

--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -80,6 +80,23 @@ patchloom md table-append README.md --heading "## API" --row "| new | row |" --a
 
 Add `--apply` to all write commands. Without it, patchloom previews changes without writing.
 
+## Project configuration
+
+Create `.patchloom.toml` in the project root to set defaults for all commands:
+
+```toml
+[write_policy]
+ensure_final_newline = true
+normalize_eol = "lf"
+trim_trailing_whitespace = true
+collapse_blanks = true
+
+[exclude]
+globs = ["target/**", "node_modules/**"]
+```
+
+CLI flags override config values. The file is searched upward from the working directory.
+
 ## Workflow examples
 
 ### Rename a function across a codebase

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1394%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1395%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1394 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1395 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -67,6 +67,7 @@ Create a `.patchloom.toml` in your project root to set per-project defaults. CLI
 ensure_final_newline = true
 normalize_eol = "lf"
 trim_trailing_whitespace = true
+collapse_blanks = true
 
 [exclude]
 globs = ["target/**", "node_modules/**"]

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -275,6 +275,22 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
         out.push_str(
             "Add `--apply` to all write commands. Without it, patchloom previews changes without writing.\n\n",
         );
+
+        out.push_str(
+            "## Project configuration\n\n\
+             Create `.patchloom.toml` in the project root to set defaults for all commands:\n\n\
+             ```toml\n\
+             [write_policy]\n\
+             ensure_final_newline = true\n\
+             normalize_eol = \"lf\"\n\
+             trim_trailing_whitespace = true\n\
+             collapse_blanks = true\n\
+             \n\
+             [exclude]\n\
+             globs = [\"target/**\", \"node_modules/**\"]\n\
+             ```\n\n\
+             CLI flags override config values. The file is searched upward from the working directory.\n\n",
+        );
     }
 
     // Workflow examples (CLI only)
@@ -594,6 +610,14 @@ mod tests {
         let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
         assert!(out.contains("--whole-line"));
         assert!(out.contains("--collapse-blanks"));
+    }
+
+    #[test]
+    fn agent_rules_includes_project_config_section() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(out.contains("## Project configuration"));
+        assert!(out.contains(".patchloom.toml"));
+        assert!(out.contains("collapse_blanks"));
     }
 
     #[test]


### PR DESCRIPTION
## Changes

- **docs**: Add project configuration section to agent-rules output and fix config example in concepts.md
- **ci**: Add harden-runner step to docs workflow build job (was the only workflow missing it)

## Verification

- `make check` passes (1395 tests: 753 unit + 642 integration)
- All 15 workflows now have harden-runner

Signed-off-by: Sebastien Tardif <seb@tardif.ca>