### PR TITLE
docs: refine v0.2.0 release notes intro

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Patchloom v0.2.0
 
-Patchloom is now a library. This release exposes the core editing engine as a public Rust API, hardens transaction safety, and adds three-way patch merging.
+Patchloom has always been a CLI and an MCP server. Starting with this release, it is also a Rust library. This release exposes the core editing engine as a public API, hardens transaction safety, and adds three-way patch merging.
 
 ## Library API
 


### PR DESCRIPTION
Fix the opening line to acknowledge all three roles (CLI, MCP server, library) instead of implying patchloom only became a library.