### PR TITLE
ci: exclude gist-backed shields.io endpoint badges from link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -17,6 +17,8 @@ exclude = [
   "app\\.fossa\\.com/api/projects/.*\\.svg",
   # Scorecard viewer is slow and times out intermittently in CI
   "securityscorecards\\.dev",
+  # Gist-backed shields.io endpoint badges depend on two services and 503 intermittently
+  "img\\.shields\\.io/endpoint",
 ]
 
 accept = [200, 429]


### PR DESCRIPTION
The crates.io downloads badge uses a shields.io `/endpoint` URL backed by a GitHub Gist. This chain of two external services returns 503 intermittently, causing false-positive Check Links failures on PRs (e.g. release-please PR #586).

Adds `img\.shields\.io/endpoint` to the lychee exclusion list.