### PR TITLE
fix: ignore .lycheecache and add `make git-clean` (tech-debt #736)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ benches/mcp/results/
 tests/agent/.venv/
 tests/agent/.pytest_cache/
 __pycache__/
+
+# lychee link checker local cache (cache = true in lychee.toml for faster local runs)
+# This file is a performance cache only and must never be committed.
+.lycheecache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,15 +25,27 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make check-patchloom-md` | Verify PATCHLOOM.md matches `patchloom agent-rules` output (part of `check`) |
 | `make audit-test-hygiene` | Audit test names and weak assertions for staleness after refactors (run after MPI or breaking changes) |
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
-<<<<<<< HEAD
 | `make fuzz` | Run fuzz tests (8 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse, containment_check, fallback_resolve). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |
 | `make bench-mcp` | Run MCP benchmarks: per-call latency vs CLI process spawn (not part of `check`) |
 | `make bench-agent` | Run LLM agent A/B benchmarks (requires API key, not part of `check`). Use `MODEL=X RUNS=N` to configure runs |
 | `make bench-agent-dry-run` | Preview agent benchmark prompts without calling the LLM API |
 | `make bench-agent-report` | Generate comparison report from saved agent benchmark results. Use `FILE=path` for specific file |
+| `make git-clean` | Remove known temp files that pollute `git status` (e.g. `.lycheecache` from lychee) |
+| `make clean` | Remove build artifacts and temp files |
 
 Always run `make check` before committing. It is the full CI gate.
+
+## Git hygiene
+
+Keep the working tree clean:
+
+- `git status --short` should be empty (except when intentionally on the release-please synthetic branch).
+- Run `make git-clean` to remove temp files such as `.lycheecache` (created when `cache = true` in `lychee.toml`).
+- At the end of any session or before switching tasks: `git fetch --all --prune`, `make git-clean`, `git status --short`, and ensure you are on a clean `origin/main` (or the allowed release-please branch).
+- Common sources of "dirty" state: lychee cache, local edits during rebase/force work on release-please, Cargo.lock drift from different tool versions. Fix them explicitly rather than carrying them.
+
+See also the branch hygiene rules in `~/.grok/skills/patchloom-contrib/SKILL.md`.
 
 ## Project structure
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit-test-hygiene audit bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz
+.PHONY: help fmt fmt-check build test integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit-test-hygiene audit bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -53,6 +53,14 @@ verify-release-notes: ## Verify RELEASE_NOTES.md if present (for curated release
 	else \
 		echo "No RELEASE_NOTES.md present (generated changelog will be used)"; \
 	fi
+
+git-clean: ## Remove known temp files that pollute `git status` (e.g. .lycheecache). Addresses #736.
+	@rm -f .lycheecache
+	@echo "Removed known temp files polluting git status"
+
+clean: ## Remove build artifacts + known temps (cargo clean + git-clean)
+	cargo clean
+	@$(MAKE) --no-print-directory git-clean
 
 update-readme: ## Update README.md rounded test count (only changes when hundreds digit changes)
 	@unit=$$(cargo test --lib --all-features -- --list 2>/dev/null | grep ': test$$' | wc -l | tr -d ' '); \

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,6 @@
+# Local request cache for faster repeated runs.
+# The resulting .lycheecache file is deliberately ignored in .gitignore
+# (see tech-debt #736 and `make git-clean`).
 cache = true
 max_retries = 3
 retry_wait_time = 5


### PR DESCRIPTION
Fixes #736.

## Summary
- `.lycheecache` (from `lychee` with `cache = true`) is now in `.gitignore`
- Added `make git-clean` and `make clean` targets
- Added Git hygiene section + entry in dev commands table in AGENTS.md
- Expanded mandatory cleanup rule + known temps list in patchloom-contrib skill
- Updated clean-working-tree steps in multi-perspective-improve and owned-repo-gate skills with examples and recommendations
- Verified end-to-end: lychee creates the cache, `git status` never lists it, `make git-clean` removes it, tree stays clean
- (Bonus) cleaned stale conflict markers in AGENTS.md

All relevant checks passed. Skills synced.

Closes #736