### PR TITLE
chore: remove unused anstyle direct dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,6 @@ name = "patchloom"
 version = "0.1.7"
 dependencies = [
  "anstream",
- "anstyle",
  "anyhow",
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ strsim = "0.11"
 tempfile = "3"
 anyhow = "1"
 anstream = "1"
-anstyle = "1"
 ec4rs = "1"
 clap_complete = "4"
 rmcp = { version = "1", features = ["server", "transport-io", "macros"], optional = true }


### PR DESCRIPTION
## Summary

Remove `anstyle` from direct dependencies in `Cargo.toml`. It is not referenced anywhere in `src/` and is already available transitively via `clap` and `anstream`.

`cargo-machete` flagged this as unused.

Closes #598

## Verification

- `make check` passes (1442 tests)
- `cargo build --all-features` succeeds
- `cargo tree` confirms anstyle remains available transitively