### PR TITLE
test: add PTY-based integration tests for --confirm + --format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,9 +13,10 @@ Patchloom is a Rust CLI for agent-grade repo operations. It provides twenty-one 
 | `make build` | Run `cargo build --all-features` |
 | `make test` | Run unit tests (`cargo test --lib --all-features`) |
 | `make integration-test` | Run integration tests (`cargo test --test integration --all-features`) |
+| `make pty-test` | Run PTY-based interactive terminal tests (`cargo test --test pty --all-features -- --test-threads=1`) |
 | `make clippy` | Run `cargo clippy --all-targets --all-features -- -D warnings` |
-| `make check` | Run fmt-check, clippy, test, integration-test, check-patchloom-md, check-readme |
-| `make check-fast` | Fast check: fmt-check, clippy, test, integration-test (skips doc verification) |
+| `make check` | Run fmt-check, clippy, test, integration-test, pty-test, check-patchloom-md, check-readme |
+| `make check-fast` | Fast check: fmt-check, clippy, test, integration-test, pty-test (skips doc verification) |
 | `make update-readme` | Update README.md rounded test count (only changes when hundreds digit changes) |
 | `make check-readme` | Verify README.md rounded test count is accurate (part of `check`) |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -248,6 +254,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "conpty"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72b06487a0d4683349ad74d62e87ad639b09667082b3c495c5b6bab7d84b3da"
