### PR TITLE
fix(schema): add op field to md.move_section examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1441%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1442%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1441 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1442 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -433,11 +433,11 @@ pub fn operation_schemas() -> Vec<OperationSchema> {
             examples: vec![
                 OperationExample {
                     description: "Reorder within same file".into(),
-                    args: serde_json::json!({"path": "README.md", "heading": "## FAQ", "before": "## License"}),
+                    args: serde_json::json!({"op": "md.move_section", "path": "README.md", "heading": "## FAQ", "before": "## License"}),
                 },
                 OperationExample {
                     description: "Move section to another file".into(),
-                    args: serde_json::json!({"path": "spec.md", "heading": "## Appendix E", "to": "investigation.md", "after": "## Layer 4"}),
+                    args: serde_json::json!({"op": "md.move_section", "path": "spec.md", "heading": "## Appendix E", "to": "investigation.md", "after": "## Layer 4"}),
                 },
             ],
         },
@@ -902,6 +902,29 @@ mod tests {
                 "schema {}: must have 'required' field",
                 schema.name
             );
+        }
+    }
+
+    #[test]
+    fn operation_examples_include_op_field() {
+        for schema in operation_schemas() {
+            for ex in &schema.examples {
+                let op = ex
+                    .args
+                    .get("op")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "schema {} example {:?}: missing 'op' field",
+                            schema.name, ex.description
+                        )
+                    });
+                assert_eq!(
+                    op, schema.name,
+                    "schema {} example {:?}: op must match operation name",
+                    schema.name, ex.description
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Triage of [AI Code Quality findings](https://github.com/patchloom/patchloom/security/quality/ai-findings) found one real issue: `md.move_section` schema examples were the only operation examples missing the required `"op"` field. Agents copying these from `patchloom schema --examples` would produce invalid tx plans.

Adds `operation_examples_include_op_field` regression test so every example's `op` matches its schema name.

Relates to #595.

## Test plan

- [x] `cargo test --lib schema::tests::operation_examples_include_op_field`
- [x] `make check-fast`