### PR TITLE
fix: improvement cycle 13 - tests, inline refactor, error context

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1410%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1419%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1410 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1419 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1378,6 +1378,93 @@ mod tests {
     }
 
     #[test]
+    fn doc_get_zero_match_error() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("config.json");
+        fs::write(&file, r#"{"version": "1.0"}"#).unwrap();
+
+        let err = doc_get(&file, "nonexistent").unwrap_err();
+        assert!(
+            err.to_string().contains("matched nothing"),
+            "expected zero-match error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn doc_get_multi_match_returns_array() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("data.json");
+        fs::write(&file, r#"{"items": [{"name": "a"}, {"name": "b"}]}"#).unwrap();
+
+        let value = doc_get(&file, "items[*].name").unwrap();
+        assert_eq!(value, serde_json::json!(["a", "b"]));
+    }
+
+    #[test]
+    fn replace_text_regex_mode() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("code.rs");
+        fs::write(&file, "version = 1\nversion = 2\n").unwrap();
+
+        let opts = ReplaceOptions {
+            regex: true,
+            ..ReplaceOptions::default()
+        };
+        let result = replace_text(
+            &file,
+            r"version = \d+",
+            "version = 99",
+            &opts,
+            ApplyMode::Preview,
+        )
+        .unwrap();
+
+        assert!(result.changed);
+        // Regex replaces all matches
+        assert_eq!(
+            result.new_content.matches("version = 99").count(),
+            2,
+            "regex should replace all occurrences"
+        );
+    }
+
+    #[test]
+    fn replace_text_nth_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("code.rs");
+        fs::write(&file, "foo bar foo baz foo\n").unwrap();
+
+        let opts = ReplaceOptions {
+            nth: Some(2),
+            ..ReplaceOptions::default()
+        };
+        let result = replace_text(&file, "foo", "qux", &opts, ApplyMode::Preview).unwrap();
+
+        assert!(result.changed);
+        assert_eq!(result.new_content, "foo bar qux baz foo\n");
+    }
+
+    #[test]
+    fn replace_text_insert_after() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("code.rs");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let opts = ReplaceOptions {
+            insert_after: Some(" beautiful".to_string()),
+            ..ReplaceOptions::default()
+        };
+        let result = replace_text(&file, "hello", "", &opts, ApplyMode::Preview).unwrap();
+
+        assert!(result.changed);
+        assert!(
+            result.new_content.contains("hello beautiful"),
+            "insert_after should add text after match: {}",
+            result.new_content
+        );
+    }
+
+    #[test]
     fn concurrent_file_create() {
         let dir = TempDir::new().unwrap();
         let num_threads = 8;

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -526,6 +526,25 @@ mod tests {
     }
 
     #[test]
+    fn tokenize_trailing_backslash_error() {
+        let err = tokenize(r#"doc.set f.json key "trail\"#).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unexpected end of line after backslash"),
+            "expected backslash error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn tokenize_unterminated_quote_error() {
+        let err = tokenize(r#"doc.set f.json key "no close"#).unwrap_err();
+        assert!(
+            err.to_string().contains("unterminated double quote"),
+            "expected unterminated quote error, got: {err}"
+        );
+    }
+
+    #[test]
     fn parse_json_value_quoted_string() {
         let v = parse_json_value(r#""2.0.0""#).unwrap();
         assert_eq!(v, serde_json::json!("2.0.0"));

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -67,13 +67,15 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
             content.push('\n');
             content.push_str(&rules);
-            std::fs::write(&target_path, content)?;
+            std::fs::write(&target_path, content)
+                .with_context(|| format!("writing {}", target_path.display()))?;
             status!("appended patchloom rules to {rel_target}");
         } else {
             status!("skipped {rel_target}");
         }
     } else if auto_yes || confirm(&format!("Create {rel_target}?")) {
-        std::fs::write(&target_path, &rules)?;
+        std::fs::write(&target_path, &rules)
+            .with_context(|| format!("writing {}", target_path.display()))?;
         status!("created {rel_target}");
     } else {
         status!("skipped {rel_target}");
@@ -220,9 +222,11 @@ fn generate_completions(shell: &str, target: &Path) -> anyhow::Result<()> {
     let mut buf = Vec::new();
     clap_complete::generate(clap_shell, &mut cmd, "patchloom", &mut buf);
     if let Some(parent) = target.parent() {
-        std::fs::create_dir_all(parent)?;
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
     }
-    std::fs::write(target, buf)?;
+    std::fs::write(target, buf)
+        .with_context(|| format!("writing completions to {}", target.display()))?;
     Ok(())
 }
 

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -702,10 +702,6 @@ impl PatchloomService {
 /// Each individual MCP tool validates paths via `check_path` before calling
 /// this function, so no redundant validation is needed here.
 fn execute_plan_validated(plan: Plan, cwd: &std::path::Path) -> Result<CallToolResult, McpError> {
-    execute_plan_inner(plan, cwd)
-}
-
-fn execute_plan_inner(plan: Plan, cwd: &std::path::Path) -> Result<CallToolResult, McpError> {
     let (code, json) = crate::cmd::tx::execute_plan_direct(plan, cwd)
         .map_err(|e| McpError::internal_error(format!("plan execution failed: {e}"), None))?;
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -17,6 +17,7 @@ use crate::ops::replace::{
 use crate::plan::{self, Operation, Plan};
 use crate::selector;
 use crate::write::{WritePolicy, apply_policy, atomic_create_new, atomic_write};
+use anyhow::Context;
 use clap::Args;
 use globset::Glob;
 use ignore::WalkBuilder;
@@ -1816,13 +1817,14 @@ fn commit_changes(
     let noop_policy = WritePolicy::default();
     for (path, _, new_content) in changes {
         if deletions.contains(path) {
-            std::fs::remove_file(path)?;
+            std::fs::remove_file(path).with_context(|| format!("deleting {}", path.display()))?;
         } else {
             if let Some(parent) = path.parent()
                 && !parent.as_os_str().is_empty()
                 && !parent.exists()
             {
-                std::fs::create_dir_all(parent)?;
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating directory {}", parent.display()))?;
             }
             if !existed_before.contains(path) {
                 atomic_create_new(path, new_content, &noop_policy)?;
@@ -1833,7 +1835,7 @@ fn commit_changes(
     }
     for path in deletions {
         if path.exists() {
-            std::fs::remove_file(path)?;
+            std::fs::remove_file(path).with_context(|| format!("deleting {}", path.display()))?;
         }
     }
     backup.finalize()?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -363,4 +363,33 @@ color = "always"
         // Unrecognized color value falls through to Auto.
         assert!(matches!(global.color, crate::cli::global::ColorMode::Auto));
     }
+
+    #[test]
+    fn cached_config_load_with_file() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join(".patchloom.toml"),
+            "[write_policy]\nensure_final_newline = true\n",
+        )
+        .unwrap();
+
+        let cached = CachedConfig::load(dir.path());
+        assert_eq!(
+            cached.project_config().write_policy.ensure_final_newline,
+            Some(true)
+        );
+        assert_eq!(cached.config_dir(), Some(dir.path()));
+    }
+
+    #[test]
+    fn cached_config_load_defaults_when_missing() {
+        let dir = TempDir::new().unwrap();
+
+        let cached = CachedConfig::load(dir.path());
+        assert_eq!(
+            cached.project_config().write_policy.ensure_final_newline,
+            None
+        );
+        assert!(cached.config_dir().is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Cycle 13 multi-perspective improvement rotation (odd cycle: QA Engineer replaces Test Auditor).

### Changes

**9 new tests** (QA Engineer perspective):
- `tokenize_trailing_backslash_error` and `tokenize_unterminated_quote_error` for batch tokenizer error paths
- `cached_config_load_with_file` and `cached_config_load_defaults_when_missing` for CachedConfig
- `doc_get_zero_match_error`, `doc_get_multi_match_returns_array`, `replace_text_regex_mode`, `replace_text_nth_match`, `replace_text_insert_after` for API edge cases

**1 inline refactor** (Developer perspective):
- Removed trivial `execute_plan_inner` wrapper in MCP server, merging its body into `execute_plan_validated`

**6 error context improvements** (Observability/Error Detective perspective):
- Added `.with_context()` to bare `fs::write`, `fs::remove_file`, and `fs::create_dir_all` calls in `init.rs` and `tx.rs` `commit_changes` that previously propagated raw OS errors without identifying the failing file

### Test counts

762 unit + 657 integration = 1419 total (was 1410, added 9)

### Issues filed

- #573: API feature parity gaps
- #574: Fallback chain and batch tokenizer edge case coverage

### Perspectives that returned no-op

End User, Maintainer, Ops/SRE, Security, PM, Spec/Contract, Performance, Backward Compat, Adversarial, Architecture, New Contributor
