### PR TITLE
test: improvement cycle 17 — patch merge coverage and docs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -91,6 +91,9 @@ normalize_eol = "lf"
 trim_trailing_whitespace = true
 collapse_blanks = true
 
+[tx]
+strict = false
+
 [exclude]
 globs = ["target/**", "node_modules/**"]
 ```
@@ -176,13 +179,14 @@ dependencies[name=react].version # predicate filter
 | Code | Meaning |
 |------|---------|
 | 0 | Success (operation completed, or no changes needed) |
-| 1 | Failure (error during execution) |
+| 1 | Failure (error during execution), or tx `rollback_failed` when mid-commit rollback could not fully restore files |
 | 2 | Changes detected (`--check` mode found pending changes) |
 | 3 | No matches (search/replace found nothing matching the pattern) |
 | 4 | Parse error (malformed input file or plan), or tx operation staging failure (`operation_failed`) |
 | 5 | Ambiguous (replacement matched multiple locations without `--nth`, or stale/missing patch context) |
-| 6 | Validation failed (tx plan validation step returned non-zero) |
-| 7 | Rollback (tx commit or strict lifecycle failure; changes were rolled back) |
+| 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |
+| 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |
+| 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1433%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1438%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1433 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1438 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -109,11 +109,13 @@ The `tx` command runs multiple operations atomically. If any operation fails dur
 
 Plans are JSON objects with three lifecycle arrays:
 
-1. **operations** -- the mutations (replace, doc.set, md.replace_section, etc.)
+1. **operations** -- the mutations (replace, doc.set, md.replace_section, `patch.apply`, etc.)
 2. **format** -- shell commands that run after writes (e.g., `cargo fmt`)
 3. **validate** -- shell commands that verify correctness (e.g., `make check`)
 
-Strict mode defaults to on. Use `"strict": false` in the plan, `[tx] strict = false` in `.patchloom.toml`, or `patchloom tx --no-strict` to keep writes on disk when format/validate fails (exit 6). With strict mode, a format or validation failure reverts all writes (exit 7).
+`patch.apply` operations accept `on_stale: "merge"` for three-way merge when the on-disk file diverged from the patch base, and `allow_conflicts: true` to write conflict markers instead of failing.
+
+Strict mode defaults to on. Use `"strict": false` in the plan, `[tx] strict = false` in `.patchloom.toml`, or `patchloom tx --no-strict` to keep writes on disk when format/validate fails (exit 6). With strict mode, a format or validation failure reverts all writes (exit 7). If a write fails mid-commit, patchloom restores already-written files from the backup session (exit 7 `rollback`, or exit 1 `rollback_failed` if restore is incomplete).
 
 ## Exit codes
 
@@ -122,7 +124,7 @@ Every command returns a specific exit code:
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | General error |
+| 1 | General error, or tx `rollback_failed` when mid-commit rollback could not fully restore files |
 | 2 | Changes detected (with `--check`) |
 | 3 | No matches found |
 | 4 | Parse error in input, or tx operation staging failure (`operation_failed`) |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -967,6 +967,6 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:patch.apply -->
 ### `patch.apply`
 
-- **What it does:** Applies a unified diff inside a transaction.
-- **Use when:** Patch replay needs to compose with earlier in plan edits and share the same rollback or validation behavior.
-- **Related:** top level `patch apply`
+- **What it does:** Applies a unified diff inside a transaction. Supports `on_stale: "merge"` for three-way merge when the on-disk file diverged from the patch base, and `allow_conflicts: true` to write conflict markers instead of failing during staging.
+- **Use when:** Patch replay needs to compose with earlier in-plan edits and share the same rollback or validation behavior.
+- **Related:** top level `patch apply`, `patch merge`

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -288,6 +288,9 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              trim_trailing_whitespace = true\n\
              collapse_blanks = true\n\
              \n\
+             [tx]\n\
+             strict = false\n\
+             \n\
              [exclude]\n\
              globs = [\"target/**\", \"node_modules/**\"]\n\
              ```\n\n\
@@ -380,13 +383,14 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Code | Meaning |\n\
              |------|---------|\n\
              | 0 | Success (operation completed, or no changes needed) |\n\
