### PR TITLE
fix: AST MCP test coverage, docs, param validation, and git arg guard

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -17,6 +17,9 @@
 | Create, append, rename, or delete a file | `create_file`, `append_file`, `move_file`, `delete_file` |
 | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |
 | Search across files | `search_files` |
+| List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace` |
+| Validate syntax, find refs, or analyze impact | `ast_validate`, `ast_refs`, `ast_impact`, `ast_search` |
+| Repo map, imports, or structural diff | `ast_map`, `ast_deps`, `ast_diff` |
 
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-1700%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-1800%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-1700+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+1800+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -99,7 +99,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 ## By the numbers
 
 - **1,500+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
-- **22 commands** including MCP server with 31 structured tool calls
+- **22 commands** including MCP server with 43 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -109,6 +109,17 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `batch_replace` | Replace the same text across multiple files atomically |
 | `batch_tidy` | Fix whitespace in multiple files atomically |
 | `execute_plan` | Execute a full multi-op transaction plan atomically (recommended for complex/multi-file edits; equivalent to CLI `tx`). Supports inline plan or plan_path. |
+| `ast_list` | List symbol definitions (functions, classes, structs, enums, methods) in a file or directory using tree-sitter (20 languages). Filter by kind. |
+| `ast_read` | Read a specific symbol's source code by name from a file using tree-sitter. |
+| `ast_rename` | Rename identifiers across files using AST-aware renaming (skips strings and comments). |
+| `ast_validate` | Validate syntax of source files using tree-sitter. Returns parse errors with line numbers. |
+| `ast_search` | Structural search using tree-sitter queries. Supports S-expression syntax and code patterns with meta-variables. |
+| `ast_refs` | Find all references to a symbol across files. Distinguishes definitions from references. |
+| `ast_deps` | Extract import/dependency statements from source files (Rust, Python, JS/TS, Go, Java, C/C++, Ruby, PHP). |
+| `ast_map` | Generate a ranked repository map using PageRank over the symbol reference graph. Token-budget-aware output. |
+| `ast_diff` | Structural diff between two versions of a file. Shows added, removed, and modified symbols. |
+| `ast_impact` | Transitive impact analysis: trace the reference graph to find all dependents of a symbol. |
+| `ast_replace` | Replace text only within a specific symbol's body using tree-sitter scoping. |
 
 ## How MCP mode differs from CLI mode
 

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1032,7 +1032,7 @@ pub fn get_git_file_content(
     git_ref: &str,
 ) -> anyhow::Result<String> {
     let output = std::process::Command::new("git")
-        .args(["show", &format!("{git_ref}:{file_path}")])
+        .args(["show", "--", &format!("{git_ref}:{file_path}")])
         .current_dir(cwd)
         .output()?;
 

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -1270,6 +1270,7 @@ impl PatchloomService {
         Parameters(p): Parameters<AstReadParams>,
     ) -> Result<CallToolResult, McpError> {
         self.check_path(&p.path)?;
+        validate_param_size("symbol", &p.symbol)?;
         let cwd = self.cwd().to_path_buf();
         let target = cwd.join(&p.path);
 
@@ -1626,6 +1627,12 @@ impl PatchloomService {
         Parameters(p): Parameters<AstMapParams>,
     ) -> Result<CallToolResult, McpError> {
         self.check_path(&p.path)?;
+        for s in &p.focus {
+            validate_param_size("focus", s)?;
+        }
+        for s in &p.boost {
+            validate_param_size("boost", s)?;
+        }
         let cwd = self.cwd().to_path_buf();
         let target = cwd.join(&p.path);
 
@@ -1673,6 +1680,10 @@ impl PatchloomService {
         Parameters(p): Parameters<AstDiffParams>,
     ) -> Result<CallToolResult, McpError> {
         self.check_path(&p.path)?;
+        validate_param_size("from", &p.from)?;
+        if let Some(ref to) = p.to {
+            validate_param_size("to", to)?;
+        }
         let cwd = self.cwd().to_path_buf();
         let target = cwd.join(&p.path);
         let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -225,7 +225,10 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |\n\
              | Create, append, rename, or delete a file | `create_file`, `append_file`, `move_file`, `delete_file` |\n\
              | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |\n\
-             | Search across files | `search_files` |\n\n",
+             | Search across files | `search_files` |\n\
+             | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace` |\n\
+             | Validate syntax, find refs, or analyze impact | `ast_validate`, `ast_refs`, `ast_impact`, `ast_search` |\n\
+             | Repo map, imports, or structural diff | `ast_map`, `ast_deps`, `ast_diff` |\n\n",
         );
     }
     if show_cli {

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -2,14 +2,23 @@
 
 #![cfg_attr(not(feature = "cli"), allow(dead_code))]
 
+/// Command completed successfully.
 pub const SUCCESS: u8 = 0;
+/// Unrecoverable error (I/O failure, invalid arguments, etc.).
 pub const FAILURE: u8 = 1;
+/// Write command detected pending changes (`--check` mode).
 pub const CHANGES_DETECTED: u8 = 2;
+/// Search or replace found zero matches.
 pub const NO_MATCHES: u8 = 3;
+/// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
+/// Multiple candidates matched and the command could not pick one.
 pub const AMBIGUOUS: u8 = 5;
+/// A `validate` step failed (tx lifecycle).
 pub const VALIDATION_FAILED: u8 = 6;
+/// Strict-mode rollback triggered by a failed `format` or `validate` step.
 pub const ROLLBACK: u8 = 7;
+/// Patch merge produced conflict markers.
 pub const CONFLICTS: u8 = 8;
 /// Tx operation staging failure (`error_kind`: `operation_failed`).
 pub const OPERATION_FAILED: u8 = 9;

--- a/src/write.rs
+++ b/src/write.rs
@@ -341,7 +341,9 @@ pub fn policy_from_flags(
         false
     };
 
+    #[allow(unused_mut)]
     let mut indent_style: Option<IndentStyle> = None;
+    #[allow(unused_mut)]
     let mut indent_size: Option<usize> = None;
 
     let (efn, eol, ttw) = if respect_ec {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2172,3 +2172,230 @@ async fn test_mcp_sequential_writes_same_file_no_data_loss() {
 
     client.cancel().await.unwrap();
 }
+
+// --- AST MCP tool tests ---
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_list_returns_symbols() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "pub fn greet() {}\nstruct Config;\nenum Color { Red }\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "ast_list", serde_json::json!({"path": "lib.rs"})).await;
+    assert!(!is_error, "ast_list should succeed: {val}");
+    let symbols = val.as_array().expect("ast_list should return array");
+    let names: Vec<&str> = symbols.iter().filter_map(|s| s["name"].as_str()).collect();
+    assert!(names.contains(&"greet"), "should find greet: {names:?}");
+    assert!(names.contains(&"Config"), "should find Config: {names:?}");
+    assert!(names.contains(&"Color"), "should find Color: {names:?}");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_list_kind_filter() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "pub fn greet() {}\nstruct Config;\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_list",
+        serde_json::json!({"path": "lib.rs", "kind": "function"}),
+    )
+    .await;
+    assert!(!is_error, "ast_list with kind filter should succeed: {val}");
+    let symbols = val.as_array().expect("ast_list should return array");
+    let names: Vec<&str> = symbols.iter().filter_map(|s| s["name"].as_str()).collect();
+    assert!(names.contains(&"greet"), "should find greet: {names:?}");
+    assert!(
+        !names.contains(&"Config"),
+        "should NOT find Config with function filter: {names:?}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_read_returns_source() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("main.rs"),
+        "fn target() {\n    let x = 42;\n}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_read",
+        serde_json::json!({"path": "main.rs", "symbol": "target"}),
+    )
+    .await;
+    assert!(!is_error, "ast_read should succeed: {val}");
+    assert_eq!(val["symbol"], "target", "symbol name: {val}");
+    let content = val["content"].as_str().expect("content should be string");
+    assert!(
+        content.contains("let x = 42"),
+        "should contain function body: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_read_not_found() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "fn existing() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, _val) = call_tool_value(
+        &client,
+        "ast_read",
+        serde_json::json!({"path": "main.rs", "symbol": "nonexistent"}),
+    )
+    .await;
+    assert!(is_error, "ast_read with missing symbol should fail");
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_validate_clean() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ok.rs"), "fn valid() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_validate",
+        serde_json::json!({"path": "ok.rs"}),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "ast_validate should succeed on valid code: {val}"
+    );
+    // ast_validate returns an array of file results
+    let results = val.as_array().expect("ast_validate should return array");
+    assert!(
+        results.iter().all(|r| r["valid"] == true),
+        "valid code should pass validation: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_validate_syntax_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bad.rs"), "fn broken( {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_validate",
+        serde_json::json!({"path": "bad.rs"}),
+    )
+    .await;
+    // ast_validate returns success with errors in the response body
+    assert!(!is_error, "ast_validate should not be a tool error: {val}");
+    let results = val.as_array().expect("ast_validate should return array");
+    assert!(
+        results.iter().any(|r| r["valid"] == false),
+        "broken code should fail validation: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_search_finds_matches() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn first() { let x = 1; }\nfn second() { let y = 2; }\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    // Use tree-sitter S-expression query for function_item nodes
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_search",
+        serde_json::json!({"path": "lib.rs", "query": "(function_item) @fn"}),
+    )
+    .await;
+    assert!(!is_error, "ast_search should succeed: {val}");
+    let matches = val.as_array().expect("ast_search should return array");
+    assert!(
+        matches.len() >= 2,
+        "should find at least 2 function_item matches: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_rename_applies() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn old_name() {}\nfn caller() { old_name(); }\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_rename",
+        serde_json::json!({"path": "lib.rs", "old_name": "old_name", "new_name": "new_name"}),
+    )
+    .await;
+    assert!(!is_error, "ast_rename should succeed: {val}");
+
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    assert!(
+        content.contains("new_name"),
+        "file should contain renamed symbol: {content}"
+    );
+    assert!(
+        !content.contains("old_name"),
+        "old name should be gone: {content}"
+    );
+    client.cancel().await.unwrap();
+}

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -789,7 +789,7 @@ fn test_smoke_readme_command_examples() {
         "launch announcement CLI command count drifted"
     );
     assert!(
-        launch.contains("31 structured tool calls"),
+        launch.contains("43 structured tool calls"),
         "launch announcement MCP tool count drifted"
     );
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle 1 for the AST MCP tools added in PR #924.

