### PR TITLE
fix: AST improvements (#927-#931)

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -127,7 +127,48 @@ after writes, so use `"strict": true` in the plan if you want those failures to
 roll back all changes too. Lifecycle failure output includes the failing step
 number, exit status, and the `cwd` used for that step.
 
-## Step 6: Inspect and undo changes
+## Step 6: Explore code structure with AST
+
+List all functions and types in a directory:
+
+```bash
+patchloom ast list src/
+```
+
+Filter by symbol kind:
+
+```bash
+patchloom ast list src/ --kind function,struct
+```
+
+Read a specific symbol's source code:
+
+```bash
+patchloom ast read src/main.rs run
+```
+
+Find all references to a symbol across files:
+
+```bash
+patchloom ast refs process_data src/
+```
+
+Validate syntax of source files:
+
+```bash
+patchloom ast validate src/
+```
+
+Generate a ranked repository map (PageRank over the symbol graph):
+
+```bash
+patchloom ast map src/ --max-tokens 2048
+```
+
+AST commands support 20 languages including Rust, Python, TypeScript, JavaScript,
+Go, Java, C#, C/C++, Ruby, PHP, Swift, Kotlin, HCL, and more.
+
+## Step 7: Inspect and undo changes
 
 After any `--apply`, you can ask patchloom what changed and restore the latest backup session.
 
@@ -151,7 +192,7 @@ Restore the most recent backup session:
 patchloom undo --apply
 ```
 
-## Step 7: Use in CI
+## Step 8: Use in CI
 
 Check whether a plan would produce changes (exit code 2 = changes pending):
 

--- a/src/ast/map.rs
+++ b/src/ast/map.rs
@@ -198,7 +198,8 @@ fn pagerank(
     symbols: &[(String, String, SymbolKind, String, usize)],
 ) -> Vec<f64> {
     let damping = 0.85;
-    let iterations = 20;
+    let max_iterations = 100;
+    let convergence_threshold = 1e-6;
 
     // Initialize with personalization bias
     let mut scores = vec![1.0 / n as f64; n];
@@ -226,7 +227,7 @@ fn pagerank(
     // Compute out-degree
     let out_degree: Vec<usize> = edges.iter().map(|e| e.len()).collect();
 
-    for _ in 0..iterations {
+    for _ in 0..max_iterations {
         let mut new_scores = vec![0.0; n];
 
         for (i, edge_list) in edges.iter().enumerate() {
@@ -243,7 +244,18 @@ fn pagerank(
             new_scores[i] = damping * new_scores[i] + (1.0 - damping) * personalization[i];
         }
 
+        // Check convergence: L1 norm of score change
+        let delta: f64 = scores
+            .iter()
+            .zip(new_scores.iter())
+            .map(|(old, new)| (old - new).abs())
+            .sum();
+
         scores = new_scores;
+
+        if delta < convergence_threshold {
+            break;
+        }
     }
 
     scores

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -88,11 +88,28 @@ fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let kind_filter = parse_kind_filter(&args.kind);
     let lang_hint = args.lang.as_deref().map(lang_from_str);
+    crate::verbose!(
+        "ast list: target={}, kind_filter={:?}",
+        args.path,
+        kind_filter
+    );
 
     let mut any_output = false;
 
     if target.is_file() {
-        let symbols = symbols::extract_symbols_from_file(&target, lang_hint);
+        let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
+        crate::verbose!("ast list: detected language={lang} for {}", args.path);
+        if !lang.has_grammar() {
+            eprintln!(
+                "Unsupported language: {} (detected from {}). \
+                 Supported: Rust, Python, TypeScript, JavaScript, Go, Java, \
+                 C#, Ruby, PHP, Swift, Kotlin, C, C++, HCL, XML, Protobuf, \
+                 TOML, YAML, JSON, Shell.",
+                lang, args.path,
+            );
+            return Ok(exit::NO_MATCHES);
+        }
+        let symbols = symbols::extract_symbols_from_file(&target, Some(lang));
         let filtered = filter_symbols(&symbols, &kind_filter);
         if !filtered.is_empty() {
             any_output = true;
@@ -106,6 +123,7 @@ fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     } else if target.is_dir() {
         let paths = collect_source_files(&target, global)?;
+        crate::verbose!("ast list: scanning {} files in {}", paths.len(), args.path);
 
         struct ListFileResult {
             display: String,
@@ -174,6 +192,11 @@ fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let lang_hint = args.lang.as_deref().map(lang_from_str);
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
+    crate::verbose!(
+        "ast read: file={}, symbol={}, lang={lang}",
+        args.path,
+        args.symbol
+    );
     let source = std::fs::read_to_string(&target)?;
     let all_symbols = symbols::extract_symbols(&source, lang);
     let sym = symbols::find_symbol(&all_symbols, &args.symbol)
@@ -313,11 +336,18 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let target = cwd.join(&args.path);
     let lang_hint = args.lang.as_deref().map(lang_from_str);
+    crate::verbose!(
+        "ast rename: '{}' -> '{}' in {}",
+        args.old_name,
+        args.new_name,
+        args.path
+    );
 
     let mut total_replacements = 0usize;
     let mut files_changed = 0usize;
 
     let paths = resolve_target_paths(&target, &args.path, global)?;
+    crate::verbose!("ast rename: scanning {} files", paths.len());
 
     // Single backup session for all files (batched, not per-file).
     let mut backup = if global.apply {
@@ -418,10 +448,12 @@ fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::Result<u8> 
     let cwd = global.resolve_cwd()?;
     let target = cwd.join(&args.path);
     let lang_hint = args.lang.as_deref().map(lang_from_str);
+    crate::verbose!("ast validate: target={}", args.path);
 
     let mut all_valid = true;
 
     let paths = resolve_target_paths(&target, &args.path, global)?;
+    crate::verbose!("ast validate: checking {} files", paths.len());
 
     struct ValidateFileResult {
         display: String,
@@ -494,10 +526,17 @@ fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let target = cwd.join(&args.path);
     let lang_hint = args.lang.as_deref().map(lang_from_str);
+    crate::verbose!(
+        "ast search: query={}, pattern={}, target={}",
+        args.query,
+        args.pattern,
+        args.path
+    );
 
     let mut total_matches = 0usize;
 
     let paths = resolve_target_paths(&target, &args.path, global)?;
+    crate::verbose!("ast search: scanning {} files", paths.len());
 
     struct SearchFileResult {
         display: String,
@@ -579,8 +618,10 @@ fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let target = cwd.join(&args.path);
     let lang_hint = args.lang.as_deref().map(lang_from_str);
+    crate::verbose!("ast refs: symbol={}, target={}", args.symbol, args.path);
 
     let paths = resolve_target_paths(&target, &args.path, global)?;
+    crate::verbose!("ast refs: scanning {} files", paths.len());
 
     let per_file_refs: Vec<Vec<crate::ast::refs::SymbolRef>> =
         crate::par_process_files(&paths, None, &[], |path| {
@@ -641,8 +682,10 @@ fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let target = cwd.join(&args.path);
     let lang_hint = args.lang.as_deref().map(lang_from_str);
+    crate::verbose!("ast deps: target={}, reverse={}", args.path, args.reverse);
 
     let paths = resolve_target_paths(&target, &args.path, global)?;
+    crate::verbose!("ast deps: scanning {} files", paths.len());
 
     let mut any_output = false;
 
@@ -755,12 +798,18 @@ pub struct MapArgs {
 fn run_map(args: MapArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let target = cwd.join(&args.path);
+    crate::verbose!(
+        "ast map: target={}, max_tokens={}",
+        args.path,
+        args.max_tokens
+    );
 
     if !target.is_dir() {
         anyhow::bail!("path must be a directory: {}", args.path);
     }
 
     let paths = collect_source_files(&target, global)?;
+    crate::verbose!("ast map: collected {} source files", paths.len());
     let file_pairs: Vec<(std::path::PathBuf, String)> = paths
         .iter()
         .map(|p| {
@@ -830,9 +879,16 @@ fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let target = cwd.join(&args.path);
     let lang_hint = args.lang.as_deref().map(lang_from_str);
+    crate::verbose!(
+        "ast replace: symbol={}, from={}, regex={}",
+        args.symbol,
+        args.from,
+        args.regex
+    );
 
     let source = std::fs::read_to_string(&target)?;
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
+    crate::verbose!("ast replace: lang={lang}, file={}", args.path);
 
     let result = crate::ast::replace::replace_in_symbol(
         &source,
@@ -926,8 +982,10 @@ pub struct ImpactArgs {
 fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let target = cwd.join(&args.path);
+    crate::verbose!("ast impact: symbol={}, depth={}", args.symbol, args.depth);
 
     let paths = resolve_target_paths(&target, &args.path, global)?;
+    crate::verbose!("ast impact: scanning {} files", paths.len());
 
     let file_pairs: Vec<(std::path::PathBuf, String)> = paths
         .iter()
@@ -991,6 +1049,11 @@ fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let target = cwd.join(&args.path);
     let lang_hint = args.lang.as_deref().map(lang_from_str);
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
+    crate::verbose!(
+        "ast diff: file={}, from={}, lang={lang}",
+        args.path,
+        args.from
+    );
 
     // Get old version from git
     let old_source = get_git_file_content(&cwd, &args.path, &args.from)?;

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -1,0 +1,607 @@
+//! AST MCP handler implementations, extracted from mod.rs (#928).
+//!
+//! Each `pub(super)` function contains the logic for one AST MCP tool.
+//! The `#[tool]` stubs in `mod.rs` delegate directly to these functions.
+
+use rmcp::model::{CallToolResult, Content, ErrorData as McpError};
+
+use crate::cli::global::GlobalFlags;
+use crate::exit;
+
+use super::params::*;
+use super::{PatchloomService, exit_code_to_result, validate_content_size, validate_param_size};
+
+pub(super) fn handle_ast_list(
+    svc: &PatchloomService,
+    p: AstListParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let kind_filter = crate::cmd::ast::parse_kind_filter(&p.kind);
+
+    let mut results = Vec::new();
+
+    if target.is_file() {
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
+        if !lang.has_grammar() {
+            return exit_code_to_result(
+                exit::NO_MATCHES,
+                "",
+                &format!(
+                    "Unsupported language: {} (detected from {}). \
+                     Supported: Rust, Python, TypeScript, JavaScript, Go, Java, \
+                     C#, Ruby, PHP, Swift, Kotlin, C, C++, HCL, XML, Protobuf, \
+                     TOML, YAML, JSON, Shell.",
+                    lang, p.path,
+                ),
+            );
+        }
+        let symbols = crate::ast::symbols::extract_symbols_from_file(&target, Some(lang));
+        let filtered = crate::cmd::ast::filter_symbols(&symbols, &kind_filter);
+        if !filtered.is_empty() {
+            for sym in &filtered {
+                results.push(crate::cmd::ast::symbol_to_json(sym, &p.path));
+            }
+        }
+    } else if target.is_dir() {
+        let global = GlobalFlags::with_cwd(&cwd);
+        let paths = crate::cmd::ast::collect_source_files(&target, &global)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        for path in &paths {
+            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+            let symbols = crate::ast::symbols::extract_symbols_from_file(path, Some(lang));
+            let filtered = crate::cmd::ast::filter_symbols(&symbols, &kind_filter);
+            if filtered.is_empty() {
+                continue;
+            }
+            let display = crate::cmd::ast::display_path(path, &cwd);
+            for sym in &filtered {
+                results.push(crate::cmd::ast::symbol_to_json(sym, &display));
+            }
+        }
+    } else {
+        return Err(McpError::invalid_params(
+            format!("path not found: {}", p.path),
+            None,
+        ));
+    }
+
+    if results.is_empty() {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No symbols found.");
+    }
+    let json = serde_json::to_string_pretty(&results)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_read(
+    svc: &PatchloomService,
+    p: AstReadParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("symbol", &p.symbol)?;
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
+    let source = std::fs::read_to_string(&target)
+        .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
+    let all_symbols = crate::ast::symbols::extract_symbols(&source, lang);
+    let sym = crate::ast::symbols::find_symbol(&all_symbols, &p.symbol).ok_or_else(|| {
+        McpError::invalid_params(
+            format!("symbol '{}' not found in {}", p.symbol, p.path),
+            None,
+        )
+    })?;
+
+    let lines: Vec<&str> = source.lines().collect();
+    let start = sym.start_line.saturating_sub(1 + p.context);
+    let end = (sym.end_line + p.context).min(lines.len());
+    let content: String = lines[start..end].iter().map(|l| format!("{l}\n")).collect();
+
+    let obj = serde_json::json!({
+        "file": p.path,
+        "symbol": sym.name,
+        "kind": sym.kind.to_string(),
+        "start_line": sym.start_line,
+        "end_line": sym.end_line,
+        "signature": sym.signature,
+        "content": content,
+    });
+    let json = serde_json::to_string_pretty(&obj)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_rename(
+    svc: &PatchloomService,
+    p: AstRenameParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("old_name", &p.old_name)?;
+    validate_param_size("new_name", &p.new_name)?;
+    if p.old_name == p.new_name {
+        return exit_code_to_result(exit::NO_MATCHES, "", "old_name and new_name are identical.");
+    }
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+
+    let mut global = GlobalFlags::with_cwd_and_json(&cwd);
+    global.apply = true;
+
+    let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
+        .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+    let mut total_replacements = 0usize;
+    let mut files_changed = 0usize;
+    let mut backup = crate::backup::BackupSession::new(&cwd)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+    for path in &paths {
+        svc.check_path(
+            &path
+                .strip_prefix(&cwd)
+                .unwrap_or(path)
+                .display()
+                .to_string(),
+        )?;
+
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+        let source = std::fs::read_to_string(path)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        let result = if lang.has_grammar() {
+            crate::ast::rename::rename_in_source(&source, &p.old_name, &p.new_name, lang)
+        } else {
+            None
+        };
+
+        let (new_content, count) = match result {
+            Some(r) if r.replacements > 0 => (r.content, r.replacements),
+            _ => {
+                // Try word-boundary fallback
+                let re = crate::ops::replace::compile_replace_regex(
+                    &p.old_name,
+                    false,
+                    false,
+                    false,
+                    true,
+                )
+                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+                if let Some(re) = re {
+                    let count = re.find_iter(&source).count();
+                    if count > 0 {
+                        let new = re.replace_all(&source, p.new_name.as_str());
+                        (new.into_owned(), count)
+                    } else {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+            }
+        };
+
+        total_replacements += count;
+        files_changed += 1;
+        let policy = crate::write::policy_from_flags(&global, Some(path));
+        backup
+            .save_before_write(path)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        crate::write::atomic_write(path, &new_content, &policy)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    }
+
+    backup
+        .finalize()
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+    if total_replacements == 0 {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No matches found.");
+    }
+
+    let obj = serde_json::json!({
+        "ok": true,
+        "files_changed": files_changed,
+        "replacements": total_replacements,
+    });
+    let json = serde_json::to_string_pretty(&obj)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_validate(
+    svc: &PatchloomService,
+    p: AstValidateParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+
+    let global = GlobalFlags::with_cwd(&cwd);
+    let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
+        .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+    let mut results = Vec::new();
+    for path in &paths {
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+        if !lang.has_grammar() {
+            continue;
+        }
+        let result = crate::ast::validate::validate_file(path, Some(lang))
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        let display = crate::cmd::ast::display_path(path, &cwd);
+        results.push(serde_json::json!({
+            "file": display,
+            "valid": result.valid,
+            "language": result.language,
+            "errors": result.errors,
+        }));
+    }
+
+    if results.is_empty() {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No files with grammars found.");
+    }
+    let json = serde_json::to_string_pretty(&results)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_search(
+    svc: &PatchloomService,
+    p: AstSearchParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("query", &p.query)?;
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+
+    let global = GlobalFlags::with_cwd(&cwd);
+    let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
+        .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+    let mut all_matches = Vec::new();
+    for path in &paths {
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+
+        let query_str = if p.pattern {
+            crate::ast::search::compile_pattern_query(&p.query, lang)
+                .map_err(|e| McpError::invalid_params(format!("{e}"), None))?
+        } else {
+            p.query.clone()
+        };
+
+        let results = crate::ast::search::search_file(path, &query_str, Some(lang), p.max_results)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        if results.is_empty() {
+            continue;
+        }
+
+        let display = crate::cmd::ast::display_path(path, &cwd);
+        for m in &results {
+            all_matches.push(serde_json::json!({
+                "file": display,
+                "line": m.line,
+                "column": m.column,
+                "text": m.text,
+                "captures": m.captures,
+            }));
+        }
+    }
+
+    if all_matches.is_empty() {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No matches found.");
+    }
+    let json = serde_json::to_string_pretty(&all_matches)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_refs(
+    svc: &PatchloomService,
+    p: AstRefsParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("symbol", &p.symbol)?;
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+
+    let global = GlobalFlags::with_cwd(&cwd);
+    let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
+        .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+    let mut all_refs = Vec::new();
+    for path in &paths {
+        let display = crate::cmd::ast::display_path(path, &cwd);
+        let refs = crate::ast::refs::find_refs_in_file(path, &p.symbol, lang_hint, &display);
+        all_refs.extend(refs);
+    }
+
+    if !p.include_def {
+        all_refs.retain(|r| r.kind != crate::ast::refs::RefKind::Definition);
+    }
+
+    if all_refs.is_empty() {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No references found.");
+    }
+
+    let obj = serde_json::json!({
+        "symbol": p.symbol,
+        "references": all_refs,
+        "count": all_refs.len(),
+    });
+    let json = serde_json::to_string_pretty(&obj)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_deps(
+    svc: &PatchloomService,
+    p: AstDepsParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+
+    let global = GlobalFlags::with_cwd(&cwd);
+    let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
+        .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+    let mut results = Vec::new();
+
+    if p.reverse {
+        let target_name = target
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default();
+        let scan_dir = if target.is_file() {
+            target.parent().unwrap_or(&cwd).to_path_buf()
+        } else {
+            target.clone()
+        };
+        let all_files = crate::cmd::ast::collect_source_files(&scan_dir, &global)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+        for path in &all_files {
+            let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+            let matching: Vec<_> = imports
+                .iter()
+                .filter(|i| i.path.contains(target_name))
+                .collect();
+            if matching.is_empty() {
+                continue;
+            }
+            let display = crate::cmd::ast::display_path(path, &cwd);
+            for imp in &matching {
+                results.push(serde_json::json!({
+                    "file": display,
+                    "imports": imp.path,
+                    "line": imp.line,
+                    "raw": imp.raw,
+                }));
+            }
+        }
+    } else {
+        for path in &paths {
+            let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+            if imports.is_empty() {
+                continue;
+            }
+            let display = crate::cmd::ast::display_path(path, &cwd);
+            results.push(serde_json::json!({
+                "file": display,
+                "imports": imports,
+            }));
+        }
+    }
+
+    if results.is_empty() {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No imports found.");
+    }
+    let json = serde_json::to_string_pretty(&results)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_map(
+    svc: &PatchloomService,
+    p: AstMapParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    for s in &p.focus {
+        validate_param_size("focus", s)?;
+    }
+    for s in &p.boost {
+        validate_param_size("boost", s)?;
+    }
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+
+    if !target.is_dir() {
+        return Err(McpError::invalid_params(
+            format!("path must be a directory: {}", p.path),
+            None,
+        ));
+    }
+
+    let global = GlobalFlags::with_cwd(&cwd);
+    let paths = crate::cmd::ast::collect_source_files(&target, &global)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    let file_pairs: Vec<(std::path::PathBuf, String)> = paths
+        .iter()
+        .map(|fp| {
+            let display = crate::cmd::ast::display_path(fp, &cwd);
+            (fp.clone(), display)
+        })
+        .collect();
+
+    let opts = crate::ast::map::MapOptions {
+        max_tokens: p.max_tokens,
+        focus: &p.focus,
+        boost: &p.boost,
+    };
+
+    let entries = crate::ast::map::generate_map(&file_pairs, &opts);
+
+    if entries.is_empty() {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No symbols found.");
+    }
+
+    let json = serde_json::to_string_pretty(&entries)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_diff(
+    svc: &PatchloomService,
+    p: AstDiffParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("from", &p.from)?;
+    if let Some(ref to) = p.to {
+        validate_param_size("to", to)?;
+    }
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
+
+    let old_source = crate::cmd::ast::get_git_file_content(&cwd, &p.path, &p.from)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+    let new_source = if let Some(ref to_ref) = p.to {
+        crate::cmd::ast::get_git_file_content(&cwd, &p.path, to_ref)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?
+    } else {
+        std::fs::read_to_string(&target)
+            .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?
+    };
+
+    let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
+
+    if changes.is_empty() {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No structural changes.");
+    }
+
+    let obj = serde_json::json!({
+        "file": p.path,
+        "from": p.from,
+        "to": p.to.as_deref().unwrap_or("working tree"),
+        "changes": changes,
+    });
+    let json = serde_json::to_string_pretty(&obj)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_impact(
+    svc: &PatchloomService,
+    p: AstImpactParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("symbol", &p.symbol)?;
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+
+    let global = GlobalFlags::with_cwd(&cwd);
+    let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
+        .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+    let file_pairs: Vec<(std::path::PathBuf, String)> = paths
+        .iter()
+        .map(|fp| {
+            let display = crate::cmd::ast::display_path(fp, &cwd);
+            (fp.clone(), display)
+        })
+        .collect();
+
+    let nodes = crate::ast::impact::compute_impact(&p.symbol, &file_pairs, p.depth);
+
+    if nodes.is_empty() {
+        return exit_code_to_result(
+            exit::NO_MATCHES,
+            "",
+            &format!("No references found for '{}'.", p.symbol),
+        );
+    }
+
+    let obj = serde_json::json!({
+        "symbol": p.symbol,
+        "depth": p.depth,
+        "impact": nodes,
+        "direct_count": nodes.len(),
+    });
+    let json = serde_json::to_string_pretty(&obj)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}
+
+pub(super) fn handle_ast_replace(
+    svc: &PatchloomService,
+    p: AstReplaceParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("from", &p.from)?;
+    validate_content_size("to", &p.to)?;
+    validate_param_size("symbol", &p.symbol)?;
+    let cwd = svc.cwd().to_path_buf();
+    let target = cwd.join(&p.path);
+    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+    let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
+
+    let source = std::fs::read_to_string(&target)
+        .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
+
+    let result =
+        crate::ast::replace::replace_in_symbol(&source, &p.symbol, &p.from, &p.to, p.regex, lang)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+    let result = match result {
+        Some(r) => r,
+        None => {
+            return exit_code_to_result(
+                exit::NO_MATCHES,
+                "",
+                &format!("Symbol '{}' not found in {}.", p.symbol, p.path),
+            );
+        }
+    };
+
+    if result.replacements == 0 {
+        return exit_code_to_result(exit::NO_MATCHES, "", "No matches within symbol.");
+    }
+
+    // Write the file
+    let mut global = GlobalFlags::with_cwd(&cwd);
+    global.apply = true;
+    let policy = crate::write::policy_from_flags(&global, Some(&target));
+    let mut backup = crate::backup::BackupSession::new(&cwd)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    backup
+        .save_before_write(&target)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    crate::write::atomic_write(&target, &result.content, &policy)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    backup
+        .finalize()
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+
+    let obj = serde_json::json!({
+        "ok": true,
+        "symbol": p.symbol,
+        "replacements": result.replacements,
+        "start_line": result.start_line,
+        "end_line": result.end_line,
+    });
+    let json = serde_json::to_string_pretty(&obj)
+        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+    Ok(CallToolResult::success(vec![Content::text(json)]))
+}

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -32,6 +32,9 @@ fn default_strict_true() -> bool {
 
 mod params;
 
+#[cfg(feature = "ast")]
+mod ast_tools;
+
 // Re-export so the rest of the file (impls, tests) can use the names without qualification.
 use params::*;
 
@@ -1214,51 +1217,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstListParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-        let kind_filter = crate::cmd::ast::parse_kind_filter(&p.kind);
-
-        let mut results = Vec::new();
-
-        if target.is_file() {
-            let symbols = crate::ast::symbols::extract_symbols_from_file(&target, lang_hint);
-            let filtered = crate::cmd::ast::filter_symbols(&symbols, &kind_filter);
-            if !filtered.is_empty() {
-                for sym in &filtered {
-                    results.push(crate::cmd::ast::symbol_to_json(sym, &p.path));
-                }
-            }
-        } else if target.is_dir() {
-            let global = GlobalFlags::with_cwd(&cwd);
-            let paths = crate::cmd::ast::collect_source_files(&target, &global)
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            for path in &paths {
-                let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-                let symbols = crate::ast::symbols::extract_symbols_from_file(path, Some(lang));
-                let filtered = crate::cmd::ast::filter_symbols(&symbols, &kind_filter);
-                if filtered.is_empty() {
-                    continue;
-                }
-                let display = crate::cmd::ast::display_path(path, &cwd);
-                for sym in &filtered {
-                    results.push(crate::cmd::ast::symbol_to_json(sym, &display));
-                }
-            }
-        } else {
-            return Err(McpError::invalid_params(
-                format!("path not found: {}", p.path),
-                None,
-            ));
-        }
-
-        if results.is_empty() {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No symbols found.");
-        }
-        let json = serde_json::to_string_pretty(&results)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_list(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1269,40 +1231,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstReadParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        validate_param_size("symbol", &p.symbol)?;
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
-        let source = std::fs::read_to_string(&target)
-            .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
-        let all_symbols = crate::ast::symbols::extract_symbols(&source, lang);
-        let sym = crate::ast::symbols::find_symbol(&all_symbols, &p.symbol).ok_or_else(|| {
-            McpError::invalid_params(
-                format!("symbol '{}' not found in {}", p.symbol, p.path),
-                None,
-            )
-        })?;
-
-        let lines: Vec<&str> = source.lines().collect();
-        let start = sym.start_line.saturating_sub(1 + p.context);
-        let end = (sym.end_line + p.context).min(lines.len());
-        let content: String = lines[start..end].iter().map(|l| format!("{l}\n")).collect();
-
-        let obj = serde_json::json!({
-            "file": p.path,
-            "symbol": sym.name,
-            "kind": sym.kind.to_string(),
-            "start_line": sym.start_line,
-            "end_line": sym.end_line,
-            "signature": sym.signature,
-            "content": content,
-        });
-        let json = serde_json::to_string_pretty(&obj)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_read(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1313,102 +1245,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstRenameParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        validate_param_size("old_name", &p.old_name)?;
-        validate_param_size("new_name", &p.new_name)?;
-        if p.old_name == p.new_name {
-            return exit_code_to_result(
-                exit::NO_MATCHES,
-                "",
-                "old_name and new_name are identical.",
-            );
-        }
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-
-        let mut global = GlobalFlags::with_cwd_and_json(&cwd);
-        global.apply = true;
-
-        let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
-            .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
-
-        let mut total_replacements = 0usize;
-        let mut files_changed = 0usize;
-        let mut backup = crate::backup::BackupSession::new(&cwd)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-        for path in &paths {
-            self.check_path(
-                &path
-                    .strip_prefix(&cwd)
-                    .unwrap_or(path)
-                    .display()
-                    .to_string(),
-            )?;
-
-            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-            let source = std::fs::read_to_string(path)
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-            let result = if lang.has_grammar() {
-                crate::ast::rename::rename_in_source(&source, &p.old_name, &p.new_name, lang)
-            } else {
-                None
-            };
-
-            let (new_content, count) = match result {
-                Some(r) if r.replacements > 0 => (r.content, r.replacements),
-                _ => {
-                    // Try word-boundary fallback
-                    let re = crate::ops::replace::compile_replace_regex(
-                        &p.old_name,
-                        false,
-                        false,
-                        false,
-                        true,
-                    )
-                    .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-                    if let Some(re) = re {
-                        let count = re.find_iter(&source).count();
-                        if count > 0 {
-                            let new = re.replace_all(&source, p.new_name.as_str());
-                            (new.into_owned(), count)
-                        } else {
-                            continue;
-                        }
-                    } else {
-                        continue;
-                    }
-                }
-            };
-
-            total_replacements += count;
-            files_changed += 1;
-            let policy = crate::write::policy_from_flags(&global, Some(path));
-            backup
-                .save_before_write(path)
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            crate::write::atomic_write(path, &new_content, &policy)
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        }
-
-        backup
-            .finalize()
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-        if total_replacements == 0 {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No matches found.");
-        }
-
-        let obj = serde_json::json!({
-            "ok": true,
-            "files_changed": files_changed,
-            "replacements": total_replacements,
-        });
-        let json = serde_json::to_string_pretty(&obj)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_rename(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1419,38 +1259,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstValidateParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-
-        let global = GlobalFlags::with_cwd(&cwd);
-        let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
-            .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
-
-        let mut results = Vec::new();
-        for path in &paths {
-            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-            if !lang.has_grammar() {
-                continue;
-            }
-            let result = crate::ast::validate::validate_file(path, Some(lang))
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            let display = crate::cmd::ast::display_path(path, &cwd);
-            results.push(serde_json::json!({
-                "file": display,
-                "valid": result.valid,
-                "language": result.language,
-                "errors": result.errors,
-            }));
-        }
-
-        if results.is_empty() {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No files with grammars found.");
-        }
-        let json = serde_json::to_string_pretty(&results)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_validate(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1461,52 +1273,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstSearchParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        validate_param_size("query", &p.query)?;
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-
-        let global = GlobalFlags::with_cwd(&cwd);
-        let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
-            .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
-
-        let mut all_matches = Vec::new();
-        for path in &paths {
-            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-
-            let query_str = if p.pattern {
-                crate::ast::search::compile_pattern_query(&p.query, lang)
-                    .map_err(|e| McpError::invalid_params(format!("{e}"), None))?
-            } else {
-                p.query.clone()
-            };
-
-            let results =
-                crate::ast::search::search_file(path, &query_str, Some(lang), p.max_results)
-                    .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            if results.is_empty() {
-                continue;
-            }
-
-            let display = crate::cmd::ast::display_path(path, &cwd);
-            for m in &results {
-                all_matches.push(serde_json::json!({
-                    "file": display,
-                    "line": m.line,
-                    "column": m.column,
-                    "text": m.text,
-                    "captures": m.captures,
-                }));
-            }
-        }
-
-        if all_matches.is_empty() {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No matches found.");
-        }
-        let json = serde_json::to_string_pretty(&all_matches)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_search(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1517,39 +1287,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstRefsParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        validate_param_size("symbol", &p.symbol)?;
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-
-        let global = GlobalFlags::with_cwd(&cwd);
-        let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
-            .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
-
-        let mut all_refs = Vec::new();
-        for path in &paths {
-            let display = crate::cmd::ast::display_path(path, &cwd);
-            let refs = crate::ast::refs::find_refs_in_file(path, &p.symbol, lang_hint, &display);
-            all_refs.extend(refs);
-        }
-
-        if !p.include_def {
-            all_refs.retain(|r| r.kind != crate::ast::refs::RefKind::Definition);
-        }
-
-        if all_refs.is_empty() {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No references found.");
-        }
-
-        let obj = serde_json::json!({
-            "symbol": p.symbol,
-            "references": all_refs,
-            "count": all_refs.len(),
-        });
-        let json = serde_json::to_string_pretty(&obj)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_refs(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1560,69 +1301,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstDepsParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-
-        let global = GlobalFlags::with_cwd(&cwd);
-        let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
-            .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
-
-        let mut results = Vec::new();
-
-        if p.reverse {
-            let target_name = target
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or_default();
-            let scan_dir = if target.is_file() {
-                target.parent().unwrap_or(&cwd).to_path_buf()
-            } else {
-                target.clone()
-            };
-            let all_files = crate::cmd::ast::collect_source_files(&scan_dir, &global)
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-            for path in &all_files {
-                let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
-                let matching: Vec<_> = imports
-                    .iter()
-                    .filter(|i| i.path.contains(target_name))
-                    .collect();
-                if matching.is_empty() {
-                    continue;
-                }
-                let display = crate::cmd::ast::display_path(path, &cwd);
-                for imp in &matching {
-                    results.push(serde_json::json!({
-                        "file": display,
-                        "imports": imp.path,
-                        "line": imp.line,
-                        "raw": imp.raw,
-                    }));
-                }
-            }
-        } else {
-            for path in &paths {
-                let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
-                if imports.is_empty() {
-                    continue;
-                }
-                let display = crate::cmd::ast::display_path(path, &cwd);
-                results.push(serde_json::json!({
-                    "file": display,
-                    "imports": imports,
-                }));
-            }
-        }
-
-        if results.is_empty() {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No imports found.");
-        }
-        let json = serde_json::to_string_pretty(&results)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_deps(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1633,49 +1315,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstMapParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        for s in &p.focus {
-            validate_param_size("focus", s)?;
-        }
-        for s in &p.boost {
-            validate_param_size("boost", s)?;
-        }
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-
-        if !target.is_dir() {
-            return Err(McpError::invalid_params(
-                format!("path must be a directory: {}", p.path),
-                None,
-            ));
-        }
-
-        let global = GlobalFlags::with_cwd(&cwd);
-        let paths = crate::cmd::ast::collect_source_files(&target, &global)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        let file_pairs: Vec<(std::path::PathBuf, String)> = paths
-            .iter()
-            .map(|fp| {
-                let display = crate::cmd::ast::display_path(fp, &cwd);
-                (fp.clone(), display)
-            })
-            .collect();
-
-        let opts = crate::ast::map::MapOptions {
-            max_tokens: p.max_tokens,
-            focus: &p.focus,
-            boost: &p.boost,
-        };
-
-        let entries = crate::ast::map::generate_map(&file_pairs, &opts);
-
-        if entries.is_empty() {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No symbols found.");
-        }
-
-        let json = serde_json::to_string_pretty(&entries)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_map(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1686,42 +1329,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstDiffParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        validate_param_size("from", &p.from)?;
-        if let Some(ref to) = p.to {
-            validate_param_size("to", to)?;
-        }
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
-
-        let old_source = crate::cmd::ast::get_git_file_content(&cwd, &p.path, &p.from)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-        let new_source = if let Some(ref to_ref) = p.to {
-            crate::cmd::ast::get_git_file_content(&cwd, &p.path, to_ref)
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?
-        } else {
-            std::fs::read_to_string(&target)
-                .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?
-        };
-
-        let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
-
-        if changes.is_empty() {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No structural changes.");
-        }
-
-        let obj = serde_json::json!({
-            "file": p.path,
-            "from": p.from,
-            "to": p.to.as_deref().unwrap_or("working tree"),
-            "changes": changes,
-        });
-        let json = serde_json::to_string_pretty(&obj)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_diff(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1732,42 +1343,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstImpactParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        validate_param_size("symbol", &p.symbol)?;
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-
-        let global = GlobalFlags::with_cwd(&cwd);
-        let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
-            .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
-
-        let file_pairs: Vec<(std::path::PathBuf, String)> = paths
-            .iter()
-            .map(|fp| {
-                let display = crate::cmd::ast::display_path(fp, &cwd);
-                (fp.clone(), display)
-            })
-            .collect();
-
-        let nodes = crate::ast::impact::compute_impact(&p.symbol, &file_pairs, p.depth);
-
-        if nodes.is_empty() {
-            return exit_code_to_result(
-                exit::NO_MATCHES,
-                "",
-                &format!("No references found for '{}'.", p.symbol),
-            );
-        }
-
-        let obj = serde_json::json!({
-            "symbol": p.symbol,
-            "depth": p.depth,
-            "impact": nodes,
-            "direct_count": nodes.len(),
-        });
-        let json = serde_json::to_string_pretty(&obj)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_impact(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[cfg(feature = "ast")]
@@ -1778,63 +1357,10 @@ impl PatchloomService {
         &self,
         Parameters(p): Parameters<AstReplaceParams>,
     ) -> Result<CallToolResult, McpError> {
-        self.check_path(&p.path)?;
-        validate_param_size("from", &p.from)?;
-        validate_content_size("to", &p.to)?;
-        validate_param_size("symbol", &p.symbol)?;
-        let cwd = self.cwd().to_path_buf();
-        let target = cwd.join(&p.path);
-        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
-
-        let source = std::fs::read_to_string(&target)
-            .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
-
-        let result = crate::ast::replace::replace_in_symbol(
-            &source, &p.symbol, &p.from, &p.to, p.regex, lang,
-        )
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-        let result = match result {
-            Some(r) => r,
-            None => {
-                return exit_code_to_result(
-                    exit::NO_MATCHES,
-                    "",
-                    &format!("Symbol '{}' not found in {}.", p.symbol, p.path),
-                );
-            }
-        };
-
-        if result.replacements == 0 {
-            return exit_code_to_result(exit::NO_MATCHES, "", "No matches within symbol.");
-        }
-
-        // Write the file
-        let mut global = GlobalFlags::with_cwd(&cwd);
-        global.apply = true;
-        let policy = crate::write::policy_from_flags(&global, Some(&target));
-        let mut backup = crate::backup::BackupSession::new(&cwd)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        backup
-            .save_before_write(&target)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        crate::write::atomic_write(&target, &result.content, &policy)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        backup
-            .finalize()
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-        let obj = serde_json::json!({
-            "ok": true,
-            "symbol": p.symbol,
-            "replacements": result.replacements,
-            "start_line": result.start_line,
-            "end_line": result.end_line,
-        });
-        let json = serde_json::to_string_pretty(&obj)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+        let svc = self.clone();
+        tokio::task::spawn_blocking(move || ast_tools::handle_ast_replace(&svc, p))
+            .await
+            .map_err(|e| McpError::internal_error(format!("task join error: {e}"), None))?
     }
 
     #[tool(


### PR DESCRIPTION
## Summary

Addresses all 5 AST-related issues discovered during the MPI audit session.

### #928: Architecture - Extract AST MCP handlers
- Extracted all 11 AST MCP handler implementations from `mcp/mod.rs` into `mcp/ast_tools.rs` (614 lines)
- `mod.rs` reduced from 2,680 to 2,195 lines
- Thin `#[tool]` stubs in `mod.rs` delegate to `ast_tools` functions

### #927: Performance
- All 11 AST MCP handlers now wrapped in `tokio::task::spawn_blocking` to avoid blocking the async runtime (critical for HTTP transport)
- PageRank convergence check: replaced fixed 20-iteration loop with L1-norm convergence threshold (1e-6, max 100 iterations)

### #929: Observability
- Added `verbose!` diagnostic output to all 11 CLI `ast` subcommands (list, read, rename, validate, search, refs, deps, map, replace, impact, diff)
- Logs language detection, file counts, and key parameters at decision points

### #930: Documentation
- Added Step 6 ("Explore code structure with AST") to the quickstart guide
- Covers `ast list`, `ast read`, `ast refs`, `ast validate`, and `ast map` with examples

### #931: UX
- `ast list` on unsupported file types now reports the detected language name and lists all 20 supported languages, instead of the generic "No symbols found"
- Fixed in both CLI (`src/cmd/ast.rs`) and MCP handler (`ast_tools.rs`)

## Testing

`make check-fast` passes: fmt-check, clippy, 746 unit tests, library hygiene, integration tests, 10 PTY tests.

Closes #927
Closes #928
Closes #929
Closes #930
Closes #931