### PR TITLE
feat: add AST-aware operations using tree-sitter (20 languages)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,6 +771,28 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml_edit",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
+ "tree-sitter-go",
+ "tree-sitter-hcl",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-kotlin-sg",
+ "tree-sitter-language",
+ "tree-sitter-php",
+ "tree-sitter-proto",
+ "tree-sitter-python",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-swift",
+ "tree-sitter-toml-ng",
+ "tree-sitter-typescript",
+ "tree-sitter-xml",
+ "tree-sitter-yaml",
  "yaml-edit",
 ]
 
@@ -1258,6 +1280,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,6 +1467,226 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-sg"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06ec43ae3c12165d4ac08afe4e1f5fc6757ffe274fa7bd5af9007ef11ba4319"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e410ccb5fa3cbd6bf7b8e512ecf7ad9d5254395b822bfe9f751b50fa978f31c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-xml"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e670041f591d994f54d597ddcd8f4ebc930e282c4c76a42268743b71f0c8b6b3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,39 @@ exclude = [
 ]
 
 [features]
-default = ["mcp"]
+default = ["mcp", "ast"]
 # Core library: all editing operations, no MCP server, no tree-sitter grammars.
 # Use this when embedding patchloom as a library dependency.
 core = []
 # MCP server support: adds tokio async runtime, rmcp protocol, and JSON Schema.
 mcp = ["rmcp", "tokio", "schemars"]
+# AST-aware operations using tree-sitter grammars (20 languages).
+ast = [
+    "dep:tree-sitter-lib",
+    "dep:tree-sitter-language",
+    "dep:tree-sitter-rust",
+    "dep:tree-sitter-python",
+    "dep:tree-sitter-javascript",
+    "dep:tree-sitter-typescript",
+    "dep:tree-sitter-go",
+    "dep:tree-sitter-bash",
+    "dep:tree-sitter-hcl",
+    "dep:tree-sitter-toml-ng",
+    "dep:tree-sitter-yaml",
+    "dep:tree-sitter-json",
+    "dep:tree-sitter-xml",
+    "dep:tree-sitter-proto",
+    "dep:tree-sitter-c",
+    "dep:tree-sitter-cpp",
+    "dep:tree-sitter-java",
+    "dep:tree-sitter-ruby",
+    "dep:tree-sitter-c-sharp",
+    "dep:tree-sitter-swift",
+    "dep:tree-sitter-kotlin-sg",
+    "dep:tree-sitter-php",
+]
 # Full: everything. Equivalent to default today.
-full = ["mcp"]
+full = ["mcp", "ast"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -58,6 +83,28 @@ clap_complete = "4"
 rmcp = { version = "1", features = ["server", "transport-io", "macros"], optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "io-std", "macros"], optional = true }
 schemars = { version = "1", optional = true }
