### PR TITLE
test: strengthen invalid plan explain error assertion (QA hygiene for #799)

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8805,7 +8805,7 @@ fn test_explain_invalid_plan_fails() {
         .arg(&plan)
         .assert()
         .failure()
-        .stderr(predicate::str::contains(""));
+        .stderr(predicate::str::contains("expected ident").or(predicate::str::contains("parse")));
 }
 
 #[test]


### PR DESCRIPTION
QA perspective fix for remaining #792 tech-debt coverage (#799).

Strengthened bare .failure() + empty contains in explain invalid plan test to specific error content.

Refs open #799, #794 flake context.

Part of MPI cycle 1.

Closes nothing new yet; more in loop.