### PR TITLE
fix: run plan format/validate lifecycle on tx --confirm + batch cleanup (fixes #744)

### DIFF
--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -457,11 +457,8 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         no_strict: false,
         write: args.write,
     };
+    // Delegate to tx, which handles --apply / --confirm / --format / plan lifecycle.
     let result = crate::cmd::tx::run(tx_args, global)?;
-    if result == crate::exit::SUCCESS && global.apply {
-        let cwd = global.resolve_cwd()?;
-        crate::write::run_format_command(global, &cwd)?;
-    }
     Ok(result)
 }
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -2468,7 +2468,45 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         ) {
             return handle_commit_error(err, structured, compact);
         }
+
         run_format_command(global, &cwd)?;
+
+        // Run format steps, then validation steps. (full parity with direct --apply path)
+        if let Some(err) = run_lifecycle(&plan, &base_cwd, &cwd) {
+            if strict {
+                rollback_strict(
+                    &result.changes,
+                    &result.pending,
+                    &result.deletions,
+                    &result.existed_before,
+                );
+                let rollback_msg = format!("strict mode -- all changes reverted ({})", err.message);
+                if structured {
+                    emit_error_json_with_prefix(err.kind, "rollback", &rollback_msg, None, compact);
+                } else {
+                    eprintln!("tx: {rollback_msg}");
+                }
+                return Ok(exit::ROLLBACK);
+            }
+            if structured {
+                emit_error_json(err.kind, &err.message, None, compact);
+            }
+            return Ok(exit::VALIDATION_FAILED);
+        }
+
+        if result.replace_no_matches {
+            return Ok(exit::NO_MATCHES);
+        }
+        if structured {
+            let output = build_full_tx_output("success", &mut result, &cwd);
+            emit_output_json(&output, compact);
+        } else if global.show_status() {
+            let n_changed = result.changes.len();
+            let n_deleted = result.deletions.len();
+            let total = n_changed + n_deleted;
+            eprintln!("applied: {total} file(s) affected");
+        }
+        return Ok(exit::SUCCESS);
     }
 
     Ok(exit::SUCCESS)

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -39,6 +39,18 @@ fn shell_touch(path: &std::path::Path) -> String {
     format!("touch '{path}'")
 }
 
+/// Cross-platform command that always fails (non-zero exit).
+fn shell_false() -> &'static str {
+    #[cfg(windows)]
+    {
+        "cmd /C exit 1"
+    }
+    #[cfg(not(windows))]
+    {
+        "false"
+    }
+}
+
 // ── --confirm path tests ───────────────────────────────────────
 
 #[test]
@@ -241,5 +253,153 @@ fn pty_confirm_default_enter_accepts() {
     assert_eq!(
         content, "bbb\n",
         "pressing Enter should accept the default (Y)"
+    );
+}
+
+// ── tx + plan + --confirm lifecycle (format/validate steps) ───────
+
+#[test]
+fn pty_tx_confirm_yes_runs_plan_format_and_validate_steps() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "old\n").unwrap();
+    let format_marker = dir.path().join("plan_format_ran.marker");
+    let validate_marker = dir.path().join("plan_validate_ran.marker");
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [
+            {"op": "replace", "path": "f.txt", "from": "old", "to": "new"}
+        ],
+        "format": [
+            {"cmd": shell_touch(&format_marker)}
+        ],
+        "validate": [
+            {"cmd": shell_touch(&validate_marker), "required": true}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args(["tx", plan_file.to_str().unwrap(), "--confirm"]);
+
+    let mut session = spawn_pty(cmd);
+
+    // The tx will print a diff before the prompt.
+    session
+        .expect("new")
+        .expect("should see replacement in diff");
+    session.expect("Apply?").expect("should see Apply? prompt");
+    session.send_line("y").expect("failed to send y");
+    session.expect(Eof).expect("process should exit");
+
+    // Both plan format and validate steps must have executed.
+    assert!(
+        format_marker.exists(),
+        "plan 'format' step should have run after tx --confirm y"
+    );
+    assert!(
+        validate_marker.exists(),
+        "plan 'validate' step should have run after tx --confirm y"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "new\n",
+        "replace from plan should have been applied"
+    );
+}
+
+#[test]
+fn pty_tx_confirm_nonstrict_validate_failure_keeps_applied_changes() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "old\n").unwrap();
+    let format_marker = dir.path().join("plan_format_ran.marker");
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [
+            {"op": "replace", "path": "f.txt", "from": "old", "to": "new"}
+        ],
+        "format": [
+            {"cmd": shell_touch(&format_marker)}
+        ],
+        "validate": [
+            {"cmd": shell_false(), "required": true}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args([
+        "tx",
+        plan_file.to_str().unwrap(),
+        "--confirm",
+        "--no-strict",
+    ]);
+
+    let mut session = spawn_pty(cmd);
+
+    session.expect("Apply?").expect("should see Apply? prompt");
+    session.send_line("y").expect("failed to send y");
+    session.expect(Eof).expect("process should exit");
+
+    // Format step ran (before validate), replace applied, but validate failed (non-strict).
+    // Per design: changes are kept, exit code is VALIDATION_FAILED (not rolled back).
+    assert!(
+        format_marker.exists(),
+        "plan format step should run even if later validate fails"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "new\n",
+        "changes should remain after non-strict validate failure on --confirm"
+    );
+}
+
+#[test]
+fn pty_tx_confirm_strict_validate_failure_rolls_back() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "old\n").unwrap();
+    let format_marker = dir.path().join("plan_format_ran.marker");
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "strict": true,
+        "operations": [
+            {"op": "replace", "path": "f.txt", "from": "old", "to": "new"}
+        ],
+        "format": [
+            {"cmd": shell_touch(&format_marker)}
+        ],
+        "validate": [
+            {"cmd": shell_false(), "required": true}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let mut cmd = patchloom_cmd(dir.path());
+    cmd.args(["tx", plan_file.to_str().unwrap(), "--confirm"]);
+
+    let mut session = spawn_pty(cmd);
+
+    session.expect("Apply?").expect("should see Apply? prompt");
+    session.send_line("y").expect("failed to send y");
+    session.expect(Eof).expect("process should exit");
+
+    // Strict mode: on validate failure, changes rolled back.
+    // External format side-effect (marker) remains.
+    assert!(
+        format_marker.exists(),
+        "format side effect remains even on strict rollback"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "old\n",
+        "file should be rolled back on strict validate failure during --confirm"
     );
 }


### PR DESCRIPTION
Fixes #744: `tx --confirm` was skipping plan `"format"` and `"validate"` steps (and strict/rollback logic) that the direct `--apply` path ran.

- Made the `--confirm` (`should_apply()`) path in `tx::run` run the full post-commit sequence: `run_format_command` + `run_lifecycle` with identical error handling, structured output, and status messages as the `--apply` path.
- Added comprehensive PTY tests covering success, non-strict validate failure (changes kept), and strict validate failure (rollback).
- Cleaned up redundant post-`tx::run` `run_format_command` in `batch.rs` (was causing double execution for `batch --apply --format` and was the only remaining similar pattern after tx took ownership of the flag for delegated plans).

All related tests, `make check-fast`, clippy, etc. pass.