### PR TITLE
refactor: mcp handler dedup + tx execution unification (long-file hygiene)

### DIFF
--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -749,10 +749,6 @@ fn doc_readonly(action: &crate::cmd::doc::DocAction) -> Result<CallToolResult, M
     exit_code_to_result(code, &output, "No results.")
 }
 
-fn make_plan(operations: Vec<Operation>) -> Plan {
-    make_plan_strict(operations, None)
-}
-
 fn make_plan_strict(operations: Vec<Operation>, strict: Option<bool>) -> Plan {
     Plan {
         version: crate::plan::SCHEMA_VERSION.to_string(),
@@ -1157,13 +1153,12 @@ impl PatchloomService {
         Parameters(p): Parameters<ReadFileParams>,
     ) -> Result<CallToolResult, McpError> {
         self.check_path(&p.path)?;
-        execute_plan_validated(
-            make_plan(vec![Operation::Read {
+        self.run_ops(
+            vec![Operation::Read {
                 path: p.path,
                 lines: p.lines,
-            }]),
-            self.cwd(),
-            Some(&self.path_guard),
+            }],
+            None,
         )
     }
 
@@ -1395,16 +1390,15 @@ impl PatchloomService {
                 None,
             ));
         }
-        execute_plan_validated(
-            make_plan(vec![Operation::MdMoveSection {
+        self.run_ops(
+            vec![Operation::MdMoveSection {
                 path: p.path,
                 heading: p.heading,
                 to: p.to,
                 before: p.before,
                 after: p.after,
-            }]),
-            self.cwd(),
-            Some(&self.path_guard),
+            }],
+            None,
         )
     }
 
@@ -1539,18 +1533,12 @@ impl PatchloomService {
             self.check_path(&pf.path)?;
         }
 
-        execute_plan_validated(
-            make_plan_strict(
-                vec![Operation::PatchApply {
-                    diff: p.diff,
-                    on_stale: p.on_stale,
-                    allow_conflicts: p.allow_conflicts,
-                }],
-                Some(p.strict),
-            ),
-            self.cwd(),
-            Some(&self.path_guard),
-        )
+        let op = Operation::PatchApply {
+            diff: p.diff,
+            on_stale: p.on_stale,
+            allow_conflicts: p.allow_conflicts,
+        };
+        self.run_ops(vec![op], Some(p.strict))
     }
 
     #[tool(
@@ -1599,11 +1587,7 @@ impl PatchloomService {
                 after_context: None,
             })
             .collect();
-        execute_plan_validated(
-            make_plan_strict(ops, Some(p.strict)),
-            self.cwd(),
-            Some(&self.path_guard),
-        )
+        self.run_ops(ops, Some(p.strict))
     }
 
     #[tool(
@@ -1633,11 +1617,7 @@ impl PatchloomService {
                 normalize_eol: None,
             })
             .collect();
-        execute_plan_validated(
-            make_plan_strict(ops, Some(p.strict)),
-            self.cwd(),
-            Some(&self.path_guard),
-        )
+        self.run_ops(ops, Some(p.strict))
     }
 
     #[tool(

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1,12 +1,8 @@
-#![allow(dead_code)]
-
 use crate::cli::global::{EolMode, GlobalFlags};
 use crate::diff::{DiffResult, format_diff_result_colored, unified_diff};
 use crate::exit;
 
-use crate::ops::replace::{
-    ReplaceModeError, validate_replace_mode,
-};
+use crate::ops::replace::{ReplaceModeError, validate_replace_mode};
 use crate::plan::{self, Operation, Plan};
 use crate::selector;
 use crate::tx::{
@@ -20,8 +16,7 @@ use globset::Glob;
 use ignore::WalkBuilder;
 use regex::RegexBuilder;
 
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use std::path::{Path, PathBuf};
 
@@ -156,11 +151,6 @@ fn parse_selector(input: &str) -> anyhow::Result<selector::Selector> {
     selector::parse_anyhow(input)
 }
 
-
-
-
-
-
 // ---------------------------------------------------------------------------
 // Write policy
 // ---------------------------------------------------------------------------
@@ -181,31 +171,7 @@ fn plan_normalize_eol(mode: &str) -> anyhow::Result<EolMode> {
 /// Start from the CLI-derived per-file defaults, including any EditorConfig
 /// values resolved by `policy_from_flags()`, then let plan-level `write_policy`
 /// entries override only the keys they set.
-fn build_write_policy(
-    plan: &Plan,
-    global: &GlobalFlags,
-    path: &Path,
-) -> anyhow::Result<WritePolicy> {
-    let mut write_policy = crate::write::policy_from_flags(global, Some(path));
-    let Some(plan_write_policy) = &plan.write_policy else {
-        return Ok(write_policy);
-    };
 
-    if let Some(ensure_final_newline) = plan_write_policy.ensure_final_newline {
-        write_policy.ensure_final_newline = ensure_final_newline;
-    }
-    if let Some(normalize_eol) = plan_write_policy.normalize_eol.as_deref() {
-        write_policy.normalize_eol = plan_normalize_eol(normalize_eol)?;
-    }
-    if let Some(trim_trailing_whitespace) = plan_write_policy.trim_trailing_whitespace {
-        write_policy.trim_trailing_whitespace = trim_trailing_whitespace;
-    }
-    if let Some(collapse_blanks) = plan_write_policy.collapse_blanks {
-        write_policy.collapse_blanks = collapse_blanks;
-    }
-
-    Ok(write_policy)
-}
 
 // ---------------------------------------------------------------------------
 // Diff output helper
@@ -543,63 +509,7 @@ fn run_lifecycle(plan: &Plan, base_cwd: &Path, cwd: &Path) -> Option<LifecycleEr
         })
 }
 
