### PR TITLE
docs: sync AGENTS.md and CONTRIBUTING.md check target lists with Makefile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,8 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make pty-test` | Run PTY-based interactive terminal tests (`cargo test --test pty --all-features -- --test-threads=1`) |
 | `make test-library-hygiene` | Enforce Bline library set: clippy + tests under `--no-default-features --features "ast,files"` (catches dead_code, hygiene for #800 #802) |
 | `make clippy` | Run `cargo clippy --all-targets --all-features -- -D warnings` |
-| `make check` | Run fmt-check, clippy, test, integration-test, pty-test, check-patchloom-md, check-readme |
-| `make check-fast` | Fast check: fmt-check, clippy, test, test-library-hygiene, integration-test, pty-test (skips doc verification; enforces library hygiene) |
+| `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme |
+| `make check-fast` | Fast check: fmt-check, clippy, test, test-no-default, test-ast-only, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene (skips doc verification; enforces library hygiene) |
 | `make update-readme` | Update README.md rounded test count (only changes when hundreds digit changes) |
 | `make check-readme` | Verify README.md rounded test count is accurate (part of `check`) |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd patchloom
 make check
 ```
 
-`make check` runs formatting, clippy, unit tests, integration tests, and generated-doc freshness checks. While iterating locally, `make check-fast` skips the doc freshness checks.
+`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks. While iterating locally, `make check-fast` skips the doc freshness checks but adds library hygiene enforcement.
 
 ## Development workflow
 


### PR DESCRIPTION
AGENTS.md listed 7 targets for `make check` and 6 for `make check-fast`,
but the Makefile actually runs 11 and 10 respectively.

**Missing from AGENTS.md `make check` description:**
- `test-no-default` (pure library use, exercises feature gating)
- `test-ast-only` (ast feature without cli/mcp)
- `verify-release-notes` (validates RELEASE_NOTES.md if present)
- `audit-test-hygiene` (detects stale test names and weak assertions)

**Missing from AGENTS.md `make check-fast` description:**
- `test-no-default`
- `test-ast-only`
- `verify-release-notes`
- `audit-test-hygiene`

CONTRIBUTING.md prose summary was similarly incomplete, omitting feature-gating tests, release notes verification, and test hygiene audit.

This drift means agents reading AGENTS.md would not know that the gate includes feature-gating tests or release notes verification, potentially causing surprise failures when running individual targets instead of `make check`.