### PR TITLE
fix: gate AstRename/AstReplace behind cfg(feature = "ast")

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -866,11 +866,19 @@ fn op_needs_doc_flush(op: &Operation) -> bool {
             | Operation::Search { .. }
             | Operation::MdLintAgents { .. }
             | Operation::TidyFix { .. }
-    ) || cfg!(feature = "ast")
-        && matches!(
-            op,
-            Operation::AstRename { .. } | Operation::AstReplace { .. }
-        )
+    ) || {
+        #[cfg(feature = "ast")]
+        {
+            matches!(
+                op,
+                Operation::AstRename { .. } | Operation::AstReplace { .. }
+            )
+        }
+        #[cfg(not(feature = "ast"))]
+        {
+            false
+        }
+    }
 }
 
 fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {


### PR DESCRIPTION
## Problem

patchloom v0.3.0 fails to compile with `default-features = false`:

```
error[E0599]: no variant named `AstRename` found for enum `Operation`
   --> src/cmd/tx.rs:872
```

## Root cause

`op_needs_doc_flush()` in `tx.rs` used `cfg!(feature = "ast")` (runtime macro) instead of `#[cfg(feature = "ast")]` (compile-time attribute) for the AST variant match arm. `cfg!()` always compiles the code, just evaluates to `true`/`false` at runtime. Since `Operation::AstRename` and `Operation::AstReplace` don't exist without the `ast` feature, the compiler rejects the references.

## Fix

Replaced the `cfg!()` runtime check with `#[cfg(feature = "ast")]` / `#[cfg(not(feature = "ast"))]` blocks that are removed entirely at compile time when the feature is off.

## Verification

- `cargo check --no-default-features` compiles clean
- `make check` passes (1,588 tests)

Closes #679