-pub(crate) fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathBuf {
-    match plan_cwd {
-        Some(plan_cwd) => {
-            let path = Path::new(plan_cwd);
-            if path.is_absolute() {
-                path.to_path_buf()
-            } else {
-                base_cwd.join(path)
-            }
-        }
-        None => base_cwd.to_path_buf(),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Direct execution (MCP / in-process callers)
-// ---------------------------------------------------------------------------
-
 pub use crate::tx::RestoreFailGuard;
-
-/// Restore files from a backup session after a failed commit. Returns `true`
-/// when restore completed successfully.
-fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
-    crate::tx::restore_after_failed_commit(cwd, timestamp)
-}
-
-/// Apply pending changes to disk: backup originals, write modified files,
-/// delete removed files, finalize backup session.
-///
-/// If any write fails, restores all already-written files from the backup
-/// session before returning [`CommitError`].
-/// Build a JSON error string without writing to stdout.
-fn make_error_json(error_kind: &'static str, error: &str, backup_session: Option<&str>) -> String {
-    make_error_json_with_prefix(
-        error_kind,
-        legacy_error_prefix(error_kind),
-        error,
-        backup_session,
-    )
-}
-
-/// Build a JSON error string with an explicit legacy prefix.
-#[allow(dead_code)]
-fn make_error_json_with_prefix(
-    error_kind: &'static str,
-    legacy_error_prefix: &str,
-    error: &str,
-    backup_session: Option<&str>,
-) -> String {
-    serde_json::to_string_pretty(&build_error_output(
-        error_kind,
-        legacy_error_prefix,
-        error,
-        backup_session,
-    ))
-    .unwrap_or_default()
-}
 
 #[allow(dead_code)]
 fn config_tx_strict(cwd: &Path) -> Option<bool> {
@@ -959,80 +869,6 @@ mod tests {
 
     fn portable_path_str(p: &std::path::Path) -> String {
         p.to_str().unwrap().replace('\\', "/")
-    }
-
-    #[test]
-    fn read_file_content_populates_pending_from_disk() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("existing.txt");
-        fs::write(&path, "hello from disk\n").unwrap();
-        let mut pending = HashMap::new();
-        let mut existed = HashSet::new();
-
-        let content = read_file_content(&mut pending, &mut existed, &path).unwrap();
-
-        assert_eq!(content, "hello from disk\n");
-        assert_eq!(
-            pending.get(&path),
-            Some(&(
-                "hello from disk\n".to_string(),
-                "hello from disk\n".to_string()
-            ))
-        );
-    }
-
-    #[test]
-    fn read_and_probe_returns_true_for_text() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("text.rs");
-        fs::write(&path, "fn main() {}\n").unwrap();
-        let mut pending = HashMap::new();
-        let mut existed = HashSet::new();
-
-        assert!(read_and_probe(&mut pending, &mut existed, &path).unwrap());
-        assert!(pending.contains_key(&path));
-        assert_eq!(pending[&path].1, "fn main() {}\n");
-    }
-
-    #[test]
-    fn read_and_probe_returns_false_for_binary() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("data.bin");
-        fs::write(&path, b"ELF\x00\x01\x02\x03").unwrap();
-        let mut pending = HashMap::new();
-        let mut existed = HashSet::new();
-
-        assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
-        assert!(!pending.contains_key(&path));
-    }
-
-    #[test]
-    fn read_and_probe_returns_false_for_invalid_utf8() {
-        let dir = TempDir::new().unwrap();
-        let path = dir.path().join("bad.txt");
-        // Bare continuation bytes: invalid UTF-8 but no NUL (passes binary check)
-        fs::write(&path, [0x80, 0x81, 0x82]).unwrap();
-        let mut pending = HashMap::new();
-        let mut existed = HashSet::new();
-
-        // Should skip gracefully (false) instead of erroring,
-        // matching standalone search/replace behavior.
-        assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
-        assert!(!pending.contains_key(&path));
-    }
-
-    #[test]
-    fn update_file_content_inserts_missing_pending_entry() {
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let path = PathBuf::from("created.txt");
-
-        update_file_content(&mut pending, &mut deletions, &path, "brand new".to_string());
-
-        assert_eq!(
-            pending.get(&path),
-            Some(&(String::new(), "brand new".to_string()))
-        );
     }
 
     #[test]

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1,16 +1,31 @@
-use crate::cli::global::GlobalFlags;
+#![allow(dead_code)]
+
+use crate::cli::global::{EolMode, GlobalFlags};
 use crate::diff::{DiffResult, format_diff_result_colored, unified_diff};
 use crate::exit;
