### PR TITLE
feat: add cargo-semver-checks CI and fix all rustdoc warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,24 @@ jobs:
       - name: Agent benchmark dry run
         run: cd tests/agent && pytest test_bench.py::test_dry_run_prompts -v -s --dry-run-prompts
 
+  semver-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Check semver compatibility
+        uses: obi1kenobi/cargo-semver-checks-action@5b298c9520f7096a4683c0bd981a7ac5a7e249ae # v2.8
+        with:
+          feature-group: all-features
+
   audit:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -33,35 +33,35 @@ pub enum DocAction {
     Get {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[0].name).
+        /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
     },
     /// Check whether a selector path exists.
     Has {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[0].name).
+        /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
     },
     /// List object keys at a path.
     Keys {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[0].name).
+        /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
     },
     /// Count items in an array or object.
     Len {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[0].name).
+        /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
     },
     /// Set or create a value at a selector path.
     Set {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[0].name).
+        /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
         /// Value (JSON literal or bare string).
         value: String,
@@ -70,14 +70,14 @@ pub enum DocAction {
     Delete {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[0].name).
+        /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
     },
     /// Delete array items matching a predicate.
     DeleteWhere {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[0].name).
+        /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
         // ref:doc-mode:predicate
         /// Predicate in key=value format.
@@ -123,7 +123,7 @@ pub enum DocAction {
     Update {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[*].enabled).
+        /// Selector path (e.g. `server.port`, `items[*].enabled`).
         selector: String,
         /// New value (JSON literal or bare string).
         value: String,
@@ -141,7 +141,7 @@ pub enum DocAction {
     Ensure {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. server.port, items[0].name).
+        /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
         /// Value to set if missing (JSON literal or bare string).
         value: String,

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -34,7 +34,7 @@ fn default_strict_true() -> bool {
 pub struct DocSetParams {
     /// File path (relative to working directory).
     pub path: String,
-    /// Selector for the value to set (e.g., "version", "db.pool", "items[0].name").
+    /// Selector for the value to set (e.g., `version`, `db.pool`, `items[0].name`).
     pub selector: String,
     /// Value to set (string, number, boolean, object, or array).
     pub value: serde_json::Value,
@@ -88,7 +88,7 @@ pub struct DocEnsureParams {
 pub struct DocUpdateParams {
     /// File path.
     pub path: String,
-    /// Wildcard selector for items to update (e.g., "items[*]").
+    /// Wildcard selector for items to update (e.g., `items[*]`).
     pub selector: String,
     /// Value to set on each matched item.
     pub value: serde_json::Value,

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,7 +73,7 @@ pub fn find_and_load(start: &Path) -> Option<(ProjectConfig, PathBuf)> {
     }
 }
 
-/// Merge a [`ProjectConfig`] into [`GlobalFlags`], applying config values only
+/// Merge a [`ProjectConfig`] into [`GlobalFlags`](crate::cli::global::GlobalFlags), applying config values only
 /// where the CLI did not explicitly set them.
 pub fn apply_config(global: &mut crate::cli::global::GlobalFlags, config: &ProjectConfig) {
     // Write policy: config provides defaults, CLI flags win.

--- a/src/write.rs
+++ b/src/write.rs
@@ -248,7 +248,7 @@ pub fn apply_policy<'a>(content: &'a str, policy: &WritePolicy) -> std::borrow::
     s
 }
 
-/// Build a [`WritePolicy`] from [`GlobalFlags`], optionally merging
+/// Build a [`WritePolicy`] from [`GlobalFlags`](crate::cli::global::GlobalFlags), optionally merging
 /// EditorConfig properties for the given file path.
 ///
 /// Explicit CLI flags always win.  When `--respect-editorconfig` is set and


### PR DESCRIPTION
## Summary

Two improvements to the public API infrastructure:

1. **cargo-semver-checks in CI** (closes #612): Adds `obi1kenobi/cargo-semver-checks-action` to the CI workflow. Runs on PRs and push-to-main with `--all-features` to detect accidental public API breakage before merge. Catches removed/changed public functions, types, and signatures.

2. **Fix all 13 rustdoc warnings** (closes #613): Selector examples like `items[0].name` in doc comments were being parsed as markdown link references by rustdoc. Wrapped them in backticks. Also resolved `GlobalFlags` doc links with fully qualified paths.

Issue #614 (README library section) was already implemented; closed as-is.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add `semver-checks` job with pinned action SHA |
| `src/cmd/doc.rs` | Backtick-wrap selector examples in 9 doc comments |
| `src/cmd/mcp.rs` | Backtick-wrap selector examples in 2 doc comments |
| `src/config.rs` | Resolve `GlobalFlags` rustdoc link |
| `src/write.rs` | Resolve `GlobalFlags` rustdoc link |

## Verification

- `make check` passes (792 unit + 671 integration tests)
- `cargo doc --no-deps --all-features` produces 0 warnings (was 13)