### PR TITLE
docs: fix stale test count and missing exit code 8

### DIFF
--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,300+ tests**, zero unsafe code
+- **1,400+ tests**, zero unsafe code
 - **20 commands** including MCP server with 30 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -235,6 +235,7 @@ This is safe; the next `--apply` run will create a fresh backup directory.
 | 5 | Ambiguous match |
 | 6 | Validation failed |
 | 7 | Rollback (transaction failed and was rolled back) |
+| 8 | Patch merge conflicts detected |
 
 ## Next steps
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15423,7 +15423,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,300+ tests"));
+    assert!(launch.contains("1,400+ tests"));
     assert!(
         launch.contains("20 commands"),
         "launch announcement CLI command count drifted"


### PR DESCRIPTION
- launch-announcement.md: update 1,300+ to 1,400+ (actual: 1,476)
- quickstart.md: add missing exit code 8 (CONFLICTS)
- integration test: update assertion to match new count