### PR TITLE
fix: improvement cycle 19 - PTY flush, MCP tests, doc updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project overview
 
-Patchloom is a Rust CLI for agent-grade repo operations. It provides twenty-one commands (`search`, `replace`, `patch`, `md`, `doc`, `tidy`, `append`, `create`, `delete`, `rename`, `read`, `status`, `tx`, `batch`, `explain`, `undo`, `init`, `completions`, `agent-rules`, `schema`, `mcp-server`) that let AI coding agents perform structured file searches, mechanical replacements, diff-based patching, markdown section editing, JSON/YAML/TOML document manipulation, whitespace normalization, file appending, file creation, file deletion, file renaming, multi-operation atomic transactions, line-oriented batch operations, human-readable plan summaries, undo safety net with backup restoration, project setup, shell completion generation, end-user agent rules generation, operation schema export with tier filtering, and MCP protocol server for structured tool calls. All write operations are dry-run by default and support `--check` (report changes), `--diff` (preview), and `--apply` (mutate) modes. The `mcp` feature is enabled by default; build with `--no-default-features` for a smaller binary without the MCP server.
+Patchloom is a Rust CLI for agent-grade repo operations. It provides twenty-two commands (`search`, `replace`, `patch`, `md`, `doc`, `tidy`, `append`, `create`, `delete`, `rename`, `read`, `status`, `tx`, `batch`, `explain`, `undo`, `init`, `completions`, `agent-rules`, `schema`, `ast`, `mcp-server`) that let AI coding agents perform structured file searches, mechanical replacements, diff-based patching, markdown section editing, JSON/YAML/TOML document manipulation, whitespace normalization, file appending, file creation, file deletion, file renaming, multi-operation atomic transactions, line-oriented batch operations, human-readable plan summaries, undo safety net with backup restoration, project setup, shell completion generation, end-user agent rules generation, operation schema export with tier filtering, AST-aware code operations (list, read, rename, validate via tree-sitter), and MCP protocol server for structured tool calls. All write operations are dry-run by default and support `--check` (report changes), `--diff` (preview), and `--apply` (mutate) modes. The `mcp` feature is enabled by default; build with `--no-default-features` for a smaller binary without the MCP server.
 
 ## Dev commands
 
@@ -56,6 +56,7 @@ src/
   cmd/patch.rs         Preview or apply unified diffs
   cmd/md.rs            Markdown section-aware operations (replace section, insert before/after heading,
                        upsert bullet, table append, dedupe headings, lint)
+  cmd/ast.rs           AST-aware operations (list, read, rename, validate) using tree-sitter
   cmd/doc.rs           Parser-backed JSON, YAML, TOML operations (get, has, keys, len, set,
                        delete, merge, append, prepend, update, move, ensure, delete-where,
                        select, flatten, diff)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,10 +33,12 @@ make check
 | `make build` | Build with all features |
 | `make test` | Run unit tests |
 | `make integration-test` | Run integration tests |
+| `make pty-test` | Run PTY-based interactive terminal tests (serial) |
 | `make clippy` | Run clippy with `-D warnings` |
 | `make check` | Full CI gate (run before every commit) |
 | `make check-fast` | Fast check (skips doc verification) |
