### PR TITLE
fix: ast WritePolicy + confirm support, replace JSONL no-match

### DIFF
--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -239,11 +239,18 @@ fn apply_or_preview(
     backup: Option<&mut BackupSession>,
 ) -> anyhow::Result<PreviewAction> {
     let display_path = path.strip_prefix(cwd).unwrap_or(path);
-    if global.apply {
+    let policy = crate::write::policy_from_flags(global, Some(path));
+
+    let do_write = |backup: Option<&mut BackupSession>| -> anyhow::Result<()> {
         if let Some(b) = backup {
             b.save_before_write(path)?;
         }
-        crate::write::atomic_write(path, new_content, &Default::default())?;
+        crate::write::atomic_write(path, new_content, &policy)?;
+        Ok(())
+    };
+
+    if global.apply {
+        do_write(backup)?;
         if !global.quiet {
             eprintln!("{}: {status_msg}", display_path.display());
         }
@@ -258,6 +265,16 @@ fn apply_or_preview(
             crate::diff::unified_diff(&display_path.display().to_string(), original, new_content);
         if diff.has_changes {
             print!("{}", diff.hunks);
+        }
+        // --confirm: prompt after showing diff, then apply if confirmed.
+        if global.should_apply() {
+            do_write(backup)?;
+            if !global.quiet {
+                eprintln!("{}: {status_msg}", display_path.display());
+            }
+            return Ok(PreviewAction::Applied);
+        }
+        if diff.has_changes {
             Ok(PreviewAction::Diffed)
         } else {
             Ok(PreviewAction::Unchanged)

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -270,7 +270,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         if args.if_exists {
             return Ok(exit::SUCCESS);
         }
-        if global.json {
+        if global.json || global.jsonl {
             let output = ReplaceOutput {
                 ok: true,
                 match_count: 0,
@@ -278,7 +278,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 files: vec![],
                 diff: None,
             };
-            println!("{}", serde_json::to_string_pretty(&output)?);
+            global.emit_json(&output)?;
         }
         if global.show_status() {
             let path_desc = if args.paths.is_empty() {


### PR DESCRIPTION
## Summary

Fixes three behavioral bugs identified in code review:

1. **ast WritePolicy ignored**: `apply_or_preview` used `WritePolicy::default()` instead of `policy_from_flags(global, ...)`. `--ensure-final-newline`, `--trim-trailing-whitespace`, and other write policy flags silently did nothing on `ast rename` and `ast replace`.

2. **ast no `--confirm` support**: The `apply_or_preview` helper had no `--confirm` path. If passed, it silently fell through to diff preview with no prompt. Now calls `global.should_apply()` after showing the diff, matching the behavior of commands using `write_dispatch`.

3. **replace JSONL not emitted on no-match**: The no-match path only checked `global.json`, not `global.jsonl`, so `--jsonl` silently produced nothing. Now uses `global.emit_json()` for consistent output.