### PR TITLE
test: cover allow_conflicts true merge path (CLI, tx, MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1443%20passing-brightgreen)](#)
+<<<<<<< HEAD
+[![Tests](https://img.shields.io/badge/tests-1446%20passing-brightgreen)](#)
+=======
+[![Tests](https://img.shields.io/badge/tests-1446%20passing-brightgreen)](#)
+>>>>>>> ef2dd44 (test: add integration tests for allow_conflicts merge path (CLI, tx, MCP))
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +418,11 @@ flowchart LR
 
 ## Status
 
-1443 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+<<<<<<< HEAD
+1446 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+=======
+1446 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+>>>>>>> ef2dd44 (test: add integration tests for allow_conflicts merge path (CLI, tx, MCP))
 
 ## Full command reference
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4541,6 +4541,43 @@ fn test_patch_merge_check_exits_8_on_conflict() {
 }
 
 #[test]
+fn test_patch_merge_allow_conflicts_writes_markers() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
+    let patch_file = dir.path().join("stale.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
+    )
+    .unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("merge")
+        .arg(&patch_file)
+        .arg("--apply")
+        .arg("--allow-conflicts")
+        .assert()
+        .success();
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("<<<<<<< patchloom (ours)"),
+        "should have conflict markers: {content}"
+    );
+    assert!(
+        content.contains("======="),
+        "should have separator: {content}"
+    );
+    assert!(
+        content.contains(">>>>>>> patch (theirs)"),
+        "should have theirs marker: {content}"
+    );
+}
+
+#[test]
 fn test_patch_merge_apply_writes_clean_merge() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -11247,6 +11284,50 @@ fn test_tx_patch_apply_merge_conflict_without_allow_conflicts() {
 }
 
 #[test]
+fn test_tx_patch_apply_merge_conflict_with_allow_conflicts() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
+
+    let diff =
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n";
+    let plan = serde_json::json!({
+        "version": "1",
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "patch.apply",
+            "diff": diff,
+            "on_stale": "merge",
+            "allow_conflicts": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .success();
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("<<<<<<< patchloom (ours)"),
+        "should have ours marker: {content}"
+    );
+    assert!(
+        content.contains("======="),
+        "should have separator: {content}"
+    );
+    assert!(
+        content.contains(">>>>>>> patch (theirs)"),
+        "should have theirs marker: {content}"
+    );
+}
+
+#[test]
 fn test_tx_validate_timeout_kills_hanging_command() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
@@ -16855,6 +16936,48 @@ async fn test_mcp_apply_patch_merge_conflict_rejected_without_allow_conflicts() 
     assert_eq!(
         fs::read_to_string(dir.path().join("target.txt")).unwrap(),
         "line1\ncompletely different\nline3\n"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_apply_patch_merge_conflict_with_allow_conflicts() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("target.txt"),
+        "line1\ncompletely different\nline3\n",
+    )
+    .unwrap();
+
+    let diff = "--- a/target.txt\n+++ b/target.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n";
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "apply_patch",
+        serde_json::json!({"diff": diff, "on_stale": "merge", "allow_conflicts": true}),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "patch merge with allow_conflicts should succeed: {text}"
+    );
+    let content = fs::read_to_string(dir.path().join("target.txt")).unwrap();
+    assert!(
+        content.contains("<<<<<<< patchloom (ours)"),
+        "should have ours marker: {content}"
+    );
+    assert!(
+        content.contains("======="),
+        "should have separator: {content}"
+    );
+    assert!(
+        content.contains(">>>>>>> patch (theirs)"),
+        "should have theirs marker: {content}"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Add three integration tests for the opt-in success path when `allow_conflicts: true` / `--allow-conflicts` writes conflict markers and exits successfully.

### Tests added

1. **CLI**: `test_patch_merge_allow_conflicts_writes_markers` - `patchloom patch merge --apply --allow-conflicts` exits 0, writes conflict markers
2. **tx**: `test_tx_patch_apply_merge_conflict_with_allow_conflicts` - JSON plan with `allow_conflicts: true` succeeds, writes markers
3. **MCP**: `test_mcp_apply_patch_merge_conflict_with_allow_conflicts` - `apply_patch` with `allow_conflicts: true` returns success, file has markers

All three verify the presence of `<<<<<<< patchloom (ours)`, `=======`, and `>>>>>>> patch (theirs)` markers.

Closes #596

## Verification

- `make check` passes (1445 tests: 774 unit + 671 integration)