### PR TITLE
test: strengthen weak ast map assertions (QA)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -19767,8 +19767,8 @@ fn test_ast_map_basic() {
         .args(["ast", "map", ".", "--json"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("a"))
-        .stdout(predicates::str::contains("b"));
+        .stdout(predicates::str::contains("\"name\": \"a\""))
+        .stdout(predicates::str::contains("\"name\": \"b\""));
 }
 
 #[test]


### PR DESCRIPTION
New MPI cycle after previous merge.

- QA: fixed weak 1-char contains("a")/("b") in test_ast_map_basic to precise "name": "x" JSON fields.
- Other perspectives: no actionable (conventions followed, docs adequate for change).
- Verified: specific test + clippy + integration with ast feature.
- Previous cycle fixes (guard tx test, pty hardening) already on main.

Part of ongoing improvement.