### PR TITLE
fix: thread-local FORCE_RESTORE_FAIL for parallel unit tests

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1868,33 +1868,33 @@ fn commit_error(message: impl Into<String>) -> CommitError {
     }
 }
 
-/// When true, [`restore_after_failed_commit`] reports failure. Test-only; never
-/// set in production.
-#[doc(hidden)]
-pub static FORCE_RESTORE_FAIL: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
+thread_local! {
+    /// Per-thread test hook; never set in production.
+    static FORCE_RESTORE_FAIL: std::sync::atomic::AtomicBool =
+        const { std::sync::atomic::AtomicBool::new(false) };
+}
 
-/// RAII guard that forces restore failure for tests using [`FORCE_RESTORE_FAIL`].
+/// RAII guard that forces restore failure on the current thread only.
 #[doc(hidden)]
 pub struct RestoreFailGuard;
 
 impl RestoreFailGuard {
     pub fn engage() -> Self {
-        FORCE_RESTORE_FAIL.store(true, std::sync::atomic::Ordering::SeqCst);
+        FORCE_RESTORE_FAIL.with(|flag| flag.store(true, std::sync::atomic::Ordering::SeqCst));
         Self
     }
 }
 
 impl Drop for RestoreFailGuard {
     fn drop(&mut self) {
-        FORCE_RESTORE_FAIL.store(false, std::sync::atomic::Ordering::SeqCst);
+        FORCE_RESTORE_FAIL.with(|flag| flag.store(false, std::sync::atomic::Ordering::SeqCst));
     }
 }
 
 /// Restore files from a backup session after a failed commit. Returns `true`
 /// when restore completed successfully.
 fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
-    if FORCE_RESTORE_FAIL.load(std::sync::atomic::Ordering::SeqCst) {
+    if FORCE_RESTORE_FAIL.with(|flag| flag.load(std::sync::atomic::Ordering::SeqCst)) {
         return false;
     }
     crate::backup::restore_session(cwd, timestamp).is_ok()


### PR DESCRIPTION
## Problem

Main CI failed: `commit_changes_rolls_back_on_mid_write_failure` panicked with "rollback should succeed" when run in parallel with `commit_changes_reports_rollback_failed_when_restore_fails`. The global `FORCE_RESTORE_FAIL` static leaked across test threads.

## Fix

Replace the global `AtomicBool` with a `thread_local` flag so `RestoreFailGuard` only affects the current test thread.

## Test plan

- [x] `cargo test --lib commit_changes -- --test-threads=16`
- [x] `make check`