### PR TITLE
fix: honor --format in tx + improve undo errors (MPI)

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -254,7 +254,7 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
     let manifest_path = session_dir.join("manifest.json");
 
     let content = std::fs::read_to_string(&manifest_path)
-        .with_context(|| format!("no backup session found for {timestamp}"))?;
+        .with_context(|| format!("no backup session found for {timestamp} (use `patchloom undo --list` to see available sessions)"))?;
     let manifest: Manifest = serde_json::from_str(&content)
         .with_context(|| format!("parsing backup manifest for session {timestamp}"))?;
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -16,7 +16,9 @@ use crate::ops::replace::{
 };
 use crate::plan::{self, Operation, Plan};
 use crate::selector;
-use crate::write::{WritePolicy, apply_policy, atomic_create_new, atomic_write};
+use crate::write::{
+    WritePolicy, apply_policy, atomic_create_new, atomic_write, run_format_command,
+};
 use anyhow::Context;
 use clap::Args;
 use globset::Glob;
@@ -2393,6 +2395,10 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return handle_commit_error(err, structured, compact);
         }
 
+        // Run --format command (CLI write flag) after successful writes.
+        // This makes --format parity with direct commands (batch, replace, etc).
+        run_format_command(global, &cwd)?;
+
         // Show diffs if --diff flag is set.
         if global.diff && !result.changes.is_empty() {
             print_diffs(&result.changes, &cwd, global.should_color());
@@ -2453,16 +2459,16 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // --confirm: prompt after showing diffs, then apply if confirmed.
-    if !result.no_effective_changes
-        && global.should_apply()
-        && let Err(err) = commit_changes(
+    if !result.no_effective_changes && global.should_apply() {
+        if let Err(err) = commit_changes(
             &result.changes,
             &result.deletions,
             &result.existed_before,
             &cwd,
-        )
-    {
-        return handle_commit_error(err, structured, compact);
+        ) {
+            return handle_commit_error(err, structured, compact);
+        }
+        run_format_command(global, &cwd)?;
     }
 
     Ok(exit::SUCCESS)

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -98,7 +98,7 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let session = sessions
             .iter()
             .find(|s| s.timestamp == timestamp)
-            .ok_or_else(|| anyhow::anyhow!("no backup session found for {timestamp}"))?;
+            .ok_or_else(|| anyhow::anyhow!("no backup session found for {timestamp} (use `patchloom undo --list` to see available sessions)"))?;
 
         let entries: Vec<UndoPreviewEntry> = session
             .entries

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -20137,3 +20137,37 @@ fn test_format_flag_failure_is_reported() {
         .failure()
         .stderr(predicates::str::contains("format command failed"));
 }
+
+#[test]
+fn test_tx_format_flag_runs_after_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "aaa\n").unwrap();
+    let marker = dir.path().join("format_ran.marker");
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [
+            {"op": "replace", "path": "f.txt", "from": "aaa", "to": "bbb"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .args([
+            "tx",
+            plan_file.to_str().unwrap(),
+            "--apply",
+            "--format",
+            &shell_touch(&marker),
+        ])
+        .assert()
+        .success();
+
+    assert!(
+        marker.exists(),
+        "--format command should have run after tx --apply"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "bbb\n");
+}


### PR DESCRIPTION
## Summary
- QA: wired `--format`/`--format-timeout` (post-write shell) for `tx` command (was accepted on CLI but had no effect; parity with replace/append/create/batch).
- End User: improved "no backup session found" errors (both preview and --apply) to suggest `patchloom undo --list`.

## Verification
- Added `test_tx_format_flag_runs_after_apply`.
- make check-fast passed (fmt, clippy, tests, integration, pty).
- All changes on dedicated branch to satisfy pre-commit hook.

Fixes parity gap found during multi-perspective improvement. See also tech-debt #744 for related confirm/lifecycle follow-up.

Signed-off-by: $(git config user.email)