### PR TITLE
test: PathGuard coverage and DRY from QA/Dev perspectives (MPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ api::doc_set(
 )?;
 ```
 
-All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking and binary detection), and `write` (atomic file writes with policy transformations). See the `patchloom::api` module docs for the full surface.
+All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking and binary detection), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS per #781); see the `containment` and `api` module rustdocs. See the `patchloom::api` module docs for the full surface.
 
 ## Getting started
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1495,6 +1495,37 @@ mod tests {
         assert!(on_disk.contains("new_name"));
     }
 
+    /// QA coverage: exercise actual write to a conventional temp path using high-level api
+    /// under .allow_temp_directory() guard (the main motivation for relaxed policy in
+    /// library use by agents). Uses literal /tmp (exercises #781 fix path + ancestor canon).
+    #[cfg(unix)]
+    #[test]
+    fn file_create_writes_to_literal_tmp_under_allow_temp_guard() {
+        let dir = TempDir::new().unwrap();
+        let guard = PathGuard::builder(dir.path().to_path_buf())
+            .allow_temp_directory()
+            .build()
+            .unwrap();
+
+        let tmp_path = format!("/tmp/patchloom_api_tmp_test_{}.txt", std::process::id());
+        let _ = fs::remove_file(&tmp_path);
+
+        let result = file_create(
+            Path::new(&tmp_path),
+            "temp content via guard\n",
+            true, // force ok for test
+            ApplyMode::Apply,
+            Some(&guard),
+        )
+        .unwrap();
+
+        assert!(result.applied);
+        assert!(result.changed);
+        let content = fs::read_to_string(&tmp_path).unwrap();
+        assert!(content.contains("temp content via guard"));
+        let _ = fs::remove_file(&tmp_path);
+    }
+
     #[test]
     fn md_replace_section_works() {
         let dir = TempDir::new().unwrap();

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -302,9 +302,10 @@ mod tests {
     fn completion_install_path_returns_some_for_known_shells() {
         // Requires HOME to be set (normal in test environments).
         if std::env::var("HOME").is_ok() {
-            assert!(completion_install_path("bash").is_some());
-            assert!(completion_install_path("zsh").is_some());
-            assert!(completion_install_path("fish").is_some());
+            // strengthened from bare is_some per Test Auditor (gives message on fail)
+            let _ = completion_install_path("bash").expect("bash shell path");
+            let _ = completion_install_path("zsh").expect("zsh shell path");
+            let _ = completion_install_path("fish").expect("fish shell path");
             assert!(completion_install_path("elvish").is_none());
         }
     }

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -79,13 +79,10 @@ fn system_temp_directory_roots() -> Vec<PathBuf> {
 
     #[cfg(unix)]
     {
-        roots.push(PathBuf::from("/tmp"));
-        roots.push(PathBuf::from("/var/tmp"));
+        push_unique(&mut roots, PathBuf::from("/tmp"));
+        push_unique(&mut roots, PathBuf::from("/var/tmp"));
         if let Ok(v) = std::env::var("TMPDIR") {
-            let p = PathBuf::from(v);
-            if !roots.contains(&p) {
-                roots.push(p);
-            }
+            push_unique(&mut roots, PathBuf::from(v));
         }
     }
 
@@ -93,15 +90,20 @@ fn system_temp_directory_roots() -> Vec<PathBuf> {
     {
         for var in ["TEMP", "TMP"] {
             if let Ok(v) = std::env::var(var) {
-                let p = PathBuf::from(v);
-                if !roots.contains(&p) {
-                    roots.push(p);
-                }
+                push_unique(&mut roots, PathBuf::from(v));
             }
         }
     }
 
     roots
+}
+
+/// Helper to keep additional roots deduplicated (used by temp root builder
+/// and policy merge paths).
+fn push_unique(roots: &mut Vec<PathBuf>, p: PathBuf) {
+    if !roots.contains(&p) {
+        roots.push(p);
+    }
 }
 
 impl AbsolutePathPolicy {
@@ -334,9 +336,7 @@ impl PathGuardBuilder {
             }
             AbsolutePathPolicy::AllowAdditionalRoots(mut roots) => {
                 for t in temps {
-                    if !roots.contains(&t) {
-                        roots.push(t);
-                    }
+                    push_unique(&mut roots, t);
                 }
                 AbsolutePathPolicy::AllowAdditionalRoots(roots)
             }
@@ -353,9 +353,7 @@ impl PathGuardBuilder {
                 AbsolutePathPolicy::AllowAdditionalRoots(vec![extra])
             }
             AbsolutePathPolicy::AllowAdditionalRoots(mut roots) => {
-                if !roots.contains(&extra) {
-                    roots.push(extra);
-                }
+                push_unique(&mut roots, extra);
                 AbsolutePathPolicy::AllowAdditionalRoots(roots)
             }
         };
@@ -813,5 +811,26 @@ mod tests {
             let stdt = std::env::temp_dir();
             assert!(roots.iter().any(|r| r == &stdt));
         }
+    }
+
+    /// Regression for coverage: paths using ../ to escape an *allowed additional root*
+    /// (e.g. literal /tmp on macOS) must still be rejected after canonicalization.
+    /// This was not explicitly asserted in prior temp-allow tests.
+    #[cfg(unix)]
+    #[test]
+    fn allow_temp_rejects_escape_from_tmp_via_parent() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let guard = PathGuard::builder(dir.path().to_path_buf())
+            .allow_temp_directory()
+            .build()
+            .unwrap();
+
+        let escape_path = "/tmp/../etc/passwd";
+        let err = guard.check_path(escape_path).unwrap_err();
+        assert!(
+            matches!(err, ContainmentError::Escaped { .. }),
+            "expected Escaped for escape from /tmp root via .., got {:?}",
+            err
+        );
     }
 }

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -647,7 +647,8 @@ mod tests {
             path: "test".to_string(),
             source: io_err,
         };
-        assert!(err.source().is_some());
+        // strengthened (was bare is_some); expect gives context on failure
+        let _src = err.source().expect("Canonicalize error must carry inner io source");
         let msg = err.to_string();
         assert!(msg.contains("failed to canonicalize"), "got: {msg}");
     }

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -648,7 +648,9 @@ mod tests {
             source: io_err,
         };
         // strengthened (was bare is_some); expect gives context on failure
-        let _src = err.source().expect("Canonicalize error must carry inner io source");
+        let _src = err
+            .source()
+            .expect("Canonicalize error must carry inner io source");
         let msg = err.to_string();
         assert!(msg.contains("failed to canonicalize"), "got: {msg}");
     }


### PR DESCRIPTION
Improvements found in first perspectives of MPI rotation, focused on recent containment fix (#782).

- test: escape and api temp path coverage (QA)
- refactor: push_unique helper (Dev)
- docs: README mention for library users (End User)

Builds on the just-merged #782 for the fix code.

See also open tech-debts #778 etc from prior.

Will continue rotation and post-cycle gate.