### PR TITLE
fix: add concurrent-write warnings to MCP tool descriptions

### DIFF
--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -397,7 +397,7 @@ macro_rules! mcp_tool {
 impl PatchloomService {
     mcp_tool!(
         doc_set,
-        "Set a value in a JSON, YAML, or TOML file. Parser-backed, preserves comments. Use dot notation for nested paths. Example: {\"path\": \"package.json\", \"selector\": \"version\", \"value\": \"2.0.0\"}",
+        "Set a value in a JSON, YAML, or TOML file. Parser-backed, preserves comments. Use dot notation for nested paths. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"package.json\", \"selector\": \"version\", \"value\": \"2.0.0\"}",
         DocSetParams,
         |self_, p| {
             self_.check_path(&p.path)?;
@@ -951,7 +951,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
+        description = "Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
     )]
     async fn replace_text(
         &self,
@@ -1459,7 +1459,7 @@ mod tests {
         assert_eq!(
             descriptions.get("replace_text"),
             Some(
-                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
+                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
             ),
             "replace_text description drifted"
         );

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1995,3 +1995,64 @@ async fn test_mcp_doc_query_has_without_selector_returns_error() {
     );
     client.cancel().await.unwrap();
 }
+
+/// Regression test for #892: sequential MCP replace_text calls to the same
+/// file must each see the result of the previous call.
+#[tokio::test]
+async fn test_mcp_sequential_writes_same_file_no_data_loss() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("target.txt"), "line_a\nline_b\nline_c\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+
+    // Write 1: replace line_a
+    let (err1, v1) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "target.txt",
+            "from": "line_a",
+            "to": "REPLACED_A"
+        }),
+    )
+    .await;
+    assert!(!err1, "replace 1 should succeed: {v1}");
+
+    // Write 2: replace line_b (must see write 1's result)
+    let (err2, v2) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "target.txt",
+            "from": "line_b",
+            "to": "REPLACED_B"
+        }),
+    )
+    .await;
+    assert!(!err2, "replace 2 should succeed: {v2}");
+
+    // Write 3: replace line_c (must see writes 1+2's result)
+    let (err3, v3) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "target.txt",
+            "from": "line_c",
+            "to": "REPLACED_C"
+        }),
+    )
+    .await;
+    assert!(!err3, "replace 3 should succeed: {v3}");
+
+    // All three writes must be present
+    let content = fs::read_to_string(dir.path().join("target.txt")).unwrap();
+    assert_eq!(
+        content, "REPLACED_A\nREPLACED_B\nREPLACED_C\n",
+        "sequential writes lost data: {content}"
+    );
+
+    client.cancel().await.unwrap();
+}


### PR DESCRIPTION
## Summary

Addresses #892 by adding explicit concurrent-write warnings to the
most commonly used MCP write tools (`replace_text` and `doc_set`).

The MCP server instructions already warn about parallel calls to the
same file, but tool-level descriptions are more visible to agents that
read tool schemas individually.

### Changes

- Added `IMPORTANT: do NOT issue concurrent calls targeting the same
  file; use execute_plan for multi-op atomicity` to `replace_text`
  and `doc_set` tool descriptions
- Updated `mcp_lists_expected_tools` test to match new description
- Added integration test verifying sequential `replace_text` calls
  to the same file correctly preserve all writes

Closes #892