### PR TITLE
test/docs: improve cycle 1 - error path tests and public API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ api::doc_set(
 )?;
 ```
 
-All API types are `Send + Sync`. See the `patchloom::api` module docs for the full surface.
+All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking and binary detection), and `write` (atomic file writes with policy transformations). See the `patchloom::api` module docs for the full surface.
 
 ## Getting started
 

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -413,4 +413,67 @@ mod tests {
         assert_eq!(guard.root(), dir.path());
         assert!(guard.canon_root().is_absolute());
     }
+
+    #[test]
+    fn new_with_nonexistent_root_returns_canonicalize_error() {
+        let err = PathGuard::new(
+            PathBuf::from("/nonexistent_patchloom_test_dir_xyz"),
+            AbsolutePathPolicy::Reject,
+        )
+        .unwrap_err();
+        assert!(matches!(err, ContainmentError::Canonicalize { .. }));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("failed to canonicalize"),
+            "expected canonicalize message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn error_display_absolute_path() {
+        let err = ContainmentError::AbsolutePath("/etc/passwd".to_string());
+        let msg = err.to_string();
+        assert!(
+            msg.contains("absolute paths are not allowed") && msg.contains("/etc/passwd"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn error_display_escaped() {
+        let err = ContainmentError::Escaped {
+            path: "../../secret".to_string(),
+            root: "/home/user".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("escapes workspace") && msg.contains("../../secret"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn error_source_canonicalize_returns_inner_error() {
+        use std::error::Error;
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        let err = ContainmentError::Canonicalize {
+            path: "test".to_string(),
+            source: io_err,
+        };
+        assert!(err.source().is_some());
+        let msg = err.to_string();
+        assert!(msg.contains("failed to canonicalize"), "got: {msg}");
+    }
+
+    #[test]
+    fn error_source_non_canonicalize_returns_none() {
+        use std::error::Error;
+        let err = ContainmentError::AbsolutePath("/x".to_string());
+        assert!(err.source().is_none());
+        let err2 = ContainmentError::Escaped {
+            path: "..".to_string(),
+            root: "/r".to_string(),
+        };
+        assert!(err2.source().is_none());
+    }
 }

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -216,4 +216,24 @@ mod tests {
             let _ = _assert::<ShellResult>;
         };
     }
+
+    #[test]
+    fn run_with_timeout_truncates_large_stderr() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Generate stderr output much larger than STDERR_CAPTURE_MAX (512 bytes).
+        // Use printf to emit 800 'X' characters to stderr.
+        let result = run_with_timeout("printf '%0800d' 0 >&2", 5, dir.path()).unwrap();
+        // The captured stderr should be at most STDERR_CAPTURE_MAX bytes
+        // plus the "... (truncated)" suffix.
+        assert!(
+            result.stderr_head.len() <= STDERR_CAPTURE_MAX + 20,
+            "stderr should be truncated, got {} bytes",
+            result.stderr_head.len()
+        );
+        assert!(
+            result.stderr_head.contains("(truncated)"),
+            "expected truncation marker, got: {}",
+            &result.stderr_head[..result.stderr_head.len().min(100)]
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,15 @@
 //! patchloom = { version = "0.1", default-features = false }
 //! ```
 //!
-//! This gives you the full [`api`] module (doc/replace/md/file/patch operations)
-//! and the [`ops`] module for lower-level access, without pulling in `tokio`
-//! or other async runtime dependencies.
+//! This gives you the full [`api`] module (doc/replace/md/file/patch operations),
+//! the [`ops`] module for lower-level access, and utility modules:
+//!
+//! - [`containment`] -- workspace path guard preventing traversal attacks
+//! - [`exec`] -- shell command execution with process-tree management
+//! - [`files`] -- file-walking, binary detection, and text reading helpers
+//! - [`write`] -- atomic file writes with write-policy transformations
+//!
+//! No `tokio` or other async runtime dependencies are pulled in.
 //!
 //! ## Thread safety
 //!


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 1 findings:

### QA Engineer (Iteration 1)
- Added 5 tests for `containment` module: `PathGuard::new` failure path, `ContainmentError` Display messages for all 3 variants, `Error::source()` for Canonicalize (returns inner) and non-Canonicalize (returns None)
- Added 1 test for `exec` module: `run_with_timeout` correctly truncates stderr at `STDERR_CAPTURE_MAX` (512 bytes) with truncation marker

### End User (Iteration 3)
- Updated `lib.rs` crate-level docs to list the 4 recently-extracted public utility modules (`containment`, `exec`, `files`, `write`) so library consumers can discover them
- Updated README library section to mention these modules

### Other perspectives (no-op)
Developer, Maintainer, Ops/SRE, Security, Product Manager, Spec/Contract, Performance, Backward Compatibility, Adversarial, Architecture, New Contributor, Observability: no actionable findings.

`make check` passes (798 unit + 671 integration tests).

Signed-off-by: Sebastien Tardif <seb@tardif.ca>