### PR TITLE
refactor: unify WritePolicy types and eliminate EolNormalization

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -82,7 +82,7 @@ use std::path::Path;
 use crate::backup::BackupSession;
 use crate::containment::PathGuard;
 use crate::diff::{DiffResult, format_diff_result, unified_diff};
-use crate::write::{WritePolicy, atomic_write};
+use crate::write::{EolMode, WritePolicy, atomic_write};
 
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use crate::tx::{
@@ -187,22 +187,20 @@ pub struct ReplaceOptions {
 pub struct WritePolicyOptions {
     /// Ensure non-empty files end with a newline.
     pub ensure_final_newline: bool,
-    /// Normalize line endings. `None` means keep existing.
-    pub normalize_eol: Option<EolNormalization>,
+    /// Normalize line endings. `None` means keep existing (`EolMode::Keep`).
+    pub normalize_eol: Option<EolMode>,
     /// Remove trailing whitespace from each line.
     pub trim_trailing_whitespace: bool,
     /// Collapse consecutive blank lines into a single blank line.
     pub collapse_blanks: bool,
 }
 
-/// Line ending normalization mode.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum EolNormalization {
-    /// Normalize to LF (`\n`).
-    Lf,
-    /// Normalize to CRLF (`\r\n`).
-    Crlf,
-}
+/// Backward-compatible alias for [`EolMode`](crate::write::EolMode).
+#[deprecated(
+    since = "0.6.0",
+    note = "use crate::write::EolMode instead (Lf, Crlf, Keep)"
+)]
+pub type EolNormalization = EolMode;
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -217,14 +215,9 @@ pub enum EolNormalization {
 /// `write` + `atomic_write` primitives. Differences from MCP (which uses strict pre-checks + defaults)
 /// are intentional.
 pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
-    use crate::write::EolMode;
     WritePolicy {
         ensure_final_newline: opts.ensure_final_newline,
-        normalize_eol: match opts.normalize_eol {
-            None => EolMode::Keep,
-            Some(EolNormalization::Lf) => EolMode::Lf,
-            Some(EolNormalization::Crlf) => EolMode::Crlf,
-        },
+        normalize_eol: opts.normalize_eol.unwrap_or(EolMode::Keep),
         trim_trailing_whitespace: opts.trim_trailing_whitespace,
         collapse_blanks: opts.collapse_blanks,
     }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -725,7 +725,7 @@ fn apply_patch_path_matching_uses_path_components() {
 fn make_write_policy_maps_options() {
     let opts = WritePolicyOptions {
         ensure_final_newline: true,
-        normalize_eol: Some(EolNormalization::Lf),
+        normalize_eol: Some(EolMode::Lf),
         trim_trailing_whitespace: true,
         collapse_blanks: true,
     };
@@ -735,8 +735,8 @@ fn make_write_policy_maps_options() {
     assert!(policy.collapse_blanks);
     assert_eq!(
         policy.normalize_eol,
-        crate::write::EolMode::Lf,
-        "should map EolNormalization::Lf to EolMode::Lf"
+        EolMode::Lf,
+        "should map EolMode::Lf correctly"
     );
 
     // Default options should produce default policy.
@@ -1131,7 +1131,7 @@ const _: () = {
     let _ = _assert::<ApplyMode>;
     let _ = _assert::<ReplaceOptions>;
     let _ = _assert::<WritePolicyOptions>;
-    let _ = _assert::<EolNormalization>;
+    let _ = _assert::<EolMode>;
 };
 
 #[test]
@@ -1851,13 +1851,13 @@ fn read_nonexistent_file_fails() {
 #[test]
 fn make_write_policy_maps_crlf() {
     let opts = WritePolicyOptions {
-        normalize_eol: Some(EolNormalization::Crlf),
+        normalize_eol: Some(EolMode::Crlf),
         ..WritePolicyOptions::default()
     };
     let policy = make_write_policy(&opts);
     assert_eq!(
         policy.normalize_eol,
-        crate::write::EolMode::Crlf,
-        "should map EolNormalization::Crlf to EolMode::Crlf"
+        EolMode::Crlf,
+        "should map EolMode::Crlf correctly"
     );
 }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -1282,8 +1282,8 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn plan_normalize_eol_invalid_value_returns_error() {
-        let result = crate::tx::plan_normalize_eol("bogus");
+    fn parse_eol_mode_invalid_value_returns_error() {
+        let result = crate::write::parse_eol_mode("bogus");
         let msg = result
             .expect_err("invalid eol value should fail")
             .to_string();

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,12 +6,14 @@
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
+use crate::write::WritePolicyOverride;
+
 /// Project-level configuration loaded from `.patchloom.toml`.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 #[non_exhaustive]
 pub struct ProjectConfig {
-    pub write_policy: WritePolicy,
+    pub write_policy: WritePolicyOverride,
     pub exclude: Exclude,
     pub output: Output,
     pub tx: TxConfig,
@@ -22,16 +24,6 @@ pub struct ProjectConfig {
 #[non_exhaustive]
 pub struct TxConfig {
     pub strict: Option<bool>,
-}
-
-#[derive(Debug, Default, Deserialize)]
-#[serde(default, deny_unknown_fields)]
-#[non_exhaustive]
-pub struct WritePolicy {
-    pub ensure_final_newline: Option<bool>,
-    pub normalize_eol: Option<String>,
-    pub trim_trailing_whitespace: Option<bool>,
-    pub collapse_blanks: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -292,7 +284,7 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_sets_defaults() {
         let config = ProjectConfig {
-            write_policy: WritePolicy {
+            write_policy: WritePolicyOverride {
                 ensure_final_newline: Some(true),
                 normalize_eol: Some("lf".into()),
                 trim_trailing_whitespace: Some(true),
@@ -327,9 +319,9 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_cli_flags_win() {
         let config = ProjectConfig {
-            write_policy: WritePolicy {
+            write_policy: WritePolicyOverride {
                 ensure_final_newline: Some(true),
-                ..WritePolicy::default()
+                ..WritePolicyOverride::default()
             },
             exclude: Exclude {
                 globs: vec!["config_glob".into()],
@@ -382,9 +374,9 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_unknown_eol_value_ignored() {
         let config = ProjectConfig {
-            write_policy: WritePolicy {
+            write_policy: WritePolicyOverride {
                 normalize_eol: Some("CRLF".into()), // uppercase: not recognized
-                ..WritePolicy::default()
+                ..WritePolicyOverride::default()
             },
             ..ProjectConfig::default()
         };
@@ -402,9 +394,9 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_crlf_eol() {
         let config = ProjectConfig {
-            write_policy: WritePolicy {
+            write_policy: WritePolicyOverride {
                 normalize_eol: Some("crlf".into()),
-                ..WritePolicy::default()
+                ..WritePolicyOverride::default()
             },
             ..ProjectConfig::default()
         };

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -32,7 +32,7 @@ pub struct Plan {
     /// Schema version string. Validated against the supported version.
     pub version: String,
     pub cwd: Option<String>,
-    pub write_policy: Option<PlanWritePolicy>,
+    pub write_policy: Option<crate::write::WritePolicyOverride>,
     /// When omitted from the plan, defaults to strict mode at execution time.
     #[serde(default)]
     pub strict: Option<bool>,
@@ -51,16 +51,12 @@ pub struct FormatStep {
     pub timeout: Option<u64>,
 }
 
-/// Write policy settings specified in the plan.
-#[derive(Debug, Deserialize, Serialize)]
-#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
-#[non_exhaustive]
-pub struct PlanWritePolicy {
-    pub ensure_final_newline: Option<bool>,
-    pub normalize_eol: Option<String>,
-    pub trim_trailing_whitespace: Option<bool>,
-    pub collapse_blanks: Option<bool>,
-}
+/// Backward-compatible alias for [`WritePolicyOverride`](crate::write::WritePolicyOverride).
+#[deprecated(
+    since = "0.6.0",
+    note = "use crate::write::WritePolicyOverride instead"
+)]
+pub type PlanWritePolicy = crate::write::WritePolicyOverride;
 
 /// A single operation within a plan.
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -586,7 +586,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                 ensure_final_newline: ensure_final_newline.unwrap_or(true),
                 trim_trailing_whitespace: trim_trailing_whitespace.unwrap_or(false),
                 normalize_eol: if let Some(eol) = normalize_eol {
-                    plan_normalize_eol(eol)?
+                    crate::write::parse_eol_mode(eol)?
                 } else {
                     EolMode::Keep
                 },
@@ -733,17 +733,6 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
 // Write policy
 // ---------------------------------------------------------------------------
 
-pub(crate) fn plan_normalize_eol(mode: &str) -> anyhow::Result<EolMode> {
-    match mode {
-        "lf" => Ok(EolMode::Lf),
-        "crlf" => Ok(EolMode::Crlf),
-        "keep" => Ok(EolMode::Keep),
-        _ => {
-            anyhow::bail!("invalid normalize_eol value '{mode}': expected 'lf', 'crlf', or 'keep'")
-        }
-    }
-}
-
 /// Build the effective write policy for a pending file.
 ///
 /// Start from the CLI-derived per-file defaults, including any EditorConfig
@@ -755,23 +744,9 @@ fn build_write_policy(
     path: &Path,
 ) -> anyhow::Result<WritePolicy> {
     let mut write_policy = crate::write::policy_from_flags(global, Some(path));
-    let Some(plan_write_policy) = &plan.write_policy else {
-        return Ok(write_policy);
-    };
-
-    if let Some(ensure_final_newline) = plan_write_policy.ensure_final_newline {
-        write_policy.ensure_final_newline = ensure_final_newline;
+    if let Some(ov) = &plan.write_policy {
+        write_policy.apply_override(ov)?;
     }
-    if let Some(normalize_eol) = plan_write_policy.normalize_eol.as_deref() {
-        write_policy.normalize_eol = plan_normalize_eol(normalize_eol)?;
-    }
-    if let Some(trim_trailing_whitespace) = plan_write_policy.trim_trailing_whitespace {
-        write_policy.trim_trailing_whitespace = trim_trailing_whitespace;
-    }
-    if let Some(collapse_blanks) = plan_write_policy.collapse_blanks {
-        write_policy.collapse_blanks = collapse_blanks;
-    }
-
     Ok(write_policy)
 }
 

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -26,9 +26,7 @@ pub(crate) use validate::validate_operation;
 pub(crate) use execute::execute_and_collect;
 // Test-only re-exports for src/cmd/tx.rs tests
 #[cfg(test)]
-pub(crate) use execute::{
-    path_err, plan_normalize_eol, read_and_probe, read_file_content, update_file_content,
-};
+pub(crate) use execute::{path_err, read_and_probe, read_file_content, update_file_content};
 
 // lifecycle.rs
 pub use lifecycle::{CommitError, RestoreFailGuard, execute_plan_direct};

--- a/src/write.rs
+++ b/src/write.rs
@@ -38,6 +38,23 @@ impl WritePolicy {
             && !self.trim_trailing_whitespace
             && !self.collapse_blanks
     }
+
+    /// Apply an override, setting only the fields that are `Some`.
+    pub fn apply_override(&mut self, ov: &WritePolicyOverride) -> anyhow::Result<()> {
+        if let Some(v) = ov.ensure_final_newline {
+            self.ensure_final_newline = v;
+        }
+        if let Some(ref s) = ov.normalize_eol {
+            self.normalize_eol = parse_eol_mode(s)?;
+        }
+        if let Some(v) = ov.trim_trailing_whitespace {
+            self.trim_trailing_whitespace = v;
+        }
+        if let Some(v) = ov.collapse_blanks {
+            self.collapse_blanks = v;
+        }
+        Ok(())
+    }
 }
 
 impl Default for WritePolicy {
@@ -47,6 +64,34 @@ impl Default for WritePolicy {
             normalize_eol: EolMode::Keep,
             trim_trailing_whitespace: false,
             collapse_blanks: false,
+        }
+    }
+}
+
+/// Partially-specified write policy for config files, plans, and overrides.
+///
+/// Each field is optional; only `Some` values override the base [`WritePolicy`].
+/// Used by `.patchloom.toml` config, tx plan `write_policy`, and any context
+/// that needs to partially override write transformations.
+#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
+#[cfg_attr(feature = "mcp", derive(schemars::JsonSchema))]
+#[serde(default, deny_unknown_fields)]
+#[non_exhaustive]
+pub struct WritePolicyOverride {
+    pub ensure_final_newline: Option<bool>,
+    pub normalize_eol: Option<String>,
+    pub trim_trailing_whitespace: Option<bool>,
+    pub collapse_blanks: Option<bool>,
+}
+
+/// Parse a string EOL mode value into [`EolMode`].
+pub fn parse_eol_mode(mode: &str) -> anyhow::Result<EolMode> {
+    match mode {
+        "lf" => Ok(EolMode::Lf),
+        "crlf" => Ok(EolMode::Crlf),
+        "keep" => Ok(EolMode::Keep),
+        _ => {
+            anyhow::bail!("invalid normalize_eol value '{mode}': expected 'lf', 'crlf', or 'keep'")
         }
     }
 }


### PR DESCRIPTION
Consolidate four near-identical WritePolicy representations into two canonical types in `write.rs`:

- **`WritePolicy`**: runtime policy (bool fields, `EolMode`)
- **`WritePolicyOverride`**: partially-specified policy for config files, plans, and overrides (`Option` fields, `String` eol)

## What changed

| Before | After |
|--------|-------|
| `write::WritePolicy` | `write::WritePolicy` (unchanged) |
| `config::WritePolicy` | `write::WritePolicyOverride` |
| `plan::PlanWritePolicy` | `write::WritePolicyOverride` (deprecated alias kept) |
| `api::WritePolicyOptions` | `api::WritePolicyOptions` (now uses `EolMode` directly) |
| `api::EolNormalization` (Lf, Crlf) | `write::EolMode` (Keep, Lf, Crlf) - deprecated alias kept |
| `tx::plan_normalize_eol()` | `write::parse_eol_mode()` |
| manual field-by-field overlay in `build_write_policy` | `WritePolicy::apply_override(&WritePolicyOverride)` |

## Backward compatibility

- `plan::PlanWritePolicy` is a deprecated type alias for `WritePolicyOverride`
- `api::EolNormalization` is a deprecated type alias for `EolMode`
- `WritePolicyOptions` keeps its existing API surface, just uses `EolMode` instead of `EolNormalization`
- All serde serialization is identical (same field names and types)

## Net effect

4 WritePolicy types + 2 EOL enums + 2 conversion functions reduced to 2 WritePolicy types + 1 EOL enum + 1 `apply_override` method.

Closes #5