### PR TITLE
fix: replace broken shields.io badges with gist endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,6 +217,20 @@ jobs:
             echo "color=red" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Extract crate version
+        id: version
+        run: |
+          version=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch crates.io download count
+        id: downloads
+        run: |
+          count=$(curl -fsSL -H "User-Agent: patchloom-ci" \
+            "https://crates.io/api/v1/crates/patchloom" \
+            | python3 -c "import json,sys; print(json.load(sys.stdin)['crate']['downloads'])")
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
       - name: Update coverage badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         continue-on-error: true
@@ -228,6 +242,42 @@ jobs:
           label: coverage
           message: ${{ steps.cov.outputs.percentage }}%
           color: ${{ steps.color.outputs.color }}
+
+      - name: Update release badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 6a26adf6bfae45f530465f626c9154f4
+          filename: release.json
+          label: release
+          message: v${{ steps.version.outputs.version }}
+          color: blue
+
+      - name: Update crates.io version badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 6a26adf6bfae45f530465f626c9154f4
+          filename: crate-version.json
+          label: crates.io
+          message: v${{ steps.version.outputs.version }}
+          color: orange
+
+      - name: Update crates.io downloads badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 6a26adf6bfae45f530465f626c9154f4
+          filename: crates-downloads.json
+          label: downloads
+          message: ${{ steps.downloads.outputs.count }}
+          color: blue
 
   bench:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 [![CI](https://github.com/patchloom/patchloom/actions/workflows/ci.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
-[![crates.io](https://img.shields.io/crates/v/patchloom?logo=rust)](https://crates.io/crates/patchloom)
-[![Release](https://img.shields.io/github/v/release/patchloom/patchloom?logo=github&sort=semver)](https://github.com/patchloom/patchloom/releases/latest)
+[![crates.io](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/crate-version.json&logo=rust)](https://crates.io/crates/patchloom)
+[![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
 [![Tests](https://img.shields.io/badge/tests-1438%20passing-brightgreen)](#)
@@ -17,7 +17,7 @@
 [![FOSSA Status](https://github.com/patchloom/patchloom/actions/workflows/fossa.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/fossa.yml)
 [![Docs](https://img.shields.io/badge/docs-patchloom.github.io-blue?logo=mdbook)](https://patchloom.github.io/patchloom/)
 
-[![crates.io downloads](https://img.shields.io/crates/d/patchloom?logo=rust)](https://crates.io/crates/patchloom)
+[![crates.io downloads](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/crates-downloads.json&logo=rust)](https://crates.io/crates/patchloom)
 
 **One binary. Every platform. Structured file edits for AI agents.**
 


### PR DESCRIPTION
## Problem

The README badge row shows two error states on GitHub:

1. **Release** — shields.io returns `Unable to select next GitHub token from pool` (their shared GitHub API token pool is exhausted).
2. **crates.io** — GitHub's camo cache is serving a stale shields.io `invalid` image for the version badge (downloads badge on the next line is affected by the same upstream flakiness).

## Fix

Route the three shields.io-dependent badges through the existing coverage gist (same pattern as the Coverage badge):

- `release.json` — version from `Cargo.toml`
- `crate-version.json` — crates.io version
- `crates-downloads.json` — download count from crates.io API

CI updates all three on pushes to `main`. Gist files are already seeded with current values.

## Verification

- All three new badge URLs render correctly via shields.io endpoint
- No Rust code changes