### PR TITLE
test: MPI batch 1 (QA, Test Auditor, Developer)

### DIFF
--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -749,8 +749,7 @@ impl Server {
     fn replace_function_signature_basic() {
         let src = "fn old(a: i32) -> i32 { a }\nfn other() {}";
         let res = replace_function_signature(src, "old", "pub fn new(b: u32) -> u32");
-        assert!(res.is_some());
-        let out = res.unwrap();
+        let out = res.expect("replace_function_signature should succeed for matching name");
         assert!(out.contains("pub fn new(b: u32) -> u32"));
         assert!(out.contains("fn other"));
         assert!(!out.contains("fn old"));
@@ -765,8 +764,7 @@ impl Server {
             return_type: Some("-> String".to_string()),
         };
         let res = rewrite_function_signature(src, "old", &edit);
-        assert!(res.is_some());
-        let out = res.unwrap();
+        let out = res.expect("rewrite_function_signature should succeed for matching name");
         assert!(out.contains("pub(crate) fn old(x: u32, y: &str) -> String"));
         assert!(out.contains("fn other"));
         assert!(!out.contains("fn old(a: i32)"));

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -324,12 +324,12 @@ impl GlobalFlags {
     }
 
     /// Test helper with cwd set (simulates --cwd for cmd unit tests).
+    /// Builds on with_cwd and forces color=Never for test determinism.
+    #[allow(clippy::field_reassign_with_default)]
     pub fn test_with_cwd(dir: &std::path::Path) -> Self {
-        GlobalFlags {
-            cwd: Some(dir.to_string_lossy().into_owned()),
-            color: ColorMode::Never,
-            ..GlobalFlags::default()
-        }
+        let mut g = Self::with_cwd(dir);
+        g.color = ColorMode::Never;
+        g
     }
 
     /// Test helper with apply=true (for write cmd tests that want mutation).
@@ -357,6 +357,15 @@ impl GlobalFlags {
         GlobalFlags {
             cwd: Some(cwd.as_ref().to_string_lossy().into_owned()),
             json: true,
+            ..Default::default()
+        }
+    }
+
+    /// Create GlobalFlags with cwd and jsonl=true (for line-delimited JSON in MCP/tx tests).
+    pub fn with_cwd_and_jsonl(cwd: impl AsRef<std::path::Path>) -> Self {
+        GlobalFlags {
+            cwd: Some(cwd.as_ref().to_string_lossy().into_owned()),
+            jsonl: true,
             ..Default::default()
         }
     }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -2944,12 +2944,7 @@ mod tests {
             session: None,
             apply: false,
         };
-        let mut global = GlobalFlags {
-            json: true,
-            quiet: false,
-            cwd: Some(dir.path().to_string_lossy().to_string()),
-            ..GlobalFlags::default()
-        };
+        let mut global = GlobalFlags::with_cwd_and_json(dir.path());
         let code = crate::cmd::undo::run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);
 
@@ -2982,12 +2977,7 @@ mod tests {
             session: Some(ts),
             apply: false,
         };
-        let global = GlobalFlags {
-            json: true,
-            quiet: false,
-            cwd: Some(dir.path().to_string_lossy().to_string()),
-            ..GlobalFlags::default()
-        };
+        let global = GlobalFlags::with_cwd_and_json(dir.path());
         let code = crate::cmd::undo::run(args, &global).unwrap();
         assert_eq!(code, exit::CHANGES_DETECTED);
     }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -2944,13 +2944,12 @@ mod tests {
             session: None,
             apply: false,
         };
-        let mut global = GlobalFlags::with_cwd_and_json(dir.path());
+        let global = GlobalFlags::with_cwd_and_json(dir.path());
         let code = crate::cmd::undo::run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);
 
         // Also test JSONL mode.
