### PR TITLE
refactor: code-review polish plan execution (hygiene start + full plan)

### DIFF
--- a/PLAN-for-code-review-items.md
+++ b/PLAN-for-code-review-items.md
@@ -1,0 +1,90 @@
+# Execution Plan for Code-Review Items (Great Design Polish for Patchloom)
+
+Created from the strict code-review feedback.
+
+## Overall Principles (from review)
+- Ambitious structural simplification ("code judo").
+- No file bloat >1k LOC without strong reason.
+- Prefer deleting complexity over rearranging.
+- Preserve behavior and public/MCP contracts.
+- Use explicit git add, make check before commit -s, full hygiene.
+- Verification at each phase.
+
+## Phased Plan
+
+### Phase 1: Decompose the giants (api.rs first)
+- 1.1 Create src/api/ directory module.
+- 1.2 Split into:
+  - mod.rs : docs, types (EditResult, ApplyMode*, Options), shared helpers (make_*, apply_mutation, write_if_apply, ensure, build_edit_result)
+  - doc.rs : LoadedDoc, load/finish, all doc_* fns
+  - file.rs : all file_* fns
+  - md.rs : all md_* + LintIssue reexport
+  - replace.rs : replace_text
+  - patch.rs : apply_patch*
+  - tidy.rs : tidy
+  - search.rs : search*
+  - read.rs : read
+  - plan.rs : parse_plan, execute_plan
+- 1.3 Reexports in mod.rs to keep `patchloom::api::foo` identical.
+- 1.4 Update internal calls, tests, doctests, lib.rs docs if needed.
+- 1.5 Run cargo check --all-features after each submodule.
+- 1.6 Full make check before commit.
+- Then repeat for cmd/tx.rs (thin to surface) and ops/doc.rs .
+
+### Phase 2: Canonical write story
+- Audit all call sites of apply_mutation, write_if_apply, backup_write_files, atomic, fs ops in apply paths.
+- Make file_rename use a generalized cross file apply_mutation helper.
+- Update md_move_section cross file to use shared.
+- Make remaining MCP shims and ast apply paths use the helpers (or tx for atomic).
+- Add tests for the unified paths.
+- Update docs in api and lib.
+
+### Phase 3: MCP repetition
+- Introduce a declarative macro `mcp_tool!` or `register_mcp_tools!` in cmd/mcp.rs.
+- Table of (name, description, ParamsType, op_constructor, extra_validates, strict).
+- Generate the #[tool] async fn that does check, validate, run_ops.
+- Preserve all 32 tool schemas and names.
+- Update the expected tools test.
+- Remove boilerplate from handlers.
+
+### Phase 4: tx/cmd split polish
+- Identify duplicated fns in cmd/tx.rs (build_*, emit_*, run_lifecycle, describe_*, validate_* that are not CLI specific).
+- Move pure ones to pub(crate) in src/tx.rs .
+- Update cmd/tx.rs to call them or thin wrappers.
+- Remove or cfg_attr the dead_code allows.
+- Ensure CLI specific (colored output, confirm, args) stay in cmd/tx.
+
+### Phase 5: dead_code / feature hygiene
+- Global grep for #[allow(dead_code)] and broad allows.
+- Replace with #[cfg_attr(not(feature = "cli"), allow(dead_code))] on specific items.
+- Or move code behind cfg(feature = "cli").
+- Run make test-library-hygiene and the matrix after changes.
+- Aim for 0 broad allows in main paths.
+- Use the existing target.
+
+### Phase 6: Code judo audit
+- Grep for repeated if/ match on ApplyMode, Operation variants, preview/apply.
+- Look for opportunities to collapse using Plan for single ops where possible, or a dispatcher.
+- Examples: make preview/apply more uniform in helpers.
+- Use more of the Operation model for single file ops.
+- Remove unnecessary branches.
+- Implement 2-3 high value simplifications.
+
+## Execution Rules
+- After each logical change or phase: cargo check, make check-fast + hygiene matrix.
+- Explicit: git add src/api/mod.rs src/api/doc.rs ... (only changed).
+- make check (full) before git commit -s .
+- Update todos.
+- At end, full make check, git status clean, push, update PR #832 or new.
+- Preserve all tests, behavior, public API, MCP tool contracts.
+
+## Success Criteria
+- api.rs < 1500 LOC main, submodules <800.
+- All writes visibly use shared helpers.
+- MCP handlers dramatically shorter (generated).
+- cmd/tx.rs obviously thin.
+- 0 or minimal dead_code allows, hygiene target passes without allows.
+- Some complexity deleted (fewer branches).
+- All gates green.
+
+This plan directly addresses the review to make Patchloom look like a great designed project.

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 
 use std::path::{Path, PathBuf};
 
-#[allow(dead_code)]
+#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 #[derive(Debug, Args)]
 #[non_exhaustive]
 #[command(after_help = "\
@@ -41,7 +41,7 @@ pub struct TxArgs {
 const DEFAULT_LIFECYCLE_TIMEOUT_SECS: u64 = 60;
 use crate::exec;
 
-#[allow(dead_code)]
+#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 fn validate_operation(op: &Operation) -> anyhow::Result<()> {
     match op {
         Operation::Replace {
@@ -131,7 +131,7 @@ fn validate_operation(op: &Operation) -> anyhow::Result<()> {
     }
 }
 
-#[allow(dead_code)]
+#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 fn validate_plan_operations(plan: &Plan) -> anyhow::Result<()> {
     for op in &plan.operations {
         validate_operation(op)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ pub fn is_verbose() -> bool {
 }
 
 /// Enable verbose mode globally. Called once at startup.
-#[allow(dead_code)]
+#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 fn enable_verbose() {
     VERBOSE.store(true, std::sync::atomic::Ordering::Relaxed);
 }


### PR DESCRIPTION
**Plan to address the 6 code-review items for great design**

See attached PLAN-for-code-review-items.md in the branch for the detailed phased plan.

Executed so far:
- Item 5: hygiene - cfg_attr for dead_code in cmd/tx and lib (reduces broad allows).

Full plan:
1. Decompose giants (api.rs first)
2. Canonical write story
3. MCP repetition (macro)
4. tx/cmd split polish
5. Feature hygiene (this PR starts)
6. Code judo audit

All changes will follow make check, explicit add, -s commits.

This will make Patchloom a great designed project per the strict review.

Refs previous #831, #832.