### PR TITLE
refactor: migrate raw serde_json calls to emit_json/emit_json_items

### DIFF
--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -244,12 +244,8 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let original = read(&file)?;
             let (new, removed) = dedupe_headings_in(&original);
             if !removed.is_empty() {
-                if global.json {
-                    println!("{}", serde_json::to_string_pretty(&removed)?);
-                } else if global.jsonl {
-                    for h in &removed {
-                        println!("{}", serde_json::to_string(h)?);
-                    }
+                if global.json || global.jsonl {
+                    global.emit_json_items(&removed)?;
                 } else if !global.quiet {
                     for h in &removed {
                         eprintln!("md: removed duplicate: {h}");
@@ -263,12 +259,8 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let content = read(&file)?;
             let issues = lint_agents_content(&content);
 
-            if global.json {
-                println!("{}", serde_json::to_string_pretty(&issues)?);
-            } else if global.jsonl {
-                for issue in &issues {
-                    println!("{}", serde_json::to_string(issue)?);
-                }
+            if global.json || global.jsonl {
+                global.emit_json_items(&issues)?;
             } else if !global.quiet {
                 for issue in &issues {
                     match (issue.line, &issue.heading) {

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -137,17 +137,13 @@ fn emit_patch_files_output(
     results: &[PatchFileResult],
 ) -> anyhow::Result<()> {
     if global.json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&PatchFilesOutput {
-                ok,
-                files: results.to_vec(),
-            })?
-        );
+        let output = PatchFilesOutput {
+            ok,
+            files: results.to_vec(),
+        };
+        global.emit_json(&output)?;
     } else if global.jsonl {
-        for r in results {
-            println!("{}", serde_json::to_string(r)?);
-        }
+        global.emit_json_items(results)?;
     }
     Ok(())
 }

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -92,7 +92,7 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         match read_one_file(&resolved_str, parsed_lines) {
             Ok(output) => {
                 if global.jsonl {
-                    println!("{}", serde_json::to_string(&output)?);
+                    global.emit_json(&output)?;
                 } else if global.json {
                     outputs.push(output);
                 } else if !global.quiet {
@@ -123,9 +123,9 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if global.json {
         if !multi && outputs.len() == 1 {
-            println!("{}", serde_json::to_string_pretty(&outputs[0])?);
+            global.emit_json(&outputs[0])?;
         } else {
-            println!("{}", serde_json::to_string_pretty(&outputs)?);
+            global.emit_json(&outputs)?;
         }
     }
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -270,7 +270,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         if args.if_exists {
             return Ok(exit::SUCCESS);
         }
-        if global.json {
+        if global.json || global.jsonl {
             let output = ReplaceOutput {
                 ok: true,
                 match_count: 0,
@@ -278,7 +278,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 files: vec![],
                 diff: None,
             };
-            println!("{}", serde_json::to_string_pretty(&output)?);
+            global.emit_json(&output)?;
         }
         if global.show_status() {
             let path_desc = if args.paths.is_empty() {

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -45,20 +45,17 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if args.list {
         let sessions = backup::list_sessions(&cwd)?;
         if sessions.is_empty() {
-            if global.json {
-                println!("[]");
+            if global.json || global.jsonl {
+                let empty: Vec<()> = vec![];
+                global.emit_json(&empty)?;
             } else if global.show_status() {
                 eprintln!("no backup sessions found");
             }
             return Ok(exit::NO_MATCHES);
         }
 
-        if global.json {
-            println!("{}", serde_json::to_string_pretty(&sessions)?);
-        } else if global.jsonl {
-            for session in &sessions {
-                println!("{}", serde_json::to_string(session)?);
-            }
+        if global.json || global.jsonl {
+            global.emit_json_items(&sessions)?;
         } else if !global.quiet {
             for s in &sessions {
                 let file_count = s.entries.len();


### PR DESCRIPTION
Migrate CLI output paths from manual `serde_json::to_string_pretty` / `serde_json::to_string` calls to `GlobalFlags::emit_json()` and `emit_json_items()` for consistent JSON/JSONL formatting across commands.

## Changes

- **md.rs**: `emit_json_items` for dedupe-headings and lint-agents collections (per-item JSONL streaming)
- **patch.rs**: `emit_json` for JSON wrapper, `emit_json_items` for JSONL per-file results
- **read.rs**: `emit_json` for both JSON and JSONL single-item output
- **replace.rs**: extend no-match early-return to handle `--jsonl` via `emit_json`
- **undo.rs**: `emit_json_items` for session list (per-item JSONL)

## Not migrated (by design)

- **search.rs**: builds output into a String buffer (returned from `format_results`), not stdout
- **doc.rs**: uses `OutputMode` enum to format return strings, not direct stdout
- **tx.rs**: has its own `emit_output_json` helper with context-specific compact/pretty logic
- **schema.rs**: outputs schema envelope, not standard user-facing JSON output
- **mcp/mod.rs**: MCP protocol responses via `CallToolResult`, not CLI stdout

Closes #10