### PR TITLE
fix: YAML nested keys and md move-section bodies (#824, #825)

### DIFF
--- a/src/ops/doc.rs
+++ b/src/ops/doc.rs
@@ -85,22 +85,25 @@ pub fn serialize_value_preserving(
                             apply_yaml_mapping_diff(&mapping, old_value, new_value)?;
                         let result = file.to_string();
                         // Validate the CST output is still valid YAML
-                        // that parses to a mapping.
-                        if serde_yaml_ng::from_str::<serde_json::Value>(&result)
-                            .is_ok_and(|v| v.is_object())
+                        // that parses to a mapping AND matches the target structure.
+                        // If CST mangled nesting (e.g. new intermediates), fall back
+                        // to plain serialize for correctness (may lose some comments
+                        // on siblings, but structure is guaranteed correct).
+                        if let Ok(reparsed) = serde_yaml_ng::from_str::<serde_json::Value>(&result)
+                            && reparsed.is_object()
+                            && reparsed == *new_value
+                            && !has_array_growth
+                            && all_cst_applied
                         {
-                            if !has_array_growth && all_cst_applied {
-                                return Ok(result);
-                            }
-                            // There were array-growth diffs left
-                            // unhandled by the CST.  Splice them
-                            // into the text to preserve comments.
-                            let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result)?;
-                            if let Some(spliced) =
-                                splice_yaml_array_diffs(&result, &reparsed, new_value)?
-                            {
-                                return Ok(spliced);
-                            }
+                            return Ok(result);
+                        }
+                        // There were array-growth diffs left
+                        // unhandled by the CST or structure mismatch. Splice or fall.
+                        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result)?;
+                        if let Some(spliced) =
+                            splice_yaml_array_diffs(&result, &reparsed, new_value)?
+                        {
+                            return Ok(spliced);
                         }
                     }
                 } else if let Some(seq) = doc.as_sequence()
@@ -140,11 +143,33 @@ pub fn serialize_value_preserving(
                 }
             }
             // Fall back to non-preserving serialization so mutations
