### PR TITLE
fix: git arg guard, ast_rename no-op guard, 6 AST MCP tests, ref docs

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -374,8 +374,8 @@ Patchloom can be used as a Rust library (disable default `cli` feature for small
 <!-- ref:command:ast -->
 ## `ast`
 
-- **What it does:** AST-aware operations on source code using tree-sitter grammars (20 languages). Subcommands: `list` (extract symbol definitions), `read` (read a symbol by name), `rename` (rename identifiers, skipping strings/comments), `validate` (syntax validation).
-- **Use when:** You need to list, read, rename, or validate symbols with structural awareness (skip strings, comments, and documentation). Especially useful for rename operations where the old name appears inside strings that should not be changed.
+- **What it does:** AST-aware operations on source code using tree-sitter grammars (20 languages). Subcommands: `list` (extract symbol definitions), `read` (read a symbol by name), `rename` (rename identifiers, skipping strings/comments), `validate` (syntax validation), `search` (structural queries), `refs` (find references), `deps` (extract imports), `map` (ranked repo map via PageRank), `diff` (structural diff vs git refs), `impact` (transitive impact analysis), `replace` (scoped text replacement within a symbol).
+- **Use when:** You need to list, read, rename, validate, search, or analyze symbols with structural awareness (skip strings, comments, and documentation). Especially useful for rename operations where the old name appears inside strings that should not be changed, and for impact analysis before refactoring.
 - **Prefer instead:** Use `replace --word-boundary` for quick identifier renames when AST precision is not required. Use a language server (LSP) when cross-file type-aware rename is needed.
 - **Related:** [`replace`](#replace), [`search`](#search)
 

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1031,8 +1031,11 @@ pub fn get_git_file_content(
     file_path: &str,
     git_ref: &str,
 ) -> anyhow::Result<String> {
+    if git_ref.starts_with('-') {
+        anyhow::bail!("invalid git ref: must not start with '-'");
+    }
     let output = std::process::Command::new("git")
-        .args(["show", "--", &format!("{git_ref}:{file_path}")])
+        .args(["show", &format!("{git_ref}:{file_path}")])
         .current_dir(cwd)
         .output()?;
 

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -1316,6 +1316,13 @@ impl PatchloomService {
         self.check_path(&p.path)?;
         validate_param_size("old_name", &p.old_name)?;
         validate_param_size("new_name", &p.new_name)?;
+        if p.old_name == p.new_name {
+            return exit_code_to_result(
+                exit::NO_MATCHES,
+                "",
+                "old_name and new_name are identical.",
+            );
+        }
         let cwd = self.cwd().to_path_buf();
         let target = cwd.join(&p.path);
         let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2399,3 +2399,221 @@ async fn test_mcp_ast_rename_applies() {
     );
     client.cancel().await.unwrap();
 }
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_refs_finds_references() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn helper() {}\nfn main() { helper(); helper(); }\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_refs",
+        serde_json::json!({"path": "lib.rs", "symbol": "helper"}),
+    )
+    .await;
+    assert!(!is_error, "ast_refs should succeed: {val}");
+    let binding = val.to_string();
+    let text = val.as_str().unwrap_or(&binding);
+    assert!(
+        text.contains("helper"),
+        "should contain references to helper: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_deps_extracts_imports() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("main.rs"),
+        "use std::collections::HashMap;\nuse std::io;\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "ast_deps", serde_json::json!({"path": "main.rs"})).await;
+    assert!(!is_error, "ast_deps should succeed: {val}");
+    let binding = val.to_string();
+    let text = val.as_str().unwrap_or(&binding);
+    assert!(
+        text.contains("std::collections::HashMap") || text.contains("HashMap"),
+        "should contain HashMap import: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_map_returns_ranked_symbols() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(
+        src.join("lib.rs"),
+        "pub fn core_fn() {}\npub fn caller() { core_fn(); }\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_map",
+        serde_json::json!({"path": "src", "max_tokens": 1024}),
+    )
+    .await;
+    assert!(!is_error, "ast_map should succeed: {val}");
+    let binding = val.to_string();
+    let text = val.as_str().unwrap_or(&binding);
+    assert!(
+        text.contains("core_fn") || text.contains("caller"),
+        "map should contain symbol names: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_diff_detects_changes() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    // Set up a git repo with a committed file, then modify it
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn original() {}\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "lib.rs"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    // Now modify the file (add a new function)
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn original() {}\nfn added() {}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_diff",
+        serde_json::json!({"path": "lib.rs", "from": "HEAD"}),
+    )
+    .await;
+    assert!(!is_error, "ast_diff should succeed: {val}");
+    let binding = val.to_string();
+    let text = val.as_str().unwrap_or(&binding);
+    assert!(
+        text.contains("added"),
+        "diff should detect the new function: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_impact_traces_dependents() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir(&src).unwrap();
+    fs::write(
+        src.join("lib.rs"),
+        "pub fn base() {}\npub fn mid() { base(); }\npub fn top() { mid(); }\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_impact",
+        serde_json::json!({"path": "src", "symbol": "base", "depth": 2}),
+    )
+    .await;
+    assert!(!is_error, "ast_impact should succeed: {val}");
+    let binding = val.to_string();
+    let text = val.as_str().unwrap_or(&binding);
+    assert!(
+        text.contains("mid"),
+        "impact should include mid as a dependent of base: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_ast_replace_within_symbol() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn target() { let val = 42; }\nfn other() { let val = 99; }\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_replace",
+        serde_json::json!({
+            "path": "lib.rs",
+            "symbol": "target",
+            "from": "42",
+            "to": "100"
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_replace should succeed: {val}");
+
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    assert!(
+        content.contains("100"),
+        "target function should have 100: {content}"
+    );
+    assert!(
+        content.contains("99"),
+        "other function should still have 99: {content}"
+    );
+    client.cancel().await.unwrap();
+}


### PR DESCRIPTION
## Summary

MPI Cycle 2 fixes. Follows up on PR #925 (Cycle 1).

### Changes

**Security:**
- Fix git show arg injection guard: the `--` separator from Cycle 1 broke the feature (`git show -- HEAD:file.rs` treats the argument as a pathspec, not an object name, producing empty output). Replaced with input validation rejecting git refs starting with `-`.

**Adversarial:**
- Add early-return guard in `ast_rename` MCP handler when `old_name == new_name` (avoids needless file I/O and spurious backup sessions).

**QA (tests):**
- Add 6 integration tests for previously uncovered AST MCP tools: `ast_refs`, `ast_deps`, `ast_map`, `ast_diff`, `ast_impact`, `ast_replace`. All 11 AST MCP tools now have integration test coverage.

**End User (docs):**
- Update `docs/reference/README.md` `ast` command section to list all 11 subcommands (was only listing 4: list, read, rename, validate).

### Verification

`make check` passes (1809 tests: 1053 unit + 746 integration + 10 PTY).