### PR TITLE
fix: resolve tech-debt issues #620-#623

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,12 +244,6 @@ patchloom mcp-server
 
 MCP-capable agents call patchloom tools directly as structured JSON, with no shell quoting or command construction. The agent sends `{"path": "config.json", "selector": "version", "value": "2.0"}` instead of building `patchloom doc set config.json version '"2.0"' --apply`.
 
-To allow tx plans with format/validate lifecycle steps (shell command execution), add `--allow-shell`:
-
-```bash
-patchloom mcp-server --allow-shell
-```
-
 See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent configuration and the full security model.
 
 ### As a Rust library

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -20,8 +20,6 @@ Add to `~/.grok/config.toml`:
 [mcp_servers.patchloom]
 command = "/path/to/patchloom"
 args = ["mcp-server"]
-# Add "--allow-shell" to args to enable format/validate lifecycle steps:
-# args = ["mcp-server", "--allow-shell"]
 ```
 
 ### Claude Desktop (JSON)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -313,7 +313,6 @@ These are the main entry points. If you are deciding between commands, start her
 
 - **What it does:** Starts an MCP (Model Context Protocol) server on stdio, exposing patchloom operations as structured tool calls. Included by default in all builds.
 - **Use when:** An MCP-capable AI agent can call patchloom tools directly via structured tool calls instead of constructing shell commands. This eliminates the shell-syntax construction tax and reduces agent errors.
-- **`--allow-shell`:** By default, the MCP server rejects tx plans that contain `format` or `validate` lifecycle steps (which execute shell commands). Pass `--allow-shell` to permit these steps. This flag has no effect on the CLI `tx` command, which always allows lifecycle steps.
 - **Prefer instead:** Use the CLI directly when the agent does not support MCP, or when patchloom is invoked from scripts and CI.
 - **Related:** `batch`, `tx`
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -199,6 +199,48 @@ fn build_edit_result(
 // Document operations (JSON/YAML/TOML)
 // ---------------------------------------------------------------------------
 
+/// A parsed document loaded from disk, ready for mutation.
+struct LoadedDoc {
+    path_str: String,
+    format: ops::doc::FileFormat,
+    original: String,
+    value: serde_json::Value,
+}
+
+/// Load and parse a JSON/YAML/TOML file.
+fn load_doc(path: &Path) -> anyhow::Result<LoadedDoc> {
+    let path_str = path.to_string_lossy().into_owned();
+    let format = ops::doc::detect_format(&path_str)?;
+    let original = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {}", path.display()))?;
+    let value = ops::doc::parse_doc(&original, &format)?;
+    Ok(LoadedDoc {
+        path_str,
+        format,
+        original,
+        value,
+    })
+}
+
+/// Serialize a mutated document and build an `EditResult`.
+fn finish_doc_edit(
+    path: &Path,
+    doc: &LoadedDoc,
+    new_value: &serde_json::Value,
+    mode: ApplyMode,
+) -> anyhow::Result<EditResult> {
+    let new_content =
+        ops::doc::serialize_value_preserving(&doc.original, &doc.value, new_value, &doc.format)?;
+    let policy = WritePolicy::default();
+    let applied = write_if_apply(path, &new_content, mode, &policy)?;
+    Ok(build_edit_result(
+        &doc.path_str,
+        doc.original.clone(),
+        new_content,
+        applied,
+    ))
+}
+
 /// Set a value at a selector path in a JSON, YAML, or TOML file.
 ///
 /// The file format is detected from the extension. The selector uses
@@ -209,40 +251,24 @@ pub fn doc_set(
     value: serde_json::Value,
     mode: ApplyMode,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
     let segments = selector::parse_anyhow(selector)?;
-    ops::doc::set_at_path(&mut doc, &segments, value)?;
+    ops::doc::set_at_path(&mut new_value, &segments, value)?;
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 /// Delete a value at a selector path in a JSON, YAML, or TOML file.
 pub fn doc_delete(path: &Path, selector: &str, mode: ApplyMode) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
     let segments = selector::parse_anyhow(selector)?;
-    ops::doc::delete_at_selector(&mut doc, &segments)?;
+    ops::doc::delete_at_selector(&mut new_value, &segments)?;
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 /// Deep-merge a value into the root of a JSON, YAML, or TOML file.
@@ -251,34 +277,22 @@ pub fn doc_merge(
     value: serde_json::Value,
     mode: ApplyMode,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
-    ops::doc::deep_merge(&mut doc, &value);
+    ops::doc::deep_merge(&mut new_value, &value);
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 /// Get a value at a selector path from a JSON, YAML, or TOML file.
 ///
 /// This is a read-only operation; the `mode` parameter is ignored.
 pub fn doc_get(path: &Path, selector: &str) -> anyhow::Result<serde_json::Value> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let doc = ops::doc::parse_doc(&content, &format)?;
+    let doc = load_doc(path)?;
 
     let segments = selector::parse_anyhow(selector)?;
-    let result = selector::eval(&doc, &segments);
+    let result = selector::eval(&doc.value, &segments);
     match result.len() {
         0 => bail!("selector '{}' matched nothing", selector),
         1 => Ok(result
@@ -294,14 +308,10 @@ pub fn doc_get(path: &Path, selector: &str) -> anyhow::Result<serde_json::Value>
 
 /// Check whether a selector path exists in a JSON, YAML, or TOML file.
 pub fn doc_has(path: &Path, selector: &str) -> anyhow::Result<bool> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let content = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let doc = ops::doc::parse_doc(&content, &format)?;
+    let doc = load_doc(path)?;
 
     let segments = selector::parse_anyhow(selector)?;
-    let result = selector::eval(&doc, &segments);
+    let result = selector::eval(&doc.value, &segments);
     Ok(!result.is_empty())
 }
 
@@ -312,25 +322,17 @@ pub fn doc_append(
     value: serde_json::Value,
     mode: ApplyMode,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
     let segments = selector::parse_anyhow(selector)?;
-    let target = ops::doc::navigate_mut(&mut doc, &segments, false)?;
+    let target = ops::doc::navigate_mut(&mut new_value, &segments, false)?;
     let arr = target
         .as_array_mut()
         .ok_or_else(|| anyhow::anyhow!("selector does not point to an array"))?;
     arr.push(value);
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 /// Prepend a value to an array at a selector path.
@@ -340,25 +342,17 @@ pub fn doc_prepend(
     value: serde_json::Value,
     mode: ApplyMode,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
     let segments = selector::parse_anyhow(selector)?;
-    let target = ops::doc::navigate_mut(&mut doc, &segments, false)?;
+    let target = ops::doc::navigate_mut(&mut new_value, &segments, false)?;
     let arr = target
         .as_array_mut()
         .ok_or_else(|| anyhow::anyhow!("selector does not point to an array"))?;
     arr.insert(0, value);
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 /// Update all values matching a selector with a new value.
@@ -371,21 +365,13 @@ pub fn doc_update(
     value: serde_json::Value,
     mode: ApplyMode,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
     let segments = selector::parse_anyhow(selector)?;
-    ops::doc::update_matching(&mut doc, &segments, &value);
+    ops::doc::update_matching(&mut new_value, &segments, &value);
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 /// Ensure a value exists at a selector path; set it only if missing.
@@ -395,25 +381,17 @@ pub fn doc_ensure(
     value: serde_json::Value,
     mode: ApplyMode,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
     let segments = selector::parse_anyhow(selector)?;
     // Only set if the path does not already exist.
-    let existing = selector::eval(&doc, &segments);
+    let existing = selector::eval(&new_value, &segments);
     if existing.is_empty() {
-        ops::doc::set_at_path(&mut doc, &segments, value)?;
+        ops::doc::set_at_path(&mut new_value, &segments, value)?;
     }
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 /// Delete array elements matching a predicate (e.g., `"name=old"`).
@@ -423,21 +401,13 @@ pub fn doc_delete_where(
     predicate: &str,
     mode: ApplyMode,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
     let segments = selector::parse_anyhow(selector)?;
-    ops::doc::delete_where(&mut doc, &segments, predicate)?;
+    ops::doc::delete_where(&mut new_value, &segments, predicate)?;
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 /// Move a value from one selector path to another within the same file.
@@ -447,22 +417,14 @@ pub fn doc_move(
     to_selector: &str,
     mode: ApplyMode,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let format = ops::doc::detect_format(&path_str)?;
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-    let old_value = ops::doc::parse_doc(&original, &format)?;
-    let mut doc = old_value.clone();
+    let doc = load_doc(path)?;
+    let mut new_value = doc.value.clone();
 
     let from_segments = selector::parse_anyhow(from_selector)?;
     let to_segments = selector::parse_anyhow(to_selector)?;
-    ops::doc::move_at_path(&mut doc, &from_segments, &to_segments)?;
+    ops::doc::move_at_path(&mut new_value, &from_segments, &to_segments)?;
 
-    let new_content = ops::doc::serialize_value_preserving(&original, &old_value, &doc, &format)?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy)?;
-    Ok(build_edit_result(&path_str, original, new_content, applied))
+    finish_doc_edit(path, &doc, &new_value, mode)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -549,17 +549,13 @@ pub struct PatchloomService {
     tool_router: ToolRouter<Self>,
     /// Path guard: validates and canonicalizes paths relative to cwd.
     path_guard: crate::containment::PathGuard,
-    /// Whether tx plans may include format/validate lifecycle steps that
-    /// execute shell commands. Controlled by `--allow-shell` on startup.
-    #[expect(dead_code)]
-    allow_shell: bool,
     /// Optional path for logging MCP tool calls as JSONL.
     /// Set via `--log <path>` or `PATCHLOOM_MCP_LOG` env var.
     call_log: Option<PathBuf>,
 }
 
 impl PatchloomService {
-    pub fn new(cwd: PathBuf, allow_shell: bool, log_flag: Option<String>) -> anyhow::Result<Self> {
+    pub fn new(cwd: PathBuf, log_flag: Option<String>) -> anyhow::Result<Self> {
         let path_guard = crate::containment::PathGuard::new(
             cwd.clone(),
             crate::containment::AbsolutePathPolicy::Reject,
@@ -572,7 +568,6 @@ impl PatchloomService {
         Ok(Self {
             tool_router: Self::tool_router(),
             path_guard,
-            allow_shell,
             call_log,
         })
     }
@@ -1505,13 +1500,9 @@ impl ServerHandler for PatchloomService {
 }
 
 /// Run the MCP server on stdio.
-pub fn run_mcp_server(
-    global: &GlobalFlags,
-    allow_shell: bool,
-    log: Option<String>,
-) -> anyhow::Result<u8> {
+pub fn run_mcp_server(global: &GlobalFlags, log: Option<String>) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
-    let service = PatchloomService::new(cwd, allow_shell, log)?;
+    let service = PatchloomService::new(cwd, log)?;
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
@@ -1539,15 +1530,8 @@ mod tests {
     async fn spawn_test_client(
         cwd: std::path::PathBuf,
     ) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
-        spawn_test_client_with_shell(cwd, false).await
-    }
-
-    async fn spawn_test_client_with_shell(
-        cwd: std::path::PathBuf,
-        allow_shell: bool,
-    ) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
         let (server_transport, client_transport) = tokio::io::duplex(16384);
-        let service = PatchloomService::new(cwd, allow_shell, None).unwrap();
+        let service = PatchloomService::new(cwd, None).unwrap();
         tokio::spawn(async move {
             let server = service.serve(server_transport).await.unwrap();
             server.waiting().await.unwrap();
@@ -1751,8 +1735,7 @@ mod tests {
     ) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
         let (server_transport, client_transport) = tokio::io::duplex(16384);
         let service =
-            PatchloomService::new(cwd, false, Some(log_path.to_string_lossy().into_owned()))
-                .unwrap();
+            PatchloomService::new(cwd, Some(log_path.to_string_lossy().into_owned())).unwrap();
         tokio::spawn(async move {
             let server = service.serve(server_transport).await.unwrap();
             server.waiting().await.unwrap();

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -62,11 +62,6 @@ pub enum Command {
     /// Start an MCP (Model Context Protocol) server on stdio.
     #[cfg(feature = "mcp")]
     McpServer {
-        /// Allow tx plans to run shell commands via format/validate lifecycle
-        /// steps. Without this flag, plans containing shell commands are
-        /// rejected. Enable only when the MCP client is trusted.
-        #[arg(long)]
-        allow_shell: bool,
         /// Log every tool call to a JSONL file (tool name, duration, status).
         /// Also settable via PATCHLOOM_MCP_LOG env var; the flag takes precedence.
         #[arg(long)]
@@ -455,9 +450,9 @@ pub fn dispatch(cli: Cli) -> anyhow::Result<u8> {
     // Write commands call load_project_config after merge_write.
     match cli.command {
         #[cfg(feature = "mcp")]
-        Command::McpServer { allow_shell, log } => {
+        Command::McpServer { log } => {
             load_project_config(&mut global);
-            mcp::run_mcp_server(&global, allow_shell, log)
+            mcp::run_mcp_server(&global, log)
         }
         Command::Schema(args) => schema::run(args, &global),
         Command::AgentRules(args) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -360,8 +360,8 @@ color = "always"
         assert!(global.normalize_eol.is_none());
         let warning = invalid_normalize_eol_warning("CRLF");
         assert!(warning.contains("CRLF"));
-        assert!(warning.contains("lf"));
-        assert!(warning.contains("crlf"));
+        assert!(warning.contains("\"lf\""));
+        assert!(warning.contains("\"crlf\""));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15235,24 +15235,6 @@ fn test_makefile_has_audit_target() {
 }
 
 #[test]
-fn test_readme_documents_allow_shell_flag() {
-    let readme = fs::read_to_string(repo_root().join("README.md")).unwrap();
-    assert!(
-        readme.contains("--allow-shell"),
-        "README should mention --allow-shell for MCP server"
-    );
-}
-
-#[test]
-fn test_mcp_setup_documents_allow_shell_flag() {
-    let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
-    assert!(
-        doc.contains("--allow-shell"),
-        "mcp-setup.md should document the --allow-shell flag"
-    );
-}
-
-#[test]
 fn test_mcp_setup_documents_search_files_modes() {
     let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
     assert!(doc.contains("literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes"));
@@ -16358,22 +16340,12 @@ fn has_mcp_support() -> bool {
 
 /// Spawn `patchloom mcp-server` in a tempdir and return a connected MCP client.
 async fn spawn_mcp_client(cwd: &Path) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
-    spawn_mcp_client_opts(cwd, false).await
-}
-
-async fn spawn_mcp_client_opts(
-    cwd: &Path,
-    allow_shell: bool,
-) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
     use rmcp::ServiceExt;
     use rmcp::transport::TokioChildProcess;
 
     let bin = assert_cmd::cargo::cargo_bin("patchloom");
     let mut cmd = tokio::process::Command::new(bin);
     cmd.arg("mcp-server").current_dir(cwd);
-    if allow_shell {
-        cmd.arg("--allow-shell");
-    }
 
     let transport = TokioChildProcess::new(cmd).expect("failed to spawn patchloom mcp-server");
     ().serve(transport)
@@ -18462,7 +18434,11 @@ fn test_schema_json_output() {
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
 
     // Envelope must contain version, operations, and plan_envelope.
-    assert!(parsed.get("version").is_some(), "missing version");
+    let version = parsed
+        .get("version")
+        .and_then(|v| v.as_str())
+        .expect("version must be a non-empty string");
+    assert!(!version.is_empty(), "version must not be empty");
     let ops = parsed
         .get("operations")
         .and_then(|v| v.as_array())
@@ -18474,29 +18450,44 @@ fn test_schema_json_output() {
 
     // Every operation must have name, description, parameters, min_tier.
     for op in ops {
-        assert!(op.get("name").is_some(), "missing name in schema entry");
+        let name = op
+            .get("name")
+            .and_then(|v| v.as_str())
+            .expect("name must be a non-empty string in schema entry");
+        assert!(!name.is_empty(), "name must not be empty in schema entry");
+        let desc = op
+            .get("description")
+            .and_then(|v| v.as_str())
+            .expect("description must be a non-empty string in schema entry");
         assert!(
-            op.get("description").is_some(),
-            "missing description in schema entry"
+            !desc.is_empty(),
+            "description must not be empty for op {name}"
         );
         assert!(
-            op.get("parameters").is_some(),
-            "missing parameters in schema entry"
+            op.get("parameters").and_then(|v| v.as_object()).is_some(),
+            "parameters must be an object for op {name}"
         );
         assert!(
-            op.get("min_tier").is_some(),
-            "missing min_tier in schema entry"
+            op.get("min_tier").and_then(|v| v.as_str()).is_some(),
+            "min_tier must be a string for op {name}"
         );
     }
 
-    // Plan envelope must include write_policy with all fields.
+    // Plan envelope must include write_policy with all fields as schema objects.
     let wp = parsed
         .pointer("/plan_envelope/write_policy/properties")
         .expect("plan_envelope.write_policy.properties must exist");
-    assert!(wp.get("ensure_final_newline").is_some());
-    assert!(wp.get("normalize_eol").is_some());
-    assert!(wp.get("trim_trailing_whitespace").is_some());
-    assert!(wp.get("collapse_blanks").is_some());
+    for key in [
+        "ensure_final_newline",
+        "normalize_eol",
+        "trim_trailing_whitespace",
+        "collapse_blanks",
+    ] {
+        assert!(
+            wp.get(key).and_then(|v| v.as_object()).is_some(),
+            "write_policy property {key} must be a schema object"
+        );
+    }
 }
 
 #[test]
@@ -18599,8 +18590,9 @@ fn test_schema_examples_flag() {
         .and_then(|v| v.as_array())
         .expect("operations must be an array");
     assert!(
-        with.iter().any(|op| op.get("examples").is_some()),
-        "at least one op should have examples with --examples flag"
+        with.iter()
+            .any(|op| op.get("examples").and_then(|v| v.as_array()).is_some()),
+        "at least one op should have examples (as an array) with --examples flag"
     );
 }
 
@@ -19292,10 +19284,21 @@ async fn test_mcp_concurrent_doc_set_same_file() {
     let content = fs::read_to_string(dir.path().join("config.json")).unwrap();
     let v: serde_json::Value = serde_json::from_str(&content)
         .unwrap_or_else(|_| panic!("file should be valid JSON after concurrent writes: {content}"));
-    // All three original keys must still be present (no key loss from partial writes).
-    assert!(v.get("a").is_some(), "key 'a' should exist");
-    assert!(v.get("b").is_some(), "key 'b' should exist");
-    assert!(v.get("c").is_some(), "key 'c' should exist");
+    // All three original keys must still be present with valid string values
+    // (no key loss or corruption from partial writes). Values may be old or new
+    // depending on which concurrent write succeeded.
+    for key in ["a", "b", "c"] {
+        let val = v
+            .get(key)
+            .and_then(|v| v.as_str())
+            .unwrap_or_else(|| panic!("key '{key}' must exist as a string"));
+        let old = format!("old_{key}");
+        let new = format!("new_{key}");
+        assert!(
+            val == old || val == new,
+            "key '{key}' has unexpected value {val:?}, expected {old:?} or {new:?}"
+        );
+    }
 
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Resolves all 4 open tech-debt issues in a single PR.

### #620: Remove dead `allow_shell` field from MCP server

The `allow_shell` field was stored in `PatchloomService` but never read by any handler. Removes the field, constructor parameter, `--allow-shell` CLI flag, and all documentation references.

**Files:** `src/cmd/mcp.rs`, `src/cmd/mod.rs`, `README.md`, `docs/getting-started/mcp-setup.md`, `docs/reference/README.md`, `tests/integration.rs`

### #621: Extract shared boilerplate in `doc_*` API functions

Introduces `load_doc()` and `finish_doc_edit()` helpers that encapsulate the repeated 4-line load/parse and serialize/write patterns. All 11 `doc_*` functions now use the helpers, reducing ~66 lines of duplicated boilerplate.

**Files:** `src/api.rs`

### #622: Fix tautological `contains("lf")` assertion in config test

`contains("lf")` is always true when `contains("crlf")` is true. Replaced with `contains("\"lf\"")` to verify the standalone quoted token appears in the warning message.

**Files:** `src/config.rs`

### #623: Strengthen `is_some()` assertions in integration tests

- Schema entry assertions: verify `name`/`description` are non-empty strings, `parameters` is an object, `min_tier` is a string
- Write policy properties: verified as schema objects (not just key presence)
- Concurrent write assertions: verify values are valid strings matching expected old/new values (not just key existence)
- Examples assertion: verify `examples` is an array (not just present)

**Files:** `tests/integration.rs`

## Testing

- `make check` passes (669 tests)
- Net -66 lines (142 added, 208 removed)

Closes #620
Closes #621
Closes #622
Closes #623