### PR TITLE
fix: remove release PR body editor that broke v0.5.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,23 +130,11 @@ jobs:
           git commit -s -m "chore: sync PATCHLOOM.md with version bump"
           git push
 
-      - name: Keep release PR body reasonable (tech-debt #740)
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          PR_NUMBER=$(echo '${{ needs.release-please.outputs.pr }}' | jq -r '.number // empty')
-          if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
-            echo "No PR number available"
-            exit 0
-          fi
-
-          CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body || echo "")
-          if echo "$CURRENT_BODY" | grep -qE '## \[[0-9]+\.[0-9]+\.[0-9]+\]'; then
-            echo "Setting short curated body on release PR #$PR_NUMBER"
-            gh pr edit "$PR_NUMBER" --body $':robot: Release PR\n\nSee [RELEASE_NOTES.md](https://github.com/patchloom/patchloom/blob/main/RELEASE_NOTES.md) for the curated highlights of this release.\n\nThe detailed changelog will be part of the published GitHub Release.' || echo "Failed to edit PR body (non-fatal)"
-          else
-            echo "PR body looks reasonable, leaving as-is"
-          fi
+      # NOTE: Do NOT edit the release-please PR body. release-please
+      # parses its own PR body on merge to detect the release. Replacing
+      # the body causes "Pull request body did not match" and the release
+      # tag is never created. This step was removed after it broke the
+      # v0.5.0 release (run 28121302481). See tech-debt #740.
 
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:


### PR DESCRIPTION
The 'Keep release PR body reasonable' step (tech-debt #740) edited the release-please PR body to a short curated message. When PR #776 was merged, release-please could not parse the body and never created the `patchloom-v0.5.0` tag or release.

**Root cause:** release-please parses its own PR body on merge to detect what was released. Replacing the body with a short message makes it unrecognizable.

**Secondary bug:** The step had a shell injection vulnerability: raw JSON from `${{ needs.release-please.outputs.pr }}` was expanded inline into the shell script. Parentheses in commit messages (e.g. `closes (#123)`) broke the shell syntax with `unexpected EOF while looking for matching ')'`.

**Fix:** Remove the step entirely. The release-please PR body must not be modified.

The v0.5.0 tag has been manually created and pushed to trigger the release build.

Ref #740