### PR TITLE
test: add find_refs_with_tree parity test and search_files no-match MCP regression test

### DIFF
--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -377,6 +377,28 @@ int main() {
         assert!(refs.is_empty());
     }
 
+    /// Verify that `find_refs_in_source_with_tree` produces the same results
+    /// as `find_refs_in_source` when given a pre-parsed tree (regression guard
+    /// for the tree-cache optimization added in #934).
+    #[test]
+    fn find_refs_with_tree_matches_full_parse() {
+        let source = "fn greet() {}\nfn main() { greet(); greet(); }\n";
+        let lang = Language::Rust;
+        let (tree, _) = crate::ast::parse_source(source, lang).expect("parse should succeed");
+        let via_full = find_refs_in_source(source, "greet", lang, "test.rs");
+        let via_tree = find_refs_in_source_with_tree(source, "greet", &tree, "test.rs");
+        assert_eq!(
+            via_full.len(),
+            via_tree.len(),
+            "with_tree should produce the same number of refs"
+        );
+        for (a, b) in via_full.iter().zip(via_tree.iter()) {
+            assert_eq!(a.line, b.line);
+            assert_eq!(a.kind, b.kind);
+            assert_eq!(a.context, b.context);
+        }
+    }
+
     #[test]
     fn ref_kind_serializes() {
         let json = serde_json::to_string(&RefKind::Definition).unwrap();

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -301,6 +301,35 @@ async fn test_mcp_doc_get_reads_value() {
     client.cancel().await.unwrap();
 }
 
+/// Regression test for #939: search_files with zero matches must return a
+/// descriptive "No matches found." message, not the generic exit-code text.
+#[tokio::test]
+async fn test_mcp_search_no_match_returns_descriptive_message() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("hello.txt"), "nothing relevant here\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "search_files",
+        serde_json::json!({"pattern": "zzz_nonexistent_pattern_zzz"}),
+    )
+    .await;
+    assert!(is_error, "search with no matches should return error");
+    assert!(
+        text.contains("No matches found"),
+        "response should say 'No matches found', got: {text}"
+    );
+    assert!(
+        !text.contains("Operation failed with exit code"),
+        "generic message should not appear: {text}"
+    );
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_search_rejects_absolute_path() {
     if !has_mcp_support() {


### PR DESCRIPTION
Add two tests surfaced during multi-perspective improvement rotation:

- **`find_refs_with_tree_matches_full_parse`** (unit test in `src/ast/refs.rs`): verifies that `find_refs_in_source_with_tree` (pre-parsed tree path) produces identical results to `find_refs_in_source` (full parse path). Guards against drift between the two code paths.

- **`test_mcp_search_no_match_returns_descriptive_message`** (MCP integration test): regression test for #939. Verifies that `search_files` with zero matches returns the descriptive "No matches found." message instead of the generic "Operation failed with exit code N." text.

Ref #939