### PR TITLE
docs: mention editor extension in README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Security](https://github.com/patchloom/patchloom/actions/workflows/security.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/security.yml)
 [![crates.io](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/crate-version.json&logo=rust)](https://crates.io/crates/patchloom)
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
+[![VS Code Marketplace](https://img.shields.io/visual-studio-marketplace/v/patchloom.patchloom?label=VS%20Code&logo=visualstudiocode)](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
 [![Tests](https://img.shields.io/badge/tests-1400%2B%20passing-brightgreen)](#)
@@ -172,6 +173,17 @@ Pre-built binaries for Linux, macOS, and Windows are on the
 See [Installation](./docs/getting-started/installation.md) for shell
 installer scripts, source builds, and shell completion setup.
 
+### Editor extension
+
+Install the companion extension for VS Code, Cursor, Windsurf, or VSCodium:
+
+- [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom)
+- [Open VSX Registry](https://open-vsx.org/extension/patchloom/patchloom)
+
+The extension auto-discovers the CLI (or installs it for you), generates
+AGENTS.md, configures MCP servers, and adds Quick Actions to the command
+palette. See the [Editor Extension guide](./docs/getting-started/editor-extension.md) for details.
+
 ## Quick start
 
 ### 1. Set up your project
@@ -246,6 +258,8 @@ MCP-capable agents call patchloom tools directly as structured JSON, with no she
 
 See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent configuration and the full security model.
 
+> **Using VS Code, Cursor, or Windsurf?** The [Patchloom extension](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom) handles setup automatically: it installs the binary, runs init, and configures your editor's MCP settings.
+
 ### As a Rust library
 
 Add patchloom as a dependency (omit the MCP server with `default-features = false`):
@@ -286,6 +300,7 @@ All API types are `Send + Sync`. Beyond the `api` module, utility modules are al
 | [Installation](https://patchloom.github.io/patchloom/getting-started/installation.html) | Install options and shell completions |
 | [Core concepts](https://patchloom.github.io/patchloom/getting-started/concepts.html) | Write modes, transaction plans, exit codes |
 | [MCP setup](https://patchloom.github.io/patchloom/getting-started/mcp-setup.html) | Configure patchloom as an MCP server for your agent |
+| [Editor extension](https://patchloom.github.io/patchloom/getting-started/editor-extension.html) | VS Code, Cursor, Windsurf, and VSCodium integration |
 | [Quickstart](https://patchloom.github.io/patchloom/getting-started/quickstart.html) | 5-minute walkthrough |
 | [Reference](https://patchloom.github.io/patchloom/reference/) | Every command, operation, and mode |
 | [Examples](./examples/README.md) | Transaction plan templates |
@@ -409,6 +424,11 @@ flowchart LR
 ## Status
 
 1400+ tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+
+| Component | Status |
+|---|---|
+| CLI | Published on [crates.io](https://crates.io/crates/patchloom) and [Homebrew](https://github.com/patchloom/homebrew-tap) |
+| Editor extension | Published on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom) and [Open VSX](https://open-vsx.org/extension/patchloom/patchloom) |
 
 ## Full command reference
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ All API types are `Send + Sync`. Beyond the `api` module, utility modules are al
 | [Installation](https://patchloom.github.io/patchloom/getting-started/installation.html) | Install options and shell completions |
 | [Core concepts](https://patchloom.github.io/patchloom/getting-started/concepts.html) | Write modes, transaction plans, exit codes |
 | [MCP setup](https://patchloom.github.io/patchloom/getting-started/mcp-setup.html) | Configure patchloom as an MCP server for your agent |
-| [Editor extension](https://patchloom.github.io/patchloom/getting-started/editor-extension.html) | VS Code, Cursor, Windsurf, and VSCodium integration |
+| [Editor extension](./docs/getting-started/editor-extension.md) | VS Code, Cursor, Windsurf, and VSCodium integration |
 | [Quickstart](https://patchloom.github.io/patchloom/getting-started/quickstart.html) | 5-minute walkthrough |
 | [Reference](https://patchloom.github.io/patchloom/reference/) | Every command, operation, and mode |
 | [Examples](./examples/README.md) | Transaction plan templates |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Quickstart](getting-started/quickstart.md)
 - [Core Concepts](getting-started/concepts.md)
 - [MCP Setup](getting-started/mcp-setup.md)
+- [Editor Extension](getting-started/editor-extension.md)
 
 # Reference
 

--- a/docs/getting-started/editor-extension.md
+++ b/docs/getting-started/editor-extension.md
@@ -1,0 +1,89 @@
+# Editor Extension
+
+Patchloom has a companion editor extension that handles binary discovery,
+AGENTS.md generation, MCP server configuration, and structured file
+operations from the command palette. It works in VS Code, Cursor,
+Windsurf, and VSCodium.
+
+## Install
+
+Install from either registry:
+
+- [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom)
+- [Open VSX Registry](https://open-vsx.org/extension/patchloom/patchloom)
+
+Or search for **Patchloom** in the Extensions view (`Ctrl+Shift+X` /
+`Cmd+Shift+X`).
+
+## What the extension does
+
+### One-click workspace setup
+
+Run `Patchloom: Setup Workspace` from the command palette. It walks
+through binary detection, `AGENTS.md` generation, and MCP server
+configuration in one pass. If the CLI is not installed, you can install
+it directly from the command palette with `Patchloom: Install Patchloom`.
+
+### MCP server configuration
+
+`Patchloom: Configure MCP` injects the Patchloom MCP server into your
+editor's config file. Supports:
+
+- **VS Code** (`.vscode/mcp.json`)
+- **Cursor** (`.cursor/mcp.json`)
+- **Windsurf** (`~/.codeium/windsurf/mcp_config.json`)
+
+This replaces the manual JSON editing described in the
+[MCP Setup guide](mcp-setup.md).
+
+### Agent rules generation
+
+`Patchloom: Initialize Project` generates an `AGENTS.md` file from
+`patchloom agent-rules`. If one already exists, the extension opens a
+diff so you can merge updates manually.
+
+### Quick actions
+
+`Patchloom: Quick Action` opens an interactive picker with structured
+editing operations:
+
+| Action | What it does |
+|--------|-------------|
+| Replace text | Literal text replacement with diff preview |
+| Tidy file | Whitespace and newline cleanup with diff preview |
+| Set structured value | Update a JSON, YAML, or TOML key with diff preview |
+| Search text | Find pattern matches across workspace files |
+| Create file | Scaffold a new file and open it in the editor |
+| Read structured value | Read a JSON/YAML/TOML key and copy to clipboard |
+| Merge patch (three-way) | Apply a stale patch using three-way merge |
+
+### Batch operations
+
+`Patchloom: Batch Apply` opens a line-oriented plan template where you
+compose multiple operations (replace, tidy, doc set). The extension pipes
+the plan to `patchloom batch --apply` so all changes land atomically.
+
+### Status bar
+
+The status bar shows MCP and binary readiness at a glance. Click it for
+full diagnostics, including per-editor MCP configuration status.
+
+### Verify MCP Server
+
+`Patchloom: Verify MCP Server` spawns the MCP server, sends a JSON-RPC
+`initialize` handshake, and confirms the server responds correctly.
+
+## When to use the extension vs the CLI
+
+The extension automates the setup steps described in the
+[Quickstart](quickstart.md): installing the binary, running
+`patchloom init`, and configuring MCP. If you use VS Code, Cursor,
+Windsurf, or VSCodium, the extension is the fastest way to get started.
+
+The CLI remains necessary for CI scripts, non-editor agents, and
+environments where a VS Code extension is not available.
+
+## Source and issues
+
+- Repository: [github.com/patchloom/patchloom-vscode](https://github.com/patchloom/patchloom-vscode)
+- Issues: [github.com/patchloom/patchloom-vscode/issues](https://github.com/patchloom/patchloom-vscode/issues)


### PR DESCRIPTION
Add discoverability for the [patchloom-vscode](https://github.com/patchloom/patchloom-vscode) extension across the README and docs site.

**Changes:**

- **README badge**: VS Code Marketplace version badge in the top badge row
- **README install section**: new "Editor extension" subsection with Marketplace and Open VSX links
- **README quick start**: callout note in the MCP section that the extension automates setup
- **README status section**: component status table with CLI and extension rows
- **README getting started table**: new row linking to the editor extension doc page
- **Docs site**: new `docs/getting-started/editor-extension.md` page covering install, features, quick actions, batch operations, and when to use the extension vs the CLI
- **Docs SUMMARY.md**: added the new page under Getting Started

Closes #639