### PR TITLE
test: cover default strict and --no-strict CLI paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1431%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1433%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1431 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1433 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -129,6 +129,7 @@ Every command returns a specific exit code:
 | 5 | Ambiguous (multiple replace matches, or stale patch context) |
 | 6 | Validation failed (writes may remain) |
 | 7 | Rollback (strict mode, no writes remain) |
+| 8 | Patch merge conflicts detected (apply blocked unless `--allow-conflicts`) |
 
 These codes let CI pipelines and agent frameworks branch on outcomes without parsing output.
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -482,6 +482,8 @@ mod tests {
         let plan = parse_plan(json).unwrap();
         assert_eq!(plan.strict, None);
         assert!(effective_strict(plan.strict, None, false));
+        assert!(!effective_strict(plan.strict, None, true));
+        assert!(!effective_strict(Some(true), None, true));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -12572,6 +12572,71 @@ fn test_tx_strict_mode_restores_deleted_file_on_failure() {
 }
 
 #[test]
+fn test_tx_default_strict_reverts_on_format_failure() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "original",
+            "to": "changed"
+        }],
+        "format": [{
+            "cmd": shell_exit_1()
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(7);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
+}
+
+#[test]
+fn test_tx_no_strict_cli_overrides_default_on_format_failure() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "original",
+            "to": "changed"
+        }],
+        "format": [{
+            "cmd": shell_exit_1()
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .arg("--no-strict")
+        .assert()
+        .code(6);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "changed\n");
+}
+
+#[test]
 fn test_tx_non_strict_format_failure_exits_6_not_7() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary

Multi-perspective QA pass after merging #580/#581 (#587).

## Changes

- Integration tests: default strict rollback when `strict` omitted; `--no-strict` CLI override exits 6 with writes retained
- `docs/getting-started/concepts.md`: document exit code 8 (`CONFLICTS`)
- Unit test: `effective_strict` honors `--no-strict` over plan field

## Validation

```bash
make check
```

663 integration + 770 unit tests passing.