+dependencies = [
+ "windows 0.44.0",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +365,18 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "expectrl"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede784925953fcab9a3351d5009bcb8d2b0c13e940924c88087e8e2ce0c4717a"
+dependencies = [
+ "conpty",
+ "nix 0.26.4",
+ "ptyprocess",
+ "regex",
 ]
 
 [[package]]
@@ -666,6 +693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,11 +714,24 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -754,6 +803,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "ec4rs",
+ "expectrl",
  "globset",
  "ignore",
  "libc",
@@ -801,6 +851,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "ppv-lite86"
@@ -868,10 +924,10 @@ checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
  "indexmap",
- "nix",
+ "nix 0.31.3",
  "tokio",
  "tracing",
- "windows",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -882,7 +938,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.13.0",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -891,6 +947,15 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e05aef7befb11a210468a2d77d978dde2c6381a0381e33beb575e91f57fe8cf"
+dependencies = [
+ "nix 0.26.4",
 ]
 
 [[package]]
@@ -964,7 +1029,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1077,7 +1142,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1835,7 +1900,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1848,6 +1913,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "windows"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e745dab35a0c4c77aa3ce42d595e13d2003d6902d6b08c9ef5fc326d08da12b"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]
@@ -1961,6 +2035,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
 name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,6 +2057,48 @@ checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
@@ -2042,7 +2173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"
+expectrl = "0.7"
 predicates = "3"
 proptest = "1"
 rmcp = { version = "1", features = ["client", "transport-io", "transport-child-process"] }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test integration-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz
+.PHONY: help fmt fmt-check build test integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz
 
 .DEFAULT_GOAL := help
 
@@ -20,31 +20,38 @@ test: ## Run unit tests
 integration-test: ## Run integration tests
 	cargo test --test integration --all-features
 
+pty-test: ## Run PTY-based interactive terminal tests (serial)
+	cargo test --test pty --all-features -- --test-threads=1
+
 clippy: ## Run clippy linter
 	cargo clippy --all-targets --all-features -- -D warnings
 
-check: fmt-check clippy test integration-test check-patchloom-md check-readme ## Run all checks (full CI gate)
+check: fmt-check clippy test integration-test pty-test check-patchloom-md check-readme ## Run all checks (full CI gate)
 
-check-fast: fmt-check clippy test integration-test ## Fast check (skips doc verification)
+check-fast: fmt-check clippy test integration-test pty-test ## Fast check (skips doc verification)
 
 update-readme: ## Update README.md rounded test count (only changes when hundreds digit changes)
 	@unit=$$(cargo test --lib --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
 	integ=$$(cargo test --test integration --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
+	pty=$$(cargo test --test pty --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
 	if [ -z "$$unit" ] || [ -z "$$integ" ]; then echo "ERROR: failed to parse test counts (unit=$$unit integ=$$integ)"; exit 1; fi; \
-	total=$$((unit + integ)); \
+	pty=$${pty:-0}; \
+	total=$$((unit + integ + pty)); \
 	rounded=$$((total / 100 * 100)); \
 	all_cmds=$$(NO_COLOR=1 cargo run --all-features --quiet -- --help 2>/dev/null | sed -n '/^Commands:/,/^$$/p' | grep '^ ' | grep -cv '^ *help'); \
 	sed -i.bak "s/tests-[0-9]*%2B%20passing/tests-$$rounded%2B%20passing/" README.md; \
 	sed -i.bak "s/[0-9]*+ tests across [0-9]* commands/$$rounded+ tests across $$all_cmds commands/" README.md; \
 	rm -f README.md.bak; \
-	echo "README.md updated: $$rounded+ tests (actual: $$total = $$unit unit + $$integ integration), $$all_cmds commands"
+	echo "README.md updated: $$rounded+ tests (actual: $$total = $$unit unit + $$integ integration + $$pty pty), $$all_cmds commands"
 
 check-readme: ## Verify README.md rounded test count is accurate
 	@if grep -q '<<<<<<' README.md; then echo "ERROR: README.md contains conflict markers"; exit 1; fi; \
 	unit=$$(cargo test --lib --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
 	integ=$$(cargo test --test integration --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
+	pty=$$(cargo test --test pty --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \
 	if [ -z "$$unit" ] || [ -z "$$integ" ]; then echo "ERROR: failed to parse test counts (unit=$$unit integ=$$integ)"; exit 1; fi; \
-	total=$$((unit + integ)); \
+	pty=$${pty:-0}; \
+	total=$$((unit + integ + pty)); \
 	rounded=$$((total / 100 * 100)); \
 	if ! grep -q "tests-$${rounded}%2B%20passing" README.md; then \
 		echo "ERROR: README.md badge says a different rounded count than $${rounded}+. Run 'make update-readme'."; \

--- a/src/write.rs
+++ b/src/write.rs
@@ -371,7 +371,7 @@ pub fn run_format_command(
     cwd: &std::path::Path,
 ) -> anyhow::Result<()> {
     let cmd = match global.format.as_deref() {
-        Some(cmd) if global.apply => cmd,
+        Some(cmd) => cmd,
         _ => return Ok(()),
     };
     let timeout_secs = global.format_timeout.unwrap_or(30);

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -1,0 +1,245 @@
+//! PTY-based integration tests for interactive terminal behavior.
+//!
+//! These tests spawn the patchloom binary inside a pseudo-terminal so that
+//! `is_terminal()` returns `true`, enabling the `--confirm` code path.
+//! This lets us test the full interactive confirm + format pipeline that
+//! is unreachable from normal `assert_cmd` tests (which run without a TTY).
+//!
+//! Run with: `cargo test --test pty --all-features -- --test-threads=1`
+//!
+//! These tests MUST run serially (`--test-threads=1`) because concurrent
+//! PTY allocation can cause timeouts. The Makefile target handles this.
+
+use expectrl::{Eof, Session};
+use std::fs;
+use std::process::Command;
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// Build a `Command` for the patchloom binary with `--cwd` set.
+fn patchloom_cmd(cwd: &std::path::Path) -> Command {
+    let bin = env!("CARGO_BIN_EXE_patchloom");
+    let mut cmd = Command::new(bin);
+    cmd.arg("--cwd").arg(cwd);
+    // Disable color to make output matching reliable.
+    cmd.arg("--color=never");
+    cmd
+}
+
+/// Spawn a PTY session with a generous timeout for CI reliability.
+fn spawn_pty(cmd: Command) -> Session {
+    let mut session = Session::spawn(cmd).expect("failed to spawn PTY session");
+    session.set_expect_timeout(Some(Duration::from_secs(10)));
+    session
+}
+
+/// Create a cross-platform `touch <path>` command string.
+fn shell_touch(path: &std::path::Path) -> String {
+    let path = path.display();
+    format!("touch '{path}'")
+}
+
+// ── --confirm path tests ───────────────────────────────────────
+
+#[test]
+fn pty_replace_confirm_yes_applies() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "aaa\n").unwrap();
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args(["replace", "aaa", "--to", "bbb", "--confirm"]);
+
+    let mut session = spawn_pty(cmd);
+
+    // Expect the diff output (contains the replacement preview).
+    session.expect("aaa").expect("should see old text in diff");
+
+    // Expect the confirm prompt.
+    session.expect("Apply?").expect("should see Apply? prompt");
+
+    // Answer yes.
+    session.send_line("y").expect("failed to send y");
+
+    // Wait for process to exit.
+    session.expect(Eof).expect("process should exit");
+
+    // Verify the file was actually modified.
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, "bbb\n", "file should be modified after confirm y");
+}
+
+#[test]
+fn pty_replace_confirm_no_does_not_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "aaa\n").unwrap();
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args(["replace", "aaa", "--to", "bbb", "--confirm"]);
+
+    let mut session = spawn_pty(cmd);
+
+    session.expect("Apply?").expect("should see Apply? prompt");
+    session.send_line("n").expect("failed to send n");
+    session.expect(Eof).expect("process should exit");
+
+    // File must be unchanged.
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        content, "aaa\n",
+        "file should NOT be modified after confirm n"
+    );
+}
+
+// ── --confirm + --format tests ─────────────────────────────────
+
+#[test]
+fn pty_replace_confirm_yes_runs_format_command() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "aaa\n").unwrap();
+    let marker = dir.path().join("format_ran.marker");
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args([
+        "replace",
+        "aaa",
+        "--to",
+        "bbb",
+        "--confirm",
+        "--format",
+        &shell_touch(&marker),
+    ]);
+
+    let mut session = spawn_pty(cmd);
+
+    session.expect("Apply?").expect("should see Apply? prompt");
+    session.send_line("y").expect("failed to send y");
+    session.expect(Eof).expect("process should exit");
+
+    assert!(
+        marker.exists(),
+        "--format command should have run after --confirm y"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "bbb\n");
+}
+
+#[test]
+fn pty_replace_confirm_no_skips_format_command() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "aaa\n").unwrap();
+    let marker = dir.path().join("format_ran.marker");
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args([
+        "replace",
+        "aaa",
+        "--to",
+        "bbb",
+        "--confirm",
+        "--format",
+        &shell_touch(&marker),
+    ]);
+
+    let mut session = spawn_pty(cmd);
+
+    session.expect("Apply?").expect("should see Apply? prompt");
+    session.send_line("n").expect("failed to send n");
+    session.expect(Eof).expect("process should exit");
+
+    assert!(
+        !marker.exists(),
+        "--format should NOT run when user declines"
+    );
+}
+
+#[test]
+fn pty_append_confirm_yes_runs_format_command() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "line\n").unwrap();
+    let marker = dir.path().join("format_ran.marker");
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args([
+        "append",
+        "f.txt",
+        "--content",
+        "extra",
+        "--confirm",
+        "--format",
+        &shell_touch(&marker),
+    ]);
+
+    let mut session = spawn_pty(cmd);
+
+    // Consume diff output before matching the prompt.
+    session.expect("extra").expect("should see diff output");
+    session.expect("Apply?").expect("should see Apply? prompt");
+    session.send_line("y").expect("failed to send y");
+    session.expect(Eof).expect("process should exit");
+
+    assert!(
+        marker.exists(),
+        "--format command should have run after append --confirm y"
+    );
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(content.contains("extra"), "content should be appended");
+}
+
+#[test]
+fn pty_create_confirm_yes_runs_format_command() {
+    let dir = TempDir::new().unwrap();
+    let marker = dir.path().join("format_ran.marker");
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args([
+        "create",
+        "new.txt",
+        "--content",
+        "hello\n",
+        "--confirm",
+        "--format",
+        &shell_touch(&marker),
+    ]);
+
+    let mut session = spawn_pty(cmd);
+
+    session.expect("Apply?").expect("should see Apply? prompt");
+    session.send_line("y").expect("failed to send y");
+    session.expect(Eof).expect("process should exit");
+
+    assert!(
+        marker.exists(),
+        "--format command should have run after create --confirm y"
+    );
+    assert!(
+        dir.path().join("new.txt").exists(),
+        "file should be created"
+    );
+}
+
+#[test]
+fn pty_confirm_default_enter_accepts() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "aaa\n").unwrap();
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args(["replace", "aaa", "--to", "bbb", "--confirm"]);
+
+    let mut session = spawn_pty(cmd);
+
+    session.expect("Apply?").expect("should see Apply? prompt");
+    // Press Enter with no input (default is Y).
+    session.send_line("").expect("failed to send enter");
+    session.expect(Eof).expect("process should exit");
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        content, "bbb\n",
+        "pressing Enter should accept the default (Y)"
+    );
+}


