### PR TITLE
docs: remove junk text, fix stale version and unsafe claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Add patchloom as a dependency (omit the MCP server with `default-features = fals
 
 ```toml
 [dependencies]
-patchloom = { version = "0.1", default-features = false }
+patchloom = { version = "0.3", default-features = false }
 ```
 
 ```rust
@@ -461,5 +461,3 @@ All commits must be signed off with `git commit -s`.
 ## Security
 
 For current security reporting guidance, see [SECURITY.md](./SECURITY.md).
-hook test
-# test

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,500+ tests**, zero unsafe code
+- **1,500+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
 - **22 commands** including MCP server with 31 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)


### PR DESCRIPTION
## Summary

Fix three documentation issues reported during the v0.3.0 audit.

### Changes

- **README.md**: Remove junk text (`hook test` / `# test`) at end of file
- **README.md**: Update library version example from `0.1` to `0.3`
- **docs/blog/launch-announcement.md**: Fix false "zero unsafe code" claim to acknowledge the one `unsafe killpg` in exec.rs behind `#[expect]`

Closes #684
Closes #692