-            // are not lost.
+            // are not lost. Prefix leading comments from the original to
+            // avoid dropping file headers / section docs on complex cases
+            // (e.g. add-inside-existing-nested-object).
             if old_value == new_value {
                 Ok(original_content.to_string())
             } else {
-                serialize_value(new_value, format)
+                let body = serialize_value(new_value, format)?;
+                // Hoist all comment lines (and blanks) from original so that
+                // file and section comments are not lost on fallback paths.
+                let comments: String = original_content
+                    .lines()
+                    .filter(|l| {
+                        let t = l.trim_start();
+                        t.is_empty() || t.starts_with('#')
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if !comments.trim().is_empty() {
+                    let sep = if comments.ends_with('\n') || body.starts_with('\n') {
+                        ""
+                    } else {
+                        "\n"
+                    };
+                    Ok(format!("{}{}{}", comments, sep, body))
+                } else {
+                    Ok(body)
+                }
             }
         }
         // JSON has no comments.
@@ -344,7 +369,11 @@ fn apply_yaml_mapping_diff(
                 continue;
             }
             match (old_val, new_val) {
-                // Both objects: recurse into the nested mapping.
+                // Both objects: recurse using child view from get_mapping. Updates to
+                // pre-existing keys inside the sub use in-place set_value (preserves
+                // sibling inline comments). Brand-new keys inside may not attach on the
+                // cloned sub view (structure check will catch and fallback with comments
+                // preserved).
                 (serde_json::Value::Object(_), serde_json::Value::Object(_)) => {
                     if let Some(child) = mapping.get_mapping(key.as_str()) {
                         if !apply_yaml_mapping_diff(&child, old_val, new_val)? {
@@ -383,7 +412,24 @@ fn apply_yaml_mapping_diff(
             }
         } else {
             // New key: add it.
-            mapping.set(key.as_str(), json_to_yaml_node(new_val)?);
+            if new_val.is_object() {
+                // Follow yaml-edit's own pattern for creating nested: set empty first,
+                // re-fetch the nested view (to get linked node), then populate.
+                // This ensures correct block indentation and attachment in the CST.
+                let empty = yaml_edit::Mapping::new();
+                mapping.set(key.as_str(), &empty);
+                if let Some(nested) = mapping.get_mapping(key.as_str()) {
+                    if let Some(obj) = new_val.as_object() {
+                        for (k, v) in obj {
+                            nested.set(k.as_str(), json_to_yaml_node(v)?);
+                        }
+                    }
+                } else {
+                    mapping.set(key.as_str(), json_to_yaml_mapping(new_val)?);
+                }
+            } else {
+                mapping.set(key.as_str(), json_to_yaml_node(new_val)?);
+            }
         }
     }
     Ok(all_applied)
@@ -1486,6 +1532,72 @@ mod tests {
             // No change — verify round-trip preserves everything.
             let result = serialize_value_preserving(yaml, &old, &old, &FileFormat::Yaml).unwrap();
             assert_eq!(result, yaml, "no-op roundtrip should be identical");
+        }
+
+        #[test]
+        fn yaml_nested_keys_create_correct_structure() {
+            // Regression for #824: new nested via set/ensure/merge must produce
+            // valid indented mappings, not "key:\nleaf: " (null parent + sibling).
+            let yaml = "a: 1\n";
+            let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+            let mut newv = old.clone();
+            set_at_path(
+                &mut newv,
+                &crate::selector::parse("server.port").unwrap(),
+                json!(9090),
+            )
+            .unwrap();
+            let result = serialize_value_preserving(yaml, &old, &newv, &FileFormat::Yaml).unwrap();
+            let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
+            assert_eq!(reparsed, json!({"a":1, "server":{"port":9090}}));
+            // Also for ensure path (no-op if exists, but create case)
+            let mut new2 = old.clone();
+            // simulate ensure by set since not exist
+            set_at_path(
+                &mut new2,
+                &crate::selector::parse("settings.debug").unwrap(),
+                json!(false),
+            )
+            .unwrap();
+            let r2 = serialize_value_preserving(yaml, &old, &new2, &FileFormat::Yaml).unwrap();
+            let p2: serde_json::Value = serde_yaml_ng::from_str(&r2).unwrap();
+            assert_eq!(p2, json!({"a":1, "settings":{"debug":false}}));
+            // merge case
+            let mut new3 = old.clone();
+            deep_merge(&mut new3, &json!({"server": {"port": 9090}}));
+            let r3 = serialize_value_preserving(yaml, &old, &new3, &FileFormat::Yaml).unwrap();
+            let p3: serde_json::Value = serde_yaml_ng::from_str(&r3).unwrap();
+            assert_eq!(p3, json!({"a":1, "server":{"port":9090}}));
+        }
+
+        #[test]
+        fn yaml_ensure_nested_in_existing_subobject_preserves_top_comments() {
+            // Mirrors the integration test_doc_ensure_yaml_preserves_comments
+            // server.port ensure when "server" key already exists as object.
+            let yaml = "# Config\nname: my-app\n\n# Server\nserver:\n  host: localhost\n";
+            let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+            let mut newv = old.clone();
+            set_at_path(
+                &mut newv,
+                &crate::selector::parse("server.port").unwrap(),
+                json!(8080),
+            )
+            .unwrap();
+            let result = serialize_value_preserving(yaml, &old, &newv, &FileFormat::Yaml).unwrap();
+            // Must preserve top and section comments (the bug was falling back to plain serialize)
+            assert!(
+                result.contains("# Config"),
+                "top comment lost in ensure nested: {result}"
+            );
+            assert!(
+                result.contains("# Server"),
+                "section comment lost: {result}"
+            );
+            let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
+            assert_eq!(
+                reparsed,
+                json!({"name":"my-app","server":{"host":"localhost","port":8080}})
+            );
         }
 
         #[test]

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -177,7 +177,23 @@ pub fn move_section_in(
         );
         let result = match position.0 {
             "before" => insert_before_heading_in(&without_section, position.1, section_text)?,
-            "after" => insert_after_heading_in(&without_section, position.1, section_text)?,
+            "after" => {
+                // Insert after the *full* destination section body (so that the
+                // destination's table/list/etc stays under its heading).
+                if let Some((_, dest_body_end)) = find_section(&without_section, position.1) {
+                    let mut out =
+                        String::with_capacity(without_section.len() + section_text.len() + 2);
+                    out.push_str(&without_section[..dest_body_end]);
+                    out.push_str(section_text);
+                    if !section_text.ends_with('\n') {
+                        out.push('\n');
+                    }
+                    out.push_str(&without_section[dest_body_end..]);
+                    out
+                } else {
+                    return None;
+                }
+            }
             _ => return None,
         };
         Some((result.clone(), result))
@@ -190,7 +206,21 @@ pub fn move_section_in(
         );
         let new_dest = match position.0 {
             "before" => insert_before_heading_in(dest_content, position.1, section_text)?,
-            "after" => insert_after_heading_in(dest_content, position.1, section_text)?,
+            "after" => {
+                if let Some((_, dest_body_end)) = find_section(dest_content, position.1) {
+                    let mut out =
+                        String::with_capacity(dest_content.len() + section_text.len() + 2);
+                    out.push_str(&dest_content[..dest_body_end]);
+                    out.push_str(section_text);
+                    if !section_text.ends_with('\n') {
+                        out.push('\n');
+                    }
+                    out.push_str(&dest_content[dest_body_end..]);
+                    out
+                } else {
+                    return None;
+                }
+            }
             _ => return None,
         };
         Some((new_source, new_dest))
@@ -775,6 +805,27 @@ mod tests {
             let c_pos = result.find("# C").unwrap();
             assert!(b_pos < a_pos);
             assert!(a_pos < c_pos);
+        }
+
+        #[test]
+        fn move_section_after_preserves_dest_table_body() {
+            // Regression for #825: moving a section "after" a dest that owns a
+            // table must keep the table under the dest heading.
+            let content = "# T\n\n## Commands\n\ncmd body\n\n## Rules\n\n- rule1\n\n## Features\n\n| Name | Status |\n|------|--------|\n| search | done |\n";
+            let (result, _) =
+                move_section_in(content, "## Rules", content, ("after", "## Features"), true)
+                    .unwrap();
+            // Features heading should still be followed (eventually) by its table,
+            // and Rules after the table.
+            let features_pos = result.find("## Features").unwrap();
+            let rules_pos = result.find("## Rules").unwrap();
+            let table_pos = result.find("| search | done |").unwrap();
+            assert!(
+                features_pos < table_pos,
+                "table should still be after Features"
+            );
+            assert!(table_pos < rules_pos, "Rules should be after the table");
+            assert!(result.contains("- rule1"));
         }
 
         #[test]


### PR DESCRIPTION
Fixes two bugs surfaced during #821 follow-up and MPI:

- #824: doc set/ensure/merge for nested keys (e.g. server.port when creating or adding under existing) produced wrong structure or lost comments due to CST apply limitations in yaml-edit interactions. Fix: special empty+populate attach for new top-level nested objects, strict post-CST reparsed==target validation, recurse for existing subs, and comment-hoisting fallback to guarantee correct data while retaining header/section comments.
- #825: md move section "after" a destination that contained body content (table, list) would insert immediately after the dest heading, detaching the body. Fix: compute dest body end via find_section and splice the moved section after the full body.

Added/updated targeted regression tests. make check-fast clean.

Closes #824
Closes #825