### PR TITLE
perf: build reverse dep map in ast_impact; fix CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,8 @@ make check
 
 ### Useful make targets
 
+This is a quick-reference subset. For the complete list, see [AGENTS.md](./AGENTS.md).
+
 | Command | What it does |
 |---------|-------------|
 | `make fmt` | Run `cargo fmt --all` |
@@ -39,7 +41,6 @@ make check
 | `make check-fast` | Fast check (skips doc verification) |
 | `make update-readme` | Update README.md rounded test count |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |
-| `cargo check --all-targets` | Type-check all targets without building |
 
 ## Adding a new command
 

--- a/src/ast/impact.rs
+++ b/src/ast/impact.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use serde::Serialize;
 
 use super::Language;
-use super::refs::{RefKind, find_refs_in_source_with_tree};
+use super::refs::{RefKind, find_all_refs_in_source_with_tree};
 use super::symbols::extract_symbols;
 
 /// A node in the impact tree.
@@ -47,98 +47,86 @@ pub fn compute_impact(
     let mut visited = HashSet::new();
     visited.insert(symbol_name.to_string());
 
-    // Cache parsed symbols per file to avoid O(N * parse_cost) re-parsing
-    // when multiple references exist in the same file.
-    let mut symbol_cache: HashMap<String, Vec<super::symbols::SymbolDef>> = HashMap::new();
+    // Build a global reverse dependency map in a single pass over all files.
+    // For each identifier reference found in the AST, record which symbol
+    // contains it. This turns the per-depth O(files) scan into O(1) lookups.
+    let mut reverse_deps: HashMap<String, Vec<ReverseRef>> = HashMap::new();
 
-    // Pre-parse all files once; reuse trees for all symbol lookups.
-    let tree_cache: HashMap<String, tree_sitter_lib::Tree> = file_data
-        .iter()
-        .filter_map(|(_, display, source, lang)| {
-            let (tree, _) = super::parse_source(source, *lang)?;
-            Some(((*display).to_string(), tree))
-        })
-        .collect();
+    for (_, display, source, lang) in &file_data {
+        // Parse tree (needed for ref extraction).
+        let Some((tree, _)) = super::parse_source(source, *lang) else {
+            continue;
+        };
 
-    find_dependents(
-        symbol_name,
-        &file_data,
-        max_depth,
-        1,
-        &mut visited,
-        &mut symbol_cache,
-        &tree_cache,
-    )
+        // Extract symbols for containment lookup.
+        let symbols = extract_symbols(source, *lang);
+
+        // Collect all identifier references in this file.
+        let all_refs = find_all_refs_in_source_with_tree(source, &tree, display);
+
+        for (ref_name, sym_ref) in all_refs {
+            if sym_ref.kind != RefKind::Reference {
+                continue;
+            }
+            let containing = find_containing_in(&symbols, sym_ref.line);
+            let dependent_name = containing.unwrap_or_else(|| format!("<{}>", display));
+            reverse_deps.entry(ref_name).or_default().push(ReverseRef {
+                symbol: dependent_name,
+                file: sym_ref.file,
+                line: sym_ref.line,
+                context: sym_ref.context,
+            });
+        }
+    }
+
+    find_dependents(symbol_name, &reverse_deps, max_depth, 1, &mut visited)
+}
+
+/// A reference edge in the reverse dependency map.
+struct ReverseRef {
+    /// The symbol that contains the reference (the dependent).
+    symbol: String,
+    /// File where the reference occurs.
+    file: String,
+    /// 1-based line number.
+    line: usize,
+    /// The source line (trimmed).
+    context: String,
 }
 
 fn find_dependents(
     symbol_name: &str,
-    file_data: &[(&Path, &str, String, Language)],
+    reverse_deps: &HashMap<String, Vec<ReverseRef>>,
     max_depth: usize,
     current_depth: usize,
     visited: &mut HashSet<String>,
-    symbol_cache: &mut HashMap<String, Vec<super::symbols::SymbolDef>>,
-    tree_cache: &HashMap<String, tree_sitter_lib::Tree>,
 ) -> Vec<ImpactNode> {
     let mut results = Vec::new();
 
-    for (_, display, source, lang) in file_data {
-        let key = (*display).to_string();
-        let refs = if let Some(tree) = tree_cache.get(&key) {
-            find_refs_in_source_with_tree(source, symbol_name, tree, display)
-        } else {
-            // Fallback: parse on the fly (should not happen with pre-built cache)
-            super::refs::find_refs_in_source(source, symbol_name, *lang, display)
-        };
-        if refs.is_empty() {
-            continue;
-        }
+    if let Some(refs) = reverse_deps.get(symbol_name) {
+        for r in refs {
+            if visited.contains(&r.symbol) {
+                continue;
+            }
+            visited.insert(r.symbol.clone());
 
-        // Parse symbols once per file, cache the result.
-        let key = (*display).to_string();
-        if !symbol_cache.contains_key(&key) {
-            symbol_cache.insert(key.clone(), extract_symbols(source, *lang));
-        }
-
-        // Collect dependent names before recursing to avoid overlapping
-        // mutable borrows on `symbol_cache`.
-        let pending: Vec<_> = refs
-            .iter()
-            .filter(|r| r.kind == RefKind::Reference)
-            .filter_map(|r| {
-                let symbols = symbol_cache
-                    .get(&key)
-                    .expect("symbol_cache entry inserted before recursion");
-                let containing = find_containing_in(symbols, r.line);
-                let name = containing.unwrap_or_else(|| format!("<{}>", display));
-                if visited.contains(&name) {
-                    return None;
-                }
-                visited.insert(name.clone());
-                Some((name, r.file.clone(), r.line, r.context.clone()))
-            })
-            .collect();
-
-        for (dependent_name, file, line, context) in pending {
             let dependents = if current_depth < max_depth {
                 find_dependents(
-                    &dependent_name,
-                    file_data,
+                    &r.symbol,
+                    reverse_deps,
                     max_depth,
                     current_depth + 1,
                     visited,
-                    symbol_cache,
-                    tree_cache,
                 )
             } else {
                 Vec::new()
             };
 
             results.push(ImpactNode {
-                symbol: dependent_name,
-                file,
-                line,
-                context,
+                symbol: r.symbol.clone(),
+                file: r.file.clone(),
+                line: r.line,
+                context: r.context.clone(),
                 dependents,
             });
         }

--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -113,6 +113,22 @@ pub fn find_refs_in_source_with_tree(
     refs
 }
 
+/// Find ALL identifier references in source (unfiltered by name).
+///
+/// Returns `(identifier_name, SymbolRef)` pairs for every identifier node
+/// in the AST. Used by impact analysis to build a reverse dependency map
+/// in a single pass instead of re-scanning per symbol.
+pub fn find_all_refs_in_source_with_tree(
+    source: &str,
+    tree: &tree_sitter_lib::Tree,
+    file_path: &str,
+) -> Vec<(String, SymbolRef)> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut refs = Vec::new();
+    collect_all_refs(tree.root_node(), source, &lines, file_path, &mut refs);
+    refs
+}
+
 /// Find refs across multiple files.
 pub fn find_refs_in_file(
     path: &Path,
@@ -171,6 +187,55 @@ fn collect_refs(
     if cursor.goto_first_child() {
         loop {
             collect_refs(cursor.node(), source, symbol_name, lines, file_path, refs);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn collect_all_refs(
+    node: tree_sitter_lib::Node,
+    source: &str,
+    lines: &[&str],
+    file_path: &str,
+    refs: &mut Vec<(String, SymbolRef)>,
+) {
+    if SKIP_KINDS.contains(&node.kind()) {
+        return;
+    }
+
+    if IDENTIFIER_KINDS.contains(&node.kind())
+        && let Ok(text) = node.utf8_text(source.as_bytes())
+    {
+        let line = node.start_position().row + 1;
+        let context = lines
+            .get(node.start_position().row)
+            .unwrap_or(&"")
+            .trim()
+            .to_string();
+
+        let kind = if is_definition_site(node) {
+            RefKind::Definition
+        } else {
+            RefKind::Reference
+        };
+
+        refs.push((
+            text.to_string(),
+            SymbolRef {
+                file: file_path.to_string(),
+                line,
+                context,
+                kind,
+            },
+        ));
+    }
+
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            collect_all_refs(cursor.node(), source, lines, file_path, refs);
             if !cursor.goto_next_sibling() {
                 break;
             }

--- a/tests/integration/misc_tests.rs
+++ b/tests/integration/misc_tests.rs
@@ -76,7 +76,6 @@ fn test_contributing_make_targets_table_covers_key_targets() {
         "make integration-test",
         "make clippy",
         "make update-readme",
-        "cargo check --all-targets",
     ] {
         assert!(
             contributing.contains(&format!("| `{target}`")),


### PR DESCRIPTION
Fix 3 real findings from the GitHub AI code quality scanner.

## ast_impact: O(files) per-depth scan replaced with upfront reverse dep map

`find_dependents` previously iterated over all files at each recursion depth to search for references to each newly discovered symbol. With `max_depth=3` and 100 files, this meant 100 tree walks per symbol per depth level.

Now `compute_impact` builds a global reverse dependency map in a single pass: scan all files once, extract all identifier references, resolve containing symbols, and group by referenced identifier. `find_dependents` then does HashMap lookups instead of file scans.

New helper: `find_all_refs_in_source_with_tree` in `refs.rs` collects all identifier references without filtering by name.

## CONTRIBUTING.md

- Added note that the make targets table is a quick-reference subset of AGENTS.md
- Removed `cargo check --all-targets` row (not a `make` target, inconsistent with all other entries)
- Updated integration test that asserted its presence