### PR TITLE
fix: CRLF byte offset, lint false positive, path matching

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -852,7 +852,9 @@ pub fn apply_patch(path: &Path, patch_text: &str, mode: ApplyMode) -> anyhow::Re
     let path_str_ref: &str = &path_str;
     let hunks: Vec<_> = patch_files
         .iter()
-        .filter(|pf| pf.path == path_str_ref || path_str_ref.ends_with(&pf.path))
+        .filter(|pf| {
+            pf.path == path_str_ref || std::path::Path::new(path_str_ref).ends_with(&pf.path)
+        })
         .flat_map(|pf| pf.hunks.iter())
         .collect();
 
@@ -1490,6 +1492,28 @@ mod tests {
         assert!(results.iter().all(|r| r.changed && r.applied));
         assert_eq!(fs::read_to_string(&a).unwrap(), "AAA\n");
         assert_eq!(fs::read_to_string(&b).unwrap(), "BBB\n");
+    }
+
+    #[test]
+    fn apply_patch_path_matching_uses_path_components() {
+        // Regression: string ends_with matched "notb/foo.rs" for a patch
+        // targeting "b/foo.rs". Path::ends_with does component matching.
+        let dir = TempDir::new().unwrap();
+        let sub = dir.path().join("notb");
+        fs::create_dir(&sub).unwrap();
+        let file = sub.join("foo.rs");
+        fs::write(&file, "original\n").unwrap();
+
+        // Patch targets "b/foo.rs" which should NOT match "notb/foo.rs"
+        let patch = "\
+--- a/b/foo.rs\n\
++++ b/b/foo.rs\n\
+@@ -1 +1 @@\n\
+-original\n\
++changed\n";
+
+        let result = apply_patch(&file, patch, ApplyMode::Preview);
+        assert!(result.is_err() || !result.unwrap().changed);
     }
 
     #[test]

--- a/src/ast/diff.rs
+++ b/src/ast/diff.rs
@@ -147,8 +147,17 @@ fn extract_body<'a>(source: &'a str, sym: &SymbolDef) -> &'a str {
     if start >= lines.len() || start >= end {
         return "";
     }
-    let start_byte: usize = source.lines().take(start).map(|l| l.len() + 1).sum();
-    let end_byte: usize = source.lines().take(end).map(|l| l.len() + 1).sum();
+    let line_sep_len = if source.contains("\r\n") { 2 } else { 1 };
+    let start_byte: usize = source
+        .lines()
+        .take(start)
+        .map(|l| l.len() + line_sep_len)
+        .sum();
+    let end_byte: usize = source
+        .lines()
+        .take(end)
+        .map(|l| l.len() + line_sep_len)
+        .sum();
     &source[start_byte..end_byte.min(source.len())]
 }
 
@@ -222,6 +231,23 @@ mod tests {
         let source = "fn foo() {\n    let x = 1;\n}\n";
         let changes = structural_diff(source, source, Language::Rust);
         assert!(changes.is_empty());
+    }
+
+    #[test]
+    fn extract_body_crlf() {
+        let source = "line1\r\nline2\r\nline3\r\n";
+        let sym = SymbolDef {
+            name: "test".into(),
+            kind: crate::ast::symbols::SymbolKind::Function,
+            start_line: 2,
+            end_line: 3,
+            signature: String::new(),
+            children: vec![],
+            depth: 0,
+        };
+        let body = extract_body(source, &sym);
+        // Lines 2-3 inclusive = "line2\r\nline3\r\n"
+        assert_eq!(body, "line2\r\nline3\r\n");
     }
 
     #[test]

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -204,6 +204,22 @@ fn strip_inline_code(line: &str) -> Cow<'_, str> {
     Cow::Owned(result)
 }
 
