### PR TITLE
fix: remove dead test code in containment path guard

### DIFF
--- a/src/containment.rs
+++ b/src/containment.rs
@@ -271,7 +271,6 @@ mod tests {
     #[test]
     fn relative_path_within_workspace() {
         let dir = tempfile::TempDir::new().unwrap();
-        fs::write(dir.path().join("src").join("..").join("file.txt"), "ok").ok();
         fs::write(dir.path().join("file.txt"), "ok").unwrap();
         let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
         assert!(guard.check_path("file.txt").is_ok());


### PR DESCRIPTION
The `fs::write` through `src/../file.txt` silently failed (`.ok()`) because the `src/` directory was never created in the tempdir. The next line writes `file.txt` directly and succeeds. Remove the dead line.

Found via GitHub AI Code Quality scanner.