### PR TITLE
fix: run --format command in --confirm paths for all write commands

### DIFF
--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -160,6 +160,7 @@ pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             backup.save_before_write(&path)?;
             atomic_write(&path, &combined, &policy)?;
             backup.finalize()?;
+            crate::write::run_format_command(global, &cwd)?;
         }
         let output = AppendOutput {
             ok: true,
@@ -188,6 +189,7 @@ pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         backup.save_before_write(&path)?;
         atomic_write(&path, &combined, &policy)?;
         backup.finalize()?;
+        crate::write::run_format_command(global, &cwd)?;
     }
 
     Ok(exit::SUCCESS)

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -192,6 +192,7 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 fs::create_dir_all(parent)?;
             }
             create_with_backup(&path, &content, args.force, &cwd, &policy)?;
+            crate::write::run_format_command(global, &cwd)?;
         }
         let output = CreateOutput {
             ok: true,
@@ -225,6 +226,7 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             fs::create_dir_all(parent)?;
         }
         create_with_backup(&path, &content, args.force, &cwd, &policy)?;
+        crate::write::run_format_command(global, &cwd)?;
     }
 
     Ok(exit::SUCCESS)

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -85,6 +85,7 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let applied = global.should_apply();
         if applied {
             delete_with_backup(&path, &cwd)?;
+            crate::write::run_format_command(global, &cwd)?;
         }
         let output = DeleteOutput {
             ok: true,
@@ -108,6 +109,7 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // --confirm: prompt after showing preview, then delete if confirmed.
     if global.should_apply() {
         delete_with_backup(&path, &cwd)?;
+        crate::write::run_format_command(global, &cwd)?;
         if global.show_status() {
             eprintln!("deleted {}", args.file);
         }

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -148,6 +148,7 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let applied = global.should_apply();
         if applied {
             rename_with_backup(&src, &dst, &args, &policy, &cwd)?;
+            crate::write::run_format_command(global, &cwd)?;
         }
         let output = RenameOutput {
             ok: true,
@@ -178,6 +179,7 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // --confirm: prompt after showing preview, then rename if confirmed.
     if global.should_apply() {
         rename_with_backup(&src, &dst, &args, &policy, &cwd)?;
+        crate::write::run_format_command(global, &cwd)?;
         if global.show_status() {
             eprintln!("renamed {} -> {}", args.from, args.to);
         }

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -318,6 +318,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         .map(|r| (r.path.as_path(), r.fixed.as_str(), &noop))
                         .collect();
                     crate::backup::backup_write_files(&root, &writes)?;
+                    crate::write::run_format_command(global, &root)?;
                     return Ok(exit::SUCCESS);
                 }
                 Ok(exit::CHANGES_DETECTED)


### PR DESCRIPTION
## Summary

The `--format` flag added in #667 was only wired into the `--apply` code path. The `--confirm` paths (both JSON and non-JSON) wrote files without calling `run_format_command` afterward. This meant that when a user confirmed a write via `--confirm`, the formatter would silently not run.

## Changes

Added `run_format_command` calls to the `--confirm` write paths in 5 commands:

| File | Paths fixed |
|---|---|
| `src/cmd/append.rs` | JSON confirm + non-JSON confirm |
| `src/cmd/create.rs` | JSON confirm + non-JSON confirm |
| `src/cmd/delete.rs` | JSON confirm + non-JSON confirm |
| `src/cmd/rename.rs` | JSON confirm + non-JSON confirm |
| `src/cmd/tidy.rs` | non-JSON confirm |

`replace`, `md`, `doc`, and `patch` already had correct coverage because their confirm paths share the same write call as `--apply`.

## Verification

`make check` passes: 887 unit + 691 integration tests.