### PR TITLE
feat(ast): add search, refs, and deps subcommands

### DIFF
--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -1,0 +1,501 @@
+//! Dependency/import analysis using tree-sitter.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::{Language, parse_source};
+
+/// A single import/dependency extracted from a file.
+#[derive(Debug, Clone, Serialize)]
+pub struct Import {
+    /// The import path or module name.
+    pub path: String,
+    /// 1-based line number.
+    pub line: usize,
+    /// The raw import statement text.
+    pub raw: String,
+}
+
+/// Extract imports from source code.
+pub fn extract_imports(source: &str, lang: Language) -> Vec<Import> {
+    let Some((tree, _)) = parse_source(source, lang) else {
+        return Vec::new();
+    };
+
+    let mut imports = Vec::new();
+    collect_imports(tree.root_node(), source, lang, &mut imports);
+    imports
+}
+
+/// Extract imports from a file.
+pub fn extract_imports_from_file(path: &Path, lang_hint: Option<Language>) -> Vec<Import> {
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+    if !lang.has_grammar() {
+        return Vec::new();
+    }
+    let Ok(source) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    extract_imports(&source, lang)
+}
+
+fn collect_imports(
+    node: tree_sitter_lib::Node,
+    source: &str,
+    lang: Language,
+    imports: &mut Vec<Import>,
+) {
+    match lang {
+        Language::Rust => collect_rust_imports(node, source, imports),
+        Language::Python => collect_python_imports(node, source, imports),
+        Language::JavaScript | Language::TypeScript => collect_js_imports(node, source, imports),
+        Language::Go => collect_go_imports(node, source, imports),
+        Language::Java => collect_java_imports(node, source, imports),
+        Language::C | Language::Cpp => collect_c_imports(node, source, imports),
+        Language::Ruby => collect_ruby_imports(node, source, imports),
+        Language::Php => collect_php_imports(node, source, imports),
+        _ => collect_generic_imports(node, source, imports),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Language-specific import extractors
+// ---------------------------------------------------------------------------
+
+fn collect_rust_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "use_declaration" || node.kind() == "extern_crate_declaration" {
+        if let Ok(text) = node.utf8_text(source.as_bytes()) {
+            let path = extract_path_from_text(text, &["use ", "extern crate "], &[';']);
+            imports.push(Import {
+                path,
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+    // mod declarations with a body are not imports; only `mod foo;` is
+    if node.kind() == "mod_item" {
+        if let Ok(text) = node.utf8_text(source.as_bytes())
+            && text.trim().ends_with(';')
+        {
+            let path = extract_path_from_text(text, &["mod "], &[';']);
+            imports.push(Import {
+                path,
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_rust_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_python_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "import_statement" || node.kind() == "import_from_statement" {
+        if let Ok(text) = node.utf8_text(source.as_bytes()) {
+            let path = extract_path_from_text(text, &["from ", "import "], &[]);
+            imports.push(Import {
+                path,
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_python_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_js_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "import_statement" {
+        if let Ok(text) = node.utf8_text(source.as_bytes()) {
+            // Extract the module path from the string literal
+            let path = extract_quoted_string(text).unwrap_or_else(|| text.trim().to_string());
+            imports.push(Import {
+                path,
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+
+    // Also check for require() calls
+    if node.kind() == "call_expression" {
+        if let Ok(text) = node.utf8_text(source.as_bytes())
+            && text.starts_with("require(")
+        {
+            let path = extract_quoted_string(text).unwrap_or_else(|| text.trim().to_string());
+            imports.push(Import {
+                path,
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_js_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_go_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "import_declaration" {
+        // Go imports can have a single spec or multiple in parens
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                if child.kind() == "import_spec" || child.kind() == "import_spec_list" {
+                    collect_go_import_specs(child, source, imports);
+                } else if child.kind() == "interpreted_string_literal"
+                    && let Ok(text) = child.utf8_text(source.as_bytes())
+                {
+                    let path = text.trim_matches('"').to_string();
+                    imports.push(Import {
+                        path,
+                        line: child.start_position().row + 1,
+                        raw: text.to_string(),
+                    });
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_go_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_go_import_specs(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "import_spec" {
+        // Find the string literal child
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            if child.kind() == "interpreted_string_literal"
+                && let Ok(text) = child.utf8_text(source.as_bytes())
+            {
+                let path = text.trim_matches('"').to_string();
+                imports.push(Import {
+                    path,
+                    line: child.start_position().row + 1,
+                    raw: node
+                        .utf8_text(source.as_bytes())
+                        .unwrap_or_default()
+                        .trim()
+                        .to_string(),
+                });
+            }
+        }
+    } else {
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                collect_go_import_specs(cursor.node(), source, imports);
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+fn collect_java_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "import_declaration" {
+        if let Ok(text) = node.utf8_text(source.as_bytes()) {
+            let path = extract_path_from_text(text, &["import ", "import static "], &[';']);
+            imports.push(Import {
+                path,
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_java_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_c_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "preproc_include" {
+        if let Ok(text) = node.utf8_text(source.as_bytes()) {
+            let path = if let Some(p) = extract_angle_bracket_path(text) {
+                p
+            } else {
+                extract_quoted_string(text).unwrap_or_else(|| text.trim().to_string())
+            };
+            imports.push(Import {
+                path,
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_c_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_ruby_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "call"
+        && let Ok(text) = node.utf8_text(source.as_bytes())
+        && (text.starts_with("require ") || text.starts_with("require_relative "))
+    {
+        let path = extract_quoted_string(text).unwrap_or_else(|| text.trim().to_string());
+        imports.push(Import {
+            path,
+            line: node.start_position().row + 1,
+            raw: text.trim().to_string(),
+        });
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_ruby_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_php_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    if node.kind() == "namespace_use_declaration" {
+        if let Ok(text) = node.utf8_text(source.as_bytes()) {
+            let path = extract_path_from_text(text, &["use "], &[';']);
+            imports.push(Import {
+                path,
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_php_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_generic_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
+    let kind = node.kind();
+    if kind.contains("import") || kind.contains("include") || kind == "use_declaration" {
+        if let Ok(text) = node.utf8_text(source.as_bytes()) {
+            imports.push(Import {
+                path: text.trim().to_string(),
+                line: node.start_position().row + 1,
+                raw: text.trim().to_string(),
+            });
+        }
+        return;
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_generic_imports(cursor.node(), source, imports);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn extract_path_from_text(text: &str, prefixes: &[&str], suffixes: &[char]) -> String {
+    let mut s = text.trim();
+    for prefix in prefixes {
+        if let Some(rest) = s.strip_prefix(prefix) {
+            s = rest;
+            break;
+        }
+    }
+    let mut result = s.trim().to_string();
+    for suffix in suffixes {
+        if result.ends_with(*suffix) {
+            result.pop();
+        }
+    }
+    result.trim().to_string()
+}
+
+fn extract_quoted_string(text: &str) -> Option<String> {
+    // Find content between quotes (single or double)
+    for quote in ['"', '\''] {
+        if let Some(start) = text.find(quote)
+            && let Some(end) = text[start + 1..].find(quote)
+        {
+            return Some(text[start + 1..start + 1 + end].to_string());
+        }
+    }
+    None
+}
+
+fn extract_angle_bracket_path(text: &str) -> Option<String> {
+    let start = text.find('<')?;
+    let end = text.find('>')?;
+    if start < end {
+        Some(text[start + 1..end].to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_imports() {
+        let source = r#"
+use std::path::Path;
+use crate::ast::Language;
+extern crate serde;
+mod helpers;
+"#;
+        let imports = extract_imports(source, Language::Rust);
+        assert!(imports.len() >= 3);
+        let paths: Vec<&str> = imports.iter().map(|i| i.path.as_str()).collect();
+        assert!(paths.iter().any(|p| p.contains("std::path::Path")));
+        assert!(paths.iter().any(|p| p.contains("crate::ast::Language")));
+    }
+
+    #[test]
+    fn python_imports() {
+        let source = r#"
+import os
+from pathlib import Path
+import sys
+"#;
+        let imports = extract_imports(source, Language::Python);
+        assert!(imports.len() >= 3);
+    }
+
+    #[test]
+    fn js_imports() {
+        let source = r#"
+import React from 'react';
+import { useState } from 'react';
+const fs = require('fs');
+"#;
+        let imports = extract_imports(source, Language::JavaScript);
+        assert!(imports.len() >= 2); // import statements
+    }
+
+    #[test]
+    fn go_imports() {
+        let source = r#"
+package main
+
+import (
+    "fmt"
+    "os"
+)
+"#;
+        let imports = extract_imports(source, Language::Go);
+        assert!(imports.len() >= 2);
+        let paths: Vec<&str> = imports.iter().map(|i| i.path.as_str()).collect();
+        assert!(paths.contains(&"fmt"));
+        assert!(paths.contains(&"os"));
+    }
+
+    #[test]
+    fn java_imports() {
+        let source = r#"
+import java.util.List;
+import java.io.File;
+"#;
+        let imports = extract_imports(source, Language::Java);
+        assert_eq!(imports.len(), 2);
+    }
+
+    #[test]
+    fn c_includes() {
+        let source = "#include <stdio.h>\n#include \"myheader.h\"\n";
+        let imports = extract_imports(source, Language::C);
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].path, "stdio.h");
+        assert_eq!(imports[1].path, "myheader.h");
+    }
+
+    #[test]
+    fn unknown_language_returns_empty() {
+        let imports = extract_imports("anything", Language::Unknown);
+        assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn extract_quoted_string_works() {
+        assert_eq!(
+            extract_quoted_string("require('fs')"),
+            Some("fs".to_string())
+        );
+        assert_eq!(
+            extract_quoted_string("import \"react\""),
+            Some("react".to_string())
+        );
+        assert_eq!(extract_quoted_string("no quotes"), None);
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -4,7 +4,10 @@
 //! extraction, AST-aware rename, and syntax validation for 20 languages.
 //! All functionality is gated on the `ast` feature flag.
 
+pub mod deps;
+pub mod refs;
 pub mod rename;
+pub mod search;
 pub mod symbols;
 pub mod validate;
 

--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -1,0 +1,263 @@
+//! Find references to a symbol across files.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::{Language, parse_source};
+
+/// Kind of reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RefKind {
+    /// The definition site.
+    Definition,
+    /// A usage/call site.
+    Reference,
+}
+
+/// A single reference to a symbol.
+#[derive(Debug, Clone, Serialize)]
+pub struct SymbolRef {
+    /// File path (relative).
+    pub file: String,
+    /// 1-based line number.
+    pub line: usize,
+    /// The source line containing the reference (trimmed).
+    pub context: String,
+    /// Whether this is a definition or reference.
+    pub kind: RefKind,
+}
+
+/// Node kinds that typically indicate a definition context.
+const DEFINITION_PARENT_KINDS: &[&str] = &[
+    "function_item",
+    "function_definition",
+    "function_declaration",
+    "method_declaration",
+    "method_definition",
+    "struct_item",
+    "struct_declaration",
+    "enum_item",
+    "enum_declaration",
+    "trait_item",
+    "trait_declaration",
+    "impl_item",
+    "class_definition",
+    "class_declaration",
+    "interface_declaration",
+    "type_declaration",
+    "type_item",
+    "mod_item",
+    "const_item",
+    "type_spec",
+];
+
+/// Identifier node kinds to scan.
+const IDENTIFIER_KINDS: &[&str] = &[
+    "identifier",
+    "type_identifier",
+    "field_identifier",
+    "property_identifier",
+    "simple_identifier",
+];
+
+/// Node kinds whose subtrees should be skipped (strings, comments).
+const SKIP_KINDS: &[&str] = &[
+    "string_literal",
+    "raw_string_literal",
+    "string",
+    "string_content",
+    "string_fragment",
+    "template_string",
+    "line_comment",
+    "block_comment",
+    "comment",
+    "doc_comment",
+];
+
+/// Find all references to `symbol_name` in the given source code.
+pub fn find_refs_in_source(
+    source: &str,
+    symbol_name: &str,
+    lang: Language,
+    file_path: &str,
+) -> Vec<SymbolRef> {
+    let Some((tree, _)) = parse_source(source, lang) else {
+        return Vec::new();
+    };
+
+    let lines: Vec<&str> = source.lines().collect();
+    let mut refs = Vec::new();
+    collect_refs(
+        tree.root_node(),
+        source,
+        symbol_name,
+        &lines,
+        file_path,
+        &mut refs,
+    );
+    refs
+}
+
+/// Find refs across multiple files.
+pub fn find_refs_in_file(
+    path: &Path,
+    symbol_name: &str,
+    lang_hint: Option<Language>,
+    display_path: &str,
+) -> Vec<SymbolRef> {
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+    if !lang.has_grammar() {
+        return Vec::new();
+    }
+    let Ok(source) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    find_refs_in_source(&source, symbol_name, lang, display_path)
+}
+
+fn collect_refs(
+    node: tree_sitter_lib::Node,
+    source: &str,
+    symbol_name: &str,
+    lines: &[&str],
+    file_path: &str,
+    refs: &mut Vec<SymbolRef>,
+) {
+    if SKIP_KINDS.contains(&node.kind()) {
+        return;
+    }
+
+    if IDENTIFIER_KINDS.contains(&node.kind())
+        && let Ok(text) = node.utf8_text(source.as_bytes())
+        && text == symbol_name
+    {
+        let line = node.start_position().row + 1;
+        let context = lines
+            .get(node.start_position().row)
+            .unwrap_or(&"")
+            .trim()
+            .to_string();
+
+        let kind = if is_definition_site(node) {
+            RefKind::Definition
+        } else {
+            RefKind::Reference
+        };
+
+        refs.push(SymbolRef {
+            file: file_path.to_string(),
+            line,
+            context,
+            kind,
+        });
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_refs(cursor.node(), source, symbol_name, lines, file_path, refs);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+/// Check if this identifier node is in a definition position.
+fn is_definition_site(node: tree_sitter_lib::Node) -> bool {
+    // Walk up parents to see if we're directly inside a definition node
+    // where this identifier is the "name" child
+    if let Some(parent) = node.parent()
+        && DEFINITION_PARENT_KINDS.contains(&parent.kind())
+    {
+        // Check if this node is the "name" field of the parent
+        // by checking the field name
+        let mut cursor = parent.walk();
+        for child in parent.children(&mut cursor) {
+            if child.id() == node.id() {
+                // This identifier is a direct child of a definition node.
+                // It's a definition if it's the name child (first identifier).
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_refs_rust() {
+        let source = r#"
+fn setup_file() -> String {
+    String::new()
+}
+
+fn main() {
+    let x = setup_file();
+    let y = setup_file();
+}
+"#;
+        let refs = find_refs_in_source(source, "setup_file", Language::Rust, "test.rs");
+        assert!(refs.len() >= 3); // 1 def + 2 refs
+        let defs: Vec<_> = refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Definition)
+            .collect();
+        let uses: Vec<_> = refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Reference)
+            .collect();
+        assert!(!defs.is_empty());
+        assert!(uses.len() >= 2);
+    }
+
+    #[test]
+    fn find_refs_skips_strings_and_comments() {
+        let source = r#"
+fn target() {}
+
+fn main() {
+    // target is important
+    let s = "target";
+    target();
+}
+"#;
+        let refs = find_refs_in_source(source, "target", Language::Rust, "test.rs");
+        // Should find def + call, but NOT string or comment
+        for r in &refs {
+            assert!(!r.context.starts_with("//"));
+            assert!(!r.context.contains("\"target\""));
+        }
+    }
+
+    #[test]
+    fn find_refs_python() {
+        let source = r#"
+def helper():
+    pass
+
+def main():
+    helper()
+    helper()
+"#;
+        let refs = find_refs_in_source(source, "helper", Language::Python, "test.py");
+        assert!(refs.len() >= 3);
+    }
+
+    #[test]
+    fn unknown_language_returns_empty() {
+        let refs = find_refs_in_source("anything", "x", Language::Unknown, "test.txt");
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn ref_kind_serializes() {
+        let json = serde_json::to_string(&RefKind::Definition).unwrap();
+        assert_eq!(json, "\"definition\"");
+    }
+}

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -1,0 +1,239 @@
+//! Structural code search using tree-sitter queries.
+//!
+//! Supports raw S-expression query mode. Pattern mode with meta-variables
+//! is a higher-level wrapper that compiles code patterns to queries.
+
+use std::path::Path;
+
+use serde::Serialize;
+
+use tree_sitter_lib::StreamingIterator;
+
+use super::{Language, parse_source};
+
+/// A single structural search match.
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchMatch {
+    /// 1-based line number.
+    pub line: usize,
+    /// 0-based column.
+    pub column: usize,
+    /// The matched source text.
+    pub text: String,
+    /// Named captures (if any).
+    pub captures: Vec<Capture>,
+}
+
+/// A named capture from a query.
+#[derive(Debug, Clone, Serialize)]
+pub struct Capture {
+    /// Capture name (without @).
+    pub name: String,
+    /// The captured text.
+    pub text: String,
+    /// 1-based line number.
+    pub line: usize,
+}
+
+/// Search source code using a tree-sitter S-expression query.
+pub fn search_query(
+    source: &str,
+    query_str: &str,
+    lang: Language,
+    max_results: Option<usize>,
+) -> anyhow::Result<Vec<SearchMatch>> {
+    let (tree, ts_lang) =
+        parse_source(source, lang).ok_or_else(|| anyhow::anyhow!("no grammar for {lang}"))?;
+
+    let query = tree_sitter_lib::Query::new(&ts_lang, query_str)
+        .map_err(|e| anyhow::anyhow!("invalid query: {e}"))?;
+
+    let mut cursor = tree_sitter_lib::QueryCursor::new();
+    let source_bytes = source.as_bytes();
+    let mut matches = cursor.matches(&query, tree.root_node(), source_bytes);
+
+    let mut results = Vec::new();
+    let limit = max_results.unwrap_or(usize::MAX);
+
+    while let Some(m) = matches.next() {
+        if results.len() >= limit {
+            break;
+        }
+
+        let mut captures = Vec::new();
+        let mut primary_node = None;
+
+        for cap in m.captures {
+            let name = query.capture_names()[cap.index as usize].to_string();
+            let text = cap
+                .node
+                .utf8_text(source_bytes)
+                .unwrap_or_default()
+                .to_string();
+            let line = cap.node.start_position().row + 1;
+
+            if primary_node.is_none() {
+                primary_node = Some(cap.node);
+            }
+
+            captures.push(Capture { name, text, line });
+        }
+
+        if let Some(node) = primary_node {
+            let text = node.utf8_text(source_bytes).unwrap_or_default().to_string();
+            results.push(SearchMatch {
+                line: node.start_position().row + 1,
+                column: node.start_position().column,
+                text,
+                captures,
+            });
+        }
+    }
+
+    Ok(results)
+}
+
+/// Search a file using a query string.
+pub fn search_file(
+    path: &Path,
+    query_str: &str,
+    lang_hint: Option<Language>,
+    max_results: Option<usize>,
+) -> anyhow::Result<Vec<SearchMatch>> {
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+    if !lang.has_grammar() {
+        return Ok(Vec::new());
+    }
+    let source = std::fs::read_to_string(path)?;
+    search_query(&source, query_str, lang, max_results)
+}
+
+/// Compile a simple pattern string into a tree-sitter query.
+///
+/// Pattern mode: the pattern is parsed as source code for the target language,
+/// and its AST node kinds are converted into an S-expression query.
+/// `$NAME` meta-variables become `@name` captures on identifier nodes.
+///
+/// For MVP, we support a simpler approach: find AST nodes of a specific
+/// kind that match a text pattern.
+pub fn compile_pattern_query(pattern: &str, lang: Language) -> anyhow::Result<String> {
+    // Parse the pattern to get its AST structure
+    let (tree, _) = parse_source(pattern, lang)
+        .ok_or_else(|| anyhow::anyhow!("cannot parse pattern for {lang}"))?;
+
+    let root = tree.root_node();
+    // Walk to the first meaningful child (skip source_file wrapper)
+    let child = if root.child_count() == 1 {
+        root.child(0).unwrap_or(root)
+    } else {
+        root
+    };
+
+    // Build a query from the AST structure
+    let mut query = String::new();
+    build_query_from_node(child, pattern, &mut query, &mut 0);
+    Ok(query)
+}
+
+fn build_query_from_node(
+    node: tree_sitter_lib::Node,
+    source: &str,
+    query: &mut String,
+    capture_idx: &mut usize,
+) {
+    let kind = node.kind();
+    let text = node.utf8_text(source.as_bytes()).unwrap_or_default();
+
+    // Check for meta-variables ($NAME pattern)
+    if text.starts_with('$') && !text.starts_with("$$$") {
+        // Single meta-variable: match any node of this kind
+        let capture_name = &text[1..];
+        query.push_str(&format!("({kind} ) @{capture_name}"));
+        *capture_idx += 1;
+        return;
+    }
+
+    if node.child_count() == 0 {
+        // Leaf node: match exact text
+        query.push_str(&format!("({kind}) @cap{capture_idx}"));
+        *capture_idx += 1;
+        return;
+    }
+
+    query.push_str(&format!("({kind}"));
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if !child.is_named() {
+            continue;
+        }
+        query.push(' ');
+        build_query_from_node(child, source, query, capture_idx);
+    }
+    query.push(')');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_query_finds_function_calls() {
+        let source = r#"
+fn main() {
+    let x = foo();
+    let y = bar();
+    let z = foo();
+}
+"#;
+        let query = r#"(call_expression function: (identifier) @fn)"#;
+        let results = search_query(source, query, Language::Rust, None).unwrap();
+        assert!(results.len() >= 3);
+    }
+
+    #[test]
+    fn search_query_respects_max_results() {
+        let source = "fn a() {}\nfn b() {}\nfn c() {}\n";
+        let query = "(function_item name: (identifier) @name)";
+        let results = search_query(source, query, Language::Rust, Some(2)).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn search_query_captures_names() {
+        let source = "fn hello() {}\n";
+        let query = "(function_item name: (identifier) @name)";
+        let results = search_query(source, query, Language::Rust, None).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].captures[0].name, "name");
+        assert_eq!(results[0].captures[0].text, "hello");
+    }
+
+    #[test]
+    fn search_query_invalid_query_returns_error() {
+        let result = search_query("fn main() {}", "(invalid query !!!", Language::Rust, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn search_query_python() {
+        let source = "def foo():\n    pass\ndef bar():\n    pass\n";
+        let query = "(function_definition name: (identifier) @name)";
+        let results = search_query(source, query, Language::Python, None).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn search_query_go_struct() {
+        let source = "package main\ntype Config struct {\n    Host string\n}\n";
+        let query = "(type_declaration (type_spec name: (type_identifier) @name))";
+        let results = search_query(source, query, Language::Go, None).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].captures[0].text, "Config");
+    }
+
+    #[test]
+    fn unknown_language_returns_error() {
+        let result = search_query("anything", "(identifier)", Language::Unknown, None);
+        assert!(result.is_err());
+    }
+}

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1,4 +1,4 @@
-//! AST-aware subcommands: `patchloom ast list|read|rename|validate`.
+//! AST-aware subcommands: `patchloom ast list|read|rename|validate|search|refs|deps`.
 
 use crate::ast::Language;
 use crate::ast::symbols::{self, SymbolDef, SymbolKind};
@@ -16,6 +16,12 @@ pub enum AstCommand {
     Rename(RenameArgs),
     /// Validate syntax of source files.
     Validate(ValidateArgs),
+    /// Structural search using tree-sitter queries.
+    Search(SearchArgs),
+    /// Find all references to a symbol across files.
+    Refs(RefsArgs),
+    /// Extract import/dependency statements from files.
+    Deps(DepsArgs),
 }
 
 #[derive(Debug, Args)]
@@ -30,6 +36,9 @@ pub fn run(args: AstArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         AstCommand::Read(a) => run_read(a, global),
         AstCommand::Rename(a) => run_rename(a, global),
         AstCommand::Validate(a) => run_validate(a, global),
+        AstCommand::Search(a) => run_search(a, global),
+        AstCommand::Refs(a) => run_refs(a, global),
+        AstCommand::Deps(a) => run_deps(a, global),
     }
 }
 
@@ -362,6 +371,295 @@ fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::Result<u8> 
         Ok(exit::SUCCESS)
     } else {
         Ok(exit::FAILURE)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ast search
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct SearchArgs {
+    /// Tree-sitter S-expression query, or a code pattern (with --pattern).
+    pub query: String,
+
+    /// File or directory to search.
+    pub path: String,
+
+    /// Treat the query as a code pattern with meta-variables ($VAR, $$$MULTI).
+    #[arg(long)]
+    pub pattern: bool,
+
+    /// Language hint (required for pattern mode; detected from extension otherwise).
+    #[arg(long)]
+    pub lang: Option<String>,
+
+    /// Maximum number of results.
+    #[arg(long)]
+    pub max_results: Option<usize>,
+}
+
+fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+
+    let mut total_matches = 0usize;
+
+    let paths = if target.is_file() {
+        vec![target.clone()]
+    } else if target.is_dir() {
+        collect_source_files(&target, global)?
+    } else {
+        anyhow::bail!("path not found: {}", args.path);
+    };
+
+    for path in &paths {
+        let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+
+        let query_str = if args.pattern {
+            crate::ast::search::compile_pattern_query(&args.query, lang)?
+        } else {
+            args.query.clone()
+        };
+
+        let results =
+            crate::ast::search::search_file(path, &query_str, Some(lang), args.max_results)?;
+        if results.is_empty() {
+            continue;
+        }
+
+        let display_path = path.strip_prefix(&cwd).unwrap_or(path);
+        let display = display_path.display().to_string();
+
+        for m in &results {
+            total_matches += 1;
+            if global.json || global.jsonl {
+                let obj = serde_json::json!({
+                    "file": display,
+                    "line": m.line,
+                    "column": m.column,
+                    "text": m.text,
+                    "captures": m.captures,
+                });
+                if global.jsonl {
+                    println!("{}", serde_json::to_string(&obj)?);
+                } else {
+                    println!("{}", serde_json::to_string_pretty(&obj)?);
+                }
+            } else {
+                println!(
+                    "{}:{}:{}: {}",
+                    display,
+                    m.line,
+                    m.column,
+                    m.text.lines().next().unwrap_or("")
+                );
+                for cap in &m.captures {
+                    println!("  @{} = \"{}\"", cap.name, cap.text);
+                }
+            }
+        }
+    }
+
+    if total_matches == 0 {
+        Ok(exit::NO_MATCHES)
+    } else {
+        Ok(exit::SUCCESS)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ast refs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct RefsArgs {
+    /// Symbol name to find references for.
+    pub symbol: String,
+
+    /// File or directory to search.
+    pub path: String,
+
+    /// Include the definition site in results.
+    #[arg(long)]
+    pub include_def: bool,
+
+    /// Language hint.
+    #[arg(long)]
+    pub lang: Option<String>,
+}
+
+fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+
+    let paths = if target.is_file() {
+        vec![target.clone()]
+    } else if target.is_dir() {
+        collect_source_files(&target, global)?
+    } else {
+        anyhow::bail!("path not found: {}", args.path);
+    };
+
+    let mut all_refs = Vec::new();
+
+    for path in &paths {
+        let display_path = path.strip_prefix(&cwd).unwrap_or(path);
+        let display = display_path.display().to_string();
+        let refs = crate::ast::refs::find_refs_in_file(path, &args.symbol, lang_hint, &display);
+        all_refs.extend(refs);
+    }
+
+    if !args.include_def {
+        all_refs.retain(|r| r.kind != crate::ast::refs::RefKind::Definition);
+    }
+
+    if all_refs.is_empty() {
+        return Ok(exit::NO_MATCHES);
+    }
+
+    if global.json || global.jsonl {
+        let obj = serde_json::json!({
+            "symbol": args.symbol,
+            "references": all_refs,
+            "count": all_refs.len(),
+        });
+        if global.jsonl {
+            println!("{}", serde_json::to_string(&obj)?);
+        } else {
+            println!("{}", serde_json::to_string_pretty(&obj)?);
+        }
+    } else {
+        for r in &all_refs {
+            let kind_label = match r.kind {
+                crate::ast::refs::RefKind::Definition => "def",
+                crate::ast::refs::RefKind::Reference => "ref",
+            };
+            println!("{}:{}: [{}] {}", r.file, r.line, kind_label, r.context);
+        }
+    }
+
+    Ok(exit::SUCCESS)
+}
+
+// ---------------------------------------------------------------------------
+// ast deps
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct DepsArgs {
+    /// File or directory to analyze.
+    pub path: String,
+
+    /// Show reverse dependencies (what imports this file).
+    #[arg(long)]
+    pub reverse: bool,
+
+    /// Language hint.
+    #[arg(long)]
+    pub lang: Option<String>,
+}
+
+fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+
+    let paths = if target.is_file() {
+        vec![target.clone()]
+    } else if target.is_dir() {
+        collect_source_files(&target, global)?
+    } else {
+        anyhow::bail!("path not found: {}", args.path);
+    };
+
+    let mut any_output = false;
+
+    if args.reverse {
+        // For reverse deps, scan all files and find which ones import
+        // anything matching the target file's module path
+        let target_name = target
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default();
+
+        let scan_dir = if target.is_file() {
+            target.parent().unwrap_or(&cwd).to_path_buf()
+        } else {
+            target.clone()
+        };
+        let all_files = collect_source_files(&scan_dir, global)?;
+
+        for path in &all_files {
+            let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+            let matching: Vec<_> = imports
+                .iter()
+                .filter(|i| i.path.contains(target_name))
+                .collect();
+            if matching.is_empty() {
+                continue;
+            }
+            any_output = true;
+            let display_path = path.strip_prefix(&cwd).unwrap_or(path);
+            let display = display_path.display().to_string();
+
+            if global.json || global.jsonl {
+                for imp in &matching {
+                    let obj = serde_json::json!({
+                        "file": display,
+                        "imports": imp.path,
+                        "line": imp.line,
+                        "raw": imp.raw,
+                    });
+                    if global.jsonl {
+                        println!("{}", serde_json::to_string(&obj)?);
+                    } else {
+                        println!("{}", serde_json::to_string_pretty(&obj)?);
+                    }
+                }
+            } else {
+                for imp in &matching {
+                    println!("{}:{}: {}", display, imp.line, imp.raw);
+                }
+            }
+        }
+    } else {
+        for path in &paths {
+            let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+            if imports.is_empty() {
+                continue;
+            }
+            any_output = true;
+            let display_path = path.strip_prefix(&cwd).unwrap_or(path);
+            let display = display_path.display().to_string();
+
+            if global.json || global.jsonl {
+                let obj = serde_json::json!({
+                    "file": display,
+                    "imports": imports,
+                });
+                if global.jsonl {
+                    println!("{}", serde_json::to_string(&obj)?);
+                } else {
+                    println!("{}", serde_json::to_string_pretty(&obj)?);
+                }
+            } else {
+                println!("{display}");
+                println!("  imports:");
+                for imp in &imports {
+                    println!("    {}", imp.path);
+                }
+                println!();
+            }
+        }
+    }
+
+    if any_output {
+        Ok(exit::SUCCESS)
+    } else {
+        Ok(exit::NO_MATCHES)
     }
 }
 


### PR DESCRIPTION
Adds three new `ast` subcommands for Phase 2 of the AST feature set:

## `ast search` (#649)
Structural code search using tree-sitter S-expression queries. Supports:
- Raw query mode with S-expression syntax
- Pattern compilation from code patterns with meta-variables ($VAR)
- Named capture extraction
- Max results limiting

## `ast refs` (#651)
Find all references to a symbol across files. Features:
- Definition vs reference site classification
- Skips strings and comments (AST-aware)
- Supports --include-def to show definition sites
- Per-language identifier and definition node detection

## `ast deps` (#652)
Extract import/dependency statements from source files. Supports:
- Per-language extractors: Rust (use/mod/extern crate), Python (import/from), JS/TS (import/require), Go, Java, C/C++ (#include), Ruby (require), PHP (use)
- Generic fallback for unsupported languages
- Reverse dependency lookup (--reverse)

All three subcommands integrate with existing `ast` infrastructure: --json/--jsonl output, --lang hints, directory scanning with glob filtering.

Closes #649
Closes #651
Closes #652