### PR TITLE
docs: fix documentation gaps and update anyhow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ src/
   cmd/append.rs        Append content to an existing file
   cmd/batch.rs         Line-oriented batch operations, parses positional args, delegates to tx engine
   cmd/mcp/mod.rs       MCP server (feature-gated): 19 auto-generated tools via MCP_TOOL_REGISTRY +
-                       13 hand-written #[tool] handlers, dynamic registration via ToolRoute::new_dyn()
+                       24 hand-written #[tool] handlers, dynamic registration via ToolRoute::new_dyn()
   cmd/mcp/params.rs    Parameter structs for hand-written MCP tool handlers only; simple tools use
                        Operation variant schemas directly via operation_variant_schema()
   cmd/search.rs        Literal/regex search across files with context, count, files-with-matches, -i

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,500+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
+- **1,800+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
 - **22 commands** including MCP server with 43 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -130,11 +130,11 @@ Every command returns a specific exit code:
 | 2 | Changes detected (with `--check`) |
 | 3 | No matches found |
 | 4 | Parse error in input |
-| 9 | Tx operation staging failure (`operation_failed`) |
 | 5 | Ambiguous (multiple replace matches, or stale patch context) |
 | 6 | Validation failed (writes may remain) |
 | 7 | Rollback (strict mode, no writes remain) |
 | 8 | Patch merge conflicts detected (apply blocked unless `--allow-conflicts`) |
+| 9 | Tx operation staging failure (`operation_failed`) |
 
 These codes let CI pipelines and agent frameworks branch on outcomes without parsing output.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -277,6 +277,7 @@ This is safe; the next `--apply` run will create a fresh backup directory.
 | 6 | Validation failed |
 | 7 | Rollback (transaction failed and was rolled back) |
 | 8 | Patch merge conflicts detected |
+| 9 | Tx operation staging failure |
 
 ## Next steps
 

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -783,7 +783,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,500+ tests"));
+    assert!(launch.contains("1,800+ tests"));
     assert!(
         launch.contains("22 commands"),
         "launch announcement CLI command count drifted"


### PR DESCRIPTION
Multi-perspective improvement cycle (convergence stage).

## Changes

### Dependency update
- Update anyhow 1.0.102 to 1.0.103

### Documentation gaps (found by deep audit, Step B)
- **quickstart.md**: Add missing exit code 9 (OPERATION_FAILED) to exit codes table
- **concepts.md**: Reorder exit codes to sequential 0-9 (code 9 was misplaced between 4 and 5)
- **AGENTS.md**: Update MCP tool count from 19+13 to 19+24 (total 43)
- **launch-announcement.md**: Update test count from 1,500+ to 1,800+
- **smoke_tests.rs**: Update assertion to match new launch announcement count

## Verification

`make check` passes (1,056 unit + 750 integration + 10 PTY tests).