### PR TITLE
fix: route file MCP tools through tx engine for structured JSON responses

### DIFF
--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -37,31 +37,6 @@ struct AppendOutput {
 }
 
 /// Append content to a file, without writing to stdout.
-/// Used by the MCP server for direct in-process file appending.
-///
-/// Now creates a BackupSession (parent dir as root) for undo safety and
-/// crash consistency, matching other MCP write shims and the library API.
-#[cfg(feature = "mcp")]
-pub(crate) fn apply_append(path: &std::path::Path, content: &str) -> anyhow::Result<()> {
-    if !path.exists() {
-        bail!("file does not exist: {}", path.display());
-    }
-    if !path.is_file() {
-        bail!("target is not a file: {}", path.display());
-    }
-
-    let existing = fs::read_to_string(path)?;
-    let combined = crate::ops::file::append_content(&existing, content);
-
-    let policy = crate::write::WritePolicy::default();
-    let cwd = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let mut backup = BackupSession::new(cwd)?;
-    backup.save_before_write(path)?;
-    atomic_write(path, &combined, &policy)?;
-    backup.finalize()?;
-    Ok(())
-}
-
 pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
 

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -65,43 +65,6 @@ fn create_with_backup(
     Ok(())
 }
 
-/// Create a file, without writing to stdout.
-/// Used by the MCP server for direct in-process file creation.
-///
-/// Now creates a BackupSession (using the file's parent as root, like the
-/// library api layer) so that `patchloom undo` works and crashes are safe.
-/// Mirrors the logic in create_with_backup but accepts only the path (MCP
-/// callers already resolved abs path after their check_path).
-#[cfg(feature = "mcp")]
-pub(crate) fn apply_create(
-    path: &std::path::Path,
-    content: &str,
-    force: bool,
-) -> anyhow::Result<()> {
-    if path.exists() && !path.is_file() {
-        bail!("target is not a file: {}", path.display());
-    }
-
-    // Ensure parent directories exist.
-    if let Some(parent) = path.parent()
-        && !parent.as_os_str().is_empty()
-    {
-        fs::create_dir_all(parent)?;
-    }
-
-    let policy = crate::write::WritePolicy::default();
-    let cwd = path.parent().unwrap_or_else(|| std::path::Path::new("."));
-    let mut backup = BackupSession::new(cwd)?;
-    backup.save_before_write(path)?;
-    if force {
-        atomic_write(path, content, &policy)?;
-    } else {
-        atomic_create_new(path, content, &policy)?;
-    }
-    backup.finalize()?;
-    Ok(())
-}
-
 pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
 

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -31,19 +31,6 @@ fn delete_with_backup(path: &std::path::Path, cwd: &std::path::Path) -> anyhow::
     Ok(())
 }
 
-/// Delete a file with backup, without writing to stdout.
-/// Used by the MCP server for direct in-process deletes.
-#[cfg(feature = "mcp")]
-pub(crate) fn apply_delete(path: &std::path::Path, cwd: &std::path::Path) -> anyhow::Result<()> {
-    if !path.exists() {
-        anyhow::bail!("file not found: {}", path.display());
-    }
-    if !path.is_file() {
-        anyhow::bail!("target is not a file: {}", path.display());
-    }
-    delete_with_backup(path, cwd)
-}
-
 pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let path = cwd.join(&args.file);

--- a/src/cmd/mcp.rs
+++ b/src/cmd/mcp.rs
@@ -1158,16 +1158,14 @@ impl PatchloomService {
         |self_, p| {
             self_.check_path(&p.from)?;
             self_.check_path(&p.to)?;
-
-            let src = self_.cwd().join(&p.from);
-            let dst = self_.cwd().join(&p.to);
-            match crate::cmd::rename::apply_rename(&src, &dst, p.force, self_.cwd()) {
-                Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Renamed {} -> {}",
-                    p.from, p.to
-                ))])),
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!("{e:#}"))])),
-            }
+            self_.run_one_op(
+                Operation::FileRename {
+                    from: p.from,
+                    to: p.to,
+                    force: p.force,
+                },
+                None,
+            )
         }
     );
 
@@ -1178,15 +1176,13 @@ impl PatchloomService {
         |self_, p| {
             self_.check_path(&p.path)?;
             validate_content_size("content", &p.content)?;
-
-            let abs = self_.cwd().join(&p.path);
-            match crate::cmd::append::apply_append(&abs, &p.content) {
-                Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Appended to {}",
-                    p.path
-                ))])),
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!("{e:#}"))])),
-            }
+            self_.run_one_op(
+                Operation::FileAppend {
+                    path: p.path,
+                    content: p.content,
+                },
+                None,
+            )
         }
     );
 
@@ -1197,15 +1193,14 @@ impl PatchloomService {
         |self_, p| {
             self_.check_path(&p.path)?;
             validate_content_size("content", &p.content)?;
-
-            let abs = self_.cwd().join(&p.path);
-            match crate::cmd::create::apply_create(&abs, &p.content, p.force) {
-                Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Created {}",
-                    p.path
-                ))])),
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!("{e:#}"))])),
-            }
+            self_.run_one_op(
+                Operation::FileCreate {
+                    path: p.path,
+                    content: p.content,
+                    force: Some(p.force),
+                },
+                None,
+            )
         }
     );
 
