### PR TITLE
fix: preserve idempotent delete semantics in tx engine

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1427,6 +1427,76 @@ mod tests {
     }
 
     #[test]
+    fn tx_doc_delete_missing_key_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("data.json");
+        fs::write(&f, r#"{"a": 1}"#).unwrap();
+
+        let plan = format!(
+            r#"{{
+  "version": "1",
+  "operations": [
+    {{"op": "doc.delete", "path": "{}", "selector": "nonexistent"}}
+  ]
+}}"#,
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::SUCCESS,
+            "doc.delete on missing key should succeed (idempotent)"
+        );
+    }
+
+    #[test]
+    fn tx_doc_delete_where_no_match_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("data.json");
+        fs::write(&f, r#"{"items": [{"name": "a"}]}"#).unwrap();
+
+        let plan = format!(
+            r#"{{
+  "version": "1",
+  "operations": [
+    {{"op": "doc.delete_where", "path": "{}", "selector": "items", "predicate": "name=nonexistent"}}
+  ]
+}}"#,
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::SUCCESS,
+            "doc.delete_where with zero matches should succeed (idempotent)"
+        );
+    }
+
+    #[test]
     fn tx_strict_mode_rollback_on_operation_failure() {
         let dir = TempDir::new().unwrap();
         let f = dir.path().join("data.txt");

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -906,6 +906,7 @@ pub fn update_matching(
 /// This enum captures the 9 doc write operations so that both the CLI
 /// (`cmd/doc.rs`) and the transaction engine (`tx.rs`) share a single
 /// dispatch path instead of duplicating the match logic.
+#[derive(Debug)]
 pub enum DocMutation {
     Set {
         selector: String,
@@ -944,6 +945,7 @@ pub enum DocMutation {
 }
 
 /// Result of applying a [`DocMutation`] to a document root.
+#[derive(Debug)]
 pub enum MutationResult {
     /// The mutation was applied and the document was modified.
     Applied,

--- a/src/tx.rs
+++ b/src/tx.rs
@@ -941,13 +941,19 @@ pub(crate) fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
     let (path, mutation) = op_to_doc_mutation(op);
     let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
         .map_err(path_err(path))?;
-    let label = op_label(op);
+
+    // Delete and DeleteWhere are idempotent: a no-match is not an error
+    // (the old code silently discarded the bool/count return value).
+    // Update is strict: no-match means the selector was wrong.
+    let strict_no_match = matches!(op, Operation::DocUpdate { .. });
 
     match apply_doc_mutation(root, mutation).map_err(path_err(path))? {
         MutationResult::Applied | MutationResult::AlreadyExists => Ok(()),
-        MutationResult::NoMatch => {
+        MutationResult::NoMatch if strict_no_match => {
+            let label = op_label(op);
             anyhow::bail!("{path}: {label} matched nothing");
         }
+        MutationResult::NoMatch => Ok(()),
         MutationResult::TypeError(msg) => {
             anyhow::bail!("{path}: {msg}");
         }


### PR DESCRIPTION
## Summary

Follow-up to PR #888. The reviewer found that unifying doc dispatch through `apply_doc_mutation` inadvertently tightened the behavior of `doc.delete` and `doc.delete_where` in the transaction engine: deleting a non-existent key or matching zero items now failed and rolled back the transaction, whereas previously it was a silent no-op.

## Changes

- `execute_doc_op` now treats `MutationResult::NoMatch` as success for `DocDelete` and `DocDeleteWhere` (idempotent operations), preserving pre-#888 behavior
- `DocUpdate` remains strict: no-match is an error (the old code explicitly checked `if count == 0 { bail!() }`)
- Added `#[derive(Debug)]` to `DocMutation` and `MutationResult` enums (follows crate convention)
- Added 2 unit tests verifying idempotent delete behavior in transactions

## Verification

`make check` passes: 996 unit tests, 725 integration tests, 10 PTY tests, fmt, clippy all green.