### PR TITLE
ci: improve handling of release-please PR bodies (tech-debt #740)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,31 @@ jobs:
           git commit -s -m "chore: sync PATCHLOOM.md with version bump"
           git push
 
+      - name: Keep release PR body reasonable (tech-debt #740)
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBER=$(echo '${{ needs.release-please.outputs.pr }}' | jq -r '.number // empty')
+          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+            echo "No PR number available"
+            exit 0
+          fi
+
+          CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body || echo "")
+          if echo "$CURRENT_BODY" | grep -qE '## \[[0-9]+\.[0-9]+\.[0-9]+\]'; then
+            echo "Setting short curated body on release PR #$PR_NUMBER"
+            gh pr edit "$PR_NUMBER" --body "$(cat << 'EOPRBODY'
+:robot: Release PR
+
+See [RELEASE_NOTES.md](https://github.com/patchloom/patchloom/blob/main/RELEASE_NOTES.md) for the curated highlights of this release.
+
+The detailed changelog will be part of the published GitHub Release.
+EOPRBODY
+)" || echo "Failed to edit PR body (non-fatal)"
+          else
+            echo "PR body looks reasonable, leaving as-is"
+          fi
+
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
     needs: [release-please]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,13 @@ Keep the working tree clean:
 
 See also the branch hygiene rules in `~/.grok/skills/patchloom-contrib/SKILL.md`.
 
+## Release PRs (release-please)
+
+- The open release-please PR (#724 etc.) title must be correct. Use `gh pr edit --title` when it shows the wrong version.
+- The PR *body* can be very long and may temporarily show the wrong next version header (release-please behavior). This is tracked as tech-debt #740.
+- Primary curation is done via `RELEASE_NOTES.md` (applied to the final GitHub Release by the host job, not the PR body).
+- See `patchloom-contrib` skill ("Curated release notes" and "Major version bumps" sections) for the full process.
+
 ## Project structure
 
 ```


### PR DESCRIPTION
Addresses #740.

## Changes
- Performed one-time cleanup of the body on current open release PR #724 (short curated intro pointing to RELEASE_NOTES.md).
- Clarified policy in documentation:
  - `RELEASE_NOTES.md` is for the final GitHub **Release**.
  - The open release-please **PR body** may remain long/noisy; we only promise the title is correct.
- Added guidance in AGENTS.md (new "Release PRs (release-please)" section) and `patchloom-contrib` skill.
- Extended the `sync-generated-files` job to automatically set a short reasonable body when it detects a bad version header (using the GitHub App token).

See updated skill sections for the full recommended process during major bumps / forces.

Related: #738 (desync), previous curation work (#731–#733).