### PR TITLE
feat(ast): add map, replace, impact, and diff subcommands

### DIFF
--- a/src/ast/diff.rs
+++ b/src/ast/diff.rs
@@ -1,0 +1,243 @@
+//! Structural diff: compare symbols between two versions of a file.
+
+use serde::Serialize;
+
+use super::Language;
+use super::symbols::{SymbolDef, extract_symbols};
+
+/// A single structural change.
+#[derive(Debug, Clone, Serialize)]
+pub struct StructuralChange {
+    /// Symbol name.
+    pub name: String,
+    /// Kind of symbol (fn, struct, etc.).
+    pub kind: String,
+    /// What changed.
+    pub change: ChangeKind,
+    /// 1-based line number (in the "new" version, or the "old" if removed).
+    pub line: usize,
+    /// Optional detail (e.g. "parameter added").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+/// Classification of change.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChangeKind {
+    Added,
+    Removed,
+    SignatureChanged,
+    BodyChanged,
+}
+
+impl std::fmt::Display for ChangeKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Added => write!(f, "+"),
+            Self::Removed => write!(f, "-"),
+            Self::SignatureChanged => write!(f, "~"),
+            Self::BodyChanged => write!(f, "~"),
+        }
+    }
+}
+
+/// Compare two versions of source code and return structural changes.
+pub fn structural_diff(
+    old_source: &str,
+    new_source: &str,
+    lang: Language,
+) -> Vec<StructuralChange> {
+    let old_symbols = extract_symbols(old_source, lang);
+    let new_symbols = extract_symbols(new_source, lang);
+
+    let mut changes = Vec::new();
+    diff_symbol_lists(
+        &old_symbols,
+        &new_symbols,
+        old_source,
+        new_source,
+        &mut changes,
+    );
+    changes
+}
+
+fn diff_symbol_lists(
+    old: &[SymbolDef],
+    new: &[SymbolDef],
+    old_source: &str,
+    new_source: &str,
+    changes: &mut Vec<StructuralChange>,
+) {
+    // Index old symbols by name
+    let old_map: std::collections::HashMap<&str, &SymbolDef> =
+        old.iter().map(|s| (s.name.as_str(), s)).collect();
+    let new_map: std::collections::HashMap<&str, &SymbolDef> =
+        new.iter().map(|s| (s.name.as_str(), s)).collect();
+
+    // Added symbols (in new but not old)
+    for sym in new {
+        if !old_map.contains_key(sym.name.as_str()) {
+            changes.push(StructuralChange {
+                name: sym.name.clone(),
+                kind: sym.kind.to_string(),
+                change: ChangeKind::Added,
+                line: sym.start_line,
+                detail: Some(format!("added at line {}", sym.start_line)),
+            });
+        }
+    }
+
+    // Removed symbols (in old but not new)
+    for sym in old {
+        if !new_map.contains_key(sym.name.as_str()) {
+            changes.push(StructuralChange {
+                name: sym.name.clone(),
+                kind: sym.kind.to_string(),
+                change: ChangeKind::Removed,
+                line: sym.start_line,
+                detail: Some(format!("was at line {}", sym.start_line)),
+            });
+        }
+    }
+
+    // Changed symbols (in both)
+    for new_sym in new {
+        if let Some(old_sym) = old_map.get(new_sym.name.as_str()) {
+            // Compare signatures
+            if old_sym.signature != new_sym.signature {
+                changes.push(StructuralChange {
+                    name: new_sym.name.clone(),
+                    kind: new_sym.kind.to_string(),
+                    change: ChangeKind::SignatureChanged,
+                    line: new_sym.start_line,
+                    detail: Some(format!("was: {}", old_sym.signature)),
+                });
+            } else {
+                // Compare body content
+                let old_body = extract_body(old_source, old_sym);
+                let new_body = extract_body(new_source, new_sym);
+                if old_body != new_body {
+                    changes.push(StructuralChange {
+                        name: new_sym.name.clone(),
+                        kind: new_sym.kind.to_string(),
+                        change: ChangeKind::BodyChanged,
+                        line: new_sym.start_line,
+                        detail: Some(format!("lines {}-{}", new_sym.start_line, new_sym.end_line)),
+                    });
+                }
+            }
+
+            // Recurse into children
+            diff_symbol_lists(
+                &old_sym.children,
+                &new_sym.children,
+                old_source,
+                new_source,
+                changes,
+            );
+        }
+    }
+}
+
+fn extract_body<'a>(source: &'a str, sym: &SymbolDef) -> &'a str {
+    let lines: Vec<&str> = source.lines().collect();
+    let start = sym.start_line.saturating_sub(1);
+    let end = sym.end_line.min(lines.len());
+    if start >= lines.len() || start >= end {
+        return "";
+    }
+    let start_byte: usize = source.lines().take(start).map(|l| l.len() + 1).sum();
+    let end_byte: usize = source.lines().take(end).map(|l| l.len() + 1).sum();
+    &source[start_byte..end_byte.min(source.len())]
+}
+
+/// Render changes as human-readable text.
+pub fn render_changes(file: &str, changes: &[StructuralChange]) -> String {
+    let mut out = format!("{file}\n");
+    for c in changes {
+        let detail = c.detail.as_deref().unwrap_or("");
+        out.push_str(&format!(
+            "  {} {} {}: {} [{}]\n",
+            c.change, c.kind, c.name, detail, c.line
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_added_function() {
+        let old = "fn foo() {}\n";
+        let new = "fn foo() {}\nfn bar() {}\n";
+        let changes = structural_diff(old, new, Language::Rust);
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.name == "bar" && c.change == ChangeKind::Added)
+        );
+    }
+
+    #[test]
+    fn detects_removed_function() {
+        let old = "fn foo() {}\nfn bar() {}\n";
+        let new = "fn foo() {}\n";
+        let changes = structural_diff(old, new, Language::Rust);
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.name == "bar" && c.change == ChangeKind::Removed)
+        );
+    }
+
+    #[test]
+    fn detects_signature_change() {
+        let old = "fn foo() {}\n";
+        let new = "fn foo(x: i32) {}\n";
+        let changes = structural_diff(old, new, Language::Rust);
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.name == "foo" && c.change == ChangeKind::SignatureChanged)
+        );
+    }
+
+    #[test]
+    fn detects_body_change() {
+        let old = "fn foo() {\n    let x = 1;\n}\n";
+        let new = "fn foo() {\n    let x = 2;\n}\n";
+        let changes = structural_diff(old, new, Language::Rust);
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.name == "foo" && c.change == ChangeKind::BodyChanged)
+        );
+    }
+
+    #[test]
+    fn no_changes_returns_empty() {
+        let source = "fn foo() {\n    let x = 1;\n}\n";
+        let changes = structural_diff(source, source, Language::Rust);
+        assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn python_diff() {
+        let old = "def hello():\n    pass\n";
+        let new = "def hello():\n    print('hi')\ndef world():\n    pass\n";
+        let changes = structural_diff(old, new, Language::Python);
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.name == "world" && c.change == ChangeKind::Added)
+        );
+        assert!(
+            changes
+                .iter()
+                .any(|c| c.name == "hello" && c.change == ChangeKind::BodyChanged)
+        );
+    }
+}

