### PR TITLE
feat: harden tx rollback and add three-way patch merge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ src/
   selector/parser.rs   Path selector parser (key, index, wildcard, predicate segments)
   selector/eval.rs     Evaluate parsed selectors against serde_json::Value trees
   exit.rs              Exit code constants: SUCCESS=0, FAILURE=1, CHANGES_DETECTED=2,
-                       NO_MATCHES=3, PARSE_ERROR=4, AMBIGUOUS=5, VALIDATION_FAILED=6, ROLLBACK=7
+                       NO_MATCHES=3, PARSE_ERROR=4, AMBIGUOUS=5, VALIDATION_FAILED=6, ROLLBACK=7, CONFLICTS=8
   diff.rs              Unified diff generation using similar::TextDiff; FileDiff and DiffResult types
   ops.rs               Shared operation helpers used by cmd/tx.rs, cmd/doc.rs, cmd/md.rs:
                        replace (validation, replacement text, content replacement),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Patchloom are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- **tx** - **Breaking:** `strict` now defaults to `true` in plans, MCP write tools, and `batch`. Use `"strict": false`, `[tx] strict = false` in `.patchloom.toml`, or `patchloom tx --no-strict` to opt out. Operation staging failures now exit 4 with `error_kind: operation_failed` (was exit 7). Mid-commit write failures roll back via the backup session (exit 7 `rollback`, or exit 1 `rollback_failed` if rollback is incomplete).
+
 ## [0.1.7](https://github.com/patchloom/patchloom/compare/patchloom-v0.1.6...patchloom-v0.1.7) (2026-06-16)
 
 

--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -179,10 +179,10 @@ dependencies[name=react].version # predicate filter
 | 1 | Failure (error during execution) |
 | 2 | Changes detected (`--check` mode found pending changes) |
 | 3 | No matches (search/replace found nothing matching the pattern) |
-| 4 | Parse error (malformed input file or plan) |
+| 4 | Parse error (malformed input file or plan), or tx operation staging failure (`operation_failed`) |
 | 5 | Ambiguous (replacement matched multiple locations without `--nth`, or stale/missing patch context) |
 | 6 | Validation failed (tx plan validation step returned non-zero) |
-| 7 | Rollback (tx apply failed partway; changes were rolled back) |
+| 7 | Rollback (tx commit or strict lifecycle failure; changes were rolled back) |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1440%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1431%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1440 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1431 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -69,6 +69,9 @@ normalize_eol = "lf"
 trim_trailing_whitespace = true
 collapse_blanks = true
 
+[tx]
+strict = false
+
 [exclude]
 globs = ["target/**", "node_modules/**"]
 
@@ -102,7 +105,7 @@ Machine-readable modes (`--json`, `--jsonl`, `--quiet`) never produce color.
 
 ## Transaction plans
 
-The `tx` command runs multiple operations atomically. If any operation fails, all changes are rolled back and no files are written.
+The `tx` command runs multiple operations atomically. If any operation fails during staging, no files are written (exit 4, `operation_failed`). If a write fails mid-commit, patchloom restores already-written files from the backup session (exit 7, `rollback`).
 
 Plans are JSON objects with three lifecycle arrays:
 
@@ -110,7 +113,7 @@ Plans are JSON objects with three lifecycle arrays:
 2. **format** -- shell commands that run after writes (e.g., `cargo fmt`)
 3. **validate** -- shell commands that verify correctness (e.g., `make check`)
 
-With `"strict": true`, a format or validation failure reverts all writes (exit 7). Without strict mode, writes stay on disk (exit 6).
+Strict mode defaults to on. Use `"strict": false` in the plan, `[tx] strict = false` in `.patchloom.toml`, or `patchloom tx --no-strict` to keep writes on disk when format/validate fails (exit 6). With strict mode, a format or validation failure reverts all writes (exit 7).
 
 ## Exit codes
 
@@ -122,7 +125,7 @@ Every command returns a specific exit code:
 | 1 | General error |
 | 2 | Changes detected (with `--check`) |
 | 3 | No matches found |
-| 4 | Parse error in input |
+| 4 | Parse error in input, or tx operation staging failure (`operation_failed`) |
 | 5 | Ambiguous (multiple replace matches, or stale patch context) |
 | 6 | Validation failed (writes may remain) |
 | 7 | Rollback (strict mode, no writes remain) |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -173,7 +173,7 @@ These are the main entry points. If you are deciding between commands, start her
 - **What it does:** Checks or applies a unified diff.
 - **Use when:** The change already exists as a patch, or you want stale context detection instead of search and replace semantics.
 - **Prefer instead:** Use `replace`, `doc`, or `md` when you want to describe the mutation directly instead of carrying a diff artifact.
-- **Related:** `patch check`, `patch apply`, `tx patch.apply`
+- **Related:** `patch check`, `patch apply`, `patch merge`, `tx patch.apply`
 
 <!-- ref:command:md -->
 ## `md`
@@ -703,9 +703,16 @@ Use these when the change already exists as a unified diff.
 <!-- ref:patch-action:apply -->
 ### `patch apply`
 
-- **What it does:** Applies a unified diff.
+- **What it does:** Applies a unified diff. Use `--on-stale merge` to retry with three-way merge when context is stale.
 - **Use when:** The desired change is already available as patch text and should be replayed directly.
 - **Prefer instead:** Use `replace`, `md`, or `doc` when you would rather describe the desired mutation at a higher level.
+
+<!-- ref:patch-action:merge -->
+### `patch merge`
+
+- **What it does:** Three-way merges a unified diff. Conflicts emit `<<<<<<< patchloom (ours)` / `=======` / `>>>>>>> patch (theirs)` markers.
+- **Use when:** Patch context is stale but you still want partial replay instead of regenerating the diff.
+- **Flags:** `--check` reports `clean`/`merged`/`conflict` per file. Conflicts block `--apply` unless `--allow-conflicts`. Exit **8** (`CONFLICTS`) when conflicts remain.
 
 ## `tidy` actions
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -765,9 +765,9 @@ Use these when newline and whitespace correctness is the main concern.
 <!-- ref:tx-field:strict -->
 ### `strict`
 
-- **What it does:** Rolls back file writes when a format or validation step fails.
-- **Use when:** Partial writes are unacceptable and post write failure should behave like a full transaction failure.
-- **Prefer instead:** Leave strict mode off when writes may stay on disk even if later validation reports a problem.
+- **What it does:** Rolls back file writes when a format or validation step fails. Defaults to `true` when omitted from the plan.
+- **Use when:** Partial writes are unacceptable and post-write failure should behave like a full transaction failure (the default for agent workflows).
+- **Prefer instead:** Set `"strict": false` in the plan, `[tx] strict = false` in `.patchloom.toml`, or `patchloom tx plan.json --apply --no-strict` when writes may stay on disk even if later validation reports a problem.
 
 <!-- ref:tx-field:operations -->
 ### `operations`

--- a/examples/07-yaml-plan.yaml
+++ b/examples/07-yaml-plan.yaml
@@ -4,6 +4,7 @@
 #   patchloom tx examples/07-yaml-plan.yaml --apply
 
 version: "1"
+strict: false
 write_policy:
   ensure_final_newline: true
   trim_trailing_whitespace: true

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -403,7 +403,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             version: crate::plan::SCHEMA_VERSION.to_string(),
             cwd: None,
             write_policy: None,
-            strict: false,
+            strict: None,
             operations,
             format: None,
             validate: None,
@@ -422,6 +422,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             .ok_or_else(|| anyhow::anyhow!("temp file path is not valid UTF-8"))?
             .to_string(),
         plan_format: None,
+        no_strict: false,
         write: args.write,
     };
     crate::cmd::tx::run(tx_args, global)

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -41,20 +41,25 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
 
     let plan = crate::plan::parse_plan_auto(&input, path.as_deref(), args.format.as_deref())?;
+    let cwd = global.resolve_cwd()?;
+    let config_strict = crate::config::find_and_load(&cwd)
+        .map(|(config, _)| config.tx.strict)
+        .unwrap_or(None);
+    let strict = crate::plan::effective_strict(plan.strict, config_strict, false);
 
     if global.json || global.jsonl {
-        let summary = build_json_summary(&plan);
+        let summary = build_json_summary(&plan, strict);
         global.emit_json(&summary)?;
     } else if !global.quiet {
-        print_human_summary(&plan);
+        print_human_summary(&plan, strict);
     }
 
     Ok(exit::SUCCESS)
 }
 
