### PR TITLE
feat: add --word-boundary flag to prevent partial-word matches

### DIFF
--- a/AST-IMPLEMENTATION-PLAN.md
+++ b/AST-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,389 @@
+# AST Implementation Plan
+
+Persistent plan for implementing all issues above #635 (#646-#655).
+Use as a session handoff document. Check off steps as they complete.
+
+## Dependency graph
+
+```
+#646 word_boundary (standalone, no deps)
+  |
+  v
+#647 Phase 1: AST core + rename + list + read + validate
+  |
+  +---> #649 ast search (Phase 2a)
+  +---> #650 ast map with PageRank (Phase 2b, needs list)
+  +---> #651 ast refs (Phase 2c)
+  +---> #652 ast deps (Phase 2d)
+  |       |
+  |       v
+  +---> #653 ast replace (Phase 3a, needs read)
+  +---> #654 ast impact (Phase 3b, needs refs)
+  +---> #655 ast diff (Phase 3c, needs list)
+```
+
+## Step 1: #646 word_boundary (no deps, enables fallback)
+
+**Files to create/modify:**
+- `src/api.rs`: Add `word_boundary: bool` to `ReplaceOptions`
+- `src/ops.rs`: Implement `\b`-wrapped regex in `replace_content()`
+- `src/cmd/replace.rs`: Add `--word-boundary` / `-w` CLI flag
+- `src/cmd/mcp.rs`: Add `word_boundary` param to `replace_text` MCP tool
+- `src/schema.rs`: Update operation schema if needed
+- `tests/integration.rs`: Tests for word boundary replace
+- Unit tests in `src/ops.rs` `mod tests`
+
+**Acceptance criteria from issue:**
+- [ ] `ReplaceOptions.word_boundary` field (default `false`)
+- [ ] Does not match `BenchSetupFile` when searching for `SetupFile`
+- [ ] Does match standalone `SetupFile` in `use crate::SetupFile;`
+- [ ] Handles regex metacharacters in search string
+- [ ] CLI `--word-boundary` flag
+- [ ] Backward compatible (default false)
+
+**Verify:** `make check`
+
+---
+
+## Step 2: #647 Phase 1a - AST infrastructure + tree-sitter setup
+
+**Files to create/modify:**
+- `Cargo.toml`: Add `ast` feature flag with tree-sitter deps
+- `src/ast/mod.rs` (new): Module root, re-exports
+- `src/ast/grammar.rs` (new): Language detection (extension -> grammar),
+  lazy grammar loading, parse file to tree
+- `src/ast/nodes.rs` (new): Language-specific identifier node types table,
+  definition query patterns per language
+- `src/lib.rs`: Add `pub mod ast;` (cfg-gated on `ast` feature)
+
+**Key design decisions:**
+- `src/ast/` is a new module directory (like `src/selector/`)
+- Feature-gated: `#[cfg(feature = "ast")] pub mod ast;`
+- Grammar loading: one function `parse_file(path, lang_hint) -> Tree`
+- Language detection: extension map (`.rs` -> Rust, `.py` -> Python, etc.)
+- No caching in Phase 1 (add in Phase 2 with ast map)
+
+**Crate selection:** Use `tree-sitter` crate (v0.24+) with individual
+grammar crates (`tree-sitter-rust`, `tree-sitter-python`, etc.).
+Start with the 6 most common languages for Phase 1 (Rust, Python,
+TypeScript/JavaScript, Go, Java, C/C++). Add remaining grammars
+incrementally as tests confirm they work.
+
+**Verify:** `cargo build --features ast` compiles. Unit tests for
+language detection and file parsing.
+
+---
+
+## Step 3: #647 Phase 1b - `patchloom rename` (AST-aware)
+
+The existing `src/cmd/rename.rs` is file rename (mv). AST symbol rename
+is a new command that needs a different name or the existing rename
+needs to be restructured.
+
+**Approach:** The issue says `patchloom rename OLD NEW PATH`. The existing
+rename command is `patchloom rename FROM_PATH TO_PATH`. These have
+different signatures (2 args + path vs 2 paths). Options:
+1. New subcommand: `patchloom symbol-rename` (ugly)
+2. Detect by argument pattern (fragile)
+3. Rename existing to `patchloom mv` and take `rename` for AST (breaking)
+4. Use `patchloom ast rename` as a subcommand under `ast`
+
+**Recommended: Option 4.** Use `patchloom ast rename OLD NEW [PATHS]`.
+Keeps existing `rename` (file move) untouched. All AST operations live
+under `patchloom ast` subcommand group.
+
+**Files to create/modify:**
+- `src/cmd/ast.rs` (new): AST subcommand group with `AstCommand` enum
+- `src/cmd/ast/rename.rs` (new): AST rename implementation
+- `src/ast/rename.rs` (new): Core `rename_symbol()` function
+- `src/cmd/mod.rs`: Add `pub mod ast;` (cfg-gated), add `Ast` variant
+- `src/api.rs`: Add `pub fn rename_symbol()` to public API
+- `tests/integration.rs`: Rename tests (strings, comments, identifiers)
+
+**Core logic:**
+```rust
+pub fn rename_symbol(path, old_name, new_name, opts) -> EditResult {
+    // 1. Read file
+    // 2. Detect language from extension
+    // 3. Parse with tree-sitter
+    // 4. Walk AST, collect identifier nodes matching old_name
+    // 5. Filter to only identifier-type nodes (skip strings, comments)
+    // 6. Replace in reverse order (to preserve byte offsets)
+    // 7. Return EditResult with diff
+    // Fallback: if no grammar or parse fails, use replace_text with word_boundary
+}
+```
+
+**Tests must verify:**
+- Renames `SetupFile` in `struct SetupFile { }` (type_identifier)
+- Renames `SetupFile` in `let x: SetupFile = ...` (type_identifier)
+- Renames `setup_file` in `fn setup_file()` (identifier)
+- Does NOT rename inside `"Loading SetupFile..."` (string)
+- Does NOT rename inside `// comment about SetupFile` (comment)
+- Does NOT rename inside `/// doc comment` (doc comment)
+- Falls back to word-boundary replace for unknown extensions
+- Falls back when `ast` feature disabled
+
+**Verify:** `make check`
+
+---
+
+## Step 4: #647 Phase 1c - `patchloom ast list`
+
+**Files to create/modify:**
+- `src/cmd/ast/list.rs` (new): CLI subcommand
+- `src/ast/symbols.rs` (new): Core symbol extraction logic
+- `src/api.rs`: Add `pub fn list_symbols()` to public API
+- `tests/integration.rs`: List tests
+
+**Core logic:**
+```rust
+pub struct SymbolDef {
+    pub name: String,
+    pub kind: SymbolKind, // Function, Struct, Enum, Trait, Class, Method, ...
+    pub start_line: usize,
+    pub end_line: usize,
+    pub signature: String,
+    pub children: Vec<SymbolDef>, // nested (methods inside impl, tests inside mod)
+}
+
+pub fn list_symbols(path, opts) -> Vec<SymbolDef>;
+```
+
+**Language-specific queries:** Each language needs tree-sitter queries
+that capture definitions. Use tag queries similar to Cline's approach:
+- Rust: `function_item`, `struct_item`, `enum_item`, `trait_item`,
+  `impl_item`, `mod_item`, `const_item`, `static_item`, `type_item`
+- Python: `function_definition`, `class_definition`
+- JS/TS: `function_declaration`, `class_declaration`, `method_definition`
+- Go: `function_declaration`, `method_declaration`, `type_declaration`
+- Java: `class_declaration`, `method_declaration`, `interface_declaration`
+- C/C++: `function_definition`, `struct_specifier`, `class_specifier`
+
+**Must support:**
+- `--kind function,struct` filtering
+- `--compact` mode (Cline-style, definition names only)
+- `--json` / `--jsonl` output
+- Directory recursion with `--glob` filtering
+
+**Verify:** `make check`
+
+---
+
+## Step 5: #647 Phase 1d - `patchloom ast read`
+
+**Files to create/modify:**
+- `src/cmd/ast/read.rs` (new): CLI subcommand
+- `src/ast/symbols.rs`: Add `read_symbol()` function
+- `src/api.rs`: Add `pub fn read_symbol()` to public API
+- `tests/integration.rs`: Read tests
+
+**Core logic:** Find symbol by name in AST, extract its full source text
+from start_line to end_line. Support `Class::method` syntax for nested
+symbols. `--context N` adds N lines before/after.
+
+**Verify:** `make check`
+
+---
+
+## Step 6: #647 Phase 1e - `patchloom ast validate`
+
+**Files to create/modify:**
+- `src/cmd/ast/validate.rs` (new): CLI subcommand
+- `src/ast/validate.rs` (new): Core validation logic
+- `src/api.rs`: Add `pub fn validate_syntax()` to public API
+- `tests/integration.rs`: Validate tests (valid file, invalid file, directory)
+
+**Core logic:** Parse file with tree-sitter, check `tree.root_node().has_error()`.
+Report error node locations. Exit code 0 = valid, 1 = errors.
+
+**Verify:** `make check`
+
+---
+
+## Step 7: #647 MCP tools for Phase 1
+
+**Files to modify:**
+- `src/cmd/mcp.rs`: Add MCP tools for all Phase 1 operations:
+  - `rename_symbol` (ast rename)
+  - `ast_list_symbols` (ast list)
+  - `ast_read_symbol` (ast read)
+  - `ast_validate` (ast validate)
+- Update `mcp_lists_expected_tools` test with new tool names and count
+
+**All MCP tools gated on both `mcp` + `ast` features.**
+
+**Verify:** `make check`
+
+---
+
+## Step 8: #647 finalize - ancillary files, close issue
+
+- `src/cmd/mod.rs`: Update agent-rules generator with new commands
+- `docs/reference/README.md`: Add `ast` command documentation
+- `tests/agent/drivers/base.py`: Add `ast` to `_PATCHLOOM_SUBCOMMANDS`
+- `make sync-patchloom-md && make update-readme && make check`
+- Close #647 after all acceptance criteria verified
+
+---
+
+## Step 9: #649 ast search (Phase 2a)
+
+**Files to create/modify:**
+- `src/cmd/ast/search.rs` (new): CLI subcommand
+- `src/ast/search.rs` (new): Pattern matching engine
+- `src/api.rs`: Add `pub fn ast_search()` to public API
+- `src/cmd/mcp.rs`: Add `ast_search` MCP tool
+- `tests/integration.rs`: Structural search tests
+
+**Two modes:**
+1. Pattern mode: Parse pattern as code, extract AST, match against target
+   AST with meta-variable binding ($VAR, $$$MULTI)
+2. Query mode: Pass raw S-expression to tree-sitter query API
+
+**Verify:** `make check`
+
+---
+
+## Step 10: #651 ast refs (Phase 2c)
+
+**Files to create/modify:**
+- `src/cmd/ast/refs.rs` (new): CLI subcommand
+- `src/ast/refs.rs` (new): Reference finding logic
+- `src/api.rs`: Add `pub fn find_references()` to public API
+- `src/cmd/mcp.rs`: Add `ast_refs` MCP tool
+- `tests/integration.rs`: Reference finding tests
+
+**Core logic:** For each file in scope, parse with tree-sitter, find all
+identifier nodes matching the symbol name. Distinguish definitions from
+references based on node parent type. Report file, line, context, kind.
+
+**Verify:** `make check`
+
+---
+
+## Step 11: #652 ast deps (Phase 2d)
+
+**Files to create/modify:**
+- `src/cmd/ast/deps.rs` (new): CLI subcommand
+- `src/ast/deps.rs` (new): Import extraction logic
+- `src/api.rs`: Add `pub fn analyze_deps()` to public API
+- `src/cmd/mcp.rs`: Add `ast_deps` MCP tool
+- `tests/integration.rs`: Dependency analysis tests
+
+**Language-specific import extraction queries:**
+- Rust: `use_declaration`, `mod_item`, `extern_crate_declaration`
+- Python: `import_statement`, `import_from_statement`
+- JS/TS: `import_statement`, `call_expression` where fn is `require`
+- Go: `import_declaration`
+- Java: `import_declaration`
+- C/C++: `preproc_include`
+
+**Verify:** `make check`
+
+---
+
+## Step 12: #650 ast map with PageRank (Phase 2b)
+
+**Files to create/modify:**
+- `src/cmd/ast/map.rs` (new): CLI subcommand
+- `src/ast/map.rs` (new): Repo map generation with ranking
+- `src/api.rs`: Add `pub fn repo_map()` to public API
+- `src/cmd/mcp.rs`: Add `ast_map` MCP tool
+- `tests/integration.rs`: Repo map tests
+
+**Depends on:** ast list (symbols), ast refs (reference graph).
+
+**Core logic:**
+1. Extract all definitions from all files (via `list_symbols`)
+2. Extract all references (via identifier scan)
+3. Build directed graph: edges from reference sites to definitions
+4. Compute PageRank scores (implement simple PageRank, no networkx dep)
+5. Sort symbols by score
+6. Render top symbols within `--max-tokens` budget
+7. `--focus` and `--boost` bias the ranking
+
+**PageRank implementation:** Simple iterative PageRank in pure Rust
+(~50 lines). No need for a graph library dependency.
+
+**Token counting:** Estimate tokens as `content.len() / 4` (rough
+approximation). No tokenizer dependency needed.
+
+**Verify:** `make check`
+
+---
+
+## Step 13: #653 ast replace (Phase 3a)
+
+**Files to create/modify:**
+- `src/cmd/ast/replace.rs` (new): CLI subcommand
+- `src/ast/replace.rs` (new): Symbol-scoped replace logic
+- `src/api.rs`: Add `pub fn ast_replace()` to public API
+- `src/cmd/mcp.rs`: Add `ast_replace` MCP tool
+- `tests/integration.rs`: Symbol-scoped replace tests
+
+**Core logic:** Locate symbol via AST (reuse `read_symbol` logic), then
+run `replace_text` scoped to only the symbol's line range.
+
+**Verify:** `make check`
+
+---
+
+## Step 14: #654 ast impact (Phase 3b)
+
+**Files to create/modify:**
+- `src/cmd/ast/impact.rs` (new): CLI subcommand
+- `src/ast/impact.rs` (new): Transitive impact analysis
+- `src/api.rs`: Add `pub fn analyze_impact()` to public API
+- `src/cmd/mcp.rs`: Add `ast_impact` MCP tool
+- `tests/integration.rs`: Impact analysis tests
+
+**Core logic:** Build reference graph (reuse refs logic), compute
+transitive closure up to `--depth` limit. Render as tree showing
+call chains.
+
+**Verify:** `make check`
+
+---
+
+## Step 15: #655 ast diff (Phase 3c)
+
+**Files to create/modify:**
+- `src/cmd/ast/diff.rs` (new): CLI subcommand
+- `src/ast/diff.rs` (new): Structural diff logic
+- `src/api.rs`: Add `pub fn ast_diff()` to public API
+- `src/cmd/mcp.rs`: Add `ast_diff` MCP tool
+- `tests/integration.rs`: AST diff tests
+
+**Core logic:**
+1. Get file contents at two git refs (or working tree vs HEAD)
+2. Parse both with tree-sitter
+3. Extract definitions from both (via `list_symbols`)
+4. Diff the two symbol lists: added, removed, signature changed, body changed
+5. Render human-readable or JSON output
+
+**Verify:** `make check`
+
+---
+
+## Step 16: Final verification and cleanup
+
+- Run `make check` one final time
+- Run `make sync-patchloom-md && make update-readme`
+- Verify all 9 issues (#646-#655) have acceptance criteria met
+- Close all issues with commit references
+- Push to main via PR
+
+---
+
+## Session handoff template
+
+When starting a new session to continue this plan:
+
+```
+Continue implementing the patchloom AST plan at AST-IMPLEMENTATION-PLAN.md.
+The plan covers issues #646-#655. Check which steps are completed (marked
+with [x]) and continue from the next unchecked step. Run `make check`
+after each step. All issues above #635 must be fully implemented and
+tested before the plan is complete.
+```

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -433,6 +433,13 @@ These are meaningful command-specific modes that change how a top-level command 
 - **Use when:** The target text appears with inconsistent capitalization and should still be updated uniformly.
 - **Prefer instead:** Use case-sensitive replace when exact spelling is part of the safety boundary.
 
+<!-- ref:replace-mode:word-boundary -->
+### `replace --word-boundary`
+
+- **What it does:** Wraps the search pattern with `\b` (word boundary) anchors so it only matches as a standalone word. Prevents `SetupFile` from matching inside `BenchSetupFile`. The pattern is auto-escaped for regex metacharacters before anchoring.
+- **Use when:** Renaming identifiers where the old name is a substring of other identifiers (e.g. `SetupFile` vs `BenchSetupFile`, `Task` vs `TaskResult`).
+- **Prefer instead:** Use AST-aware rename (#647) when you need to skip matches inside strings and comments. Word boundary only prevents partial-word matches, not string/comment matches.
+
 <!-- ref:replace-mode:whole-line -->
 ### `replace --whole-line`
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -102,6 +102,11 @@ pub struct ReplaceOptions {
     pub range: Option<(usize, Option<usize>)>,
     /// Return success (no error) even when the pattern matches nothing.
     pub if_exists: bool,
+    /// When true, match only at word boundaries (`\b` in regex terms).
+    /// Prevents `SetupFile` from matching inside `BenchSetupFile`.
+    /// The pattern is auto-escaped for regex metacharacters before
+    /// wrapping with `\b` anchors.
+    pub word_boundary: bool,
 }
 
 /// Write policy options for controlling file write transformations.
@@ -461,6 +466,7 @@ pub fn replace_text(
         opts.regex,
         opts.case_insensitive,
         opts.multiline,
+        opts.word_boundary,
     )?;
 
     let direct_to = if opts.insert_before.is_none() && opts.insert_after.is_none() {
@@ -950,6 +956,7 @@ pub fn search(
             pattern,
             regex,
             case_insensitive,
+            false,
             false,
         )?)
     } else {

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -139,6 +139,7 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
                 if_exists: false,
                 whole_line: false,
                 range: None,
+                word_boundary: false,
             })
         }
         "file.create" => {

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -353,6 +353,7 @@ mod tests {
             if_exists: false,
             whole_line: false,
             range: None,
+            word_boundary: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Replace "v1" with "v2" in README.md (literal)"#);
@@ -374,6 +375,7 @@ mod tests {
             if_exists: false,
             whole_line: false,
             range: None,
+            word_boundary: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -489,6 +491,7 @@ mod tests {
             if_exists: false,
             whole_line: false,
             range: None,
+            word_boundary: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -514,6 +517,7 @@ mod tests {
             if_exists: false,
             whole_line: false,
             range: None,
+            word_boundary: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Insert "// added" after "use crate" in lib.rs"#);
@@ -535,6 +539,7 @@ mod tests {
             if_exists: false,
             whole_line: true,
             range: Some("10:50".into()),
+            word_boundary: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("whole-line"), "{desc}");
@@ -641,6 +646,7 @@ mod tests {
             if_exists: false,
             whole_line: false,
             range: None,
+            word_boundary: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("**/*.rs"), "{desc}");
@@ -662,6 +668,7 @@ mod tests {
             if_exists: false,
             whole_line: false,
             range: None,
+            word_boundary: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("(delete)"), "{desc}");

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -158,6 +158,10 @@ pub struct ReplaceParams {
     pub whole_line: bool,
     /// Restrict matching to a line range (e.g. "10:50"). Requires whole_line=true.
     pub range: Option<String>,
+    /// Match only at word boundaries. Prevents 'SetupFile' from matching
+    /// inside 'BenchSetupFile'. Auto-escapes regex metacharacters.
+    #[serde(default)]
+    pub word_boundary: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,
@@ -1107,7 +1111,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range. Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
+        description = "Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
     )]
     async fn replace_text(
         &self,
@@ -1145,6 +1149,7 @@ impl PatchloomService {
                     if_exists: p.if_exists,
                     whole_line: p.whole_line,
                     range: p.range,
+                    word_boundary: p.word_boundary,
                 }],
                 Some(p.strict),
             ),
@@ -1447,6 +1452,7 @@ impl PatchloomService {
                 if_exists: false,
                 whole_line: false,
                 range: None,
+                word_boundary: false,
             })
             .collect();
         execute_plan_validated(make_plan_strict(ops, Some(p.strict)), self.cwd())
@@ -1594,7 +1600,7 @@ mod tests {
         assert_eq!(
             descriptions.get("replace_text"),
             Some(
-                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range. Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
+                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
             ),
             "replace_text description drifted"
         );

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -60,6 +60,12 @@ pub struct ReplaceArgs {
     /// Useful for deleting lines (--whole-line --to '') or replacing full lines.
     #[arg(long, short = 'L')]
     pub whole_line: bool,
+    // ref:replace-mode:word-boundary
+    /// Match only at word boundaries. Prevents 'SetupFile' from matching
+    /// inside 'BenchSetupFile'. The pattern is auto-escaped for regex
+    /// metacharacters before wrapping with \\b anchors.
+    #[arg(long, short = 'w')]
+    pub word_boundary: bool,
     // ref:replace-mode:range
     /// Restrict matching to a line range (e.g. '10:50'). 1-based, inclusive.
     #[arg(long, short = 'R')]
@@ -130,7 +136,7 @@ fn build_replacement(args: &ReplaceArgs) -> String {
         &args.to,
         &args.insert_before,
         &args.insert_after,
-        args.regex || args.case_insensitive,
+        args.regex || args.case_insensitive || args.word_boundary,
     )
 }
 
@@ -151,6 +157,7 @@ fn collect_replacements(
         args.regex,
         args.case_insensitive,
         args.multiline,
+        args.word_boundary,
     )?;
 
     let from = &args.from;
@@ -412,6 +419,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: None,
             write: Default::default(),
@@ -454,6 +462,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: None,
             write: Default::default(),
@@ -483,6 +492,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: None,
             write: Default::default(),
@@ -587,6 +597,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: None,
             write: Default::default(),
@@ -613,6 +624,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: None,
             write: Default::default(),
@@ -687,6 +699,7 @@ mod tests {
             multiline: true,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: None,
             write: Default::default(),
@@ -716,6 +729,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: None,
             write: Default::default(),
@@ -809,6 +823,7 @@ mod tests {
             multiline: false,
             nth: Some(0),
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: None,
             write: Default::default(),
@@ -839,6 +854,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: true,
             range: None,
             write: Default::default(),
@@ -875,6 +891,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: true,
             range: None,
             write: Default::default(),
@@ -904,6 +921,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: true,
             range: None,
             write: Default::default(),
@@ -932,6 +950,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: true,
             range: Some("1:3".to_string()),
             write: Default::default(),
@@ -962,6 +981,7 @@ mod tests {
             multiline: false,
             nth: Some(2),
             case_insensitive: false,
+            word_boundary: false,
             whole_line: true,
             range: None,
             write: Default::default(),
@@ -992,6 +1012,7 @@ mod tests {
             multiline: false,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: false,
             range: Some("1:5".to_string()),
             write: Default::default(),
@@ -1021,6 +1042,7 @@ mod tests {
             multiline: true,
             nth: None,
             case_insensitive: false,
+            word_boundary: false,
             whole_line: true,
             range: None,
             write: Default::default(),
@@ -1030,6 +1052,117 @@ mod tests {
             err.to_string()
                 .contains("--whole-line and --multiline cannot be combined"),
             "{err}"
+        );
+    }
+
+    #[test]
+    fn word_boundary_prevents_partial_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        fs::write(
+            &file,
+            "struct SetupFile {}\nstruct BenchSetupFile {}\nlet x: SetupFile = todo!();\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            from: "SetupFile".to_string(),
+            to: Some("NewFile".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: true,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &default_global()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 2);
+        assert_eq!(
+            replacements[0].replaced,
+            "struct NewFile {}\nstruct BenchSetupFile {}\nlet x: NewFile = todo!();\n",
+            "word_boundary should rename standalone SetupFile but not inside BenchSetupFile"
+        );
+    }
+
+    #[test]
+    fn word_boundary_with_metacharacters() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        fs::write(&file, "type A = Option<SetupFile>;\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "SetupFile".to_string(),
+            to: Some("NewFile".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: true,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &default_global()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(
+            replacements[0].replaced, "type A = Option<NewFile>;\n",
+            "word_boundary should match at angle bracket boundaries"
+        );
+    }
+
+    #[test]
+    fn word_boundary_does_not_match_in_string() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        // In a string, SetupFile is still at word boundaries (quotes are non-word chars)
+        // so word_boundary alone won't skip strings -- that needs AST (#647).
+        // But it WILL prevent matching inside compound identifiers.
+        fs::write(
+            &file,
+            "let name = \"SetupFile\";\nlet x: SetupFileConfig = todo!();\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            from: "SetupFile".to_string(),
+            to: Some("NewFile".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: true,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &default_global()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        // SetupFile in the string IS matched (word boundaries don't know about strings)
+        // SetupFileConfig is NOT matched (no word boundary between SetupFile and Config)
+        assert_eq!(
+            replacements[0].replaced,
+            "let name = \"NewFile\";\nlet x: SetupFileConfig = todo!();\n",
         );
     }
 }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -466,9 +466,22 @@ fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<us
         unreachable!()
     };
     let regex_mode = mode.as_deref() == Some("regex");
-    let use_regex = regex_mode || *case_insensitive;
+    let word_boundary = matches!(
+        op,
+        Operation::Replace {
+            word_boundary: true,
+            ..
+        }
+    );
+    let use_regex = regex_mode || *case_insensitive || word_boundary;
     let replacement = replacement_text(from, to, insert_before, insert_after, use_regex);
-    let compiled_re = compile_replace_regex(from, regex_mode, *case_insensitive, *multiline)?;
+    let compiled_re = compile_replace_regex(
+        from,
+        regex_mode,
+        *case_insensitive,
+        *multiline,
+        word_boundary,
+    )?;
     let parsed_range = range
         .as_deref()
         .map(crate::cmd::read::parse_line_range)

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1272,10 +1272,27 @@ pub mod replace {
         regex_mode: bool,
         case_insensitive: bool,
         multiline: bool,
+        word_boundary: bool,
     ) -> anyhow::Result<Option<Regex>> {
+        if word_boundary && !regex_mode {
+            // Escape the literal pattern and wrap with \b anchors.
+            let escaped = regex::escape(pattern);
+            let wb_pattern = format!("\\b{escaped}\\b");
+            return Ok(Some(
+                regex::RegexBuilder::new(&wb_pattern)
+                    .case_insensitive(case_insensitive)
+                    .dot_matches_new_line(multiline)
+                    .build()?,
+            ));
+        }
         if regex_mode {
+            let effective = if word_boundary {
+                format!("\\b(?:{pattern})\\b")
+            } else {
+                pattern.to_string()
+            };
             Ok(Some(
-                regex::RegexBuilder::new(pattern)
+                regex::RegexBuilder::new(&effective)
                     .case_insensitive(case_insensitive)
                     .dot_matches_new_line(multiline)
                     .build()?,
@@ -3476,7 +3493,7 @@ mod tests {
 
         #[test]
         fn compile_regex_mode_returns_some() {
-            let re = compile_replace_regex(r"\d+", true, false, false)
+            let re = compile_replace_regex(r"\d+", true, false, false, false)
                 .unwrap()
                 .expect("regex mode should return Some");
             assert!(re.is_match("abc123"));
@@ -3484,7 +3501,7 @@ mod tests {
 
         #[test]
         fn compile_regex_multiline_dot_matches_newline() {
-            let re = compile_replace_regex("a.b", true, false, true)
+            let re = compile_replace_regex("a.b", true, false, true, false)
                 .unwrap()
                 .unwrap();
             assert!(
@@ -3495,13 +3512,13 @@ mod tests {
 
         #[test]
         fn compile_invalid_regex_returns_error() {
-            let result = compile_replace_regex("(unclosed", true, false, false);
+            let result = compile_replace_regex("(unclosed", true, false, false, false);
             assert!(result.is_err());
         }
 
         #[test]
         fn compile_literal_case_insensitive_returns_some() {
-            let re = compile_replace_regex("hello", false, true, false)
+            let re = compile_replace_regex("hello", false, true, false, false)
                 .unwrap()
                 .expect("case-insensitive literal should return Some");
             assert!(re.is_match("HELLO"));
@@ -3509,8 +3526,51 @@ mod tests {
 
         #[test]
         fn compile_plain_literal_returns_none() {
-            let re = compile_replace_regex("hello", false, false, false).unwrap();
+            let re = compile_replace_regex("hello", false, false, false, false).unwrap();
             assert!(re.is_none());
+        }
+
+        #[test]
+        fn compile_word_boundary_literal() {
+            let re = compile_replace_regex("SetupFile", false, false, false, true)
+                .unwrap()
+                .expect("word_boundary should return Some");
+            assert!(re.is_match("SetupFile"), "should match standalone word");
+            assert!(
+                re.is_match("use crate::SetupFile;"),
+                "should match at word boundary"
+            );
+            assert!(
+                !re.is_match("BenchSetupFile"),
+                "should NOT match inside a longer word"
+            );
+            assert!(
+                !re.is_match("SetupFileConfig"),
+                "should NOT match when followed by more word chars"
+            );
+        }
+
+        #[test]
+        fn compile_word_boundary_escapes_metacharacters() {
+            // Test that regex metacharacters in the pattern are properly escaped.
+            // Use a pattern with dots and parens that would be regex-special.
+            let re = compile_replace_regex("foo.bar()", false, false, false, true)
+                .unwrap()
+                .expect("word_boundary with metacharacters should return Some");
+            // The escaped pattern should NOT match "fooXbar()" (dot is literal)
+            assert!(
+                !re.is_match("fooXbarX"),
+                "dot should be literal, not wildcard"
+            );
+        }
+
+        #[test]
+        fn compile_word_boundary_case_insensitive() {
+            let re = compile_replace_regex("setupfile", false, true, false, true)
+                .unwrap()
+                .expect("word_boundary + case_insensitive should return Some");
+            assert!(re.is_match("SetupFile"));
+            assert!(!re.is_match("BenchSetupFile"));
         }
 
         // ── replace_whole_lines tests ─────────────────────────────────
@@ -3525,7 +3585,7 @@ mod tests {
 
         #[test]
         fn whole_lines_delete_regex() {
-            let re = compile_replace_regex(r"let _\w+", true, false, false)
+            let re = compile_replace_regex(r"let _\w+", true, false, false, false)
                 .unwrap()
                 .unwrap();
             let content = "fn main() {\n    let _x = foo();\n    let y = bar();\n}\n";
@@ -3571,7 +3631,7 @@ mod tests {
 
         #[test]
         fn whole_lines_regex_capture_groups() {
-            let re = compile_replace_regex(r"version = (\d+)", true, false, false)
+            let re = compile_replace_regex(r"version = (\d+)", true, false, false, false)
                 .unwrap()
                 .unwrap();
             let content = "name = foo\nversion = 3\nrelease = true\n";

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -85,6 +85,9 @@ pub enum Operation {
         whole_line: bool,
         /// Line range restriction (e.g. "10:50"). Only valid with whole_line.
         range: Option<String>,
+        /// Match only at word boundaries (\b). Prevents partial matches.
+        #[serde(default)]
+        word_boundary: bool,
     },
     #[serde(rename = "doc.set", alias = "doc_set")]
     DocSet {


### PR DESCRIPTION
## Summary

Add `word_boundary` option to replace operations that wraps the search pattern with `\b` (regex word boundary) anchors. This prevents partial matches where the search term appears as a substring of a longer identifier (e.g. `SetupFile` matching inside `BenchSetupFile`).

## Changes

- **`src/api.rs`**: Add `word_boundary: bool` field to `ReplaceOptions`, pass it through to `compile_replace_regex()`
- **`src/ops.rs`**: Extend `compile_replace_regex()` with a `word_boundary` parameter; auto-escapes literal patterns before wrapping with `\b`
- **`src/cmd/replace.rs`**: Add `--word-boundary` / `-w` CLI flag to `ReplaceArgs`
- **`src/plan.rs`**: Add `word_boundary` field to `Operation::Replace`
- **`src/cmd/tx.rs`**: Wire `word_boundary` through transaction execution
- **`src/cmd/mcp.rs`**: Add `word_boundary` param to MCP `replace_text` tool
- **`src/cmd/batch.rs`**, **`src/cmd/explain.rs`**: Update existing `Operation::Replace` literals with `word_boundary: false`
- **`docs/reference/README.md`**: Add reference entry for `replace --word-boundary`

## Testing

- 3 new unit tests in `src/ops.rs` (literal, metacharacter escaping, case-insensitive)
- 3 new unit tests in `src/cmd/replace.rs` (partial match prevention, metacharacters, substring)
- All existing tests updated with `word_boundary: false`
- `make check` passes: 813 unit tests, 669 integration tests (0 failures)

Closes #646