### PR TITLE
fix: remove redundant allow(dead_code) and fix vacuous test assertions

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -63,7 +63,6 @@ pub struct TxArgs {
 const DEFAULT_LIFECYCLE_TIMEOUT_SECS: u64 = 60;
 
 #[cfg_attr(not(feature = "cli"), allow(dead_code))]
-#[allow(dead_code)]
 fn validate_operation(op: &Operation) -> anyhow::Result<()> {
     match op {
         Operation::Replace {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -17064,10 +17064,14 @@ async fn test_mcp_apply_patch_merge_conflict_rejected_without_allow_conflicts() 
         "conflicting merge without allow_conflicts should fail: {val}"
     );
     assert_eq!(val["ok"], false, "patch conflict ok should be false: {val}");
-    let raw_text = val.get("raw_text").and_then(|v| v.as_str()).unwrap_or("");
+    let response_str = val.to_string();
     assert!(
-        !raw_text.contains("<<<<<<<"),
-        "conflict markers must not be written: {val}"
+        response_str.contains("conflict"),
+        "response should mention conflict: {val}"
+    );
+    assert!(
+        !response_str.contains("<<<<<<<"),
+        "conflict markers must not appear in response: {val}"
     );
     assert_eq!(
         fs::read_to_string(dir.path().join("target.txt")).unwrap(),
@@ -17783,12 +17787,14 @@ async fn test_mcp_git_status_errors_without_git_repo() {
     let dir = TempDir::new().unwrap(); // no git init - expect error from collect_status
 
     let client = spawn_mcp_client(dir.path()).await;
-    let (is_error, val) = call_tool_value(&client, "git_status", serde_json::json!({})).await;
-    assert!(is_error, "git_status should error outside git repo: {val}");
-    let err_text = val.get("raw_text").and_then(|v| v.as_str()).unwrap_or("");
+    let (is_error, err_text) = call_tool_text(&client, "git_status", serde_json::json!({})).await;
+    assert!(
+        is_error,
+        "git_status should error outside git repo: {err_text}"
+    );
     assert!(
         err_text.contains("git") || err_text.contains("repository") || err_text.contains("failed"),
-        "error should mention git/repo: {val}"
+        "error should mention git/repo: {err_text}"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Two tech-debt items found during session self-audit.

### 1. Redundant `#[allow(dead_code)]` on `validate_operation` (`src/cmd/tx.rs:66`)

The function had both:
```rust
#[cfg_attr(not(feature = "cli"), allow(dead_code))]
#[allow(dead_code)]
```

The unconditional `#[allow(dead_code)]` makes the conditional `cfg_attr` meaningless. Removed the redundant line so clippy will catch this function becoming dead code when `cli` is enabled.

### 2. Vacuous `raw_text` assertions in MCP integration tests

Two tests used `val.get("raw_text")` to inspect error content, but `raw_text` is a synthetic field created by `call_tool_value` only when JSON parsing fails. When the MCP tool returns valid structured JSON (confirmed by other assertions in the same test), `raw_text` is never present, making the checks vacuously true.

**Patch conflict test** (`test_mcp_apply_patch_merge_conflict_rejected_without_allow_conflicts`):
- Before: checked non-existent `raw_text` field for conflict markers (always empty string, always passed)
- After: checks the actual serialized JSON response for the word "conflict" and absence of `<<<<<<<` markers

**git_status error test** (`test_mcp_git_status_errors_without_git_repo`):
- Before: parsed to JSON then checked `raw_text` fallback (fragile, depends on error format)
- After: uses `call_tool_text` directly to check the raw error string

## Verification

`make check` passes (948 unit + 713 integration + 10 PTY tests).

Closes #863
Closes #864