### PR TITLE
docs: curate great RELEASE_NOTES.md for v0.4.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,54 @@
-## 0.4.0
+# Patchloom 0.4.0
 
-This is a major release focused on making Patchloom more usable as a library and improving long-term maintainability.
+This is a major release focused on making Patchloom an excellent, safe, and ergonomic library for Rust applications and AI coding agents, while continuing to polish the CLI and MCP surfaces.
 
-### Highlights
+## Highlights
 
-* **CLI is now optional**: The `cli` feature (clap + all commands) is enabled by default, but you can use `default-features = false` (or select only `mcp` and/or `ast`) for a much smaller dependency footprint when using Patchloom as a pure Rust library. This replaces the previous blunt `core` feature.
+**PathGuard for safe library embedding**
 
-* **More of the public API is reusable**: Types like `LintIssue` and others have been moved to more appropriate modules (e.g. `ops::md`) and re-exported so they can be used directly without pulling in command implementations.
+The biggest addition in 0.4.0 is first-class support for `PathGuard` (and the flexible `AbsolutePathPolicy` builder) across the entire public library API.
 
-* **Semver safety**: All public structs and enums are now marked `#[non_exhaustive]`. This prevents future breaking changes when new fields are added.
+- All high-level functions in `patchloom::api` (`replace_text`, `doc_*`, `md_*`, `file_*`, `tidy`, `execute_plan`, etc.) now accept an optional `guard: Option<&PathGuard>` as the final parameter.
+- `execute_plan` performs upfront validation using the centralized `declared_paths` helper.
+- The builder makes common relaxed policies easy: `PathGuard::builder(root).allow_temp_directory().build()`.
+- Strict `Reject` policy, cross-file operation safety (rename, md.move_section, etc.), and symlink-aware checks are all enforced at the right time.
 
-### Other changes
+This was driven by real downstream usage (e.g. bline) and closes a long tail of PathGuard-related tech debt (#748–#750, #755–#759, #762).
 
-See the full changelog in this PR for the complete list of features, fixes, and improvements that have landed since the last release.
+**Library modularity and semver safety**
+
+- The `cli` feature is now optional. Use `default-features = false` + `features = ["mcp", "ast"]` (or any subset) for a dramatically smaller dependency tree when embedding Patchloom.
+- Many public types were moved to more reusable locations (`ops`, `write`, etc.) and re-exported.
+- All public structs and enums are now `#[non_exhaustive]` for future-proofing.
+
+## Other notable improvements
+
+- Shared `declared_paths` helper eliminates duplicated path collection logic between `cmd/tx` upfront guard checks and MCP validation (#762).
+- Extensive new tests for guard behavior (relaxed policies, destination rejection, cross-file operations, cfg combinations).
+- Hygiene wins: removal of now-dead `TxState.guard` code, direct unit coverage for the path declaration helper, stronger test assertions in several areas.
+- Numerous fixes for atomicity, confirm flows, Windows path handling, and edge cases from the recent improvement cycles.
+- Better documentation and examples for the library API surface.
+
+## Migration notes
+
+If you were already using the library API, the new `guard` parameter is trailing and optional. Update call sites:
+
+```rust
+// Before
+api::replace_text(path, old, new, &opts, mode)?;
+
+// After (no guard)
+api::replace_text(path, old, new, &opts, mode, None)?;
+
+// With guard
+let guard = PathGuard::builder(cwd).allow_temp_directory().build()?;
+api::replace_text(path, old, new, &opts, mode, Some(&guard))?;
+```
+
+See the `patchloom::api` module documentation for full details and examples.
+
+## Thank you
+
+Thanks to everyone who filed issues, reviewed, and used the library in real agent tooling. This release makes the "library first" story much stronger.
+
+Full changelog and commit history are in the release PR.


### PR DESCRIPTION
Polished, user-facing release notes for the 0.4.0 release.

Highlights PathGuard / library embedding story, the declared_paths hygiene win, migration guidance, and the overall modularity/semver work.

This will be consumed by the release host job to produce the final GitHub Release description (per project process).

See also the version correction on the release-please PR #724 (now titled 0.4.0).