-             | 1 | Failure (error during execution) |\n\
+             | 1 | Failure (error during execution), or tx `rollback_failed` when mid-commit rollback could not fully restore files |\n\
              | 2 | Changes detected (`--check` mode found pending changes) |\n\
              | 3 | No matches (search/replace found nothing matching the pattern) |\n\
              | 4 | Parse error (malformed input file or plan), or tx operation staging failure (`operation_failed`) |\n\
              | 5 | Ambiguous (replacement matched multiple locations without `--nth`, or stale/missing patch context) |\n\
-             | 6 | Validation failed (tx plan validation step returned non-zero) |\n\
-             | 7 | Rollback (tx commit or strict lifecycle failure; changes were rolled back) |\n\n",
+             | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |\n\
+             | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |\n\
+             | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |\n\n",
         );
     }
 
@@ -620,6 +624,14 @@ mod tests {
         assert!(out.contains("## Project configuration"));
         assert!(out.contains(".patchloom.toml"));
         assert!(out.contains("collapse_blanks"));
+        assert!(out.contains("[tx]"));
+    }
+
+    #[test]
+    fn agent_rules_exit_codes_include_conflicts_and_rollback_failed() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(out.contains("| 8 |"));
+        assert!(out.contains("rollback_failed"));
     }
 
     #[test]

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -3490,6 +3490,17 @@ mod tests {
     }
 
     #[test]
+    fn handle_commit_error_rollback_failed_exits_failure() {
+        let err = CommitError {
+            message: "write failed".into(),
+            rollback_ok: false,
+            backup_session: Some("1234567890".into()),
+        };
+        let code = handle_commit_error(err, true, false).unwrap();
+        assert_eq!(code, exit::FAILURE);
+    }
+
+    #[test]
     fn commit_changes_rolls_back_on_mid_write_failure() {
         let dir = TempDir::new().unwrap();
         let f1 = dir.path().join("a.txt");

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -484,6 +484,8 @@ mod tests {
         assert!(effective_strict(plan.strict, None, false));
         assert!(!effective_strict(plan.strict, None, true));
         assert!(!effective_strict(Some(true), None, true));
+        assert!(!effective_strict(None, Some(false), false));
+        assert!(effective_strict(Some(true), Some(false), false));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11154,6 +11154,70 @@ fn test_tx_patch_apply_uses_pending_file_state() {
 }
 
 #[test]
+fn test_tx_patch_apply_on_stale_merge() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\nold line\nline3\nextra\n").unwrap();
+
+    let diff =
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n";
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "patch.apply",
+            "diff": diff,
+            "on_stale": "merge"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line1\nnew line\nline3\nextra\n"
+    );
+}
+
+#[test]
+fn test_tx_patch_apply_merge_conflict_without_allow_conflicts() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
+
+    let diff =
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n";
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "patch.apply",
+            "diff": diff,
+            "on_stale": "merge"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(4); // OPERATION_FAILED during staging
+}
+
+#[test]
 fn test_tx_validate_timeout_kills_hanging_command() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -16695,6 +16759,36 @@ async fn test_mcp_patch_round_trip() {
     assert_eq!(
         fs::read_to_string(dir.path().join("target.txt")).unwrap(),
         "new line\n"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_apply_patch_on_stale_merge() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("target.txt"),
+        "line1\nold line\nline3\nextra\n",
+    )
+    .unwrap();
+
+    let diff = "--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n";
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "apply_patch",
+        serde_json::json!({"diff": diff, "on_stale": "merge"}),
+    )
+    .await;
+    assert!(!is_error, "patch merge should succeed: {text}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("target.txt")).unwrap(),
+        "line1\nnew line\nline3\nextra\n"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 17 after #587/#588 landed on main.

- **QA:** Integration tests for `patch.apply` with `on_stale: merge` in tx plans and MCP `apply_patch`; staging failure when merge conflicts lack `allow_conflicts`; unit test for `rollback_failed` exit code
- **Developer:** Unit test for `effective_strict` config precedence
- **End user / Spec:** Agent-rules exit code table now includes 8 (`CONFLICTS`) and `rollback_failed`; concepts.md and reference docs document `on_stale`/`allow_conflicts`; `[tx] strict` in config example

## Test plan

- [x] `make check` (772 unit + 666 integration)