### PR TITLE
fix: resolve tech-debt #691, #694, #708 (clap optional, AST tests, fuzz)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Patchloom is a Rust CLI for agent-grade repo operations. It provides twenty-two 
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |
 | `make check-patchloom-md` | Verify PATCHLOOM.md matches `patchloom agent-rules` output (part of `check`) |
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
-| `make fuzz` | Run fuzz tests (6 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
+| `make fuzz` | Run fuzz tests (8 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse, containment check, fallback resolve). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |
 | `make bench-mcp` | Run MCP benchmarks: per-call latency vs CLI process spawn (not part of `check`) |
 | `make bench-agent` | Run LLM agent A/B benchmarks (requires API key, not part of `check`). Use `MODEL=X RUNS=N` to configure runs |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,10 @@ exclude = [
 ]
 
 [features]
-default = ["mcp", "ast"]
+default = ["cli", "mcp", "ast"]
+# CLI (clap parser + all commands). Enabled by default; disable for pure-library use
+# to avoid pulling clap and related dependencies.
+cli = ["dep:clap", "dep:clap_complete", "dep:anstream", "dep:ec4rs", "dep:ignore", "dep:globset"]
 # MCP server support: adds tokio async runtime, rmcp protocol, and JSON Schema.
 mcp = ["rmcp", "tokio", "schemars"]
 # AST-aware operations using tree-sitter grammars (20 languages).
@@ -57,26 +60,26 @@ ast = [
     "dep:tree-sitter-php",
 ]
 # Full: everything. Equivalent to default today.
-full = ["mcp", "ast"]
+full = ["cli", "mcp", "ast"]
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
 yaml-edit = "0.2"
 toml_edit = { version = "0.25", features = ["serde"] }
-ignore = "0.4"
-globset = "0.4"
+ignore = { version = "0.4", optional = true }
+globset = { version = "0.4", optional = true }
 memchr = "2"
 regex = "1"
 similar = { version = "3", features = ["text"] }
 strsim = "0.11"
 tempfile = "3"
 anyhow = "1"
-anstream = "1"
-ec4rs = "1"
-clap_complete = "4"
+anstream = { version = "1", optional = true }
+ec4rs = { version = "1", optional = true }
+clap_complete = { version = "4", optional = true }
 rmcp = { version = "1", features = ["server", "transport-io", "macros"], optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "io-std", "macros"], optional = true }
 schemars = { version = "1", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ FUZZ_TIME ?= 60
 
 fuzz: ## Run fuzz tests (requires nightly). Use FUZZ_TIME=N for seconds per target.
 	@NIGHTLY_BIN=$$(rustup run nightly rustc --print sysroot)/bin; \
-	for target in fuzz_selector_parse fuzz_patch_parse fuzz_patch_apply fuzz_batch_tokenize fuzz_selector_eval fuzz_doc_parse; do \
+	for target in fuzz_selector_parse fuzz_patch_parse fuzz_patch_apply fuzz_batch_tokenize fuzz_selector_eval fuzz_doc_parse fuzz_containment_check fuzz_fallback_resolve; do \
 		echo "==> Fuzzing $$target for $(FUZZ_TIME)s..."; \
 		PATH="$$NIGHTLY_BIN:$$PATH" cargo fuzz run $$target -- -max_total_time=$(FUZZ_TIME) || exit 1; \
 	done; \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1500%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1600%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -426,7 +426,7 @@ flowchart LR
 
 ## Status
 
-1500+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1600+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent con
 
 ### As a Rust library
 
-Add patchloom as a dependency (omit the MCP server with `default-features = false`):
+Add patchloom as a dependency (omit CLI/MCP/AST with `default-features = false`):
 
 ```toml
 [dependencies]

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -44,18 +44,18 @@ cd patchloom
 cargo install --path .
 ```
 
-This builds with all features by default (MCP server + AST operations).
-To build a smaller binary without specific features:
+This builds with all features by default (CLI + MCP server + AST operations).
+To build a smaller binary without optional features (CLI is always included for the binary):
 
 ```bash
-# Without MCP server (no tokio/async dependencies)
-cargo install --path . --no-default-features --features ast
+# CLI + AST only (no MCP server, no tokio/async)
+cargo install --path . --no-default-features --features "cli,ast"
 
-# Without AST operations (no tree-sitter grammars)
-cargo install --path . --no-default-features --features mcp
+# CLI + MCP only (no AST grammars)
+cargo install --path . --no-default-features --features "cli,mcp"
 
-# Minimal: no MCP, no AST
-cargo install --path . --no-default-features
+# CLI only (no MCP, no AST)
+cargo install --path . --no-default-features --features cli
 ```
 
 If you're contributing from a source checkout, use `make check-fast`
@@ -64,12 +64,17 @@ while iterating and `make check` before committing.
 ## As a Rust library
 
 Add patchloom as a dependency to embed structured file editing in your own
-Rust tools. Disable default features to omit the MCP server and its async
-dependencies:
+Rust tools. Disable default features to omit CLI (clap), MCP server, and AST:
 
 ```toml
 [dependencies]
-patchloom = { version = "0.1", default-features = false }
+patchloom = { version = "0.3", default-features = false }
+```
+
+To add AST support without CLI/MCP:
+
+```toml
+patchloom = { version = "0.3", default-features = false, features = ["ast"] }
 ```
 
 See the [crate documentation](https://docs.rs/patchloom) for the full API

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -61,7 +61,7 @@ Patchloom is also a Rust library. Add it as a dependency to embed structured fil
 
 ```toml
 [dependencies]
-patchloom = { version = "0.1", default-features = false }
+patchloom = { version = "0.3", default-features = false }
 ```
 
 The `api` module exposes doc, replace, markdown, file, and patch operations. All API types are `Send + Sync`. Disabling default features omits the MCP server and its async dependencies.

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -77,6 +86,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +125,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +153,18 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -172,6 +222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "countme"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +259,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +302,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ec4rs"
@@ -252,6 +348,94 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -319,10 +503,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "ignore"
@@ -375,6 +589,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +640,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,11 +661,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "patchloom"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anstream",
- "anstyle",
  "anyhow",
  "clap",
  "clap_complete",
@@ -441,12 +680,38 @@ dependencies = [
  "libc",
  "memchr",
  "regex",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml_ng",
  "similar",
+ "strsim",
  "tempfile",
+ "tokio",
  "toml_edit",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
+ "tree-sitter-go",
+ "tree-sitter-hcl",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-kotlin-sg",
+ "tree-sitter-language",
+ "tree-sitter-php",
+ "tree-sitter-proto",
+ "tree-sitter-python",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-swift",
+ "tree-sitter-toml-ng",
+ "tree-sitter-typescript",
+ "tree-sitter-xml",
+ "tree-sitter-yaml",
  "yaml-edit",
 ]
 
@@ -458,7 +723,14 @@ dependencies = [
  "libfuzzer-sys",
  "patchloom",
  "serde_json",
+ "tempfile",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "prettyplease"
@@ -501,6 +773,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,6 +820,41 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rmcp"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
 
 [[package]]
 name = "rowan"
@@ -561,6 +888,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +906,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -605,6 +964,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -663,6 +1033,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +1079,61 @@ name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "toml_datetime"
@@ -736,6 +1173,257 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-sg"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06ec43ae3c12165d4ac08afe4e1f5fc6757ffe274fa7bd5af9007ef11ba4319"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-proto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e410ccb5fa3cbd6bf7b8e512ecf7ad9d5254395b822bfe9f751b50fa978f31c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-toml-ng"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9adc2c898ae49730e857d75be403da3f92bb81d8e37a2f918a08dd10de5ebb1"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-xml"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e670041f591d994f54d597ddcd8f4ebc930e282c4c76a42268743b71f0c8b6b3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -790,6 +1478,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,10 +1566,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
+tempfile = "3"
 
 [dependencies.patchloom]
 path = ".."
@@ -45,4 +46,14 @@ doc = false
 [[bin]]
 name = "fuzz_doc_parse"
 path = "fuzz_targets/fuzz_doc_parse.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_containment_check"
+path = "fuzz_targets/fuzz_containment_check.rs"
+doc = false
+
+[[bin]]
+name = "fuzz_fallback_resolve"
+path = "fuzz_targets/fuzz_fallback_resolve.rs"
 doc = false

--- a/fuzz/fuzz_targets/fuzz_containment_check.rs
+++ b/fuzz/fuzz_targets/fuzz_containment_check.rs
@@ -1,0 +1,15 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use patchloom::containment::{AbsolutePathPolicy, PathGuard};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        // Use a real tempdir because PathGuard performs canonicalization.
+        if let Ok(tmp) = tempfile::tempdir() {
+            if let Ok(guard) = PathGuard::new(tmp.path().to_path_buf(), AbsolutePathPolicy::Reject) {
+                let _ = guard.check_path(s);
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_fallback_resolve.rs
+++ b/fuzz/fuzz_targets/fuzz_fallback_resolve.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: (&str, &str, Option<&str>, Option<&str>)| {
+    let (content, target, before, after) = data;
+    // resolve_with_fallback must never panic on arbitrary inputs.
+    let _ = patchloom::fallback::resolve_with_fallback(content, target, before, after);
+});

--- a/src/api.rs
+++ b/src/api.rs
@@ -137,7 +137,7 @@ pub enum EolNormalization {
 
 /// Convert user-facing `WritePolicyOptions` to the internal `WritePolicy`.
 pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
-    use crate::cli::global::EolMode;
+    use crate::write::EolMode;
     WritePolicy {
         ensure_final_newline: opts.ensure_final_newline,
         normalize_eol: match opts.normalize_eol {
@@ -654,9 +654,9 @@ pub fn md_dedupe_headings(
 
 /// A lint issue found in a markdown file.
 ///
-/// Re-exported from `cmd::md` so library consumers don't need to import
+/// Re-exported from `ops::md` so library consumers don't need to import
 /// from the internal `cmd` module path.
-pub use crate::cmd::md::LintIssue;
+pub use crate::ops::md::LintIssue;
 
 /// Lint a markdown file for common agent-rules issues (duplicate headings,
 /// missing sections, etc.).
@@ -665,7 +665,7 @@ pub use crate::cmd::md::LintIssue;
 pub fn md_lint_agents(path: &Path) -> anyhow::Result<Vec<LintIssue>> {
     let content = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
-    Ok(crate::cmd::md::lint_agents_content(&content))
+    Ok(crate::ops::md::lint_agents_content(&content))
 }
 
 /// Insert content before a markdown heading.
@@ -1031,6 +1031,10 @@ pub fn parse_plan(input: &str) -> anyhow::Result<crate::plan::Plan> {
 ///
 /// All operations succeed or all are rolled back. Returns the exit code
 /// and a JSON string with the operation results.
+///
+/// Requires the `cli` feature (enabled by default) because it reuses the
+/// transaction execution engine (which is part of the CLI command set).
+#[cfg(feature = "cli")]
 pub fn execute_plan(plan: crate::plan::Plan, cwd: &Path) -> anyhow::Result<(u8, String)> {
     crate::cmd::tx::execute_plan_direct(plan, cwd)
 }
@@ -1363,6 +1367,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn execute_plan_runs_operations() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("test.txt");
@@ -1534,7 +1539,7 @@ mod tests {
         assert!(policy.collapse_blanks);
         assert_eq!(
             policy.normalize_eol,
-            crate::cli::global::EolMode::Lf,
+            crate::write::EolMode::Lf,
             "should map EolNormalization::Lf to EolMode::Lf"
         );
 
@@ -2233,7 +2238,7 @@ mod tests {
         let policy = make_write_policy(&opts);
         assert_eq!(
             policy.normalize_eol,
-            crate::cli::global::EolMode::Crlf,
+            crate::write::EolMode::Crlf,
             "should map EolNormalization::Crlf to EolMode::Crlf"
         );
     }

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -1,8 +1,10 @@
+#[cfg(feature = "cli")]
 use clap::Args;
 use std::io::BufRead;
 
 /// Color mode for terminal output.
-#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+#[derive(Debug, Clone, Copy, Default)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum ColorMode {
     /// Auto-detect: color when stdout is a terminal.
     #[default]
@@ -13,80 +15,76 @@ pub enum ColorMode {
     Never,
 }
 
-/// Write policy for EOL normalization.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, clap::ValueEnum)]
-pub enum EolMode {
-    /// Keep existing line endings.
-    #[default]
-    Keep,
-    /// Normalize to LF.
-    Lf,
-    /// Normalize to CRLF.
-    Crlf,
-}
+/// Write policy for EOL normalization. Re-exported from `write` so that
+/// CLI code can continue to use `crate::cli::global::EolMode`.
+pub use crate::write::EolMode;
 
 /// Flags available to all subcommands (read and write).
 ///
 /// Write-only flags are `#[clap(skip)]` here so they don't appear in
 /// read-only subcommand help. Write commands flatten [`WriteFlags`]
 /// separately and the dispatcher merges them via [`GlobalFlags::merge_write`].
-#[derive(Debug, Default, Args)]
+#[derive(Debug, Default)]
+#[cfg_attr(feature = "cli", derive(Args))]
 pub struct GlobalFlags {
     /// Emit machine-readable JSON output.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub json: bool,
 
     /// Emit one JSON object per result line.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub jsonl: bool,
 
     /// Suppress non-JSON human-readable output.
-    #[arg(long, short = 'q', global = true)]
+    #[cfg_attr(feature = "cli", arg(long, short = 'q', global = true))]
     pub quiet: bool,
 
     /// Enable verbose diagnostic output on stderr for debugging.
     /// Can also be enabled via the PATCHLOOM_LOG environment variable.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub verbose: bool,
 
     /// Set working directory.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub cwd: Option<String>,
 
     /// Restrict target files by glob pattern (may be repeated).
-    #[arg(long, global = true, action = clap::ArgAction::Append)]
+    #[cfg_attr(feature = "cli", arg(long, global = true, action = clap::ArgAction::Append))]
     pub glob: Vec<String>,
 
     /// Read file list from a file or stdin (`-`), one path per line.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub files_from: Option<String>,
 
     /// When to use color: auto (default), always, or never.
-    #[arg(long, global = true, value_enum, default_value = "auto")]
+    #[cfg_attr(
+        feature = "cli",
+        arg(long, global = true, value_enum, default_value = "auto")
+    )]
     pub color: ColorMode,
 
     // -- Write-only flags (populated via merge_write in dispatch) -----------
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub diff: bool,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub apply: bool,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub check: bool,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub ensure_final_newline: bool,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub normalize_eol: Option<EolMode>,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub trim_trailing_whitespace: bool,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub respect_editorconfig: bool,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub collapse_blanks: bool,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub confirm: bool,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub format: Option<String>,
-    #[clap(skip)]
+    #[cfg_attr(feature = "cli", clap(skip))]
     pub format_timeout: Option<u64>,
 }
 
@@ -95,51 +93,52 @@ pub struct GlobalFlags {
 /// Use `global = true` so these propagate into nested subcommands
 /// (e.g. `doc set`, `patch apply`). They only appear in help when
 /// the parent command flattens this struct.
-#[derive(Debug, Default, Args)]
+#[derive(Debug, Default)]
+#[cfg_attr(feature = "cli", derive(Args))]
 pub struct WriteFlags {
     /// Print unified diff for any write operation.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub diff: bool,
 
     /// Actually mutate files.
-    #[arg(long, global = true, conflicts_with = "check")]
+    #[cfg_attr(feature = "cli", arg(long, global = true, conflicts_with = "check"))]
     pub apply: bool,
 
     /// Compute and report changes without writing.
-    #[arg(long, global = true, conflicts_with = "apply")]
+    #[cfg_attr(feature = "cli", arg(long, global = true, conflicts_with = "apply"))]
     pub check: bool,
 
     /// Ensure non-empty written files end with a newline.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub ensure_final_newline: bool,
 
     /// Normalize line endings after write.
-    #[arg(long, global = true, value_enum)]
+    #[cfg_attr(feature = "cli", arg(long, global = true, value_enum))]
     pub normalize_eol: Option<EolMode>,
 
     /// Remove trailing whitespace on touched lines.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub trim_trailing_whitespace: bool,
 
     /// Read write policy from .editorconfig when present.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub respect_editorconfig: bool,
 
     /// Collapse consecutive blank lines into a single blank line after writing.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub collapse_blanks: bool,
 
     /// Show diff then prompt before applying. Implies --apply on confirmation.
-    #[arg(long, global = true, conflicts_with_all = ["apply", "check"])]
+    #[cfg_attr(feature = "cli", arg(long, global = true, conflicts_with_all = ["apply", "check"]))]
     pub confirm: bool,
 
     /// Run a shell command after successful --apply (e.g. "cargo fmt --all").
     /// Ignored in --diff and --check modes.
-    #[arg(long, global = true)]
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
     pub format: Option<String>,
 
     /// Timeout in seconds for the --format command (default: 30).
-    #[arg(long, global = true, default_value = "30")]
+    #[cfg_attr(feature = "cli", arg(long, global = true, default_value = "30"))]
     pub format_timeout: Option<u64>,
 }
 
@@ -215,7 +214,14 @@ impl GlobalFlags {
                 if std::env::var_os("NO_COLOR").is_some() {
                     return false;
                 }
-                anstream::stdout().is_terminal()
+                #[cfg(feature = "cli")]
+                {
+                    anstream::stdout().is_terminal()
+                }
+                #[cfg(not(feature = "cli"))]
+                {
+                    false
+                }
             }
         }
     }
@@ -226,7 +232,16 @@ impl GlobalFlags {
     /// not set. This lets commands print brief summaries for humans without
     /// interfering with machine-readable stdout.
     pub fn show_status(&self) -> bool {
-        !self.quiet && !self.json && !self.jsonl && anstream::stderr().is_terminal()
+        !self.quiet && !self.json && !self.jsonl && {
+            #[cfg(feature = "cli")]
+            {
+                anstream::stderr().is_terminal()
+            }
+            #[cfg(not(feature = "cli"))]
+            {
+                false
+            }
+        }
     }
 
     /// Resolve the working directory from `--cwd`, defaulting to the process

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,10 +1,14 @@
 pub mod global;
 
+#[cfg(feature = "cli")]
 use crate::cmd::Command;
+#[cfg(feature = "cli")]
 use clap::Parser;
+#[cfg(feature = "cli")]
 use global::GlobalFlags;
 
 /// Patchloom: agent-grade repo operations.
+#[cfg(feature = "cli")]
 #[derive(Debug, Parser)]
 #[command(name = "patchloom", version, about)]
 pub struct Cli {

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -1384,7 +1384,7 @@ impl PatchloomService {
         let abs = self.cwd().join(&p.path);
         let content = std::fs::read_to_string(&abs)
             .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
-        let issues = crate::cmd::md::lint_agents_content(&content);
+        let issues = crate::ops::md::lint_agents_content(&content);
         let json = serde_json::to_string_pretty(&issues)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
         Ok(CallToolResult::success(vec![Content::text(json)]))

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -3,15 +3,12 @@ use crate::diff::{self, DiffResult, unified_diff};
 use crate::exit;
 use crate::ops::md::{
     dedupe_headings_in, find_section, insert_after_heading_in, insert_before_heading_in,
-    move_section_in, non_fenced_lines, parse_headings, replace_section_in, table_append_in,
-    upsert_bullet_in,
+    lint_agents_content, move_section_in, replace_section_in, table_append_in, upsert_bullet_in,
 };
 use crate::write::policy_from_flags;
 use anyhow::Context;
 use clap::Args;
 use serde::Serialize;
-use std::borrow::Cow;
-use std::collections::HashSet;
 
 use std::path::Path;
 
@@ -174,107 +171,6 @@ fn apply_mutation(
     }
 
     Ok(exit::SUCCESS)
-}
-
-// ---------------------------------------------------------------------------
-// Lint
-// ---------------------------------------------------------------------------
-
-/// Remove backtick-delimited inline code spans from a line, returning
-/// the remaining prose.  This lets lint checks ignore content inside
-/// backticks (e.g. ``Never use `git add .` ``).
-fn strip_inline_code(line: &str) -> Cow<'_, str> {
-    if !line.contains('`') {
-        return Cow::Borrowed(line);
-    }
-    let mut result = String::with_capacity(line.len());
-    let mut rest = line;
-    while let Some(open) = rest.find('`') {
-        result.push_str(&rest[..open]);
-        let after_open = &rest[open + 1..];
-        if let Some(close) = after_open.find('`') {
-            rest = &after_open[close + 1..];
-        } else {
-            // Unmatched backtick — keep the rest as-is.
-            rest = after_open;
-            break;
-        }
-    }
-    result.push_str(rest);
-    Cow::Owned(result)
-}
-
-/// Check for `git add .` (dangerous) without matching `git add .gitignore`
-/// or other dotfile paths. The dot must be followed by whitespace or EOL.
-fn has_dangerous_git_add_dot(line: &str) -> bool {
-    let needle = "git add .";
-    let mut start = 0;
-    while let Some(pos) = line[start..].find(needle) {
-        let abs = start + pos;
-        let after = abs + needle.len();
-        if after >= line.len() || line.as_bytes()[after].is_ascii_whitespace() {
-            return true;
-        }
-        start = abs + 1;
-    }
-    false
-}
-
-/// A lint issue found in a markdown file.
-#[derive(Debug, Serialize)]
-pub struct LintIssue {
-    /// Description of the issue.
-    pub issue: &'static str,
-    /// Line number where the issue was found (if applicable).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub line: Option<usize>,
-    /// Heading text related to the issue (if applicable).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub heading: Option<String>,
-}
-
-pub(crate) fn lint_agents_content(content: &str) -> Vec<LintIssue> {
-    let mut issues = Vec::new();
-
-    // 1. Duplicate headings (same text at same level).
-    let headings = parse_headings(content);
-    let mut seen: HashSet<(usize, String)> = HashSet::new();
-    for h in &headings {
-        let key = (h.level, h.text.trim().to_string());
-        if !seen.insert(key) {
-            issues.push(LintIssue {
-                issue: "duplicate heading",
-                line: Some(h.line_start + 1), // 1-based
-                heading: Some(format!("{} {}", "#".repeat(h.level), h.text)),
-            });
-        }
-    }
-
-    // 2. Dangerous git add commands (skip fenced code blocks and inline code).
-    for (idx, line) in non_fenced_lines(content) {
-        let stripped = strip_inline_code(line);
-        if has_dangerous_git_add_dot(&stripped)
-            || stripped.contains("git add -A")
-            || stripped.contains("git add --all")
-        {
-            issues.push(LintIssue {
-                issue: "dangerous command",
-                line: Some(idx + 1),
-                heading: None,
-            });
-        }
-    }
-
-    // 3. Missing final newline.
-    if !content.is_empty() && !content.ends_with('\n') {
-        issues.push(LintIssue {
-            issue: "missing final newline",
-            line: None,
-            heading: None,
-        });
-    }
-
-    issues
 }
 
 // ---------------------------------------------------------------------------
@@ -468,6 +364,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::md::{has_dangerous_git_add_dot, strip_inline_code};
     use std::fs;
     use tempfile::TempDir;
 
@@ -914,7 +811,7 @@ mod tests {
     #[test]
     fn parse_headings_basic() {
         let content = "# A\ntext\n## B\nmore\n# C\n";
-        let h = parse_headings(content);
+        let h = crate::ops::md::parse_headings(content);
         assert_eq!(h.len(), 3);
         assert_eq!(h[0].level, 1);
         assert_eq!(h[0].text, "A");

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -94,7 +94,7 @@ struct TxReadResult {
 struct TxLintResult {
     path: String,
     issue_count: usize,
-    issues: Vec<crate::cmd::md::LintIssue>,
+    issues: Vec<crate::ops::md::LintIssue>,
 }
 
 #[derive(Debug, Args)]
@@ -1298,7 +1298,7 @@ fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usi
         Operation::MdLintAgents { path } => {
             let file_path = tx.cwd.join(path);
             let content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
-            let issues = crate::cmd::md::lint_agents_content(content);
+            let issues = crate::ops::md::lint_agents_content(content);
             tx.tx_lints.push(TxLintResult {
                 path: path.clone(),
                 issue_count: issues.len(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,9 @@ pub fn find_and_load(start: &Path) -> Option<(ProjectConfig, PathBuf)> {
 
 /// Merge a [`ProjectConfig`] into [`GlobalFlags`](crate::cli::global::GlobalFlags), applying config values only
 /// where the CLI did not explicitly set them.
+///
+/// Only available with the `cli` feature.
+#[cfg(feature = "cli")]
 pub fn apply_config(global: &mut crate::cli::global::GlobalFlags, config: &ProjectConfig) {
     // Write policy: config provides defaults, CLI flags win.
     if !global.ensure_final_newline && config.write_policy.ensure_final_newline == Some(true) {
@@ -286,6 +289,7 @@ color = "always"
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn apply_config_sets_defaults() {
         let config = ProjectConfig {
             write_policy: WritePolicy {
@@ -320,6 +324,7 @@ color = "always"
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn apply_config_cli_flags_win() {
         let config = ProjectConfig {
             write_policy: WritePolicy {
@@ -374,6 +379,7 @@ color = "always"
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn apply_config_unknown_eol_value_ignored() {
         let config = ProjectConfig {
             write_policy: WritePolicy {
@@ -393,6 +399,7 @@ color = "always"
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn apply_config_crlf_eol() {
         let config = ProjectConfig {
             write_policy: WritePolicy {
@@ -411,6 +418,7 @@ color = "always"
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn apply_config_unknown_color_value_stays_auto() {
         let config = ProjectConfig {
             output: Output {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,33 +9,40 @@
 //!
 //! | Feature | Default | Description |
 //! |---------|---------|-------------|
-//! | `core`  | no      | Marker feature for core library usage (no extra deps) |
+//! | `cli`   | **yes** | CLI parser (clap) and all subcommand implementations. Disable for pure library use. |
 //! | `mcp`   | **yes** | MCP server support (adds `tokio`, `rmcp`, `schemars`) |
 //! | `ast`   | **yes** | AST-aware operations using tree-sitter (20 language grammars) |
-//! | `full`  | no      | Everything: `mcp` + `ast` |
+//! | `full`  | no      | Everything: `cli` + `mcp` + `ast` |
 //!
 //! ## Embedding as a library
 //!
-//! To use patchloom as a library without the MCP server overhead:
+//! To use patchloom as a library (no CLI, no MCP):
 //!
 //! ```toml
 //! [dependencies]
-//! patchloom = { version = "0.1", default-features = false }
+//! patchloom = { version = "0.3", default-features = false }
 //! ```
 //!
-//! This gives you the full [`api`] module (doc/replace/md/file/patch operations),
-//! the [`ops`] module for lower-level access, and utility modules:
+//! Or with AST support:
+//!
+//! ```toml
+//! patchloom = { version = "0.3", default-features = false, features = ["ast"] }
+//! ```
+//!
+//! This gives you the [`api`] module (primary editing interface), [`ops`],
+//! and utility modules:
 //!
 //! - [`containment`] -- workspace path guard preventing traversal attacks
 //! - [`exec`] -- shell command execution with process-tree management
 //! - [`fallback`] -- multi-strategy edit recovery (exact, anchor, similarity)
-//! - [`files`] -- file-walking, binary detection, and text reading helpers
 //! - [`write`] -- atomic file writes with write-policy transformations
+//!
+//! (The `files`, `cli`, and `cmd` modules are only available with the `cli` feature.)
 //!
 //! With `features = ["ast"]`, the [`ast`] module provides tree-sitter parsing,
 //! symbol extraction, structural search, rename, and more for 20 languages.
 //!
-//! No `tokio` or other async runtime dependencies are pulled in.
+//! No `clap`, `tokio` or other heavy dependencies are pulled in when `cli` and `mcp` are disabled.
 //!
 //! ## Thread safety
 //!
@@ -60,6 +67,7 @@ pub mod api;
 pub mod ast;
 pub mod backup;
 pub mod cli;
+#[cfg(feature = "cli")]
 pub mod cmd;
 pub mod config;
 pub mod containment;
@@ -67,6 +75,7 @@ pub(crate) mod diff;
 pub mod exec;
 pub(crate) mod exit;
 pub mod fallback;
+#[cfg(feature = "cli")]
 pub mod files;
 pub mod ops;
 pub mod plan;
@@ -74,10 +83,8 @@ pub mod schema;
 pub mod selector;
 pub mod write;
 
+#[cfg(feature = "cli")]
 pub(crate) use files::*;
-
-use clap::Parser;
-use cli::Cli;
 
 // ---------------------------------------------------------------------------
 // Verbose logging
@@ -109,8 +116,13 @@ macro_rules! verbose {
 }
 
 /// Run the patchloom CLI. Returns the exit code as a u8.
+///
+/// Requires the `cli` feature (enabled by default).
+#[cfg(feature = "cli")]
 pub fn run() -> anyhow::Result<u8> {
-    let cli = Cli::parse();
+    use clap::Parser;
+
+    let cli = crate::cli::Cli::parse();
 
     // Enable verbose mode from --verbose flag or PATCHLOOM_LOG env var.
     if cli.global.verbose || std::env::var_os("PATCHLOOM_LOG").is_some() {

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -1,4 +1,7 @@
+use std::borrow::Cow;
 use std::collections::HashSet;
+
+use serde::Serialize;
 
 #[derive(Debug, Clone)]
 pub struct HeadingInfo {
@@ -380,6 +383,102 @@ pub fn table_append_in(
 pub fn table_append_for_tx(content: &str, heading: &str, row: &str) -> Option<String> {
     let (body_start, body_end) = find_section(content, heading)?;
     table_append_in(content, body_start, body_end, row)
+}
+
+/// Strip inline code spans (between backticks) from a line so that
+/// we don't false-positive on code examples.
+pub(crate) fn strip_inline_code(line: &str) -> Cow<'_, str> {
+    if !line.contains('`') {
+        return Cow::Borrowed(line);
+    }
+    let mut result = String::with_capacity(line.len());
+    let mut rest = line;
+    while let Some(open) = rest.find('`') {
+        result.push_str(&rest[..open]);
+        let after_open = &rest[open + 1..];
+        if let Some(close) = after_open.find('`') {
+            rest = &after_open[close + 1..];
+        } else {
+            // Unmatched backtick — keep the rest as-is.
+            rest = after_open;
+            break;
+        }
+    }
+    result.push_str(rest);
+    Cow::Owned(result)
+}
+
+/// Detects a literal "git add ." (or "git add ." followed by whitespace)
+/// that is not inside code.
+pub(crate) fn has_dangerous_git_add_dot(line: &str) -> bool {
+    let needle = "git add .";
+    let mut start = 0;
+    while let Some(pos) = line[start..].find(needle) {
+        let abs = start + pos;
+        let after = abs + needle.len();
+        if after >= line.len() || line.as_bytes()[after].is_ascii_whitespace() {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
+/// A lint issue found in a markdown file.
+#[derive(Debug, Serialize)]
+pub struct LintIssue {
+    /// Description of the issue.
+    pub issue: &'static str,
+    /// Line number where the issue was found (if applicable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<usize>,
+    /// Heading text related to the issue (if applicable).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub heading: Option<String>,
+}
+
+pub fn lint_agents_content(content: &str) -> Vec<LintIssue> {
+    let mut issues = Vec::new();
+
+    // 1. Duplicate headings (same text at same level).
+    let headings = parse_headings(content);
+    let mut seen: HashSet<(usize, String)> = HashSet::new();
+    for h in &headings {
+        let key = (h.level, h.text.trim().to_string());
+        if !seen.insert(key) {
+            issues.push(LintIssue {
+                issue: "duplicate heading",
+                line: Some(h.line_start + 1), // 1-based
+                heading: Some(format!("{} {}", "#".repeat(h.level), h.text)),
+            });
+        }
+    }
+
+    // 2. Dangerous git add commands (skip fenced code blocks and inline code).
+    for (idx, line) in non_fenced_lines(content) {
+        let stripped = strip_inline_code(line);
+        if has_dangerous_git_add_dot(&stripped)
+            || stripped.contains("git add -A")
+            || stripped.contains("git add --all")
+        {
+            issues.push(LintIssue {
+                issue: "dangerous command",
+                line: Some(idx + 1),
+                heading: None,
+            });
+        }
+    }
+
+    // 3. Missing final newline.
+    if !content.is_empty() && !content.ends_with('\n') {
+        issues.push(LintIssue {
+            issue: "missing final newline",
+            line: None,
+            heading: None,
+        });
+    }
+
+    issues
 }
 
 #[cfg(test)]

--- a/src/write.rs
+++ b/src/write.rs
@@ -5,9 +5,21 @@ use std::path::Path;
 use anyhow::Context;
 use tempfile::NamedTempFile;
 
-// Re-export so library consumers can use `patchloom::write::EolMode`
-// without reaching into the CLI module.
-pub use crate::cli::global::EolMode;
+/// Line ending normalization mode.
+///
+/// This type is re-exported at the crate root level of `write` for library use
+/// (independent of the optional `cli` feature).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
+pub enum EolMode {
+    /// Keep existing line endings.
+    #[default]
+    Keep,
+    /// Normalize to LF.
+    Lf,
+    /// Normalize to CRLF.
+    Crlf,
+}
 
 /// Controls which transformations are applied before writing a file.
 pub struct WritePolicy {
@@ -254,6 +266,9 @@ pub fn apply_policy<'a>(content: &'a str, policy: &WritePolicy) -> std::borrow::
 /// Explicit CLI flags always win.  When `--respect-editorconfig` is set and
 /// `file_path` is provided, EditorConfig values fill in any flag that was not
 /// explicitly set by the user.
+///
+/// Only available with the `cli` feature.
+#[cfg(feature = "cli")]
 pub fn policy_from_flags(
     global: &crate::cli::global::GlobalFlags,
     file_path: Option<&std::path::Path>,
@@ -378,6 +393,7 @@ pub fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow:
 /// Only runs when `global.apply` is true and `global.format` is `Some`.
 /// Returns the appropriate exit code: `SUCCESS` on success, `VALIDATION_FAILED`
 /// on format command failure.
+#[cfg(feature = "cli")]
 pub fn run_format_command(
     global: &crate::cli::global::GlobalFlags,
     cwd: &std::path::Path,
@@ -402,6 +418,7 @@ pub fn run_format_command(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "cli")]
     use crate::cli::global::GlobalFlags;
     use std::fs;
 
@@ -529,11 +546,13 @@ mod tests {
         assert_eq!(got, "foo\nbar\n");
     }
 
+    #[cfg(feature = "cli")]
     fn test_global_flags() -> GlobalFlags {
         GlobalFlags::default()
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn policy_from_flags_explicit_flags_win() {
         let dir = tempfile::tempdir().unwrap();
         let ec_path = dir.path().join(".editorconfig");
@@ -560,6 +579,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn policy_from_flags_editorconfig_provides_defaults() {
         let dir = tempfile::tempdir().unwrap();
         let ec_path = dir.path().join(".editorconfig");
@@ -673,6 +693,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn policy_from_flags_no_editorconfig_uses_defaults() {
         let global = test_global_flags();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19780,7 +19780,10 @@ fn test_ast_diff_basic() {
     };
     assert!(git(&["init", "-q"]).success(), "git init failed");
     assert!(git(&["add", "-A"]).success(), "git add failed");
-    assert!(git(&["commit", "-q", "-m", "init"]).success(), "git commit failed; no HEAD");
+    assert!(
+        git(&["commit", "-q", "-m", "init"]).success(),
+        "git commit failed; no HEAD"
+    );
     // Modify after commit so there is a structural diff vs HEAD.
     fs::write(&f, "fn v1(){}\nfn v2(){}\n").unwrap();
     patchloom_in(dir.path())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19657,6 +19657,135 @@ fn test_explain_ast_replace_description() {
         ));
 }
 
+// --- AST subcommand integration coverage (for #694) ---
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_list_basic() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, "pub fn foo() {}\nstruct Bar;\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "list", "lib.rs", "--json"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("foo"))
+        .stdout(predicates::str::contains("Bar"));
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_read_basic() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("main.rs");
+    fs::write(&f, "fn target() { let x=1; }\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "read", "main.rs", "target"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("target"));
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_validate_ok() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("ok.rs");
+    fs::write(&f, "fn ok() {}\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "validate", "ok.rs"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_search_basic() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("s.rs");
+    fs::write(&f, "fn f() { let y = 42; }\n").unwrap();
+    // simple structural query for function item
+    patchloom_in(dir.path())
+        .args(["ast", "search", "(function_item) @fn", "s.rs", "--json"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_refs_basic() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("r.rs");
+    fs::write(&f, "fn callee() {}\nfn caller() { callee(); }\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "refs", "callee", "r.rs", "--json"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_deps_basic() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("d.rs");
+    fs::write(&f, "use std::collections::HashMap;\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "deps", "d.rs", "--json"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_map_basic() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("m.rs");
+    fs::write(&f, "fn a(){} fn b(){ a(); }\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "map", ".", "--json"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_impact_basic() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("i.rs");
+    fs::write(&f, "fn entry(){ helper(); }\nfn helper(){}\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "impact", "helper", "i.rs", "--json"])
+        .assert()
+        .success();
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_diff_basic() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("diff.rs");
+    fs::write(&f, "fn v1(){}\n").unwrap();
+    // Initialize minimal git repo so --from HEAD works for dispatch coverage.
+    let _ = std::process::Command::new("git")
+        .args(["init", "-q"])
+        .current_dir(dir.path())
+        .status();
+    let _ = std::process::Command::new("git")
+        .args(["add", "-A"])
+        .current_dir(dir.path())
+        .status();
+    let _ = std::process::Command::new("git")
+        .args(["commit", "-q", "-m", "init"])
+        .current_dir(dir.path())
+        .status();
+    // Modify after commit so there is a structural diff vs HEAD.
+    fs::write(&f, "fn v1(){}\nfn v2(){}\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "diff", "diff.rs", "--from", "HEAD", "--json"])
+        .assert()
+        .success();
+}
+
 #[test]
 fn test_explain_replace_word_boundary() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19766,18 +19766,21 @@ fn test_ast_diff_basic() {
     let f = dir.path().join("diff.rs");
     fs::write(&f, "fn v1(){}\n").unwrap();
     // Initialize minimal git repo so --from HEAD works for dispatch coverage.
-    let _ = std::process::Command::new("git")
-        .args(["init", "-q"])
-        .current_dir(dir.path())
-        .status();
-    let _ = std::process::Command::new("git")
-        .args(["add", "-A"])
-        .current_dir(dir.path())
-        .status();
-    let _ = std::process::Command::new("git")
-        .args(["commit", "-q", "-m", "init"])
-        .current_dir(dir.path())
-        .status();
+    // Use explicit author to make commit succeed in CI without global git config.
+    let git = |args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .env("GIT_AUTHOR_NAME", "CI")
+            .env("GIT_AUTHOR_EMAIL", "ci@example.com")
+            .env("GIT_COMMITTER_NAME", "CI")
+            .env("GIT_COMMITTER_EMAIL", "ci@example.com")
+            .status()
+            .expect("git command failed to spawn")
+    };
+    assert!(git(&["init", "-q"]).success(), "git init failed");
+    assert!(git(&["add", "-A"]).success(), "git add failed");
+    assert!(git(&["commit", "-q", "-m", "init"]).success(), "git commit failed; no HEAD");
     // Modify after commit so there is a structural diff vs HEAD.
     fs::write(&f, "fn v1(){}\nfn v2(){}\n").unwrap();
     patchloom_in(dir.path())


### PR DESCRIPTION
Fixes the three remaining open tech-debt issues from the v0.3 audit:

- #691: clap is now behind an optional `cli` feature (default on). `GlobalFlags`/`EolMode` available for library tx/api use. `cmd`/`files` gated so pure lib (`default-features=false`) pays no clap compile cost.
- #694: Added 9 new integration tests covering the previously untested AST subcommands (list, read, validate, search, refs, deps, map, impact, diff).
- #708: Added `fuzz_containment_check` (PathGuard) and `fuzz_fallback_resolve`; updated Makefile, docs, and fuzz crate.

All changes verified locally with `make check-fast`, clippy, unit+integration tests (including new), and `--no-default-features` build.

Closes #691
Closes #694
Closes #708