### PR TITLE
ci: restrict coverage upload to push-to-main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,10 +178,7 @@ jobs:
           path: coverage.xml
 
       - name: Upload coverage
-        if: >-
-          always() &&
-          (github.event_name != 'pull_request' ||
-           github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
         with:
           file: coverage.xml


### PR DESCRIPTION
## Problem

Auto-merge deletes the PR branch before the coverage job completes, causing GitHub's coverage API to reject the upload (HTTP 400) for a commit that no longer belongs to any branch. This made CI show as "failed" on PR #604 even though all tests passed.

## Fix

Only upload to GitHub's native code coverage on push to main, where the branch and commit are guaranteed to exist. PRs still generate coverage and upload the XML artifact for manual inspection.

## Before

```yaml
if: >-
  always() &&
  (github.event_name != 'pull_request' ||
   github.event.pull_request.head.repo.full_name == github.repository)
```

## After

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```