### PR TITLE
fix: FOSSA false positive and TLS error path test

### DIFF
--- a/scripts/fossa-filter.py
+++ b/scripts/fossa-filter.py
@@ -30,6 +30,14 @@ Documented false positives
    flags GPL because the source tarball includes GPL-licensed test vectors
    from OpenSSL. These test files are not compiled into the binary.
    Pulled in transitively via rustls/aws-lc-rs for TLS support.
+
+5. security-framework  APSL-2.0
+   security-framework is MIT/Apache-2.0 licensed Rust bindings to Apple's
+   Security.framework. FOSSA flags APSL-2.0 because the underlying macOS
+   system library is Apple-licensed, but the crate itself does not bundle
+   Apple code; it links to the system library at runtime. This is standard
+   for any Rust crate using native macOS APIs. Pulled in transitively via
+   rustls-platform-verifier for TLS certificate verification.
 """
 
 import json
@@ -70,6 +78,10 @@ def is_false_positive(pkg: str, license_id: str, issue_type: str = "") -> bool:
 
     # aws-lc-sys: Apache-2.0/ISC; GPL flags from test vectors in source tarball
     if pkg == "aws-lc-sys" and license_id.startswith("GPL-"):
+        return True
+
+    # security-framework: MIT/Apache-2.0 bindings; APSL-2.0 is the system library
+    if pkg == "security-framework" and license_id == "APSL-2.0":
         return True
 
     return False

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -20793,6 +20793,31 @@ fn test_mcp_http_tls_key_requires_tls_cert() {
         .stderr(predicates::str::contains("--tls-cert"));
 }
 
+/// Verify that invalid TLS cert content produces a clear error.
+#[cfg(feature = "mcp-http")]
+#[test]
+fn test_mcp_http_invalid_tls_cert_fails_with_error() {
+    if !has_mcp_http_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bad-cert.pem"), "not a certificate\n").unwrap();
+    fs::write(dir.path().join("bad-key.pem"), "not a key\n").unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "mcp-server",
+            "--http",
+            "--tls-cert",
+            dir.path().join("bad-cert.pem").to_str().unwrap(),
+            "--tls-key",
+            dir.path().join("bad-key.pem").to_str().unwrap(),
+        ])
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("TLS"));
+}
+
 /// Verify that search_files works over HTTPS (TLS) transport with --port 0.
 /// This exercises the TLS server setup (axum_server::bind_rustls) and the
 /// ephemeral port banner fix (#867).


### PR DESCRIPTION
MPI cycle 1 improvements:

1. **FOSSA false positive fix**: Add `security-framework` APSL-2.0 to the FOSSA filter. The `reqwest` dev-dependency (added in #869) pulls in `security-framework` via `rustls-platform-verifier` on macOS. The crate is MIT/Apache-2.0 but FOSSA flags APSL-2.0 from the underlying Apple system library.

2. **TLS error path test** (QA perspective): Add `test_mcp_http_invalid_tls_cert_fails_with_error` to verify that providing invalid certificate content to `--tls-cert`/`--tls-key` produces a clear TLS error message.