### PR TITLE
fix: tx validation gaps, search --jsonl no-match, YAML MCP tests

### DIFF
--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -560,15 +560,13 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         !results.matches.is_empty()
     };
     if !has_matches {
-        if global.json {
-            let payload = SearchOutput {
-                ok: true,
-                match_count: 0,
-                file_count: 0,
-                matches: vec![],
-            };
-            println!("{}", serde_json::to_string_pretty(&payload)?);
-        }
+        let payload = SearchOutput {
+            ok: true,
+            match_count: 0,
+            file_count: 0,
+            matches: vec![],
+        };
+        global.emit_json(&payload)?;
         if global.show_status() {
             let paths: Vec<&str> = args.paths.iter().map(|s| s.as_str()).collect();
             let path_desc = if paths.is_empty() {

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -45,6 +45,9 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
             insert_before,
             insert_after,
             nth,
+            whole_line,
+            multiline,
+            range,
             ..
         } => {
             if from.is_empty() {
@@ -52,6 +55,12 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
             }
             if *nth == Some(0) {
                 anyhow::bail!("replace nth is 1-based; use 1 for the first occurrence");
+            }
+            if *whole_line && *multiline {
+                anyhow::bail!("replace: whole_line and multiline cannot be combined");
+            }
+            if range.is_some() && !*whole_line {
+                anyhow::bail!("replace: range requires whole_line=true");
             }
             match validate_replace_mode(
                 to.is_some(),
@@ -132,4 +141,104 @@ pub(crate) fn validate_plan_operations(plan: &Plan) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: build a minimal valid Replace operation, then override fields.
+    fn replace_op(whole_line: bool, multiline: bool, range: Option<&str>) -> Operation {
+        Operation::Replace {
+            glob: None,
+            path: Some("f.txt".into()),
+            mode: None,
+            from: "needle".into(),
+            to: Some("replacement".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline,
+            if_exists: false,
+            whole_line,
+            range: range.map(String::from),
+            word_boundary: false,
+            before_context: None,
+            after_context: None,
+        }
+    }
+
+    #[test]
+    fn replace_whole_line_and_multiline_rejected() {
+        let op = replace_op(true, true, None);
+        let err = validate_operation(&op).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("whole_line and multiline cannot be combined"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn replace_range_without_whole_line_rejected() {
+        let op = replace_op(false, false, Some("10:50"));
+        let err = validate_operation(&op).unwrap_err();
+        assert!(
+            err.to_string().contains("range requires whole_line=true"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn replace_range_with_whole_line_accepted() {
+        let op = replace_op(true, false, Some("10:50"));
+        assert!(validate_operation(&op).is_ok());
+    }
+
+    #[test]
+    fn replace_whole_line_without_multiline_accepted() {
+        let op = replace_op(true, false, None);
+        assert!(validate_operation(&op).is_ok());
+    }
+
+    #[test]
+    fn replace_empty_from_rejected() {
+        let op = Operation::Replace {
+            glob: None,
+            path: Some("f.txt".into()),
+            mode: None,
+            from: String::new(),
+            to: Some("x".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: false,
+            range: None,
+            word_boundary: false,
+            before_context: None,
+            after_context: None,
+        };
+        let err = validate_operation(&op).unwrap_err();
+        assert!(
+            err.to_string().contains("non-empty search pattern"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn replace_nth_zero_rejected() {
+        let mut op = replace_op(false, false, None);
+        if let Operation::Replace { ref mut nth, .. } = op {
+            *nth = Some(0);
+        }
+        let err = validate_operation(&op).unwrap_err();
+        assert!(
+            err.to_string().contains("nth is 1-based"),
+            "unexpected error: {err}"
+        );
+    }
 }

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1995,3 +1995,119 @@ async fn test_mcp_doc_query_has_without_selector_returns_error() {
     );
     client.cancel().await.unwrap();
 }
+
+/// Regression test for #895: doc_set via MCP must create intermediate YAML
+/// keys without corrupting the document structure.
+#[tokio::test]
+async fn test_mcp_doc_set_yaml_deep_nested_path_creation() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("config.yaml"), "existing: value\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+
+    // Set a deeply nested path that requires creating intermediate keys
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_set",
+        serde_json::json!({
+            "path": "config.yaml",
+            "selector": "level1.level2.level3",
+            "value": "deep_value"
+        }),
+    )
+    .await;
+    assert!(!is_error, "doc_set deep nested should succeed: {val}");
+    assert_eq!(val["ok"], true, "doc_set ok field: {val}");
+
+    // Verify the file is valid YAML and has the correct structure
+    let content = fs::read_to_string(dir.path().join("config.yaml")).unwrap();
+    let parsed: serde_json::Value = serde_yaml_ng::from_str(&content)
+        .unwrap_or_else(|e| panic!("YAML parse failed after doc_set: {e}\ncontent:\n{content}"));
+    assert_eq!(
+        parsed["existing"], "value",
+        "doc_set clobbered existing key: {content}"
+    );
+    assert_eq!(
+        parsed["level1"]["level2"]["level3"], "deep_value",
+        "doc_set did not create nested path: {content}"
+    );
+
+    // Round-trip: read back the value via doc_get to verify MCP consistency
+    let (is_error2, val2) = call_tool_value(
+        &client,
+        "doc_get",
+        serde_json::json!({
+            "path": "config.yaml",
+            "selector": "level1.level2.level3"
+        }),
+    )
+    .await;
+    assert!(!is_error2, "doc_get should succeed: {val2}");
+    assert_eq!(
+        val2, "deep_value",
+        "doc_get returned wrong value after doc_set: {val2}"
+    );
+
+    client.cancel().await.unwrap();
+}
+
+/// Regression test for #895: doc_set via MCP on YAML with multiple sequential
+/// nested writes must preserve all previous writes.
+#[tokio::test]
+async fn test_mcp_doc_set_yaml_multiple_nested_writes() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("app.yaml"), "app:\n  name: test\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+
+    // First write: set a nested config value
+    let (err1, v1) = call_tool_value(
+        &client,
+        "doc_set",
+        serde_json::json!({
+            "path": "app.yaml",
+            "selector": "app.database.host",
+            "value": "localhost"
+        }),
+    )
+    .await;
+    assert!(!err1, "first doc_set should succeed: {v1}");
+
+    // Second write: set another nested config value in the same subtree
+    let (err2, v2) = call_tool_value(
+        &client,
+        "doc_set",
+        serde_json::json!({
+            "path": "app.yaml",
+            "selector": "app.database.port",
+            "value": 5432
+        }),
+    )
+    .await;
+    assert!(!err2, "second doc_set should succeed: {v2}");
+
+    // Verify both writes and the original data are all present
+    let content = fs::read_to_string(dir.path().join("app.yaml")).unwrap();
+    let parsed: serde_json::Value = serde_yaml_ng::from_str(&content)
+        .unwrap_or_else(|e| panic!("YAML parse failed: {e}\ncontent:\n{content}"));
+    assert_eq!(
+        parsed["app"]["name"], "test",
+        "original key clobbered: {content}"
+    );
+    assert_eq!(
+        parsed["app"]["database"]["host"], "localhost",
+        "first nested write lost: {content}"
+    );
+    assert_eq!(
+        parsed["app"]["database"]["port"], 5432,
+        "second nested write lost: {content}"
+    );
+
+    client.cancel().await.unwrap();
+}

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -829,3 +829,29 @@ fn test_search_follows_symlink_within_cwd() {
         .success()
         .stdout(predicates::str::contains("needle"));
 }
+
+#[test]
+fn test_search_jsonl_no_match_emits_valid_jsonl() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "hello\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("search")
+        .arg("zzz_no_match_zzz")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3), "should exit 3 (no matches)");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.is_empty(),
+        "--jsonl no-match should emit a JSON line, got empty stdout"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["match_count"], 0);
+    assert_eq!(parsed["file_count"], 0);
+    assert!(parsed["matches"].as_array().unwrap().is_empty());
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -5801,3 +5801,71 @@ async fn test_mcp_http_replace_text_round_trip() {
     client.cancel().await.unwrap();
     child.kill().await.ok();
 }
+
+#[test]
+fn test_tx_replace_range_without_whole_line_rejected() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\nline2\nline3\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "line2",
+            "to": "replaced",
+            "range": "1:3",
+            "whole_line": false
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(4)
+        .stderr(predicates::str::contains("range requires whole_line=true"));
+
+    // File must not be modified
+    assert_eq!(fs::read_to_string(&file).unwrap(), "line1\nline2\nline3\n");
+}
+
+#[test]
+fn test_tx_replace_whole_line_and_multiline_rejected() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\nline2\nline3\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "from": "line2",
+            "to": "replaced",
+            "whole_line": true,
+            "multiline": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(4)
+        .stderr(predicates::str::contains(
+            "whole_line and multiline cannot be combined",
+        ));
+
+    // File must not be modified
+    assert_eq!(fs::read_to_string(&file).unwrap(), "line1\nline2\nline3\n");
+}


### PR DESCRIPTION
## Summary

Three bug fixes and regression tests for issues reported against the MCP and CLI paths.

### Commit 1: tx validation gaps (#893)

The `tx/validate.rs` validation was missing two constraint checks that exist in the MCP `replace_text` handler:

1. `range` requires `whole_line=true` (range was silently ignored without it)
2. `whole_line` and `multiline` cannot be combined

This allowed `execute_plan` callers (including the MCP `execute_plan` tool) to bypass validation that the direct `replace_text` tool enforced. Added 6 unit tests and 2 integration tests.

### Commit 2: search --jsonl no-match (#900)

The no-match code path in `cmd/search.rs` checked `global.json` but not `global.jsonl`, so `--jsonl` mode produced empty stdout on no matches. Fixed by using `global.emit_json()` which handles both modes. Added an integration test.

### Commit 3: MCP YAML regression tests (#895)

Added two MCP integration tests exercising `doc_set` on YAML files with deep nested path creation and sequential writes. Both tests pass, confirming #895 is not reproducible on current main. Tests serve as regression guards.

Closes #893
Closes #900
Ref #895