### PR TITLE
fix(ci): remove dependabot[bot] from auto-approve actor list

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -22,7 +22,6 @@ jobs:
       pull-requests: write
     if: >
       github.actor == 'SebTardif' ||
-      github.actor == 'dependabot[bot]' ||
       github.actor == 'patchloom-release[bot]'
     steps:
       - name: Harden Runner


### PR DESCRIPTION
## Problem

Every Dependabot PR showed a red X on the `Auto-approve` check because
`auto-approve.yml` included `dependabot[bot]` in its actor list. The
`pull_request` trigger cannot access repo secrets for Dependabot PRs
(GitHub restricts secret access), so the App token generation step always
failed with:

```
The 'private-key' input must be set to a non-empty string.
```

## Root cause

Two workflows competed for Dependabot PRs:

| Workflow | Trigger | Secret access? | Result |
|----------|---------|----------------|--------|
| `auto-approve.yml` | `pull_request` | No | Always fails |
| `dependabot-auto-merge.yml` | `pull_request_target` | Yes | Works correctly |

## Fix

Remove `dependabot[bot]` from the `auto-approve.yml` actor list. The
`dependabot-auto-merge.yml` workflow already handles Dependabot PRs
correctly via `pull_request_target` (runs in the base branch context
with full secret access).