@@ -1215,15 +1210,7 @@ impl PatchloomService {
         DeleteFileParams,
         |self_, p| {
             self_.check_path(&p.path)?;
-
-            let abs = self_.cwd().join(&p.path);
-            match crate::cmd::delete::apply_delete(&abs, self_.cwd()) {
-                Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Deleted {}",
-                    p.path
-                ))])),
-                Err(e) => Ok(CallToolResult::error(vec![Content::text(format!("{e:#}"))])),
-            }
+            self_.run_one_op(Operation::FileDelete { path: p.path }, None)
         }
     );
 }

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -203,44 +203,6 @@ fn rename_with_backup(
     Ok(())
 }
 
-/// Perform a rename with backup, without writing to stdout.
-/// Used by the MCP server for direct in-process renames.
-#[cfg(feature = "mcp")]
-pub(crate) fn apply_rename(
-    from: &std::path::Path,
-    to: &std::path::Path,
-    force: bool,
-    cwd: &std::path::Path,
-) -> anyhow::Result<()> {
-    if validate_rename_paths(
-        from,
-        to,
-        force,
-        &from.display().to_string(),
-        &to.display().to_string(),
-    )? == RenameValidation::NoOp
-    {
-        return Ok(());
-    }
-
-    let mut backup = crate::backup::BackupSession::new(cwd)?;
-    backup.save_before_delete(from)?;
-    backup.save_before_write(to)?;
-
-    // Create parent directories if needed.
-    if let Some(parent) = to.parent()
-        && !parent.as_os_str().is_empty()
-        && !parent.exists()
-    {
-        fs::create_dir_all(parent)?;
-    }
-
-    // Binary-safe rename via fs::rename (with cross-device fallback).
-    rename_or_copy(from, to)?;
-    backup.finalize()?;
-    Ok(())
-}
-
 /// Perform the actual file rename: create parent dirs, move or transform the
 /// content, and remove the source.
 fn do_rename(
@@ -517,19 +479,6 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert!(file.exists(), "file must not be deleted");
-        assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
-    }
-
-    #[cfg(feature = "mcp")]
-    #[test]
-    fn apply_rename_same_path_is_noop_without_force() {
-        let dir = TempDir::new().unwrap();
-        let file = dir.path().join("same.txt");
-        fs::write(&file, "hello\n").unwrap();
-
-        apply_rename(&file, &file, false, dir.path()).unwrap();
-
-        assert!(file.exists(), "file should still exist");
         assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -16886,6 +16886,9 @@ async fn test_mcp_file_rename_round_trip() {
     )
     .await;
     assert!(!is_error, "rename should succeed: {val}");
+    assert_eq!(val["ok"], true, "rename ok field: {val}");
+    assert_eq!(val["files_created"], 1, "rename files_created: {val}");
+    assert_eq!(val["files_deleted"], 1, "rename files_deleted: {val}");
     assert!(
         !dir.path().join("old_name.txt").exists(),
         "old file should not exist"
@@ -16916,11 +16919,8 @@ async fn test_mcp_create_round_trip() {
     )
     .await;
     assert!(!is_error, "create should succeed: {val}");
-    let msg = val.get("raw_text").and_then(|v| v.as_str()).unwrap_or("");
-    assert!(
-        msg.contains("Created") && msg.contains("new_file.txt"),
-        "create response should confirm file creation: {val}"
-    );
+    assert_eq!(val["ok"], true, "create ok field: {val}");
+    assert_eq!(val["files_created"], 1, "create files_created: {val}");
     assert!(
         dir.path().join("new_file.txt").exists(),
         "file should exist after create"
@@ -16975,11 +16975,8 @@ async fn test_mcp_delete_round_trip() {
     )
     .await;
     assert!(!is_error, "delete should succeed: {val}");
-    let msg = val.get("raw_text").and_then(|v| v.as_str()).unwrap_or("");
-    assert!(
-        msg.contains("Deleted") && msg.contains("doomed.txt"),
-        "delete response should confirm file deletion: {val}"
-    );
+    assert_eq!(val["ok"], true, "delete ok field: {val}");
+    assert_eq!(val["files_deleted"], 1, "delete files_deleted: {val}");
     assert!(
         !dir.path().join("doomed.txt").exists(),
         "file should not exist after delete"
@@ -18326,6 +18323,8 @@ async fn test_mcp_append_file_round_trip() {
     )
     .await;
     assert!(!is_error, "append_file should succeed: {val}");
+    assert_eq!(val["ok"], true, "append ok field: {val}");
+    assert_eq!(val["files_changed"], 1, "append files_changed: {val}");
     assert_eq!(
         fs::read_to_string(&file).unwrap(),
         "line one\nline two\n",


### PR DESCRIPTION
## Summary

Route `create_file`, `delete_file`, `move_file`, and `append_file` MCP tools through `run_one_op`/`execute_plan` instead of custom `apply_*` shims. All four tools now return structured `TxOutput` JSON (`ok`, `status`, `files_changed`, `files_created`, `files_deleted`, `changes[]`, `backup_session`) consistent with every other write tool.

## Changes

- **`src/cmd/mcp.rs`**: Replace custom handlers with `run_one_op(Operation::*)` calls for all four tools
- **`src/cmd/append.rs`**: Remove dead `apply_append` shim (was only called by old MCP handler)
- **`src/cmd/create.rs`**: Remove dead `apply_create` shim
- **`src/cmd/delete.rs`**: Remove dead `apply_delete` shim
- **`src/cmd/rename.rs`**: Remove dead `apply_rename` shim and its unit test
- **`tests/integration.rs`**: Replace `raw_text` workaround assertions with structured JSON field checks (`val["ok"]`, `val["files_created"]`, `val["files_deleted"]`, `val["files_changed"]`)

## Testing

`make check` passes (948 unit + 710 integration + 10 PTY tests).

Closes #859