### PR DESCRIPTION
## Summary

Add PTY-based integration tests that spawn patchloom inside a pseudo-terminal via `expectrl`, enabling testing of the `--confirm` interactive code path that is unreachable from normal `assert_cmd` tests (where `is_terminal()` returns `false`).

## Changes

- **`tests/pty.rs`**: 7 new PTY-based integration tests covering:
  - `replace --confirm` with y/n answers
  - `--confirm` + `--format` verifying the format command runs after confirmation
  - `append` and `create` with `--confirm` + `--format`
  - Default Enter accepts (Y)

- **`src/write.rs`**: Fix `run_format_command()` which had an overly restrictive `global.apply` guard that silently skipped `--format` in `--confirm` paths (where `apply=false`, `confirm=true`).

- **`Makefile`**: Add `make pty-test` target (runs with `--test-threads=1` for PTY reliability). Include `pty-test` in `check` and `check-fast` targets. Update `update-readme` and `check-readme` to include PTY test count.

- **`AGENTS.md`**: Document `make pty-test` and updated `check`/`check-fast` descriptions.

- **`Cargo.toml`**: Add `expectrl = "0.7"` to dev-dependencies.

## Testing approach

This follows the pattern used by Rust CLI projects like `ish`, `r3bl-open-core`, `tess`, and `berth`:
1. `expectrl` in `[dev-dependencies]`
2. Separate test file (`tests/pty.rs`)
3. `--test-threads=1` (mandatory; PTY allocation is not parallelizable)
4. Dedicated Makefile target
5. `assert_cmd` for non-interactive paths, PTY only for what truly needs a terminal

All 1585 tests pass: 887 unit + 691 integration + 7 PTY.