### Changes

**QA (tests):**
- 8 new AST MCP integration tests covering `ast_list`, `ast_read`, `ast_rename`, `ast_validate`, `ast_search` (all in `tests/integration/mcp_tool_tests.rs`)
- Fix library hygiene warnings for `indent_style`/`indent_size` in `src/write.rs`
- Update README test count badge (1700+ to 1800+)

**End User (docs):**
- Add all 11 AST MCP tools to `docs/getting-started/mcp-setup.md` Available tools table (32 to 43 tools)
- Add 3 AST rows to the MCP tool selection guide in `src/cmd/mod.rs` agent-rules generator
- Regenerate `PATCHLOOM.md`

**Maintainer (docs):**
- Add doc comments to all 10 exit code constants in `src/exit.rs` (previously only `OPERATION_FAILED` was documented)

**Security (hardening):**
- Add `validate_param_size` on `ast_read` symbol, `ast_map` focus/boost, `ast_diff` from/to params
- Add `--` separator in `get_git_file_content` to prevent git argument injection via crafted ref strings

**PM (docs):**
- Fix stale MCP tool count in `docs/blog/launch-announcement.md` (31 to 43)
- Update corresponding smoke test assertion

### Verification

`make check` passes (1803 tests: 1053 unit + 740 integration + 10 PTY).