### PR TITLE
refactor: add RestoreFailGuard for rollback_failed test hook

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1874,6 +1874,23 @@ fn commit_error(message: impl Into<String>) -> CommitError {
 pub static FORCE_RESTORE_FAIL: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
+/// RAII guard that forces restore failure for tests using [`FORCE_RESTORE_FAIL`].
+#[doc(hidden)]
+pub struct RestoreFailGuard;
+
+impl RestoreFailGuard {
+    pub fn engage() -> Self {
+        FORCE_RESTORE_FAIL.store(true, std::sync::atomic::Ordering::SeqCst);
+        Self
+    }
+}
+
+impl Drop for RestoreFailGuard {
+    fn drop(&mut self) {
+        FORCE_RESTORE_FAIL.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
 /// Restore files from a backup session after a failed commit. Returns `true`
 /// when restore completed successfully.
 fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
@@ -3531,9 +3548,8 @@ mod tests {
         let deletions = HashSet::new();
         let existed_before: HashSet<_> = [f1.clone()].into();
 
-        FORCE_RESTORE_FAIL.store(true, std::sync::atomic::Ordering::SeqCst);
+        let _guard = RestoreFailGuard::engage();
         let err = commit_changes(&changes, &deletions, &existed_before, dir.path()).unwrap_err();
-        FORCE_RESTORE_FAIL.store(false, std::sync::atomic::Ordering::SeqCst);
 
         assert!(!err.rollback_ok, "restore should be reported as failed");
         assert!(err.backup_session.is_some());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3797,11 +3797,10 @@ fn test_tx_mid_commit_failure_rolls_back() {
 }
 
 /// End-to-end tx path when mid-commit restore cannot complete (exit 1,
-/// `rollback_failed`). Uses [`patchloom::cmd::tx::FORCE_RESTORE_FAIL`] (test
-/// builds only) because racing filesystem permissions against restore is unreliable.
+/// `rollback_failed`). Uses [`patchloom::cmd::tx::RestoreFailGuard`] because
+/// racing filesystem permissions against restore is unreliable.
 #[test]
 fn test_tx_rollback_failed_when_restore_incomplete() {
-    use std::sync::atomic::Ordering;
     let dir = TempDir::new().unwrap();
     let good = dir.path().join("good.txt");
     fs::write(&good, "original\n").unwrap();
@@ -3817,9 +3816,8 @@ fn test_tx_rollback_failed_when_restore_incomplete() {
     }))
     .unwrap();
 
-    patchloom::cmd::tx::FORCE_RESTORE_FAIL.store(true, Ordering::SeqCst);
+    let _guard = patchloom::cmd::tx::RestoreFailGuard::engage();
     let (code, json_str) = patchloom::cmd::tx::execute_plan_direct(plan, dir.path()).unwrap();
-    patchloom::cmd::tx::FORCE_RESTORE_FAIL.store(false, Ordering::SeqCst);
 
     assert_eq!(code, 1, "json: {json_str}");
     let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();


### PR DESCRIPTION
## Summary

MPI cycle 18 (Developer): RAII guard for `FORCE_RESTORE_FAIL` prevents test pollution when rollback_failed tests run in parallel with normal rollback tests.

## Test plan

- [x] `make check`