### PR TITLE
refactor: extract shared declared_paths helper for PathGuard validation (fixes #762)

### DIFF
--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -520,71 +520,26 @@ fn validate_operation_paths(
     )
     .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
     for op in operations {
-        let paths: Vec<&str> = match op {
-            Operation::DocSet { path, .. }
-            | Operation::DocDelete { path, .. }
-            | Operation::DocAppend { path, .. }
-            | Operation::DocPrepend { path, .. }
-            | Operation::DocEnsure { path, .. }
-            | Operation::DocDeleteWhere { path, .. }
-            | Operation::DocUpdate { path, .. }
-            | Operation::DocMove { path, .. }
-            | Operation::MdReplaceSection { path, .. }
-            | Operation::MdInsertAfterHeading { path, .. }
-            | Operation::MdInsertBeforeHeading { path, .. }
-            | Operation::MdUpsertBullet { path, .. }
-            | Operation::MdTableAppend { path, .. }
-            | Operation::MdDedupeHeadings { path, .. }
-            | Operation::MdLintAgents { path, .. }
-            | Operation::TidyFix { path, .. }
-            | Operation::FileAppend { path, .. }
-            | Operation::FileCreate { path, .. }
-            | Operation::FileDelete { path, .. }
-            | Operation::Read { path, .. }
-            | Operation::Search { path, .. } => vec![path.as_str()],
-            #[cfg(feature = "ast")]
-            Operation::AstRename { path, .. } | Operation::AstReplace { path, .. } => {
-                vec![path.as_str()]
-            }
-            Operation::MdMoveSection { path, to, .. } => {
-                let mut p = vec![path.as_str()];
-                if let Some(to) = to {
-                    p.push(to.as_str());
-                }
-                p
-            }
-            Operation::DocMerge { path, .. } => vec![path.as_str()],
-            Operation::Replace { path, glob, .. } => {
-                let mut p = Vec::new();
-                if let Some(path) = path {
-                    p.push(path.as_str());
-                }
-                if let Some(glob) = glob {
-                    p.push(glob.as_str());
-                }
-                p
-            }
-            Operation::FileRename { from, to, .. } => vec![from.as_str(), to.as_str()],
-            Operation::PatchApply { diff, .. } => {
-                // Validate paths embedded in the unified diff text (#229).
-                let patch_files = crate::ops::patch::parse_patch(diff).map_err(|e| {
-                    McpError::invalid_params(
-                        format!("failed to parse diff for path validation: {e}"),
-                        None,
-                    )
-                })?;
-                for pf in &patch_files {
-                    guard
-                        .check_path(&pf.path)
-                        .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
-                }
-                vec![]
-            }
-        };
-        for path in paths {
+        for path in crate::plan::declared_paths(op) {
             guard
                 .check_path(path)
                 .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        }
+        if let Operation::PatchApply { diff, .. } = op {
+            // Validate paths embedded in the unified diff text (special case
+            // because paths live inside the diff payload, not as top-level
+            // declared fields).
+            let patch_files = crate::ops::patch::parse_patch(diff).map_err(|e| {
+                McpError::invalid_params(
+                    format!("failed to parse diff for path validation: {e}"),
+                    None,
+                )
+            })?;
+            for pf in &patch_files {
+                guard
+                    .check_path(&pf.path)
+                    .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+            }
         }
     }
     Ok(())

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -2211,54 +2211,12 @@ pub fn execute_plan_direct(
     };
 
     // PathGuard enforcement for library callers of execute_plan (addresses #755).
-    // Upfront check on declared paths; dynamic (globs, patches) checked at use or best-effort.
+    // Upfront check on declared paths using shared helper; dynamic (globs
+    // patterns, patch embedded paths) are best-effort or handled by loaders.
     if let Some(g) = guard {
         for op in &plan.operations {
-            // Check primary path for most ops.
-            if let Some(p) = match op {
-                Operation::Replace { path: Some(p), .. } => Some(p.as_str()),
-                Operation::Replace { glob: Some(g), .. } => Some(g.as_str()), // pattern-level
-                Operation::DocSet { path: p, .. } => Some(p.as_str()),
-                Operation::DocDelete { path: p, .. } => Some(p.as_str()),
-                Operation::DocMerge { path: p, .. } => Some(p.as_str()),
-                Operation::DocAppend { path: p, .. } => Some(p.as_str()),
-                Operation::DocPrepend { path: p, .. } => Some(p.as_str()),
-                Operation::DocUpdate { path: p, .. } => Some(p.as_str()),
-                Operation::DocMove { path: p, .. } => Some(p.as_str()),
-                Operation::DocEnsure { path: p, .. } => Some(p.as_str()),
-                Operation::DocDeleteWhere { path: p, .. } => Some(p.as_str()),
-                Operation::MdReplaceSection { path: p, .. } => Some(p.as_str()),
-                Operation::MdInsertAfterHeading { path: p, .. } => Some(p.as_str()),
-                Operation::MdInsertBeforeHeading { path: p, .. } => Some(p.as_str()),
-                Operation::MdUpsertBullet { path: p, .. } => Some(p.as_str()),
-                Operation::MdTableAppend { path: p, .. } => Some(p.as_str()),
-                Operation::MdMoveSection { path: p, .. } => Some(p.as_str()),
-                Operation::MdDedupeHeadings { path: p, .. } => Some(p.as_str()),
-                Operation::TidyFix { path: p, .. } => Some(p.as_str()),
-                Operation::FileAppend { path: p, .. } => Some(p.as_str()),
-                Operation::FileCreate { path: p, .. } => Some(p.as_str()),
-                Operation::FileDelete { path: p, .. } => Some(p.as_str()),
-                Operation::FileRename { from: p, .. } => Some(p.as_str()),
-                Operation::PatchApply { .. } => None, // diff may contain paths; validated by MCP pre or at apply loader
-                Operation::Read { path: p, .. } => Some(p.as_str()),
-                Operation::Search { path: p, .. } => Some(p.as_str()),
-                Operation::MdLintAgents { path: p, .. } => Some(p.as_str()),
-                #[cfg(feature = "ast")]
-                Operation::AstRename { path: p, .. } => Some(p.as_str()),
-                #[cfg(feature = "ast")]
-                Operation::AstReplace { path: p, .. } => Some(p.as_str()),
-                _ => None,
-            } {
+            for p in crate::plan::declared_paths(op) {
                 g.check_path(p)
-                    .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
-            }
-            // Cross dest for move/rename.
-            if let Some(dest) = match op {
-                Operation::MdMoveSection { to: Some(d), .. } => Some(d.as_str()),
-                Operation::FileRename { to: d, .. } => Some(d.as_str()),
-                _ => None,
-            } {
-                g.check_path(dest)
                     .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
             }
         }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -272,6 +272,71 @@ pub enum Operation {
     },
 }
 
+/// Returns the file paths (as `&str`) that are declared by the operation
+/// and should be subject to PathGuard / containment validation.
+///
+/// This eliminates duplication between:
+/// - upfront checks in `execute_plan` (library use, #755)
+/// - test validation logic in MCP
+///
+/// - `Replace`: includes `path` (if present) and `glob` pattern (if present).
+/// - Cross-file ops (`FileRename`, `MdMoveSection`): includes both source
+///   and destination file paths.
+/// - `PatchApply`: returns empty; embedded paths are validated by the
+///   caller (MCP always parses the diff and checks before execute).
+/// - All other ops: their primary `path` (or equivalent).
+/// - AST variants are included only when the `ast` feature is enabled.
+pub(crate) fn declared_paths(op: &Operation) -> Vec<&str> {
+    match op {
+        Operation::Replace { path, glob, .. } => {
+            let mut p = Vec::new();
+            if let Some(s) = path {
+                p.push(s.as_str());
+            }
+            if let Some(s) = glob {
+                p.push(s.as_str());
+            }
+            p
+        }
+        Operation::FileRename { from, to, .. } => vec![from.as_str(), to.as_str()],
+        Operation::MdMoveSection { path, to, .. } => {
+            let mut p = vec![path.as_str()];
+            if let Some(t) = to {
+                p.push(t.as_str());
+            }
+            p
+        }
+        Operation::PatchApply { .. } => vec![],
+        // Single-path operations (file, doc, md, read, search, tidy, lint, etc.)
+        Operation::DocSet { path, .. }
+        | Operation::DocDelete { path, .. }
+        | Operation::DocMerge { path, .. }
+        | Operation::DocAppend { path, .. }
+        | Operation::DocPrepend { path, .. }
+        | Operation::DocUpdate { path, .. }
+        | Operation::DocMove { path, .. }
+        | Operation::DocEnsure { path, .. }
+        | Operation::DocDeleteWhere { path, .. }
+        | Operation::MdReplaceSection { path, .. }
+        | Operation::MdInsertAfterHeading { path, .. }
+        | Operation::MdInsertBeforeHeading { path, .. }
+        | Operation::MdUpsertBullet { path, .. }
+        | Operation::MdTableAppend { path, .. }
+        | Operation::MdDedupeHeadings { path, .. }
+        | Operation::TidyFix { path, .. }
+        | Operation::FileAppend { path, .. }
+        | Operation::FileCreate { path, .. }
+        | Operation::FileDelete { path, .. }
+        | Operation::Read { path, .. }
+        | Operation::Search { path, .. }
+        | Operation::MdLintAgents { path, .. } => vec![path.as_str()],
+        #[cfg(feature = "ast")]
+        Operation::AstRename { path, .. } | Operation::AstReplace { path, .. } => {
+            vec![path.as_str()]
+        }
+    }
+}
+
 /// A validation step to run after applying operations.
 #[derive(Debug, Deserialize, Serialize)]
 #[non_exhaustive]


### PR DESCRIPTION
Extracts a shared `pub(crate) fn declared_paths(op: &Operation) -> Vec<&str>` in `src/plan.rs`.

This removes duplication between:
- the large match in `tx::execute_plan_direct` for upfront PathGuard checks (library `execute_plan` + guard support from #755 batch)
- the similar match in `mcp::validate_operation_paths` (test helper)

The helper correctly handles:
- primary paths + globs for Replace
- cross-file dests (FileRename, MdMoveSection)
- all single-path ops
- PatchApply (returns empty; special-cased by callers that parse the diff)
- AST variants (cfg-gated)

Updated both call sites to use it. Net code reduction, easier maintenance for future ops.

Fixes #762 fully (as identified in the improve cycle).

All rechecks passed:
- `make check-fast`
- `cargo test --lib --all-features` + integration
- clippy -D warnings
- no-default + ast feature combos

Closes #762