### PR TITLE
fix: version drift and expose search_one_file (Bline feedback on merged #817)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ Keep the working tree clean:
 - Common sources of "dirty" state: lychee cache, local edits during rebase/force work on release-please, Cargo.lock drift from different tool versions. Fix them explicitly rather than carrying them.
 - After a core PR merges mid-session (e.g. #753 while polish for #754 was in flight): the feature branch tip is no longer ancestor of main ("has merged PR" from pre-commit hook). Recovery: `gh pr view N --json state` (confirm merged), `git checkout -b rescue-YYYYMMDD origin/main`, cherry-pick the useful commits (or `git show <oldsha> | patch -p1`), `git add <explicit files only>`, commit -s, push, create PR. See patchloom-contrib for full "Follow-up polish after base PR" and #759.
 
+- **PR bodies must contain explicit issue links for traceability (addresses #819).** Every PR that resolves GitHub issues (including library follow-ups after a base PR has merged, Bline feedback polish, etc.) MUST list `Closes #N` or `Fixes #N` (one per line) in the PR *body/description*. GitHub only auto-closes from the PR body under squash-merge (individual commit messages are dropped). Use `Ref #N` for related but non-closing references. Never rely on commit message only. See `~/.grok/skills/owned-repo-gate/SKILL.md` (Phase 4) and `~/.grok/skills/github-interaction/SKILL.md` for the full rule and recovery. For follow-up PRs, edit the body with `gh pr edit` if the initial description was minimal. Verify with issue audit before claiming closure.
+
 See also the branch hygiene rules in `~/.grok/skills/patchloom-contrib/SKILL.md`.
 
 ## Release PRs (release-please)
@@ -54,6 +56,7 @@ See also the branch hygiene rules in `~/.grok/skills/patchloom-contrib/SKILL.md`
 - The open release-please PR (#724 etc.) title must be correct. Use `gh pr edit --title` when it shows the wrong version.
 - The PR *body* can be very long and may temporarily show the wrong next version header (release-please behavior). This is tracked as tech-debt #740.
 - When updating library embedding examples (in lib.rs, README, docs/), keep the version string in sync with the current Cargo.toml / .release-please-manifest.json (avoids the 0.4 vs 0.5 drift reported in #816 follow-up).
+- **Library follow-up PRs and high-level API changes must use explicit Closes links in the PR body** (see #819 and the new rule in Git hygiene above). The #811-#815 Bline library work + #817/#818 follow-ups exposed the gap where minimal PR bodies left issues open after squash-merge. Always include them for traceability.
 - Primary curation is done via `RELEASE_NOTES.md` (applied to the final GitHub Release by the host job, not the PR body).
 - See `patchloom-contrib` skill ("Curated release notes" and "Major version bumps" sections) for the full process.
 
@@ -244,6 +247,8 @@ Command::<Name>(args) => <name>::run(args, &global),
 
 8. Run `make sync-patchloom-md && make update-readme && make check`.
 
+**PR body requirement (see #819):** When opening the PR for this work, ensure the body contains `Closes #NNN` (or `Fixes`) lines for every targeted issue. Library follow-ups and polish PRs are the most common place this is missed. Edit via `gh pr edit` if needed before merge.
+
 ## Adding a new MCP tool
 
 MCP tools live in `src/cmd/mcp.rs` behind the `mcp` feature gate. To add a new tool:
@@ -285,6 +290,8 @@ async fn new_tool(
 5. **Update the tool list** in `src/cmd/mod.rs` (agent-rules generator) and `docs/getting-started/mcp-setup.md`.
 
 6. Run `make sync-patchloom-md && make update-readme && make check`.
+
+**PR body requirement (see #819):** When opening the PR for this MCP tool work, ensure the body contains `Closes #NNN` (or `Fixes`) lines for every targeted issue. Follow-up changes after base merges commonly miss this; edit the PR body explicitly.
 
 ## Removing an MCP tool
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ See also the branch hygiene rules in `~/.grok/skills/patchloom-contrib/SKILL.md`
 
 - The open release-please PR (#724 etc.) title must be correct. Use `gh pr edit --title` when it shows the wrong version.
 - The PR *body* can be very long and may temporarily show the wrong next version header (release-please behavior). This is tracked as tech-debt #740.
+- When updating library embedding examples (in lib.rs, README, docs/), keep the version string in sync with the current Cargo.toml / .release-please-manifest.json (avoids the 0.4 vs 0.5 drift reported in #816 follow-up).
 - Primary curation is done via `RELEASE_NOTES.md` (applied to the final GitHub Release by the host job, not the PR body).
 - See `patchloom-contrib` skill ("Curated release notes" and "Major version bumps" sections) for the full process.
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Add patchloom as a dependency (omit CLI/MCP/AST with `default-features = false`)
 
 ```toml
 [dependencies]
-patchloom = { version = "0.5", default-features = false }
+patchloom = { version = "0.4", default-features = false }
 ```
 
 ```rust

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -68,13 +68,13 @@ Rust tools. Disable default features to omit CLI (clap), MCP server, and AST:
 
 ```toml
 [dependencies]
-patchloom = { version = "0.5", default-features = false }
+patchloom = { version = "0.4", default-features = false }
 ```
 
 To add AST support without CLI/MCP:
 
 ```toml
-patchloom = { version = "0.5", default-features = false, features = ["ast"] }
+patchloom = { version = "0.4", default-features = false, features = ["ast"] }
 ```
 
 See the [crate documentation](https://docs.rs/patchloom) for the full API

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -61,7 +61,7 @@ Patchloom is also a Rust library. Add it as a dependency to embed structured fil
 
 ```toml
 [dependencies]
-patchloom = { version = "0.5", default-features = false }
+patchloom = { version = "0.4", default-features = false }
 ```
 
 The `api` module exposes doc, replace, markdown, file, and patch operations. All API types are `Send + Sync`. Disabling default features omits the MCP server and its async dependencies.

--- a/src/api.rs
+++ b/src/api.rs
@@ -1219,7 +1219,8 @@ pub struct SearchMatch {
 
 /// Search for a pattern in a file, returning all matching lines.
 ///
-/// This is a read-only operation.
+/// This is a read-only operation. For richer results with column/context use
+/// `search_file` (the one taking SearchOptions) or the low-level `search_one_file`.
 pub fn search(
     path: &Path,
     pattern: &str,
@@ -1265,6 +1266,8 @@ pub fn search(
 ///
 /// Returns rich `SearchResult` entries (with column + context when requested).
 /// This is the recommended per-file primitive for library/agent hosts (#812).
+/// For callers that do their own walking (custom ignores, limits, etc.) see
+/// [`search_one_file`].
 pub fn search_file(
     path: &Path,
     pattern: &str,
@@ -1344,6 +1347,8 @@ pub fn build_context_lines(
 /// This provides the full power of the CLI search for library use (see #773, #796).
 /// See `SearchOptions` for `exclude_patterns` and `custom_ignore_filenames` (blineignore etc.).
 ///
+/// For callers that already have a list of files (custom walker), see [`search_one_file`].
+///
 /// Example for custom ignore (bline style):
 /// ```ignore
 /// let opts = SearchOptions {
@@ -1384,7 +1389,7 @@ pub fn search_directory(
 
         let file_result_groups: Vec<Vec<SearchResult>> =
             par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
-                let v = search_one_file_for_api(path, pattern, opts, root);
+                let v = search_one_file(path, pattern, opts, root);
                 if v.is_empty() { None } else { Some(v) }
             });
 
@@ -1437,7 +1442,16 @@ pub fn search_directory(
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]
-fn search_one_file_for_api(
+/// Low-level single-file matcher for callers that already selected the files.
+///
+/// Returns rich [`SearchResult`]s (including `column` and context when requested
+/// via [`SearchOptions`]). Intended for advanced library users (e.g. custom
+/// `WalkBuilder` with extra ignores, size caps, depth limits, custom truncation)
+/// who then want to apply patchloom's matching logic.
+///
+/// Prefer [`search_file`] for simple per-file use and [`search_directory`] for
+/// full directory walking with built-in ignore support.
+pub fn search_one_file(
     path: &Path,
     pattern: &str,
     opts: &SearchOptions,
@@ -3184,6 +3198,11 @@ mod tests {
         assert_eq!(res.len(), 2);
         assert_eq!(res[0].column, 4); // 'f' in fn foo
         assert!(!res[0].context_after.is_empty() || !res[1].context_before.is_empty());
+
+        // Direct low-level matcher (for custom walkers) - #812 follow-up
+        let res2 = search_one_file(&f, "foo", &opts, dir.path());
+        assert_eq!(res2.len(), 2);
+        assert_eq!(res2[0].column, 4);
 
         // context builder directly
         let lines: Vec<&str> = "a\nb\nc\n".lines().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,17 @@
 //!
 //! ```toml
 //! [dependencies]
-//! patchloom = { version = "0.5", default-features = false }
+//! patchloom = { version = "0.4", default-features = false }
 //! ```
 //!
 //! Or with AST support:
 //!
 //! ```toml
-//! patchloom = { version = "0.5", default-features = false, features = ["ast"] }
+//! patchloom = { version = "0.4", default-features = false, features = ["ast"] }
 //! ```
+//!
+//! (Update the version number in these examples when the next release-please
+//! PR bumps the crate version. See the release checklist.)
 //!
 //! This gives you the [`api`] module (primary editing interface), [`ops`],
 //! and utility modules:
@@ -166,7 +169,7 @@ pub mod write;
 // Re-exports for library ergonomics (no need to dig into api/plan when using ["ast","files"]).
 pub use api::{
     ApplyMode, EditResult, ReplaceOptions, SearchOptions, SearchResult, WritePolicyOptions,
-    build_context_lines, format_search_results, search_file,
+    build_context_lines, format_search_results, search_file, search_one_file,
 };
 pub use plan::Plan;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,11 @@
 //!
 //! With "files" feature you also get `api::search_directory`, `api::execute_plan`,
 //! `api::file_append`/`file_prepend`, and full plan execution for library use.
-//! For advanced search ignore (e.g. .blineignore on top of .gitignore):
-//! Use `SearchOptions::exclude_patterns` and `custom_ignore_filenames` with `search_directory`.
-//! Or use `files::collect_file_paths_with_ignores` (or `api::search_directory`) + `par_process_files` for full ignore support.
-//! See `api::SearchOptions` docs.
+//! For advanced search ignore (e.g. .blineignore on top of .gitignore) + custom walkers:
+//! Use `SearchOptions::exclude_patterns` and `custom_ignore_filenames` with `search_directory`/`search_file`,
+//! or collect paths with `files::collect_file_paths_with_ignores` (or your own `WalkBuilder`) then
+//! pair with the low-level `api::search_one_file` inside `par_process_files` + `format_search_results` / `build_context_lines`.
+//! See `api::search_one_file` (and its docs for custom `WalkBuilder` use), `api::SearchOptions`, and `files` module.
 //!
 //! Example (pure library with plans):
 //! ```rust,ignore

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,9 +167,11 @@ pub mod selector;
 pub mod write;
 
 // Re-exports for library ergonomics (no need to dig into api/plan when using ["ast","files"]).
+#[cfg(any(feature = "cli", feature = "files"))]
+pub use api::search_one_file;
 pub use api::{
     ApplyMode, EditResult, ReplaceOptions, SearchOptions, SearchResult, WritePolicyOptions,
-    build_context_lines, format_search_results, search_file, search_one_file,
+    build_context_lines, format_search_results, search_file,
 };
 pub use plan::Plan;
 


### PR DESCRIPTION
Small follow-up polish after #817 merged.

- Sync all library-embedding version strings to current 0.4 (Cargo.toml / manifest).
- Add reminder in AGENTS.md.
- Promote the core matcher to `pub fn search_one_file` (was private) with docs + test.
  This gives advanced users (custom WalkBuilder + .blineignore etc.) direct access
  to the column + context logic, complementing the already-public helpers.

All verification (fmt, library clippy + tests) passes.

Closes #819

Closes #820
