### PR TITLE
docs: clarify RestoreFailGuard canonical location after #792 extraction

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,7 +165,7 @@ All subcommands receive a `&GlobalFlags` reference. Read-only flags (`--json`, `
 - Test both the internal functions and the public `run()` function to verify exit codes.
 - When embedding file paths in YAML or TOML plan strings in integration tests, use `portable_path_str(&path)` (defined in `tests/integration.rs`) to convert backslashes to forward slashes. Windows paths like `C:\Users` contain `\U` which YAML and TOML parsers interpret as a unicode escape sequence.
 - For non-existent file paths in tests, use `nonexistent_path("name")` which returns a platform-appropriate path.
-- `cargo test --lib` runs tests in parallel (CI too). For test-only failure-injection hooks, use `thread_local!` plus an RAII guard (e.g. `RestoreFailGuard` in `src/cmd/tx.rs`), not a process-global `static`. Verify hook-related unit tests with `cargo test --lib <filter> -- --test-threads=16` before push.
+- `cargo test --lib` runs tests in parallel (CI too). For test-only failure-injection hooks, use `thread_local!` plus an RAII guard (e.g. `RestoreFailGuard`, defined in `src/tx.rs` and re-exported via `cmd::tx` for CLI/test paths), not a process-global `static`. Verify hook-related unit tests with `cargo test --lib <filter> -- --test-threads=16` before push.
 - Integration tests that need `#[cfg(test)]` hooks on tx commit/rollback paths must call in-process helpers such as `execute_plan_direct()` in `tests/integration.rs`. `assert_cmd::cargo_bin` subprocesses load the release binary and cannot see library `cfg(test)` hooks.
 
 ### Writes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,10 @@
 //! The `files` module (pure helpers like `is_binary`, `read_text_file`, and scanning tools when "files" feature enabled) is always available.
 //! The `cli` and `cmd` modules require the `cli` feature.
 //!
+//! For pure library use with plans and execution (post #792), prefer
+//! `features = ["ast", "files"]` (or "files"). `execute_plan` is available
+//! under `any(feature = "cli", "files")` and delegates to the `tx` module.
+//!
 //! ## Migration for high-level api::* signature changes (PathGuard, #758)
 //!
 //! The addition of the trailing `guard: Option<&PathGuard>` parameter to all mutating


### PR DESCRIPTION
Closes #792 (documentation/guard location follow-up).

This updates the canonical location note in AGENTS.md (and adds a small lib.rs note) to match the tx module extraction and re-export in the #792/#793 library embedding work.

Addresses remaining tech-debt items around docs and pure-library usage notes in #794-#802.

Changes:
- AGENTS.md: update RestoreFailGuard example to `src/tx.rs` + reexport via cmd::tx
- src/lib.rs: note on execute_plan availability with "files" feature for library embedders

The core implementation (src/tx.rs engine, execute_plan under files, file_append, hygiene for ast+files builds) landed in #793.

Refs: #792, #793, #798

Signed-off-by: $(git config user.name) <$(git config user.email)>