### PR TITLE
test: replace is_some() + unwrap() with expect() in ast tests

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -276,18 +276,14 @@ mod tests {
     #[test]
     fn parse_source_rust() {
         let source = "fn main() { println!(\"hello\"); }";
-        let result = parse_source(source, Language::Rust);
-        assert!(result.is_some());
-        let (tree, _) = result.unwrap();
+        let (tree, _) = parse_source(source, Language::Rust).expect("should parse Rust source");
         assert!(!tree.root_node().has_error());
     }
 
     #[test]
     fn parse_source_python() {
         let source = "def hello():\n    print('hello')\n";
-        let result = parse_source(source, Language::Python);
-        assert!(result.is_some());
-        let (tree, _) = result.unwrap();
+        let (tree, _) = parse_source(source, Language::Python).expect("should parse Python source");
         assert!(!tree.root_node().has_error());
     }
 

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -552,9 +552,8 @@ impl Server {
 }
 "#;
         let symbols = extract_symbols(source, Language::Rust);
-        let found = find_symbol(&symbols, "Server::start");
-        assert!(found.is_some());
-        assert_eq!(found.unwrap().name, "start");
+        let found = find_symbol(&symbols, "Server::start").expect("should find Server::start");
+        assert_eq!(found.name, "start");
     }
 
     #[test]
@@ -565,8 +564,7 @@ impl Server {
 }
 "#;
         let symbols = extract_symbols(source, Language::Rust);
-        let found = find_symbol(&symbols, "start");
-        assert!(found.is_some());
+        find_symbol(&symbols, "start").expect("should find 'start' via unqualified search");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Improvement cycle 20 (Test Auditor perspective): replace 4 instances of the `assert!(x.is_some()); x.unwrap()` anti-pattern with `.expect("msg")` in AST module tests.

### Changes

- `src/ast/symbols.rs`: `find_symbol_qualified` and `find_symbol_unqualified_searches_children` tests
- `src/ast/mod.rs`: `parse_source_rust` and `parse_source_python` tests

The `.expect()` form provides identical panic behavior but with a descriptive message instead of a bare `assertion failed`.

`make check-fast` passes: 694 integration + 7 PTY tests green.