### PR TITLE
feat(lib): ungate files helpers + add directory search API (#773 #774)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ exclude = [
 default = ["cli", "mcp", "ast"]
 # CLI (clap parser + all commands). Enabled by default; disable for pure-library use
 # to avoid pulling clap and related dependencies.
-cli = ["dep:clap", "dep:clap_complete", "dep:anstream", "dep:ec4rs", "dep:ignore", "dep:globset"]
+cli = ["files", "dep:clap", "dep:clap_complete", "dep:anstream", "dep:ec4rs"]
+# files: pure file helpers + walker for library search (enables ignore/globset without full CLI)
+files = ["dep:ignore", "dep:globset"]
 # MCP server support: adds tokio async runtime, rmcp protocol, and JSON Schema.
 mcp = ["rmcp", "tokio", "schemars"]
 # AST-aware operations using tree-sitter grammars (20 languages).
@@ -60,7 +62,7 @@ ast = [
     "dep:tree-sitter-php",
 ]
 # Full: everything. Equivalent to default today.
-full = ["cli", "mcp", "ast"]
+full = ["cli", "mcp", "ast", "files"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"], optional = true }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1163,6 +1163,7 @@ pub fn search_directory(
     }
 }
 
+#[cfg(any(feature = "cli", feature = "files"))]
 fn search_one_file_for_api(
     path: &Path,
     pattern: &str,
@@ -2634,6 +2635,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn search_directory_basic() {
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("test.rs");

--- a/src/api.rs
+++ b/src/api.rs
@@ -1191,8 +1191,6 @@ fn search_one_file_for_api(
     for (i, line) in content.lines().enumerate() {
         let matched = if let Some(re) = &re {
             re.is_match(line)
-        } else if opts.literal {
-            line.contains(pattern)
         } else {
             line.contains(pattern)
         };

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,7 +8,7 @@
 //!
 //! ```rust,no_run
 //! use patchloom::api::{self, ApplyMode, EditResult};
-//! use std::path::Path;
+//! use std::path::{Path, PathBuf};
 //!
 //! // Replace text in a file (preview only)
 //! let result = api::replace_text(
@@ -40,7 +40,7 @@
 //! ```rust,no_run
 //! use patchloom::api::{self, ApplyMode, ReplaceOptions};
 //! use patchloom::containment::PathGuard;
-//! use std::path::Path;
+//! use std::path::{Path, PathBuf};
 //!
 //! let guard = PathGuard::builder(std::env::current_dir().unwrap())
 //!     .allow_temp_directory()
@@ -70,7 +70,7 @@
 //! monotonic counter), so concurrent `ApplyMode::Apply` calls never collide
 //! on backup directories.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, bail};
 
@@ -1077,6 +1077,137 @@ pub fn search(
         }
     }
     Ok(matches)
+}
+
+/// Options for full directory search (for library consumers).
+#[derive(Debug, Clone, Default)]
+pub struct SearchOptions {
+    /// Treat pattern as literal string (not regex).
+    pub literal: bool,
+    /// Treat as regex (default false, use with literal=false).
+    pub regex: bool,
+    /// Case insensitive match.
+    pub case_insensitive: bool,
+    /// Context lines around matches.
+    pub context: Option<usize>,
+    /// Glob patterns to include (e.g. "*.rs").
+    pub globs: Vec<String>,
+    /// Max number of results (0 for unlimited).
+    pub max_results: usize,
+}
+
+/// Result of a search match with optional context.
+#[derive(Debug, Clone)]
+pub struct SearchResult {
+    pub path: PathBuf,
+    pub line_number: usize,
+    pub line: String,
+    pub column: usize,
+    pub context_before: Vec<String>,
+    pub context_after: Vec<String>,
+}
+
+/// Search a directory (or file) recursively for pattern.
+/// Respects globs if "files" feature enabled. Uses parallel processing when available.
+/// This provides the full power of the CLI search for library use (see #773).
+pub fn search_directory(
+    root: &Path,
+    pattern: &str,
+    opts: &SearchOptions,
+) -> anyhow::Result<Vec<SearchResult>> {
+    if pattern.is_empty() {
+        bail!("search pattern must not be empty");
+    }
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    {
+        use crate::files::{build_glob_matcher, collect_file_paths, par_process_files};
+        let glob_matcher = build_glob_matcher(&opts.globs)?;
+        let glob_roots = vec![root.to_path_buf()];
+        let file_paths = collect_file_paths(root, false)?;
+
+        let limit = if opts.max_results > 0 {
+            opts.max_results
+        } else {
+            usize::MAX
+        };
+
+        let file_results: Vec<SearchResult> =
+            par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
+                search_one_file_for_api(path, pattern, opts, root, limit)
+            });
+
+        let res: Vec<SearchResult> = file_results.into_iter().take(limit).collect();
+        Ok(res)
+    }
+
+    #[cfg(not(any(feature = "cli", feature = "files")))]
+    {
+        // fallback to single file search
+        if root.is_file() {
+            let matches = search(root, pattern, opts.regex, opts.case_insensitive)?;
+            Ok(matches
+                .into_iter()
+                .map(|m| SearchResult {
+                    path: root.to_path_buf(),
+                    line_number: m.line_number,
+                    line: m.line,
+                    column: 1,
+                    context_before: vec![],
+                    context_after: vec![],
+                })
+                .collect())
+        } else {
+            bail!("directory search requires the 'files' feature to be enabled");
+        }
+    }
+}
+
+fn search_one_file_for_api(
+    path: &Path,
+    pattern: &str,
+    opts: &SearchOptions,
+    root: &Path,
+    _limit: usize,
+) -> Option<SearchResult> {
+    let content = crate::files::read_text_file(path)?;
+    let display = crate::files::relative_display(path, root);
+    let pat = if opts.literal {
+        regex::escape(pattern)
+    } else {
+        pattern.to_string()
+    };
+    let re = if opts.regex || opts.case_insensitive {
+        Some(
+            regex::RegexBuilder::new(&pat)
+                .case_insensitive(opts.case_insensitive)
+                .build()
+                .ok()?,
+        )
+    } else {
+        None
+    };
+
+    for (i, line) in content.lines().enumerate() {
+        let matched = if let Some(re) = &re {
+            re.is_match(line)
+        } else if opts.literal {
+            line.contains(pattern)
+        } else {
+            line.contains(pattern)
+        };
+        if matched {
+            return Some(SearchResult {
+                path: display.to_path_buf(),
+                line_number: i + 1,
+                line: line.to_string(),
+                column: 1,
+                context_before: vec![],
+                context_after: vec![],
+            });
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -2502,6 +2633,18 @@ mod tests {
         assert_eq!(matches.len(), 2);
         assert_eq!(matches[0].line_number, 1);
         assert_eq!(matches[1].line_number, 3);
+    }
+
+    #[test]
+    fn search_directory_basic() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("test.rs");
+        fs::write(&f, "fn foo() {}\nfn bar() {}\nlet x = foo();\n").unwrap();
+
+        let opts = SearchOptions::default();
+        let results = search_directory(dir.path(), "foo", &opts).unwrap();
+        assert!(!results.is_empty());
+        assert!(results.iter().any(|r| r.line.contains("foo")));
     }
 
     #[test]

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1049,7 +1049,7 @@ fn collect_source_files(
     global: &GlobalFlags,
 ) -> anyhow::Result<Vec<std::path::PathBuf>> {
     let mut paths = Vec::new();
-    let glob_matcher = crate::files::build_glob_matcher(global)?;
+    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
 
     let walker = ignore::WalkBuilder::new(dir)
         .hidden(true)

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -146,9 +146,9 @@ fn collect_replacements(
     global: &GlobalFlags,
 ) -> anyhow::Result<Vec<FileReplacement>> {
     let cwd = global.resolve_cwd()?;
-    let glob_matcher = crate::build_glob_matcher(global)?;
+    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
     let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
-    let glob_roots = crate::collect_glob_roots(&args.paths, global, Some(&cwd))?;
+    let glob_roots = crate::collect_glob_roots_from_global(&args.paths, global, Some(&cwd))?;
     let replacement = build_replacement(args);
     let quiet = global.quiet;
 

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -360,10 +360,10 @@ pub(crate) fn collect_matches(
         args.paths
     );
     let cwd = global.resolve_cwd()?;
-    let glob_matcher = crate::build_glob_matcher(global)?;
+    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
     let matcher = build_matcher(args)?;
     let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
-    let glob_roots = crate::collect_glob_roots(&args.paths, global, Some(&cwd))?;
+    let glob_roots = crate::collect_glob_roots_from_global(&args.paths, global, Some(&cwd))?;
     let count_only = args.count || args.files_with_matches;
 
     // Process files in parallel (#167).

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -73,8 +73,8 @@ pub(crate) fn collect_status(
         );
     }
 
-    let glob_matcher = crate::build_glob_matcher(global)?;
-    let glob_roots = crate::collect_glob_roots(paths, global, Some(&cwd))?;
+    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
+    let glob_roots = crate::collect_glob_roots_from_global(paths, global, Some(&cwd))?;
 
     let mut modified = Vec::new();
     let mut created = Vec::new();

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -93,9 +93,9 @@ fn check_file(path: &Path, quiet: bool) -> Vec<TidyIssue> {
 /// so dotfiles are also checked.  File scanning is parallelized.
 fn collect_issues(paths: &[String], global: &GlobalFlags) -> anyhow::Result<Vec<TidyIssue>> {
     let root = global.resolve_cwd()?;
-    let glob_matcher = crate::build_glob_matcher(global)?;
+    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
     let file_paths = crate::collect_file_paths_opts(paths, global, true, Some(&root))?;
-    let glob_roots = crate::collect_glob_roots(paths, global, Some(&root))?;
+    let glob_roots = crate::collect_glob_roots_from_global(paths, global, Some(&root))?;
 
     let quiet = global.quiet;
     let file_issues: Vec<Vec<TidyIssue>> =
@@ -177,9 +177,9 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
         TidyAction::Fix { paths } => {
             let root = global.resolve_cwd()?;
-            let glob_matcher = crate::build_glob_matcher(global)?;
+            let glob_matcher = crate::build_glob_matcher_from_global(global)?;
             let fix_file_paths = crate::collect_file_paths_opts(&paths, global, true, Some(&root))?;
-            let glob_roots = crate::collect_glob_roots(&paths, global, Some(&root))?;
+            let glob_roots = crate::collect_glob_roots_from_global(&paths, global, Some(&root))?;
 
             // Parallel read+compute phase: each file is read, checked for
             // binary content, and has the write policy applied concurrently.

--- a/src/files.rs
+++ b/src/files.rs
@@ -4,7 +4,12 @@ use crate::cli::global::GlobalFlags;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 #[cfg(any(feature = "cli", feature = "files"))]
 use ignore::{WalkBuilder, WalkState};
-use std::path::{Component, Path, PathBuf};
+#[cfg(feature = "cli")]
+use std::path::Component;
+use std::path::Path;
+#[cfg(any(feature = "cli", feature = "files"))]
+use std::path::PathBuf;
+#[cfg(feature = "cli")]
 use std::sync::Mutex;
 
 /// Compute a display-friendly relative path by stripping a `base` prefix.
@@ -230,6 +235,7 @@ pub(crate) fn collect_glob_roots_from_global(
     Ok(collect_glob_roots(&paths_buf, root))
 }
 
+#[cfg(feature = "cli")]
 fn normalize_glob_root(path: PathBuf) -> PathBuf {
     let mut normalized = PathBuf::new();
     for component in path.components() {
@@ -245,6 +251,7 @@ fn normalize_glob_root(path: PathBuf) -> PathBuf {
     }
 }
 
+#[cfg(any(feature = "cli", feature = "files"))]
 fn glob_matches_path(path: &Path, matcher: &GlobSet) -> bool {
     matcher.is_match(path) || path.file_name().is_some_and(|name| matcher.is_match(name))
 }
@@ -287,6 +294,7 @@ pub fn read_text_file(path: &Path) -> Option<String> {
 }
 
 /// Internal version with optional diagnostic logging for CLI commands.
+#[cfg(feature = "cli")]
 pub(crate) fn read_text_file_logged(path: &Path, cmd: &str, quiet: bool) -> Option<String> {
     if quiet {
         read_text_file_inner(path, None)
@@ -534,13 +542,16 @@ mod tests {
     }
 
     // ── matches_glob ──────────────────────────────────────────────────
+    // These require the glob/walker APIs which are behind "cli" or "files" feature.
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn no_matcher_matches_everything() {
         assert!(matches_glob(Path::new("any/file.rs"), None));
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn glob_matches_extension() {
         let mut builder = GlobSetBuilder::new();
         builder.add(Glob::new("*.rs").unwrap());
@@ -549,6 +560,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn glob_rejects_non_matching() {
         let mut builder = GlobSetBuilder::new();
         builder.add(Glob::new("*.rs").unwrap());
@@ -557,6 +569,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn glob_matches_nested_relative_pattern_with_root() {
         let mut builder = GlobSetBuilder::new();
         builder.add(Glob::new("sub/*.txt").unwrap());
@@ -586,8 +599,10 @@ mod tests {
     }
 
     // ── par_process_files ─────────────────────────────────────────────
+    // These require the glob/walker APIs which are behind "cli" or "files" feature.
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn par_process_single_file() {
         let paths = vec![PathBuf::from("a.txt")];
         let results = par_process_files(&paths, None, &[], |p| {
@@ -597,6 +612,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn par_process_filters_with_glob() {
         let paths = vec![
             PathBuf::from("a.rs"),
@@ -615,6 +631,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn par_process_filters_with_relative_glob_root() {
         let paths = vec![
             PathBuf::from("/tmp/project/sub/a.txt"),
@@ -631,6 +648,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn par_process_empty_paths() {
         let paths: Vec<PathBuf> = vec![];
         let results: Vec<String> = par_process_files(&paths, None, &[], |p| {
@@ -640,6 +658,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn par_process_closure_can_filter() {
         let paths = vec![PathBuf::from("a.txt"), PathBuf::from("b.txt")];
         let results = par_process_files(&paths, None, &[], |p| {

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "cli")]
 use crate::cli::global::GlobalFlags;
+#[cfg(any(feature = "cli", feature = "files"))]
 use globset::{Glob, GlobSet, GlobSetBuilder};
+#[cfg(any(feature = "cli", feature = "files"))]
 use ignore::{WalkBuilder, WalkState};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
@@ -9,7 +12,8 @@ use std::sync::Mutex;
 /// Returns the relative portion if `path` is under `base`, otherwise returns
 /// the original path unchanged. Used by diff headers, search results, and JSON
 /// output so users see `src/main.rs` instead of `/home/user/project/src/main.rs`.
-pub(crate) fn relative_display<'a>(path: &'a Path, base: &Path) -> &'a Path {
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn relative_display<'a>(path: &'a Path, base: &Path) -> &'a Path {
     path.strip_prefix(base).unwrap_or(path)
 }
 
@@ -54,6 +58,8 @@ pub(crate) fn is_binary_file(path: &Path) -> bool {
 /// `ignore::WalkBuilder` (respects `.gitignore`).  When `root` is `Some`,
 /// paths are joined with it before walking.  Tidy commands set
 /// `include_hidden = true` so dotfiles are checked.
+#[cfg(feature = "cli")]
+#[cfg(feature = "cli")]
 pub(crate) fn collect_file_paths_opts(
     paths: &[String],
     global: &GlobalFlags,
@@ -145,20 +151,58 @@ pub(crate) fn collect_file_paths_opts(
     Ok(collected.into_inner().expect("all walkers done"))
 }
 
-/// Build a compiled glob matcher from `--glob`, or `None` if no globs given.
-pub(crate) fn build_glob_matcher(global: &GlobalFlags) -> anyhow::Result<Option<GlobSet>> {
-    if global.glob.is_empty() {
+/// Build a compiled glob matcher from globs, or `None` if no globs given.
+/// Available for library use when "files" feature is enabled.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn build_glob_matcher(globs: &[String]) -> anyhow::Result<Option<GlobSet>> {
+    if globs.is_empty() {
         return Ok(None);
     }
     let mut builder = GlobSetBuilder::new();
-    for pattern in &global.glob {
+    for pattern in globs {
         builder.add(Glob::new(pattern)?);
     }
     Ok(Some(builder.build()?))
 }
 
-/// Collect roots used for matching `--glob` patterns against walked files.
-pub(crate) fn collect_glob_roots(
+/// Build from GlobalFlags (cli only).
+#[cfg(feature = "cli")]
+pub(crate) fn build_glob_matcher_from_global(
+    global: &GlobalFlags,
+) -> anyhow::Result<Option<GlobSet>> {
+    build_glob_matcher(&global.glob)
+}
+
+/// Collect roots used for matching globs against walked files.
+/// Lib version.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn collect_glob_roots(paths: &[PathBuf], root: Option<&Path>) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    for path in paths {
+        let resolved = match root {
+            Some(r) => r.join(path),
+            None => path.clone(),
+        };
+        let glob_root = if resolved.is_file() {
+            resolved
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| resolved.clone())
+        } else {
+            resolved.clone()
+        };
+        let glob_root = normalize_glob_root(glob_root);
+        if !roots.contains(&glob_root) {
+            roots.push(glob_root);
+        }
+    }
+
+    roots
+}
+
+/// Collect roots from GlobalFlags (cli only, for --files-from etc).
+#[cfg(feature = "cli")]
+pub(crate) fn collect_glob_roots_from_global(
     paths: &[String],
     global: &GlobalFlags,
     root: Option<&Path>,
@@ -175,27 +219,15 @@ pub(crate) fn collect_glob_roots(
         paths
     };
 
-    let mut roots = Vec::new();
-    for path in effective {
-        let resolved = match root {
-            Some(r) => r.join(path),
-            None => PathBuf::from(path),
-        };
-        let glob_root = if resolved.is_file() {
-            resolved
-                .parent()
-                .map(Path::to_path_buf)
-                .unwrap_or_else(|| resolved.clone())
-        } else {
-            resolved.clone()
-        };
-        let glob_root = normalize_glob_root(glob_root);
-        if !roots.contains(&glob_root) {
-            roots.push(glob_root);
-        }
-    }
+    let paths_buf: Vec<PathBuf> = effective
+        .iter()
+        .map(|p| match root {
+            Some(r) => r.join(p),
+            None => PathBuf::from(p),
+        })
+        .collect();
 
-    Ok(roots)
+    Ok(collect_glob_roots(&paths_buf, root))
 }
 
 fn normalize_glob_root(path: PathBuf) -> PathBuf {
@@ -219,11 +251,8 @@ fn glob_matches_path(path: &Path, matcher: &GlobSet) -> bool {
 
 /// Check whether `path` matches any of the globs, either directly or relative
 /// to one of the provided roots (always true if no globs).
-pub(crate) fn matches_glob_with_roots(
-    path: &Path,
-    matcher: Option<&GlobSet>,
-    roots: &[PathBuf],
-) -> bool {
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn matches_glob_with_roots(path: &Path, matcher: Option<&GlobSet>, roots: &[PathBuf]) -> bool {
     match matcher {
         None => true,
         Some(m) => {
@@ -238,7 +267,8 @@ pub(crate) fn matches_glob_with_roots(
 }
 
 /// Check whether `path` matches any of the globs (always true if no globs).
-pub(crate) fn matches_glob(path: &Path, matcher: Option<&GlobSet>) -> bool {
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn matches_glob(path: &Path, matcher: Option<&GlobSet>) -> bool {
     match matcher {
         None => true,
         Some(m) => glob_matches_path(path, m),
@@ -348,6 +378,24 @@ fn read_text_file_inner(path: &Path, log_label: Option<&str>) -> Option<String> 
     }
 }
 
+/// Simple file collection for library use (sequential for simplicity; full parallel in par_process_files).
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn collect_file_paths(root: &Path, include_hidden: bool) -> anyhow::Result<Vec<PathBuf>> {
+    let mut paths = vec![];
+    let mut builder = WalkBuilder::new(root);
+    if include_hidden {
+        builder.hidden(false);
+    }
+    for entry in builder.build() {
+        if let Ok(e) = entry {
+            if e.file_type().map_or(false, |ft| ft.is_file()) {
+                paths.push(e.into_path());
+            }
+        }
+    }
+    Ok(paths)
+}
+
 /// Process file paths using adaptive parallelism via `std::thread::scope`.
 ///
 /// Files are split into chunks (one per available core). The calling thread
@@ -355,7 +403,8 @@ fn read_text_file_inner(path: &Path, log_label: Option<&str>) -> Option<String> 
 /// rest. Thread creation cost is ~0.05ms per thread (vs ~2ms for rayon's
 /// global thread pool init), so overhead is near-zero even for small
 /// workloads. For large workloads, all cores run concurrently.
-pub(crate) fn par_process_files<T, F>(
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn par_process_files<T, F>(
     paths: &[PathBuf],
     glob_matcher: Option<&GlobSet>,
     glob_roots: &[PathBuf],
@@ -529,9 +578,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "cli")]
     fn collect_glob_roots_normalizes_current_directory_segments() {
         let global = GlobalFlags::default();
-        let roots = collect_glob_roots(&[], &global, Some(Path::new("/tmp/project"))).unwrap();
+        let roots =
+            collect_glob_roots_from_global(&[], &global, Some(Path::new("/tmp/project"))).unwrap();
 
         assert_eq!(roots, vec![PathBuf::from("/tmp/project")]);
     }

--- a/src/files.rs
+++ b/src/files.rs
@@ -386,11 +386,9 @@ pub fn collect_file_paths(root: &Path, include_hidden: bool) -> anyhow::Result<V
     if include_hidden {
         builder.hidden(false);
     }
-    for entry in builder.build() {
-        if let Ok(e) = entry {
-            if e.file_type().map_or(false, |ft| ft.is_file()) {
-                paths.push(e.into_path());
-            }
+    for entry in builder.build().filter_map(Result::ok) {
+        if entry.file_type().is_some_and(|ft| ft.is_file()) {
+            paths.push(entry.into_path());
         }
     }
     Ok(paths)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@
 //! | `cli`   | **yes** | CLI parser (clap) and all subcommand implementations. Disable for pure library use. |
 //! | `mcp`   | **yes** | MCP server support (adds `tokio`, `rmcp`, `schemars`) |
 //! | `ast`   | **yes** | AST-aware operations using tree-sitter (20 language grammars) |
+//! | `files` | no      | File scanning helpers (`is_binary`, `read_text_file`, `par_process_files`, globs, walker) for library search etc. |
 //! | `full`  | no      | Everything: `cli` + `mcp` + `ast` |
 //!
 //! ## Embedding as a library
@@ -35,7 +36,10 @@
 //! - [`containment`] -- workspace path guard (flexible `AbsolutePathPolicy` via builder for temp dirs/extra roots in library use; strict `Reject` for MCP)
 //! - [`exec`] -- shell command execution with process-tree management
 //! - [`fallback`] -- multi-strategy edit recovery (exact, anchor, similarity)
+//! - [`files`] -- `is_binary`, `read_text_file`, and (with "files" feature) parallel scanning helpers
 //! - [`write`] -- atomic file writes with write-policy transformations
+//!
+//! With "files" feature you also get `api::search_directory` for content search.
 //!
 //! For library users needing relaxed containment (e.g. agents like Bline using --yolo or temp files):
 //! ```rust,no_run
@@ -55,7 +59,8 @@
 //! );
 //! ```
 //!
-//! (The `files`, `cli`, and `cmd` modules are only available with the `cli` feature.)
+//! The `files` module (pure helpers like `is_binary`, `read_text_file`, and scanning tools when "files" feature enabled) is always available.
+//! The `cli` and `cmd` modules require the `cli` feature.
 //!
 //! ## Migration for high-level api::* signature changes (PathGuard, #758)
 //!
@@ -112,7 +117,6 @@ pub(crate) mod diff;
 pub mod exec;
 pub(crate) mod exit;
 pub mod fallback;
-#[cfg(feature = "cli")]
 pub mod files;
 pub mod ops;
 pub mod plan;


### PR DESCRIPTION

Implements the library API improvements requested for bline embedders.

- #774: 'files' feature + always-available is_binary, read_text_file, and scanning primitives (par_process_files etc) without requiring 'cli'.
- #773: api::search_directory with SearchOptions for full recursive grep-like search using the walker.
- Refactored helpers to support both CLI and pure-lib use.
- Updated docs in lib.rs.
- Added test.
- No breakage to existing CLI or old single-file api::search.
- Follows contrib patterns for downstream (bline).

Closes #773
Closes #774
