### PR TITLE
refactor: reduce GlobalFlags construction boilerplate (Phase 6 judo)

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -340,22 +340,41 @@ impl GlobalFlags {
     }
 }
 
+/// Non-test helpers for common construction patterns (reduces boilerplate
+/// in MCP, tx, and test code after centralization).
+impl GlobalFlags {
+    /// Create GlobalFlags with a specific cwd (used by MCP tools and tx paths
+    /// to simulate the working directory).
+    pub fn with_cwd(cwd: impl AsRef<std::path::Path>) -> Self {
+        GlobalFlags {
+            cwd: Some(cwd.as_ref().to_string_lossy().into_owned()),
+            ..Default::default()
+        }
+    }
+
+    /// Create GlobalFlags with cwd and json=true (common for MCP read tools).
+    pub fn with_cwd_and_json(cwd: impl AsRef<std::path::Path>) -> Self {
+        GlobalFlags {
+            cwd: Some(cwd.as_ref().to_string_lossy().into_owned()),
+            json: true,
+            ..Default::default()
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn should_apply_returns_true_when_apply_set() {
-        let g = GlobalFlags {
-            apply: true,
-            ..GlobalFlags::default()
-        };
+        let g = GlobalFlags::test_apply();
         assert!(g.should_apply());
     }
 
     #[test]
     fn should_apply_returns_false_by_default() {
-        let g = GlobalFlags::default();
+        let g = GlobalFlags::test_default();
         assert!(!g.should_apply());
     }
 

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -1264,14 +1264,10 @@ impl PatchloomService {
             assert_count: p.assert_count,
             max_results: p.max_results,
         };
-        let global = GlobalFlags {
-            json: true,
-            cwd: Some(self.cwd().to_string_lossy().into_owned()),
-            glob: p.globs,
-            exclude: p.exclude_patterns,
-            ignore_file: p.custom_ignore_filenames,
-            ..GlobalFlags::default()
-        };
+        let mut global = GlobalFlags::with_cwd_and_json(self.cwd());
+        global.glob = p.globs;
+        global.exclude = p.exclude_patterns;
+        global.ignore_file = p.custom_ignore_filenames;
         let results = crate::cmd::search::collect_matches(&search_args, &global)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
 
@@ -1322,10 +1318,7 @@ impl PatchloomService {
         &self,
         #[allow(unused_variables)] Parameters(p): Parameters<serde_json::Value>,
     ) -> Result<CallToolResult, McpError> {
-        let global = GlobalFlags {
-            cwd: Some(self.cwd().to_string_lossy().into_owned()),
-            ..GlobalFlags::default()
-        };
+        let global = GlobalFlags::with_cwd(self.cwd());
         let status = crate::cmd::status::collect_status(&[], &global)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
         let json = serde_json::to_string_pretty(&status)

--- a/src/files.rs
+++ b/src/files.rs
@@ -648,7 +648,7 @@ mod tests {
     #[test]
     #[cfg(feature = "cli")]
     fn collect_glob_roots_normalizes_current_directory_segments() {
-        let global = GlobalFlags::default();
+        let global = GlobalFlags::test_default();
         let roots =
             collect_glob_roots_from_global(&[], &global, Some(Path::new("/tmp/project"))).unwrap();
 

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -2115,10 +2115,7 @@ pub(crate) fn validate_and_prepare_plan(
     let config_strict = config_tx_strict(&effective_cwd);
     let strict = plan::effective_strict(plan.strict, config_strict, no_strict);
 
-    let mut global = GlobalFlags {
-        cwd: Some(effective_cwd.to_string_lossy().into_owned()),
-        ..GlobalFlags::default()
-    };
+    let mut global = GlobalFlags::with_cwd(&effective_cwd);
     if let Some((config, _)) = crate::config::find_and_load(&effective_cwd) {
         crate::config::apply_config(&mut global, &config);
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -271,7 +271,7 @@ pub fn apply_policy<'a>(content: &'a str, policy: &WritePolicy) -> std::borrow::
 /// Usable from library tx execution paths as well (GlobalFlags can be simulated).
 pub fn policy_from_flags(
     global: &crate::cli::global::GlobalFlags,
-    file_path: Option<&std::path::Path>,
+    #[allow(unused_variables)] file_path: Option<&std::path::Path>,
 ) -> WritePolicy {
     let efn = global.ensure_final_newline;
     let eol = global.normalize_eol.map(|m| match m {
@@ -287,40 +287,45 @@ pub fn policy_from_flags(
         false
     };
 
-    let (efn, eol, ttw) = if respect_ec && let Some(path) = file_path {
+    let (efn, eol, ttw) = if respect_ec {
         #[cfg(feature = "cli")]
-        if let Ok(props) = ec4rs::properties_of(path) {
-            let mut new_efn = efn;
-            let mut new_eol = eol;
-            let mut new_ttw = ttw;
+        if let Some(p) = file_path {
+            #[allow(unused_variables)]
+            if let Ok(props) = ec4rs::properties_of(p) {
+                let mut new_efn = efn;
+                let mut new_eol = eol;
+                let mut new_ttw = ttw;
 
-            // insert_final_newline
-            if !global.ensure_final_newline
-                && let Ok(ec4rs::property::FinalNewline::Value(true)) =
-                    props.get::<ec4rs::property::FinalNewline>()
-            {
-                new_efn = true;
-            }
+                // insert_final_newline
+                if !global.ensure_final_newline
+                    && let Ok(ec4rs::property::FinalNewline::Value(true)) =
+                        props.get::<ec4rs::property::FinalNewline>()
+                {
+                    new_efn = true;
+                }
 
-            // end_of_line
-            if global.normalize_eol.is_none()
-                && let Ok(val) = props.get::<ec4rs::property::EndOfLine>()
-            {
-                new_eol = Some(match val {
-                    ec4rs::property::EndOfLine::Lf => EolMode::Lf,
-                    ec4rs::property::EndOfLine::CrLf => EolMode::Crlf,
-                    ec4rs::property::EndOfLine::Cr => EolMode::Keep,
-                });
-            }
+                // end_of_line
+                if global.normalize_eol.is_none()
+                    && let Ok(val) = props.get::<ec4rs::property::EndOfLine>()
+                {
+                    new_eol = Some(match val {
+                        ec4rs::property::EndOfLine::Lf => EolMode::Lf,
+                        ec4rs::property::EndOfLine::CrLf => EolMode::Crlf,
+                        ec4rs::property::EndOfLine::Cr => EolMode::Keep,
+                    });
+                }
 
-            // trim_trailing_whitespace
-            if !global.trim_trailing_whitespace
-                && let Ok(ec4rs::property::TrimTrailingWs::Value(true)) =
-                    props.get::<ec4rs::property::TrimTrailingWs>()
-            {
-                new_ttw = true;
+                // trim_trailing_whitespace
+                if !global.trim_trailing_whitespace
+                    && let Ok(ec4rs::property::TrimTrailingWs::Value(true)) =
+                        props.get::<ec4rs::property::TrimTrailingWs>()
+                {
+                    new_ttw = true;
+                }
+                (new_efn, new_eol, new_ttw)
+            } else {
+                (efn, eol, ttw)
             }
-            (new_efn, new_eol, new_ttw)
         } else {
             (efn, eol, ttw)
         }


### PR DESCRIPTION
Finish Phase 6 Code Judo on GlobalFlags patterns as noted in PLAN.

- Added `GlobalFlags::with_cwd` and `with_cwd_and_json` helpers to cut repeated `GlobalFlags { cwd: Some(..), ..default() }` and similar in mcp, tx, tests.
- Updated sites in src/cmd/mcp.rs, src/tx.rs, src/files.rs, src/cli/global.rs tests.
- Fixed hygiene build unused param in write.rs policy_from_flags.
- Preserved all test intent (reverted config test changes).

This + previous work completes the listed priorities 1-2. Hygiene targets and check-fast green.

For self-merge: enable auto-merge after creation.