### PR TITLE
test: MPI cycle 1 (QA glob test + lib api ref doc)

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -267,6 +267,11 @@ These are the main entry points. If you are deciding between commands, start her
 - **What it does:** Prints the contents of one or more files, optionally restricted to a line range. Multiple files get `==> path <==` separators in text mode, a JSON array in `--json` mode, and one object per line in `--jsonl` mode. If at least one requested file is read successfully, the command still exits successfully and reports errors only for the missing files.
 - **Use when:** An agent needs to inspect one or several files before deciding on an edit. For AI agents, native read_file tools are typically faster for single-file reads.
 - **Prefer instead:** Use `search` when you need pattern matching, or `doc get` when the file is structured and you want a single value.
+
+## Library API
+
+Patchloom can be used as a Rust library (disable default `cli` feature for smaller dep). See `patchloom::api` (search_directory with context/globs/max_results, replace_text, read, etc) and `execute_plan` for tx. Full details and examples in crate docs and README "Embedding as a library". Recent expansions (#779 etc) and hygiene (#784) improved coverage.
+
 - **Related:** `search`, `doc get`
 
 <!-- ref:command:status -->

--- a/src/api.rs
+++ b/src/api.rs
@@ -2800,6 +2800,20 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
+    fn search_directory_invalid_glob_errors() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("f.txt"), "content\n").unwrap();
+        let opts = SearchOptions {
+            globs: vec!["[unclosed".to_string()],
+            ..Default::default()
+        };
+        let err = search_directory(dir.path(), "foo", &opts).unwrap_err();
+        // exact message from glob parse (exercises build_glob_matcher error path)
+        assert!(err.to_string().contains("parsing glob") || err.to_string().contains("unclosed"));
+    }
+
+    #[test]
     fn search_no_match_returns_empty() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("code.rs");


### PR DESCRIPTION
Full multi-perspective-improve cycle 1 for patchloom (after pre-rotation gate).

**Pre-rotation gate completed:**
- CI: links 504 transient on release (report only).
- Open PRs: only #776 release 0.5.0 (approved/BLOCKED, report only - do not merge).
- Open issues: #784 #787 #788 fixed via hygiene PR #789 (assertions, audit script, examples note + recent #784 summary included); #632 #633 #634 noted as larger dist work (>15min, external accounts) with comments.
- Clean tree, branch hygiene.

**Cycle rotations (14 perspectives, mechanical checks throughout):**
- Included previous/recent work summary in every iter to avoid rediscovery: hygiene fixes for #784 (asserts/contains), #787 (script), #788 (examples/doc contains) in unmerged #789 + prior #786 etc.
- QA: fixed missing glob error path test for api::search_directory.
- All others (Dev, EndUser, Maint, Ops, Sec, PM, Spec, Perf, Compat, Adv, Arch, Contrib, Obs): no-op after greps (unwraps, short contains, dead_code, globs, errors, wrapping, docs, etc).
- 1 fix total this cycle.

**Post-cycle 5 checks (all passed):**
- A untracked: no dead allows, no untracked workarounds, weak in hygiene scope.
- B docs: added Library API section to reference/README.md; examples verified.
- C skill: updated patchloom-contrib with MPI gate + summary lesson.
- D/E: no new issues; tracked via #784 etc + PRs.

See gate todos and iters for details. Recent hygiene included to avoid rediscovery.

Closes nothing new (hygiene issues via #789).