### PR TITLE
refactor: merge_write destructuring and format detection consolidation

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -184,18 +184,34 @@ pub(crate) fn confirm_prompt_interactive(
 
 impl GlobalFlags {
     /// Copy write-only flags from a [`WriteFlags`] into this struct.
+    ///
+    /// Uses destructuring so the compiler errors if a new field is added to
+    /// [`WriteFlags`] without updating this function.
     pub fn merge_write(&mut self, w: &WriteFlags) {
-        self.diff = w.diff;
-        self.apply = w.apply;
-        self.check = w.check;
-        self.confirm = w.confirm;
-        self.ensure_final_newline = w.ensure_final_newline;
-        self.normalize_eol = w.normalize_eol;
-        self.trim_trailing_whitespace = w.trim_trailing_whitespace;
-        self.respect_editorconfig = w.respect_editorconfig;
-        self.collapse_blanks = w.collapse_blanks;
-        self.format = w.format.clone();
-        self.format_timeout = w.format_timeout;
+        let WriteFlags {
+            diff,
+            apply,
+            check,
+            confirm,
+            ensure_final_newline,
+            normalize_eol,
+            trim_trailing_whitespace,
+            respect_editorconfig,
+            collapse_blanks,
+            ref format,
+            format_timeout,
+        } = *w;
+        self.diff = diff;
+        self.apply = apply;
+        self.check = check;
+        self.confirm = confirm;
+        self.ensure_final_newline = ensure_final_newline;
+        self.normalize_eol = normalize_eol;
+        self.trim_trailing_whitespace = trim_trailing_whitespace;
+        self.respect_editorconfig = respect_editorconfig;
+        self.collapse_blanks = collapse_blanks;
+        self.format = format.clone();
+        self.format_timeout = format_timeout;
     }
 
     /// Whether to proceed with the write after optional confirmation.
@@ -441,6 +457,39 @@ mod tests {
         let mut g = GlobalFlags::default();
         g.merge_write(&w);
         assert!(g.confirm);
+    }
+
+    /// Verify merge_write copies every field. If a new field is added to
+    /// WriteFlags, this test (and the destructuring in merge_write) will
+    /// fail to compile until updated.
+    #[test]
+    fn merge_write_copies_all_fields() {
+        let w = WriteFlags {
+            diff: true,
+            apply: true,
+            check: false,
+            confirm: true,
+            ensure_final_newline: true,
+            normalize_eol: Some(EolMode::Lf),
+            trim_trailing_whitespace: true,
+            respect_editorconfig: true,
+            collapse_blanks: true,
+            format: Some("cargo fmt".into()),
+            format_timeout: Some(60),
+        };
+        let mut g = GlobalFlags::default();
+        g.merge_write(&w);
+        assert!(g.diff);
+        assert!(g.apply);
+        assert!(!g.check);
+        assert!(g.confirm);
+        assert!(g.ensure_final_newline);
+        assert_eq!(g.normalize_eol, Some(EolMode::Lf));
+        assert!(g.trim_trailing_whitespace);
+        assert!(g.respect_editorconfig);
+        assert!(g.collapse_blanks);
+        assert_eq!(g.format.as_deref(), Some("cargo fmt"));
+        assert_eq!(g.format_timeout, Some(60));
     }
 
     #[test]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -150,19 +150,28 @@ pub fn validate_edit(
     let mut warnings = Vec::new();
 
     // If we can detect the file format, validate the result.
-    if let Some(path) = file_path {
-        if path.ends_with(".json") {
-            if let Err(e) = serde_json::from_str::<serde_json::Value>(&new_content) {
-                errors.push(format!("result would be invalid JSON: {e}"));
+    if let Some(path) = file_path
+        && let Ok(fmt) = crate::ops::doc::detect_format(path)
+    {
+        let parse_err = match fmt {
+            crate::ops::doc::FileFormat::Json => {
+                serde_json::from_str::<serde_json::Value>(&new_content)
+                    .err()
+                    .map(|e| format!("result would be invalid JSON: {e}"))
             }
-        } else if path.ends_with(".yaml") || path.ends_with(".yml") {
-            if let Err(e) = serde_yaml_ng::from_str::<serde_json::Value>(&new_content) {
-                errors.push(format!("result would be invalid YAML: {e}"));
+            crate::ops::doc::FileFormat::Yaml => {
+                serde_yaml_ng::from_str::<serde_json::Value>(&new_content)
+                    .err()
+                    .map(|e| format!("result would be invalid YAML: {e}"))
             }
-        } else if path.ends_with(".toml")
-            && let Err(e) = toml_edit::de::from_str::<serde_json::Value>(&new_content)
-        {
-            errors.push(format!("result would be invalid TOML: {e}"));
+            crate::ops::doc::FileFormat::Toml => {
+                toml_edit::de::from_str::<serde_json::Value>(&new_content)
+                    .err()
+                    .map(|e| format!("result would be invalid TOML: {e}"))
+            }
+        };
+        if let Some(msg) = parse_err {
+            errors.push(msg);
         }
     }
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -387,13 +387,11 @@ pub fn parse_plan_auto(
 ) -> anyhow::Result<Plan> {
     let fmt = format_hint.or_else(|| {
         path.and_then(|p| {
-            if p.ends_with(".yaml") || p.ends_with(".yml") {
-                Some("yaml")
-            } else if p.ends_with(".toml") {
-                Some("toml")
-            } else {
-                None
-            }
+            crate::ops::doc::detect_format(p).ok().map(|f| match f {
+                crate::ops::doc::FileFormat::Yaml => "yaml",
+                crate::ops::doc::FileFormat::Toml => "toml",
+                crate::ops::doc::FileFormat::Json => "json",
+            })
         })
     });
     match fmt {


### PR DESCRIPTION
## Summary

Two quick refactors that improve compile-time safety and reduce code duplication.

### Commit 1: merge_write() destructuring (#904)

Changed `merge_write()` to destructure `WriteFlags` so the compiler
errors if a new field is added to `WriteFlags` without updating the
function. Previously, field-by-field copy could silently miss new fields.

Added a comprehensive test that sets all 11 WriteFlags fields and verifies
they are correctly copied to GlobalFlags.

### Commit 2: Format detection consolidation (#902)

Both `fallback.rs` and `plan.rs` had inline format detection using
`str::ends_with()` instead of the canonical `Path::extension()`-based
`detect_format()` in `ops/doc/mod.rs`. This meant three places maintained
the same extension mapping independently.

Now both call `detect_format()` and handle the error case appropriately:
- `fallback.rs`: skips validation for unknown extensions (unchanged behavior)
- `plan.rs`: falls back to JSON parsing for unknown extensions (unchanged behavior)

Fixed a `collapsible_if` clippy lint in `fallback.rs` using Rust 2024 edition
`if-let` chains.

Closes #904
Closes #902