--- a/src/ast/impact.rs
+++ b/src/ast/impact.rs
@@ -1,0 +1,182 @@
+//! Transitive impact analysis: what breaks if you change a symbol?
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::Language;
+use super::refs::{RefKind, find_refs_in_source};
+use super::symbols::extract_symbols;
+
+/// A node in the impact tree.
+#[derive(Debug, Clone, Serialize)]
+pub struct ImpactNode {
+    /// Symbol name.
+    pub symbol: String,
+    /// File where the reference occurs.
+    pub file: String,
+    /// 1-based line number.
+    pub line: usize,
+    /// The source line (trimmed).
+    pub context: String,
+    /// Transitive dependents (callers of this caller).
+    pub dependents: Vec<ImpactNode>,
+}
+
+/// Compute the transitive impact of changing a symbol.
+pub fn compute_impact(
+    symbol_name: &str,
+    files: &[(impl AsRef<Path>, String)],
+    max_depth: usize,
+) -> Vec<ImpactNode> {
+    // Collect all file sources
+    let file_data: Vec<(&Path, &str, String, Language)> = files
+        .iter()
+        .filter_map(|(path, display)| {
+            let path = path.as_ref();
+            let lang = Language::from_path(path);
+            if !lang.has_grammar() {
+                return None;
+            }
+            let source = std::fs::read_to_string(path).ok()?;
+            Some((path, display.as_str(), source, lang))
+        })
+        .collect();
+
+    let mut visited = HashSet::new();
+    visited.insert(symbol_name.to_string());
+
+    find_dependents(symbol_name, &file_data, max_depth, 1, &mut visited)
+}
+
+fn find_dependents(
+    symbol_name: &str,
+    file_data: &[(&Path, &str, String, Language)],
+    max_depth: usize,
+    current_depth: usize,
+    visited: &mut HashSet<String>,
+) -> Vec<ImpactNode> {
+    let mut results = Vec::new();
+
+    for (_, display, source, lang) in file_data {
+        let refs = find_refs_in_source(source, symbol_name, *lang, display);
+        for r in &refs {
+            if r.kind != RefKind::Reference {
+                continue;
+            }
+
+            // Find which symbol contains this reference line
+            let containing = find_containing_symbol(source, *lang, r.line);
+            let dependent_name = containing.unwrap_or_else(|| format!("<{}>", display));
+
+            if visited.contains(&dependent_name) {
+                continue;
+            }
+            visited.insert(dependent_name.clone());
+
+            let dependents = if current_depth < max_depth {
+                find_dependents(
+                    &dependent_name,
+                    file_data,
+                    max_depth,
+                    current_depth + 1,
+                    visited,
+                )
+            } else {
+                Vec::new()
+            };
+
+            results.push(ImpactNode {
+                symbol: dependent_name,
+                file: r.file.clone(),
+                line: r.line,
+                context: r.context.clone(),
+                dependents,
+            });
+        }
+    }
+
+    // Deduplicate by (symbol, file) keeping the first occurrence
+    let mut seen = HashSet::new();
+    results.retain(|node| seen.insert((node.symbol.clone(), node.file.clone())));
+
+    results
+}
+
+/// Find the symbol that contains a given line number.
+fn find_containing_symbol(source: &str, lang: Language, line: usize) -> Option<String> {
+    let symbols = extract_symbols(source, lang);
+    find_containing_in(&symbols, line)
+}
+
+fn find_containing_in(symbols: &[super::symbols::SymbolDef], line: usize) -> Option<String> {
+    for sym in symbols {
+        if line >= sym.start_line && line <= sym.end_line {
+            // Check children first for more specific match
+            if let Some(child_name) = find_containing_in(&sym.children, line) {
+                return Some(child_name);
+            }
+            return Some(sym.name.clone());
+        }
+    }
+    None
+}
+
+/// Render impact tree as human-readable text.
+pub fn render_impact_tree(symbol: &str, nodes: &[ImpactNode], indent: usize) -> String {
+    let mut out = String::new();
+    if indent == 0 {
+        out.push_str(&format!("{symbol}\n"));
+    }
+    let pad = "   ".repeat(indent);
+    for node in nodes {
+        out.push_str(&format!(
+            "{pad}<- {} ({}:{})\n",
+            node.symbol, node.file, node.line
+        ));
+        if !node.dependents.is_empty() {
+            out.push_str(&render_impact_tree(
+                &node.symbol,
+                &node.dependents,
+                indent + 1,
+            ));
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_containing_symbol_works() {
+        let source = "fn foo() {\n    let x = 1;\n}\n\nfn bar() {\n    let y = 2;\n}\n";
+        let result = find_containing_symbol(source, Language::Rust, 2);
+        assert_eq!(result, Some("foo".to_string()));
+        let result = find_containing_symbol(source, Language::Rust, 6);
+        assert_eq!(result, Some("bar".to_string()));
+    }
+
+    #[test]
+    fn render_impact_tree_formats_correctly() {
+        let nodes = vec![ImpactNode {
+            symbol: "caller".into(),
+            file: "main.rs".into(),
+            line: 10,
+            context: "caller()".into(),
+            dependents: vec![],
+        }];
+        let output = render_impact_tree("target", &nodes, 0);
+        assert!(output.contains("target\n"));
+        assert!(output.contains("<- caller (main.rs:10)"));
+    }
+
+    #[test]
+    fn empty_impact_returns_empty() {
+        let nodes: Vec<ImpactNode> = Vec::new();
+        let output = render_impact_tree("target", &nodes, 0);
+        assert_eq!(output, "target\n");
+    }
+}

--- a/src/ast/map.rs
+++ b/src/ast/map.rs
@@ -1,0 +1,398 @@
+//! Repository map with PageRank ranking and token-budget-aware output.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use serde::Serialize;
+
+use super::Language;
+use super::refs::{RefKind, find_refs_in_source};
+use super::symbols::{SymbolDef, SymbolKind, extract_symbols};
+
+/// A symbol entry in the repository map.
+#[derive(Debug, Clone, Serialize)]
+pub struct MapEntry {
+    /// File path (relative).
+    pub file: String,
+    /// Symbol name.
+    pub name: String,
+    /// Symbol kind.
+    pub kind: String,
+    /// One-line signature.
+    pub signature: String,
+    /// 1-based line number.
+    pub line: usize,
+    /// PageRank score (higher = more important).
+    pub score: f64,
+}
+
+/// Options for generating a repository map.
+pub struct MapOptions<'a> {
+    /// Maximum approximate token count for output.
+    pub max_tokens: usize,
+    /// File paths to boost (their symbols get higher initial rank).
+    pub focus: &'a [String],
+    /// Symbol names to boost.
+    pub boost: &'a [String],
+}
+
+impl Default for MapOptions<'_> {
+    fn default() -> Self {
+        Self {
+            max_tokens: 1024,
+            focus: &[],
+            boost: &[],
+        }
+    }
+}
+
+/// Collected file data for graph building.
+struct FileData {
+    path: String,
+    source: String,
+    lang: Language,
+    symbols: Vec<SymbolDef>,
+}
+
+/// Generate a ranked repository map from a directory of source files.
+pub fn generate_map(files: &[(impl AsRef<Path>, String)], opts: &MapOptions<'_>) -> Vec<MapEntry> {
+    // Phase 1: Parse all files and extract symbols
+    let file_data: Vec<FileData> = files
+        .iter()
+        .filter_map(|(path, display)| {
+            let path = path.as_ref();
+            let lang = Language::from_path(path);
+            if !lang.has_grammar() {
+                return None;
+            }
+            let source = std::fs::read_to_string(path).ok()?;
+            let symbols = extract_symbols(&source, lang);
+            if symbols.is_empty() {
+                return None;
+            }
+            Some(FileData {
+                path: display.clone(),
+                source,
+                lang,
+                symbols,
+            })
+        })
+        .collect();
+
+    // Phase 2: Build reference graph and compute PageRank
+    let mut all_symbols: Vec<(String, String, SymbolKind, String, usize)> = Vec::new(); // (file, name, kind, sig, line)
+    let mut name_to_idx: HashMap<String, Vec<usize>> = HashMap::new();
+
+    for fd in &file_data {
+        collect_flat_symbols(&fd.symbols, &fd.path, &mut all_symbols, &mut name_to_idx);
+    }
+
+    let n = all_symbols.len();
+    if n == 0 {
+        return Vec::new();
+    }
+
+    // Build adjacency: edges[i] = list of j where symbol i references symbol j
+    let mut edges: Vec<Vec<usize>> = vec![Vec::new(); n];
+
+    for fd in &file_data {
+        for (idx, (_, name, _, _, _)) in all_symbols.iter().enumerate() {
+            if all_symbols[idx].0 != fd.path {
+                continue;
+            }
+            // Find what this symbol references in other symbols
+            let refs = find_refs_in_source(&fd.source, name, fd.lang, &fd.path);
+            for r in &refs {
+                if r.kind == RefKind::Reference {
+                    // This file references `name`, add edges from referencing symbols
+                    // to the definition of `name` in other files
+                    if let Some(targets) = name_to_idx.get(name.as_str()) {
+                        for &target in targets {
+                            if target != idx {
+                                edges[idx].push(target);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Also find cross-file references: for each file, scan for identifiers
+    // that match symbol names in other files
+    for fd in &file_data {
+        for (name, indices) in &name_to_idx {
+            // Skip symbols defined in this file
+            if indices.iter().all(|&i| all_symbols[i].0 == fd.path) {
+                continue;
+            }
+            let refs = find_refs_in_source(&fd.source, name, fd.lang, &fd.path);
+            if refs.iter().any(|r| r.kind == RefKind::Reference) {
+                // Find symbols in this file that could be the referencing context
+                let file_symbols: Vec<usize> =
+                    (0..n).filter(|&i| all_symbols[i].0 == fd.path).collect();
+                for &src in &file_symbols {
+                    for &dst in indices {
+                        if all_symbols[dst].0 != fd.path && !edges[src].contains(&dst) {
+                            edges[src].push(dst);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Phase 3: PageRank
+    let scores = pagerank(&edges, n, opts, &all_symbols);
+
+    // Phase 4: Build entries sorted by score
+    let mut entries: Vec<MapEntry> = all_symbols
+        .into_iter()
+        .enumerate()
+        .map(|(i, (file, name, kind, sig, line))| MapEntry {
+            file,
+            name,
+            kind: kind.to_string(),
+            signature: sig,
+            line,
+            score: scores[i],
+        })
+        .collect();
+
+    entries.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Phase 5: Token budget selection
+    truncate_to_budget(&mut entries, opts.max_tokens);
+
+    entries
+}
+
+fn collect_flat_symbols(
+    symbols: &[SymbolDef],
+    file: &str,
+    out: &mut Vec<(String, String, SymbolKind, String, usize)>,
+    name_to_idx: &mut HashMap<String, Vec<usize>>,
+) {
+    for sym in symbols {
+        let idx = out.len();
+        name_to_idx.entry(sym.name.clone()).or_default().push(idx);
+        out.push((
+            file.to_string(),
+            sym.name.clone(),
+            sym.kind,
+            sym.signature.clone(),
+            sym.start_line,
+        ));
+        collect_flat_symbols(&sym.children, file, out, name_to_idx);
+    }
+}
+
+fn pagerank(
+    edges: &[Vec<usize>],
+    n: usize,
+    opts: &MapOptions<'_>,
+    symbols: &[(String, String, SymbolKind, String, usize)],
+) -> Vec<f64> {
+    let damping = 0.85;
+    let iterations = 20;
+
+    // Initialize with personalization bias
+    let mut scores = vec![1.0 / n as f64; n];
+
+    // Apply focus/boost to initial scores
+    for (i, (file, name, _, _, _)) in symbols.iter().enumerate() {
+        if opts.focus.iter().any(|f| file.contains(f.as_str())) {
+            scores[i] *= 3.0;
+        }
+        if opts.boost.iter().any(|b| b == name) {
+            scores[i] *= 5.0;
+        }
+    }
+
+    // Normalize
+    let sum: f64 = scores.iter().sum();
+    if sum > 0.0 {
+        for s in &mut scores {
+            *s /= sum;
+        }
+    }
+
+    let personalization = scores.clone();
+
+    // Compute out-degree
+    let out_degree: Vec<usize> = edges.iter().map(|e| e.len()).collect();
+
+    for _ in 0..iterations {
+        let mut new_scores = vec![0.0; n];
+
+        for (i, edge_list) in edges.iter().enumerate() {
+            if out_degree[i] > 0 {
+                let share = scores[i] / out_degree[i] as f64;
+                for &j in edge_list {
+                    new_scores[j] += share;
+                }
+            }
+        }
+
+        // Apply damping with personalization
+        for i in 0..n {
+            new_scores[i] = damping * new_scores[i] + (1.0 - damping) * personalization[i];
+        }
+
+        scores = new_scores;
+    }
+
+    scores
+}
+
+/// Rough token estimate: ~4 chars per token.
+fn estimate_tokens(entry: &MapEntry) -> usize {
+    (entry.signature.len() + entry.file.len() + 10) / 4
+}
+
+fn truncate_to_budget(entries: &mut Vec<MapEntry>, max_tokens: usize) {
+    let mut total = 0;
+    let mut keep = entries.len();
+    for (i, entry) in entries.iter().enumerate() {
+        total += estimate_tokens(entry);
+        if total > max_tokens {
+            keep = i;
+            break;
+        }
+    }
+    entries.truncate(keep);
+}
+
+/// Render the map as a human-readable tree string.
+pub fn render_tree(entries: &[MapEntry]) -> String {
+    let mut out = String::new();
+    let mut current_file = "";
+
+    for entry in entries {
+        if entry.file != current_file {
+            if !out.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(&entry.file);
+            out.push('\n');
+            current_file = &entry.file;
+        }
+        out.push_str(&format!(
+            "  {} {} [line {}]\n",
+            entry.kind, entry.signature, entry.line
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pagerank_trivial() {
+        // Two nodes pointing at each other
+        let edges = vec![vec![1], vec![0]];
+        let symbols = vec![
+            (
+                "a.rs".into(),
+                "foo".into(),
+                SymbolKind::Function,
+                String::new(),
+                1,
+            ),
+            (
+                "b.rs".into(),
+                "bar".into(),
+                SymbolKind::Function,
+                String::new(),
+                1,
+            ),
+        ];
+        let opts = MapOptions::default();
+        let scores = pagerank(&edges, 2, &opts, &symbols);
+        // Both should have equal score
+        assert!((scores[0] - scores[1]).abs() < 0.01);
+    }
+
+    #[test]
+    fn truncate_respects_budget() {
+        let mut entries: Vec<MapEntry> = (0..100)
+            .map(|i| MapEntry {
+                file: format!("f{i}.rs"),
+                name: format!("sym{i}"),
+                kind: "fn".into(),
+                signature: format!("fn sym{i}()"),
+                line: i + 1,
+                score: 1.0 / (i + 1) as f64,
+            })
+            .collect();
+        truncate_to_budget(&mut entries, 50);
+        assert!(entries.len() < 100);
+    }
+
+    #[test]
+    fn render_tree_groups_by_file() {
+        let entries = vec![
+            MapEntry {
+                file: "a.rs".into(),
+                name: "foo".into(),
+                kind: "fn".into(),
+                signature: "fn foo()".into(),
+                line: 1,
+                score: 1.0,
+            },
+            MapEntry {
+                file: "a.rs".into(),
+                name: "bar".into(),
+                kind: "fn".into(),
+                signature: "fn bar()".into(),
+                line: 5,
+                score: 0.5,
+            },
+            MapEntry {
+                file: "b.rs".into(),
+                name: "baz".into(),
+                kind: "fn".into(),
+                signature: "fn baz()".into(),
+                line: 1,
+                score: 0.3,
+            },
+        ];
+        let tree = render_tree(&entries);
+        assert!(tree.contains("a.rs\n"));
+        assert!(tree.contains("b.rs\n"));
+        assert!(tree.contains("fn foo()"));
+    }
+
+    #[test]
+    fn boost_increases_score() {
+        let edges = vec![vec![], vec![]];
+        let symbols = vec![
+            (
+                "a.rs".into(),
+                "target".into(),
+                SymbolKind::Function,
+                String::new(),
+                1,
+            ),
+            (
+                "b.rs".into(),
+                "other".into(),
+                SymbolKind::Function,
+                String::new(),
+                1,
+            ),
+        ];
+        let opts = MapOptions {
+            boost: &["target".into()],
+            ..MapOptions::default()
+        };
+        let scores = pagerank(&edges, 2, &opts, &symbols);
+        assert!(scores[0] > scores[1]);
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -5,8 +5,12 @@
 //! All functionality is gated on the `ast` feature flag.
 
 pub mod deps;
+pub mod diff;
+pub mod impact;
+pub mod map;
 pub mod refs;
 pub mod rename;
+pub mod replace;
 pub mod search;
 pub mod symbols;
 pub mod validate;

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -1,0 +1,170 @@
+//! Symbol-scoped replacement: replace text only within a specific symbol's body.
+
+use std::path::Path;
+
+use super::Language;
+use super::symbols::{extract_symbols, find_symbol};
+
+/// Result of a symbol-scoped replacement.
+#[derive(Debug)]
+pub struct ScopedReplaceResult {
+    /// The full file content after replacement.
+    pub content: String,
+    /// Number of replacements made within the symbol.
+    pub replacements: usize,
+    /// 1-based start line of the symbol.
+    pub start_line: usize,
+    /// 1-based end line of the symbol.
+    pub end_line: usize,
+}
+
+/// Replace text only within the body of a specific symbol.
+pub fn replace_in_symbol(
+    source: &str,
+    symbol_name: &str,
+    from: &str,
+    to: &str,
+    regex: bool,
+    lang: Language,
+) -> anyhow::Result<Option<ScopedReplaceResult>> {
+    let symbols = extract_symbols(source, lang);
+    let sym = match find_symbol(&symbols, symbol_name) {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+
+    let lines: Vec<&str> = source.lines().collect();
+    let start_idx = sym.start_line.saturating_sub(1);
+    let end_idx = sym.end_line.min(lines.len());
+
+    // Extract the symbol body
+    let body: String = lines[start_idx..end_idx]
+        .iter()
+        .map(|l| format!("{l}\n"))
+        .collect();
+
+    // Perform replacement within the body
+    let (new_body, count) = if regex {
+        let re = regex::Regex::new(from)?;
+        let count = re.find_iter(&body).count();
+        let new = re.replace_all(&body, to).into_owned();
+        (new, count)
+    } else {
+        let count = body.matches(from).count();
+        let new = body.replace(from, to);
+        (new, count)
+    };
+
+    if count == 0 {
+        return Ok(Some(ScopedReplaceResult {
+            content: source.to_string(),
+            replacements: 0,
+            start_line: sym.start_line,
+            end_line: sym.end_line,
+        }));
+    }
+
+    // Reconstruct the full file: prefix + new body + suffix
+    let mut result = String::new();
+    for line in &lines[..start_idx] {
+        result.push_str(line);
+        result.push('\n');
+    }
+    result.push_str(&new_body);
+    // new_body already has trailing newlines; add suffix
+    for line in &lines[end_idx..] {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Preserve original trailing newline behavior
+    if !source.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    Ok(Some(ScopedReplaceResult {
+        content: result,
+        replacements: count,
+        start_line: sym.start_line,
+        end_line: sym.end_line,
+    }))
+}
+
+/// Replace text within a symbol in a file.
+pub fn replace_in_symbol_file(
+    path: &Path,
+    symbol_name: &str,
+    from: &str,
+    to: &str,
+    regex: bool,
+    lang_hint: Option<Language>,
+) -> anyhow::Result<Option<ScopedReplaceResult>> {
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
+    if !lang.has_grammar() {
+        return Ok(None);
+    }
+    let source = std::fs::read_to_string(path)?;
+    replace_in_symbol(&source, symbol_name, from, to, regex, lang)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn replace_within_function() {
+        let source = r#"fn foo() {
+    let x = 1;
+    let y = 1;
+}
+
+fn bar() {
+    let x = 1;
+}
+"#;
+        let result = replace_in_symbol(source, "foo", "1", "42", false, Language::Rust)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.replacements, 2);
+        // foo's body should have 42, bar's should still have 1
+        assert!(result.content.contains("fn foo()"));
+        assert!(result.content.contains("let x = 42"));
+        let bar_section: &str = result.content.split("fn bar()").nth(1).unwrap();
+        assert!(bar_section.contains("let x = 1"));
+    }
+
+    #[test]
+    fn replace_with_regex() {
+        let source = "fn run() {\n    exit::FAILURE\n    exit::NO_MATCHES\n}\n";
+        let result = replace_in_symbol(
+            source,
+            "run",
+            r"exit::\w+",
+            "exit::SUCCESS",
+            true,
+            Language::Rust,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(result.replacements, 2);
+        assert!(result.content.contains("exit::SUCCESS"));
+        assert!(!result.content.contains("exit::FAILURE"));
+    }
+
+    #[test]
+    fn symbol_not_found_returns_none() {
+        let source = "fn foo() {}\n";
+        let result =
+            replace_in_symbol(source, "nonexistent", "x", "y", false, Language::Rust).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn no_match_returns_zero_replacements() {
+        let source = "fn foo() {\n    let x = 1;\n}\n";
+        let result = replace_in_symbol(source, "foo", "zzz", "yyy", false, Language::Rust)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.replacements, 0);
+    }
+}

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -22,6 +22,14 @@ pub enum AstCommand {
     Refs(RefsArgs),
     /// Extract import/dependency statements from files.
     Deps(DepsArgs),
+    /// Generate a ranked repository map (PageRank).
+    Map(MapArgs),
+    /// Replace text only within a specific symbol's body.
+    Replace(ReplaceArgs),
+    /// Transitive impact analysis of changing a symbol.
+    Impact(ImpactArgs),
+    /// Structural diff between two versions of a file.
+    Diff(DiffArgs),
 }
 
 #[derive(Debug, Args)]
@@ -39,6 +47,10 @@ pub fn run(args: AstArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         AstCommand::Search(a) => run_search(a, global),
         AstCommand::Refs(a) => run_refs(a, global),
         AstCommand::Deps(a) => run_deps(a, global),
+        AstCommand::Map(a) => run_map(a, global),
+        AstCommand::Replace(a) => run_replace(a, global),
+        AstCommand::Impact(a) => run_impact(a, global),
+        AstCommand::Diff(a) => run_diff(a, global),
     }
 }
 
@@ -661,6 +673,343 @@ fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     } else {
         Ok(exit::NO_MATCHES)
     }
+}
+
+// ---------------------------------------------------------------------------
+// ast map
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct MapArgs {
+    /// Directory to map.
+    pub path: String,
+
+    /// Maximum approximate token count for output.
+    #[arg(long, default_value = "1024")]
+    pub max_tokens: usize,
+
+    /// Boost symbols from these files (comma-separated paths).
+    #[arg(long, value_delimiter = ',')]
+    pub focus: Vec<String>,
+
+    /// Boost these symbol names (comma-separated).
+    #[arg(long, value_delimiter = ',')]
+    pub boost: Vec<String>,
+}
+
+fn run_map(args: MapArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+
+    if !target.is_dir() {
+        anyhow::bail!("path must be a directory: {}", args.path);
+    }
+
+    let paths = collect_source_files(&target, global)?;
+    let file_pairs: Vec<(std::path::PathBuf, String)> = paths
+        .iter()
+        .map(|p| {
+            let display = p.strip_prefix(&cwd).unwrap_or(p).display().to_string();
+            (p.clone(), display)
+        })
+        .collect();
+
+    let opts = crate::ast::map::MapOptions {
+        max_tokens: args.max_tokens,
+        focus: &args.focus,
+        boost: &args.boost,
+    };
+
+    let entries = crate::ast::map::generate_map(&file_pairs, &opts);
+
+    if entries.is_empty() {
+        return Ok(exit::NO_MATCHES);
+    }
+
+    if global.json || global.jsonl {
+        if global.jsonl {
+            for entry in &entries {
+                println!("{}", serde_json::to_string(entry)?);
+            }
+        } else {
+            println!("{}", serde_json::to_string_pretty(&entries)?);
+        }
+    } else {
+        print!("{}", crate::ast::map::render_tree(&entries));
+    }
+
+    Ok(exit::SUCCESS)
+}
+
+// ---------------------------------------------------------------------------
+// ast replace
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct ReplaceArgs {
+    /// File containing the symbol.
+    pub path: String,
+
+    /// Symbol name to scope the replacement to.
+    pub symbol: String,
+
+    /// Text or regex pattern to find.
+    #[arg(long)]
+    pub from: String,
+
+    /// Replacement text.
+    #[arg(long)]
+    pub to: String,
+
+    /// Treat --from as a regex pattern.
+    #[arg(long)]
+    pub regex: bool,
+
+    /// Language hint.
+    #[arg(long)]
+    pub lang: Option<String>,
+
+    #[command(flatten)]
+    pub write: crate::cli::global::WriteFlags,
+}
+
+fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+
+    let source = std::fs::read_to_string(&target)?;
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
+
+    let result = crate::ast::replace::replace_in_symbol(
+        &source,
+        &args.symbol,
+        &args.from,
+        &args.to,
+        args.regex,
+        lang,
+    )?;
+
+    let result = match result {
+        Some(r) => r,
+        None => {
+            if !global.quiet {
+                eprintln!("symbol '{}' not found in {}", args.symbol, args.path);
+            }
+            return Ok(exit::NO_MATCHES);
+        }
+    };
+
+    if result.replacements == 0 {
+        return Ok(exit::NO_MATCHES);
+    }
+
+    let display_path = target.strip_prefix(&cwd).unwrap_or(&target);
+
+    if global.apply {
+        crate::write::atomic_write(&target, &result.content, &Default::default())?;
+        if !global.quiet {
+            eprintln!(
+                "{}: {} replacement{} in symbol '{}'",
+                display_path.display(),
+                result.replacements,
+                if result.replacements == 1 { "" } else { "s" },
+                args.symbol,
+            );
+        }
+    } else if global.check {
+        if !global.quiet {
+            eprintln!(
+                "{}: {} replacement{} in symbol '{}' (check mode)",
+                display_path.display(),
+                result.replacements,
+                if result.replacements == 1 { "" } else { "s" },
+                args.symbol,
+            );
+        }
+    } else {
+        let diff = crate::diff::unified_diff(
+            &display_path.display().to_string(),
+            &source,
+            &result.content,
+        );
+        if diff.has_changes {
+            print!("{}", diff.hunks);
+        }
+    }
+
+    if global.json || global.jsonl {
+        let obj = serde_json::json!({
+            "ok": true,
+            "symbol": args.symbol,
+            "replacements": result.replacements,
+            "start_line": result.start_line,
+            "end_line": result.end_line,
+        });
+        println!("{}", serde_json::to_string_pretty(&obj)?);
+    }
+
+    if global.check {
+        Ok(exit::CHANGES_DETECTED)
+    } else {
+        Ok(exit::SUCCESS)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ast impact
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct ImpactArgs {
+    /// Symbol name to analyze.
+    pub symbol: String,
+
+    /// Directory to scan for references.
+    pub path: String,
+
+    /// Maximum traversal depth (1 = direct refs only).
+    #[arg(long, default_value = "3")]
+    pub depth: usize,
+
+    /// Language hint.
+    #[arg(long)]
+    pub lang: Option<String>,
+}
+
+fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+
+    let paths = if target.is_file() {
+        vec![target.clone()]
+    } else if target.is_dir() {
+        collect_source_files(&target, global)?
+    } else {
+        anyhow::bail!("path not found: {}", args.path);
+    };
+
+    let file_pairs: Vec<(std::path::PathBuf, String)> = paths
+        .iter()
+        .map(|p| {
+            let display = p.strip_prefix(&cwd).unwrap_or(p).display().to_string();
+            (p.clone(), display)
+        })
+        .collect();
+
+    let nodes = crate::ast::impact::compute_impact(&args.symbol, &file_pairs, args.depth);
+
+    if nodes.is_empty() {
+        if !global.quiet {
+            eprintln!("no references found for '{}'", args.symbol);
+        }
+        return Ok(exit::NO_MATCHES);
+    }
+
+    if global.json || global.jsonl {
+        let obj = serde_json::json!({
+            "symbol": args.symbol,
+            "depth": args.depth,
+            "impact": nodes,
+            "direct_count": nodes.len(),
+        });
+        if global.jsonl {
+            println!("{}", serde_json::to_string(&obj)?);
+        } else {
+            println!("{}", serde_json::to_string_pretty(&obj)?);
+        }
+    } else {
+        print!(
+            "{}",
+            crate::ast::impact::render_impact_tree(&args.symbol, &nodes, 0)
+        );
+    }
+
+    Ok(exit::SUCCESS)
+}
+
+// ---------------------------------------------------------------------------
+// ast diff
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Args)]
+pub struct DiffArgs {
+    /// File to diff.
+    pub path: String,
+
+    /// Git ref for the "old" version (default: HEAD).
+    #[arg(long, default_value = "HEAD")]
+    pub from: String,
+
+    /// Git ref for the "new" version (default: working tree).
+    #[arg(long)]
+    pub to: Option<String>,
+
+    /// Language hint.
+    #[arg(long)]
+    pub lang: Option<String>,
+}
+
+fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let target = cwd.join(&args.path);
+    let lang_hint = args.lang.as_deref().map(lang_from_str);
+    let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
+
+    // Get old version from git
+    let old_source = get_git_file_content(&cwd, &args.path, &args.from)?;
+
+    // Get new version
+    let new_source = if let Some(ref to_ref) = args.to {
+        get_git_file_content(&cwd, &args.path, to_ref)?
+    } else {
+        std::fs::read_to_string(&target)?
+    };
+
+    let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
+
+    if changes.is_empty() {
+        if !global.quiet {
+            eprintln!("no structural changes");
+        }
+        return Ok(exit::NO_MATCHES);
+    }
+
+    if global.json || global.jsonl {
+        let obj = serde_json::json!({
+            "file": args.path,
+            "from": args.from,
+            "to": args.to.as_deref().unwrap_or("working tree"),
+            "changes": changes,
+        });
+        if global.jsonl {
+            println!("{}", serde_json::to_string(&obj)?);
+        } else {
+            println!("{}", serde_json::to_string_pretty(&obj)?);
+        }
+    } else {
+        print!("{}", crate::ast::diff::render_changes(&args.path, &changes));
+    }
+
+    Ok(exit::SUCCESS)
+}
+
+fn get_git_file_content(
+    cwd: &std::path::Path,
+    file_path: &str,
+    git_ref: &str,
+) -> anyhow::Result<String> {
+    let output = std::process::Command::new("git")
+        .args(["show", &format!("{git_ref}:{file_path}")])
+        .current_dir(cwd)
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git show {git_ref}:{file_path} failed: {}", stderr.trim());
+    }
+
+    Ok(String::from_utf8(output.stdout)?)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Phase 3 of the AST feature set. Adds four new `ast` subcommands:

## `ast map` (#650)
PageRank-ranked repository map with token-budget-aware output:
- Extracts symbols and references across all files
- Builds a directed reference graph and runs PageRank
- `--max-tokens` controls output size (default 1024)
- `--focus` boosts symbols from specified files
- `--boost` boosts specific symbol names
- Human-readable tree and JSON output

## `ast replace` (#653)
Symbol-scoped text replacement:
- Locates symbol by name using AST (supports qualified names like `Impl::method`)
- Scopes replacement to only the symbol's body (start_line to end_line)
- Supports literal and regex patterns
- `--apply`/`--check`/`--diff` modes

## `ast impact` (#654)
Transitive blast radius analysis:
- Finds all direct and transitive callers/references
- `--depth` limits traversal (default 3)
- Tree-structured output showing call chains
- JSON output with full paths and line numbers

## `ast diff` (#655)
Structural diff between git versions:
- Compares symbols between two versions of a file
- Classifies changes: added, removed, signature changed, body changed
- Supports git refs (`HEAD`, `HEAD~1`, commit SHAs, branch names)
- Defaults to working tree vs HEAD

All subcommands support --json/--jsonl output, --lang hints, and integrate with existing `ast` infrastructure.

881 unit + 669 integration = 1550 tests passing.

Closes #650
Closes #653
Closes #654
Closes #655