### PR TITLE
fix: align release-please with semver-checks for pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
     ".": {
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "bump-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Problem

PR #642 (release-please v0.2.1) has a red CI check: `semver-checks` fails with 5 breaking API changes (new struct fields, enum variants, changed function arity). These are all legitimate feature additions, but release-please proposed a **patch** bump because `bump-patch-for-minor-pre-major: true` collapsed `feat:` commits into patch bumps.

## Fix

Remove `bump-patch-for-minor-pre-major` from `release-please-config.json`. This aligns the two tools:

| Commit type | Before (broken) | After |
|-------------|-----------------|-------|
| `fix:` | patch (0.x.**y**) | patch (0.x.**y**) |
| `feat:` | patch (0.x.**y**) | minor (0.**x**.0) |
| `feat!:` | minor (0.**x**.0) | minor (0.**x**.0) |

`bump-minor-pre-major` remains so breaking changes stay minor (not major) while pre-1.0.

Once this merges, release-please will regenerate PR #642 with the correct version bump (0.3.0 instead of 0.2.1), and `semver-checks` will pass.