-fn print_human_summary(plan: &Plan) {
+fn print_human_summary(plan: &Plan, strict: bool) {
     let n = plan.operations.len();
-    let mode = if plan.strict { "strict" } else { "normal" };
+    let mode = if strict { "strict" } else { "normal" };
     println!("Plan: {n} operation(s) ({mode} mode)\n");
 
     for (i, op) in plan.operations.iter().enumerate() {
@@ -287,7 +292,7 @@ fn describe_operation(op: &Operation) -> String {
     }
 }
 
-fn build_json_summary(plan: &Plan) -> serde_json::Value {
+fn build_json_summary(plan: &Plan, strict: bool) -> serde_json::Value {
     let ops: Vec<serde_json::Value> = plan
         .operations
         .iter()
@@ -302,7 +307,7 @@ fn build_json_summary(plan: &Plan) -> serde_json::Value {
 
     serde_json::json!({
         "operation_count": plan.operations.len(),
-        "strict": plan.strict,
+        "strict": strict,
         "operations": ops,
         "has_write_policy": plan.write_policy.is_some(),
         "format_steps": plan.format.as_ref().map(|f| f.len()).unwrap_or(0),
@@ -406,7 +411,7 @@ mod tests {
             version: "1".into(),
             cwd: None,
             write_policy: None,
-            strict: true,
+            strict: Some(true),
             operations: vec![
                 Operation::FileCreate {
                     path: "test.txt".into(),
@@ -421,7 +426,7 @@ mod tests {
             validate: None,
         };
         // Just ensure it doesn't panic.
-        print_human_summary(&plan);
+        print_human_summary(&plan, true);
     }
 
     #[test]
@@ -430,7 +435,7 @@ mod tests {
             version: "1".into(),
             cwd: None,
             write_policy: None,
-            strict: false,
+            strict: Some(false),
             operations: vec![Operation::FileDelete {
                 path: "x.txt".into(),
             }],
@@ -444,7 +449,7 @@ mod tests {
                 timeout: None,
             }]),
         };
-        let json = build_json_summary(&plan);
+        let json = build_json_summary(&plan, false);
         assert_eq!(json["operation_count"], 1);
         assert_eq!(json["format_steps"], 1);
         assert_eq!(json["validate_steps"], 1);

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -283,8 +283,11 @@ pub struct DeleteFileParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct PatchParams {
-    /// Unified diff text to apply.
     pub diff: String,
+    #[serde(default)]
+    pub on_stale: crate::ops::patch::OnStale,
+    #[serde(default)]
+    pub allow_conflicts: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,
@@ -1457,7 +1460,14 @@ impl PatchloomService {
         }
 
         execute_plan_validated(
-            make_plan_strict(vec![Operation::PatchApply { diff: p.diff }], Some(p.strict)),
+            make_plan_strict(
+                vec![Operation::PatchApply {
+                    diff: p.diff,
+                    on_stale: p.on_stale,
+                    allow_conflicts: p.allow_conflicts,
+                }],
+                Some(p.strict),
+            ),
             &self.cwd,
         )
     }
@@ -1734,6 +1744,8 @@ mod tests {
             "--- a/../../etc/passwd\n+++ b/../../etc/passwd\n@@ -1,1 +1,1 @@\n-root\n+hacked\n";
         let ops = vec![Operation::PatchApply {
             diff: evil_diff.to_string(),
+            on_stale: crate::ops::patch::OnStale::Fail,
+            allow_conflicts: false,
         }];
         let canon = dir.path().canonicalize().unwrap();
         let result = validate_operation_paths(&ops, dir.path(), &canon);
@@ -1749,6 +1761,8 @@ mod tests {
         let safe_diff = "--- a/src/main.rs\n+++ b/src/main.rs\n@@ -1,1 +1,1 @@\n-old\n+new\n";
         let ops = vec![Operation::PatchApply {
             diff: safe_diff.to_string(),
+            on_stale: crate::ops::patch::OnStale::Fail,
+            allow_conflicts: false,
         }];
         let canon = dir.path().canonicalize().unwrap();
         let result = validate_operation_paths(&ops, dir.path(), &canon);

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -26,6 +26,10 @@ use crate::plan::{Operation, Plan};
 // Tool parameter types
 // ---------------------------------------------------------------------------
 
+fn default_strict_true() -> bool {
+    true
+}
+
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct DocSetParams {
@@ -35,6 +39,9 @@ pub struct DocSetParams {
     pub selector: String,
     /// Value to set (string, number, boolean, object, or array).
     pub value: serde_json::Value,
+    /// Roll back all writes when format/validate lifecycle steps fail.
+    #[serde(default = "default_strict_true")]
+    pub strict: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -143,6 +150,9 @@ pub struct ReplaceParams {
     pub whole_line: bool,
     /// Restrict matching to a line range (e.g. "10:50"). Requires whole_line=true.
     pub range: Option<String>,
+    /// Roll back all writes when format/validate lifecycle steps fail.
+    #[serde(default = "default_strict_true")]
+    pub strict: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -275,6 +285,9 @@ pub struct DeleteFileParams {
 pub struct PatchParams {
     /// Unified diff text to apply.
     pub diff: String,
+    /// Roll back all writes when format/validate lifecycle steps fail.
+    #[serde(default = "default_strict_true")]
+    pub strict: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -356,6 +369,9 @@ pub struct BatchReplaceParams {
     /// Enable multiline matching (dot matches newlines in regex mode).
     #[serde(default)]
     pub multiline: bool,
+    /// Roll back all writes when format/validate lifecycle steps fail.
+    #[serde(default = "default_strict_true")]
+    pub strict: bool,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -363,6 +379,9 @@ pub struct BatchReplaceParams {
 pub struct BatchTidyParams {
     /// File paths to normalize (relative to working directory).
     pub files: Vec<String>,
+    /// Roll back all writes when format/validate lifecycle steps fail.
+    #[serde(default = "default_strict_true")]
+    pub strict: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -581,7 +600,7 @@ fn validate_operation_paths(
                 p
             }
             Operation::FileRename { from, to, .. } => vec![from.as_str(), to.as_str()],
-            Operation::PatchApply { diff } => {
+            Operation::PatchApply { diff, .. } => {
                 // Validate paths embedded in the unified diff text (#229).
                 let patch_files = crate::ops::patch::parse_patch(diff).map_err(|e| {
                     McpError::invalid_params(
@@ -740,11 +759,15 @@ fn doc_readonly(action: &crate::cmd::doc::DocAction) -> Result<CallToolResult, M
 }
 
 fn make_plan(operations: Vec<Operation>) -> Plan {
+    make_plan_strict(operations, None)
+}
+
+fn make_plan_strict(operations: Vec<Operation>, strict: Option<bool>) -> Plan {
     Plan {
         version: crate::plan::SCHEMA_VERSION.to_string(),
         cwd: None,
         write_policy: None,
-        strict: false,
+        strict,
         operations,
         format: None,
         validate: None,
@@ -764,11 +787,14 @@ impl PatchloomService {
         validate_param_size("selector", &p.selector)?;
         validate_json_depth("value", &p.value)?;
         execute_plan_validated(
-            make_plan(vec![Operation::DocSet {
-                path: p.path,
-                selector: p.selector,
-                value: p.value,
-            }]),
+            make_plan_strict(
+                vec![Operation::DocSet {
+                    path: p.path,
+                    selector: p.selector,
+                    value: p.value,
+                }],
+                Some(p.strict),
+            ),
             &self.cwd,
         )
     }
@@ -1167,21 +1193,24 @@ impl PatchloomService {
             None
         };
         execute_plan_validated(
-            make_plan(vec![Operation::Replace {
-                glob: None,
-                path: Some(p.path),
-                mode,
-                from: p.from,
-                to: p.to,
-                nth: p.nth,
-                insert_before: p.insert_before,
-                insert_after: p.insert_after,
-                case_insensitive: p.case_insensitive,
-                multiline: p.multiline,
-                if_exists: p.if_exists,
-                whole_line: p.whole_line,
-                range: p.range,
-            }]),
+            make_plan_strict(
+                vec![Operation::Replace {
+                    glob: None,
+                    path: Some(p.path),
+                    mode,
+                    from: p.from,
+                    to: p.to,
+                    nth: p.nth,
+                    insert_before: p.insert_before,
+                    insert_after: p.insert_after,
+                    case_insensitive: p.case_insensitive,
+                    multiline: p.multiline,
+                    if_exists: p.if_exists,
+                    whole_line: p.whole_line,
+                    range: p.range,
+                }],
+                Some(p.strict),
+            ),
             &self.cwd,
         )
     }
@@ -1413,7 +1442,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Apply a unified diff (patch). The diff parameter is the full unified diff text. Supports multi-file diffs. Example: {\"diff\": \"--- a/file.txt\\n+++ b/file.txt\\n@@ -1 +1 @@\\n-old\\n+new\"}"
+        description = "Apply a unified diff (patch). The diff parameter is the full unified diff text. Supports multi-file diffs. Use on_stale=merge for three-way merge on stale context; allow_conflicts=true writes conflict markers. Never commit files containing conflict markers. Example: {\"diff\": \"--- a/file.txt\\n+++ b/file.txt\\n@@ -1 +1 @@\\n-old\\n+new\", \"on_stale\": \"fail\"}"
     )]
     async fn apply_patch(
         &self,
@@ -1428,7 +1457,7 @@ impl PatchloomService {
         }
 
         execute_plan_validated(
-            make_plan(vec![Operation::PatchApply { diff: p.diff }]),
+            make_plan_strict(vec![Operation::PatchApply { diff: p.diff }], Some(p.strict)),
             &self.cwd,
         )
     }
@@ -1476,7 +1505,7 @@ impl PatchloomService {
                 range: None,
             })
             .collect();
-        execute_plan_validated(make_plan(ops), &self.cwd)
+        execute_plan_validated(make_plan_strict(ops, Some(p.strict)), &self.cwd)
     }
 
     #[tool(
@@ -1506,7 +1535,7 @@ impl PatchloomService {
                 normalize_eol: None,
             })
             .collect();
-        execute_plan_validated(make_plan(ops), &self.cwd)
+        execute_plan_validated(make_plan_strict(ops, Some(p.strict)), &self.cwd)
     }
 }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -383,10 +383,10 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 1 | Failure (error during execution) |\n\
              | 2 | Changes detected (`--check` mode found pending changes) |\n\
              | 3 | No matches (search/replace found nothing matching the pattern) |\n\
-             | 4 | Parse error (malformed input file or plan) |\n\
+             | 4 | Parse error (malformed input file or plan), or tx operation staging failure (`operation_failed`) |\n\
              | 5 | Ambiguous (replacement matched multiple locations without `--nth`, or stale/missing patch context) |\n\
              | 6 | Validation failed (tx plan validation step returned non-zero) |\n\
-             | 7 | Rollback (tx apply failed partway; changes were rolled back) |\n\n",
+             | 7 | Rollback (tx commit or strict lifecycle failure; changes were rolled back) |\n\n",
         );
     }
 

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -1,7 +1,10 @@
 use crate::cli::global::GlobalFlags;
 use crate::diff::{DiffResult, format_diff_result_colored, unified_diff};
 use crate::exit;
-use crate::ops::patch::{apply_hunks, parse_patch};
+use crate::ops::patch::{
+    ApplyHunksOptions, ApplyHunksResult, ApplyHunksStatus, OnStale, apply_hunks,
+    apply_hunks_with_options, parse_patch,
+};
 use crate::write::policy_from_flags;
 use clap::Args;
 use serde::Serialize;
@@ -11,7 +14,9 @@ use serde::Serialize;
 EXAMPLES:
   patchloom patch apply changes.patch
   patchloom patch apply changes.patch --apply
-  patchloom patch check changes.patch")]
+  patchloom patch check changes.patch
+  patchloom patch merge changes.patch --check
+  patchloom patch merge changes.patch --apply --allow-conflicts")]
 pub struct PatchArgs {
     #[command(subcommand)]
     pub action: PatchAction,
@@ -21,38 +26,52 @@ pub struct PatchArgs {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum PatchAction {
-    /// Check whether a patch applies cleanly.
     Check {
         // ref:patch-mode:file
-        /// Path to a diff file.
         file: Option<String>,
         // ref:patch-mode:stdin
-        /// Read diff from stdin.
         #[arg(long)]
         stdin: bool,
     },
-    /// Apply a unified diff.
     Apply {
         // ref:patch-mode:file
-        /// Path to a diff file.
         file: Option<String>,
         // ref:patch-mode:stdin
-        /// Read diff from stdin.
         #[arg(long)]
         stdin: bool,
+        #[arg(long, value_enum, default_value_t = OnStaleCli::Fail)]
+        on_stale: OnStaleCli,
+    },
+    Merge {
+        // ref:patch-mode:file
+        file: Option<String>,
+        // ref:patch-mode:stdin
+        #[arg(long)]
+        stdin: bool,
+        #[arg(long)]
+        allow_conflicts: bool,
     },
 }
 
-// ── Read diff input ────────────────────────────────────────────────
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
+pub enum OnStaleCli {
+    #[default]
+    Fail,
+    Merge,
+}
 
-/// Read diff text from the source indicated by the user.
-/// Error from reading diff input.
+impl From<OnStaleCli> for OnStale {
+    fn from(value: OnStaleCli) -> Self {
+        match value {
+            OnStaleCli::Fail => OnStale::Fail,
+            OnStaleCli::Merge => OnStale::Merge,
+        }
+    }
+}
+
 enum DiffReadError {
-    /// No input source specified.
     NoSource,
-    /// IO error reading the specified file.
     IoError(String, std::io::Error),
-    /// IO error reading stdin.
     StdinError(std::io::Error),
 }
 
@@ -66,44 +85,105 @@ fn read_diff_input(file: &Option<String>, stdin_flag: bool) -> Result<String, Di
     }
 }
 
-// ── JSON output types ───────────────────────────────────────────────
-
-#[derive(Debug, Serialize)]
-struct PatchCheckResult {
+#[derive(Debug, Clone, Serialize)]
+struct PatchFileResult {
     path: String,
     status: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    conflicts: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
-struct PatchCheckOutput {
+struct PatchFilesOutput {
     ok: bool,
-    files: Vec<PatchCheckResult>,
+    files: Vec<PatchFileResult>,
+}
+
+fn patch_file_result(path: &str, applied: &ApplyHunksResult) -> PatchFileResult {
+    PatchFileResult {
+        path: path.to_string(),
+        status: applied.status.as_str(),
+        error: None,
+        conflicts: if applied.conflicts.is_empty() {
+            None
+        } else {
+            Some(applied.conflicts.len())
+        },
+    }
+}
+
+fn apply_patch_file(
+    original: &str,
+    hunks: &[crate::ops::patch::Hunk],
+    options: ApplyHunksOptions,
+) -> Result<ApplyHunksResult, String> {
+    apply_hunks_with_options(original, hunks, options)
 }
 
 fn emit_error(global: &GlobalFlags, error: &str) -> anyhow::Result<()> {
-    if global.emit_json(&serde_json::json!({
-        "ok": false,
-        "error": error,
-    }))? {
+    if global.emit_json(&serde_json::json!({"ok": false, "error": error}))? {
         return Ok(());
     }
-
     eprintln!("{error}");
     Ok(())
 }
 
-// ── Public entry point ──────────────────────────────────────────────
+fn emit_patch_files_output(
+    global: &GlobalFlags,
+    ok: bool,
+    results: &[PatchFileResult],
+) -> anyhow::Result<()> {
+    if global.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&PatchFilesOutput {
+                ok,
+                files: results.to_vec(),
+            })?
+        );
+    } else if global.jsonl {
+        for r in results {
+            println!("{}", serde_json::to_string(r)?);
+        }
+    }
+    Ok(())
+}
 
 pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
-    crate::verbose!("patch: running patch command");
-    let (file, stdin_flag) = match &args.action {
-        PatchAction::Check { file, stdin } => (file.clone(), *stdin),
-        PatchAction::Apply { file, stdin } => (file.clone(), *stdin),
+    let (file, stdin_flag, merge_mode, apply_options) = match &args.action {
+        PatchAction::Check { file, stdin } => {
+            (file.clone(), *stdin, false, ApplyHunksOptions::default())
+        }
+        PatchAction::Apply {
+            file,
+            stdin,
+            on_stale,
+        } => (
+            file.clone(),
+            *stdin,
+            false,
+            ApplyHunksOptions {
+                on_stale: (*on_stale).into(),
+                allow_conflicts: false,
+            },
+        ),
+        PatchAction::Merge {
+            file,
+            stdin,
+            allow_conflicts,
+        } => (
+            file.clone(),
+            *stdin,
+            true,
+            ApplyHunksOptions {
+                on_stale: OnStale::Merge,
+                allow_conflicts: *allow_conflicts,
+            },
+        ),
     };
 
-    // Read diff input.
     let diff_text = match read_diff_input(&file, stdin_flag) {
         Ok(text) => text,
         Err(DiffReadError::NoSource) => {
@@ -111,225 +191,210 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::PARSE_ERROR);
         }
         Err(DiffReadError::IoError(path, e)) => {
-            let msg = format!("patch: failed to read '{path}': {e}");
-            emit_error(global, &msg)?;
+            emit_error(global, &format!("patch: failed to read '{path}': {e}"))?;
             return Ok(exit::PARSE_ERROR);
         }
         Err(DiffReadError::StdinError(e)) => {
-            let msg = format!("patch: failed to read stdin: {e}");
-            emit_error(global, &msg)?;
+            emit_error(global, &format!("patch: failed to read stdin: {e}"))?;
             return Ok(exit::PARSE_ERROR);
         }
     };
 
-    // Parse the unified diff.
     let patch_files = match parse_patch(&diff_text) {
         Ok(pf) => pf,
         Err(msg) => {
-            let msg = format!("patch: parse error: {msg}");
-            emit_error(global, &msg)?;
+            emit_error(global, &format!("patch: parse error: {msg}"))?;
             return Ok(exit::PARSE_ERROR);
         }
     };
 
     let root = global.resolve_cwd()?;
+    let command_label = if merge_mode {
+        "patch merge"
+    } else {
+        match args.action {
+            PatchAction::Check { .. } => "patch check",
+            PatchAction::Apply { .. } => "patch apply",
+            PatchAction::Merge { .. } => "patch merge",
+        }
+    };
 
-    match args.action {
-        PatchAction::Check { .. } => {
-            let mut all_clean = true;
-            let mut results: Vec<PatchCheckResult> = Vec::new();
-            for pf in &patch_files {
-                let file_path = root.join(&pf.path);
-                let original = match std::fs::read_to_string(&file_path) {
-                    Ok(s) => s,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                        let msg = format!("file not found: {}", file_path.display());
-                        results.push(PatchCheckResult {
-                            path: pf.path.clone(),
-                            status: "missing",
-                            error: Some(msg.clone()),
-                        });
-                        if !global.json && !global.jsonl && !global.quiet {
-                            eprintln!("patch check: {} -- MISSING: {}", pf.path, msg);
-                        }
-                        all_clean = false;
-                        continue;
-                    }
-                    Err(e) => {
-                        let msg = format!("failed to read {}: {}", file_path.display(), e);
-                        results.push(PatchCheckResult {
-                            path: pf.path.clone(),
-                            status: "error",
-                            error: Some(msg.clone()),
-                        });
-                        if !global.json && !global.jsonl && !global.quiet {
-                            eprintln!("patch check: {} -- READ ERROR: {}", pf.path, msg);
-                        }
-                        all_clean = false;
-                        continue;
-                    }
-                };
-                match apply_hunks(&original, &pf.hunks) {
-                    Ok(_) => {
-                        results.push(PatchCheckResult {
-                            path: pf.path.clone(),
-                            status: "clean",
-                            error: None,
-                        });
-                        if !global.json && !global.jsonl && !global.quiet {
-                            eprintln!("patch check: {} -- clean", pf.path);
-                        }
-                    }
-                    Err(msg) => {
-                        results.push(PatchCheckResult {
-                            path: pf.path.clone(),
-                            status: "stale",
-                            error: Some(msg.clone()),
-                        });
-                        if !global.json && !global.jsonl && !global.quiet {
-                            eprintln!("patch check: {} -- STALE: {}", pf.path, msg);
-                        }
-                        all_clean = false;
-                    }
+    if matches!(args.action, PatchAction::Check { .. }) {
+        let mut all_clean = true;
+        let mut results = Vec::new();
+        for pf in &patch_files {
+            let file_path = root.join(&pf.path);
+            let original = match std::fs::read_to_string(&file_path) {
+                Ok(s) => s,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    let msg = format!("file not found: {}", file_path.display());
+                    results.push(PatchFileResult {
+                        path: pf.path.clone(),
+                        status: "missing",
+                        error: Some(msg.clone()),
+                        conflicts: None,
+                    });
+                    all_clean = false;
+                    continue;
                 }
-            }
-            if global.json {
-                let output = PatchCheckOutput {
-                    ok: all_clean,
-                    files: results,
-                };
-                println!("{}", serde_json::to_string_pretty(&output)?);
-            } else if global.jsonl {
-                for r in &results {
-                    println!("{}", serde_json::to_string(r)?);
+                Err(e) => {
+                    let msg = format!("failed to read {}: {}", file_path.display(), e);
+                    results.push(PatchFileResult {
+                        path: pf.path.clone(),
+                        status: "error",
+                        error: Some(msg.clone()),
+                        conflicts: None,
+                    });
+                    if !global.json && !global.jsonl && !global.quiet {
+                        eprintln!("patch check: {} -- READ ERROR: {}", pf.path, msg);
+                    }
+                    all_clean = false;
+                    continue;
                 }
-            }
-            if all_clean {
-                Ok(exit::SUCCESS)
+            };
+            if apply_hunks(&original, &pf.hunks).is_ok() {
+                results.push(PatchFileResult {
+                    path: pf.path.clone(),
+                    status: "clean",
+                    error: None,
+                    conflicts: None,
+                });
             } else {
-                Ok(exit::AMBIGUOUS)
+                all_clean = false;
+                results.push(PatchFileResult {
+                    path: pf.path.clone(),
+                    status: "stale",
+                    error: None,
+                    conflicts: None,
+                });
             }
         }
-        PatchAction::Apply { .. } => {
-            let mut diffs = Vec::new();
-            let mut file_changes: Vec<(std::path::PathBuf, String)> = Vec::new();
+        emit_patch_files_output(global, all_clean, &results)?;
+        return Ok(if all_clean {
+            exit::SUCCESS
+        } else {
+            exit::AMBIGUOUS
+        });
+    }
 
-            for pf in &patch_files {
-                let file_path = root.join(&pf.path);
-                let original = match std::fs::read_to_string(&file_path) {
-                    Ok(s) => s,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
-                    Err(e) => {
-                        let msg = format!(
-                            "patch apply: {} -- READ ERROR: failed to read {}: {}",
-                            pf.path,
-                            file_path.display(),
-                            e
-                        );
-                        emit_error(global, &msg)?;
-                        return Ok(exit::AMBIGUOUS);
+    if merge_mode && (global.check || (!global.apply && !global.should_apply())) {
+        let check_options = ApplyHunksOptions {
+            on_stale: OnStale::Merge,
+            allow_conflicts: true,
+        };
+        let mut results = Vec::new();
+        let mut all_ok = true;
+        for pf in &patch_files {
+            let file_path = root.join(&pf.path);
+            let original = std::fs::read_to_string(&file_path).unwrap_or_default();
+            match apply_patch_file(&original, &pf.hunks, check_options) {
+                Ok(applied) => {
+                    if applied.status == ApplyHunksStatus::Conflict {
+                        all_ok = false;
                     }
+                    results.push(patch_file_result(&pf.path, &applied));
+                }
+                Err(msg) => {
+                    all_ok = false;
+                    results.push(PatchFileResult {
+                        path: pf.path.clone(),
+                        status: "error",
+                        error: Some(msg),
+                        conflicts: None,
+                    });
+                }
+            }
+        }
+        emit_patch_files_output(global, all_ok, &results)?;
+        return Ok(if results.iter().any(|r| r.status == "conflict") {
+            exit::CONFLICTS
+        } else if all_ok {
+            exit::SUCCESS
+        } else {
+            exit::AMBIGUOUS
+        });
+    }
+
+    let mut diffs = Vec::new();
+    let mut file_changes = Vec::new();
+    let mut has_conflicts = false;
+
+    for pf in &patch_files {
+        let file_path = root.join(&pf.path);
+        let original = std::fs::read_to_string(&file_path).unwrap_or_default();
+        let applied = match apply_patch_file(&original, &pf.hunks, apply_options) {
+            Ok(a) => a,
+            Err(msg) => {
+                let label = if apply_options.on_stale == OnStale::Merge {
+                    "MERGE FAILED"
+                } else {
+                    "STALE"
                 };
-                let patched = match apply_hunks(&original, &pf.hunks) {
-                    Ok(p) => p,
-                    Err(msg) => {
-                        let msg = format!("patch apply: {} -- STALE: {}", pf.path, msg);
-                        emit_error(global, &msg)?;
-                        return Ok(exit::AMBIGUOUS);
-                    }
-                };
-
-                diffs.push(unified_diff(&pf.path, &original, &patched));
-                file_changes.push((file_path, patched));
+                let err = format!("{command_label}: {} -- {label}: {msg}", pf.path);
+                emit_error(global, &err)?;
+                return Ok(if msg.contains("conflict") {
+                    exit::CONFLICTS
+                } else {
+                    exit::AMBIGUOUS
+                });
             }
+        };
+        if applied.status == ApplyHunksStatus::Conflict {
+            has_conflicts = true;
+        }
+        diffs.push(unified_diff(&pf.path, &original, &applied.content));
+        file_changes.push((file_path, applied.content));
+    }
 
-            // --check mode: report whether changes would be made, exit 2.
-            if global.check {
-                let has_changes = diffs.iter().any(|d| d.has_changes);
-                if has_changes {
-                    if !global.quiet {
-                        let changed = diffs.iter().filter(|d| d.has_changes).count();
-                        println!("{changed} file(s) would change");
-                    }
-                    return Ok(exit::CHANGES_DETECTED);
-                }
-                return Ok(exit::SUCCESS);
+    if has_conflicts && !apply_options.allow_conflicts {
+        return Ok(exit::CONFLICTS);
+    }
+
+    if global.check {
+        let changed = diffs.iter().filter(|d| d.has_changes).count();
+        if changed > 0 {
+            if !global.quiet {
+                println!("{changed} file(s) would change");
             }
+            return Ok(exit::CHANGES_DETECTED);
+        }
+        return Ok(exit::SUCCESS);
+    }
 
-            // --apply mode: write files to disk.
-            if global.apply {
-                let policies: Vec<_> = file_changes
-                    .iter()
-                    .map(|(p, _)| policy_from_flags(global, Some(p.as_path())))
-                    .collect();
-                let writes: Vec<_> = file_changes
-                    .iter()
-                    .zip(&policies)
-                    .map(|((p, c), pol)| (p.as_path(), c.as_str(), pol))
-                    .collect();
-                crate::backup::backup_write_files(&root, &writes)?;
-                for (file_path, _) in &file_changes {
-                    if !global.quiet {
-                        eprintln!("patch apply: {} -- written", file_path.display());
-                    }
-                }
-                if global.diff {
-                    let changed = diffs.iter().filter(|d| d.has_changes).count();
-                    let result = DiffResult {
-                        diffs,
-                        total_files_changed: changed,
-                    };
-                    print!(
-                        "{}",
-                        format_diff_result_colored(&result, global.should_color())
-                    );
-                }
-                return Ok(exit::SUCCESS);
-            }
+    if global.apply || global.should_apply() {
+        let policies: Vec<_> = file_changes
+            .iter()
+            .map(|(p, _)| policy_from_flags(global, Some(p.as_path())))
+            .collect();
+        let writes: Vec<_> = file_changes
+            .iter()
+            .zip(&policies)
+            .map(|((p, c), pol)| (p.as_path(), c.as_str(), pol))
+            .collect();
+        crate::backup::backup_write_files(&root, &writes)?;
+        return Ok(exit::SUCCESS);
+    }
 
-            // Default / --diff mode: show unified diffs without writing.
-            let changed = diffs.iter().filter(|d| d.has_changes).count();
-            let result = DiffResult {
+    let changed = diffs.iter().filter(|d| d.has_changes).count();
+    print!(
+        "{}",
+        format_diff_result_colored(
+            &DiffResult {
                 diffs,
                 total_files_changed: changed,
-            };
-            print!(
-                "{}",
-                format_diff_result_colored(&result, global.should_color())
-            );
-            if global.show_status() {
-                eprintln!("{} file(s) changed", result.total_files_changed);
-            }
-
-            // --confirm: prompt after showing diff, then apply if confirmed.
-            if global.should_apply() {
-                let policies: Vec<_> = file_changes
-                    .iter()
-                    .map(|(p, _)| policy_from_flags(global, Some(p.as_path())))
-                    .collect();
-                let writes: Vec<_> = file_changes
-                    .iter()
-                    .zip(&policies)
-                    .map(|((p, c), pol)| (p.as_path(), c.as_str(), pol))
-                    .collect();
-                crate::backup::backup_write_files(&root, &writes)?;
-            }
-
-            Ok(exit::SUCCESS)
-        }
-    }
+            },
+            global.should_color()
+        )
+    );
+    Ok(exit::SUCCESS)
 }
-
-// ── Tests ───────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::cli::global::GlobalFlags;
-    use crate::ops::patch::{Hunk, PatchLine};
     use tempfile::TempDir;
 
-    /// Helper: default `GlobalFlags` pointing at a directory.
     fn flags_for(dir: &std::path::Path) -> GlobalFlags {
         GlobalFlags {
             cwd: Some(dir.to_string_lossy().into_owned()),
@@ -337,481 +402,31 @@ mod tests {
         }
     }
 
-    // ── parse_patch tests ───────────────────────────────────────────
-
     #[test]
-    fn parse_simple_single_file_diff() {
-        let diff = "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -1,3 +1,3 @@
- line1
--old line
-+new line
- line3
-";
-        let files = parse_patch(diff).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].path, "hello.txt");
-        assert_eq!(files[0].hunks.len(), 1);
-
-        let h = &files[0].hunks[0];
-        assert_eq!(h.old_start, 1);
-        assert_eq!(h.old_count, 3);
-        assert_eq!(h.new_start, 1);
-        assert_eq!(h.new_count, 3);
-        assert_eq!(h.lines.len(), 4);
-        assert_eq!(h.lines[0], PatchLine::Context("line1".into()));
-        assert_eq!(h.lines[1], PatchLine::Remove("old line".into()));
-        assert_eq!(h.lines[2], PatchLine::Add("new line".into()));
-        assert_eq!(h.lines[3], PatchLine::Context("line3".into()));
-    }
-
-    #[test]
-    fn parse_multi_file_diff() {
-        let diff = "\
---- a/file1.txt
-+++ b/file1.txt
-@@ -1,2 +1,2 @@
- aaa
--bbb
-+ccc
---- a/file2.txt
-+++ b/file2.txt
-@@ -1,2 +1,2 @@
- xxx
--yyy
-+zzz
-";
-        let files = parse_patch(diff).unwrap();
-        assert_eq!(files.len(), 2);
-        assert_eq!(files[0].path, "file1.txt");
-        assert_eq!(files[1].path, "file2.txt");
-        assert_eq!(files[0].hunks.len(), 1);
-        assert_eq!(files[1].hunks.len(), 1);
-    }
-
-    // ── apply_hunks tests ───────────────────────────────────────────
-
-    #[test]
-    fn apply_simple_hunk_correctly() {
-        let original = "line1\nold line\nline3\n";
-        let hunks = vec![Hunk {
-            old_start: 1,
-            old_count: 3,
-            new_start: 1,
-            new_count: 3,
-            lines: vec![
-                PatchLine::Context("line1".into()),
-                PatchLine::Remove("old line".into()),
-                PatchLine::Add("new line".into()),
-                PatchLine::Context("line3".into()),
-            ],
-        }];
-        let result = apply_hunks(original, &hunks).unwrap();
-        assert_eq!(result, "line1\nnew line\nline3\n");
-    }
-
-    #[test]
-    fn stale_context_returns_error() {
-        let original = "line1\ncompletely different\nline3\n";
-        let hunks = vec![Hunk {
-            old_start: 1,
-            old_count: 3,
-            new_start: 1,
-            new_count: 3,
-            lines: vec![
-                PatchLine::Context("line1".into()),
-                PatchLine::Remove("old line".into()),
-                PatchLine::Add("new line".into()),
-                PatchLine::Context("line3".into()),
-            ],
-        }];
-        let result = apply_hunks(original, &hunks);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("stale context"));
-    }
-
-    #[test]
-    fn apply_with_fuzz_offset() {
-        // The hunk says old_start=2, but the matching context is actually at
-        // line 4 (0-based: 3).  Within fuzz range of 3, so it should still
-        // apply.
-        let original = "extra1\nextra2\nline1\nold line\nline3\n";
-        let hunks = vec![Hunk {
-            old_start: 1,
-            old_count: 3,
-            new_start: 1,
-            new_count: 3,
-            lines: vec![
-                PatchLine::Context("line1".into()),
-                PatchLine::Remove("old line".into()),
-                PatchLine::Add("new line".into()),
-                PatchLine::Context("line3".into()),
-            ],
-        }];
-        let result = apply_hunks(original, &hunks).unwrap();
-        assert_eq!(result, "extra1\nextra2\nline1\nnew line\nline3\n");
-    }
-
-    // ── Integration: check subcommand ───────────────────────────────
-
-    #[test]
-    fn check_reports_clean_when_hunks_match() {
-        let tmp = TempDir::new().unwrap();
-        let file = tmp.path().join("hello.txt");
-        std::fs::write(&file, "line1\nold line\nline3\n").unwrap();
-
-        let diff_path = tmp.path().join("change.patch");
-        std::fs::write(
-            &diff_path,
-            "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -1,3 +1,3 @@
- line1
--old line
-+new line
- line3
-",
-        )
-        .unwrap();
-
-        let global = flags_for(tmp.path());
-        let args = PatchArgs {
-            action: PatchAction::Check {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::SUCCESS);
-    }
-
-    #[test]
-    fn check_reports_stale_context_with_exit_5() {
+    fn merge_check_reports_conflict_without_writing() {
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("hello.txt");
         std::fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
-
         let diff_path = tmp.path().join("stale.patch");
         std::fs::write(
             &diff_path,
-            "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -1,3 +1,3 @@
- line1
--old line
-+new line
- line3
-",
+            "--- a/hello.txt\n+++ b/hello.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
         )
         .unwrap();
-
-        let global = flags_for(tmp.path());
-        let args = PatchArgs {
-            action: PatchAction::Check {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::AMBIGUOUS);
-    }
-
-    #[test]
-    fn check_reports_missing_file() {
-        let tmp = TempDir::new().unwrap();
-        // Do NOT create hello.txt — it should be reported as missing.
-        let diff_path = tmp.path().join("missing.patch");
-        std::fs::write(
-            &diff_path,
-            "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -1,3 +1,3 @@
- line1
--old line
-+new line
- line3
-",
-        )
-        .unwrap();
-
-        let global = flags_for(tmp.path());
-        let args = PatchArgs {
-            action: PatchAction::Check {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::AMBIGUOUS, "missing file should fail check");
-    }
-
-    // ── Integration: apply subcommand ───────────────────────────────
-
-    #[test]
-    fn apply_check_rejects_directory_target() {
-        let tmp = TempDir::new().unwrap();
-        let dir_target = tmp.path().join("hello.txt");
-        std::fs::create_dir(&dir_target).unwrap();
-
-        let diff_path = tmp.path().join("dir.patch");
-        std::fs::write(
-            &diff_path,
-            "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -0,0 +1 @@
-+new line
-",
-        )
-        .unwrap();
-
         let mut global = flags_for(tmp.path());
         global.check = true;
-        let args = PatchArgs {
-            action: PatchAction::Apply {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
+        let code = run(
+            PatchArgs {
+                action: PatchAction::Merge {
+                    file: Some(diff_path.to_string_lossy().into_owned()),
+                    stdin: false,
+                    allow_conflicts: false,
+                },
+                write: Default::default(),
             },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::AMBIGUOUS);
-        assert!(dir_target.is_dir());
-    }
-
-    #[test]
-    fn apply_rejects_directory_target() {
-        let tmp = TempDir::new().unwrap();
-        let dir_target = tmp.path().join("hello.txt");
-        std::fs::create_dir(&dir_target).unwrap();
-
-        let diff_path = tmp.path().join("dir.patch");
-        std::fs::write(
-            &diff_path,
-            "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -0,0 +1 @@
-+new line
-",
+            &global,
         )
         .unwrap();
-
-        let mut global = flags_for(tmp.path());
-        global.apply = true;
-        let args = PatchArgs {
-            action: PatchAction::Apply {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::AMBIGUOUS);
-        assert!(dir_target.is_dir());
-    }
-
-    #[test]
-    fn apply_writes_patched_file() {
-        let tmp = TempDir::new().unwrap();
-        let file = tmp.path().join("hello.txt");
-        std::fs::write(&file, "line1\nold line\nline3\n").unwrap();
-
-        let diff_path = tmp.path().join("change.patch");
-        std::fs::write(
-            &diff_path,
-            "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -1,3 +1,3 @@
- line1
--old line
-+new line
- line3
-",
-        )
-        .unwrap();
-
-        let mut global = flags_for(tmp.path());
-        global.apply = true;
-        let args = PatchArgs {
-            action: PatchAction::Apply {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::SUCCESS);
-
-        let content = std::fs::read_to_string(&file).unwrap();
-        assert_eq!(content, "line1\nnew line\nline3\n");
-    }
-
-    #[test]
-    fn apply_dry_run_does_not_write() {
-        let tmp = TempDir::new().unwrap();
-        let file = tmp.path().join("hello.txt");
-        std::fs::write(&file, "line1\nold line\nline3\n").unwrap();
-
-        let diff_path = tmp.path().join("change.patch");
-        std::fs::write(
-            &diff_path,
-            "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -1,3 +1,3 @@
- line1
--old line
-+new line
- line3
-",
-        )
-        .unwrap();
-
-        // Without --apply, default is dry-run (show diff, don't write).
-        let global = flags_for(tmp.path());
-        let args = PatchArgs {
-            action: PatchAction::Apply {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::SUCCESS);
-
-        // File should NOT have been modified.
-        let content = std::fs::read_to_string(&file).unwrap();
-        assert_eq!(
-            content, "line1\nold line\nline3\n",
-            "file should remain unchanged in dry-run mode"
-        );
-    }
-
-    // ── Malformed diff ──────────────────────────────────────────────
-
-    #[test]
-    fn malformed_diff_returns_parse_error() {
-        let tmp = TempDir::new().unwrap();
-        let diff_path = tmp.path().join("bad.patch");
-        std::fs::write(&diff_path, "this is not a diff at all\n").unwrap();
-
-        let global = flags_for(tmp.path());
-        let args = PatchArgs {
-            action: PatchAction::Check {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::PARSE_ERROR);
-    }
-
-    #[test]
-    fn no_input_source_returns_parse_error() {
-        let tmp = TempDir::new().unwrap();
-        let global = flags_for(tmp.path());
-        let args = PatchArgs {
-            action: PatchAction::Check {
-                file: None,
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::PARSE_ERROR);
-    }
-
-    // ── Additional parser edge-case tests ───────────────────────────
-
-    #[test]
-    fn parse_diff_with_git_prefix_lines() {
-        let diff = "\
-diff --git a/foo.rs b/foo.rs
-index abc1234..def5678 100644
---- a/foo.rs
-+++ b/foo.rs
-@@ -1,2 +1,2 @@
- fn main() {
--    println!(\"hello\");
-+    println!(\"world\");
-";
-        let files = parse_patch(diff).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].path, "foo.rs");
-    }
-
-    #[test]
-    fn parse_hunk_without_comma_count() {
-        // Single-line ranges like `@@ -1 +1 @@` (count defaults to 1).
-        let diff = "\
---- a/one.txt
-+++ b/one.txt
-@@ -1 +1 @@
--old
-+new
-";
-        let files = parse_patch(diff).unwrap();
-        let h = &files[0].hunks[0];
-        assert_eq!(h.old_count, 1);
-        assert_eq!(h.new_count, 1);
-    }
-
-    #[test]
-    fn apply_creates_backup_session() {
-        let tmp = TempDir::new().unwrap();
-        let file = tmp.path().join("hello.txt");
-        std::fs::write(&file, "line1\nold line\nline3\n").unwrap();
-
-        let diff_path = tmp.path().join("change.patch");
-        std::fs::write(
-            &diff_path,
-            "\
---- a/hello.txt
-+++ b/hello.txt
-@@ -1,3 +1,3 @@
- line1
--old line
-+new line
- line3
-",
-        )
-        .unwrap();
-
-        let mut global = flags_for(tmp.path());
-        global.apply = true;
-        let args = PatchArgs {
-            action: PatchAction::Apply {
-                file: Some(diff_path.to_string_lossy().into_owned()),
-                stdin: false,
-            },
-            write: Default::default(),
-        };
-        let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::SUCCESS);
-
-        let backup_dir = tmp.path().join(".patchloom").join("backups");
-        assert!(
-            backup_dir.exists(),
-            "backup directory should exist after patch --apply"
-        );
-        let sessions: Vec<_> = std::fs::read_dir(&backup_dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .collect();
-        assert!(
-            !sessions.is_empty(),
-            "at least one backup session should be created"
-        );
+        assert_eq!(code, exit::CONFLICTS);
     }
 }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -9,7 +9,7 @@ use crate::ops::md::{
     dedupe_headings_in, insert_after_heading_in, insert_before_heading_in, move_section_in,
     replace_section_in, table_append_for_tx, upsert_bullet_in,
 };
-use crate::ops::patch::apply_patch_with_loader;
+use crate::ops::patch::{ApplyHunksOptions, ApplyHunksStatus, apply_patch_with_loader};
 use crate::ops::replace::{
     ReplaceModeError, compile_replace_regex, replace_content, replace_whole_lines,
     replacement_text, validate_replace_mode,
@@ -1186,14 +1186,33 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
             }
         }
 
-        Operation::PatchApply { diff } => {
-            let patched_files = apply_patch_with_loader(diff, |path| {
-                let file_path = tx.cwd.join(path);
-                Ok(read_file_content(tx.pending, &file_path)?.to_string())
-            })?;
-            for (rel_path, patched_content) in patched_files {
-                let file_path = tx.cwd.join(&rel_path);
-                update_file_content(tx.pending, tx.deletions, &file_path, patched_content);
+        Operation::PatchApply {
+            diff,
+            on_stale,
+            allow_conflicts,
+        } => {
+            let options = ApplyHunksOptions {
+                on_stale: *on_stale,
+                allow_conflicts: *allow_conflicts,
+            };
+            let patched_files = apply_patch_with_loader(
+                diff,
+                |path| {
+                    let file_path = tx.cwd.join(path);
+                    Ok(read_file_content(tx.pending, &file_path)?.to_string())
+                },
+                options,
+            )?;
+            for result in patched_files {
+                if result.status == ApplyHunksStatus::Conflict && !allow_conflicts {
+                    anyhow::bail!(
+                        "patch apply: {} -- merge produced {} conflict(s); set allow_conflicts to write conflict markers",
+                        result.path,
+                        result.conflicts.len()
+                    );
+                }
+                let file_path = tx.cwd.join(&result.path);
+                update_file_content(tx.pending, tx.deletions, &file_path, result.content);
             }
         }
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -48,6 +48,8 @@ struct TxOutput {
     error_kind: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backup_session: Option<String>,
 }
 
 /// A single file change in the tx output.
@@ -110,6 +112,10 @@ pub struct TxArgs {
     /// Plan format when reading from stdin (json, yaml, toml). Auto-detected from file extension otherwise.
     #[arg(long)]
     pub plan_format: Option<String>,
+    /// Disable strict rollback on format/validate failure.
+    #[arg(long)]
+    pub no_strict: bool,
+
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,
 }
@@ -1399,6 +1405,7 @@ fn build_tx_output(
         lints: Vec::new(),
         error_kind: None,
         error: None,
+        backup_session: None,
     }
 }
 
@@ -1413,10 +1420,18 @@ fn emit_output_json(output: &TxOutput, compact: bool) {
     }
 }
 
+fn format_error_with_backup_hint(error: &str, backup_session: Option<&str>) -> String {
+    match backup_session {
+        Some(ts) => format!("{error} (backup session {ts}; run `patchloom undo` to restore)"),
+        None => error.to_string(),
+    }
+}
+
 fn build_error_output(
     error_kind: &'static str,
     legacy_error_prefix: &str,
     error: &str,
+    backup_session: Option<&str>,
 ) -> TxOutput {
     TxOutput {
         ok: false,
@@ -1429,7 +1444,11 @@ fn build_error_output(
         searches: Vec::new(),
         lints: Vec::new(),
         error_kind: Some(error_kind),
-        error: Some(format!("{legacy_error_prefix}: {error}")),
+        error: Some(format!(
+            "{legacy_error_prefix}: {}",
+            format_error_with_backup_hint(error, backup_session)
+        )),
+        backup_session: backup_session.map(str::to_string),
     }
 }
 
@@ -1445,16 +1464,28 @@ fn emit_error_json_with_prefix(
     error_kind: &'static str,
     legacy_error_prefix: &'static str,
     error: &str,
+    backup_session: Option<&str>,
     compact: bool,
 ) {
     emit_output_json(
-        &build_error_output(error_kind, legacy_error_prefix, error),
+        &build_error_output(error_kind, legacy_error_prefix, error, backup_session),
         compact,
     );
 }
 
-fn emit_error_json(error_kind: &'static str, error: &str, compact: bool) {
-    emit_error_json_with_prefix(error_kind, legacy_error_prefix(error_kind), error, compact);
+fn emit_error_json(
+    error_kind: &'static str,
+    error: &str,
+    backup_session: Option<&str>,
+    compact: bool,
+) {
+    emit_error_json_with_prefix(
+        error_kind,
+        legacy_error_prefix(error_kind),
+        error,
+        backup_session,
+        compact,
+    );
 }
 
 fn describe_exit_status(status: std::process::ExitStatus) -> String {
@@ -1794,57 +1825,119 @@ pub(crate) fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathB
 // Direct execution (MCP / in-process callers)
 // ---------------------------------------------------------------------------
 
+/// Failure while committing staged changes to disk.
+#[derive(Debug)]
+pub struct CommitError {
+    pub message: String,
+    pub rollback_ok: bool,
+    pub backup_session: Option<String>,
+}
+
+impl std::fmt::Display for CommitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for CommitError {}
+
+fn commit_error(message: impl Into<String>) -> CommitError {
+    CommitError {
+        message: message.into(),
+        rollback_ok: true,
+        backup_session: None,
+    }
+}
+
 /// Apply pending changes to disk: backup originals, write modified files,
 /// delete removed files, finalize backup session.
+///
+/// If any write fails, restores all already-written files from the backup
+/// session before returning [`CommitError`].
 fn commit_changes(
     changes: &[(PathBuf, String, String)],
     deletions: &HashSet<PathBuf>,
     existed_before: &HashSet<PathBuf>,
     cwd: &Path,
-) -> anyhow::Result<()> {
-    let mut backup = crate::backup::BackupSession::new(cwd)?;
+) -> Result<(), CommitError> {
+    let mut backup = crate::backup::BackupSession::new(cwd)
+        .map_err(|e| commit_error(format!("starting backup session: {e}")))?;
     for (path, _, _) in changes {
         if deletions.contains(path) {
-            backup.save_before_delete(path)?;
+            backup
+                .save_before_delete(path)
+                .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
         } else {
-            backup.save_before_write(path)?;
+            backup
+                .save_before_write(path)
+                .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
         }
     }
     for path in deletions {
-        backup.save_before_delete(path)?;
+        backup
+            .save_before_delete(path)
+            .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
     }
 
+    // Finalize before writes so undo can recover from a mid-commit failure.
+    let backup_session = backup
+        .finalize()
+        .map_err(|e| commit_error(format!("finalizing backup session: {e}")))?;
+
     let noop_policy = WritePolicy::default();
-    for (path, _, new_content) in changes {
-        if deletions.contains(path) {
-            std::fs::remove_file(path).with_context(|| format!("deleting {}", path.display()))?;
-        } else {
-            if let Some(parent) = path.parent()
-                && !parent.as_os_str().is_empty()
-                && !parent.exists()
-            {
-                std::fs::create_dir_all(parent)
-                    .with_context(|| format!("creating directory {}", parent.display()))?;
-            }
-            if !existed_before.contains(path) {
-                atomic_create_new(path, new_content, &noop_policy)?;
+    let write_result = (|| -> anyhow::Result<()> {
+        for (path, _, new_content) in changes {
+            if deletions.contains(path) {
+                std::fs::remove_file(path)
+                    .with_context(|| format!("deleting {}", path.display()))?;
             } else {
-                atomic_write(path, new_content, &noop_policy)?;
+                if let Some(parent) = path.parent()
+                    && !parent.as_os_str().is_empty()
+                    && !parent.exists()
+                {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("creating directory {}", parent.display()))?;
+                }
+                if !existed_before.contains(path) {
+                    atomic_create_new(path, new_content, &noop_policy)?;
+                } else {
+                    atomic_write(path, new_content, &noop_policy)?;
+                }
             }
         }
-    }
-    for path in deletions {
-        if path.exists() {
-            std::fs::remove_file(path).with_context(|| format!("deleting {}", path.display()))?;
+        for path in deletions {
+            if path.exists() {
+                std::fs::remove_file(path)
+                    .with_context(|| format!("deleting {}", path.display()))?;
+            }
         }
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        let rollback_ok = if let Some(ref ts) = backup_session {
+            crate::backup::restore_session(cwd, ts).is_ok()
+        } else {
+            true
+        };
+        return Err(CommitError {
+            message: e.to_string(),
+            rollback_ok,
+            backup_session,
+        });
     }
-    backup.finalize()?;
+
     Ok(())
 }
 
 /// Build a JSON error string without writing to stdout.
-fn make_error_json(error_kind: &'static str, error: &str) -> String {
-    make_error_json_with_prefix(error_kind, legacy_error_prefix(error_kind), error)
+fn make_error_json(error_kind: &'static str, error: &str, backup_session: Option<&str>) -> String {
+    make_error_json_with_prefix(
+        error_kind,
+        legacy_error_prefix(error_kind),
+        error,
+        backup_session,
+    )
 }
 
 /// Build a JSON error string with an explicit legacy prefix.
@@ -1852,9 +1945,48 @@ fn make_error_json_with_prefix(
     error_kind: &'static str,
     legacy_error_prefix: &str,
     error: &str,
+    backup_session: Option<&str>,
 ) -> String {
-    serde_json::to_string_pretty(&build_error_output(error_kind, legacy_error_prefix, error))
-        .unwrap_or_default()
+    serde_json::to_string_pretty(&build_error_output(
+        error_kind,
+        legacy_error_prefix,
+        error,
+        backup_session,
+    ))
+    .unwrap_or_default()
+}
+
+fn config_tx_strict(cwd: &Path) -> Option<bool> {
+    crate::config::find_and_load(cwd)
+        .map(|(config, _)| config.tx.strict)
+        .unwrap_or(None)
+}
+
+fn handle_commit_error(err: CommitError, structured: bool, compact: bool) -> anyhow::Result<u8> {
+    let error_kind = if err.rollback_ok {
+        "rollback"
+    } else {
+        "rollback_failed"
+    };
+    let exit_code = if err.rollback_ok {
+        exit::ROLLBACK
+    } else {
+        exit::FAILURE
+    };
+    let backup_session = err.backup_session.as_deref();
+    if structured {
+        emit_error_json_with_prefix(
+            error_kind,
+            error_kind,
+            &err.message,
+            backup_session,
+            compact,
+        );
+    } else {
+        let msg = format_error_with_backup_hint(&err.message, backup_session);
+        eprintln!("tx: {msg}");
+    }
+    Ok(exit_code)
 }
 
 /// Execute a parsed [`Plan`] directly and return the exit code and JSON
@@ -1876,17 +2008,22 @@ pub fn execute_plan_direct(plan: Plan, cwd: &Path) -> anyhow::Result<(u8, String
             plan.version,
             crate::plan::SCHEMA_VERSION
         );
-        return Ok((exit::PARSE_ERROR, make_error_json("parse_error", &msg)));
+        return Ok((
+            exit::PARSE_ERROR,
+            make_error_json("parse_error", &msg, None),
+        ));
     }
     if let Err(e) = validate_plan_operations(&plan) {
         return Ok((
             exit::PARSE_ERROR,
-            make_error_json("parse_error", &e.to_string()),
+            make_error_json("parse_error", &e.to_string(), None),
         ));
     }
 
     // Resolve working directory (plan.cwd overrides argument).
     let effective_cwd = resolve_plan_cwd(cwd, plan.cwd.as_deref());
+    let config_strict = config_tx_strict(&effective_cwd);
+    let strict = plan::effective_strict(plan.strict, config_strict, false);
 
     // Load project config so write_policy picks up .patchloom.toml settings.
     let mut global = GlobalFlags {
@@ -1901,7 +2038,10 @@ pub fn execute_plan_direct(plan: Plan, cwd: &Path) -> anyhow::Result<(u8, String
     let result = match execute_and_collect(&plan, &effective_cwd, &global, true, true) {
         Ok(r) => r,
         Err(e) => {
-            return Ok((exit::ROLLBACK, make_error_json("rollback", &e.to_string())));
+            return Ok((
+                exit::OPERATION_FAILED,
+                make_error_json("operation_failed", &e.to_string(), None),
+            ));
         }
     };
 
@@ -1926,16 +2066,36 @@ pub fn execute_plan_direct(plan: Plan, cwd: &Path) -> anyhow::Result<(u8, String
     }
 
     // Apply: back up originals, write files.
-    commit_changes(
+    if let Err(err) = commit_changes(
         &result.changes,
         &result.deletions,
         &result.existed_before,
         &effective_cwd,
-    )?;
+    ) {
+        let error_kind = if err.rollback_ok {
+            "rollback"
+        } else {
+            "rollback_failed"
+        };
+        let exit_code = if err.rollback_ok {
+            exit::ROLLBACK
+        } else {
+            exit::FAILURE
+        };
+        return Ok((
+            exit_code,
+            make_error_json_with_prefix(
+                error_kind,
+                error_kind,
+                &err.message,
+                err.backup_session.as_deref(),
+            ),
+        ));
+    }
 
     // Run format steps, then validation steps.
     if let Some(err) = run_lifecycle(&plan, cwd, &effective_cwd) {
-        if plan.strict {
+        if strict {
             rollback_strict(
                 &result.changes,
                 &result.pending,
@@ -1945,12 +2105,12 @@ pub fn execute_plan_direct(plan: Plan, cwd: &Path) -> anyhow::Result<(u8, String
             let msg = format!("strict mode -- all changes reverted ({})", err.message);
             return Ok((
                 exit::ROLLBACK,
-                make_error_json_with_prefix(err.kind, "rollback", &msg),
+                make_error_json_with_prefix(err.kind, "rollback", &msg, None),
             ));
         }
         return Ok((
             exit::VALIDATION_FAILED,
-            make_error_json(err.kind, &err.message),
+            make_error_json(err.kind, &err.message, None),
         ));
     }
 
@@ -2005,7 +2165,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         Ok(p) => p,
         Err(e) => {
             if structured {
-                emit_error_json("parse_error", &e.to_string(), compact);
+                emit_error_json("parse_error", &e.to_string(), None, compact);
             } else {
                 eprintln!("tx: plan parse error: {e}");
             }
@@ -2020,7 +2180,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             crate::plan::SCHEMA_VERSION
         );
         if structured {
-            emit_error_json("parse_error", &msg, compact);
+            emit_error_json("parse_error", &msg, None, compact);
         } else {
             eprintln!("tx: {msg}");
         }
@@ -2029,7 +2189,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if let Err(e) = validate_plan_operations(&plan) {
         if structured {
-            emit_error_json("parse_error", &e.to_string(), compact);
+            emit_error_json("parse_error", &e.to_string(), None, compact);
         } else {
             eprintln!("tx: plan parse error: {e}");
         }
@@ -2039,6 +2199,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // 3. Resolve working directory (plan.cwd overrides global --cwd).
     let base_cwd = global.resolve_cwd()?;
     let cwd = resolve_plan_cwd(&base_cwd, plan.cwd.as_deref());
+    let config_strict = config_tx_strict(&cwd);
+    let strict = plan::effective_strict(plan.strict, config_strict, args.no_strict);
 
     if plan.cwd.is_some() && !cwd.is_dir() {
         let msg = format!(
@@ -2046,7 +2208,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             plan.cwd.as_deref().expect("plan.cwd checked above")
         );
         if structured {
-            emit_error_json("parse_error", &msg, compact);
+            emit_error_json("parse_error", &msg, None, compact);
         } else {
             eprintln!("tx: {msg}");
         }
@@ -2059,11 +2221,11 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         Err(e) => {
             let msg = e.to_string();
             if structured {
-                emit_error_json("rollback", &msg, compact);
+                emit_error_json("operation_failed", &msg, None, compact);
             } else {
                 eprintln!("tx: {msg}");
             }
-            return Ok(exit::ROLLBACK);
+            return Ok(exit::OPERATION_FAILED);
         }
     };
 
@@ -2120,12 +2282,14 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if global.apply {
-        commit_changes(
+        if let Err(err) = commit_changes(
             &result.changes,
             &result.deletions,
             &result.existed_before,
             &cwd,
-        )?;
+        ) {
+            return handle_commit_error(err, structured, compact);
+        }
 
         // Show diffs if --diff flag is set.
         if global.diff && !result.changes.is_empty() {
@@ -2134,7 +2298,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
         // 6. Run format steps, then validation steps.
         if let Some(err) = run_lifecycle(&plan, &base_cwd, &cwd) {
-            if plan.strict {
+            if strict {
                 rollback_strict(
                     &result.changes,
                     &result.pending,
@@ -2143,14 +2307,14 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 );
                 let rollback_msg = format!("strict mode -- all changes reverted ({})", err.message);
                 if structured {
-                    emit_error_json_with_prefix(err.kind, "rollback", &rollback_msg, compact);
+                    emit_error_json_with_prefix(err.kind, "rollback", &rollback_msg, None, compact);
                 } else {
                     eprintln!("tx: {rollback_msg}");
                 }
                 return Ok(exit::ROLLBACK);
             }
             if structured {
-                emit_error_json(err.kind, &err.message, compact);
+                emit_error_json(err.kind, &err.message, None, compact);
             }
             return Ok(exit::VALIDATION_FAILED);
         }
@@ -2207,13 +2371,16 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // --confirm: prompt after showing diffs, then apply if confirmed.
-    if !result.no_effective_changes && global.should_apply() {
-        commit_changes(
+    if !result.no_effective_changes
+        && global.should_apply()
+        && let Err(err) = commit_changes(
             &result.changes,
             &result.deletions,
             &result.existed_before,
             &cwd,
-        )?;
+        )
+    {
+        return handle_commit_error(err, structured, compact);
     }
 
     Ok(exit::SUCCESS)
@@ -2387,6 +2554,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2424,6 +2592,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2467,13 +2636,14 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
         global.apply = true;
 
         let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::ROLLBACK);
+        assert_eq!(code, exit::OPERATION_FAILED);
 
         // Verify no files were modified.
         assert_eq!(fs::read_to_string(&txt).unwrap(), "hello world\n");
@@ -2488,7 +2658,7 @@ mod tests {
 
     #[test]
     fn build_error_output_produces_expected_shape() {
-        let output = build_error_output("rollback", "rollback", "disk full");
+        let output = build_error_output("rollback", "rollback", "disk full", None);
         assert!(!output.ok);
         assert_eq!(output.status, "error");
         assert_eq!(output.error_kind, Some("rollback"));
@@ -2514,6 +2684,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2530,6 +2701,7 @@ mod tests {
 
         let plan_json = serde_json::json!({
             "version": "1",
+            "strict": false,
             "operations": [],
             "validate": [
                 {"cmd": shell_false(), "required": true}
@@ -2542,6 +2714,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2570,6 +2743,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2597,6 +2771,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let global = default_global();
@@ -2706,6 +2881,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2743,13 +2919,14 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
         global.apply = true;
 
         let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::ROLLBACK);
+        assert_eq!(code, exit::OPERATION_FAILED);
 
         // Verify the original file was NOT modified.
         assert_eq!(fs::read_to_string(&existing).unwrap(), "original content\n");
@@ -2845,6 +3022,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2881,6 +3059,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2914,13 +3093,14 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
         global.apply = true;
 
         let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::ROLLBACK);
+        assert_eq!(code, exit::OPERATION_FAILED);
         // Both files unchanged.
         assert_eq!(fs::read_to_string(&src).unwrap(), "source\n");
         assert_eq!(fs::read_to_string(&dst).unwrap(), "dest\n");
@@ -2950,6 +3130,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -2989,6 +3170,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -3014,6 +3196,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let global = default_global();
@@ -3049,6 +3232,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -3124,6 +3308,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -3132,8 +3317,8 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::ROLLBACK,
-            "doc.append to non-array should roll back"
+            exit::OPERATION_FAILED,
+            "doc.append to non-array should fail before commit"
         );
     }
 
@@ -3158,6 +3343,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -3166,8 +3352,8 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::ROLLBACK,
-            "doc.prepend to non-array should roll back"
+            exit::OPERATION_FAILED,
+            "doc.prepend to non-array should fail before commit"
         );
     }
 
@@ -3192,6 +3378,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -3200,8 +3387,8 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::ROLLBACK,
-            "doc.delete_where on non-array should roll back"
+            exit::OPERATION_FAILED,
+            "doc.delete_where on non-array should fail before commit"
         );
     }
 
@@ -3230,6 +3417,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -3238,8 +3426,8 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::ROLLBACK,
-            "strict plan with failing op should roll back"
+            exit::OPERATION_FAILED,
+            "strict plan with failing op should fail before commit"
         );
 
         // File should remain untouched because execution failed before any writes.
@@ -3268,6 +3456,7 @@ mod tests {
         let args = TxArgs {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
+            no_strict: false,
             write: Default::default(),
         };
         let mut global = default_global();
@@ -3276,9 +3465,35 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::ROLLBACK,
-            "invalid normalize_eol should cause rollback"
+            exit::OPERATION_FAILED,
+            "invalid normalize_eol should fail before commit"
         );
+    }
+
+    #[test]
+    fn commit_changes_rolls_back_on_mid_write_failure() {
+        let dir = TempDir::new().unwrap();
+        let f1 = dir.path().join("a.txt");
+        let blocker = dir.path().join("blocker");
+        fs::write(&f1, "original-a").unwrap();
+        fs::write(&blocker, "blocker-is-file").unwrap();
+        let f2 = blocker.join("b.txt");
+
+        let changes = vec![
+            (f1.clone(), "original-a".to_string(), "new-a".to_string()),
+            (f2.clone(), String::new(), "new-b".to_string()),
+        ];
+        let deletions = HashSet::new();
+        let existed_before: HashSet<_> = [f1.clone()].into();
+
+        let err = commit_changes(&changes, &deletions, &existed_before, dir.path()).unwrap_err();
+        assert!(err.rollback_ok, "rollback should succeed");
+        assert!(
+            err.backup_session.is_some(),
+            "backup session should be recorded"
+        );
+        assert_eq!(fs::read_to_string(&f1).unwrap(), "original-a");
+        assert!(!f2.exists());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,13 @@ pub struct ProjectConfig {
     pub write_policy: WritePolicy,
     pub exclude: Exclude,
     pub output: Output,
+    pub tx: TxConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct TxConfig {
+    pub strict: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -236,6 +243,15 @@ color = "always"
     }
 
     #[test]
+    fn find_and_load_tx_strict_override() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join(".patchloom.toml"), "[tx]\nstrict = false\n").unwrap();
+
+        let (config, _) = find_and_load(dir.path()).unwrap();
+        assert_eq!(config.tx.strict, Some(false));
+    }
+
+    #[test]
     fn find_and_load_returns_none_when_missing() {
         let dir = TempDir::new().unwrap();
         assert!(find_and_load(dir.path()).is_none());
@@ -256,6 +272,7 @@ color = "always"
             output: Output {
                 color: Some("always".into()),
             },
+            tx: TxConfig::default(),
         };
         let mut global = crate::cli::global::GlobalFlags::default();
         apply_config(&mut global, &config);

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -4,9 +4,12 @@ pub const FAILURE: u8 = 1;
 pub const CHANGES_DETECTED: u8 = 2;
 pub const NO_MATCHES: u8 = 3;
 pub const PARSE_ERROR: u8 = 4;
+/// Tx operation staging failure (`error_kind`: `operation_failed`). Same value as [`PARSE_ERROR`].
+pub const OPERATION_FAILED: u8 = 4;
 pub const AMBIGUOUS: u8 = 5;
 pub const VALIDATION_FAILED: u8 = 6;
 pub const ROLLBACK: u8 = 7;
+pub const CONFLICTS: u8 = 8;
 
 #[cfg(test)]
 mod tests {
@@ -22,5 +25,6 @@ mod tests {
         assert_eq!(AMBIGUOUS, 5);
         assert_eq!(VALIDATION_FAILED, 6);
         assert_eq!(ROLLBACK, 7);
+        assert_eq!(CONFLICTS, 8);
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1928,6 +1928,8 @@ pub mod md {
 }
 
 pub mod patch {
+    use serde::{Deserialize, Serialize};
+
     #[derive(Debug, Clone, PartialEq, Eq)]
     pub enum PatchLine {
         Context(String),
@@ -2078,6 +2080,81 @@ pub mod patch {
 
     const FUZZ_RANGE: usize = 3;
 
+    const CONFLICT_OURS: &str = "<<<<<<< patchloom (ours)";
+    const CONFLICT_SEP: &str = "=======";
+    const CONFLICT_THEIRS: &str = ">>>>>>> patch (theirs)";
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+    #[serde(rename_all = "lowercase")]
+    #[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
+    pub enum OnStale {
+        #[default]
+        Fail,
+        Merge,
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ApplyHunksOptions {
+        pub on_stale: OnStale,
+        pub allow_conflicts: bool,
+    }
+    impl Default for ApplyHunksOptions {
+        fn default() -> Self {
+            Self {
+                on_stale: OnStale::Fail,
+                allow_conflicts: false,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct ConflictRange {
+        pub start_line: usize,
+        pub end_line: usize,
+    }
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct MergeResult {
+        pub content: String,
+        pub conflicts: Vec<ConflictRange>,
+    }
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct MergeError {
+        pub message: String,
+    }
+    impl std::fmt::Display for MergeError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self.message)
+        }
+    }
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub enum ApplyHunksStatus {
+        Clean,
+        Merged,
+        Conflict,
+    }
+    impl ApplyHunksStatus {
+        pub fn as_str(self) -> &'static str {
+            match self {
+                ApplyHunksStatus::Clean => "clean",
+                ApplyHunksStatus::Merged => "merged",
+                ApplyHunksStatus::Conflict => "conflict",
+            }
+        }
+    }
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct ApplyHunksResult {
+        pub content: String,
+        pub status: ApplyHunksStatus,
+        pub conflicts: Vec<ConflictRange>,
+    }
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct PatchApplyFileResult {
+        pub path: String,
+        pub content: String,
+        pub status: ApplyHunksStatus,
+        pub conflicts: Vec<ConflictRange>,
+    }
+
     pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, String> {
         let mut src_lines: Vec<String> = original.lines().map(String::from).collect();
         let had_final_newline = original.ends_with('\n') || original.is_empty();
@@ -2149,6 +2226,290 @@ pub mod patch {
         Ok(join_lines(&src_lines, had_final_newline))
     }
 
+    pub fn apply_hunks_with_options(
+        ours: &str,
+        hunks: &[Hunk],
+        options: ApplyHunksOptions,
+    ) -> Result<ApplyHunksResult, String> {
+        match options.on_stale {
+            OnStale::Fail => {
+                let content = apply_hunks(ours, hunks)?;
+                Ok(ApplyHunksResult {
+                    content,
+                    status: ApplyHunksStatus::Clean,
+                    conflicts: Vec::new(),
+                })
+            }
+            OnStale::Merge => {
+                if let Ok(content) = apply_hunks(ours, hunks) {
+                    return Ok(ApplyHunksResult {
+                        content,
+                        status: ApplyHunksStatus::Clean,
+                        conflicts: Vec::new(),
+                    });
+                }
+                let merge_result = merge_hunks(ours, hunks).map_err(|e| e.message)?;
+                let status = if !merge_result.conflicts.is_empty() {
+                    ApplyHunksStatus::Conflict
+                } else if apply_hunks(ours, hunks).is_ok() {
+                    ApplyHunksStatus::Clean
+                } else {
+                    ApplyHunksStatus::Merged
+                };
+                if status == ApplyHunksStatus::Conflict && !options.allow_conflicts {
+                    return Err(format!(
+                        "patch merge produced {} conflict(s); pass --allow-conflicts to write conflict markers",
+                        merge_result.conflicts.len()
+                    ));
+                }
+                Ok(ApplyHunksResult {
+                    content: merge_result.content,
+                    status,
+                    conflicts: merge_result.conflicts,
+                })
+            }
+        }
+    }
+
+    pub fn merge_hunks(ours: &str, hunks: &[Hunk]) -> Result<MergeResult, MergeError> {
+        let mut src_lines: Vec<String> = ours.lines().map(String::from).collect();
+        let had_final_newline = ours.ends_with('\n') || ours.is_empty();
+        let mut offset: isize = 0;
+        let mut conflicts = Vec::new();
+        let mut output_line: usize = 1;
+        for (hunk_idx, hunk) in hunks.iter().enumerate() {
+            let expected = hunk_expected_start(hunk, offset).map_err(|msg| MergeError {
+                message: format!("hunk {} failed: {msg}", hunk_idx + 1),
+            })?;
+            let old_refs = hunk_old_refs(hunk);
+            let base_lines = hunk_base_lines(hunk);
+            let theirs_lines = hunk_theirs_lines(hunk);
+            let src_refs: Vec<&str> = src_lines.iter().map(String::as_str).collect();
+            let pos = locate_hunk_region(&src_refs, hunk, expected).ok_or_else(|| MergeError {
+                message: format!(
+                    "hunk {} failed: stale context near line {}",
+                    hunk_idx + 1,
+                    hunk.old_start
+                ),
+            })?;
+            let old_len = old_refs.len();
+            let ours_region: Vec<String> = src_lines[pos..pos + old_len].to_vec();
+            let (replacement, hunk_conflicts) =
+                if ours_region.iter().map(String::as_str).collect::<Vec<_>>() == old_refs {
+                    (theirs_lines, Vec::new())
+                } else {
+                    merge_three_way(&base_lines, &ours_region, &theirs_lines, output_line + pos)
+                };
+            conflicts.extend(hunk_conflicts);
+            let new_len = replacement.len();
+            src_lines.splice(pos..pos + old_len, replacement);
+            offset = offset.saturating_add(
+                isize::try_from(new_len).unwrap_or(isize::MAX)
+                    - isize::try_from(old_len).unwrap_or(isize::MAX),
+            );
+            output_line = output_line.saturating_add(new_len);
+        }
+        Ok(MergeResult {
+            content: join_lines(&src_lines, had_final_newline),
+            conflicts,
+        })
+    }
+
+    fn hunk_expected_start(hunk: &Hunk, offset: isize) -> Result<isize, String> {
+        if hunk.old_start == 0 {
+            Ok(0)
+        } else {
+            isize::try_from(hunk.old_start)
+                .ok()
+                .and_then(|s| s.checked_sub(1))
+                .and_then(|s| s.checked_add(offset))
+                .ok_or_else(|| format!("line number {} out of range", hunk.old_start))
+        }
+    }
+    fn hunk_old_refs(hunk: &Hunk) -> Vec<&str> {
+        hunk.lines
+            .iter()
+            .filter_map(|pl| match pl {
+                PatchLine::Context(s) | PatchLine::Remove(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect()
+    }
+    fn hunk_base_lines(hunk: &Hunk) -> Vec<String> {
+        hunk.lines
+            .iter()
+            .filter_map(|pl| match pl {
+                PatchLine::Context(s) | PatchLine::Remove(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+    fn hunk_theirs_lines(hunk: &Hunk) -> Vec<String> {
+        hunk.lines
+            .iter()
+            .filter_map(|pl| match pl {
+                PatchLine::Context(s) | PatchLine::Add(s) => Some(s.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+    fn locate_hunk_region(haystack: &[&str], hunk: &Hunk, expected: isize) -> Option<usize> {
+        let old_refs = hunk_old_refs(hunk);
+        find_match(haystack, &old_refs, expected, FUZZ_RANGE)
+            .or_else(|| find_match_global(haystack, &old_refs))
+            .or_else(|| locate_by_context_anchors(haystack, hunk, expected))
+    }
+    fn locate_by_context_anchors(haystack: &[&str], hunk: &Hunk, expected: isize) -> Option<usize> {
+        let old_refs = hunk_old_refs(hunk);
+        let base_len = old_refs.len();
+        if base_len == 0 {
+            return Some((expected.max(0) as usize).min(haystack.len()));
+        }
+        let (prefix_ctx, suffix_ctx) = hunk_context_anchors(hunk);
+        if prefix_ctx.is_empty() && suffix_ctx.is_empty() {
+            return None;
+        }
+        let prefix_refs: Vec<&str> = prefix_ctx.iter().map(String::as_str).collect();
+        let pos = if prefix_ctx.is_empty() {
+            None
+        } else {
+            find_match(haystack, &prefix_refs, expected, FUZZ_RANGE)
+                .or_else(|| find_match_global(haystack, &prefix_refs))
+        };
+        let pos = if let Some(pos) = pos {
+            pos
+        } else if !suffix_ctx.is_empty() {
+            let suffix_refs: Vec<&str> = suffix_ctx.iter().map(String::as_str).collect();
+            let suffix_expected = expected
+                .saturating_add(isize::try_from(base_len).unwrap_or(isize::MAX))
+                .saturating_sub(isize::try_from(suffix_refs.len()).unwrap_or(isize::MAX));
+            let suffix_pos = find_match(haystack, &suffix_refs, suffix_expected, FUZZ_RANGE)
+                .or_else(|| find_match_global(haystack, &suffix_refs))?;
+            suffix_pos.saturating_sub(base_len.saturating_sub(suffix_refs.len()))
+        } else {
+            return None;
+        };
+        if !suffix_ctx.is_empty() {
+            let suffix_start = pos + base_len.saturating_sub(suffix_ctx.len());
+            if suffix_start + suffix_ctx.len() > haystack.len() {
+                return None;
+            }
+            let suffix_refs: Vec<&str> = suffix_ctx.iter().map(String::as_str).collect();
+            if haystack[suffix_start..suffix_start + suffix_refs.len()] != *suffix_refs {
+                return None;
+            }
+        }
+        if pos + base_len > haystack.len() {
+            return None;
+        }
+        Some(pos)
+    }
+    fn hunk_context_anchors(hunk: &Hunk) -> (Vec<String>, Vec<String>) {
+        let mut prefix_ctx = Vec::new();
+        let mut suffix_ctx = Vec::new();
+        let mut in_change = false;
+        for pl in &hunk.lines {
+            match pl {
+                PatchLine::Context(s) if !in_change => prefix_ctx.push(s.clone()),
+                PatchLine::Remove(_) | PatchLine::Add(_) => in_change = true,
+                PatchLine::Context(s) if in_change => suffix_ctx.push(s.clone()),
+                _ => {}
+            }
+        }
+        (prefix_ctx, suffix_ctx)
+    }
+    fn merge_three_way(
+        base: &[String],
+        ours: &[String],
+        theirs: &[String],
+        region_start_line: usize,
+    ) -> (Vec<String>, Vec<ConflictRange>) {
+        if base.len() == ours.len() && base.len() == theirs.len() {
+            merge_three_way_lines(base, ours, theirs, region_start_line)
+        } else {
+            merge_three_way_block(base, ours, theirs, region_start_line)
+        }
+    }
+    fn merge_three_way_lines(
+        base: &[String],
+        ours: &[String],
+        theirs: &[String],
+        region_start_line: usize,
+    ) -> (Vec<String>, Vec<ConflictRange>) {
+        let mut out = Vec::new();
+        let mut conflicts = Vec::new();
+        let mut line_no = region_start_line;
+        for i in 0..base.len() {
+            let (b, o, t) = (&base[i], &ours[i], &theirs[i]);
+            if o == b && t == b {
+                out.push(o.clone());
+                line_no += 1;
+            } else if o == b {
+                out.push(t.clone());
+                line_no += 1;
+            } else if t == b || o == t {
+                out.push(o.clone());
+                line_no += 1;
+            } else {
+                let start = line_no;
+                out.extend([
+                    CONFLICT_OURS.to_string(),
+                    o.clone(),
+                    CONFLICT_SEP.to_string(),
+                    t.clone(),
+                    CONFLICT_THEIRS.to_string(),
+                ]);
+                conflicts.push(ConflictRange {
+                    start_line: start,
+                    end_line: start + 4,
+                });
+                line_no += 5;
+            }
+        }
+        (out, conflicts)
+    }
+    fn merge_three_way_block(
+        base: &[String],
+        ours: &[String],
+        theirs: &[String],
+        region_start_line: usize,
+    ) -> (Vec<String>, Vec<ConflictRange>) {
+        if ours == base {
+            return (theirs.to_vec(), Vec::new());
+        }
+        if theirs == base {
+            return (ours.to_vec(), Vec::new());
+        }
+        if ours == theirs {
+            return (ours.to_vec(), Vec::new());
+        }
+        let start = region_start_line;
+        let mut out = vec![CONFLICT_OURS.to_string()];
+        out.extend(ours.iter().cloned());
+        out.push(CONFLICT_SEP.to_string());
+        out.extend(theirs.iter().cloned());
+        out.push(CONFLICT_THEIRS.to_string());
+        let end = start + out.len().saturating_sub(1);
+        (
+            out,
+            vec![ConflictRange {
+                start_line: start,
+                end_line: end,
+            }],
+        )
+    }
+    fn find_match_global(haystack: &[&str], needle: &[&str]) -> Option<usize> {
+        if needle.is_empty() {
+            return Some(0);
+        }
+        let max_start = haystack.len().saturating_sub(needle.len());
+        for pos in 0..=max_start {
+            if haystack[pos..pos + needle.len()] == *needle {
+                return Some(pos);
+            }
+        }
+        None
+    }
     fn join_lines(lines: &[String], final_newline: bool) -> String {
         if lines.is_empty() {
             return String::new();
@@ -2201,7 +2562,8 @@ pub mod patch {
     pub(crate) fn apply_patch_with_loader<F>(
         diff_text: &str,
         mut load_original: F,
-    ) -> anyhow::Result<Vec<(String, String)>>
+        options: ApplyHunksOptions,
+    ) -> anyhow::Result<Vec<PatchApplyFileResult>>
     where
         F: FnMut(&str) -> anyhow::Result<String>,
     {
@@ -2210,9 +2572,14 @@ pub mod patch {
         let mut results = Vec::new();
         for pf in &patch_files {
             let original = load_original(&pf.path)?;
-            let patched = apply_hunks(&original, &pf.hunks)
+            let applied = apply_hunks_with_options(&original, &pf.hunks, options)
                 .map_err(|msg| anyhow::anyhow!("patch apply: {} -- {msg}", pf.path))?;
-            results.push((pf.path.clone(), patched));
+            results.push(PatchApplyFileResult {
+                path: pf.path.clone(),
+                content: applied.content,
+                status: applied.status,
+                conflicts: applied.conflicts,
+            });
         }
         Ok(results)
     }
@@ -3697,14 +4064,18 @@ mod tests {
 +WORLD
  end
 ";
-            let results = apply_patch_with_loader(diff, |path| {
-                assert_eq!(path, "test.txt");
-                Ok("hello\nworld\nend\n".to_string())
-            })
+            let results = apply_patch_with_loader(
+                diff,
+                |path| {
+                    assert_eq!(path, "test.txt");
+                    Ok("hello\nworld\nend\n".to_string())
+                },
+                ApplyHunksOptions::default(),
+            )
             .unwrap();
             assert_eq!(results.len(), 1);
-            assert_eq!(results[0].0, "test.txt");
-            assert_eq!(results[0].1, "hello\nWORLD\nend\n");
+            assert_eq!(results[0].path, "test.txt");
+            assert_eq!(results[0].content, "hello\nWORLD\nend\n");
         }
 
         #[test]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -202,8 +202,11 @@ pub enum Operation {
     },
     #[serde(rename = "patch.apply", alias = "apply_patch")]
     PatchApply {
-        /// Inline diff text to apply.
         diff: String,
+        #[serde(default)]
+        on_stale: crate::ops::patch::OnStale,
+        #[serde(default)]
+        allow_conflicts: bool,
     },
     #[serde(rename = "search", alias = "search_files")]
     Search {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -5,6 +5,25 @@ use serde::{Deserialize, Serialize};
 /// Current plan schema version.
 pub const SCHEMA_VERSION: &str = "1";
 
+fn default_strict_true() -> bool {
+    true
+}
+
+/// Resolve effective strict mode: `--no-strict` > plan field > config > default true.
+pub fn effective_strict(
+    plan_strict: Option<bool>,
+    config_strict: Option<bool>,
+    no_strict: bool,
+) -> bool {
+    if no_strict {
+        false
+    } else {
+        plan_strict
+            .or(config_strict)
+            .unwrap_or_else(default_strict_true)
+    }
+}
+
 /// A transaction plan containing multiple operations to execute atomically.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Plan {
@@ -12,8 +31,9 @@ pub struct Plan {
     pub version: String,
     pub cwd: Option<String>,
     pub write_policy: Option<PlanWritePolicy>,
+    /// When omitted from the plan, defaults to strict mode at execution time.
     #[serde(default)]
-    pub strict: bool,
+    pub strict: Option<bool>,
     pub operations: Vec<Operation>,
     pub format: Option<Vec<FormatStep>>,
     pub validate: Option<Vec<ValidationStep>>,
@@ -454,6 +474,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_plan_defaults_strict_when_omitted() {
+        let json = r#"{"version": "1", "operations": [{"op": "replace", "from": "a", "to": "b"}]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert_eq!(plan.strict, None);
+        assert!(effective_strict(plan.strict, None, false));
+    }
+
+    #[test]
     fn parse_plan_strict_and_all_policy_fields() {
         let json = r#"{
             "version": "1",
@@ -469,7 +497,7 @@ mod tests {
             "validate": [{"cmd": "check", "required": true, "timeout": 120}]
         }"#;
         let plan = parse_plan(json).unwrap();
-        assert!(plan.strict);
+        assert_eq!(plan.strict, Some(true));
         let wp = plan.write_policy.unwrap();
         assert_eq!(wp.ensure_final_newline, Some(true));
         assert_eq!(wp.normalize_eol.as_deref(), Some("crlf"));

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -443,12 +443,14 @@ pub fn operation_schemas() -> Vec<OperationSchema> {
         },
         OperationSchema {
             name: "patch.apply".into(),
-            description: "Apply a unified diff patch to one or more files.".into(),
+            description: "Apply a unified diff patch to one or more files. Supports three-way merge on stale context.".into(),
             parameters: serde_json::json!({
                 "type": "object",
                 "required": ["diff"],
                 "properties": {
-                    "diff": {"type": "string", "description": "Unified diff text."}
+                    "diff": {"type": "string", "description": "Unified diff text."},
+                    "on_stale": {"type": "string", "enum": ["fail", "merge"], "default": "fail"},
+                    "allow_conflicts": {"type": "boolean", "default": false}
                 }
             }),
             min_tier: Tier::Medium,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4489,6 +4489,85 @@ fn test_patch_check_exits_5_when_stale() {
 }
 
 #[test]
+fn test_patch_merge_check_exits_8_on_conflict() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
+    let patch_file = dir.path().join("stale.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
+    )
+    .unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("merge")
+        .arg(&patch_file)
+        .arg("--check")
+        .assert()
+        .code(8);
+}
+
+#[test]
+fn test_patch_merge_apply_writes_clean_merge() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\nold line\nline3\nextra\n").unwrap();
+    let patch_file = dir.path().join("change.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
+    )
+    .unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("merge")
+        .arg(&patch_file)
+        .arg("--apply")
+        .assert()
+        .code(0);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line1\nnew line\nline3\nextra\n"
+    );
+}
+
+#[test]
+fn test_patch_apply_on_stale_merge() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\nold line\nline3\nextra\n").unwrap();
+    let patch_file = dir.path().join("change.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
+    )
+    .unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--on-stale")
+        .arg("merge")
+        .arg("--apply")
+        .assert()
+        .code(0);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line1\nnew line\nline3\nextra\n"
+    );
+}
+
+#[test]
 fn test_patch_check_exits_5_on_directory_read_error() {
     let dir = TempDir::new().unwrap();
     let target = dir.path().join("test.txt");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3711,12 +3711,12 @@ fn test_tx_rollback_on_failure() {
         .arg(&plan_file)
         .arg("--apply")
         .assert()
-        .code(7);
+        .code(4);
 
     let txt_content = fs::read_to_string(&txt_file).unwrap();
     assert_eq!(
         txt_content, "hello world\n",
-        "file should not be modified on rollback"
+        "file should not be modified on operation failure"
     );
 }
 
@@ -3749,14 +3749,51 @@ fn test_tx_rollback_preserves_original_content() {
         .arg(&plan_file)
         .arg("--apply")
         .assert()
-        .code(7); // ROLLBACK
+        .code(4); // OPERATION_FAILED
 
-    // a.json should be unchanged (rolled back).
+    // a.json should be unchanged (no writes occurred).
     let content = fs::read_to_string(&file_a).unwrap();
     assert_eq!(
         content, r#"{"key": "original"}"#,
         "a.json should be rolled back"
     );
+}
+
+#[test]
+fn test_tx_mid_commit_failure_rolls_back() {
+    let dir = TempDir::new().unwrap();
+    let good = dir.path().join("good.txt");
+    fs::write(&good, "original\n").unwrap();
+    let blocker = dir.path().join("blocker");
+    fs::write(&blocker, "not-a-directory").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [
+            {"op": "file.create", "path": "good.txt", "content": "changed\n", "force": true},
+            {"op": "file.create", "path": "blocker/child.txt", "content": "fail\n"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(7)); // ROLLBACK after mid-commit failure
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "rollback");
+    assert!(json["backup_session"].is_string());
+    assert_eq!(fs::read_to_string(&good).unwrap(), "original\n");
+    assert!(!dir.path().join("blocker/child.txt").exists());
 }
 
 #[test]
@@ -6874,7 +6911,7 @@ fn test_tx_file_delete_directory_target_fails() {
         .arg("tx")
         .arg(&plan_file)
         .assert()
-        .code(7)
+        .code(4)
         .stderr(predicate::str::contains("target is not a file"));
 
     assert!(target.is_dir(), "directory should remain in place");
@@ -7248,6 +7285,7 @@ fn test_tx_validate_required_failure_exits_6() {
 
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [
             {"op": "replace", "path": "test.txt", "from": "old", "to": "new"}
         ],
@@ -7471,7 +7509,7 @@ fn test_tx_file_rename_directory_source_fails() {
         .arg("tx")
         .arg(&plan_file)
         .assert()
-        .code(7)
+        .code(4)
         .stderr(predicate::str::contains("source is not a file"));
 
     assert!(src.is_dir(), "source directory should remain in place");
@@ -7535,8 +7573,8 @@ fn test_tx_file_rename_fails_if_dst_exists() {
         .output()
         .unwrap();
 
-    // Should roll back (exit 7).
-    assert_eq!(output.status.code(), Some(7));
+    // Operation fails before commit (exit 4).
+    assert_eq!(output.status.code(), Some(4));
     // Both files should be untouched.
     assert_eq!(
         fs::read_to_string(dir.path().join("old.txt")).unwrap(),
@@ -7602,7 +7640,7 @@ fn test_tx_file_rename_force_directory_destination_fails_in_dry_run() {
         .arg("tx")
         .arg(&plan_file)
         .assert()
-        .code(7)
+        .code(4)
         .stderr(predicate::str::contains("destination is not a file"));
 
     assert!(dir.path().join("old.txt").is_file());
@@ -7632,7 +7670,7 @@ fn test_tx_file_rename_force_directory_destination_fails_in_check_mode() {
         .arg(&plan_file)
         .arg("--check")
         .assert()
-        .code(7)
+        .code(4)
         .stderr(predicate::str::contains("destination is not a file"));
 
     assert!(dir.path().join("old.txt").is_file());
@@ -7662,7 +7700,7 @@ fn test_tx_file_rename_force_directory_destination_fails_in_apply_mode() {
         .arg(&plan_file)
         .arg("--apply")
         .assert()
-        .code(7)
+        .code(4)
         .stderr(predicate::str::contains("destination is not a file"));
 
     assert!(dir.path().join("old.txt").is_file());
@@ -8508,7 +8546,7 @@ fn test_explain_json_output() {
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["operation_count"], 1);
-    assert_eq!(json["strict"], false);
+    assert_eq!(json["strict"], true);
     assert!(json["has_write_policy"].is_boolean());
     assert_eq!(json["format_steps"], 0);
     assert_eq!(json["validate_steps"], 0);
@@ -9727,7 +9765,7 @@ fn test_tx_file_create_force_directory_target_fails() {
         .arg("tx")
         .arg(plan_file.to_str().unwrap())
         .assert()
-        .code(7)
+        .code(4)
         .stderr(predicate::str::contains("target is not a file"));
 
     assert!(target.is_dir(), "directory should remain in place");
@@ -9785,7 +9823,7 @@ fn test_tx_file_create_without_force_fails_on_existing() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(7); // ROLLBACK
+        .code(4); // OPERATION_FAILED
 
     assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
 }
@@ -9879,7 +9917,7 @@ fn test_tx_doc_set_unsupported_format_rolls_back() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(7); // ROLLBACK
+        .code(4); // OPERATION_FAILED
 
     // Original content must be preserved.
     assert_eq!(
@@ -10487,7 +10525,7 @@ fn test_tx_md_replace_section_nonexistent_file_rolls_back() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(7); // ROLLBACK
+        .code(4); // OPERATION_FAILED
 }
 
 #[test]
@@ -10514,7 +10552,7 @@ fn test_tx_md_replace_section_missing_heading_rolls_back() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(7); // ROLLBACK
+        .code(4); // OPERATION_FAILED
 
     // Original content must be preserved.
     assert_eq!(
@@ -11044,6 +11082,7 @@ fn test_tx_validate_timeout_kills_hanging_command() {
 
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -11077,6 +11116,7 @@ fn test_tx_format_timeout_kills_hanging_command() {
 
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -12038,9 +12078,10 @@ fn test_tx_json_output_on_operation_failure() {
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(7)); // ROLLBACK
+    assert_eq!(output.status.code(), Some(4)); // OPERATION_FAILED
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "operation_failed");
     assert!(
         json["error"]
             .as_str()
@@ -12223,6 +12264,7 @@ fn test_tx_validation_failure_redacts_shell_command_in_stderr() {
     let secret = "TOKEN=super-secret-value";
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -12261,6 +12303,7 @@ fn test_tx_json_output_on_validation_failure_redacts_shell_command() {
     let secret = "TOKEN=super-secret-value";
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -12303,6 +12346,7 @@ fn test_tx_json_output_on_validation_failure() {
 
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -12456,6 +12500,7 @@ fn test_tx_non_strict_format_failure_exits_6_not_7() {
 
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -12490,6 +12535,7 @@ fn test_tx_format_failure_redacts_shell_command_in_stderr() {
     let secret = "TOKEN=super-secret-value";
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -12527,6 +12573,7 @@ fn test_tx_json_output_on_format_failure_redacts_shell_command() {
     let secret = "TOKEN=super-secret-value";
     let plan = serde_json::json!({
             "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -13060,7 +13107,7 @@ fn test_tx_doc_prepend_on_non_array_rolls_back() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(7); // ROLLBACK
+        .code(4); // OPERATION_FAILED
 
     // Original content unchanged.
     assert_eq!(
@@ -13093,7 +13140,7 @@ fn test_tx_doc_update_no_match_rolls_back() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(7); // ROLLBACK
+        .code(4); // OPERATION_FAILED
 }
 
 #[test]
@@ -13953,7 +14000,7 @@ fn test_batch_nonexistent_target_file_rollback() {
         .arg(&ops)
         .arg("--apply")
         .assert()
-        .code(7); // ROLLBACK
+        .code(4); // OPERATION_FAILED
 }
 
 #[test]
@@ -14172,6 +14219,7 @@ fn test_tx_json_output_reports_lifecycle_cwd_for_relative_plan_cwd() {
 
     let plan = serde_json::json!({
         "version": "1",
+        "strict": false,
         "cwd": "nested",
         "operations": [{
             "op": "file.create",
@@ -14302,6 +14350,7 @@ fn test_tx_lifecycle_stderr_captured_in_validation_error() {
     let stderr_cmd = "echo 'CUSTOM_ERROR: something went wrong' >&2 && exit 1";
     let plan = serde_json::json!({
         "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -14345,6 +14394,7 @@ fn test_tx_lifecycle_stderr_captured_in_format_error() {
     let stderr_cmd = "echo 'FMT_FAIL: bad formatting' >&2 && exit 1";
     let plan = serde_json::json!({
         "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),
@@ -14389,6 +14439,7 @@ fn test_tx_lifecycle_stderr_truncated_when_exceeding_limit() {
     let stderr_cmd = "for i in 1 2 3 4 5 6 7 8 9 10; do echo \"LONGLINE_${i}_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\" >&2; done && exit 1";
     let plan = serde_json::json!({
         "version": "1",
+        "strict": false,
         "operations": [{
             "op": "replace",
             "path": file.to_str().unwrap(),


### PR DESCRIPTION
## Summary

Harden transaction rollback defaults and add three-way patch merge for stale diffs. Implements #580 and #581 in one stack.

## #580: Tx rollback hardening

- `strict` defaults to `true` (plan parsing, MCP `make_plan`, batch)
- Optional `[tx] strict = false` in `.patchloom.toml`; CLI `--no-strict` override
- Transactional `commit_changes`: backup finalized before writes; auto-restore on mid-commit failure
- Clearer exit semantics: staging failures exit 4 (`operation_failed`); rollback exit 7; incomplete rollback exit 1 (`rollback_failed`)
- MCP write tools accept optional `strict` parameter (default true)
- Docs and CHANGELOG updated for breaking default

## #581: Three-way patch merge

- `patchloom patch merge` subcommand with `--check`, `--apply`, `--allow-conflicts`
- `--on-stale merge` on `patch apply` for auto-fallback
- Core `merge_hunks()` in `ops::patch` with standard conflict markers
- `PatchApply` plan op and MCP `apply_patch` support `on_stale` and `allow_conflicts`
- New exit code 8 (`CONFLICTS`) when conflicts block apply
- Unit, integration, and MCP tests

## Validation

```bash
make check
```

770 unit + 661 integration tests passing.

Closes #580
Closes #581