### PR TITLE
test: add tx guard rejection coverage + harden pty flake (QA)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3825,6 +3825,36 @@ fn test_tx_rollback_failed_when_restore_incomplete() {
     assert!(json["backup_session"].is_string());
 }
 
+/// Guard rejection during upfront declared_paths check in execute_plan_direct.
+/// Covers the PathGuard/tx validation path added for #755 (previously only
+/// exercised with `None` guard in integration, or unit tests in containment.rs).
+#[test]
+fn test_tx_guard_rejects_escaping_declared_path() {
+    let dir = TempDir::new().unwrap();
+    let guard = patchloom::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        patchloom::containment::AbsolutePathPolicy::Reject,
+    )
+    .unwrap();
+
+    // Relative escape via declared path (rename cross "file" uses both)
+    let plan: patchloom::plan::Plan = serde_json::from_value(serde_json::json!({
+        "version": "1",
+        "operations": [
+            {"op": "file.rename", "from": "ok.txt", "to": "../escape.txt", "force": false}
+        ]
+    }))
+    .unwrap();
+
+    let res = patchloom::cmd::tx::execute_plan_direct(plan, dir.path(), Some(&guard));
+    assert!(res.is_err(), "guard should reject before any apply");
+    let msg = res.unwrap_err().to_string();
+    assert!(
+        msg.contains("path rejected by workspace guard") || msg.contains("Escaped"),
+        "unexpected error: {msg}"
+    );
+}
+
 #[test]
 fn test_tx_success_applies_all() {
     let dir = TempDir::new().unwrap();

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -187,8 +187,11 @@ fn pty_append_confirm_yes_runs_format_command() {
 
     let mut session = spawn_pty(cmd);
 
-    // Consume diff output before matching the prompt.
-    session.expect("extra").expect("should see diff output");
+    // Consume diff output (header is reliably emitted early) before matching the prompt.
+    // "extra" (added content) may race under high load; filename in diff header is stable.
+    session
+        .expect("f.txt")
+        .expect("should see diff output (file header)");
     session.expect("Apply?").expect("should see Apply? prompt");
     session.send_line("y").expect("failed to send y");
     session.expect(Eof).expect("process should exit");


### PR DESCRIPTION
Gate-cleaned main, added integration test for PathGuard enforcement in execute_plan_direct (addresses test gap for recent #755 work). Hardened a timing-sensitive PTY expect in append-confirm test to use stable diff header string instead of content (reduces flakes under load).

- make check-fast green (after fix)
- explicit stage only changed tests
- DCO signed

Part of multi-perspective improve start.