+tree-sitter-lib = { package = "tree-sitter", version = "0.26", optional = true }
+tree-sitter-language = { version = "0.1", optional = true }
+tree-sitter-rust = { version = "0.24", optional = true }
+tree-sitter-python = { version = "0.25", optional = true }
+tree-sitter-javascript = { version = "0.25", optional = true }
+tree-sitter-typescript = { version = "0.23", optional = true }
+tree-sitter-go = { version = "0.25", optional = true }
+tree-sitter-bash = { version = "0.25", optional = true }
+tree-sitter-hcl = { version = "1.1", optional = true }
+tree-sitter-toml-ng = { version = "0.7", optional = true }
+tree-sitter-yaml = { version = "0.7", optional = true }
+tree-sitter-json = { version = "0.24", optional = true }
+tree-sitter-xml = { version = "0.7", optional = true }
+tree-sitter-proto = { version = "0.4", optional = true }
+tree-sitter-c = { version = "0.24", optional = true }
+tree-sitter-cpp = { version = "0.23", optional = true }
+tree-sitter-java = { version = "0.23", optional = true }
+tree-sitter-ruby = { version = "0.23", optional = true }
+tree-sitter-c-sharp = { version = "0.23", optional = true }
+tree-sitter-swift = { version = "0.7", optional = true }
+tree-sitter-kotlin-sg = { version = "0.4", optional = true }
+tree-sitter-php = { version = "0.24", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -78,6 +125,9 @@ implicit_clone = "warn"
 cloned_instead_of_copied = "warn"
 redundant_else = "warn"
 semicolon_if_nothing_returned = "warn"
+
+[package.metadata.cargo-machete]
+ignored = ["tree-sitter-language"]
 
 # The profile that 'dist' will build with
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1400%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1500%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -423,7 +423,7 @@ flowchart LR
 
 ## Status
 
-1400+ tests across 20 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1500+ tests across 21 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -25,7 +25,7 @@ file.create VERSION "2.0.0"
 EOF
 ```
 
-20 commands cover structured document editing, search and replace, markdown section editing, multi-file batching, atomic transactions with rollback, diff patching, file lifecycle operations, operation schema export, and an MCP server that exposes everything as structured tool calls for MCP-capable agents.
+21 commands cover structured document editing, search and replace, markdown section editing, multi-file batching, atomic transactions with rollback, diff patching, file lifecycle operations, AST-aware code operations (rename, list, read, validate using tree-sitter), operation schema export, and an MCP server that exposes everything as structured tool calls for MCP-capable agents.
 
 ## The honest benchmark
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -324,6 +324,14 @@ These are the main entry points. If you are deciding between commands, start her
 - **Prefer instead:** Nothing, if Patchloom is only used from scripts or ephemeral CI runners.
 - **Related:** [installation guide](../getting-started/installation.md)
 
+<!-- ref:command:ast -->
+## `ast`
+
+- **What it does:** AST-aware operations on source code using tree-sitter grammars (20 languages). Subcommands: `list` (extract symbol definitions), `read` (read a symbol by name), `rename` (rename identifiers, skipping strings/comments), `validate` (syntax validation).
+- **Use when:** You need to list, read, rename, or validate symbols with structural awareness (skip strings, comments, and documentation). Especially useful for rename operations where the old name appears inside strings that should not be changed.
+- **Prefer instead:** Use `replace --word-boundary` for quick identifier renames when AST precision is not required. Use a language server (LSP) when cross-file type-aware rename is needed.
+- **Related:** [`replace`](#replace), [`search`](#search)
+
 ## Command modes
 
 These are meaningful command-specific modes that change how a top-level command behaves, even though they are not separate subcommands.

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,0 +1,299 @@
+//! AST-aware operations using tree-sitter grammars.
+//!
+//! This module provides language detection, source file parsing, symbol
+//! extraction, AST-aware rename, and syntax validation for 20 languages.
+//! All functionality is gated on the `ast` feature flag.
+
+pub mod rename;
+pub mod symbols;
+pub mod validate;
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// A programming, markup, or data language detected by file extension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Language {
+    Rust,
+    TypeScript,
+    JavaScript,
+    Python,
+    Go,
+    Java,
+    CSharp,
+    Ruby,
+    Php,
+    Swift,
+    Kotlin,
+    Cpp,
+    C,
+    Hcl,
+    Xml,
+    Protobuf,
+    Dockerfile,
+    Markdown,
+    Toml,
+    Yaml,
+    Json,
+    Shell,
+    Unknown,
+}
+
+impl Language {
+    /// Detect language from a file extension string (without the leading dot).
+    pub fn from_extension(ext: &str) -> Self {
+        match ext.to_lowercase().as_str() {
+            "rs" => Self::Rust,
+            "ts" | "tsx" => Self::TypeScript,
+            "js" | "jsx" | "mjs" | "cjs" => Self::JavaScript,
+            "py" | "pyi" => Self::Python,
+            "go" => Self::Go,
+            "java" => Self::Java,
+            "cs" => Self::CSharp,
+            "rb" => Self::Ruby,
+            "php" => Self::Php,
+            "swift" => Self::Swift,
+            "kt" | "kts" => Self::Kotlin,
+            "c" | "h" => Self::C,
+            "cpp" | "cxx" | "cc" | "hpp" | "hxx" => Self::Cpp,
+            "hcl" | "tf" | "tfvars" => Self::Hcl,
+            "xml" | "xsl" | "xslt" | "xsd" | "svg" | "plist" => Self::Xml,
+            "proto" => Self::Protobuf,
+            "dockerfile" => Self::Dockerfile,
+            "md" | "mdx" => Self::Markdown,
+            "toml" => Self::Toml,
+            "yml" | "yaml" => Self::Yaml,
+            "json" => Self::Json,
+            "sh" | "bash" | "zsh" => Self::Shell,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Detect language from a file path by its extension.
+    pub fn from_path(path: &Path) -> Self {
+        // Handle extensionless files by filename.
+        if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+            let lower = name.to_lowercase();
+            if lower == "dockerfile" || lower.starts_with("dockerfile.") {
+                return Self::Dockerfile;
+            }
+            if lower == "makefile" || lower == "gnumakefile" {
+                return Self::Shell; // Makefiles use shell syntax
+            }
+        }
+        match path.extension().and_then(|e| e.to_str()) {
+            Some(ext) => Self::from_extension(ext),
+            None => Self::Unknown,
+        }
+    }
+
+    /// Returns `true` if this language has tree-sitter grammar support.
+    pub fn has_grammar(self) -> bool {
+        !matches!(self, Self::Markdown | Self::Dockerfile | Self::Unknown)
+    }
+}
+
+impl std::fmt::Display for Language {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Rust => "Rust",
+            Self::TypeScript => "TypeScript",
+            Self::JavaScript => "JavaScript",
+            Self::Python => "Python",
+            Self::Go => "Go",
+            Self::Java => "Java",
+            Self::CSharp => "C#",
+            Self::Ruby => "Ruby",
+            Self::Php => "PHP",
+            Self::Swift => "Swift",
+            Self::Kotlin => "Kotlin",
+            Self::Cpp => "C++",
+            Self::C => "C",
+            Self::Hcl => "HCL",
+            Self::Xml => "XML",
+            Self::Protobuf => "Protobuf",
+            Self::Dockerfile => "Dockerfile",
+            Self::Markdown => "Markdown",
+            Self::Toml => "TOML",
+            Self::Yaml => "YAML",
+            Self::Json => "JSON",
+            Self::Shell => "Shell",
+            Self::Unknown => "Unknown",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Map a [`Language`] to its tree-sitter grammar.
+pub(crate) fn ts_language_for(lang: Language) -> Option<tree_sitter_lib::Language> {
+    match lang {
+        Language::Rust => Some(tree_sitter_rust::LANGUAGE.into()),
+        Language::Python => Some(tree_sitter_python::LANGUAGE.into()),
+        Language::TypeScript => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
+        Language::JavaScript => Some(tree_sitter_javascript::LANGUAGE.into()),
+        Language::Go => Some(tree_sitter_go::LANGUAGE.into()),
+        Language::Shell => Some(tree_sitter_bash::LANGUAGE.into()),
+        Language::Hcl => Some(tree_sitter_hcl::LANGUAGE.into()),
+        Language::Toml => Some(tree_sitter_toml_ng::LANGUAGE.into()),
+        Language::Yaml => Some(tree_sitter_yaml::LANGUAGE.into()),
+        Language::Json => Some(tree_sitter_json::LANGUAGE.into()),
+        Language::Xml => Some(tree_sitter_xml::LANGUAGE_XML.into()),
+        Language::Protobuf => Some(tree_sitter_proto::LANGUAGE.into()),
+        Language::C => Some(tree_sitter_c::LANGUAGE.into()),
+        Language::Cpp => Some(tree_sitter_cpp::LANGUAGE.into()),
+        Language::Java => Some(tree_sitter_java::LANGUAGE.into()),
+        Language::Ruby => Some(tree_sitter_ruby::LANGUAGE.into()),
+        Language::CSharp => Some(tree_sitter_c_sharp::LANGUAGE.into()),
+        Language::Swift => Some(tree_sitter_swift::LANGUAGE.into()),
+        Language::Kotlin => Some(tree_sitter_kotlin_sg::LANGUAGE.into()),
+        Language::Php => Some(tree_sitter_php::LANGUAGE_PHP.into()),
+        _ => None,
+    }
+}
+
+/// Parse source text for a given language, returning the tree-sitter tree.
+pub(crate) fn parse_source(
+    source: &str,
+    lang: Language,
+) -> Option<(tree_sitter_lib::Tree, tree_sitter_lib::Language)> {
+    let ts_lang = ts_language_for(lang)?;
+    let mut parser = tree_sitter_lib::Parser::new();
+    parser.set_language(&ts_lang).ok()?;
+    let tree = parser.parse(source, None)?;
+    Some((tree, ts_lang))
+}
+
+/// Find the text of the first child with a given node kind.
+pub(crate) fn child_text_by_kind<'a>(
+    node: tree_sitter_lib::Node<'a>,
+    kind: &str,
+    source: &'a str,
+) -> Option<&'a str> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == kind {
+            return child.utf8_text(source.as_bytes()).ok();
+        }
+    }
+    None
+}
+
+/// Find the text of the first child matching any of the given kinds.
+pub(crate) fn child_text_by_kinds<'a>(
+    node: tree_sitter_lib::Node<'a>,
+    kinds: &[&str],
+    source: &'a str,
+) -> Option<&'a str> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if kinds.contains(&child.kind()) {
+            return child.utf8_text(source.as_bytes()).ok();
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn language_from_extension() {
+        assert_eq!(Language::from_extension("rs"), Language::Rust);
+        assert_eq!(Language::from_extension("ts"), Language::TypeScript);
+        assert_eq!(Language::from_extension("tsx"), Language::TypeScript);
+        assert_eq!(Language::from_extension("js"), Language::JavaScript);
+        assert_eq!(Language::from_extension("py"), Language::Python);
+        assert_eq!(Language::from_extension("go"), Language::Go);
+        assert_eq!(Language::from_extension("java"), Language::Java);
+        assert_eq!(Language::from_extension("cs"), Language::CSharp);
+        assert_eq!(Language::from_extension("rb"), Language::Ruby);
+        assert_eq!(Language::from_extension("php"), Language::Php);
+        assert_eq!(Language::from_extension("swift"), Language::Swift);
+        assert_eq!(Language::from_extension("kt"), Language::Kotlin);
+        assert_eq!(Language::from_extension("c"), Language::C);
+        assert_eq!(Language::from_extension("cpp"), Language::Cpp);
+        assert_eq!(Language::from_extension("hcl"), Language::Hcl);
+        assert_eq!(Language::from_extension("tf"), Language::Hcl);
+        assert_eq!(Language::from_extension("proto"), Language::Protobuf);
+        assert_eq!(Language::from_extension("sh"), Language::Shell);
+        assert_eq!(Language::from_extension("toml"), Language::Toml);
+        assert_eq!(Language::from_extension("yml"), Language::Yaml);
+        assert_eq!(Language::from_extension("json"), Language::Json);
+        assert_eq!(Language::from_extension("xml"), Language::Xml);
+        assert_eq!(Language::from_extension("unknown"), Language::Unknown);
+    }
+
+    #[test]
+    fn language_from_extension_case_insensitive() {
+        assert_eq!(Language::from_extension("RS"), Language::Rust);
+        assert_eq!(Language::from_extension("Py"), Language::Python);
+    }
+
+    #[test]
+    fn language_from_path_uses_extension() {
+        assert_eq!(
+            Language::from_path(Path::new("src/main.rs")),
+            Language::Rust
+        );
+        assert_eq!(
+            Language::from_path(Path::new("lib/foo.py")),
+            Language::Python
+        );
+    }
+
+    #[test]
+    fn language_from_path_dockerfile() {
+        assert_eq!(
+            Language::from_path(Path::new("Dockerfile")),
+            Language::Dockerfile
+        );
+        assert_eq!(
+            Language::from_path(Path::new("Dockerfile.prod")),
+            Language::Dockerfile
+        );
+    }
+
+    #[test]
+    fn has_grammar_excludes_non_parseable() {
+        assert!(Language::Rust.has_grammar());
+        assert!(Language::Python.has_grammar());
+        assert!(!Language::Markdown.has_grammar());
+        assert!(!Language::Dockerfile.has_grammar());
+        assert!(!Language::Unknown.has_grammar());
+    }
+
+    #[test]
+    fn parse_source_rust() {
+        let source = "fn main() { println!(\"hello\"); }";
+        let result = parse_source(source, Language::Rust);
+        assert!(result.is_some());
+        let (tree, _) = result.unwrap();
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parse_source_python() {
+        let source = "def hello():\n    print('hello')\n";
+        let result = parse_source(source, Language::Python);
+        assert!(result.is_some());
+        let (tree, _) = result.unwrap();
+        assert!(!tree.root_node().has_error());
+    }
+
+    #[test]
+    fn parse_source_unknown_returns_none() {
+        let result = parse_source("anything", Language::Unknown);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn display_formatting() {
+        assert_eq!(Language::Rust.to_string(), "Rust");
+        assert_eq!(Language::CSharp.to_string(), "C#");
+        assert_eq!(Language::Cpp.to_string(), "C++");
+    }
+}

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -1,0 +1,208 @@
+//! AST-aware symbol rename: replace only identifier nodes, skipping
+//! strings, comments, and documentation.
+
+use std::path::Path;
+
+use super::{Language, parse_source};
+
+/// Node kinds that represent identifier tokens (rename targets).
+const IDENTIFIER_KINDS: &[&str] = &[
+    "identifier",
+    "type_identifier",
+    "field_identifier",
+    "property_identifier",
+    "simple_identifier",
+    "shorthand_field_identifier",
+];
+
+/// Node kinds whose subtrees should be skipped entirely during rename.
+const SKIP_KINDS: &[&str] = &[
+    "string_literal",
+    "raw_string_literal",
+    "string",
+    "string_content",
+    "string_fragment",
+    "template_string",
+    "line_comment",
+    "block_comment",
+    "comment",
+    "doc_comment",
+    // Python
+    "string_start",
+    "string_end",
+    "concatenated_string",
+    "interpolation",
+];
+
+/// Result of an AST-aware rename operation.
+#[derive(Debug)]
+pub struct RenameResult {
+    /// The new file content after renaming.
+    pub content: String,
+    /// Number of replacements made.
+    pub replacements: usize,
+}
+
+/// Rename all identifier occurrences of `old_name` to `new_name` in source code,
+/// skipping strings and comments.
+///
+/// Returns `None` if the language has no grammar or parsing fails.
+pub fn rename_in_source(
+    source: &str,
+    old_name: &str,
+    new_name: &str,
+    lang: Language,
+) -> Option<RenameResult> {
+    let (tree, _) = parse_source(source, lang)?;
+
+    // Collect byte ranges to replace (in reverse order for offset stability)
+    let mut replacements = Vec::new();
+    collect_rename_nodes(tree.root_node(), source, old_name, &mut replacements);
+
+    // Sort by start byte descending so we can replace from end to start
+    replacements.sort_by_key(|&(start, _)| std::cmp::Reverse(start));
+
+    let replacements_count = replacements.len();
+    let mut result = source.to_string();
+    for (start, end) in &replacements {
+        result.replace_range(*start..*end, new_name);
+    }
+
+    Some(RenameResult {
+        content: result,
+        replacements: replacements_count,
+    })
+}
+
+/// Rename identifiers in a file. Falls back to word-boundary replace if
+/// tree-sitter cannot parse the language.
+pub fn rename_in_file(
+    path: &Path,
+    old_name: &str,
+    new_name: &str,
+    lang_hint: Option<Language>,
+) -> anyhow::Result<Option<RenameResult>> {
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+    let source = std::fs::read_to_string(path)?;
+    Ok(rename_in_source(&source, old_name, new_name, lang))
+}
+
+fn collect_rename_nodes(
+    node: tree_sitter_lib::Node,
+    source: &str,
+    old_name: &str,
+    results: &mut Vec<(usize, usize)>,
+) {
+    // Skip string/comment subtrees entirely
+    if SKIP_KINDS.contains(&node.kind()) {
+        return;
+    }
+
+    // Check if this is a matching identifier node
+    if IDENTIFIER_KINDS.contains(&node.kind())
+        && let Ok(text) = node.utf8_text(source.as_bytes())
+        && text == old_name
+    {
+        results.push((node.start_byte(), node.end_byte()));
+        return; // Leaf node, no children to visit
+    }
+
+    // Recurse into children
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_rename_nodes(cursor.node(), source, old_name, results);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rename_rust_identifier_skips_strings() {
+        let source = r#"
+fn setup_file() -> &str {
+    let name = "setup_file";
+    // setup_file is important
+    setup_file
+}
+"#;
+        let result = rename_in_source(source, "setup_file", "init_file", Language::Rust).unwrap();
+        // Should rename the function name and the trailing expression
+        // but NOT the string literal or comment
+        assert!(result.content.contains("fn init_file()"));
+        assert!(result.content.contains("\"setup_file\"")); // string untouched
+        assert!(result.content.contains("// setup_file")); // comment untouched
+        assert!(result.replacements >= 2);
+    }
+
+    #[test]
+    fn rename_rust_type_identifier() {
+        let source = r#"
+struct SetupFile {
+    name: String,
+}
+
+impl SetupFile {
+    fn new() -> SetupFile {
+        SetupFile { name: String::new() }
+    }
+}
+"#;
+        let result = rename_in_source(source, "SetupFile", "ConfigFile", Language::Rust).unwrap();
+        assert!(result.content.contains("struct ConfigFile"));
+        assert!(result.content.contains("impl ConfigFile"));
+        assert!(result.content.contains("-> ConfigFile"));
+        assert!(!result.content.contains("SetupFile"));
+    }
+
+    #[test]
+    fn rename_python_skips_strings_and_comments() {
+        let source = r#"
+def setup_file():
+    """setup_file docs"""
+    name = "setup_file"
+    # setup_file comment
+    return setup_file()
+"#;
+        let result = rename_in_source(source, "setup_file", "init_file", Language::Python).unwrap();
+        assert!(result.content.contains("def init_file():"));
+        // Strings and comments should be untouched
+        assert!(result.content.contains("\"setup_file\""));
+        assert!(result.content.contains("# setup_file"));
+    }
+
+    #[test]
+    fn rename_no_matches_returns_zero() {
+        let source = "fn main() {}\n";
+        let result =
+            rename_in_source(source, "nonexistent", "replacement", Language::Rust).unwrap();
+        assert_eq!(result.replacements, 0);
+        assert_eq!(result.content, source);
+    }
+
+    #[test]
+    fn rename_unknown_language_returns_none() {
+        let result = rename_in_source("anything", "x", "y", Language::Unknown);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn rename_go_identifier() {
+        let source = r#"
+package main
+
+func SetupFile() string {
+    return "SetupFile"
+}
+"#;
+        let result = rename_in_source(source, "SetupFile", "InitFile", Language::Go).unwrap();
+        assert!(result.content.contains("func InitFile()"));
+        assert!(result.content.contains("\"SetupFile\"")); // string untouched
+    }
+}

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -1,0 +1,598 @@
+//! Symbol extraction from source files using tree-sitter AST parsing.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::{Language, child_text_by_kind, child_text_by_kinds, parse_source};
+
+/// The kind of symbol extracted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolKind {
+    Function,
+    Struct,
+    Enum,
+    Trait,
+    Impl,
+    Class,
+    Method,
+    Const,
+    Type,
+    Interface,
+    Module,
+}
+
+impl std::fmt::Display for SymbolKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Function => "fn",
+            Self::Struct => "struct",
+            Self::Enum => "enum",
+            Self::Trait => "trait",
+            Self::Impl => "impl",
+            Self::Class => "class",
+            Self::Method => "method",
+            Self::Const => "const",
+            Self::Type => "type",
+            Self::Interface => "interface",
+            Self::Module => "mod",
+        };
+        f.write_str(s)
+    }
+}
+
+impl SymbolKind {
+    /// Parse from a string like "function", "struct", etc.
+    pub fn from_str_loose(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "fn" | "func" | "function" => Some(Self::Function),
+            "struct" => Some(Self::Struct),
+            "enum" => Some(Self::Enum),
+            "trait" => Some(Self::Trait),
+            "impl" => Some(Self::Impl),
+            "class" => Some(Self::Class),
+            "method" => Some(Self::Method),
+            "const" | "constant" => Some(Self::Const),
+            "type" => Some(Self::Type),
+            "interface" => Some(Self::Interface),
+            "mod" | "module" => Some(Self::Module),
+            _ => None,
+        }
+    }
+}
+
+/// A single extracted symbol definition.
+#[derive(Debug, Clone, Serialize)]
+pub struct SymbolDef {
+    /// The symbol name.
+    pub name: String,
+    /// The kind of symbol.
+    pub kind: SymbolKind,
+    /// 1-based start line.
+    pub start_line: usize,
+    /// 1-based end line (inclusive).
+    pub end_line: usize,
+    /// One-line signature (up to opening brace or first line).
+    pub signature: String,
+    /// Nested symbols (e.g. methods inside impl, functions inside mod).
+    pub children: Vec<SymbolDef>,
+    /// Nesting depth (0 = top-level).
+    pub depth: usize,
+}
+
+/// Extract all symbol definitions from source code.
+pub fn extract_symbols(source: &str, lang: Language) -> Vec<SymbolDef> {
+    let Some((tree, _)) = parse_source(source, lang) else {
+        return Vec::new();
+    };
+
+    let mut symbols = Vec::new();
+    let mut cursor = tree.walk();
+    visit_node(&mut cursor, source, lang, 0, &mut symbols);
+    symbols
+}
+
+/// Read a file and extract symbols.
+pub fn extract_symbols_from_file(path: &Path, lang_hint: Option<Language>) -> Vec<SymbolDef> {
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+    if !lang.has_grammar() {
+        return Vec::new();
+    }
+    let Ok(source) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    extract_symbols(&source, lang)
+}
+
+/// Find a symbol by name, optionally qualified (e.g. "Impl::method").
+pub fn find_symbol<'a>(symbols: &'a [SymbolDef], name: &str) -> Option<&'a SymbolDef> {
+    if let Some((parent, child)) = name.split_once("::") {
+        // Qualified name: find parent, then child
+        for sym in symbols {
+            if sym.name == parent {
+                for c in &sym.children {
+                    if c.name == child {
+                        return Some(c);
+                    }
+                }
+            }
+        }
+        None
+    } else {
+        // Unqualified: search top-level, then children
+        for sym in symbols {
+            if sym.name == name {
+                return Some(sym);
+            }
+        }
+        for sym in symbols {
+            for c in &sym.children {
+                if c.name == name {
+                    return Some(c);
+                }
+            }
+        }
+        None
+    }
+}
+
+fn visit_node(
+    cursor: &mut tree_sitter_lib::TreeCursor,
+    source: &str,
+    language: Language,
+    depth: usize,
+    symbols: &mut Vec<SymbolDef>,
+) {
+    let node = cursor.node();
+    if let Some(mut sym) = try_extract_symbol(node, source, language, depth) {
+        // Collect children inside this symbol's scope
+        if cursor.goto_first_child() {
+            loop {
+                visit_node(cursor, source, language, depth + 1, &mut sym.children);
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+            cursor.goto_parent();
+        }
+        symbols.push(sym);
+    } else if cursor.goto_first_child() {
+        loop {
+            visit_node(cursor, source, language, depth, symbols);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+        cursor.goto_parent();
+    }
+}
+
+fn try_extract_symbol(
+    node: tree_sitter_lib::Node,
+    source: &str,
+    language: Language,
+    depth: usize,
+) -> Option<SymbolDef> {
+    let (kind, name) = match language {
+        Language::Rust => extract_rust(node, source)?,
+        Language::Python => extract_python(node, source)?,
+        Language::TypeScript | Language::JavaScript => extract_ts_js(node, source, language)?,
+        Language::Go => extract_go(node, source)?,
+        Language::Hcl => extract_hcl(node, source)?,
+        Language::Protobuf => extract_proto(node, source)?,
+        Language::Shell => extract_bash(node, source)?,
+        _ => extract_generic(node, source)?,
+    };
+
+    let start_line = node.start_position().row + 1;
+    let end_line = node.end_position().row + 1;
+    let signature = node_signature(node, source);
+
+    Some(SymbolDef {
+        name,
+        kind,
+        start_line,
+        end_line,
+        signature,
+        children: Vec::new(),
+        depth,
+    })
+}
+
+fn node_signature(node: tree_sitter_lib::Node, source: &str) -> String {
+    let start = node.start_byte();
+    let mut end = node.end_byte().min(start + 200);
+    while end > start && !source.is_char_boundary(end) {
+        end -= 1;
+    }
+    let raw = &source[start..end];
+    let sig = match raw.find('{') {
+        Some(brace) => raw[..brace].trim(),
+        None => raw.lines().next().unwrap_or(raw).trim(),
+    };
+    sig.to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Language-specific extractors (matching bline's patterns)
+// ---------------------------------------------------------------------------
+
+fn extract_rust(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {
+    match node.kind() {
+        "function_item" => {
+            let name = child_text_by_kind(node, "identifier", source)?;
+            Some((SymbolKind::Function, name.to_string()))
+        }
+        "struct_item" => {
+            let name = child_text_by_kind(node, "type_identifier", source)?;
+            Some((SymbolKind::Struct, name.to_string()))
+        }
+        "enum_item" => {
+            let name = child_text_by_kind(node, "type_identifier", source)?;
+            Some((SymbolKind::Enum, name.to_string()))
+        }
+        "trait_item" => {
+            let name = child_text_by_kind(node, "type_identifier", source)?;
+            Some((SymbolKind::Trait, name.to_string()))
+        }
+        "impl_item" => {
+            let name = child_text_by_kind(node, "type_identifier", source)?;
+            Some((SymbolKind::Impl, name.to_string()))
+        }
+        "const_item" => {
+            let name = child_text_by_kind(node, "identifier", source)?;
+            Some((SymbolKind::Const, name.to_string()))
+        }
+        "type_item" => {
+            let name = child_text_by_kind(node, "type_identifier", source)?;
+            Some((SymbolKind::Type, name.to_string()))
+        }
+        "mod_item" => {
+            let name = child_text_by_kind(node, "identifier", source)?;
+            Some((SymbolKind::Module, name.to_string()))
+        }
+        _ => None,
+    }
+}
+
+fn extract_python(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {
+    match node.kind() {
+        "function_definition" => {
+            let name = child_text_by_kind(node, "identifier", source)?;
+            let kind = if node
+                .parent()
+                .and_then(|p| p.parent())
+                .is_some_and(|gp| gp.kind() == "class_definition")
+            {
+                SymbolKind::Method
+            } else {
+                SymbolKind::Function
+            };
+            Some((kind, name.to_string()))
+        }
+        "class_definition" => {
+            let name = child_text_by_kind(node, "identifier", source)?;
+            Some((SymbolKind::Class, name.to_string()))
+        }
+        _ => None,
+    }
+}
+
+fn extract_ts_js(
+    node: tree_sitter_lib::Node,
+    source: &str,
+    language: Language,
+) -> Option<(SymbolKind, String)> {
+    match node.kind() {
+        "function_declaration" => {
+            let name = child_text_by_kind(node, "identifier", source)?;
+            Some((SymbolKind::Function, name.to_string()))
+        }
+        "class_declaration" => {
+            let name = child_text_by_kinds(node, &["type_identifier", "identifier"], source)?;
+            Some((SymbolKind::Class, name.to_string()))
+        }
+        "method_definition" => {
+            let name = child_text_by_kind(node, "property_identifier", source)?;
+            Some((SymbolKind::Method, name.to_string()))
+        }
+        "interface_declaration" if language == Language::TypeScript => {
+            let name = child_text_by_kinds(node, &["type_identifier", "identifier"], source)?;
+            Some((SymbolKind::Interface, name.to_string()))
+        }
+        "lexical_declaration" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.kind() == "variable_declarator" {
+                    if let Some(first) = node.child(0)
+                        && first.utf8_text(source.as_bytes()).ok() != Some("const")
+                    {
+                        return None;
+                    }
+                    let name = child_text_by_kind(child, "identifier", source)?;
+                    return Some((SymbolKind::Const, name.to_string()));
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn extract_go(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {
+    match node.kind() {
+        "function_declaration" => {
+            let name = child_text_by_kind(node, "identifier", source)?;
+            Some((SymbolKind::Function, name.to_string()))
+        }
+        "method_declaration" => {
+            let name = child_text_by_kinds(node, &["field_identifier", "identifier"], source)?;
+            Some((SymbolKind::Method, name.to_string()))
+        }
+        "type_declaration" => {
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if child.kind() == "type_spec" {
+                    let name =
+                        child_text_by_kinds(child, &["type_identifier", "identifier"], source)?;
+                    let mut inner = child.walk();
+                    for grandchild in child.children(&mut inner) {
+                        match grandchild.kind() {
+                            "struct_type" => {
+                                return Some((SymbolKind::Struct, name.to_string()));
+                            }
+                            "interface_type" => {
+                                return Some((SymbolKind::Interface, name.to_string()));
+                            }
+                            _ => {}
+                        }
+                    }
+                    return Some((SymbolKind::Type, name.to_string()));
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn extract_hcl(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {
+    if node.kind() != "block" {
+        return None;
+    }
+    let block_type = child_text_by_kind(node, "identifier", source)?;
+    let mut labels = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "string_lit"
+            && let Ok(text) = child.utf8_text(source.as_bytes())
+        {
+            labels.push(text.trim_matches('"').to_string());
+        }
+    }
+    let (kind, name) = match block_type {
+        "resource" | "data" => {
+            let name = if labels.len() >= 2 {
+                format!("{}.{}", labels[0], labels[1])
+            } else if !labels.is_empty() {
+                labels[0].clone()
+            } else {
+                return None;
+            };
+            (SymbolKind::Struct, name)
+        }
+        "variable" | "output" => {
+            let name = labels.first()?.clone();
+            (SymbolKind::Const, name)
+        }
+        "module" | "provider" => {
+            let name = labels
+                .first()
+                .cloned()
+                .unwrap_or_else(|| block_type.to_string());
+            (SymbolKind::Module, name)
+        }
+        "locals" | "terraform" => (SymbolKind::Module, block_type.to_string()),
+        _ => return None,
+    };
+    Some((kind, name))
+}
+
+fn extract_proto(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {
+    match node.kind() {
+        "message" => {
+            let name = child_text_by_kinds(node, &["message_name", "identifier"], source)?;
+            Some((SymbolKind::Struct, name.to_string()))
+        }
+        "enum" => {
+            let name = child_text_by_kinds(node, &["enum_name", "identifier"], source)?;
+            Some((SymbolKind::Enum, name.to_string()))
+        }
+        "service" => {
+            let name = child_text_by_kinds(node, &["service_name", "identifier"], source)?;
+            Some((SymbolKind::Interface, name.to_string()))
+        }
+        "rpc" => {
+            let name = child_text_by_kinds(node, &["rpc_name", "identifier"], source)?;
+            Some((SymbolKind::Method, name.to_string()))
+        }
+        _ => None,
+    }
+}
+
+fn extract_bash(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {
+    if node.kind() != "function_definition" {
+        return None;
+    }
+    let name = child_text_by_kinds(node, &["word", "name", "identifier"], source)?;
+    Some((SymbolKind::Function, name.to_string()))
+}
+
+// Generic extractor for languages without a hand-tuned extractor
+
+const GENERIC_NAME_KINDS: &[&str] = &[
+    "identifier",
+    "name",
+    "type_identifier",
+    "property_identifier",
+    "field_identifier",
+    "simple_identifier",
+];
+
+fn extract_generic(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {
+    let kind = node.kind();
+    let symbol_kind = match kind {
+        "function_item" | "function_definition" | "function_declaration" => SymbolKind::Function,
+        "method_definition" | "method_declaration" => SymbolKind::Method,
+        "class_definition" | "class_declaration" => SymbolKind::Class,
+        "interface_declaration" => SymbolKind::Interface,
+        "struct_item" | "struct_declaration" | "struct_specifier" => SymbolKind::Struct,
+        "enum_item" | "enum_declaration" | "enum_specifier" => SymbolKind::Enum,
+        "type_declaration" | "type_item" | "type_alias_declaration" => SymbolKind::Type,
+        "module_declaration" | "mod_item" | "namespace_declaration" => SymbolKind::Module,
+        "trait_item" | "trait_declaration" | "protocol_declaration" => SymbolKind::Trait,
+        _ => return None,
+    };
+
+    if let Some(name) = child_text_by_kinds(node, GENERIC_NAME_KINDS, source) {
+        return Some((symbol_kind, name.to_string()));
+    }
+
+    // C-family: name nested inside a declarator node
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if (child.kind().contains("declarator") || child.kind() == "name")
+            && let Some(name) = child_text_by_kinds(child, GENERIC_NAME_KINDS, source)
+        {
+            return Some((symbol_kind, name.to_string()));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_rust_symbols() {
+        let source = r#"
+struct Foo {
+    x: i32,
+}
+
+fn bar() -> i32 {
+    42
+}
+
+impl Foo {
+    fn baz(&self) -> i32 {
+        self.x
+    }
+}
+"#;
+        let symbols = extract_symbols(source, Language::Rust);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"Foo"));
+        assert!(names.contains(&"bar"));
+        // impl Foo should contain baz as a child
+        let impl_sym = symbols.iter().find(|s| s.kind == SymbolKind::Impl).unwrap();
+        assert_eq!(impl_sym.name, "Foo");
+        assert_eq!(impl_sym.children.len(), 1);
+        assert_eq!(impl_sym.children[0].name, "baz");
+    }
+
+    #[test]
+    fn extract_python_symbols() {
+        let source = r#"
+class MyClass:
+    def method(self):
+        pass
+
+def standalone():
+    pass
+"#;
+        let symbols = extract_symbols(source, Language::Python);
+        let class = symbols.iter().find(|s| s.name == "MyClass").unwrap();
+        assert_eq!(class.kind, SymbolKind::Class);
+        assert_eq!(class.children.len(), 1);
+        assert_eq!(class.children[0].name, "method");
+        assert_eq!(class.children[0].kind, SymbolKind::Method);
+
+        let func = symbols.iter().find(|s| s.name == "standalone").unwrap();
+        assert_eq!(func.kind, SymbolKind::Function);
+    }
+
+    #[test]
+    fn extract_go_symbols() {
+        let source = r#"
+package main
+
+func main() {
+    fmt.Println("hello")
+}
+
+type Config struct {
+    Host string
+}
+"#;
+        let symbols = extract_symbols(source, Language::Go);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"main"));
+        assert!(names.contains(&"Config"));
+    }
+
+    #[test]
+    fn find_symbol_qualified() {
+        let source = r#"
+impl Server {
+    fn start(&self) {}
+    fn stop(&self) {}
+}
+"#;
+        let symbols = extract_symbols(source, Language::Rust);
+        let found = find_symbol(&symbols, "Server::start");
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().name, "start");
+    }
+
+    #[test]
+    fn find_symbol_unqualified_searches_children() {
+        let source = r#"
+impl Server {
+    fn start(&self) {}
+}
+"#;
+        let symbols = extract_symbols(source, Language::Rust);
+        let found = find_symbol(&symbols, "start");
+        assert!(found.is_some());
+    }
+
+    #[test]
+    fn symbol_kind_from_str() {
+        assert_eq!(
+            SymbolKind::from_str_loose("function"),
+            Some(SymbolKind::Function)
+        );
+        assert_eq!(SymbolKind::from_str_loose("fn"), Some(SymbolKind::Function));
+        assert_eq!(
+            SymbolKind::from_str_loose("struct"),
+            Some(SymbolKind::Struct)
+        );
+        assert_eq!(SymbolKind::from_str_loose("CONST"), Some(SymbolKind::Const));
+        assert_eq!(SymbolKind::from_str_loose("unknown"), None);
+    }
+
+    #[test]
+    fn unknown_language_returns_empty() {
+        assert!(extract_symbols("anything", Language::Unknown).is_empty());
+    }
+
+    #[test]
+    fn signature_truncates_at_brace() {
+        let source = "fn hello(x: i32) {\n    x + 1\n}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        assert_eq!(symbols[0].signature, "fn hello(x: i32)");
+    }
+}

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -1,0 +1,131 @@
+//! Syntax validation using tree-sitter parsing.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::{Language, parse_source};
+
+/// A syntax error found during validation.
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntaxError {
+    /// 1-based line number.
+    pub line: usize,
+    /// 0-based column.
+    pub column: usize,
+    /// The problematic source text (truncated).
+    pub text: String,
+}
+
+/// Result of validating a source file.
+#[derive(Debug, Serialize)]
+pub struct ValidationResult {
+    /// Whether the file parsed without errors.
+    pub valid: bool,
+    /// Errors found during parsing.
+    pub errors: Vec<SyntaxError>,
+    /// The language detected or specified.
+    pub language: String,
+}
+
+/// Validate syntax of source code for a given language.
+pub fn validate_source(source: &str, lang: Language) -> Option<ValidationResult> {
+    let (tree, _) = parse_source(source, lang)?;
+    let root = tree.root_node();
+
+    let mut errors = Vec::new();
+    if root.has_error() {
+        collect_errors(root, source, &mut errors);
+    }
+
+    Some(ValidationResult {
+        valid: errors.is_empty(),
+        errors,
+        language: lang.to_string(),
+    })
+}
+
+/// Validate syntax of a file.
+pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result<ValidationResult> {
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+    if !lang.has_grammar() {
+        anyhow::bail!("no grammar available for {lang}");
+    }
+    let source = std::fs::read_to_string(path)?;
+    validate_source(&source, lang)
+        .ok_or_else(|| anyhow::anyhow!("failed to parse {}", path.display()))
+}
+
+fn collect_errors(node: tree_sitter_lib::Node, source: &str, errors: &mut Vec<SyntaxError>) {
+    if node.is_error() || node.is_missing() {
+        let start = node.start_byte();
+        let mut end = node.end_byte().min(start + 50);
+        while end > start && !source.is_char_boundary(end) {
+            end -= 1;
+        }
+        let text = source[start..end].to_string();
+        errors.push(SyntaxError {
+            line: node.start_position().row + 1,
+            column: node.start_position().column,
+            text,
+        });
+        return; // Don't recurse into error nodes
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.has_error() || child.is_error() || child.is_missing() {
+                collect_errors(child, source, errors);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_rust_code() {
+        let source = "fn main() { println!(\"hello\"); }\n";
+        let result = validate_source(source, Language::Rust).unwrap();
+        assert!(result.valid);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn invalid_rust_code() {
+        let source = "fn main( { }\n";
+        let result = validate_source(source, Language::Rust).unwrap();
+        assert!(!result.valid);
+        assert!(!result.errors.is_empty());
+    }
+
+    #[test]
+    fn valid_python_code() {
+        let source = "def hello():\n    pass\n";
+        let result = validate_source(source, Language::Python).unwrap();
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn unknown_language_returns_none() {
+        let result = validate_source("anything", Language::Unknown);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn error_location_is_correct() {
+        let source = "fn main(\n";
+        let result = validate_source(source, Language::Rust).unwrap();
+        assert!(!result.valid);
+        assert!(!result.errors.is_empty());
+        // Error should be on line 1 or 2
+        assert!(result.errors[0].line <= 2);
+    }
+}

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1,0 +1,516 @@
+//! AST-aware subcommands: `patchloom ast list|read|rename|validate`.
+
+use crate::ast::Language;
+use crate::ast::symbols::{self, SymbolDef, SymbolKind};
+use crate::cli::global::GlobalFlags;
+use crate::exit;
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Subcommand)]
+pub enum AstCommand {
+    /// List symbol definitions in a file or directory.
+    List(ListArgs),
+    /// Read a specific symbol by name.
+    Read(ReadArgs),
+    /// Rename identifiers in source code (AST-aware, skips strings/comments).
+    Rename(RenameArgs),
+    /// Validate syntax of source files.
+    Validate(ValidateArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct AstArgs {
+    #[command(subcommand)]
+    pub command: AstCommand,
+}
+
+pub fn run(args: AstArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    match args.command {
+        AstCommand::List(a) => run_list(a, global),
+        AstCommand::Read(a) => run_read(a, global),
+        AstCommand::Rename(a) => run_rename(a, global),
+        AstCommand::Validate(a) => run_validate(a, global),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ast list
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct ListArgs {
+    /// File or directory to list symbols from.
+    pub path: String,
+
+    /// Filter by symbol kind (comma-separated: function,struct,enum,...).
+    #[arg(long)]
+    pub kind: Option<String>,
+
+    /// Compact mode: definition names only (Cline-style, maximum token efficiency).
+    #[arg(long)]
+    pub compact: bool,
+
+    /// Language hint (overrides extension detection).
+    #[arg(long)]
+    pub lang: Option<String>,
+}
+
+fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+
+    let kind_filter = parse_kind_filter(&args.kind);
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+
+    let mut any_output = false;
+
+    if target.is_file() {
+        let symbols = symbols::extract_symbols_from_file(&target, lang_hint);
+        let filtered = filter_symbols(&symbols, &kind_filter);
+        if !filtered.is_empty() {
+            any_output = true;
+            if global.json || global.jsonl {
+                print_symbols_json(&args.path, &filtered, global.jsonl);
+            } else if args.compact {
+                print_symbols_compact(&args.path, &filtered);
+            } else {
+                print_symbols_human(&args.path, &filtered);
+            }
+        }
+    } else if target.is_dir() {
+        let paths = collect_source_files(&target, global)?;
+        for path in &paths {
+            let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+            let symbols = symbols::extract_symbols_from_file(path, Some(lang));
+            let filtered = filter_symbols(&symbols, &kind_filter);
+            if filtered.is_empty() {
+                continue;
+            }
+            any_output = true;
+            let display_path = path.strip_prefix(&cwd).unwrap_or(path);
+            let display = display_path.display().to_string();
+            if global.json || global.jsonl {
+                print_symbols_json(&display, &filtered, global.jsonl);
+            } else if args.compact {
+                print_symbols_compact(&display, &filtered);
+            } else {
+                print_symbols_human(&display, &filtered);
+            }
+        }
+    } else {
+        anyhow::bail!("path not found: {}", args.path);
+    }
+
+    if any_output {
+        Ok(exit::SUCCESS)
+    } else {
+        Ok(exit::NO_MATCHES)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ast read
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct ReadArgs {
+    /// File to read from.
+    pub path: String,
+
+    /// Symbol name (e.g. "run" or "Server::start").
+    pub symbol: String,
+
+    /// Number of context lines before/after the symbol.
+    #[arg(long, short, default_value = "0")]
+    pub context: usize,
+
+    /// Language hint.
+    #[arg(long)]
+    pub lang: Option<String>,
+}
+
+fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
+    let source = std::fs::read_to_string(&target)?;
+    let all_symbols = symbols::extract_symbols(&source, lang);
+    let sym = symbols::find_symbol(&all_symbols, &args.symbol)
+        .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in {}", args.symbol, args.path))?;
+
+    let lines: Vec<&str> = source.lines().collect();
+    let start = sym.start_line.saturating_sub(1 + args.context);
+    let end = (sym.end_line + args.context).min(lines.len());
+
+    if global.json || global.jsonl {
+        let content: String = lines[start..end].iter().map(|l| format!("{l}\n")).collect();
+        let obj = serde_json::json!({
+            "file": args.path,
+            "symbol": sym.name,
+            "kind": sym.kind.to_string(),
+            "start_line": sym.start_line,
+            "end_line": sym.end_line,
+            "signature": sym.signature,
+            "content": content,
+        });
+        if global.jsonl {
+            println!("{}", serde_json::to_string(&obj)?);
+        } else {
+            println!("{}", serde_json::to_string_pretty(&obj)?);
+        }
+    } else {
+        for (i, line) in lines[start..end].iter().enumerate() {
+            let line_num = start + i + 1;
+            println!("{line_num:>4} | {line}");
+        }
+    }
+
+    Ok(exit::SUCCESS)
+}
+
+// ---------------------------------------------------------------------------
+// ast rename
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct RenameArgs {
+    /// The identifier to rename.
+    pub old_name: String,
+
+    /// The new identifier name.
+    pub new_name: String,
+
+    /// File or directory to rename in.
+    pub path: String,
+
+    /// Language hint.
+    #[arg(long)]
+    pub lang: Option<String>,
+
+    #[command(flatten)]
+    pub write: crate::cli::global::WriteFlags,
+}
+
+fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+
+    let mut total_replacements = 0usize;
+    let mut files_changed = 0usize;
+
+    let paths = if target.is_file() {
+        vec![target.clone()]
+    } else if target.is_dir() {
+        collect_source_files(&target, global)?
+    } else {
+        anyhow::bail!("path not found: {}", args.path);
+    };
+
+    for path in &paths {
+        let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+        let source = std::fs::read_to_string(path)?;
+        let result = if lang.has_grammar() {
+            crate::ast::rename::rename_in_source(&source, &args.old_name, &args.new_name, lang)
+        } else {
+            // Fallback to word-boundary replace
+            None
+        };
+
+        let (new_content, count) = match result {
+            Some(r) if r.replacements > 0 => (r.content, r.replacements),
+            _ => {
+                // Try word-boundary fallback for unknown languages or zero AST matches
+                let re = crate::ops::replace::compile_replace_regex(
+                    &args.old_name,
+                    false,
+                    false,
+                    false,
+                    true,
+                )?;
+                if let Some(re) = re {
+                    let new = re.replace_all(&source, args.new_name.as_str());
+                    let count = re.find_iter(&source).count();
+                    if count > 0 {
+                        (new.into_owned(), count)
+                    } else {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        total_replacements += count;
+        files_changed += 1;
+        let display_path = path.strip_prefix(&cwd).unwrap_or(path);
+
+        if global.apply {
+            crate::write::atomic_write(path, &new_content, &Default::default())?;
+            if !global.quiet {
+                eprintln!(
+                    "{}: {} replacement{}",
+                    display_path.display(),
+                    count,
+                    if count == 1 { "" } else { "s" }
+                );
+            }
+        } else if global.check {
+            if !global.quiet {
+                eprintln!(
+                    "{}: {} replacement{} (check mode)",
+                    display_path.display(),
+                    count,
+                    if count == 1 { "" } else { "s" }
+                );
+            }
+        } else {
+            // Default dry-run: show diff
+            let diff = crate::diff::unified_diff(
+                &display_path.display().to_string(),
+                &source,
+                &new_content,
+            );
+            if diff.has_changes {
+                print!("{}", diff.hunks);
+            }
+        }
+    }
+
+    if global.json || global.jsonl {
+        let obj = serde_json::json!({
+            "ok": true,
+            "files_changed": files_changed,
+            "replacements": total_replacements,
+        });
+        println!("{}", serde_json::to_string_pretty(&obj)?);
+    }
+
+    if total_replacements == 0 {
+        Ok(exit::NO_MATCHES)
+    } else if global.check {
+        Ok(exit::CHANGES_DETECTED)
+    } else {
+        Ok(exit::SUCCESS)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ast validate
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct ValidateArgs {
+    /// File or directory to validate.
+    pub path: String,
+
+    /// Language hint.
+    #[arg(long)]
+    pub lang: Option<String>,
+}
+
+fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+
+    let mut all_valid = true;
+
+    let paths = if target.is_file() {
+        vec![target.clone()]
+    } else if target.is_dir() {
+        collect_source_files(&target, global)?
+    } else {
+        anyhow::bail!("path not found: {}", args.path);
+    };
+
+    for path in &paths {
+        let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+        if !lang.has_grammar() {
+            continue;
+        }
+        let result = crate::ast::validate::validate_file(path, Some(lang))?;
+        let display_path = path.strip_prefix(&cwd).unwrap_or(path);
+
+        if global.json || global.jsonl {
+            let obj = serde_json::json!({
+                "file": display_path.display().to_string(),
+                "valid": result.valid,
+                "language": result.language,
+                "errors": result.errors,
+            });
+            if global.jsonl {
+                println!("{}", serde_json::to_string(&obj)?);
+            } else {
+                println!("{}", serde_json::to_string_pretty(&obj)?);
+            }
+        } else if !result.valid {
+            all_valid = false;
+            eprintln!("{}: INVALID ({})", display_path.display(), result.language);
+            for err in &result.errors {
+                eprintln!("  line {}:{}: {}", err.line, err.column, err.text.trim());
+            }
+        } else if !global.quiet {
+            eprintln!("{}: OK ({})", display_path.display(), result.language);
+        }
+    }
+
+    if all_valid {
+        Ok(exit::SUCCESS)
+    } else {
+        Ok(exit::FAILURE)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn lang_from_str(s: &str) -> Language {
+    Language::from_extension(s)
+}
+
+fn parse_kind_filter(kind_arg: &Option<String>) -> Vec<SymbolKind> {
+    match kind_arg {
+        Some(s) => s
+            .split(',')
+            .filter_map(|k| SymbolKind::from_str_loose(k.trim()))
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+fn filter_symbols<'a>(symbols: &'a [SymbolDef], kind_filter: &[SymbolKind]) -> Vec<&'a SymbolDef> {
+    if kind_filter.is_empty() {
+        return symbols.iter().collect();
+    }
+    symbols
+        .iter()
+        .filter(|s| kind_filter.contains(&s.kind))
+        .collect()
+}
+
+fn collect_source_files(
+    dir: &std::path::Path,
+    global: &GlobalFlags,
+) -> anyhow::Result<Vec<std::path::PathBuf>> {
+    let mut paths = Vec::new();
+    let glob_matcher = crate::files::build_glob_matcher(global)?;
+
+    let walker = ignore::WalkBuilder::new(dir)
+        .hidden(true)
+        .git_ignore(true)
+        .build();
+
+    for entry in walker {
+        let entry = entry?;
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        let path = entry.path();
+        let lang = Language::from_path(path);
+        if !lang.has_grammar() {
+            continue;
+        }
+        if !crate::files::matches_glob(path, glob_matcher.as_ref()) {
+            continue;
+        }
+        paths.push(path.to_path_buf());
+    }
+    paths.sort();
+    Ok(paths)
+}
+
+fn print_symbols_human(path: &str, symbols: &[&SymbolDef]) {
+    println!("{path}");
+    for sym in symbols {
+        print_symbol_human(sym, 1);
+    }
+    println!();
+}
+
+fn print_symbol_human(sym: &SymbolDef, indent: usize) {
+    let pad = "  ".repeat(indent);
+    println!(
+        "{pad}{} {} [{}:{}]",
+        sym.kind, sym.name, sym.start_line, sym.end_line
+    );
+    for child in &sym.children {
+        print_symbol_human(child, indent + 1);
+    }
+}
+
+fn print_symbols_compact(path: &str, symbols: &[&SymbolDef]) {
+    println!("{path}");
+    println!("|----");
+    for sym in symbols {
+        print_symbol_compact(sym, 0);
+    }
+    println!("|----");
+    println!();
+}
+
+fn print_symbol_compact(sym: &SymbolDef, indent: usize) {
+    let pad = "  ".repeat(indent);
+    println!("|{pad}{} {}", sym.kind, sym.name);
+    for child in &sym.children {
+        print_symbol_compact(child, indent + 1);
+    }
+}
+
+fn print_symbols_json(path: &str, symbols: &[&SymbolDef], jsonl: bool) {
+    for sym in symbols {
+        let obj = symbol_to_json(sym, path);
+        if jsonl {
+            println!("{}", serde_json::to_string(&obj).unwrap_or_default());
+        } else {
+            println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
+        }
+    }
+}
+
+fn symbol_to_json(sym: &SymbolDef, path: &str) -> serde_json::Value {
+    let children: Vec<serde_json::Value> = sym
+        .children
+        .iter()
+        .map(|c| symbol_to_json(c, path))
+        .collect();
+    serde_json::json!({
+        "file": path,
+        "name": sym.name,
+        "kind": sym.kind.to_string(),
+        "start_line": sym.start_line,
+        "end_line": sym.end_line,
+        "signature": sym.signature,
+        "children": children,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_kind_filter_works() {
+        let filter = parse_kind_filter(&Some("function,struct".to_string()));
+        assert_eq!(filter.len(), 2);
+        assert!(filter.contains(&SymbolKind::Function));
+        assert!(filter.contains(&SymbolKind::Struct));
+    }
+
+    #[test]
+    fn parse_kind_filter_empty() {
+        let filter = parse_kind_filter(&None);
+        assert!(filter.is_empty());
+    }
+
+    #[test]
+    fn lang_from_str_works() {
+        assert_eq!(lang_from_str("rs"), Language::Rust);
+        assert_eq!(lang_from_str("py"), Language::Python);
+        assert_eq!(lang_from_str("go"), Language::Go);
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "ast")]
+pub mod ast;
 pub mod batch;
 pub mod create;
 pub mod delete;
@@ -53,6 +55,9 @@ pub enum Command {
     Explain(explain::ExplainArgs),
     /// Restore files from a backup created by --apply.
     Undo(undo::UndoArgs),
+    /// AST-aware operations: list, read, rename, validate.
+    #[cfg(feature = "ast")]
+    Ast(ast::AstArgs),
     /// Export operation schemas, tier-filtered listings, or system prompt fragments.
     Schema(schema::SchemaArgs),
     /// Print agent rules for using patchloom (AGENTS.md content for end users).
@@ -535,6 +540,15 @@ pub fn dispatch(cli: Cli) -> anyhow::Result<u8> {
             global.merge_write(&args.write);
             load_project_config(&mut global);
             batch::run(args, &global)
+        }
+        #[cfg(feature = "ast")]
+        Command::Ast(args) => {
+            // ast rename has write flags; list/read/validate are read-only
+            if let ast::AstCommand::Rename(ref rename_args) = args.command {
+                global.merge_write(&rename_args.write);
+            }
+            load_project_config(&mut global);
+            ast::run(args, &global)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@
 //! |---------|---------|-------------|
 //! | `core`  | no      | Marker feature for core library usage (no extra deps) |
 //! | `mcp`   | **yes** | MCP server support (adds `tokio`, `rmcp`, `schemars`) |
-//! | `full`  | no      | Everything: currently equivalent to `mcp` |
+//! | `ast`   | **yes** | AST-aware operations using tree-sitter (20 language grammars) |
+//! | `full`  | no      | Everything: `mcp` + `ast` |
 //!
 //! ## Embedding as a library
 //!
@@ -51,6 +52,8 @@
 //! across threads, avoiding repeated disk reads.
 
 pub mod api;
+#[cfg(feature = "ast")]
+pub mod ast;
 pub mod backup;
 pub mod cli;
 pub mod cmd;

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -94,7 +94,7 @@ _PATCHLOOM_SUBCOMMANDS = {
     "search", "replace", "patch", "md", "doc", "tidy",
     "create", "delete", "rename", "read", "status", "tx",
     "batch", "explain", "undo", "init", "completions",
-    "agent-rules", "mcp-server", "schema",
+    "agent-rules", "mcp-server", "schema", "ast",
 }
 
 


### PR DESCRIPTION
## Summary

Add `patchloom ast` subcommand group with four operations: `list`, `read`, `rename`, and `validate`. All operations use tree-sitter grammars for 20 languages, gated on the `ast` feature flag (enabled by default).

## New commands

| Command | What it does |
|---------|-------------|
| `ast list` | Extract symbol definitions with line ranges, signatures, nesting. Supports `--compact`, `--kind`, `--json` |
| `ast read` | Read a specific symbol by name (supports `Class::method` syntax, `--context`) |
| `ast rename` | Rename identifiers, skipping strings/comments/docs. Falls back to word-boundary replace |
| `ast validate` | Syntax validation via tree-sitter parsing. Reports error locations |

## Languages (20)

Rust, Python, TypeScript, JavaScript, Go, Java, C#, Ruby, PHP, Swift, Kotlin, C++, C, HCL/Terraform, TOML, YAML, JSON, XML, Protobuf, Shell/Bash

## Architecture

- `src/ast/mod.rs`: Language enum, extension detection, grammar mapping, `parse_source()`
- `src/ast/symbols.rs`: Per-language symbol extractors (matching bline's patterns)
- `src/ast/rename.rs`: AST-aware rename with identifier/skip-kind classification
- `src/ast/validate.rs`: Syntax validation with error collection
- `src/cmd/ast.rs`: CLI subcommand dispatch

## Testing

- 31 new unit tests across 4 AST modules
- All existing tests pass (669 integration + 844 unit = 1513 total)
- `make check` passes

## Dependency versions

Tree-sitter versions match bline for compatibility:
- `tree-sitter` 0.26, `tree-sitter-language` 0.1
- All 20 grammar crates at the same versions as bline-index

Closes #647