### PR TITLE
test: direct coverage for declared_paths + remove dead TxState.guard (MPI)

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -463,19 +463,6 @@ struct TxState<'a> {
     cwd: &'a Path,
     quiet: bool,
     structured: bool,
-    #[allow(dead_code)]
-    guard: Option<&'a crate::containment::PathGuard>,
-}
-
-impl<'a> TxState<'a> {
-    #[allow(dead_code)]
-    fn check_path(&self, p: &str) -> anyhow::Result<()> {
-        if let Some(g) = self.guard {
-            g.check_path(p)
-                .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
-        }
-        Ok(())
-    }
 }
 
 /// Execute a replace operation within a transaction.
@@ -1820,7 +1807,6 @@ fn execute_and_collect(
     global: &GlobalFlags,
     quiet: bool,
     structured: bool,
-    guard: Option<&crate::containment::PathGuard>,
 ) -> anyhow::Result<TxExecResult> {
     let mut pending: HashMap<PathBuf, (String, String)> = HashMap::new();
     let mut deletions: HashSet<PathBuf> = HashSet::new();
@@ -1864,7 +1850,6 @@ fn execute_and_collect(
             cwd,
             quiet,
             structured,
-            guard,
         };
         match execute_operation(op, &mut tx) {
             Ok(count) => {
@@ -2223,7 +2208,7 @@ pub fn execute_plan_direct(
     }
 
     // Execute operations and collect changes in memory.
-    let mut result = match execute_and_collect(&plan, &effective_cwd, &global, true, true, guard) {
+    let mut result = match execute_and_collect(&plan, &effective_cwd, &global, true, true) {
         Ok(r) => r,
         Err(e) => {
             return Ok((
@@ -2375,8 +2360,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // 4. Execute all operations, collecting changes in memory (no writes).
-    let mut result = match execute_and_collect(&plan, &cwd, global, global.quiet, structured, None)
-    {
+    let mut result = match execute_and_collect(&plan, &cwd, global, global.quiet, structured) {
         Ok(r) => r,
         Err(e) => {
             let msg = e.to_string();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -624,4 +624,46 @@ mod tests {
         assert_eq!(val.required, Some(true));
         assert_eq!(val.timeout, Some(120));
     }
+
+    #[test]
+    fn declared_paths_covers_operation_variants() {
+        // Replace with path + glob (both collected for guard)
+        let json = r#"{"version":"1","operations":[{"op":"replace","path":"src/main.rs","glob":"**/*.rs","from":"old","to":"new"}]}"#;
+        let plan = parse_plan(json).unwrap();
+        let ps = declared_paths(&plan.operations[0]);
+        assert!(ps.contains(&"src/main.rs") && ps.contains(&"**/*.rs"));
+
+        // FileRename (cross-file paths)
+        let json = r#"{"version":"1","operations":[{"op":"file.rename","from":"old.txt","to":"new.txt","force":false}]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert_eq!(
+            declared_paths(&plan.operations[0]),
+            vec!["old.txt", "new.txt"]
+        );
+
+        // MdMoveSection same-file (to omitted)
+        let json = r#"{"version":"1","operations":[{"op":"md.move_section","path":"doc.md","heading":"Section"}]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert_eq!(declared_paths(&plan.operations[0]), vec!["doc.md"]);
+
+        // MdMoveSection cross-file
+        let json = r#"{"version":"1","operations":[{"op":"md.move_section","path":"src.md","heading":"H","to":"dst.md"}]}"#;
+        let plan = parse_plan(json).unwrap();
+        let ps = declared_paths(&plan.operations[0]);
+        assert!(ps.contains(&"src.md") && ps.contains(&"dst.md"));
+
+        // PatchApply: declared empty (diff paths handled by caller in MCP)
+        let json = r#"{"version":"1","operations":[{"op":"patch.apply","diff":"--- a/x\n+++ b/x\n@@ -1 +1 @@\n- old\n+ new\n"}]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert!(declared_paths(&plan.operations[0]).is_empty());
+
+        // Representative single-path ops
+        let json = r#"{"version":"1","operations":[{"op":"doc.set","path":"c.json","selector":"v","value":42}]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert_eq!(declared_paths(&plan.operations[0]), vec!["c.json"]);
+
+        let json = r#"{"version":"1","operations":[{"op":"read","path":"f.txt"}]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert_eq!(declared_paths(&plan.operations[0]), vec!["f.txt"]);
+    }
 }


### PR DESCRIPTION
QA + Developer perspective fixes from multi-perspective improvement loop (post #762 declared_paths extraction and PathGuard work).

- Added `declared_paths_covers_operation_variants` unit test exercising all arms of the shared helper (Replace path+glob, cross-file rename/move, Patch empty, single-path ops). Guards future op additions for guard validation in tx and mcp.
- Removed now-dead `TxState.guard` field and its `check_path` (upfront validation in execute_plan_direct + declared_paths is the active path; the stored field was unused after refactor).

Changes are small, targeted, with tests passing and clippy/fmt clean.

Refs: #762, #755 follow-ups, guard/tx/api hygiene.