### PR TITLE
ci: add retry logic to lychee link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,4 +1,6 @@
 cache = true
+max_retries = 3
+retry_wait_time = 5
 
 exclude = [
   "medium\\.com",


### PR DESCRIPTION
## Problem

The link checker has no retry logic. Transient server errors cause hard CI failures that block auto-merge:

- PR #678: GitHub returned 500 on `/issues/438`, blocking the release notes cleanup PR
- PR #677: `no-color.org` dropped the connection from the CI runner

Both were transient, not real broken links. But since "Check Links" is a required check, a single flaky response blocks the entire PR.

## Fix

Add `max_retries = 3` and `retry_wait_time = 5` to `lychee.toml`. Lychee will retry failed requests up to 3 times with a 5-second wait between attempts before reporting an error.