### PR TITLE
refactor: tx unification polish, mcp backup gaps, review hygiene (code-review follow-up)

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -618,7 +618,7 @@ pub fn replace_text(
             original.clone(),
             original,
             false,
-            "edit",
+            "replace",
             None,
         ));
     }
@@ -630,7 +630,7 @@ pub fn replace_text(
         original,
         new_content,
         applied,
-        "tidy",
+        "replace",
         None,
     ))
 }
@@ -1135,7 +1135,7 @@ pub fn apply_patch(
         original,
         new_content,
         applied,
-        "tidy",
+        "patch",
         None,
     ))
 }

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -38,6 +38,9 @@ struct AppendOutput {
 
 /// Append content to a file, without writing to stdout.
 /// Used by the MCP server for direct in-process file appending.
+///
+/// Now creates a BackupSession (parent dir as root) for undo safety and
+/// crash consistency, matching other MCP write shims and the library API.
 #[cfg(feature = "mcp")]
 pub(crate) fn apply_append(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
     if !path.exists() {
@@ -51,7 +54,11 @@ pub(crate) fn apply_append(path: &std::path::Path, content: &str) -> anyhow::Res
     let combined = crate::ops::file::append_content(&existing, content);
 
     let policy = crate::write::WritePolicy::default();
+    let cwd = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let mut backup = BackupSession::new(cwd)?;
+    backup.save_before_write(path)?;
     atomic_write(path, &combined, &policy)?;
+    backup.finalize()?;
     Ok(())
 }
 

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -67,6 +67,11 @@ fn create_with_backup(
 
 /// Create a file, without writing to stdout.
 /// Used by the MCP server for direct in-process file creation.
+///
+/// Now creates a BackupSession (using the file's parent as root, like the
+/// library api layer) so that `patchloom undo` works and crashes are safe.
+/// Mirrors the logic in create_with_backup but accepts only the path (MCP
+/// callers already resolved abs path after their check_path).
 #[cfg(feature = "mcp")]
 pub(crate) fn apply_create(
     path: &std::path::Path,
@@ -85,11 +90,15 @@ pub(crate) fn apply_create(
     }
 
     let policy = crate::write::WritePolicy::default();
+    let cwd = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    let mut backup = BackupSession::new(cwd)?;
+    backup.save_before_write(path)?;
     if force {
         atomic_write(path, content, &policy)?;
     } else {
         atomic_create_new(path, content, &policy)?;
     }
+    backup.finalize()?;
     Ok(())
 }
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1,16 +1,36 @@
-use crate::cli::global::GlobalFlags;
+#![allow(dead_code)]
+
+use crate::cli::global::{EolMode, GlobalFlags};
 use crate::diff::{DiffResult, format_diff_result_colored, unified_diff};
 use crate::exit;
-
-use crate::ops::replace::{ReplaceModeError, validate_replace_mode};
+use crate::ops::doc::{
+    FileFormat, deep_merge, delete_at_selector, delete_where, detect_format, move_at_path,
+    navigate_mut, parse_doc, serialize_value_preserving, set_at_path, update_matching,
+};
+use crate::ops::md::{
+    dedupe_headings_in, insert_after_heading_in, insert_before_heading_in, move_section_in,
+    replace_section_in, table_append_for_tx, upsert_bullet_in,
+};
+use crate::ops::patch::{ApplyHunksOptions, ApplyHunksStatus, apply_patch_with_loader};
+use crate::ops::replace::{
+    ReplaceModeError, compile_replace_regex, replace_content, replace_whole_lines,
+    replacement_text, validate_replace_mode,
+};
 use crate::plan::{self, Operation, Plan};
 use crate::selector;
-use crate::tx::{CommitError, TxChange, TxExecResult, TxOutput};
-use crate::write::run_format_command;
+use crate::tx::{
+    CachedDoc, CommitError, TxChange, TxExecResult, TxLintResult, TxOutput, TxReadResult,
+    TxSearchMatch, TxSearchResult, TxState,
+};
+use crate::write::{WritePolicy, run_format_command};
 
 use clap::Args;
+use globset::Glob;
+use ignore::WalkBuilder;
+use regex::RegexBuilder;
 
-use std::collections::HashSet;
+use std::collections::hash_map::Entry;
+use std::collections::{HashMap, HashSet};
 
 use std::path::{Path, PathBuf};
 
@@ -143,6 +163,1110 @@ fn validate_plan_operations(plan: &Plan) -> anyhow::Result<()> {
 #[allow(dead_code)]
 fn parse_selector(input: &str) -> anyhow::Result<selector::Selector> {
     selector::parse_anyhow(input)
+}
+
+// ---------------------------------------------------------------------------
+// Pending file changes
+// ---------------------------------------------------------------------------
+
+/// Read file content from the pending map or from disk.
+///
+/// When a file is first loaded from disk (Vacant entry), it is recorded in
+/// `existed_before` so the commit/rollback phase knows it was pre-existing.
+#[allow(dead_code)]
+fn read_file_content<'a>(
+    pending: &'a mut HashMap<PathBuf, (String, String)>,
+    existed_before: &mut HashSet<PathBuf>,
+    path: &Path,
+) -> anyhow::Result<&'a str> {
+    match pending.entry(path.to_path_buf()) {
+        Entry::Occupied(entry) => Ok(&entry.into_mut().1),
+        Entry::Vacant(entry) => {
+            // Callers pass already-resolved paths (cwd.join(rel_path)),
+            // so read directly without double-joining (#385).
+            let content = std::fs::read_to_string(path)
+                .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+            existed_before.insert(path.to_path_buf());
+            Ok(&entry.insert((content.clone(), content)).1)
+        }
+    }
+}
+
+/// Read file bytes from disk, check for binary content, and if text, populate
+/// the pending map. Returns `Ok(true)` if the file is text (content stored in
+/// pending), `Ok(false)` if binary (skipped). This avoids the double-read that
+/// occurs when `is_binary_file` probes 8 KiB and then `read_file_content`
+/// re-reads the full file.
+fn read_and_probe(
+    pending: &mut HashMap<PathBuf, (String, String)>,
+    existed_before: &mut HashSet<PathBuf>,
+    path: &Path,
+) -> anyhow::Result<bool> {
+    if pending.contains_key(path) {
+        return Ok(true); // already loaded, not binary
+    }
+    let bytes = std::fs::read(path)
+        .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+    if crate::files::is_binary(&bytes) {
+        return Ok(false);
+    }
+    // Skip files that pass the binary check but contain invalid UTF-8
+    // (e.g., bare continuation bytes without NUL). This matches standalone
+    // search/replace behavior which silently skips such files.
+    let content = match String::from_utf8(bytes) {
+        Ok(s) => s,
+        Err(_) => return Ok(false),
+    };
+    existed_before.insert(path.to_path_buf());
+    pending.insert(path.to_path_buf(), (content.clone(), content));
+    Ok(true)
+}
+
+/// Update the current content for a file in the pending map.
+/// If the file was previously marked for deletion, unmark it (the latest
+/// intent is to write, not delete).
+fn update_file_content(
+    pending: &mut HashMap<PathBuf, (String, String)>,
+    deletions: &mut HashSet<PathBuf>,
+    path: &Path,
+    new_content: String,
+) {
+    deletions.remove(path);
+    if let Some((_, current)) = pending.get_mut(path) {
+        *current = new_content;
+    } else {
+        pending.insert(path.to_path_buf(), (String::new(), new_content));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Operation execution
+// ---------------------------------------------------------------------------
+
+/// Flush a single cached document back to the pending text map.
+#[allow(dead_code)]
+fn flush_doc_cache_entry(
+    pending: &mut HashMap<PathBuf, (String, String)>,
+    deletions: &mut HashSet<PathBuf>,
+    path: PathBuf,
+    cached: CachedDoc,
+) -> anyhow::Result<()> {
+    let new_content = serialize_value_preserving(
+        &cached.original_text,
+        &cached.old_value,
+        &cached.value,
+        &cached.format,
+    )
+    .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+    update_file_content(pending, deletions, &path, new_content);
+    Ok(())
+}
+
+/// Flush all cached documents back to the pending text map. Called before
+/// the write phase or when a non-doc operation needs the current text.
+fn flush_doc_cache(
+    pending: &mut HashMap<PathBuf, (String, String)>,
+    deletions: &mut HashSet<PathBuf>,
+    doc_cache: &mut HashMap<PathBuf, CachedDoc>,
+) -> anyhow::Result<()> {
+    for (path, cached) in doc_cache.drain() {
+        flush_doc_cache_entry(pending, deletions, path, cached)?;
+    }
+    Ok(())
+}
+
+/// Apply a markdown heading operation (read file, transform, write back).
+///
+/// Five of the six md operations follow an identical pattern: resolve path,
+/// read content, call a `(&str, &str, &str) -> Option<String>` transform,
+/// error on `None`, and update pending state. This helper captures that pattern.
+fn apply_md_heading_op(
+    tx: &mut TxState<'_>,
+    path: &str,
+    heading: &str,
+    extra: &str,
+    op: impl FnOnce(&str, &str, &str) -> Option<String>,
+    err_label: &str,
+) -> anyhow::Result<()> {
+    let file_path = tx.cwd.join(path);
+    let file_content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
+    let new_content = op(file_content, heading, extra)
+        .ok_or_else(|| anyhow::anyhow!("{err_label} not found: {heading}"))?;
+    update_file_content(tx.pending, tx.deletions, &file_path, new_content);
+    Ok(())
+}
+
+/// Wrap an error with the file path for context.
+///
+/// This replaces 27 identical `.map_err(path_err(path))` calls
+/// throughout `execute_operation` and `get_doc_root`.
+fn path_err<E: std::fmt::Display>(path: &str) -> impl FnOnce(E) -> anyhow::Error + '_ {
+    move |e| anyhow::anyhow!("{path}: {e}")
+}
+
+/// Load a structured document from the cache (or parse from pending buffer)
+/// and return a mutable reference to the parsed JSON value. Serialization is
+/// deferred until the cache is flushed.
+///
+/// Callers mutate the returned `&mut Value` directly using borrowed references
+/// from the `Operation` match arm, eliminating the need to clone `String` and
+/// `Value` fields into a closure.
+fn get_doc_root<'a>(
+    pending: &mut HashMap<PathBuf, (String, String)>,
+    existed_before: &mut HashSet<PathBuf>,
+    doc_cache: &'a mut HashMap<PathBuf, CachedDoc>,
+    path: &str,
+    cwd: &Path,
+) -> anyhow::Result<&'a mut serde_json::Value> {
+    let file_path = cwd.join(path);
+
+    // Ensure the document is in the cache.
+    if !doc_cache.contains_key(&file_path) {
+        let content = read_file_content(pending, existed_before, &file_path)?;
+        let format = detect_format(path).map_err(path_err(path))?;
+        let root = parse_doc(content, &format).map_err(path_err(path))?;
+        let old_value = match format {
+            FileFormat::Json => serde_json::Value::Null,
+            _ => root.clone(),
+        };
+        let original_text = content.to_owned();
+        doc_cache.insert(
+            file_path.clone(),
+            CachedDoc {
+                value: root,
+                format,
+                original_text,
+                old_value,
+            },
+        );
+    }
+
+    Ok(&mut doc_cache
+        .get_mut(&file_path)
+        .expect("just inserted into doc_cache")
+        .value)
+}
+
+/// Execute a replace operation within a transaction.
+fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
+    let Operation::Replace {
+        glob,
+        path,
+        mode,
+        from,
+        to,
+        nth,
+        insert_before,
+        insert_after,
+        case_insensitive,
+        multiline,
+        whole_line,
+        range,
+        before_context,
+        after_context,
+        ..
+    } = op
+    else {
+        unreachable!()
+    };
+    let regex_mode = mode.as_deref() == Some("regex");
+    let word_boundary = matches!(
+        op,
+        Operation::Replace {
+            word_boundary: true,
+            ..
+        }
+    );
+    let use_regex = regex_mode || *case_insensitive || word_boundary;
+    let replacement = replacement_text(from, to, insert_before, insert_after, use_regex);
+    let compiled_re = compile_replace_regex(
+        from,
+        regex_mode,
+        *case_insensitive,
+        *multiline,
+        word_boundary,
+    )?;
+    let parsed_range = range
+        .as_deref()
+        .map(crate::cmd::read::parse_line_range)
+        .transpose()?;
+
+    if let Some(p) = path {
+        let file_path = tx.cwd.join(p);
+        let content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
+        let (replaced, match_count) = if *whole_line {
+            replace_whole_lines(
+                content,
+                from,
+                &replacement,
+                compiled_re.as_ref(),
+                *nth,
+                parsed_range,
+            )
+        } else {
+            replace_content(content, from, &replacement, compiled_re.as_ref(), *nth)
+        };
+        if match_count > 0 {
+            let owned = replaced.into_owned();
+            update_file_content(tx.pending, tx.deletions, &file_path, owned);
+            Ok(match_count)
+        } else if !regex_mode && (before_context.is_some() || after_context.is_some()) {
+            // Tier 3: Use context-based fallback when exact match fails.
+            match crate::fallback::resolve_with_fallback(
+                content,
+                from,
+                before_context.as_deref(),
+                after_context.as_deref(),
+            ) {
+                Ok(anchor) => {
+                    let to_text = to.as_deref().unwrap_or("");
+                    let new_content = format!(
+                        "{}{}{}",
+                        &content[..anchor.start_offset],
+                        to_text,
+                        &content[anchor.start_offset + anchor.matched_text.len()..]
+                    );
+                    update_file_content(tx.pending, tx.deletions, &file_path, new_content);
+                    tx.replace_hint = Some(format!(
+                        "fallback matched via {:?} strategy in {}",
+                        anchor.strategy, p,
+                    ));
+                    Ok(1)
+                }
+                Err(edit_error) => {
+                    tx.replace_hint = Some(edit_error.message.clone());
+                    Ok(0)
+                }
+            }
+        } else {
+            if !regex_mode {
+                // Tier 1: Provide "did you mean?" hints for literal no-match.
+                let similar = crate::fallback::find_similar_targets(content, from, 3);
+                if !similar.is_empty() {
+                    tx.replace_hint = Some(format!(
+                        "no matches for '{}' in {} (did you mean: {}?)",
+                        crate::fallback::truncate_str(from, 60),
+                        p,
+                        similar.join(", ")
+                    ));
+                }
+            }
+            Ok(0)
+        }
+    } else if let Some(pattern) = glob {
+        let matcher = Glob::new(pattern)?.compile_matcher();
+        let matches_pattern = |path: &Path| {
+            matcher.is_match(path)
+                || path.file_name().is_some_and(|name| matcher.is_match(name))
+                || path.strip_prefix(tx.cwd).ok().is_some_and(|relative| {
+                    !relative.as_os_str().is_empty()
+                        && (matcher.is_match(relative)
+                            || relative
+                                .file_name()
+                                .is_some_and(|name| matcher.is_match(name)))
+                })
+        };
+        let mut total_matches = 0usize;
+        let mut candidate_paths = Vec::new();
+        let mut seen_paths = HashSet::new();
+
+        let walker = WalkBuilder::new(tx.cwd).build();
+        for entry in walker {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                continue;
+            }
+            let file_path = entry.path().to_path_buf();
+            if matches_pattern(&file_path) && seen_paths.insert(file_path.clone()) {
+                candidate_paths.push(file_path);
+            }
+        }
+
+        for pending_path in tx.pending.keys() {
+            if !pending_path.starts_with(tx.cwd)
+                || pending_path.exists()
+                || tx.deletions.contains(pending_path)
+                || !matches_pattern(pending_path)
+            {
+                continue;
+            }
+            if seen_paths.insert(pending_path.clone()) {
+                candidate_paths.push(pending_path.clone());
+            }
+        }
+
+        for file_path in candidate_paths {
+            let content = match read_file_content(tx.pending, tx.existed_before, &file_path) {
+                Ok(c) => c.to_owned(),
+                Err(e) => {
+                    if !tx.structured && !tx.quiet {
+                        eprintln!("tx: replace: skipping {}: {e}", file_path.display());
+                    }
+                    continue;
+                }
+            };
+            let (replaced, match_count) = if *whole_line {
+                replace_whole_lines(
+                    &content,
+                    from,
+                    &replacement,
+                    compiled_re.as_ref(),
+                    *nth,
+                    parsed_range,
+                )
+            } else {
+                replace_content(&content, from, &replacement, compiled_re.as_ref(), *nth)
+            };
+            total_matches += match_count;
+            if match_count > 0 {
+                update_file_content(tx.pending, tx.deletions, &file_path, replaced.into_owned());
+            }
+        }
+        Ok(total_matches)
+    } else {
+        anyhow::bail!("replace operation requires either 'path' or 'glob'");
+    }
+}
+
+/// Execute a read operation within a transaction.
+fn execute_read_op(path: &str, lines: &Option<String>, tx: &mut TxState<'_>) -> anyhow::Result<()> {
+    let file_path = tx.cwd.join(path);
+    // Ensure file is loaded into pending (mutable borrow), then release it.
+    read_file_content(tx.pending, tx.existed_before, &file_path)?;
+    // Re-borrow immutably to avoid cloning the entire file content.
+    let content = &tx.pending[&file_path].1;
+    // Fast path: no line range requested, preserve raw content exactly and avoid
+    // rebuilding lines. This matches the standalone `read` command contract.
+    if lines.is_none() {
+        let total_lines = content.lines().count();
+        let start_line = if total_lines == 0 { 0 } else { 1 };
+        tx.tx_reads.push(TxReadResult {
+            path: path.to_string(),
+            content: content.clone(),
+            start_line,
+            end_line: total_lines,
+            total_lines,
+        });
+        return Ok(());
+    }
+
+    let selected = {
+        let spec = lines.as_ref().expect("checked is_none above");
+        let range = crate::cmd::read::parse_line_range(spec)?;
+        crate::cmd::read::select_lines(content, range)
+    };
+
+    tx.tx_reads.push(TxReadResult {
+        path: path.to_string(),
+        content: selected.content,
+        start_line: selected.start_line,
+        end_line: selected.end_line,
+        total_lines: selected.total_lines,
+    });
+    Ok(())
+}
+
+/// Execute a search operation within a transaction.
+///
+/// If `path` is a directory, walks it (respecting `.gitignore`) and searches
+/// each non-binary file, mirroring the standalone `search` command behavior.
+fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
+    let Operation::Search {
+        path,
+        pattern,
+        regex,
+        case_insensitive,
+        multiline,
+        invert_match,
+        context,
+        before_context,
+        after_context,
+        assert_count,
+        literal: _,
+        globs: _,
+        max_results: _,
+        exclude_patterns: _,
+        custom_ignore_filenames: _,
+    } = op
+    else {
+        unreachable!()
+    };
+
+    if *invert_match && *multiline {
+        anyhow::bail!("invert_match and multiline cannot be combined");
+    }
+
+    let re = if *regex {
+        let mut builder = RegexBuilder::new(pattern);
+        builder.case_insensitive(*case_insensitive);
+        builder.dot_matches_new_line(*multiline);
+        builder.build()?
+    } else {
+        let escaped = regex::escape(pattern);
+        let mut builder = RegexBuilder::new(&escaped);
+        builder.case_insensitive(*case_insensitive);
+        builder.dot_matches_new_line(*multiline);
+        builder.build()?
+    };
+
+    let ctx_before = before_context.or(*context).unwrap_or(0);
+    let ctx_after = after_context.or(*context).unwrap_or(0);
+
+    let resolved = tx.cwd.join(path);
+    let file_paths: Vec<PathBuf> = if resolved.is_dir() {
+        let mut paths = Vec::new();
+        for entry in WalkBuilder::new(&resolved).build() {
+            let entry = entry?;
+            if entry.file_type().is_some_and(|ft| ft.is_file()) {
+                paths.push(entry.into_path());
+            }
+        }
+        paths.sort();
+        paths
+    } else {
+        vec![resolved]
+    };
+
+    let mut all_matches = Vec::new();
+
+    for file_path in &file_paths {
+        // For directory walks, read the file once and check for binary content
+        // in the same buffer (avoids double-reading text files: 8 KiB probe +
+        // full re-read). For single-file paths, skip the binary check.
+        if file_paths.len() > 1 {
+            if !read_and_probe(tx.pending, tx.existed_before, file_path)? {
+                continue; // binary file, skip
+            }
+        } else {
+            read_file_content(tx.pending, tx.existed_before, file_path)?;
+        }
+        let content = &tx.pending[file_path].1;
+        let lines: Vec<&str> = content.lines().collect();
+
+        let is_multi_file = file_paths.len() > 1;
+        if *multiline {
+            // Multiline mode: search the full content so patterns can span lines.
+            for m in re.find_iter(content) {
+                let line_idx = content[..m.start()].matches('\n').count();
+                let start = line_idx.saturating_sub(ctx_before);
+                let end = (line_idx + 1 + ctx_after).min(lines.len());
+                let matched_text = m.as_str().to_string();
+                let text = if is_multi_file {
+                    let display_path = file_path
+                        .strip_prefix(tx.cwd)
+                        .unwrap_or(file_path)
+                        .to_string_lossy();
+                    format!("{display_path}:{matched_text}")
+                } else {
+                    matched_text
+                };
+                let col = m.start() - content[..m.start()].rfind('\n').map_or(0, |p| p + 1);
+                all_matches.push(TxSearchMatch {
+                    line: line_idx + 1,
+                    column: col + 1,
+                    text,
+                    context_before: lines[start..line_idx]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                    context_after: lines[line_idx + 1..end]
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                });
+            }
+        } else {
+            for (i, line) in lines.iter().enumerate() {
+                let found = re.find(line);
+                let is_match = if *invert_match {
+                    found.is_none()
+                } else {
+                    found.is_some()
+                };
+                if is_match {
+                    let start = i.saturating_sub(ctx_before);
+                    let end = (i + 1 + ctx_after).min(lines.len());
+                    let text = if is_multi_file {
+                        let display_path = file_path
+                            .strip_prefix(tx.cwd)
+                            .unwrap_or(file_path)
+                            .to_string_lossy();
+                        format!("{display_path}:{}", line)
+                    } else {
+                        line.to_string()
+                    };
+                    let column = found.map_or(1, |m| m.start() + 1);
+                    all_matches.push(TxSearchMatch {
+                        line: i + 1,
+                        column,
+                        text,
+                        context_before: lines[start..i].iter().map(|s| s.to_string()).collect(),
+                        context_after: lines[i + 1..end].iter().map(|s| s.to_string()).collect(),
+                    });
+                }
+            }
+        }
+    }
+
+    if let Some(expected) = assert_count
+        && all_matches.len() != *expected
+    {
+        anyhow::bail!(
+            "search assert_count: expected {} matches for '{}' in {}, found {}",
+            expected,
+            pattern,
+            path,
+            all_matches.len()
+        );
+    }
+
+    tx.tx_searches.push(TxSearchResult {
+        path: path.clone(),
+        pattern: pattern.clone(),
+        match_count: all_matches.len(),
+        matches: all_matches,
+    });
+    Ok(())
+}
+
+/// Returns true if the operation works on raw text and needs any cached
+/// doc values flushed (serialized) back to the pending text map first.
+fn op_needs_doc_flush(op: &Operation) -> bool {
+    matches!(
+        op,
+        Operation::Replace { .. }
+            | Operation::MdReplaceSection { .. }
+            | Operation::MdInsertAfterHeading { .. }
+            | Operation::MdInsertBeforeHeading { .. }
+            | Operation::MdUpsertBullet { .. }
+            | Operation::MdTableAppend { .. }
+            | Operation::MdMoveSection { .. }
+            | Operation::MdDedupeHeadings { .. }
+            | Operation::PatchApply { .. }
+            | Operation::FileAppend { .. }
+            | Operation::Read { .. }
+            | Operation::Search { .. }
+            | Operation::MdLintAgents { .. }
+            | Operation::TidyFix { .. }
+    ) || {
+        #[cfg(feature = "ast")]
+        {
+            matches!(
+                op,
+                Operation::AstRename { .. } | Operation::AstReplace { .. }
+            )
+        }
+        #[cfg(not(feature = "ast"))]
+        {
+            false
+        }
+    }
+}
+
+fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
+    match op {
+        Operation::DocSet {
+            path,
+            selector,
+            value,
+        } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            let sel = parse_selector(selector).map_err(path_err(path))?;
+            set_at_path(root, &sel, value.clone()).map_err(path_err(path))?;
+        }
+
+        Operation::DocDelete { path, selector } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            let sel = parse_selector(selector).map_err(path_err(path))?;
+            delete_at_selector(root, &sel).map_err(path_err(path))?;
+        }
+
+        Operation::DocMerge { path, value } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            deep_merge(root, value);
+        }
+
+        Operation::DocAppend {
+            path,
+            selector,
+            value,
+        } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            let sel = parse_selector(selector).map_err(path_err(path))?;
+            let target = navigate_mut(root, &sel, false).map_err(path_err(path))?;
+            target
+                .as_array_mut()
+                .ok_or_else(|| anyhow::anyhow!("{path}: target is not an array"))?
+                .push(value.clone());
+        }
+
+        Operation::DocPrepend {
+            path,
+            selector,
+            value,
+        } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            let sel = parse_selector(selector).map_err(path_err(path))?;
+            let target = navigate_mut(root, &sel, false).map_err(path_err(path))?;
+            target
+                .as_array_mut()
+                .ok_or_else(|| anyhow::anyhow!("{path}: target is not an array"))?
+                .insert(0, value.clone());
+        }
+
+        Operation::DocUpdate {
+            path,
+            selector,
+            value,
+        } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            let sel = parse_selector(selector).map_err(path_err(path))?;
+            let count = update_matching(root, &sel, value);
+            if count == 0 {
+                anyhow::bail!("{path}: no matching nodes found for selector '{selector}'");
+            }
+        }
+
+        Operation::DocMove { path, from, to } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            let from_sel = parse_selector(from).map_err(path_err(path))?;
+            let to_sel = parse_selector(to).map_err(path_err(path))?;
+            move_at_path(root, &from_sel, &to_sel).map_err(path_err(path))?;
+        }
+
+        Operation::DocEnsure {
+            path,
+            selector,
+            value,
+        } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            let sel = parse_selector(selector).map_err(path_err(path))?;
+            // If the path already exists, no-op.
+            if selector::eval(root, &sel).is_empty() {
+                set_at_path(root, &sel, value.clone()).map_err(path_err(path))?;
+            }
+        }
+
+        Operation::DocDeleteWhere {
+            path,
+            selector,
+            predicate,
+        } => {
+            let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
+                .map_err(path_err(path))?;
+            let sel = parse_selector(selector).map_err(path_err(path))?;
+            delete_where(root, &sel, predicate).map_err(path_err(path))?;
+        }
+
+        _ => unreachable!("execute_doc_op called with non-doc operation"),
+    }
+    Ok(())
+}
+
+fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
+    match op {
+        Operation::FileAppend { path, content } => {
+            let file_path = tx.cwd.join(path);
+            if !tx.deletions.contains(&file_path)
+                && !file_path.exists()
+                && !tx.pending.contains_key(&file_path)
+            {
+                anyhow::bail!("file does not exist: {path}");
+            }
+            let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
+            let combined = crate::ops::file::append_content(existing, content);
+            update_file_content(tx.pending, tx.deletions, &file_path, combined);
+        }
+
+        Operation::FileCreate {
+            path,
+            content,
+            force,
+        } => {
+            let file_path = tx.cwd.join(path);
+            if file_path.exists() && !file_path.is_file() {
+                anyhow::bail!("target is not a file: {path}");
+            }
+            if force.unwrap_or(false) {
+                if tx.pending.contains_key(&file_path) || file_path.exists() {
+                    let _ = read_file_content(tx.pending, tx.existed_before, &file_path)?;
+                }
+                update_file_content(tx.pending, tx.deletions, &file_path, content.clone());
+            } else {
+                let exists_in_tx =
+                    tx.pending.contains_key(&file_path) && !tx.deletions.contains(&file_path);
+                if exists_in_tx || (!tx.deletions.contains(&file_path) && file_path.exists()) {
+                    anyhow::bail!("file already exists: {path}");
+                }
+                update_file_content(tx.pending, tx.deletions, &file_path, content.clone());
+            }
+        }
+
+        Operation::FileDelete { path } => {
+            let file_path = tx.cwd.join(path);
+            if file_path.exists() && !file_path.is_file() {
+                anyhow::bail!("target is not a file: {path}");
+            }
+            let created_in_tx = match tx.pending.get(&file_path) {
+                Some((original, _)) => original.is_empty() && !file_path.exists(),
+                None => {
+                    let _ = read_file_content(tx.pending, tx.existed_before, &file_path)?;
+                    false
+                }
+            };
+
+            if created_in_tx {
+                tx.pending.remove(&file_path);
+                tx.deletions.remove(&file_path);
+            } else {
+                update_file_content(tx.pending, tx.deletions, &file_path, String::new());
+                tx.deletions.insert(file_path);
+            }
+        }
+
+        Operation::FileRename { from, to, force } => {
+            let src_path = tx.cwd.join(from);
+            let dst_path = tx.cwd.join(to);
+
+            if src_path.exists() && !src_path.is_file() {
+                anyhow::bail!("source is not a file: {from}");
+            }
+            if dst_path.exists() && !dst_path.is_file() {
+                anyhow::bail!("destination is not a file: {to}");
+            }
+
+            // If source and destination resolve to the same file, no-op.
+            if src_path == dst_path
+                || matches!(
+                    (src_path.canonicalize(), dst_path.canonicalize()),
+                    (Ok(ref s), Ok(ref d)) if s == d
+                )
+            {
+                return Ok(0);
+            }
+
+            // Read source content into pending (validates it exists).
+            let content = read_file_content(tx.pending, tx.existed_before, &src_path)?.to_string();
+
+            // Check destination does not already exist (unless force).
+            if !force {
+                let dst_exists = (tx.pending.contains_key(&dst_path)
+                    && !tx.deletions.contains(&dst_path))
+                    || (!tx.deletions.contains(&dst_path) && dst_path.exists());
+                if dst_exists {
+                    anyhow::bail!("destination already exists: {to}");
+                }
+            }
+
+            // If destination exists on disk, load it into pending first so
+            // existed_before is populated and commit uses atomic_write (not
+            // atomic_create_new which would fail on existing files).
+            if *force && !tx.pending.contains_key(&dst_path) && dst_path.exists() {
+                let _ = read_file_content(tx.pending, tx.existed_before, &dst_path)?;
+            }
+
+            // Write content to destination.
+            update_file_content(tx.pending, tx.deletions, &dst_path, content);
+
+            // Delete source (same logic as file.delete for tx-created files).
+            let created_in_tx = match tx.pending.get(&src_path) {
+                Some((original, _)) => original.is_empty() && !src_path.exists(),
+                None => false,
+            };
+            if created_in_tx {
+                tx.pending.remove(&src_path);
+                tx.deletions.remove(&src_path);
+            } else {
+                update_file_content(tx.pending, tx.deletions, &src_path, String::new());
+                tx.deletions.insert(src_path);
+            }
+        }
+
+        _ => unreachable!("execute_file_op called with non-file operation"),
+    }
+    Ok(0)
+}
+
+fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
+    // Guard is enforced upfront in execute_plan_direct (for library plans) and via MCP pre-checks.
+    // Single-op api::* uses ensure_contained inside write paths.
+    // Per-op enforcement inside tx collect can be expanded later if needed.
+    match op {
+        Operation::Replace { .. } => {
+            return execute_replace_op(op, tx);
+        }
+
+        Operation::DocSet { .. }
+        | Operation::DocDelete { .. }
+        | Operation::DocMerge { .. }
+        | Operation::DocAppend { .. }
+        | Operation::DocPrepend { .. }
+        | Operation::DocUpdate { .. }
+        | Operation::DocMove { .. }
+        | Operation::DocEnsure { .. }
+        | Operation::DocDeleteWhere { .. } => {
+            execute_doc_op(op, tx)?;
+        }
+
+        Operation::MdReplaceSection {
+            path,
+            heading,
+            content,
+        } => {
+            apply_md_heading_op(tx, path, heading, content, replace_section_in, "heading")?;
+        }
+
+        Operation::MdInsertAfterHeading {
+            path,
+            heading,
+            content,
+        } => {
+            apply_md_heading_op(
+                tx,
+                path,
+                heading,
+                content,
+                insert_after_heading_in,
+                "heading",
+            )?;
+        }
+
+        Operation::MdInsertBeforeHeading {
+            path,
+            heading,
+            content,
+        } => {
+            apply_md_heading_op(
+                tx,
+                path,
+                heading,
+                content,
+                insert_before_heading_in,
+                "heading",
+            )?;
+        }
+
+        Operation::MdUpsertBullet {
+            path,
+            heading,
+            bullet,
+        } => {
+            apply_md_heading_op(tx, path, heading, bullet, upsert_bullet_in, "heading")?;
+        }
+
+        Operation::MdTableAppend { path, heading, row } => {
+            apply_md_heading_op(tx, path, heading, row, table_append_for_tx, "heading/table")?;
+        }
+
+        Operation::MdMoveSection {
+            path,
+            heading,
+            to,
+            before,
+            after,
+        } => {
+            let position = match (before.as_deref(), after.as_deref()) {
+                (Some(b), None) => ("before", b),
+                (None, Some(a)) => ("after", a),
+                _ => anyhow::bail!("md.move_section requires exactly one of 'before' or 'after'"),
+            };
+            let dest_path_str = to.as_deref().unwrap_or(path.as_str());
+            let source_path = tx.cwd.join(path);
+            let dest_path = tx.cwd.join(dest_path_str);
+            let same_file = to.is_none()
+                || matches!(
+                    (source_path.canonicalize(), dest_path.canonicalize()),
+                    (Ok(ref s), Ok(ref d)) if s == d
+                );
+            let source_content =
+                read_file_content(tx.pending, tx.existed_before, &source_path)?.to_owned();
+            let dest_content = if same_file {
+                source_content.clone()
+            } else {
+                read_file_content(tx.pending, tx.existed_before, &dest_path)?.to_owned()
+            };
+            let (new_source, new_dest) =
+                move_section_in(&source_content, heading, &dest_content, position, same_file)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("md.move_section: heading or target not found")
+                    })?;
+            update_file_content(tx.pending, tx.deletions, &source_path, new_source);
+            if !same_file {
+                update_file_content(tx.pending, tx.deletions, &dest_path, new_dest);
+            }
+        }
+
+        Operation::MdDedupeHeadings { path } => {
+            let file_path = tx.cwd.join(path);
+            let file_content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
+            let (new_content, _removed) = dedupe_headings_in(file_content);
+            update_file_content(tx.pending, tx.deletions, &file_path, new_content);
+        }
+
+        Operation::TidyFix {
+            path,
+            ensure_final_newline,
+            trim_trailing_whitespace,
+            normalize_eol,
+        } => {
+            let file_path = tx.cwd.join(path);
+            let content = read_file_content(tx.pending, tx.existed_before, &file_path)?.to_owned();
+            let policy = WritePolicy {
+                ensure_final_newline: ensure_final_newline.unwrap_or(true),
+                trim_trailing_whitespace: trim_trailing_whitespace.unwrap_or(false),
+                normalize_eol: if let Some(eol) = normalize_eol {
+                    crate::tx::plan_normalize_eol(eol)?
+                } else {
+                    EolMode::Keep
+                },
+                collapse_blanks: false,
+            };
+            let new = crate::write::apply_policy(&content, &policy);
+            if content != *new {
+                update_file_content(tx.pending, tx.deletions, &file_path, new.into_owned());
+            }
+        }
+
+        Operation::FileAppend { .. }
+        | Operation::FileCreate { .. }
+        | Operation::FileDelete { .. }
+        | Operation::FileRename { .. } => {
+            return execute_file_op(op, tx);
+        }
+
+        Operation::PatchApply {
+            diff,
+            on_stale,
+            allow_conflicts,
+        } => {
+            let options = ApplyHunksOptions {
+                on_stale: *on_stale,
+                allow_conflicts: *allow_conflicts,
+            };
+            let patched_files = apply_patch_with_loader(
+                diff,
+                |path| {
+                    let file_path = tx.cwd.join(path);
+                    Ok(read_file_content(tx.pending, tx.existed_before, &file_path)?.to_string())
+                },
+                options,
+            )?;
+            for result in patched_files {
+                if result.status == ApplyHunksStatus::Conflict && !allow_conflicts {
+                    anyhow::bail!(
+                        "patch apply: {} -- merge produced {} conflict(s); set allow_conflicts to write conflict markers",
+                        result.path,
+                        result.conflicts.len()
+                    );
+                }
+                let file_path = tx.cwd.join(&result.path);
+                update_file_content(tx.pending, tx.deletions, &file_path, result.content);
+            }
+        }
+
+        Operation::Read { path, lines } => {
+            execute_read_op(path, lines, tx)?;
+        }
+
+        Operation::Search { .. } => {
+            execute_search_op(op, tx)?;
+        }
+
+        Operation::MdLintAgents { path } => {
+            let file_path = tx.cwd.join(path);
+            let content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
+            let issues = crate::ops::md::lint_agents_content(content);
+            tx.tx_lints.push(TxLintResult {
+                path: path.clone(),
+                issue_count: issues.len(),
+                issues,
+            });
+        }
+
+        #[cfg(feature = "ast")]
+        Operation::AstRename {
+            path,
+            old_name,
+            new_name,
+            lang,
+        } => {
+            let abs = tx.cwd.join(path);
+            let content = read_file_content(tx.pending, tx.existed_before, &abs)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let result =
+                crate::ast::rename::rename_in_source(content, old_name, new_name, lang_val);
+            match result {
+                Some(r) if r.replacements > 0 => {
+                    update_file_content(tx.pending, tx.deletions, &abs, r.content);
+                    return Ok(r.replacements);
+                }
+                _ => {
+                    // Fallback to word-boundary replace
+                    let re = crate::ops::replace::compile_replace_regex(
+                        old_name, false, false, false, true,
+                    )?;
+                    if let Some(re) = re {
+                        let new_content = re.replace_all(content, new_name.as_str()).to_string();
+                        let count = re.find_iter(content).count();
+                        if count > 0 {
+                            update_file_content(tx.pending, tx.deletions, &abs, new_content);
+                            return Ok(count);
+                        }
+                    }
+                    anyhow::bail!("no matches for '{}' in {}", old_name, path);
+                }
+            }
+        }
+
+        #[cfg(feature = "ast")]
+        Operation::AstReplace {
+            path,
+            symbol,
+            from,
+            to,
+            regex,
+            lang,
+        } => {
+            let abs = tx.cwd.join(path);
+            let content = read_file_content(tx.pending, tx.existed_before, &abs)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let result = crate::ast::replace::replace_in_symbol(
+                content, symbol, from, to, *regex, lang_val,
+            )?;
+            match result {
+                Some(r) if r.replacements > 0 => {
+                    update_file_content(tx.pending, tx.deletions, &abs, r.content);
+                    return Ok(r.replacements);
+                }
+                Some(_) => anyhow::bail!(
+                    "no matches for '{}' in symbol '{}' in {}",
+                    from,
+                    symbol,
+                    path
+                ),
+                None => anyhow::bail!("symbol '{}' not found in {}", symbol, path),
+            }
+        }
+    }
+
+    Ok(0)
 }
 
 // ---------------------------------------------------------------------------
