### PR TITLE
chore: use rounded test counts to eliminate per-PR churn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,7 +291,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Testing and benchmarks
 
-- 1195 tests (593 unit + 602 integration) verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
+- 1100+ tests verified on Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - Agent integration tests: 19 scenarios with invocation-capture shim
 - 5 fuzz targets: selector parse, patch parse, patch apply, batch tokenize, selector eval
 - CLI benchmarks vs native tools (grep, sed, jq) using hyperfine

--- a/Makefile
+++ b/Makefile
@@ -27,35 +27,34 @@ check: fmt-check clippy test integration-test check-patchloom-md check-readme ##
 
 check-fast: fmt-check clippy test integration-test ## Fast check (skips doc verification)
 
-update-readme: ## Update README.md and CHANGELOG.md test counts
+update-readme: ## Update README.md rounded test count (only changes when hundreds digit changes)
 	@unit=$$(cargo test --lib --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
 	integ=$$(cargo test --test integration --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
 	if [ -z "$$unit" ] || [ -z "$$integ" ]; then echo "ERROR: failed to parse test counts (unit=$$unit integ=$$integ)"; exit 1; fi; \
 	total=$$((unit + integ)); \
-	core_cmds=$$(NO_COLOR=1 cargo run --quiet -- --help 2>/dev/null | sed -n '/^Commands:/,/^$$/p' | grep '^ ' | grep -cv '^ *help'); \
+	rounded=$$((total / 100 * 100)); \
 	all_cmds=$$(NO_COLOR=1 cargo run --all-features --quiet -- --help 2>/dev/null | sed -n '/^Commands:/,/^$$/p' | grep '^ ' | grep -cv '^ *help'); \
-	sed -i.bak "s/tests-[0-9]*%20passing/tests-$$total%20passing/" README.md; \
-	sed -i.bak "s/[0-9]* passing tests across [0-9]* commands/$$total passing tests across $$all_cmds commands/" README.md; \
-	sed -i.bak "/^## \[Unreleased\]/,/^## \[/ s/- [0-9]* tests ([0-9]* unit + [0-9]* integration)/- $$total tests ($$unit unit + $$integ integration)/" CHANGELOG.md; \
-	rm -f README.md.bak CHANGELOG.md.bak; \
-	echo "README.md and CHANGELOG.md updated: $$all_cmds total commands ($$core_cmds core), $$total tests ($$unit unit + $$integ integration)"
+	sed -i.bak "s/tests-[0-9]*%2B%20passing/tests-$$rounded%2B%20passing/" README.md; \
+	sed -i.bak "s/[0-9]*+ tests across [0-9]* commands/$$rounded+ tests across $$all_cmds commands/" README.md; \
+	rm -f README.md.bak; \
+	echo "README.md updated: $$rounded+ tests (actual: $$total = $$unit unit + $$integ integration), $$all_cmds commands"
 
-check-readme: ## Verify README.md and CHANGELOG.md test counts are fresh
-	@tmp_readme=$$(mktemp); \
-	tmp_changelog=$$(mktemp); \
-	cp README.md "$$tmp_readme"; \
-	cp CHANGELOG.md "$$tmp_changelog"; \
-	trap 'mv "$$tmp_readme" README.md; mv "$$tmp_changelog" CHANGELOG.md' EXIT; \
-	$(MAKE) update-readme >/dev/null; \
-	if cmp -s "$$tmp_readme" README.md && cmp -s "$$tmp_changelog" CHANGELOG.md; then \
-		rm -f "$$tmp_readme" "$$tmp_changelog"; \
-		trap - EXIT; \
-	else \
-		diff -u "$$tmp_readme" README.md || true; \
-		diff -u "$$tmp_changelog" CHANGELOG.md || true; \
-		echo "ERROR: README.md or CHANGELOG.md is stale. Run 'make update-readme' to refresh counts."; \
+check-readme: ## Verify README.md rounded test count is accurate
+	@if grep -q '<<<<<<' README.md; then echo "ERROR: README.md contains conflict markers"; exit 1; fi; \
+	unit=$$(cargo test --lib --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
+	integ=$$(cargo test --test integration --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
+	if [ -z "$$unit" ] || [ -z "$$integ" ]; then echo "ERROR: failed to parse test counts (unit=$$unit integ=$$integ)"; exit 1; fi; \
+	total=$$((unit + integ)); \
+	rounded=$$((total / 100 * 100)); \
+	if ! grep -q "tests-$${rounded}%2B%20passing" README.md; then \
+		echo "ERROR: README.md badge says a different rounded count than $${rounded}+. Run 'make update-readme'."; \
 		exit 1; \
-	fi
+	fi; \
+	if ! grep -q "$${rounded}+ tests across" README.md; then \
+		echo "ERROR: README.md status says a different rounded count than $${rounded}+. Run 'make update-readme'."; \
+		exit 1; \
+	fi; \
+	echo "README.md count OK: $${rounded}+ (actual: $$total)"
 
 sync-patchloom-md: ## Regenerate PATCHLOOM.md from patchloom agent-rules
 	cargo run --quiet -- agent-rules > PATCHLOOM.md

--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-<<<<<<< HEAD
-[![Tests](https://img.shields.io/badge/tests-1446%20passing-brightgreen)](#)
-=======
-[![Tests](https://img.shields.io/badge/tests-1446%20passing-brightgreen)](#)
->>>>>>> ef2dd44 (test: add integration tests for allow_conflicts merge path (CLI, tx, MCP))
+[![Tests](https://img.shields.io/badge/tests-1400%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -418,11 +414,7 @@ flowchart LR
 
 ## Status
 
-<<<<<<< HEAD
-1446 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
-=======
-1446 passing tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
->>>>>>> ef2dd44 (test: add integration tests for allow_conflicts merge path (CLI, tx, MCP))
+1400+ tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 ## Full command reference
 

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,361 tests**, zero unsafe code
+- **1,300+ tests**, zero unsafe code
 - **20 commands** including MCP server with 30 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15130,7 +15130,7 @@ fn test_launch_announcement_command_count_matches_readme() {
     // Extract command count from README (e.g., "across 19 commands").
     let readme_count: usize = readme
         .lines()
-        .find(|l| l.contains("passing tests across") && l.contains("commands"))
+        .find(|l| l.contains("tests across") && l.contains("commands"))
         .and_then(|l| {
             let idx = l.find("commands")?;
             l[..idx]
@@ -15441,7 +15441,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,361 tests"));
+    assert!(launch.contains("1,300+ tests"));
     assert!(
         launch.contains("20 commands"),
         "launch announcement CLI command count drifted"


### PR DESCRIPTION
## Summary

Replace exact test counts with rounded floors (e.g. "1400+" instead of "1446") everywhere:
- README badge and status section
- CHANGELOG
- Launch announcement
- Integration test assertions

Simplify Makefile:
- `update-readme`: computes rounded floor, only updates when hundreds digit changes
- `check-readme`: verifies rounded count matches, checks for conflict markers

This eliminates per-PR badge update commits, merge conflicts when multiple PRs land, and stale count CI failures on every test addition.

## Verification

- `make check` passes (1400+ actual: 1446)
- `make check-readme` output: `README.md count OK: 1400+ (actual: 1446)`