### PR TITLE
test: improve cycle 2 - replace is_some()+unwrap() with expect()

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -268,27 +268,24 @@ mod tests {
     fn find_agent_file_finds_agents_md() {
         let dir = tempfile::TempDir::new().unwrap();
         std::fs::write(dir.path().join("AGENTS.md"), "# Rules\n").unwrap();
-        let found = find_agent_file(dir.path());
-        assert!(found.is_some());
-        assert!(found.unwrap().ends_with("AGENTS.md"));
+        let found = find_agent_file(dir.path()).expect("should find AGENTS.md");
+        assert!(found.ends_with("AGENTS.md"));
     }
 
     #[test]
     fn find_agent_file_preserves_claude_md_case() {
         let dir = tempfile::TempDir::new().unwrap();
         std::fs::write(dir.path().join("Claude.md"), "# Rules\n").unwrap();
-        let found = find_agent_file(dir.path());
-        assert!(found.is_some());
-        assert!(found.unwrap().ends_with("Claude.md"));
+        let found = find_agent_file(dir.path()).expect("should find Claude.md");
+        assert!(found.ends_with("Claude.md"));
     }
 
     #[test]
     fn find_agent_file_supports_agents_md_variant() {
         let dir = tempfile::TempDir::new().unwrap();
         std::fs::write(dir.path().join("Agents.md"), "# Rules\n").unwrap();
-        let found = find_agent_file(dir.path());
-        assert!(found.is_some());
-        assert!(found.unwrap().ends_with("Agents.md"));
+        let found = find_agent_file(dir.path()).expect("should find Agents.md");
+        assert!(found.ends_with("Agents.md"));
     }
 
     #[test]

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -860,16 +860,17 @@ mod tests {
         let results = collect_matches(&args, &default_global()).unwrap();
         assert_eq!(results.matches.len(), 1);
         let m = &results.matches[0];
-        assert!(m.context_before.is_some(), "should have context_before");
-        assert!(m.context_after.is_some(), "should have context_after");
-        let before = m.context_before.as_ref().unwrap();
+        let before = m
+            .context_before
+            .as_ref()
+            .expect("should have context_before");
         assert_eq!(before.len(), 1);
         assert!(
             before[0].contains("Hello, world!"),
             "context before: {:?}",
             before
         );
-        let after = m.context_after.as_ref().unwrap();
+        let after = m.context_after.as_ref().expect("should have context_after");
         assert_eq!(after.len(), 1);
         assert!(
             after[0].contains("Hello again!"),

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -580,8 +580,7 @@ mod tests {
             Some("fn setup() {}"),
             Some("fn cleanup() {}"),
         );
-        assert!(result.is_some());
-        let r = result.unwrap();
+        let r = result.expect("anchor match should find a fuzzy match");
         assert_eq!(r.strategy, MatchStrategy::Anchor);
         assert!(r.matched_text.contains("proccess_data"));
     }

--- a/src/files.rs
+++ b/src/files.rs
@@ -687,8 +687,7 @@ mod tests {
         data.push(0);
         data.push(b'\n');
         std::fs::write(&file, &data).unwrap();
-        let result = read_text_file(&file);
-        assert!(result.is_some());
-        assert_eq!(result.unwrap().len(), 8194);
+        let result = read_text_file(&file).expect("NUL past 8KiB should still read as text");
+        assert_eq!(result.len(), 8194);
     }
 }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -3476,9 +3476,10 @@ mod tests {
 
         #[test]
         fn compile_regex_mode_returns_some() {
-            let re = compile_replace_regex(r"\d+", true, false, false).unwrap();
-            assert!(re.is_some());
-            assert!(re.unwrap().is_match("abc123"));
+            let re = compile_replace_regex(r"\d+", true, false, false)
+                .unwrap()
+                .expect("regex mode should return Some");
+            assert!(re.is_match("abc123"));
         }
 
         #[test]
@@ -3500,9 +3501,10 @@ mod tests {
 
         #[test]
         fn compile_literal_case_insensitive_returns_some() {
-            let re = compile_replace_regex("hello", false, true, false).unwrap();
-            assert!(re.is_some());
-            assert!(re.unwrap().is_match("HELLO"));
+            let re = compile_replace_regex("hello", false, true, false)
+                .unwrap()
+                .expect("case-insensitive literal should return Some");
+            assert!(re.is_match("HELLO"));
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 2 findings:

### Test Auditor (Iteration 1)
Replaced 9 instances of the `assert!(x.is_some()); x.unwrap()` anti-pattern with `x.expect("msg")` across 6 files:

- `src/files.rs`: read_text_file binary-past-8k test
- `src/fallback.rs`: anchor_match test
- `src/cmd/init.rs`: find_agent_file tests (3 instances)
- `src/cmd/search.rs`: context_before/context_after assertions (2 instances)
- `src/ops.rs`: compile_replace_regex tests (2 instances)

The `expect()` pattern provides the same panic-on-None behavior but with a descriptive message instead of a bare `assertion failed: result.is_some()`.

One remaining `is_some()` in `tx.rs:3419` is a legitimate existence check (the next line's `unwrap()` is on a different variable).

### Other perspectives (no-op)
All other perspectives: no actionable findings (same mature codebase as cycle 1).

`make check` passes (798 unit + 671 integration tests).

Signed-off-by: Sebastien Tardif <seb@tardif.ca>