### PR TITLE
chore: update rmcp from 1.7.0 to 1.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,9 +1083,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rmcp"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
+checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
  "base64",
@@ -1107,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aefac48c364756e97f04c0401ba3231e8607882c7c1d92da0437dc16307904d"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -455,6 +455,14 @@ mod params {
         pub strict: bool,
     }
 
+    /// No-parameter wrapper for tools that need no input (e.g., git_status).
+    /// Required because rmcp 1.8+ validates that `inputSchema` has a root
+    /// `type: "object"` field, which `serde_json::Value` does not provide.
+    #[derive(Debug, Deserialize, schemars::JsonSchema)]
+    #[serde(deny_unknown_fields)]
+    #[non_exhaustive]
+    pub(crate) struct EmptyParams {}
+
     /// Parameters for executing a full multi-step transaction plan.
     /// This is the MCP equivalent of `patchloom tx`.
     #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -1132,7 +1140,7 @@ impl PatchloomService {
     mcp_tool!(
         git_status,
         "Show uncommitted file changes vs git HEAD. Returns lists of modified, created, and deleted files. No parameters required.",
-        serde_json::Value,
+        EmptyParams,
         |self_, _p| {
             let global = GlobalFlags::with_cwd(self_.cwd());
             let status = crate::cmd::status::collect_status(&[], &global)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -18035,10 +18035,17 @@ async fn test_mcp_rejects_unknown_fields() {
         .unwrap(),
     );
     let result = client.peer().call_tool(params).await;
-    assert!(
-        result.is_err(),
-        "unknown fields must be rejected by deny_unknown_fields"
-    );
+    // rmcp 1.8+ returns deny_unknown_fields violations as a tool result with
+    // isError (not a protocol-level Err), so accept either shape.
+    match result {
+        Err(_) => { /* protocol-level rejection: OK */ }
+        Ok(r) => {
+            assert!(
+                r.is_error.unwrap_or(false),
+                "unknown fields must be rejected by deny_unknown_fields"
+            );
+        }
+    }
     // File must remain unchanged
     let content = fs::read_to_string(dir.path().join("test.json")).unwrap();
     assert_eq!(content, r#"{"a":1}"#);


### PR DESCRIPTION
## Summary

Update rmcp dependency from 1.7.0 to 1.8.0. The new version enforces stricter schema validation requiring `inputSchema` to have a root `type: "object"` field.

## Changes

- **`Cargo.lock`**: Version bump rmcp 1.7.0 to 1.8.0 (and rmcp-macros)
- **`src/cmd/mcp.rs`**: Add `EmptyParams` struct for tools that take no parameters. The `git_status` tool previously used `Parameters<serde_json::Value>`, which generated a schema without an explicit `type` field. Replaced with `Parameters<EmptyParams>` to satisfy the new validation.
- **`tests/integration.rs`**: Update `test_mcp_rejects_unknown_fields` to accept both protocol-level errors and tool results with `isError: true`, since rmcp 1.8 returns `deny_unknown_fields` violations as tool results rather than protocol errors.

## Verification

`make check` passes: 949 unit tests, 710 integration tests, 10 PTY tests.

Closes #854