### PR TITLE
fix: exit_code_to_result uses fallback for all exit codes; rename stale test

### DIFF
--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -670,24 +670,24 @@ fn execute_plan_validated(
 }
 
 /// Convert an exit code + output string into a `CallToolResult`.
-fn exit_code_to_result(
-    code: u8,
-    output: &str,
-    success_fallback: &str,
-) -> Result<CallToolResult, McpError> {
-    if code == exit::SUCCESS {
-        let msg = if output.trim().is_empty() {
-            success_fallback.to_string()
-        } else {
-            output.trim().to_string()
-        };
-        Ok(CallToolResult::success(vec![Content::text(msg)]))
-    } else {
-        let msg = if output.trim().is_empty() {
+///
+/// When `output` is non-empty it is used as-is. Otherwise `fallback` is used
+/// for both success and error results so callers can provide a descriptive
+/// message regardless of exit code. If both are empty and the code indicates
+/// failure, a generic "Operation failed with exit code N." message is returned.
+fn exit_code_to_result(code: u8, output: &str, fallback: &str) -> Result<CallToolResult, McpError> {
+    let msg = if output.trim().is_empty() {
+        if fallback.is_empty() && code != exit::SUCCESS {
             format!("Operation failed with exit code {code}.")
         } else {
-            output.trim().to_string()
-        };
+            fallback.to_string()
+        }
+    } else {
+        output.trim().to_string()
+    };
+    if code == exit::SUCCESS {
+        Ok(CallToolResult::success(vec![Content::text(msg)]))
+    } else {
         Ok(CallToolResult::error(vec![Content::text(msg)]))
     }
 }

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2113,9 +2113,10 @@ async fn test_mcp_doc_set_yaml_multiple_nested_writes() {
 }
 
 /// Regression test for #892: sequential MCP replace_text calls to the same
-/// file must each see the result of the previous call.
+/// file must each see the result of the previous call (MCP call ordering,
+/// not handler internals).
 #[tokio::test]
-async fn test_mcp_sequential_writes_same_file_no_data_loss() {
+async fn test_mcp_replace_text_sequential_calls_see_prior_writes() {
     if !has_mcp_support() {
         return;
     }
@@ -2638,6 +2639,37 @@ async fn test_mcp_ast_list_unsupported_file_names_language() {
     assert!(
         text.contains("Rust"),
         "response should list supported languages: {text}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// Regression test for #939: NO_MATCHES results must return the descriptive
+/// fallback message, not the generic "Operation failed with exit code 3."
+#[tokio::test]
+#[cfg(feature = "ast")]
+async fn test_mcp_no_matches_returns_descriptive_message() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn hello() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    // Search for a symbol that does not exist
+    let (is_error, text) = call_tool_text(
+        &client,
+        "ast_refs",
+        serde_json::json!({"path": "lib.rs", "symbol": "nonexistent_symbol_xyz"}),
+    )
+    .await;
+    assert!(is_error, "ast_refs on missing symbol should return error");
+    assert!(
+        text.contains("No references found"),
+        "response should contain descriptive message, not generic exit code: {text}"
+    );
+    assert!(
+        !text.contains("Operation failed with exit code"),
+        "generic message should not appear: {text}"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

Two fixes from session retrospective on #933-#937.

### Bug fix (#939): descriptive error messages swallowed in 13 MCP handlers

`exit_code_to_result()` had a parameter named `success_fallback` that was only used when `code == SUCCESS`. 13 call sites passed `NO_MATCHES` with the descriptive message in arg 3 and empty `""` in arg 2, causing MCP clients to see the generic "Operation failed with exit code 3." instead of messages like "No symbols found." or "No references found."

**Fix:** Renamed `success_fallback` to `fallback` and changed the function to use it for both success and error paths. When both `output` and `fallback` are empty on a non-SUCCESS code, the generic message is still returned as a last resort.

This fixes all 13 affected call sites without touching them individually, and prevents the same mistake in future calls.

**Regression test:** `test_mcp_no_matches_returns_descriptive_message` verifies `ast_refs` on a missing symbol returns "No references found" instead of the generic exit code message.

### Tech debt (#940): stale test name after spawn_blocking refactor

Renamed `test_mcp_sequential_writes_same_file_no_data_loss` to `test_mcp_replace_text_sequential_calls_see_prior_writes` to clarify the test exercises MCP call sequencing, not handler internals. `make audit-test-hygiene` no longer flags it.

### Verification

`make check` passes: 1055 unit tests, 749 integration tests, 10 PTY tests, plus fmt-check, clippy, library-hygiene, PATCHLOOM.md sync, and README count.

Closes #939
Closes #940