### PR TITLE
fix: flatten includes empty arrays and empty objects

### DIFF
--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -251,7 +251,7 @@ fn flatten_value<'a>(
     out: &mut Vec<(String, &'a serde_json::Value)>,
 ) {
     match value {
-        serde_json::Value::Object(map) => {
+        serde_json::Value::Object(map) if !map.is_empty() => {
             for (k, v) in map {
                 let restore = buf.len();
                 if !buf.is_empty() {
@@ -262,7 +262,7 @@ fn flatten_value<'a>(
                 buf.truncate(restore);
             }
         }
-        serde_json::Value::Array(arr) => {
+        serde_json::Value::Array(arr) if !arr.is_empty() => {
             for (i, v) in arr.iter().enumerate() {
                 let restore = buf.len();
                 buf.push('[');
@@ -1648,5 +1648,43 @@ mod tests {
         assert!(output.contains("b.d = 3"), "missing b.d: {output}");
         assert!(output.contains("e[0] = 10"), "missing e[0]: {output}");
         assert!(output.contains("e[1] = 20"), "missing e[1]: {output}");
+    }
+
+    #[test]
+    fn flatten_includes_empty_arrays() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"tags":[],"name":"foo","items":[1]}"#);
+        let action = DocAction::Flatten { file: path };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["tags"], serde_json::json!([]));
+        assert_eq!(parsed["name"], serde_json::json!("foo"));
+        assert_eq!(parsed["items[0]"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn flatten_includes_empty_objects() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"config":{},"name":"bar"}"#);
+        let action = DocAction::Flatten { file: path };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["config"], serde_json::json!({}));
+        assert_eq!(parsed["name"], serde_json::json!("bar"));
+    }
+
+    #[test]
+    fn flatten_includes_nested_empty_containers() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"a":{"b":[],"c":{}},"d":[1]}"#);
+        let action = DocAction::Flatten { file: path };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["a.b"], serde_json::json!([]));
+        assert_eq!(parsed["a.c"], serde_json::json!({}));
+        assert_eq!(parsed["d[0]"], serde_json::json!(1));
     }
 }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1136,6 +1136,46 @@ fn test_doc_flatten_json_output() {
         .stdout(predicate::str::contains("\"patchloom\""));
 }
 
+#[test]
+fn test_doc_flatten_includes_empty_arrays() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(
+        &file,
+        r#"{"default":["a"],"empty_arr":[],"empty_obj":{},"nested":{"deep_empty":[]}}"#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("doc")
+        .arg("flatten")
+        .arg(&file)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed["empty_arr"],
+        serde_json::json!([]),
+        "empty array missing: {stdout}"
+    );
+    assert_eq!(
+        parsed["empty_obj"],
+        serde_json::json!({}),
+        "empty object missing: {stdout}"
+    );
+    assert_eq!(
+        parsed["nested.deep_empty"],
+        serde_json::json!([]),
+        "nested empty array missing: {stdout}"
+    );
+    assert_eq!(parsed["default[0]"], serde_json::json!("a"));
+}
+
 // ---------------------------------------------------------------------------
 // doc diff
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`doc flatten` (and the MCP `doc_query` with `action=flatten`) silently dropped empty arrays (`[]`) and empty objects (`{}`) from output. Keys pointing to empty containers were excluded even though `has` confirms they exist and `len` correctly returns 0.

## Root cause

`flatten_value` in `src/cmd/doc.rs` recursed into array elements and object keys via for-loops. When a container was empty, the loop body never executed, so no entry was pushed to the output. The catch-all leaf arm only matched non-Object/non-Array values.

## Fix

Add `!is_empty()` guards on the `Object` and `Array` match arms so empty containers fall through to the catch-all leaf case and are emitted as leaf values.

## Tests

- 3 unit tests: `flatten_includes_empty_arrays`, `flatten_includes_empty_objects`, `flatten_includes_nested_empty_containers`
- 1 integration test: `test_doc_flatten_includes_empty_arrays` (JSON with mixed empty/non-empty arrays, objects, and nested empty containers)

## Verification

`make check` passes (1737 tests).

Closes #894