### PR TITLE
test: add MCP edge case tests and fix missing docs

### DIFF
--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -102,6 +102,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `md_lint` | Lint an AGENTS.md file for common issues |
 | `fix_whitespace` | Fix whitespace and line endings in a text file. Binary and invalid UTF-8 files are skipped |
 | `create_file` | Create a new file with content |
+| `append_file` | Append content to an existing file |
 | `delete_file` | Delete a file |
 | `move_file` | Move or rename a file (binary-safe) |
 | `apply_patch` | Apply a unified diff |

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -16960,6 +16960,31 @@ async fn test_mcp_create_existing_fails_without_force() {
 }
 
 #[tokio::test]
+async fn test_mcp_create_force_overwrites_existing() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("existing.txt"), "original\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "create_file",
+        serde_json::json!({"path": "existing.txt", "content": "replaced\n", "force": true}),
+    )
+    .await;
+    assert!(!is_error, "create with force should succeed: {val}");
+    assert_eq!(val["ok"], true, "create force ok field: {val}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("existing.txt")).unwrap(),
+        "replaced\n",
+        "content should be overwritten"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_delete_round_trip() {
     if !has_mcp_support() {
         return;
@@ -16980,6 +17005,48 @@ async fn test_mcp_delete_round_trip() {
     assert!(
         !dir.path().join("doomed.txt").exists(),
         "file should not exist after delete"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_delete_nonexistent_returns_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "delete_file",
+        serde_json::json!({"path": "nonexistent.txt"}),
+    )
+    .await;
+    assert!(
+        is_error,
+        "delete should fail when file does not exist: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_move_nonexistent_source_returns_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "move_file",
+        serde_json::json!({"from": "nonexistent.txt", "to": "dest.txt"}),
+    )
+    .await;
+    assert!(
+        is_error,
+        "move should fail when source does not exist: {val}"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle focused on the recently merged #859 changes (file MCP tools now route through the tx engine).

## Changes

### QA Engineer
- Add `test_mcp_create_force_overwrites_existing`: verify `create_file` with `force=true` overwrites an existing file and returns structured JSON
- Add `test_mcp_delete_nonexistent_returns_error`: verify `delete_file` on a missing file returns an error
- Add `test_mcp_move_nonexistent_source_returns_error`: verify `move_file` with a missing source returns an error

### End User
- Add missing `append_file` tool to the MCP tools table in `docs/getting-started/mcp-setup.md`

## Testing

`make check` passes (948 unit + 713 integration + 10 PTY tests).