### PR TITLE
fix: reviewer follow-ups for PathGuard batch (#755 #756)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -695,10 +695,14 @@ pub fn md_move_section(
     let policy = WritePolicy::default();
     // Write the destination file for cross-file moves.
     if let Some(dest_path) = to {
-        ensure_contained(guard, dest_path)?;
-        write_if_apply(dest_path, &new_dest, mode, &policy, guard)?;
+        if mode == ApplyMode::Apply {
+            ensure_contained(guard, dest_path)?;
+        }
+        let _ = write_if_apply(dest_path, &new_dest, mode, &policy, guard)?;
     }
-    ensure_contained(guard, path)?;
+    if mode == ApplyMode::Apply {
+        ensure_contained(guard, path)?;
+    }
     let applied = write_if_apply(path, &new_source, mode, &policy, guard)?;
     Ok(build_edit_result(&path_str, original, new_source, applied))
 }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -2244,7 +2244,9 @@ pub fn execute_plan_direct(
                 Operation::Read { path: p, .. } => Some(p.as_str()),
                 Operation::Search { path: p, .. } => Some(p.as_str()),
                 Operation::MdLintAgents { path: p, .. } => Some(p.as_str()),
+                #[cfg(feature = "ast")]
                 Operation::AstRename { path: p, .. } => Some(p.as_str()),
+                #[cfg(feature = "ast")]
                 Operation::AstReplace { path: p, .. } => Some(p.as_str()),
                 _ => None,
             } {


### PR DESCRIPTION
Cherry/recovery of small fixes from reviewer pass on the #760 batch (after auto-merge made the polish branch dead, per #759).

- ast cfg on validation match arms.
- md_move ensures only on Apply (for Preview/Check semantics).

Closes follow-ups from #755 #756.

