### PR TITLE
fix: make unit tests portable in Docker and pseudo-TTY environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1438%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1440%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1438 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1440 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1250,6 +1250,13 @@ mod tests {
         fs::write(&file, "original").unwrap();
         fs::set_permissions(&file, std::fs::Permissions::from_mode(0o000)).unwrap();
 
+        // Root (common in Docker) can still read mode-000 files. Skip when
+        // permissions do not actually block reading.
+        if fs::read_to_string(&file).is_ok() {
+            fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+            return;
+        }
+
         let err = file_create(&file, "new", true, ApplyMode::Apply).unwrap_err();
         // Restore permissions so TempDir cleanup succeeds.
         fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -131,12 +131,25 @@ pub struct WriteFlags {
 }
 
 pub(crate) fn confirm_prompt(prompt: &str) -> bool {
-    if !std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+    let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
+    confirm_prompt_interactive(prompt, is_tty, &mut std::io::stdin().lock())
+}
+
+/// Prompt for confirmation when stdin is an interactive TTY.
+///
+/// Returns `false` immediately when `is_tty` is false (safe fallback for
+/// pipes, CI, and `cargo test` without a pseudo-TTY).
+pub(crate) fn confirm_prompt_interactive(
+    prompt: &str,
+    is_tty: bool,
+    reader: &mut impl BufRead,
+) -> bool {
+    if !is_tty {
         return false;
     }
     eprint!("{prompt} [Y/n] ");
     let mut buf = String::new();
-    match std::io::stdin().read_line(&mut buf) {
+    match reader.read_line(&mut buf) {
         Ok(0) | Err(_) => false,
         Ok(_) => {
             let answer = buf.trim().to_lowercase();
@@ -277,9 +290,24 @@ mod tests {
     }
 
     #[test]
+    fn confirm_prompt_non_tty_returns_false() {
+        let mut reader = std::io::Cursor::new(b"y\n");
+        assert!(!confirm_prompt_interactive("Apply?", false, &mut reader));
+    }
+
+    #[test]
+    fn confirm_prompt_tty_accepts_default_yes() {
+        let mut reader = std::io::Cursor::new(b"\n");
+        assert!(confirm_prompt_interactive("Apply?", true, &mut reader));
+    }
+
+    #[test]
     fn should_apply_confirm_non_tty_returns_false() {
-        // In test environments, stdin is not a TTY, so --confirm should
-        // return false (safe fallback).
+        if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
+            // Docker and devcontainers often allocate a pseudo-TTY on stdin.
+            // Non-TTY behavior is covered by confirm_prompt_non_tty_returns_false.
+            return;
+        }
         let g = GlobalFlags {
             confirm: true,
             ..GlobalFlags::default()

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -606,7 +606,10 @@ mod tests {
     }
 
     fn default_global() -> GlobalFlags {
-        GlobalFlags::default()
+        GlobalFlags {
+            color: crate::cli::global::ColorMode::Never,
+            ..GlobalFlags::default()
+        }
     }
 
     fn make_args(pattern: &str, paths: Vec<String>) -> SearchArgs {


### PR DESCRIPTION
## Problem

Four unit tests fail (or hang) in Docker contributor environments:

| Test | Root cause |
|------|------------|
| `cmd::search::tests::count_output` | `ColorMode::Auto` emits ANSI codes when stdout is a TTY; assertions expect plain `hello.txt:2` |
| `cmd::search::tests::files_with_matches_output` | Same — path ends with `\x1b[0m` instead of `hello.txt` |
| `cli::global::tests::should_apply_confirm_non_tty_returns_false` | Docker `-t` allocates a pseudo-TTY on stdin; `confirm_prompt` blocks waiting for input |
| `api::tests::file_create_force_propagates_read_error` | Docker runs as root; root can read `chmod 000` files |

## Fix

- Search test helper uses `ColorMode::Never` for deterministic output parsing
- Extract `confirm_prompt_interactive(prompt, is_tty, reader)` and test non-TTY behavior with an in-memory reader (no ambient TTY dependency)
- Skip the unreadable-file test when `chmod 000` does not actually block reads (root/Docker)

## Verification

- `make test` — 783 passed
- `make clippy` — clean