### PR TITLE
feat: add Windows ARM64 and Linux musl release targets

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,7 +10,7 @@ ci = "github"
 # The installers to generate for each app
 installers = ["shell", "powershell", "homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-pc-windows-msvc", "aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # The archive format to use for non-windows builds (defaults .tar.xz)
 unix-archive = ".tar.xz"
 # The archive format to use for windows builds (defaults .zip)


### PR DESCRIPTION
Add 3 new cargo-dist release targets, bringing the total from 5 to 8:

| Target | What it covers |
|--------|---------------|
| `aarch64-pc-windows-msvc` | Windows ARM64 (Surface Pro, Snapdragon X Elite) |
| `x86_64-unknown-linux-musl` | Static Linux x86_64 (Alpine, containers, older distros) |
| `aarch64-unknown-linux-musl` | Static Linux ARM64 (AWS Graviton, ARM containers) |

The musl targets produce fully static binaries that run on any Linux distro without glibc version constraints. The Windows ARM64 target provides a native binary instead of relying on x86 emulation.

No code changes; only `dist-workspace.toml` targets list.