### PR TITLE
chore: doc comment fix, exit.rs cfg_attr cleanup, cwd naming consistency

### DIFF
--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -209,7 +209,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     };
 
-    let root = global.resolve_cwd()?;
+    let cwd = global.resolve_cwd()?;
     let command_label = if merge_mode {
         "patch merge"
     } else {
@@ -224,7 +224,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let mut all_clean = true;
         let mut results = Vec::new();
         for pf in &patch_files {
-            let file_path = root.join(&pf.path);
+            let file_path = cwd.join(&pf.path);
             let original = match std::fs::read_to_string(&file_path) {
                 Ok(s) => s,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -286,7 +286,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let mut results = Vec::new();
         let mut all_ok = true;
         for pf in &patch_files {
-            let file_path = root.join(&pf.path);
+            let file_path = cwd.join(&pf.path);
             let original = std::fs::read_to_string(&file_path).unwrap_or_default();
             match apply_patch_file(&original, &pf.hunks, check_options) {
                 Ok(applied) => {
@@ -321,7 +321,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let mut has_conflicts = false;
 
     for pf in &patch_files {
-        let file_path = root.join(&pf.path);
+        let file_path = cwd.join(&pf.path);
         let original = std::fs::read_to_string(&file_path).unwrap_or_default();
         let applied = match apply_patch_file(&original, &pf.hunks, apply_options) {
             Ok(a) => a,
@@ -372,8 +372,8 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             .zip(&policies)
             .map(|((p, c), pol)| (p.as_path(), c.as_str(), pol))
             .collect();
-        crate::backup::backup_write_files(&root, &writes)?;
-        crate::write::run_format_command(global, &root)?;
+        crate::backup::backup_write_files(&cwd, &writes)?;
+        crate::write::run_format_command(global, &cwd)?;
         return Ok(exit::SUCCESS);
     }
 

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -92,10 +92,10 @@ fn check_file(path: &Path, quiet: bool) -> Vec<TidyIssue> {
 /// glob filtering.  Uses `collect_file_paths_opts` with `include_hidden=true`
 /// so dotfiles are also checked.  File scanning is parallelized.
 fn collect_issues(paths: &[String], global: &GlobalFlags) -> anyhow::Result<Vec<TidyIssue>> {
-    let root = global.resolve_cwd()?;
+    let cwd = global.resolve_cwd()?;
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
-    let file_paths = crate::collect_file_paths_opts(paths, global, true, Some(&root))?;
-    let glob_roots = crate::collect_glob_roots_from_global(paths, global, Some(&root))?;
+    let file_paths = crate::collect_file_paths_opts(paths, global, true, Some(&cwd))?;
+    let glob_roots = crate::collect_glob_roots_from_global(paths, global, Some(&cwd))?;
 
     let quiet = global.quiet;
     let file_issues: Vec<Vec<TidyIssue>> =
@@ -171,10 +171,10 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         }
         TidyAction::Fix { paths } => {
-            let root = global.resolve_cwd()?;
+            let cwd = global.resolve_cwd()?;
             let glob_matcher = crate::build_glob_matcher_from_global(global)?;
-            let fix_file_paths = crate::collect_file_paths_opts(&paths, global, true, Some(&root))?;
-            let glob_roots = crate::collect_glob_roots_from_global(&paths, global, Some(&root))?;
+            let fix_file_paths = crate::collect_file_paths_opts(&paths, global, true, Some(&cwd))?;
+            let glob_roots = crate::collect_glob_roots_from_global(&paths, global, Some(&cwd))?;
 
             // Parallel read+compute phase: each file is read, checked for
             // binary content, and has the write policy applied concurrently.
@@ -202,7 +202,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         return None;
                     }
                     let rel_path = file_path
-                        .strip_prefix(&root)
+                        .strip_prefix(&cwd)
                         .unwrap_or(file_path)
                         .to_string_lossy()
                         .to_string();
@@ -220,7 +220,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             // Serial output/write phase for ordered, crash-safe writes.
             let any_changed = !results.is_empty();
             let mut backup = if global.apply && any_changed {
-                Some(crate::backup::BackupSession::new(&root)?)
+                Some(crate::backup::BackupSession::new(&cwd)?)
             } else {
                 None
             };
@@ -288,7 +288,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 if let Some(b) = backup {
                     b.finalize()?;
                 }
-                crate::write::run_format_command(global, &root)?;
+                crate::write::run_format_command(global, &cwd)?;
                 Ok(exit::SUCCESS)
             } else if any_changed {
                 if global.show_status() {
@@ -301,8 +301,8 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         .iter()
                         .map(|r| (r.path.as_path(), r.fixed.as_str(), &noop))
                         .collect();
-                    crate::backup::backup_write_files(&root, &writes)?;
-                    crate::write::run_format_command(global, &root)?;
+                    crate::backup::backup_write_files(&cwd, &writes)?;
+                    crate::write::run_format_command(global, &cwd)?;
                     return Ok(exit::SUCCESS);
                 }
                 Ok(exit::CHANGES_DETECTED)

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,25 +1,18 @@
-/// Exit codes for patchloom.
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
+//! Exit codes for patchloom.
+
+#![cfg_attr(not(feature = "cli"), allow(dead_code))]
+
 pub const SUCCESS: u8 = 0;
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub const FAILURE: u8 = 1;
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub const CHANGES_DETECTED: u8 = 2;
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub const NO_MATCHES: u8 = 3;
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub const PARSE_ERROR: u8 = 4;
-/// Tx operation staging failure (`error_kind`: `operation_failed`).
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
-pub const OPERATION_FAILED: u8 = 9;
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub const AMBIGUOUS: u8 = 5;
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub const VALIDATION_FAILED: u8 = 6;
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub const ROLLBACK: u8 = 7;
-#[cfg_attr(not(feature = "cli"), allow(dead_code))]
 pub const CONFLICTS: u8 = 8;
+/// Tx operation staging failure (`error_kind`: `operation_failed`).
+pub const OPERATION_FAILED: u8 = 9;
 
 #[cfg(test)]
 mod tests {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -285,13 +285,6 @@ pub enum Operation {
     },
 }
 
-/// Returns the file paths (as `&str`) that are declared by the operation
-/// and should be subject to PathGuard / containment validation.
-///
-/// This eliminates duplication between:
-/// - upfront checks in `execute_plan` (library use, #755)
-/// - test validation logic in MCP
-///
 /// Convert a doc-family `Operation` into a `(path, DocMutation)` pair.
 ///
 /// Returns `None` for non-doc operations. This is the single source of truth
@@ -389,6 +382,13 @@ pub(crate) fn op_to_doc_mutation(op: &Operation) -> Option<(&str, crate::ops::do
     }
 }
 
+/// Returns the file paths (as `&str`) that are declared by the operation
+/// and should be subject to PathGuard / containment validation.
+///
+/// This eliminates duplication between:
+/// - upfront checks in `execute_plan` (library use, #755)
+/// - test validation logic in MCP
+///
 /// - `Replace`: includes `path` (if present) and `glob` pattern (if present).
 /// - Cross-file ops (`FileRename`, `MdMoveSection`): includes both source
 ///   and destination file paths.


### PR DESCRIPTION
## Summary

Three hygiene cleanups from code review:

1. **Misplaced doc comment in plan.rs**: The `declared_paths()` doc comment (describing PathGuard/containment validation) was sitting above `op_to_doc_mutation()`, creating a confusing garbled double-comment. Moved each comment to its correct function.

2. **exit.rs cfg_attr cleanup**: Replaced 10 identical per-constant `#[cfg_attr(not(feature = "cli"), allow(dead_code))]` annotations with a single module-level `#![cfg_attr(...)]`. Verified with `--no-default-features --features "ast,files"` library build.

3. **cwd/root naming consistency**: `patch.rs` and `tidy.rs` used `let root = global.resolve_cwd()?` while every other command uses `let cwd = ...`. Renamed for consistency. `glob_roots` (a different concept) was left unchanged.