### PR TITLE
fix: address 5 structural audit findings

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -286,6 +286,25 @@ impl GlobalFlags {
         }
     }
 
+    /// Emit a collection of items in structured format.
+    ///
+    /// In `--json` mode, emits a pretty-printed JSON array of all items.
+    /// In `--jsonl` mode, emits one compact JSON line per item.
+    /// Returns `true` if structured output was emitted.
+    pub fn emit_json_items<T: serde::Serialize>(&self, items: &[T]) -> anyhow::Result<bool> {
+        if self.json {
+            println!("{}", serde_json::to_string_pretty(items)?);
+            Ok(true)
+        } else if self.jsonl {
+            for item in items {
+                println!("{}", serde_json::to_string(item)?);
+            }
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
     /// Read file paths from `--files-from`. Returns `None` if the flag is not set.
     /// When the value is `-`, reads from stdin (one path per line).
     pub fn read_files_from(&self) -> anyhow::Result<Option<Vec<String>>> {

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -232,13 +232,14 @@ fn apply_or_preview(
     global: &GlobalFlags,
     cwd: &std::path::Path,
     status_msg: &str,
+    backup: Option<&mut BackupSession>,
 ) -> anyhow::Result<PreviewAction> {
     let display_path = path.strip_prefix(cwd).unwrap_or(path);
     if global.apply {
-        let mut backup = BackupSession::new(cwd)?;
-        backup.save_before_write(path)?;
+        if let Some(b) = backup {
+            b.save_before_write(path)?;
+        }
         crate::write::atomic_write(path, new_content, &Default::default())?;
-        backup.finalize()?;
         if !global.quiet {
             eprintln!("{}: {status_msg}", display_path.display());
         }
@@ -284,6 +285,13 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let paths = resolve_target_paths(&target, &args.path, global)?;
 
+    // Single backup session for all files (batched, not per-file).
+    let mut backup = if global.apply {
+        Some(BackupSession::new(&cwd)?)
+    } else {
+        None
+    };
+
     for path in &paths {
         let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
         let source = std::fs::read_to_string(path)?;
@@ -322,7 +330,15 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         total_replacements += count;
         files_changed += 1;
         let msg = format!("{} replacement{}", count, if count == 1 { "" } else { "s" });
-        apply_or_preview(path, &source, &new_content, global, &cwd, &msg)?;
+        apply_or_preview(
+            path,
+            &source,
+            &new_content,
+            global,
+            &cwd,
+            &msg,
+            backup.as_mut(),
+        )?;
     }
 
     if global.json || global.jsonl {
@@ -332,6 +348,10 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             "replacements": total_replacements,
         });
         global.emit_json(&obj)?;
+    }
+
+    if let Some(b) = backup {
+        b.finalize()?;
     }
 
     if total_replacements == 0 {
@@ -791,7 +811,23 @@ fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         if result.replacements == 1 { "" } else { "s" },
         args.symbol,
     );
-    apply_or_preview(&target, &source, &result.content, global, &cwd, &msg)?;
+    let mut backup = if global.apply {
+        Some(BackupSession::new(&cwd)?)
+    } else {
+        None
+    };
+    apply_or_preview(
+        &target,
+        &source,
+        &result.content,
+        global,
+        &cwd,
+        &msg,
+        backup.as_mut(),
+    )?;
+    if let Some(b) = backup {
+        b.finalize()?;
+    }
     if global.apply {
         crate::write::run_format_command(global, &cwd)?;
     }
@@ -988,31 +1024,12 @@ fn collect_source_files(
     dir: &std::path::Path,
     global: &GlobalFlags,
 ) -> anyhow::Result<Vec<std::path::PathBuf>> {
-    let mut paths = Vec::new();
-    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
-
-    let walker = ignore::WalkBuilder::new(dir)
-        .hidden(true)
-        .git_ignore(true)
-        .build();
-
-    for entry in walker {
-        let entry = entry?;
-        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
-            continue;
-        }
-        let path = entry.path();
-        let lang = Language::from_path(path);
-        if !lang.has_grammar() {
-            continue;
-        }
-        if !crate::files::matches_glob(path, glob_matcher.as_ref()) {
-            continue;
-        }
-        paths.push(path.to_path_buf());
-    }
-    paths.sort();
-    Ok(paths)
+    let dir_str = dir.to_string_lossy().into_owned();
+    let mut all_paths = crate::collect_file_paths_opts(&[dir_str], global, true, None)?;
+    // Filter to files with a tree-sitter grammar.
+    all_paths.retain(|p| Language::from_path(p).has_grammar());
+    all_paths.sort();
+    Ok(all_paths)
 }
 
 fn print_symbols_human(path: &str, symbols: &[&SymbolDef]) {
@@ -1159,8 +1176,16 @@ mod tests {
         std::fs::write(&f, original).unwrap();
 
         let global = GlobalFlags::default();
-        let action =
-            apply_or_preview(&f, original, new_content, &global, dir.path(), "renamed").unwrap();
+        let action = apply_or_preview(
+            &f,
+            original,
+            new_content,
+            &global,
+            dir.path(),
+            "renamed",
+            None,
+        )
+        .unwrap();
         assert_eq!(action, PreviewAction::Diffed);
     }
 
@@ -1172,7 +1197,8 @@ mod tests {
         std::fs::write(&f, content).unwrap();
 
         let global = GlobalFlags::default();
-        let action = apply_or_preview(&f, content, content, &global, dir.path(), "no-op").unwrap();
+        let action =
+            apply_or_preview(&f, content, content, &global, dir.path(), "no-op", None).unwrap();
         assert_eq!(action, PreviewAction::Unchanged);
     }
 
@@ -1194,6 +1220,7 @@ mod tests {
             &global,
             dir.path(),
             "tested",
+            None,
         )
         .unwrap();
         assert_eq!(action, PreviewAction::Checked);
@@ -1211,8 +1238,18 @@ mod tests {
             apply: true,
             ..GlobalFlags::default()
         };
-        let action =
-            apply_or_preview(&f, original, new_content, &global, dir.path(), "applied").unwrap();
+        let mut backup = BackupSession::new(dir.path()).unwrap();
+        let action = apply_or_preview(
+            &f,
+            original,
+            new_content,
+            &global,
+            dir.path(),
+            "applied",
+            Some(&mut backup),
+        )
+        .unwrap();
+        backup.finalize().unwrap();
         assert_eq!(action, PreviewAction::Applied);
         // Verify the file was actually written.
         let on_disk = std::fs::read_to_string(&f).unwrap();

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -11,6 +11,7 @@ use crate::write::policy_from_flags;
 use anyhow::Context;
 use clap::Args;
 use serde::Serialize;
+use std::cell::Cell;
 use std::path::Path;
 
 #[derive(Debug, Args)]
@@ -496,6 +497,8 @@ struct WriteContext {
     confirm: bool,
     color: bool,
     write_policy: write::WritePolicy,
+    /// Set to `true` by `write_result` when a file is actually written.
+    wrote: Cell<bool>,
 }
 
 /// Diff / check / apply logic shared by all write subcommands.
@@ -524,6 +527,7 @@ fn write_result(
         let p = Path::new(path);
         let writes = [(p, new_content, &ctx.write_policy)];
         crate::backup::backup_write_files(cwd, &writes)?;
+        ctx.wrote.set(true);
         return Ok((String::new(), exit::SUCCESS));
     }
     // Default or explicit --diff: show unified diff.
@@ -538,6 +542,7 @@ fn write_result(
             let p = Path::new(path);
             let writes = [(p, new_content, &ctx.write_policy)];
             crate::backup::backup_write_files(cwd, &writes)?;
+            ctx.wrote.set(true);
         }
         Ok((output, exit::SUCCESS))
     } else {
@@ -924,16 +929,13 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             confirm: global.confirm,
             color: global.should_color(),
             write_policy: policy_from_flags(global, doc_file_path.map(std::path::Path::new)),
+            wrote: Cell::new(false),
         };
         let (output, code) = execute_write(&args.action, &ctx, &cwd)?;
         if code == exit::FAILURE && !output.is_empty() {
             if global.json || global.jsonl {
                 let err_obj = serde_json::json!({"ok": false, "error": &output});
-                if global.json {
-                    println!("{}", serde_json::to_string_pretty(&err_obj)?);
-                } else {
-                    println!("{}", serde_json::to_string(&err_obj)?);
-                }
+                global.emit_json(&err_obj)?;
             } else if !global.quiet {
                 eprintln!("{output}");
             }
@@ -943,11 +945,7 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             if global.json || global.jsonl {
                 let check_obj =
                     serde_json::json!({"ok": true, "has_changes": true, "message": &output});
-                if global.json {
-                    println!("{}", serde_json::to_string_pretty(&check_obj)?);
-                } else {
-                    println!("{}", serde_json::to_string(&check_obj)?);
-                }
+                global.emit_json(&check_obj)?;
             } else if !global.quiet {
                 println!("{output}");
             }
@@ -956,7 +954,7 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         if !output.is_empty() {
             println!("{output}");
         }
-        if global.apply && code == exit::SUCCESS {
+        if ctx.wrote.get() && code == exit::SUCCESS {
             crate::write::run_format_command(global, &cwd)?;
         }
         if global.apply

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -311,12 +311,8 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 files,
                 diff: None,
             };
-            println!("{}", serde_json::to_string_pretty(&output)?);
-        } else if global.jsonl {
-            for f in &files {
-                println!("{}", serde_json::to_string(f)?);
-            }
-        } else if !global.quiet {
+            global.emit_json(&output)?;
+        } else if !global.emit_json_items(&files)? && !global.quiet {
             println!("{total_matches} match(es) in {file_count} file(s)");
             for f in &files {
                 println!("  {}: {} match(es)", f.path, f.match_count);
@@ -344,17 +340,15 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 files,
                 diff: diff_text,
             };
-            println!("{}", serde_json::to_string_pretty(&output)?);
-        } else if global.jsonl {
-            for f in &files {
-                println!("{}", serde_json::to_string(f)?);
-            }
-        } else if global.diff {
-            print!("{}", make_diff_output(&replacements, color));
-        } else if !global.quiet {
-            println!("replaced {total_matches} match(es) in {file_count} file(s)");
-            for f in &files {
-                println!("  {}: {} match(es)", f.path, f.match_count);
+            global.emit_json(&output)?;
+        } else if !global.emit_json_items(&files)? {
+            if global.diff {
+                print!("{}", make_diff_output(&replacements, color));
+            } else if !global.quiet {
+                println!("replaced {total_matches} match(es) in {file_count} file(s)");
+                for f in &files {
+                    println!("  {}: {} match(es)", f.path, f.match_count);
+                }
             }
         }
         return Ok(exit::SUCCESS);
@@ -370,12 +364,8 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             files,
             diff: Some(make_diff_output(&replacements, false)),
         };
-        println!("{}", serde_json::to_string_pretty(&output)?);
-    } else if global.jsonl {
-        for f in &files {
-            println!("{}", serde_json::to_string(f)?);
-        }
-    } else {
+        global.emit_json(&output)?;
+    } else if !global.emit_json_items(&files)? {
         print!("{}", make_diff_output(&replacements, color));
     }
     if global.show_status() {

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -143,14 +143,9 @@ fn render_issues(issues: &[TidyIssue], global: &GlobalFlags) {
             issue_count: issues.len(),
             issues: issues.to_vec(),
         };
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&output).unwrap_or_default()
-        );
-    } else if global.jsonl {
-        for issue in issues {
-            println!("{}", serde_json::to_string(issue).unwrap_or_default());
-        }
+        let _ = global.emit_json(&output);
+    } else if let Ok(true) = global.emit_json_items(issues) {
+        // emitted per-item JSONL
     } else {
         for issue in issues {
             if let Some(line) = issue.line {
@@ -283,14 +278,9 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         files: fix_files,
                         diff: diff_text,
                     };
-                    println!(
-                        "{}",
-                        serde_json::to_string_pretty(&output).unwrap_or_default()
-                    );
+                    let _ = global.emit_json(&output);
                 } else {
-                    for f in &fix_files {
-                        println!("{}", serde_json::to_string(f).unwrap_or_default());
-                    }
+                    let _ = global.emit_json_items(&fix_files);
                 }
             }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -123,6 +123,10 @@ fn weak_tier_schemas() -> Vec<OperationSchema> {
                     "if_exists": {"type": "boolean", "default": false, "description": "Do not error if no matches found."},
                     "whole_line": {"type": "boolean", "default": false, "description": "Replace the entire line containing each match."},
                     "range": {"type": "string", "description": "Restrict matching to a line range (e.g. '10:50'). Requires whole_line."},
+                    "word_boundary": {"type": "boolean", "default": false, "description": "Match only at word boundaries (\\b). Prevents partial matches inside identifiers."},
+                    "glob": {"type": "string", "description": "Glob pattern to filter files (e.g. '*.rs'). Replaces path for multi-file operations."},
+                    "insert_before": {"type": "string", "description": "Insert this text before the matched text instead of replacing it."},
+                    "insert_after": {"type": "string", "description": "Insert this text after the matched text instead of replacing it."},
                     "before_context": {"type": "string", "description": "Context line(s) before the target for anchor-based fallback matching when exact match fails."},
                     "after_context": {"type": "string", "description": "Context line(s) after the target for anchor-based fallback matching when exact match fails."}
                 }
