### PR TITLE
test: remove redundant is_err() assertions before unwrap_err()

### DIFF
--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -167,12 +167,10 @@ mod tests {
             make_args(&target.to_string_lossy()),
             &GlobalFlags::default(),
         );
-        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
         assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("target is not a file")
+            err.contains("target is not a file"),
+            "expected 'target is not a file' error, got: {err}"
         );
     }
 
@@ -206,10 +204,10 @@ mod tests {
             make_args("/tmp/nonexistent_patchloom_test_file_xyz.txt"),
             &GlobalFlags::default(),
         );
-        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
         assert!(
-            result.unwrap_err().to_string().contains("file not found"),
-            "error should mention 'file not found'"
+            err.contains("file not found"),
+            "error should mention 'file not found', got: {err}"
         );
     }
 }

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -642,8 +642,9 @@ mod tests {
         let dir = make_test_dir();
         let args = make_args("", vec![dir.path().to_string_lossy().into_owned()]);
         let result = run(args, &GlobalFlags::test_default());
-        assert!(result.is_err(), "empty pattern should be rejected");
-        let msg = result.unwrap_err().to_string();
+        let msg = result
+            .expect_err("empty pattern should be rejected")
+            .to_string();
         assert!(
             msg.contains("must not be empty"),
             "error should mention empty pattern: {msg}"

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1284,8 +1284,9 @@ mod tests {
     #[test]
     fn plan_normalize_eol_invalid_value_returns_error() {
         let result = crate::tx::plan_normalize_eol("bogus");
-        assert!(result.is_err(), "invalid eol value should fail");
-        let msg = result.unwrap_err().to_string();
+        let msg = result
+            .expect_err("invalid eol value should fail")
+            .to_string();
         assert!(
             msg.contains("invalid normalize_eol"),
             "error should name the field: {msg}"

--- a/src/exec.rs
+++ b/src/exec.rs
@@ -191,7 +191,6 @@ mod tests {
     fn run_with_timeout_kills_on_timeout() {
         let dir = tempfile::TempDir::new().unwrap();
         let result = run_with_timeout("sleep 60", 1, dir.path());
-        assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("timed out"),

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -683,7 +683,6 @@ mod tests {
     fn resolve_with_fallback_structured_error() {
         let content = "fn alpha() {}\nfn beta() {}\n";
         let result = resolve_with_fallback(content, "fn completely_unrelated_xyz()", None, None);
-        assert!(result.is_err());
         let err = result.unwrap_err();
         assert_eq!(err.kind, EditErrorKind::NoMatch);
         assert!(err.message.contains("target not found"));

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -2241,11 +2241,10 @@ mod tests {
                     from: "nonexistent".into(),
                     to: "b".into(),
                 },
-            );
-            assert!(err.is_err());
+            )
+            .unwrap_err();
             assert!(
-                err.unwrap_err()
-                    .to_string()
+                err.to_string()
                     .contains("source key 'nonexistent' not found")
             );
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8577,8 +8577,9 @@ mod tx_tests {
         .unwrap();
 
         let res = patchloom::cmd::tx::execute_plan_direct(plan, dir.path(), Some(&guard));
-        assert!(res.is_err(), "guard should reject before any apply");
-        let msg = res.unwrap_err().to_string();
+        let msg = res
+            .expect_err("guard should reject before any apply")
+            .to_string();
         assert!(
             msg.contains("path rejected by workspace guard") || msg.contains("Escaped"),
             "unexpected error: {msg}"


### PR DESCRIPTION
Remove 5 instances of the redundant `assert!(result.is_err())` + `unwrap_err()` two-step pattern, collapsing each to a direct `unwrap_err()` call. This matches the style used by other error-message tests in the codebase.

The `is_err()` guard is redundant because `unwrap_err()` already panics with a clear message if the result is `Ok`.

Also improves assertion messages in `delete.rs` tests by including the actual error text for easier debugging on failure.

**Files changed:**
- `src/ops/doc/mod.rs`: `mutation_move_missing_source` test
- `src/exec.rs`: `run_with_timeout_kills_on_timeout` test
- `src/fallback.rs`: `resolve_with_fallback_structured_error` test
- `src/cmd/delete.rs`: `delete_rejects_directory` and `nonexistent_file_returns_error` tests