### PR TITLE
docs: add patch merge workflow to agent-rules output

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -129,6 +129,29 @@ patchloom replace 'TODO' --whole-line --range 10:200 --to '' notes.md --apply
 patchloom doc set .github/workflows/ci.yml jobs.test.timeout-minutes 30 --apply
 ```
 
+### Stale patch recovery via three-way merge
+
+```bash
+# Apply a patch using three-way merge when context has drifted
+patchloom patch apply changes.patch --on-stale merge --apply
+
+# Or use the merge subcommand directly
+patchloom patch merge changes.patch --apply
+
+# If merge produces conflicts, allow them to be written as markers
+# WARNING: never commit files containing conflict markers
+patchloom patch merge changes.patch --apply --allow-conflicts
+```
+
+```bash
+# Same via transaction plan (JSON):
+patchloom tx - --apply <<'EOF'
+{"version": "1", "operations": [
+{"op": "patch.apply", "diff": "...", "on_stale": "merge", "allow_conflicts": true}
+]}
+EOF
+```
+
 ### Bump a version across config files
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1442%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1443%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -414,7 +414,7 @@ flowchart LR
 
 ## Status
 
-1442 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1443 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -330,6 +330,34 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              ```\n\n",
         );
 
+        out.push_str(
+            "### Stale patch recovery via three-way merge\n\n\
+             ```bash\n\
+             # Apply a patch using three-way merge when context has drifted\n\
+             patchloom patch apply changes.patch --on-stale merge --apply\n\
+             \n\
+             # Or use the merge subcommand directly\n\
+             patchloom patch merge changes.patch --apply\n\
+             \n\
+             # If merge produces conflicts, allow them to be written as markers\n\
+             # WARNING: never commit files containing conflict markers\n\
+             patchloom patch merge changes.patch --apply --allow-conflicts\n\
+             ```\n\n",
+        );
+
+        if show_linux {
+            out.push_str(
+                "```bash\n\
+                 # Same via transaction plan (JSON):\n\
+                 patchloom tx - --apply <<'EOF'\n\
+                 {\"version\": \"1\", \"operations\": [\n\
+                   {\"op\": \"patch.apply\", \"diff\": \"...\", \"on_stale\": \"merge\", \"allow_conflicts\": true}\n\
+                 ]}\n\
+                 EOF\n\
+                 ```\n\n",
+            );
+        }
+
         if show_linux {
             out.push_str(
                 "### Bump a version across config files\n\n\
@@ -625,6 +653,14 @@ mod tests {
         assert!(out.contains(".patchloom.toml"));
         assert!(out.contains("collapse_blanks"));
         assert!(out.contains("[tx]"));
+    }
+
+    #[test]
+    fn agent_rules_includes_patch_merge_workflow() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(out.contains("--on-stale merge"));
+        assert!(out.contains("--allow-conflicts"));
+        assert!(out.contains("never commit files containing conflict markers"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add a "Stale patch recovery via three-way merge" workflow example to the agent-rules output. This covers:

- `patchloom patch apply --on-stale merge --apply`
- `patchloom patch merge --apply`
- `--allow-conflicts` flag with warning about conflict markers
- Transaction plan example (Linux only, uses heredoc)

Also adds a unit test verifying the new example strings appear in the generated output.

Closes #597

## Verification

- `make check` passes (1443 tests: 775 unit + 668 integration)
- PATCHLOOM.md regenerated via `make sync-patchloom-md`
- README test counts updated