-        global.json = false;
-        global.jsonl = true;
+        let global = GlobalFlags::with_cwd_and_jsonl(dir.path());
         let args2 = crate::cmd::undo::UndoArgs {
             list: true,
             session: None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -16493,6 +16493,20 @@ async fn call_tool_text(
     (is_error, text)
 }
 
+/// Helper to call an MCP tool and parse the response text as JSON Value.
+/// This enables honest structured assertions for tools like git_status
+/// (instead of fragile substring `contains` on the whole pretty-printed output).
+async fn call_tool_value(
+    client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
+    tool: impl Into<String>,
+    args: serde_json::Value,
+) -> (bool, serde_json::Value) {
+    let (is_error, text) = call_tool_text(client, tool, args).await;
+    let val =
+        serde_json::from_str(&text).unwrap_or_else(|_| serde_json::json!({ "raw_text": text }));
+    (is_error, val)
+}
+
 #[tokio::test]
 async fn test_mcp_doc_set_round_trip() {
     if !has_mcp_support() {
@@ -17620,19 +17634,46 @@ async fn test_mcp_status_round_trip() {
     fs::remove_file(dir.path().join("to-be-deleted.txt")).unwrap();
 
     let client = spawn_mcp_client(dir.path()).await;
-    let (is_error, text) = call_tool_text(&client, "git_status", serde_json::json!({})).await;
-    assert!(!is_error, "status should succeed: {text}");
+    let (is_error, status) = call_tool_value(&client, "git_status", serde_json::json!({})).await;
+    assert!(!is_error, "status should succeed: {status}");
+    let modified: Vec<String> = status
+        .get("modified")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let created: Vec<String> = status
+        .get("created")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let deleted: Vec<String> = status
+        .get("deleted")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
     assert!(
-        text.contains("tracked.txt"),
-        "status should show modified file: {text}"
+        modified.iter().any(|f| f.contains("tracked.txt")),
+        "status should show modified file: {status}"
     );
     assert!(
-        text.contains("created.txt"),
-        "status should show created file: {text}"
+        created.iter().any(|f| f.contains("created.txt")),
+        "status should show created file: {status}"
     );
     assert!(
-        text.contains("to-be-deleted.txt"),
-        "status should show deleted file: {text}"
+        deleted.iter().any(|f| f.contains("to-be-deleted.txt")),
+        "status should show deleted file: {status}"
     );
     client.cancel().await.unwrap();
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17602,12 +17602,37 @@ async fn test_mcp_status_round_trip() {
     // Modify the tracked file to create a diff.
     fs::write(dir.path().join("tracked.txt"), "modified\n").unwrap();
 
+    // New untracked file -> created category in status.
+    fs::write(dir.path().join("created.txt"), "new content\n").unwrap();
+
+    // Tracked then deleted -> deleted category.
+    fs::write(dir.path().join("to-be-deleted.txt"), "will be gone\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "to-be-deleted.txt"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "add for delete"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::remove_file(dir.path().join("to-be-deleted.txt")).unwrap();
+
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, text) = call_tool_text(&client, "git_status", serde_json::json!({})).await;
     assert!(!is_error, "status should succeed: {text}");
     assert!(
         text.contains("tracked.txt"),
         "status should show modified file: {text}"
+    );
+    assert!(
+        text.contains("created.txt"),
+        "status should show created file: {text}"
+    );
+    assert!(
+        text.contains("to-be-deleted.txt"),
+        "status should show deleted file: {text}"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
Multi-perspective batch 1 on fresh branch (post gate clean on main).

**Pre-rotation gate passed:**
- CI recent success on main.
- Open PRs: #776 (release v0.5.0, CLEAN, APPROVED) — reported, **NEVER merge without explicit yes**. #848 (our prior mcp conversions) approved.
- Open issues: only #632-#634 (external dist/MCP registry submits, blocked; comments added).
- Stashes dropped (old, landed), tree clean, on latest main.

**Batch fixes:**
- QA: strengthened `test_mcp_status_round_trip` to cover created + deleted categories in git_status MCP output (exercises full StatusOutput + porcelain parse for the tool added via mcp_tool!).
- Test Auditor: replaced `assert!(res.is_some()); let x = res.unwrap()` with `.expect(msg)` in two AST signature tests (honest failures, per mechanical audit).
- Developer: switched remaining direct `GlobalFlags { json: true, cwd: Some, .. }` in tx undo json tests to `with_cwd_and_json` helper (consistent with Phase 6 judo).

All changes: explicit `git add` only, `make check` green before push, DCO -s.

Recent landed context (avoid rediscovery): mcp_tool! for git_status + file ops (move/append/create/delete) + doc/md family (#848 + #844-847); GlobalFlags helpers; precise hygiene; op! batch; etc. Phase 6 complete.

Release PR #776 noted (do not merge w/o yes).