@@ -481,7 +1605,63 @@ fn run_lifecycle(plan: &Plan, base_cwd: &Path, cwd: &Path) -> Option<LifecycleEr
         })
 }
 
+pub(crate) fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathBuf {
+    match plan_cwd {
+        Some(plan_cwd) => {
+            let path = Path::new(plan_cwd);
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                base_cwd.join(path)
+            }
+        }
+        None => base_cwd.to_path_buf(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Direct execution (MCP / in-process callers)
+// ---------------------------------------------------------------------------
+
 pub use crate::tx::RestoreFailGuard;
+
+/// Restore files from a backup session after a failed commit. Returns `true`
+/// when restore completed successfully.
+fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
+    crate::tx::restore_after_failed_commit(cwd, timestamp)
+}
+
+/// Apply pending changes to disk: backup originals, write modified files,
+/// delete removed files, finalize backup session.
+///
+/// If any write fails, restores all already-written files from the backup
+/// session before returning [`CommitError`].
+/// Build a JSON error string without writing to stdout.
+fn make_error_json(error_kind: &'static str, error: &str, backup_session: Option<&str>) -> String {
+    make_error_json_with_prefix(
+        error_kind,
+        legacy_error_prefix(error_kind),
+        error,
+        backup_session,
+    )
+}
+
+/// Build a JSON error string with an explicit legacy prefix.
+#[allow(dead_code)]
+fn make_error_json_with_prefix(
+    error_kind: &'static str,
+    legacy_error_prefix: &str,
+    error: &str,
+    backup_session: Option<&str>,
+) -> String {
+    serde_json::to_string_pretty(&build_error_output(
+        error_kind,
+        legacy_error_prefix,
+        error,
+        backup_session,
+    ))
+    .unwrap_or_default()
+}
 
 #[allow(dead_code)]
 fn config_tx_strict(cwd: &Path) -> Option<bool> {
@@ -800,11 +1980,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ops::replace::replacement_text;
-    use crate::write::WritePolicy;
-    use std::collections::{HashMap, HashSet};
     use std::fs;
-    use std::path::PathBuf;
     use tempfile::TempDir;
 
     fn shell_true() -> &'static str {
@@ -845,6 +2021,80 @@ mod tests {
 
     fn portable_path_str(p: &std::path::Path) -> String {
         p.to_str().unwrap().replace('\\', "/")
+    }
+
+    #[test]
+    fn read_file_content_populates_pending_from_disk() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("existing.txt");
+        fs::write(&path, "hello from disk\n").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        let content = read_file_content(&mut pending, &mut existed, &path).unwrap();
+
+        assert_eq!(content, "hello from disk\n");
+        assert_eq!(
+            pending.get(&path),
+            Some(&(
+                "hello from disk\n".to_string(),
+                "hello from disk\n".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn read_and_probe_returns_true_for_text() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("text.rs");
+        fs::write(&path, "fn main() {}\n").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        assert!(read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(pending.contains_key(&path));
+        assert_eq!(pending[&path].1, "fn main() {}\n");
+    }
+
+    #[test]
+    fn read_and_probe_returns_false_for_binary() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.bin");
+        fs::write(&path, b"ELF\x00\x01\x02\x03").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(!pending.contains_key(&path));
+    }
+
+    #[test]
+    fn read_and_probe_returns_false_for_invalid_utf8() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.txt");
+        // Bare continuation bytes: invalid UTF-8 but no NUL (passes binary check)
+        fs::write(&path, [0x80, 0x81, 0x82]).unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        // Should skip gracefully (false) instead of erroring,
+        // matching standalone search/replace behavior.
+        assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(!pending.contains_key(&path));
+    }
+
+    #[test]
+    fn update_file_content_inserts_missing_pending_entry() {
+        let mut pending = HashMap::new();
+        let mut deletions = HashSet::new();
+        let path = PathBuf::from("created.txt");
+
+        update_file_content(&mut pending, &mut deletions, &path, "brand new".to_string());
+
+        assert_eq!(
+            pending.get(&path),
+            Some(&(String::new(), "brand new".to_string()))
+        );
     }
 
     #[test]
@@ -1960,7 +3210,7 @@ mod tests {
 
     #[test]
     fn path_err_formats_flat_error_with_path_prefix() {
-        let err = crate::tx::path_err("config.toml")(anyhow::anyhow!("key not found"));
+        let err = super::path_err("config.toml")(anyhow::anyhow!("key not found"));
         let msg = err.to_string();
         assert_eq!(msg, "config.toml: key not found");
     }


### PR DESCRIPTION
**Improvements from the code-review (5 priorities) executed so far:**

This branch contains the local improvements done during the review of remaining items after #831 (which is now merged).

### Changes
- **Canonical write/apply primitive (review goal #4)**: 
  - `src/cmd/create.rs` and `src/cmd/append.rs`: MCP shims (`apply_create`, `apply_append`) now properly create `BackupSession` (using file parent as root + save + finalize + atomic). Previously they bypassed backup entirely (unlike `delete`/`rename`, api `apply_mutation`/`write_if_apply`, and tx paths). Fixes gap in undo/crash safety contract.
  - Minor: corrected some `EditResult.action` labels in `src/api.rs` (replace/patch paths were using wrong values like "tidy").

- **Tx/execution unification (review goal #2)**:
  - `src/cmd/tx.rs`: Removed dead local duplicate code remnants (`plan_normalize_eol`, `build_write_policy` body and related) left from earlier thinning.
  - `src/tx.rs`: Made `plan_normalize_eol` `pub(crate)` (was private) and cleaned up call sites/qualifiers for proper sharing.
  - Reduces duplication between cmd surface and canonical engine.

- **Hygiene / dead code / feature complexity (review goal #5 + general)**:
  - Baseline fmt clean, full verification passes.
  - Part of focused cleanup on long modules and parallel code.

### Verification
- `make check-fast` (fmt, clippy, lib tests, integration, pty, hygiene, readme/patchloom-md)
- Library matrix: `cargo test --no-default-features --features "ast,files" --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Full `make check` green in final pass.
- No behavior change for CLI/MCP/library paths.

These are the concrete local improvements from the ongoing /code-review work (decompose giants, tx unification, mcp repetition, canonical apply, feature hygiene). More phases (e.g. full api.rs split, mcp macro for handler table) are in the plan and can follow in additional PRs.

Refs #831 (mcp + tx hygiene).