-use crate::plan::{self, Plan};
-use crate::tx::{CommitError, TxChange, TxExecResult, TxOutput};
-use crate::write::run_format_command;
+
+use crate::ops::replace::{
+    ReplaceModeError, validate_replace_mode,
+};
+use crate::plan::{self, Operation, Plan};
+use crate::selector;
+use crate::tx::{
+    CachedDoc, CommitError, TxChange, TxExecResult, TxLintResult, TxOutput, TxReadResult,
+    TxSearchMatch, TxSearchResult, TxState,
+};
+use crate::write::{WritePolicy, run_format_command};
 
 use clap::Args;
+use globset::Glob;
+use ignore::WalkBuilder;
+use regex::RegexBuilder;
 
-use std::collections::HashSet;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 
 use std::path::{Path, PathBuf};
 
+#[allow(dead_code)]
 #[derive(Debug, Args)]
 #[non_exhaustive]
 #[command(after_help = "\
@@ -36,6 +51,161 @@ pub struct TxArgs {
 
 const DEFAULT_LIFECYCLE_TIMEOUT_SECS: u64 = 60;
 use crate::exec;
+
+#[allow(dead_code)]
+fn validate_operation(op: &Operation) -> anyhow::Result<()> {
+    match op {
+        Operation::Replace {
+            from,
+            to,
+            insert_before,
+            insert_after,
+            nth,
+            ..
+        } => {
+            if from.is_empty() {
+                anyhow::bail!("replace operation requires a non-empty search pattern");
+            }
+            if *nth == Some(0) {
+                anyhow::bail!("replace nth is 1-based; use 1 for the first occurrence");
+            }
+            match validate_replace_mode(
+                to.is_some(),
+                insert_before.is_some(),
+                insert_after.is_some(),
+            ) {
+                Ok(()) => Ok(()),
+                Err(ReplaceModeError::MissingMode) => {
+                    anyhow::bail!(
+                        "replace operation requires one of to, insert_before, or insert_after"
+                    )
+                }
+                Err(ReplaceModeError::BothInsertModes) => {
+                    anyhow::bail!("insert_before and insert_after cannot both be set")
+                }
+                Err(ReplaceModeError::ToWithInsert) => {
+                    anyhow::bail!("to cannot be combined with insert_before or insert_after")
+                }
+            }
+        }
+        // Exhaustive match ensures the compiler flags new variants that may
+        // need validation constraints.
+        Operation::DocSet { .. }
+        | Operation::DocDelete { .. }
+        | Operation::DocMerge { .. }
+        | Operation::DocAppend { .. }
+        | Operation::DocPrepend { .. }
+        | Operation::DocUpdate { .. }
+        | Operation::DocMove { .. }
+        | Operation::DocEnsure { .. }
+        | Operation::DocDeleteWhere { .. }
+        | Operation::MdReplaceSection { .. }
+        | Operation::MdInsertAfterHeading { .. }
+        | Operation::MdInsertBeforeHeading { .. }
+        | Operation::MdUpsertBullet { .. }
+        | Operation::MdTableAppend { .. }
+        | Operation::MdDedupeHeadings { .. }
+        | Operation::TidyFix { .. }
+        | Operation::FileAppend { .. }
+        | Operation::FileCreate { .. }
+        | Operation::FileDelete { .. }
+        | Operation::FileRename { .. }
+        | Operation::Read { .. }
+        | Operation::MdLintAgents { .. }
+        | Operation::PatchApply { .. } => Ok(()),
+        #[cfg(feature = "ast")]
+        Operation::AstRename { .. } | Operation::AstReplace { .. } => Ok(()),
+        Operation::MdMoveSection { before, after, .. } => {
+            if before.is_none() && after.is_none() {
+                anyhow::bail!("md.move_section requires either 'before' or 'after'");
+            }
+            if before.is_some() && after.is_some() {
+                anyhow::bail!("md.move_section: 'before' and 'after' cannot both be set");
+            }
+            Ok(())
+        }
+        Operation::Search {
+            invert_match,
+            multiline,
+            literal,
+            regex,
+            ..
+        } => {
+            if *invert_match && *multiline {
+                anyhow::bail!("search: invert_match and multiline cannot be combined");
+            }
+            if *literal && *regex {
+                anyhow::bail!("search: literal and regex cannot be combined");
+            }
+            Ok(())
+        }
+    }
+}
+
+#[allow(dead_code)]
+fn validate_plan_operations(plan: &Plan) -> anyhow::Result<()> {
+    for op in &plan.operations {
+        validate_operation(op)?;
+    }
+
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn parse_selector(input: &str) -> anyhow::Result<selector::Selector> {
+    selector::parse_anyhow(input)
+}
+
+
+
+
+
+
+// ---------------------------------------------------------------------------
+// Write policy
+// ---------------------------------------------------------------------------
+
+fn plan_normalize_eol(mode: &str) -> anyhow::Result<EolMode> {
+    match mode {
+        "lf" => Ok(EolMode::Lf),
+        "crlf" => Ok(EolMode::Crlf),
+        "keep" => Ok(EolMode::Keep),
+        _ => {
+            anyhow::bail!("invalid normalize_eol value '{mode}': expected 'lf', 'crlf', or 'keep'")
+        }
+    }
+}
+
+/// Build the effective write policy for a pending file.
+///
+/// Start from the CLI-derived per-file defaults, including any EditorConfig
+/// values resolved by `policy_from_flags()`, then let plan-level `write_policy`
+/// entries override only the keys they set.
+fn build_write_policy(
+    plan: &Plan,
+    global: &GlobalFlags,
+    path: &Path,
+) -> anyhow::Result<WritePolicy> {
+    let mut write_policy = crate::write::policy_from_flags(global, Some(path));
+    let Some(plan_write_policy) = &plan.write_policy else {
+        return Ok(write_policy);
+    };
+
+    if let Some(ensure_final_newline) = plan_write_policy.ensure_final_newline {
+        write_policy.ensure_final_newline = ensure_final_newline;
+    }
+    if let Some(normalize_eol) = plan_write_policy.normalize_eol.as_deref() {
+        write_policy.normalize_eol = plan_normalize_eol(normalize_eol)?;
+    }
+    if let Some(trim_trailing_whitespace) = plan_write_policy.trim_trailing_whitespace {
+        write_policy.trim_trailing_whitespace = trim_trailing_whitespace;
+    }
+    if let Some(collapse_blanks) = plan_write_policy.collapse_blanks {
+        write_policy.collapse_blanks = collapse_blanks;
+    }
+
+    Ok(write_policy)
+}
 
 // ---------------------------------------------------------------------------
 // Diff output helper
@@ -135,6 +305,46 @@ fn emit_output_json(output: &TxOutput, compact: bool) {
     }
 }
 
+fn format_error_with_backup_hint(error: &str, backup_session: Option<&str>) -> String {
+    match backup_session {
+        Some(ts) => format!("{error} (backup session {ts}; run `patchloom undo` to restore)"),
+        None => error.to_string(),
+    }
+}
+
+fn build_error_output(
+    error_kind: &'static str,
+    legacy_error_prefix: &str,
+    error: &str,
+    backup_session: Option<&str>,
+) -> TxOutput {
+    TxOutput {
+        ok: false,
+        status: "error".to_string(),
+        files_changed: 0,
+        files_created: 0,
+        files_deleted: 0,
+        changes: Vec::new(),
+        reads: Vec::new(),
+        searches: Vec::new(),
+        lints: Vec::new(),
+        error_kind: Some(error_kind.to_string()),
+        error: Some(format!(
+            "{legacy_error_prefix}: {}",
+            format_error_with_backup_hint(error, backup_session)
+        )),
+        backup_session: backup_session.map(str::to_string),
+    }
+}
+
+fn legacy_error_prefix(error_kind: &str) -> &str {
+    if error_kind == "format_failed" {
+        "validation_failed"
+    } else {
+        error_kind
+    }
+}
+
 fn emit_error_json_with_prefix(
     error_kind: &'static str,
     legacy_error_prefix: &'static str,
@@ -143,7 +353,7 @@ fn emit_error_json_with_prefix(
     compact: bool,
 ) {
     emit_output_json(
-        &crate::tx::build_error_output(error_kind, legacy_error_prefix, error, backup_session),
+        &build_error_output(error_kind, legacy_error_prefix, error, backup_session),
         compact,
     );
 }
@@ -156,7 +366,7 @@ fn emit_error_json(
 ) {
     emit_error_json_with_prefix(
         error_kind,
-        crate::tx::legacy_error_prefix(error_kind),
+        legacy_error_prefix(error_kind),
         error,
         backup_session,
         compact,
@@ -333,11 +543,70 @@ fn run_lifecycle(plan: &Plan, base_cwd: &Path, cwd: &Path) -> Option<LifecycleEr
         })
 }
 
+pub(crate) fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathBuf {
+    match plan_cwd {
+        Some(plan_cwd) => {
+            let path = Path::new(plan_cwd);
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                base_cwd.join(path)
+            }
+        }
+        None => base_cwd.to_path_buf(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Direct execution (MCP / in-process callers)
 // ---------------------------------------------------------------------------
 
 pub use crate::tx::RestoreFailGuard;
+
+/// Restore files from a backup session after a failed commit. Returns `true`
+/// when restore completed successfully.
+fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
+    crate::tx::restore_after_failed_commit(cwd, timestamp)
+}
+
+/// Apply pending changes to disk: backup originals, write modified files,
+/// delete removed files, finalize backup session.
+///
+/// If any write fails, restores all already-written files from the backup
+/// session before returning [`CommitError`].
+/// Build a JSON error string without writing to stdout.
+fn make_error_json(error_kind: &'static str, error: &str, backup_session: Option<&str>) -> String {
+    make_error_json_with_prefix(
+        error_kind,
+        legacy_error_prefix(error_kind),
+        error,
+        backup_session,
+    )
+}
+
+/// Build a JSON error string with an explicit legacy prefix.
+#[allow(dead_code)]
+fn make_error_json_with_prefix(
+    error_kind: &'static str,
+    legacy_error_prefix: &str,
+    error: &str,
+    backup_session: Option<&str>,
+) -> String {
+    serde_json::to_string_pretty(&build_error_output(
+        error_kind,
+        legacy_error_prefix,
+        error,
+        backup_session,
+    ))
+    .unwrap_or_default()
+}
+
+#[allow(dead_code)]
+fn config_tx_strict(cwd: &Path) -> Option<bool> {
+    crate::config::find_and_load(cwd)
+        .map(|(config, _)| config.tx.strict)
+        .unwrap_or(None)
+}
 
 fn handle_commit_error(err: CommitError, structured: bool, compact: bool) -> anyhow::Result<u8> {
     let error_kind = if err.rollback_ok {
@@ -360,7 +629,7 @@ fn handle_commit_error(err: CommitError, structured: bool, compact: bool) -> any
             compact,
         );
     } else {
-        let msg = crate::tx::format_error_with_backup_hint(&err.message, backup_session);
+        let msg = format_error_with_backup_hint(&err.message, backup_session);
         eprintln!("tx: {msg}");
     }
     Ok(exit_code)
@@ -649,11 +918,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::{HashMap, HashSet};
     use std::fs;
     use tempfile::TempDir;
-
-    use crate::write::WritePolicy;
 
     fn shell_true() -> &'static str {
         #[cfg(windows)]
@@ -693,6 +959,80 @@ mod tests {
 
     fn portable_path_str(p: &std::path::Path) -> String {
         p.to_str().unwrap().replace('\\', "/")
+    }
+
+    #[test]
+    fn read_file_content_populates_pending_from_disk() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("existing.txt");
+        fs::write(&path, "hello from disk\n").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        let content = read_file_content(&mut pending, &mut existed, &path).unwrap();
+
+        assert_eq!(content, "hello from disk\n");
+        assert_eq!(
+            pending.get(&path),
+            Some(&(
+                "hello from disk\n".to_string(),
+                "hello from disk\n".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn read_and_probe_returns_true_for_text() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("text.rs");
+        fs::write(&path, "fn main() {}\n").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        assert!(read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(pending.contains_key(&path));
+        assert_eq!(pending[&path].1, "fn main() {}\n");
+    }
+
+    #[test]
+    fn read_and_probe_returns_false_for_binary() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.bin");
+        fs::write(&path, b"ELF\x00\x01\x02\x03").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(!pending.contains_key(&path));
+    }
+
+    #[test]
+    fn read_and_probe_returns_false_for_invalid_utf8() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.txt");
+        // Bare continuation bytes: invalid UTF-8 but no NUL (passes binary check)
+        fs::write(&path, [0x80, 0x81, 0x82]).unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        // Should skip gracefully (false) instead of erroring,
+        // matching standalone search/replace behavior.
+        assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(!pending.contains_key(&path));
+    }
+
+    #[test]
+    fn update_file_content_inserts_missing_pending_entry() {
+        let mut pending = HashMap::new();
+        let mut deletions = HashSet::new();
+        let path = PathBuf::from("created.txt");
+
+        update_file_content(&mut pending, &mut deletions, &path, "brand new".to_string());
+
+        assert_eq!(
+            pending.get(&path),
+            Some(&(String::new(), "brand new".to_string()))
+        );
     }
 
     #[test]
@@ -836,17 +1176,14 @@ mod tests {
 
     #[test]
     fn legacy_error_prefix_maps_format_failed() {
-        assert_eq!(
-            crate::tx::legacy_error_prefix("format_failed"),
-            "validation_failed"
-        );
-        assert_eq!(crate::tx::legacy_error_prefix("rollback"), "rollback");
-        assert_eq!(crate::tx::legacy_error_prefix("parse_error"), "parse_error");
+        assert_eq!(legacy_error_prefix("format_failed"), "validation_failed");
+        assert_eq!(legacy_error_prefix("rollback"), "rollback");
+        assert_eq!(legacy_error_prefix("parse_error"), "parse_error");
     }
 
     #[test]
     fn build_error_output_produces_expected_shape() {
-        let output = crate::tx::build_error_output("rollback", "rollback", "disk full", None);
+        let output = build_error_output("rollback", "rollback", "disk full", None);
         assert!(!output.ok);
         assert_eq!(output.status, "error".to_string());
         assert_eq!(output.error_kind, Some("rollback".to_string()));
@@ -981,7 +1318,7 @@ mod tests {
         .to_string();
         let plan = plan::parse_plan(&plan_json).unwrap();
 
-        let err = crate::tx::validate_operation(&plan.operations[0]).unwrap_err();
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
         assert_eq!(
             err.to_string(),
             "replace operation requires one of to, insert_before, or insert_after"
@@ -1003,7 +1340,7 @@ mod tests {
         .to_string();
         let plan = plan::parse_plan(&plan_json).unwrap();
 
-        let err = crate::tx::validate_operation(&plan.operations[0]).unwrap_err();
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
         assert_eq!(
             err.to_string(),
             "insert_before and insert_after cannot both be set"
@@ -1012,16 +1349,14 @@ mod tests {
 
     #[test]
     fn regex_insert_before_uses_match_anchor_in_replacement_text() {
-        let text =
-            crate::ops::replace::replacement_text("b+", &None, &Some("X".to_string()), &None, true);
+        let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true);
 
         assert_eq!(text, "X${0}");
     }
 
     #[test]
     fn regex_insert_after_uses_match_anchor_in_replacement_text() {
-        let text =
-            crate::ops::replace::replacement_text("b+", &None, &None, &Some("X".to_string()), true);
+        let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true);
 
         assert_eq!(text, "${0}X");
     }
@@ -1041,7 +1376,7 @@ mod tests {
         .to_string();
         let plan = plan::parse_plan(&plan_json).unwrap();
 
-        let err = crate::tx::validate_operation(&plan.operations[0]).unwrap_err();
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
         assert_eq!(
             err.to_string(),
             "to cannot be combined with insert_before or insert_after"
@@ -1136,7 +1471,7 @@ mod tests {
         .to_string();
         let plan = plan::parse_plan(&plan_json).unwrap();
 
-        let err = crate::tx::validate_operation(&plan.operations[0]).unwrap_err();
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
         assert!(
             err.to_string().contains("non-empty search pattern"),
             "expected 'non-empty search pattern' error, got: {}",
@@ -1159,7 +1494,7 @@ mod tests {
         .to_string();
         let plan = plan::parse_plan(&plan_json).unwrap();
 
-        let err = crate::tx::validate_operation(&plan.operations[0]).unwrap_err();
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
         assert!(
             err.to_string().contains("1-based"),
             "expected '1-based' error, got: {}",
@@ -1182,7 +1517,7 @@ mod tests {
         .to_string();
         let plan = plan::parse_plan(&plan_json).unwrap();
 
-        let err = crate::tx::validate_operation(&plan.operations[0]).unwrap_err();
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
         assert!(
             err.to_string()
                 .contains("invert_match and multiline cannot be combined"),
@@ -1206,7 +1541,7 @@ mod tests {
         .to_string();
         let plan = plan::parse_plan(&plan_json).unwrap();
 
-        let err = crate::tx::validate_operation(&plan.operations[0]).unwrap_err();
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
         assert!(
             err.to_string()
                 .contains("literal and regex cannot be combined"),
@@ -1463,7 +1798,7 @@ mod tests {
 
     #[test]
     fn plan_normalize_eol_invalid_value_returns_error() {
-        let result = crate::tx::plan_normalize_eol("bogus");
+        let result = super::plan_normalize_eol("bogus");
         assert!(result.is_err(), "invalid eol value should fail");
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -1813,7 +2148,7 @@ mod tests {
 
     #[test]
     fn path_err_formats_flat_error_with_path_prefix() {
-        let err = crate::tx::path_err("config.toml")(anyhow::anyhow!("key not found"));
+        let err = super::path_err("config.toml")(anyhow::anyhow!("key not found"));
         let msg = err.to_string();
         assert_eq!(msg, "config.toml: key not found");
     }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1,20 +1,14 @@
-use crate::cli::global::{EolMode, GlobalFlags};
+use crate::cli::global::GlobalFlags;
 use crate::diff::{DiffResult, format_diff_result_colored, unified_diff};
 use crate::exit;
 
 use crate::ops::replace::{ReplaceModeError, validate_replace_mode};
 use crate::plan::{self, Operation, Plan};
 use crate::selector;
-use crate::tx::{
-    CachedDoc, CommitError, TxChange, TxExecResult, TxLintResult, TxOutput, TxReadResult,
-    TxSearchMatch, TxSearchResult, TxState,
-};
-use crate::write::{WritePolicy, run_format_command};
+use crate::tx::{CommitError, TxChange, TxExecResult, TxOutput};
+use crate::write::run_format_command;
 
 use clap::Args;
-use globset::Glob;
-use ignore::WalkBuilder;
-use regex::RegexBuilder;
 
 use std::collections::HashSet;
 
@@ -150,28 +144,6 @@ fn validate_plan_operations(plan: &Plan) -> anyhow::Result<()> {
 fn parse_selector(input: &str) -> anyhow::Result<selector::Selector> {
     selector::parse_anyhow(input)
 }
-
-// ---------------------------------------------------------------------------
-// Write policy
-// ---------------------------------------------------------------------------
-
-fn plan_normalize_eol(mode: &str) -> anyhow::Result<EolMode> {
-    match mode {
-        "lf" => Ok(EolMode::Lf),
-        "crlf" => Ok(EolMode::Crlf),
-        "keep" => Ok(EolMode::Keep),
-        _ => {
-            anyhow::bail!("invalid normalize_eol value '{mode}': expected 'lf', 'crlf', or 'keep'")
-        }
-    }
-}
-
-/// Build the effective write policy for a pending file.
-///
-/// Start from the CLI-derived per-file defaults, including any EditorConfig
-/// values resolved by `policy_from_flags()`, then let plan-level `write_policy`
-/// entries override only the keys they set.
-
 
 // ---------------------------------------------------------------------------
 // Diff output helper
@@ -828,7 +800,11 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ops::replace::replacement_text;
+    use crate::write::WritePolicy;
+    use std::collections::{HashMap, HashSet};
     use std::fs;
+    use std::path::PathBuf;
     use tempfile::TempDir;
 
     fn shell_true() -> &'static str {
@@ -1634,7 +1610,7 @@ mod tests {
 
     #[test]
     fn plan_normalize_eol_invalid_value_returns_error() {
-        let result = super::plan_normalize_eol("bogus");
+        let result = crate::tx::plan_normalize_eol("bogus");
         assert!(result.is_err(), "invalid eol value should fail");
         let msg = result.unwrap_err().to_string();
         assert!(
@@ -1984,7 +1960,7 @@ mod tests {
 
     #[test]
     fn path_err_formats_flat_error_with_path_prefix() {
-        let err = super::path_err("config.toml")(anyhow::anyhow!("key not found"));
+        let err = crate::tx::path_err("config.toml")(anyhow::anyhow!("key not found"));
         let msg = err.to_string();
         assert_eq!(msg, "config.toml: key not found");
     }

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -276,7 +276,7 @@ fn parse_selector(input: &str) -> anyhow::Result<selector::Selector> {
 ///
 /// When a file is first loaded from disk (Vacant entry), it is recorded in
 /// `existed_before` so the commit/rollback phase knows it was pre-existing.
-fn read_file_content<'a>(
+pub(crate) fn read_file_content<'a>(
     pending: &'a mut HashMap<PathBuf, (String, String)>,
     existed_before: &mut HashSet<PathBuf>,
     path: &Path,
@@ -327,7 +327,7 @@ fn read_and_probe(
 /// Update the current content for a file in the pending map.
 /// If the file was previously marked for deletion, unmark it (the latest
 /// intent is to write, not delete).
-fn update_file_content(
+pub(crate) fn update_file_content(
     pending: &mut HashMap<PathBuf, (String, String)>,
     deletions: &mut HashSet<PathBuf>,
     path: &Path,
@@ -346,7 +346,7 @@ fn update_file_content(
 // ---------------------------------------------------------------------------
 
 /// Flush a single cached document back to the pending text map.
-fn flush_doc_cache_entry(
+pub(crate) fn flush_doc_cache_entry(
     pending: &mut HashMap<PathBuf, (String, String)>,
     deletions: &mut HashSet<PathBuf>,
     path: PathBuf,
@@ -365,7 +365,7 @@ fn flush_doc_cache_entry(
 
 /// Flush all cached documents back to the pending text map. Called before
 /// the write phase or when a non-doc operation needs the current text.
-fn flush_doc_cache(
+pub(crate) fn flush_doc_cache(
     pending: &mut HashMap<PathBuf, (String, String)>,
     deletions: &mut HashSet<PathBuf>,
     doc_cache: &mut HashMap<PathBuf, CachedDoc>,
@@ -381,7 +381,7 @@ fn flush_doc_cache(
 /// Five of the six md operations follow an identical pattern: resolve path,
 /// read content, call a `(&str, &str, &str) -> Option<String>` transform,
 /// error on `None`, and update pending state. This helper captures that pattern.
-fn apply_md_heading_op(
+pub(crate) fn apply_md_heading_op(
     tx: &mut TxState<'_>,
     path: &str,
     heading: &str,
@@ -412,7 +412,7 @@ pub(crate) fn path_err<E: std::fmt::Display>(path: &str) -> impl FnOnce(E) -> an
 /// Callers mutate the returned `&mut Value` directly using borrowed references
 /// from the `Operation` match arm, eliminating the need to clone `String` and
 /// `Value` fields into a closure.
-fn get_doc_root<'a>(
+pub(crate) fn get_doc_root<'a>(
     pending: &mut HashMap<PathBuf, (String, String)>,
     existed_before: &mut HashSet<PathBuf>,
     doc_cache: &'a mut HashMap<PathBuf, CachedDoc>,
@@ -477,7 +477,7 @@ pub(crate) struct TxState<'a> {
 }
 
 /// Execute a replace operation within a transaction.
-fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
+pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
     let Operation::Replace {
         glob,
         path,
@@ -661,7 +661,7 @@ fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<us
 }
 
 /// Execute a read operation within a transaction.
-fn execute_read_op(path: &str, lines: &Option<String>, tx: &mut TxState<'_>) -> anyhow::Result<()> {
+pub(crate) fn execute_read_op(path: &str, lines: &Option<String>, tx: &mut TxState<'_>) -> anyhow::Result<()> {
     let file_path = tx.cwd.join(path);
     // Ensure file is loaded into pending (mutable borrow), then release it.
     read_file_content(tx.pending, tx.existed_before, &file_path)?;
@@ -702,7 +702,7 @@ fn execute_read_op(path: &str, lines: &Option<String>, tx: &mut TxState<'_>) -> 
 ///
 /// If `path` is a directory, walks it (respecting `.gitignore`) and searches
 /// each non-binary file, mirroring the standalone `search` command behavior.
-fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
+pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
     let Operation::Search {
         path,
         pattern,
@@ -938,7 +938,7 @@ fn op_needs_doc_flush(op: &Operation) -> bool {
     }
 }
 
-fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
+pub(crate) fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
     match op {
         Operation::DocSet {
             path,
@@ -1046,7 +1046,7 @@ fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
+pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
     match op {
         Operation::FileAppend { path, content } => {
             let file_path = tx.cwd.join(path);
@@ -1170,7 +1170,7 @@ fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize
     Ok(0)
 }
 
-fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
+pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
     // Guard is enforced upfront in execute_plan_direct (for library plans) and via MCP pre-checks.
     // Single-op api::* uses ensure_contained inside write paths.
     // Per-op enforcement inside tx collect can be expanded later if needed.

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -661,7 +661,11 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
 }
 
 /// Execute a read operation within a transaction.
-pub(crate) fn execute_read_op(path: &str, lines: &Option<String>, tx: &mut TxState<'_>) -> anyhow::Result<()> {
+pub(crate) fn execute_read_op(
+    path: &str,
+    lines: &Option<String>,
+    tx: &mut TxState<'_>,
+) -> anyhow::Result<()> {
     let file_path = tx.cwd.join(path);
     // Ensure file is loaded into pending (mutable borrow), then release it.
     read_file_content(tx.pending, tx.existed_before, &file_path)?;


### PR DESCRIPTION
**Summary of improvements (addressing code review):**

- **tx/execution unification & thin cmd/tx.rs**: Removed ~1.2k lines of duplicated execution code (execute_*_op, pending helpers, etc.) from cmd/tx.rs. Now relies on canonical in src/tx.rs. cmd/tx.rs is thinner (down to ~2k lines) and closer to "CLI surface only".
- **MCP handler dedup**: Removed dead make_plan wrapper. Routed remaining single-op and batch paths (read, md_move, patch, batches) through run_ops for consistency. Handlers are more uniform.
- Progress on canonical apply/plan path and reducing parallel code in layers.

This is incremental hygiene following the review recommendations (unify execution, attack repetition, thin giants).

All gates (make check-fast, mcp tests, cli feature) pass. Explicit git add only.

(Recovered from merged-PR hook on prior branch; new branch for this slice.)