+/// Check for `git add .` (dangerous) without matching `git add .gitignore`
+/// or other dotfile paths. The dot must be followed by whitespace or EOL.
+fn has_dangerous_git_add_dot(line: &str) -> bool {
+    let needle = "git add .";
+    let mut start = 0;
+    while let Some(pos) = line[start..].find(needle) {
+        let abs = start + pos;
+        let after = abs + needle.len();
+        if after >= line.len() || line.as_bytes()[after].is_ascii_whitespace() {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
 /// A lint issue found in a markdown file.
 #[derive(Debug, Serialize)]
 pub struct LintIssue {
@@ -237,7 +253,7 @@ pub(crate) fn lint_agents_content(content: &str) -> Vec<LintIssue> {
     // 2. Dangerous git add commands (skip fenced code blocks and inline code).
     for (idx, line) in non_fenced_lines(content) {
         let stripped = strip_inline_code(line);
-        if stripped.contains("git add .")
+        if has_dangerous_git_add_dot(&stripped)
             || stripped.contains("git add -A")
             || stripped.contains("git add --all")
         {
@@ -832,6 +848,38 @@ mod tests {
         assert_eq!(strip_inline_code("no backticks here"), "no backticks here");
         assert_eq!(strip_inline_code("`all code`"), "");
         assert_eq!(strip_inline_code("a `b` c `d` e"), "a  c  e");
+    }
+
+    #[test]
+    fn has_dangerous_git_add_dot_true_cases() {
+        assert!(has_dangerous_git_add_dot("git add ."));
+        assert!(has_dangerous_git_add_dot("run git add . first"));
+        assert!(has_dangerous_git_add_dot("git add . && git commit"));
+    }
+
+    #[test]
+    fn has_dangerous_git_add_dot_false_for_dotfiles() {
+        assert!(!has_dangerous_git_add_dot("git add .gitignore"));
+        assert!(!has_dangerous_git_add_dot("git add .editorconfig"));
+        assert!(!has_dangerous_git_add_dot(
+            "git add .github/workflows/ci.yml"
+        ));
+    }
+
+    #[test]
+    fn lint_agents_allows_git_add_dotfile() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(&file, "# Rules\nRun git add .gitignore to stage\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &default_global()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
     }
 
     // -- final newline ------------------------------------------------------

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -330,9 +330,10 @@ pub fn anchor_match(
         let matched_text = matched.join("\n");
 
         // Compute byte offset.
+        let line_sep_len = if content.contains("\r\n") { 2 } else { 1 };
         let start_offset = lines[..i]
             .iter()
-            .map(|l| l.len() + 1) // +1 for newline
+            .map(|l| l.len() + line_sep_len)
             .sum::<usize>();
 
         return Some(AnchorMatchResult {
@@ -643,6 +644,14 @@ mod tests {
             None,
         );
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn anchor_match_crlf_offset() {
+        let content = "line1\r\nline2\r\nline3\r\n";
+        let result = anchor_match(content, "line2", Some("line1"), None).unwrap();
+        // "line1\r\n" is 7 bytes, so line2 starts at offset 7.
+        assert_eq!(result.start_offset, 7);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix three text/path matching bugs reported during the v0.3.0 audit.

### Changes

**CRLF byte offset (#685)**: `ast/diff.rs` `extract_body` and `fallback.rs` `anchor_match` both assumed single-byte (`\n`) line endings when computing byte offsets. On files with `\r\n` endings, `str::lines()` strips the `\r` but the actual bytes have 2-byte endings, causing wrong offsets (potential panics on non-char boundaries).

**Lint false positive (#700)**: The AGENTS.md linter flagged `git add .gitignore` as a dangerous command because `contains("git add .")` matched any string starting with `git add .`. Now checks that the dot is followed by whitespace or end-of-line.

**Patch path matching (#701)**: `api.rs` `apply_patch` used `&str::ends_with` for hunk-to-file matching, which is byte-suffix matching. A patch for `b/foo.rs` would incorrectly match `notb/foo.rs`. Now uses `std::path::Path::ends_with` for component-aware matching.

### Testing

- 6 new unit tests covering all three fixes
- All 1,594 existing tests pass (`make check` green)

Closes #685
Closes #700
Closes #701