### PR TITLE
feat: support RELEASE_NOTES.md override for curated release descriptions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,6 +355,7 @@ jobs:
       - build-global-artifacts
     permissions:
       "contents": "write"
+      "pull-requests": "write"
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
     if: ${{ always() && !cancelled() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
     env:
@@ -410,6 +411,51 @@ jobs:
           # Output the slimmed manifest for downstream jobs (full manifest
           # exceeds GitHub Actions ~50KB step output limit)
           echo "manifest=$(jq -c '{ci, announcement_is_prerelease, announcement_title, releases, publish_prereleases}' "$RUNNER_TEMP/plan-dist-manifest.json")" >> "$GITHUB_OUTPUT"
+      # If RELEASE_NOTES.md exists at the repo root on the tagged commit,
+      # replace the GitHub Release body with its contents. When absent,
+      # the auto-generated notes from release-please/cargo-dist stay as-is.
+      - name: Apply custom release notes
+        env:
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          if [ -f RELEASE_NOTES.md ]; then
+            echo "Custom release notes found, updating release body..."
+            gh release edit "$TAG" --notes-file RELEASE_NOTES.md
+          else
+            echo "No custom release notes, using auto-generated notes"
+          fi
+      # Clean up RELEASE_NOTES.md after the release so it does not persist
+      # on main. Branch protection prevents direct pushes, so we create a
+      # short-lived PR. A GitHub App token is used so the PR triggers CI
+      # and the auto-approve workflow.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: cleanup-token
+        with:
+          client-id: ${{ vars.AUTO_APPROVE_CLIENT_ID }}
+          private-key: ${{ secrets.AUTO_APPROVE_PRIVATE_KEY }}
+      - name: Clean up release notes file
+        env:
+          GH_TOKEN: ${{ steps.cleanup-token.outputs.token }}
+          TAG: ${{ needs.plan.outputs.tag }}
+        run: |
+          if git ls-tree HEAD --name-only | grep -q '^RELEASE_NOTES.md$'; then
+            BRANCH="chore/cleanup-release-notes-${TAG}"
+            gh api "repos/${{ github.repository }}/git/refs" \
+              -f ref="refs/heads/$BRANCH" \
+              -f sha="$(git rev-parse HEAD)"
+            FILE_SHA=$(gh api \
+              "repos/${{ github.repository }}/contents/RELEASE_NOTES.md?ref=$BRANCH" \
+              --jq '.sha')
+            gh api --method DELETE \
+              "repos/${{ github.repository }}/contents/RELEASE_NOTES.md" \
+              -f message="chore: remove release notes override" \
+              -f sha="$FILE_SHA" \
+              -f branch="$BRANCH"
+            PR_URL=$(gh pr create --base main --head "$BRANCH" \
+              --title "chore: remove release notes override" \
+              --body "Auto-cleanup after ${TAG} release.")
+            gh pr merge "$PR_URL" --auto --squash
+          fi
 
   provenance:
     needs:


### PR DESCRIPTION
## What

Adds support for curated release notes via a `RELEASE_NOTES.md` file at the repo root.

## How it works

Two new steps in the `host` job of the release workflow:

1. **Override step**: after the GitHub Release is created and artifacts uploaded, checks for `RELEASE_NOTES.md`. If present, replaces the release body via `gh release edit`. If absent, auto-generated notes stay untouched.

2. **Cleanup step**: creates a PR to delete `RELEASE_NOTES.md` from main (branch protection prevents direct pushes). Uses the GitHub App token so the PR triggers CI and auto-approve.

## Workflow for curated releases

1. AI reads the PRs included in the release and writes `RELEASE_NOTES.md`
2. Push it to main via a small PR (e.g., `docs: add release notes for vX.Y.Z`), merge it
3. Merge the release-please PR
4. Release workflow applies the curated notes and cleans up the file

When no `RELEASE_NOTES.md` exists, the release behaves identically to before (fully automated).

## Changes

- Added `pull-requests: write` permission to the `host` job (needed for cleanup PR)
- Added "Apply custom release notes" step
- Added cleanup token generation and PR creation steps

Follows the pattern from the `ci-build-release` skill, validated on [terraform-provider-coolify v0.1.5](https://github.com/coolify-terraform/terraform-provider-coolify/releases/tag/v0.1.5).