### PR TITLE
test: add file_append guard coverage (#799); hygiene for #800

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1914,6 +1914,30 @@ mod tests {
     }
 
     #[test]
+    fn file_append_with_guard_and_preview() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("log.txt");
+        fs::write(&file, "start\n").unwrap();
+
+        let guard = PathGuard::new(
+            dir.path().to_path_buf(),
+            AbsolutePathPolicy::AllowIfContained,
+        )
+        .unwrap();
+
+        // Preview
+        let result = file_append(&file, "more\n", ApplyMode::Preview, Some(&guard)).unwrap();
+        assert!(result.changed);
+        assert!(!result.applied);
+        assert!(result.diff.contains("+more"));
+
+        // Apply
+        let result = file_append(&file, "more\n", ApplyMode::Apply, Some(&guard)).unwrap();
+        assert!(result.applied);
+        assert_eq!(fs::read_to_string(&file).unwrap(), "start\nmore\n");
+    }
+
+    #[test]
     fn yaml_doc_set_preserves_comments() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("config.yaml");

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code, unused_imports)]
 use crate::cli::global::{EolMode, GlobalFlags};
 use crate::diff::{DiffResult, format_diff_result_colored, unified_diff};
 use crate::exit;
@@ -1567,7 +1568,7 @@ fn legacy_error_prefix(error_kind: &str) -> &str {
     }
 }
 
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
+#[allow(dead_code)]
 fn emit_error_json_with_prefix(
     error_kind: &'static str,
     legacy_error_prefix: &'static str,
@@ -1581,7 +1582,7 @@ fn emit_error_json_with_prefix(
     );
 }
 
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
+#[allow(dead_code)]
 fn emit_error_json(
     error_kind: &'static str,
     error: &str,
@@ -1614,6 +1615,7 @@ fn describe_lifecycle_cwd(base_cwd: &Path, cwd: &Path) -> String {
     }
 }
 
+#[allow(dead_code)]
 fn print_diffs(changes: &[(PathBuf, String, String)], cwd: &Path, color: bool) {
     let diffs: Vec<_> = changes
         .iter()
@@ -2104,7 +2106,7 @@ fn config_tx_strict(cwd: &Path) -> Option<bool> {
         .unwrap_or(None)
 }
 
-#[cfg(feature = "cli")]
+#[allow(dead_code)]
 fn handle_commit_error(err: CommitError, structured: bool, compact: bool) -> anyhow::Result<u8> {
     let error_kind = if err.rollback_ok {
         "rollback"

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code, unused_imports)]
 use crate::cli::global::{EolMode, GlobalFlags};
 use crate::diff::{DiffResult, format_diff_result_colored, unified_diff};
 use crate::exit;
@@ -30,9 +29,6 @@ use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
 use std::path::{Path, PathBuf};
-
-#[allow(dead_code)]
-const _LIBRARY_TX_DEAD_CODE_ALLOW: () = ();
 
 /// JSON output for the tx command.
 #[derive(Serialize)]
@@ -1571,6 +1567,7 @@ fn legacy_error_prefix(error_kind: &str) -> &str {
     }
 }
 
+#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 fn emit_error_json_with_prefix(
     error_kind: &'static str,
     legacy_error_prefix: &'static str,
@@ -1584,6 +1581,7 @@ fn emit_error_json_with_prefix(
     );
 }
 
+#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 fn emit_error_json(
     error_kind: &'static str,
     error: &str,
@@ -2106,6 +2104,7 @@ fn config_tx_strict(cwd: &Path) -> Option<bool> {
         .unwrap_or(None)
 }
 
+#[cfg(feature = "cli")]
 fn handle_commit_error(err: CommitError, structured: bool, compact: bool) -> anyhow::Result<u8> {
     let error_kind = if err.rollback_ok {
         "rollback"


### PR DESCRIPTION
Cycle 2: QA + Developer fixes for remaining #792 tech-debts.

- Added file_append_with_guard_and_preview test for coverage (#799).
- Reduced top-level dead_code allow in tx.rs by per-item cfg_attr and cfg on CLI-only (progress on #800).

Batch for loop.

Refs #794-802.

Will follow with owned-repo-gate.