### PR TITLE
feat: re-export EolMode from write module

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -5,7 +5,9 @@ use std::path::Path;
 use anyhow::Context;
 use tempfile::NamedTempFile;
 
-use crate::cli::global::EolMode;
+// Re-export so library consumers can use `patchloom::write::EolMode`
+// without reaching into the CLI module.
+pub use crate::cli::global::EolMode;
 
 /// Controls which transformations are applied before writing a file.
 pub struct WritePolicy {


### PR DESCRIPTION
Re-export `EolMode` from `patchloom::write` so library consumers can use `patchloom::write::EolMode::Lf` when calling `patchloom::write::normalize_eol()`, instead of reaching into `patchloom::cli::global::EolMode` (a clap-derived type).

The other three text transforms in `write` (`ensure_final_newline`, `trim_trailing_whitespace`, `collapse_blanks`) already have clean `&str -> Cow<str>` signatures. This closes the gap for `normalize_eol`.