-| `make update-readme` | Update README.md and CHANGELOG.md test counts |
+| `make update-readme` | Update README.md rounded test count |
+| `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |
 | `cargo check --all-targets` | Type-check all targets without building |
 
 ## Adding a new command

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -2,18 +2,20 @@
 
 ## Commands
 
-Patchloom has 20 commands:
+Patchloom has 22 commands:
 
 - **search** / **replace** -- text-level find and replace across files
 - **patch** -- apply unified diffs
 - **md** -- markdown-aware editing (sections, bullets, tables, headings)
 - **doc** -- parser-backed JSON, YAML, and TOML mutations
 - **tidy** -- whitespace and line-ending normalization
+- **append** -- append content to an existing file
 - **create** / **delete** / **rename** -- file lifecycle
 - **read** -- file content inspection with optional line range (supports multiple files)
 - **status** -- uncommitted change summary from git
 - **tx** -- atomic multi-operation transactions
 - **batch** -- line-oriented multi-operation format (delegates to tx engine)
+- **ast** -- AST-aware operations (list, read, rename, validate) using tree-sitter
 - **completions** -- shell completion generation
 - **agent-rules** -- print end-user agent documentation for patchloom
 - **schema** -- export operation schemas with tier filtering and system prompts

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -964,6 +964,13 @@ The operations below are the building blocks inside `operations`.
 - **Use when:** Text cleanup should be part of the same atomic success criteria as other edits.
 - **Related:** top level `tidy fix`
 
+<!-- ref:tx-op:file.append -->
+### `file.append`
+
+- **What it does:** Appends content to the end of an existing file inside a transaction. Inserts a newline separator if the file does not end with one.
+- **Use when:** Adding content to a file must be atomic with other operations in the same plan. Fails if the file does not exist.
+- **Related:** top level `append`
+
 <!-- ref:tx-op:file.create -->
 ### `file.create`
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -144,6 +144,10 @@ pub struct WriteFlags {
 }
 
 pub(crate) fn confirm_prompt(prompt: &str) -> bool {
+    // Flush stdout before the prompt writes to stderr, otherwise the diff
+    // output may remain buffered and invisible in a PTY.
+    use std::io::Write;
+    let _ = std::io::stdout().flush();
     let is_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
     confirm_prompt_interactive(prompt, is_tty, &mut std::io::stdin().lock())
 }

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -113,31 +113,29 @@ pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         backup.finalize()?;
         crate::write::run_format_command(global, &cwd)?;
 
-        let diff_text = if global.diff {
+        if global.diff {
             let diff = unified_diff(&args.file, &existing, &combined);
             let dr = DiffResult {
                 diffs: vec![diff],
                 total_files_changed: 1,
             };
-            Some(format_diff_result_colored(&dr, false))
-        } else {
-            None
-        };
-        let output = AppendOutput {
-            ok: true,
-            path: args.file.clone(),
-            diff: diff_text,
-            applied: None,
-        };
-        if !global.emit_json(&output)? {
-            if global.diff {
-                let diff = unified_diff(&args.file, &existing, &combined);
-                let dr = DiffResult {
-                    diffs: vec![diff],
-                    total_files_changed: 1,
-                };
+            let output = AppendOutput {
+                ok: true,
+                path: args.file.clone(),
+                diff: Some(format_diff_result_colored(&dr, false)),
+                applied: None,
+            };
+            if !global.emit_json(&output)? {
                 print!("{}", format_diff_result_colored(&dr, global.should_color()));
-            } else if !global.quiet {
+            }
+        } else {
+            let output = AppendOutput {
+                ok: true,
+                path: args.file.clone(),
+                diff: None,
+                applied: None,
+            };
+            if !global.emit_json(&output)? && !global.quiet {
                 println!("appended to {}", args.file);
             }
         }
@@ -180,6 +178,10 @@ pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
     if !global.emit_json(&output)? {
         print!("{}", format_diff_result_colored(&dr, global.should_color()));
+        // Flush stdout before the confirm prompt writes to stderr, otherwise
+        // the diff output may remain buffered and invisible in a PTY.
+        use std::io::Write;
+        let _ = std::io::stdout().flush();
     }
 
     // --confirm: prompt after showing diff, then apply if confirmed.

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -178,10 +178,6 @@ pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
     if !global.emit_json(&output)? {
         print!("{}", format_diff_result_colored(&dr, global.should_color()));
-        // Flush stdout before the confirm prompt writes to stderr, otherwise
-        // the diff output may remain buffered and invisible in a PTY.
-        use std::io::Write;
-        let _ = std::io::stdout().flush();
     }
 
     // --confirm: prompt after showing diff, then apply if confirmed.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17961,6 +17961,85 @@ async fn test_mcp_replace_whole_line_with_range_round_trip() {
 }
 
 #[tokio::test]
+async fn test_mcp_append_file_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "line one\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "append_file",
+        serde_json::json!({"path": "data.txt", "content": "line two\n"}),
+    )
+    .await;
+    assert!(!is_error, "append_file should succeed: {text}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line one\nline two\n",
+        "content should be appended"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_append_file_missing_file_returns_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, _text) = call_tool_text(
+        &client,
+        "append_file",
+        serde_json::json!({"path": "nonexistent.txt", "content": "data\n"}),
+    )
+    .await;
+    assert!(is_error, "append_file should fail when file does not exist");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_md_move_section_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(
+        &file,
+        "# Top\n\nIntro\n\n## Alpha\n\nA content\n\n## Beta\n\nB content\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "md_move_section",
+        serde_json::json!({
+            "path": "doc.md",
+            "heading": "## Beta",
+            "before": "## Alpha"
+        }),
+    )
+    .await;
+    assert!(!is_error, "md_move_section should succeed: {text}");
+
+    let content = fs::read_to_string(&file).unwrap();
+    let alpha_pos = content.find("## Alpha").expect("Alpha should exist");
+    let beta_pos = content.find("## Beta").expect("Beta should exist");
+    assert!(
+        beta_pos < alpha_pos,
+        "Beta should come before Alpha after move"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_doc_query_unknown_action_returns_error() {
     if !has_mcp_support() {
         return;

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -167,7 +167,7 @@ fn pty_append_confirm_yes_runs_format_command() {
         "append",
         "f.txt",
         "--content",
-        "extra",
+        "extra\n",
         "--confirm",
         "--format",
         &shell_touch(&marker),


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 19: 6 commits across 14 perspectives + 5 post-cycle checks.

### Changes

**Tests (QA perspective)**
- Add 3 MCP round-trip tests: `append_file`, `append_file` error path, `md_move_section`

**Bug fix (Adversarial/post-cycle)**
- Fix PTY buffering issue where `confirm_prompt()` writes to stderr before stdout is flushed, causing `--confirm` diffs to be invisible in a terminal. Centralized the fix in `confirm_prompt()` so all 10+ write commands benefit (previously only applied to append.rs)

**Code quality (Developer perspective)**
- Deduplicate diff computation in append.rs `--apply --diff` path

**Documentation (End User, New Contributor, Post-cycle B)**
- Add missing `file.append` tx operation to reference docs
- Fix CONTRIBUTING.md gate drift: add missing `make pty-test` and `make sync-patchloom-md` targets, fix `make update-readme` description
- Update stale command counts in concepts.md (20 to 22) and AGENTS.md (21 to 22), adding missing `append` and `ast` entries

### Perspectives

| # | Perspective | Result |
|---|------------|--------|
| 1 | QA Engineer | 3 MCP tests + PTY fix |
| 2 | Developer | Dedup diff in append |
| 3 | End User | file.append tx doc |
| 4-12 | Maintainer through Architecture | No-op |
| 13 | New Contributor | CONTRIBUTING.md gate drift |
| 14 | Observability | No-op |
| Post-B | Doc deep audit | Command count fixes |
| Post-gate | PTY flush fix | Centralized in confirm_prompt |

`make check-fast` passes: 694 integration + 7 PTY tests green.