### PR TITLE
refactor(mcp): finish run_one_op adoption + continue review items (2/3)

### DIFF
--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -1259,7 +1259,7 @@ impl PatchloomService {
             before_context: p.before_context,
             after_context: p.after_context,
         };
-        let mut tool_result = self.run_ops(vec![replace_op], Some(p.strict))?;
+        let mut tool_result = self.run_one_op(replace_op, Some(p.strict))?;
 
         // Append validation warnings to the response.
         if !validation_warnings.is_empty() {


### PR DESCRIPTION
Continue from #835 (api decomp + hygiene).

- Use run_one_op for the final direct vec![ ] site in replace handler (with post-processing for warnings).
- MCP handlers now consistently use the thin helper (item 3 progress).
- Branch off main after previous merges.
- Next: item 2 canonical writes, more macro or table for generation, tx polish.

Preserves all contracts and tests.
