### PR TITLE
fix: rebalance badge rows to 5-5-3 to prevent row 2 wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
 [![FOSSA Status](https://github.com/patchloom/patchloom/actions/workflows/fossa.yml/badge.svg)](https://github.com/patchloom/patchloom/actions/workflows/fossa.yml)
-[![Docs](https://img.shields.io/badge/docs-patchloom.github.io-blue?logo=mdbook)](https://patchloom.github.io/patchloom/)
 
+[![Docs](https://img.shields.io/badge/docs-patchloom.github.io-blue?logo=mdbook)](https://patchloom.github.io/patchloom/)
 [![VS Code Marketplace](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/d01e4551b744b77e2927555e43a4b935/raw/version.json)](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom)
 [![crates.io downloads](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/crates-downloads.json&logo=rust)](https://crates.io/crates/patchloom)
 


### PR DESCRIPTION
Row 2 had 6 badges (Tests, Coverage, OpenSSF Best Practices, Scorecard, FOSSA, Docs), causing the Docs badge to wrap and create a visual 4th row.

Move Docs to row 3 alongside VS Code Marketplace and Downloads:

- **Row 1** (5): CI, Security, crates.io, Release, License
- **Row 2** (5): Tests, Coverage, OpenSSF Best Practices, Scorecard, FOSSA
- **Row 3** (3): Docs, VS Code Marketplace, Downloads