### PR TITLE
test: add yaml_splice unit tests and ast --jsonl integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1600%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1700%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-1600+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1700+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -401,3 +401,208 @@ pub fn needs_yaml_quoting(s: &str) -> bool {
         || s.contains(" #")
         || s.contains('\n')
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -----------------------------------------------------------------------
+    // find_yaml_key_line
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn find_yaml_key_line_single_key() {
+        let yaml = "name: foo\nversion: 1\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        assert_eq!(find_yaml_key_line(&lines, &["version".into()]), Some(1));
+    }
+
+    #[test]
+    fn find_yaml_key_line_nested_path() {
+        let yaml = "top:\n  mid:\n    deep: val\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        assert_eq!(
+            find_yaml_key_line(&lines, &["top".into(), "mid".into(), "deep".into()]),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn find_yaml_key_line_missing_key() {
+        let yaml = "name: foo\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        assert_eq!(find_yaml_key_line(&lines, &["missing".into()]), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // find_first_block_entry
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn find_first_block_entry_simple() {
+        let yaml = "items:\n  - one\n  - two\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        let result = find_first_block_entry(&lines, 1);
+        assert_eq!(result, Some((1, "  ".to_string())));
+    }
+
+    #[test]
+    fn find_first_block_entry_with_comment() {
+        let yaml = "items:\n  # a comment\n  - one\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        let result = find_first_block_entry(&lines, 1);
+        assert_eq!(result, Some((2, "  ".to_string())));
+    }
+
+    #[test]
+    fn find_first_block_entry_no_entries() {
+        let yaml = "items: []\nnext: val\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        assert_eq!(find_first_block_entry(&lines, 1), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // find_block_entries_end
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn find_block_entries_end_simple() {
+        let yaml = "items:\n  - one\n  - two\nnext: val\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        assert_eq!(find_block_entries_end(&lines, 1, "  "), 3);
+    }
+
+    #[test]
+    fn find_block_entries_end_multiline_values() {
+        let yaml = "items:\n  - name: a\n    value: 1\n  - name: b\n    value: 2\nnext: x\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        assert_eq!(find_block_entries_end(&lines, 1, "  "), 5);
+    }
+
+    #[test]
+    fn find_block_entries_end_trims_trailing_blanks() {
+        let yaml = "items:\n  - one\n  - two\n\nnext: val\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        // Should NOT include the blank line between array and next key.
+        assert_eq!(find_block_entries_end(&lines, 1, "  "), 3);
+    }
+
+    // -----------------------------------------------------------------------
+    // serialize_block_entries
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn serialize_scalars() {
+        let entries = vec![
+            serde_json::json!(null),
+            serde_json::json!(true),
+            serde_json::json!(42),
+            serde_json::json!("hello"),
+        ];
+        let result = serialize_block_entries(&entries, "  ").unwrap();
+        assert!(result.contains("  - null\n"));
+        assert!(result.contains("  - true\n"));
+        assert!(result.contains("  - 42\n"));
+        assert!(result.contains("  - hello\n"));
+    }
+
+    #[test]
+    fn serialize_string_needing_quoting() {
+        let entries = vec![serde_json::json!("true"), serde_json::json!("")];
+        let result = serialize_block_entries(&entries, "").unwrap();
+        assert!(result.contains("- 'true'\n"));
+        assert!(result.contains("- ''\n"));
+    }
+
+    #[test]
+    fn serialize_object_entry() {
+        let entries = vec![serde_json::json!({"name": "a", "value": 1})];
+        let result = serialize_block_entries(&entries, "  ").unwrap();
+        // First line should be "  - ..." and continuation "    ..."
+        let first_line = result.lines().next().unwrap();
+        assert!(first_line.starts_with("  - "));
+    }
+
+    // -----------------------------------------------------------------------
+    // has_array_growth_diffs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn has_array_growth_no_change() {
+        let v = serde_json::json!({"a": [1, 2]});
+        assert!(!has_array_growth_diffs(&v, &v));
+    }
+
+    #[test]
+    fn has_array_growth_detects_growth() {
+        let old = serde_json::json!({"a": [1]});
+        let new = serde_json::json!({"a": [1, 2]});
+        assert!(has_array_growth_diffs(&old, &new));
+    }
+
+    #[test]
+    fn has_array_growth_detects_nested_growth() {
+        let old = serde_json::json!({"a": {"b": [1]}});
+        let new = serde_json::json!({"a": {"b": [1, 2]}});
+        assert!(has_array_growth_diffs(&old, &new));
+    }
+
+    #[test]
+    fn has_array_growth_shrink_is_not_growth() {
+        let old = serde_json::json!({"a": [1, 2, 3]});
+        let new = serde_json::json!({"a": [1]});
+        assert!(!has_array_growth_diffs(&old, &new));
+    }
+
+    // -----------------------------------------------------------------------
+    // needs_yaml_quoting
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn needs_quoting_booleans_and_null() {
+        assert!(needs_yaml_quoting("true"));
+        assert!(needs_yaml_quoting("True"));
+        assert!(needs_yaml_quoting("yes"));
+        assert!(needs_yaml_quoting("null"));
+        assert!(needs_yaml_quoting("~"));
+    }
+
+    #[test]
+    fn needs_quoting_numbers() {
+        assert!(needs_yaml_quoting("42"));
+        assert!(needs_yaml_quoting("3.14"));
+    }
+
+    #[test]
+    fn needs_quoting_special_chars() {
+        assert!(needs_yaml_quoting("# comment"));
+        assert!(needs_yaml_quoting("a: b"));
+        assert!(needs_yaml_quoting(""));
+    }
+
+    #[test]
+    fn plain_strings_need_no_quoting() {
+        assert!(!needs_yaml_quoting("hello"));
+        assert!(!needs_yaml_quoting("foo-bar_baz"));
+    }
+
+    // -----------------------------------------------------------------------
+    // splice_yaml_root_sequence
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn splice_root_sequence_replaces_entries() {
+        let yaml = "- one\n- two\n";
+        let cur = vec![serde_json::json!("one"), serde_json::json!("two")];
+        let tgt = vec![
+            serde_json::json!("one"),
+            serde_json::json!("two"),
+            serde_json::json!("three"),
+        ];
+        let result = splice_yaml_root_sequence(yaml, &cur, &tgt)
+            .unwrap()
+            .expect("should produce a spliced result");
+        assert!(result.contains("- three\n"));
+        assert!(result.contains("- one\n"));
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -18339,6 +18339,80 @@ mod ast_tests {
             .failure()
             .stderr(predicates::str::contains("INVALID (Rust)"));
     }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn test_ast_list_jsonl_outputs_compact_lines() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("lib.rs");
+        fs::write(&f, "pub fn foo() {}\nstruct Bar;\n").unwrap();
+        let out = patchloom_in(dir.path())
+            .args(["ast", "list", "lib.rs", "--jsonl"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let text = String::from_utf8(out).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert!(
+            lines.len() >= 2,
+            "expected at least 2 JSONL lines for 2 symbols"
+        );
+        for line in &lines {
+            let v: serde_json::Value = serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("line is not valid JSON: {e}: {line}"));
+            assert!(v.is_object(), "each JSONL line should be an object");
+            // Compact: no pretty-printing (no leading whitespace on first char).
+            assert!(
+                !line.starts_with(' '),
+                "JSONL should be compact, not pretty"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn test_ast_validate_jsonl_output() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("ok.rs");
+        fs::write(&f, "fn main() {}\n").unwrap();
+        let out = patchloom_in(dir.path())
+            .args(["ast", "validate", "ok.rs", "--jsonl"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let text = String::from_utf8(out).unwrap();
+        let v: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+        assert_eq!(v["valid"], serde_json::json!(true));
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn test_ast_search_jsonl_output() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("lib.rs");
+        fs::write(&f, "fn alpha() {}\nfn beta() {}\n").unwrap();
+        let out = patchloom_in(dir.path())
+            .args(["ast", "search", "(function_item) @fn", "lib.rs", "--jsonl"])
+            .assert()
+            .success()
+            .get_output()
+            .stdout
+            .clone();
+        let text = String::from_utf8(out).unwrap();
+        let lines: Vec<&str> = text.lines().collect();
+        assert!(
+            lines.len() >= 2,
+            "should have at least 2 JSONL lines for 2 matches"
+        );
+        for line in &lines {
+            let _: serde_json::Value = serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("not valid JSON: {e}: {line}"));
+        }
+    }
 }
 
 mod mcp_tests {


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 1. Added test coverage for recently extracted code from PR #880.

### Changes

**21 unit tests for `src/ops/doc/yaml_splice.rs`** (extracted in PR #880 with zero tests):
- `find_yaml_key_line`: single key, nested path, missing key
- `find_first_block_entry`: simple, with comments, no entries
- `find_block_entries_end`: simple, multi-line values, trailing blank trimming
- `serialize_block_entries`: scalars, strings needing quoting, object entries
- `has_array_growth_diffs`: no change, growth, nested growth, shrink
- `needs_yaml_quoting`: booleans, numbers, special chars, plain strings
- `splice_yaml_root_sequence`: appending entries

**3 integration tests for ast `--jsonl` mode** (untested after PR #880 dedup):
- `ast list --jsonl`: verifies compact single-line JSON output with 2+ lines
- `ast validate --jsonl`: verifies valid JSON with correct fields
- `ast search --jsonl`: verifies multi-match JSONL output

**README update**: test count badge updated to 1700+ (actual: 1703)

### Stats

- 1703 total tests (969 unit + 724 integration + 10 PTY)
- `make check` passes