### PR TITLE
test: cover rollback_failed and MCP patch conflict paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1438%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1441%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1438 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1441 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1868,6 +1868,21 @@ fn commit_error(message: impl Into<String>) -> CommitError {
     }
 }
 
+/// When true, [`restore_after_failed_commit`] reports failure. Test-only; never
+/// set in production.
+#[doc(hidden)]
+pub static FORCE_RESTORE_FAIL: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Restore files from a backup session after a failed commit. Returns `true`
+/// when restore completed successfully.
+fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
+    if FORCE_RESTORE_FAIL.load(std::sync::atomic::Ordering::SeqCst) {
+        return false;
+    }
+    crate::backup::restore_session(cwd, timestamp).is_ok()
+}
+
 /// Apply pending changes to disk: backup originals, write modified files,
 /// delete removed files, finalize backup session.
 ///
@@ -1935,7 +1950,7 @@ fn commit_changes(
 
     if let Err(e) = write_result {
         let rollback_ok = if let Some(ref ts) = backup_session {
-            crate::backup::restore_session(cwd, ts).is_ok()
+            restore_after_failed_commit(cwd, ts)
         } else {
             true
         };
@@ -3498,6 +3513,31 @@ mod tests {
         };
         let code = handle_commit_error(err, true, false).unwrap();
         assert_eq!(code, exit::FAILURE);
+    }
+
+    #[test]
+    fn commit_changes_reports_rollback_failed_when_restore_fails() {
+        let dir = TempDir::new().unwrap();
+        let f1 = dir.path().join("a.txt");
+        let blocker = dir.path().join("blocker");
+        fs::write(&f1, "original-a").unwrap();
+        fs::write(&blocker, "blocker-is-file").unwrap();
+        let f2 = blocker.join("b.txt");
+
+        let changes = vec![
+            (f1.clone(), "original-a".to_string(), "new-a".to_string()),
+            (f2.clone(), String::new(), "new-b".to_string()),
+        ];
+        let deletions = HashSet::new();
+        let existed_before: HashSet<_> = [f1.clone()].into();
+
+        FORCE_RESTORE_FAIL.store(true, std::sync::atomic::Ordering::SeqCst);
+        let err = commit_changes(&changes, &deletions, &existed_before, dir.path()).unwrap_err();
+        FORCE_RESTORE_FAIL.store(false, std::sync::atomic::Ordering::SeqCst);
+
+        assert!(!err.rollback_ok, "restore should be reported as failed");
+        assert!(err.backup_session.is_some());
+        assert_eq!(fs::read_to_string(&f1).unwrap(), "new-a");
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3796,6 +3796,37 @@ fn test_tx_mid_commit_failure_rolls_back() {
     assert!(!dir.path().join("blocker/child.txt").exists());
 }
 
+/// End-to-end tx path when mid-commit restore cannot complete (exit 1,
+/// `rollback_failed`). Uses [`patchloom::cmd::tx::FORCE_RESTORE_FAIL`] (test
+/// builds only) because racing filesystem permissions against restore is unreliable.
+#[test]
+fn test_tx_rollback_failed_when_restore_incomplete() {
+    use std::sync::atomic::Ordering;
+    let dir = TempDir::new().unwrap();
+    let good = dir.path().join("good.txt");
+    fs::write(&good, "original\n").unwrap();
+    let blocker = dir.path().join("blocker");
+    fs::write(&blocker, "not-a-directory").unwrap();
+
+    let plan: patchloom::plan::Plan = serde_json::from_value(serde_json::json!({
+        "version": "1",
+        "operations": [
+            {"op": "file.create", "path": "good.txt", "content": "changed\n", "force": true},
+            {"op": "file.create", "path": "blocker/child.txt", "content": "fail\n"}
+        ]
+    }))
+    .unwrap();
+
+    patchloom::cmd::tx::FORCE_RESTORE_FAIL.store(true, Ordering::SeqCst);
+    let (code, json_str) = patchloom::cmd::tx::execute_plan_direct(plan, dir.path()).unwrap();
+    patchloom::cmd::tx::FORCE_RESTORE_FAIL.store(false, Ordering::SeqCst);
+
+    assert_eq!(code, 1, "json: {json_str}");
+    let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+    assert_eq!(json["error_kind"], "rollback_failed");
+    assert!(json["backup_session"].is_string());
+}
+
 #[test]
 fn test_tx_success_applies_all() {
     let dir = TempDir::new().unwrap();
@@ -16789,6 +16820,43 @@ async fn test_mcp_apply_patch_on_stale_merge() {
     assert_eq!(
         fs::read_to_string(dir.path().join("target.txt")).unwrap(),
         "line1\nnew line\nline3\nextra\n"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_apply_patch_merge_conflict_rejected_without_allow_conflicts() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("target.txt"),
+        "line1\ncompletely different\nline3\n",
+    )
+    .unwrap();
+
+    let diff = "--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n";
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "apply_patch",
+        serde_json::json!({"diff": diff, "on_stale": "merge"}),
+    )
+    .await;
+    assert!(
+        is_error,
+        "conflicting merge without allow_conflicts should fail: {text}"
+    );
+    assert!(
+        !text.contains("<<<<<<<"),
+        "conflict markers must not be written: {text}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("target.txt")).unwrap(),
+        "line1\ncompletely different\nline3\n"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
Fixes #589, #590.

## Summary

- **#589:** End-to-end `rollback_failed` coverage via `execute_plan_direct` and a `commit_changes` unit test. Uses a `FORCE_RESTORE_FAIL` test hook because racing filesystem permissions against restore is unreliable across platforms.
- **#590:** MCP `apply_patch` integration test verifying merge conflicts are rejected when `allow_conflicts` is false.

## Test plan

- [x] `make check` (773 unit + 668 integration)