@@ -1013,6 +1017,304 @@ mod tests {
         // Roundtrip: deserialize back.
         let deserialized: Vec<OperationSchema> = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.len(), schemas.len());
+    }
+
+    /// Verify that every field accepted by `plan::Operation` for a given op
+    /// name has a corresponding entry in the hand-written schema `properties`.
+    /// This catches drift when new fields are added to the serde-based
+    /// `Operation` enum but not to the JSON Schema export.
+    #[test]
+    fn schema_properties_cover_plan_operation_fields() {
+        use crate::plan::Operation;
+
+        // Build representative Operation values for each schema op name.
+        // Only the field names matter; values are dummies.
+        let mut ops: Vec<(&str, Operation)> = vec![
+            (
+                "replace",
+                Operation::Replace {
+                    glob: Some("*.rs".into()),
+                    path: Some("f.rs".into()),
+                    mode: Some("literal".into()),
+                    from: "a".into(),
+                    to: Some("b".into()),
+                    nth: Some(1),
+                    insert_before: Some("x".into()),
+                    insert_after: Some("y".into()),
+                    case_insensitive: false,
+                    multiline: false,
+                    if_exists: false,
+                    whole_line: false,
+                    range: Some("1:10".into()),
+                    word_boundary: false,
+                    before_context: Some("ctx".into()),
+                    after_context: Some("ctx".into()),
+                },
+            ),
+            (
+                "file.create",
+                Operation::FileCreate {
+                    path: "f".into(),
+                    content: "c".into(),
+                    force: Some(true),
+                },
+            ),
+            (
+                "file.append",
+                Operation::FileAppend {
+                    path: "f".into(),
+                    content: "c".into(),
+                },
+            ),
+            ("file.delete", Operation::FileDelete { path: "f".into() }),
+            (
+                "file.rename",
+                Operation::FileRename {
+                    from: "a".into(),
+                    to: "b".into(),
+                    force: true,
+                },
+            ),
+            (
+                "tidy.fix",
+                Operation::TidyFix {
+                    path: "f".into(),
+                    ensure_final_newline: Some(true),
+                    trim_trailing_whitespace: Some(true),
+                    normalize_eol: Some("lf".into()),
+                },
+            ),
+            (
+                "doc.set",
+                Operation::DocSet {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!("v"),
+                },
+            ),
+            (
+                "doc.delete",
+                Operation::DocDelete {
+                    path: "f".into(),
+                    selector: "s".into(),
+                },
+            ),
+            (
+                "doc.merge",
+                Operation::DocMerge {
+                    path: "f".into(),
+                    value: serde_json::json!({}),
+                },
+            ),
+            (
+                "doc.append",
+                Operation::DocAppend {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!([]),
+                },
+            ),
+            (
+                "doc.prepend",
+                Operation::DocPrepend {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!([]),
+                },
+            ),
+            (
+                "doc.update",
+                Operation::DocUpdate {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!({}),
+                },
+            ),
+            (
+                "doc.move",
+                Operation::DocMove {
+                    path: "f".into(),
+                    from: "a".into(),
+                    to: "b".into(),
+                },
+            ),
+            (
+                "doc.ensure",
+                Operation::DocEnsure {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!(1),
+                },
+            ),
+            (
+                "doc.delete_where",
+                Operation::DocDeleteWhere {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    predicate: "p".into(),
+                },
+            ),
+            (
+                "md.replace_section",
+                Operation::MdReplaceSection {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    content: "c".into(),
+                },
+            ),
+            (
+                "md.insert_after_heading",
+                Operation::MdInsertAfterHeading {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    content: "c".into(),
+                },
+            ),
+            (
+                "md.insert_before_heading",
+                Operation::MdInsertBeforeHeading {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    content: "c".into(),
+                },
+            ),
+            (
+                "md.upsert_bullet",
+                Operation::MdUpsertBullet {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    bullet: "b".into(),
+                },
+            ),
+            (
+                "md.table_append",
+                Operation::MdTableAppend {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    row: "r".into(),
+                },
+            ),
+            (
+                "md.move_section",
+                Operation::MdMoveSection {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    to: None,
+                    before: None,
+                    after: None,
+                },
+            ),
+            (
+                "md.dedupe_headings",
+                Operation::MdDedupeHeadings { path: "f".into() },
+            ),
+            (
+                "md.lint_agents",
+                Operation::MdLintAgents { path: "f".into() },
+            ),
+            (
+                "patch.apply",
+                Operation::PatchApply {
+                    diff: "d".into(),
+                    on_stale: Default::default(),
+                    allow_conflicts: false,
+                },
+            ),
+            (
+                "search",
+                Operation::Search {
+                    path: "f".into(),
+                    pattern: "p".into(),
+                    regex: false,
+                    case_insensitive: false,
+                    multiline: false,
+                    invert_match: false,
+                    context: None,
+                    before_context: None,
+                    after_context: None,
+                    assert_count: None,
+                    literal: false,
+                    globs: vec![],
+                    max_results: 0,
+                    exclude_patterns: vec![],
+                    custom_ignore_filenames: vec![],
+                },
+            ),
+            (
+                "read",
+                Operation::Read {
+                    path: "f".into(),
+                    lines: None,
+                },
+            ),
+        ];
+
+        #[cfg(feature = "ast")]
+        {
+            ops.push((
+                "ast.rename",
+                Operation::AstRename {
+                    path: "f.rs".into(),
+                    old_name: "old".into(),
+                    new_name: "new".into(),
+                    lang: None,
+                },
+            ));
+            ops.push((
+                "ast.replace",
+                Operation::AstReplace {
+                    path: "f.rs".into(),
+                    symbol: "s".into(),
+                    from: "a".into(),
+                    to: "b".into(),
+                    regex: false,
+                    lang: None,
+                },
+            ));
+        }
+
+        let schemas = operation_schemas();
+        let schema_map: std::collections::HashMap<&str, &OperationSchema> =
+            schemas.iter().map(|s| (s.name.as_str(), s)).collect();
+
+        let mut missing: Vec<String> = Vec::new();
+
+        for (op_name, op_value) in &ops {
+            let schema = match schema_map.get(op_name) {
+                Some(s) => s,
+                None => {
+                    missing.push(format!("{op_name}: no schema found"));
+                    continue;
+                }
+            };
+            let props = schema
+                .parameters
+                .get("properties")
+                .and_then(|v| v.as_object())
+                .unwrap_or_else(|| {
+                    panic!("schema {op_name}: parameters.properties is not an object")
+                });
+
+            // Serialize the Operation to get its field names.
+            let serialized = serde_json::to_value(op_value).unwrap();
+            let obj = serialized.as_object().unwrap();
+            for key in obj.keys() {
+                if key == "op" {
+                    continue; // tag field, not a parameter
+                }
+                if !props.contains_key(key) {
+                    missing.push(format!(
+                        "{op_name}: plan.rs field '{key}' missing from schema properties"
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "schema/plan drift detected:\n  {}",
+            missing.join("\n  ")
+        );
     }
 
     // Static assertion: types must be Send + Sync.


### PR DESCRIPTION
## Summary

Addresses 5 structural findings from a full-repo code quality audit.

## Changes

### 1. AST backup batching (`src/cmd/ast.rs`)
`apply_or_preview` now accepts `Option<&mut BackupSession>` instead of creating per-file sessions. `run_rename` creates a single `BackupSession` before the loop, and `run_replace` does the same around its single call. This reduces backup directory churn and groups related file changes into one undo session.

### 2. AST file walking (`src/cmd/ast.rs`)
Replaced the custom `collect_source_files` (manual `ignore::WalkBuilder`) with the shared `crate::collect_file_paths_opts` + `.retain(|p| Language::from_path(p).has_grammar())`. This picks up `--files-from`, `--exclude`, and `--ignore-file` support that the custom walker was missing.

### 3. JSON output consolidation (`src/cli/global.rs`, `src/cmd/replace.rs`, `src/cmd/tidy.rs`)
Added `GlobalFlags::emit_json_items` helper (emits a JSON array in `--json` mode, one line per item in `--jsonl` mode). Migrated 5 inline serialization sites in `replace.rs` (3 sites) and `tidy.rs` (2 sites) to use it.

### 4. Schema drift detection (`src/schema.rs`)
Added 4 missing fields to the `replace` operation schema (`word_boundary`, `glob`, `insert_before`, `insert_after`). Added a comprehensive drift-detection test that serializes every `plan::Operation` variant (all ~27 operations, including `#[cfg(feature = "ast")]` variants) and cross-checks field names against schema properties.

### 5. doc.rs format command coverage (`src/cmd/doc.rs`)
Added a `wrote: Cell<bool>` flag to `WriteContext` that `write_result` sets when a file is actually written. The `run_format_command` call now checks `ctx.wrote.get()` instead of the CLI flag, so the format command fires only after confirmed writes (both `--apply` and accepted `--confirm` prompts) and does not fire when the user declines a `--confirm` prompt.

## Testing

`make check` passes: 1712 tests (977 unit + 725 integration + 10 PTY), fmt-check clean, clippy clean, PATCHLOOM.md and README.md verified.