### PR TITLE
ci: fix Scorecard pinned-deps alert for crates.io fetch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,9 +226,15 @@ jobs:
       - name: Fetch crates.io download count
         id: downloads
         run: |
-          count=$(curl -fsSL -H "User-Agent: patchloom-ci" \
-            "https://crates.io/api/v1/crates/patchloom" \
-            | python3 -c "import json,sys; print(json.load(sys.stdin)['crate']['downloads'])")
+          count=$(python3 -c "
+          import json, urllib.request
+          req = urllib.request.Request(
+              'https://crates.io/api/v1/crates/patchloom',
+              headers={'User-Agent': 'patchloom-ci'},
+          )
+          with urllib.request.urlopen(req) as resp:
+              print(json.load(resp)['crate']['downloads'])
+          ")
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
       - name: Update coverage badge


### PR DESCRIPTION
## Summary

Replace `curl | python3` with a single `python3` + `urllib.request` call when fetching crates.io download counts in CI.

## Problem

OpenSSF Scorecard alert [#39](https://github.com/patchloom/patchloom/security/code-scanning/39) flags `.github/workflows/ci.yml` line 229 as `downloadThenRun not pinned by hash` (PinnedDependenciesID). The step downloaded JSON from crates.io via `curl` and piped it directly into `python3 -c`, which Scorecard treats as an unpinned download-then-execute pattern.

## Change

- `.github/workflows/ci.yml`: fetch the crates.io API with `urllib.request` inside an inline Python script. Same User-Agent header and output shape; no external script download.

## Validation

- YAML edit only; badge update behavior unchanged.
- Scorecard should clear alert #39 on the next scheduled scan (Monday) or after merge to `main`.

Closes alert discussion for #39. Related triage: #582.