### PR TITLE
fix: rename misleading concurrent MCP test and clean cosmetic GlobalFlags shadows

### DIFF
--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -265,7 +265,6 @@ mod tests {
         };
         let mut global = GlobalFlags::test_default();
         global.check = true;
-        let global = global;
 
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::CHANGES_DETECTED);

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -428,7 +428,6 @@ mod tests {
         };
         let mut global = GlobalFlags::test_with_cwd(dir.path());
         global.apply = true;
-        let global = global;
 
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -387,7 +387,7 @@ mod tests {
         };
         let mut global = GlobalFlags::test_with_cwd(dir.path());
         global.apply = true;
-        let global = global;
+
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19809,7 +19809,8 @@ fn test_ast_validate_invalid_syntax_reports_failure() {
     patchloom_in(dir.path())
         .args(["ast", "validate", "bad.rs"])
         .assert()
-        .failure(); // ast validate for invalid should fail (details in stderr or code)
+        .failure()
+        .stderr(predicates::str::contains("INVALID (Rust)"));
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19321,11 +19321,11 @@ fn test_editorconfig_per_extension_override() {
 }
 
 // ---------------------------------------------------------------------------
-// Concurrent MCP requests to the same file
+// Concurrent MCP requests
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn test_mcp_concurrent_doc_set_same_file() {
+async fn test_mcp_concurrent_doc_set() {
     if !has_mcp_support() {
         return;
     }


### PR DESCRIPTION
Small follow-up cleanups noted during review of #720:

* Rename `test_mcp_concurrent_doc_set_same_file` → `test_mcp_concurrent_doc_set`
  (and update the outdated section header comment). The test has used
  distinct files since the #719 fix.

* Remove three unnecessary `let global = global;` rebinds after mutating
  `GlobalFlags` in unit tests (append, create, md). The `&global` borrow
  works directly.

No behavior change. All checks pass.

Follow-up to #720.