### PR TITLE
docs: improve library discoverability on crates.io and docs site

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ name = "patchloom"
 version = "0.1.7"
 edition = "2024"
 rust-version = "1.95"
-description = "A Rust CLI for agent-grade repo operations"
+description = "Structured file editing library and CLI for AI agents: parser-backed JSON/YAML/TOML edits, multi-file batching, markdown operations, and MCP server"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/patchloom/patchloom"
 homepage = "https://patchloom.github.io/patchloom/"
 readme = "README.md"
-keywords = ["cli", "agents", "patch", "markdown", "config"]
-categories = ["command-line-utilities", "development-tools", "config"]
+keywords = ["mcp", "ai-agents", "yaml", "toml", "json"]
+categories = ["command-line-utilities", "development-tools", "config", "text-processing", "parser-implementations"]
 authors = ["Sebastien Tardif"]
 exclude = [
   "benches/",

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,6 +50,21 @@ This builds with MCP support by default. To build without MCP
 If you're contributing from a source checkout, use `make check-fast`
 while iterating and `make check` before committing.
 
+## As a Rust library
+
+Add patchloom as a dependency to embed structured file editing in your own
+Rust tools. Disable default features to omit the MCP server and its async
+dependencies:
+
+```toml
+[dependencies]
+patchloom = { version = "0.1", default-features = false }
+```
+
+See the [crate documentation](https://docs.rs/patchloom) for the full API
+surface and the [introduction](../introduction.md#as-a-rust-library) for
+a quick overview.
+
 ## Shell completions
 
 After installing, generate shell completions:

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -53,6 +53,19 @@ EOF
 | Setup | `init` | Set up patchloom in the current project |
 | | `completions` | Generate shell completions |
 
+## As a Rust library
+
+Patchloom is also a Rust library. Add it as a dependency to embed structured file editing in your own tools:
+
+```toml
+[dependencies]
+patchloom = { version = "0.1", default-features = false }
+```
+
+The `api` module exposes doc, replace, markdown, file, and patch operations. All API types are `Send + Sync`. Disabling default features omits the MCP server and its async dependencies.
+
+See the [crate documentation](https://docs.rs/patchloom) for the full API surface.
+
 ## Get started
 
 Head to [Installation](getting-started/installation.md) to install, then follow the [Quickstart](getting-started/quickstart.md) to make your first edit.


### PR DESCRIPTION
Patchloom is also a Rust library, but nothing in the crates.io listing or the docs site made that obvious.

**Cargo.toml changes:**
- Description now mentions library use, structured editing, and MCP server
- Keywords: `mcp`, `ai-agents`, `yaml`, `toml`, `json` (replaces generic `cli`, `agents`, `patch`, `markdown`, `config`)
- Categories: added `text-processing` and `parser-implementations` (capped at 5)

**Docs site changes:**
- introduction.md: new "As a Rust library" section with dependency snippet and docs.rs link
- installation.md: new library dependency section before shell completions