### PR TITLE
test: improve cycle 3 - add api::search edge case tests

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1763,6 +1763,31 @@ mod tests {
     }
 
     #[test]
+    fn search_empty_pattern_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello\n").unwrap();
+        let err = search(&file, "", false, false).unwrap_err();
+        assert!(
+            err.to_string().contains("empty"),
+            "expected empty pattern error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn search_case_insensitive() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "Hello World\nhello world\nHELLO\n").unwrap();
+        let matches = search(&file, "hello", false, true).unwrap();
+        assert_eq!(
+            matches.len(),
+            3,
+            "case-insensitive should match all 3 lines"
+        );
+    }
+
+    #[test]
     fn replace_text_whole_line_mode() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("code.rs");


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 3 findings:

### QA Engineer (Iteration 1)
Added 2 missing test cases for `api::search()`:

- `search_empty_pattern_returns_error`: verifies empty pattern is rejected with a clear error message
- `search_case_insensitive`: verifies the case-insensitive flag correctly matches all case variants

### Other perspectives (no-op)
All other perspectives: no actionable findings. This codebase has been through 3 full improvement cycles with diminishing returns.

`make check` passes (800 unit + 671 integration tests).

Signed-off-by: Sebastien Tardif <seb@tardif.ca>