### PR TITLE
chore: upgrade axum-server 0.7->0.8 and expectrl 0.7->0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,12 +232,13 @@ dependencies = [
 
 [[package]]
 name = "axum-server"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
 dependencies = [
  "arc-swap",
  "bytes",
+ "either",
  "fs-err",
  "http",
  "http-body",
@@ -245,7 +246,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -599,6 +599,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b31a881d38439026e3d5dd938ab20328d36e23caca8fd5981c42e4b677f5842"
 
 [[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "expectrl"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede784925953fcab9a3351d5009bcb8d2b0c13e940924c88087e8e2ce0c4717a"
+checksum = "9e0df3044b2257277f573d1e40912ebd4d5891f7588640e3125cbbbb24ff7be3"
 dependencies = [
  "conpty",
  "nix 0.26.4",
@@ -1611,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "ptyprocess"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e05aef7befb11a210468a2d77d978dde2c6381a0381e33beb575e91f57fe8cf"
+checksum = "101be273c0b1680d7056afddbaa88f02b6e9f2dc161165c30bee9914b6025a79"
 dependencies = [
  "nix 0.26.4",
 ]
@@ -2007,15 +2013,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ clap_complete = { version = "4", optional = true }
 rmcp = { version = "1", features = ["server", "transport-io", "macros"], optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "io-std", "macros"], optional = true }
 axum = { version = "0.8", features = ["http1", "tokio"], default-features = false, optional = true }
-axum-server = { version = "0.7", features = ["tls-rustls"], default-features = false, optional = true }
+axum-server = { version = "0.8", features = ["tls-rustls"], default-features = false, optional = true }
 tokio-util = { version = "0.7", optional = true }
 schemars = "1"
 tree-sitter-lib = { package = "tree-sitter", version = "0.26", optional = true }
@@ -126,7 +126,7 @@ libc = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"
-expectrl = "0.7"
+expectrl = "0.9"
 predicates = "3"
 proptest = "1"
 rcgen = "0.14"

--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -10,7 +10,8 @@
 //! These tests MUST run serially (`--test-threads=1`) because concurrent
 //! PTY allocation can cause timeouts. The Makefile target handles this.
 
-use expectrl::{Eof, Session};
+use expectrl::session::OsSession;
+use expectrl::{Eof, Expect};
 use std::fs;
 use std::process::Command;
 use std::time::Duration;
@@ -27,8 +28,8 @@ fn patchloom_cmd(cwd: &std::path::Path) -> Command {
 }
 
 /// Spawn a PTY session with a generous timeout for CI reliability.
-fn spawn_pty(cmd: Command) -> Session {
-    let mut session = Session::spawn(cmd).expect("failed to spawn PTY session");
+fn spawn_pty(cmd: Command) -> OsSession {
+    let mut session = OsSession::spawn(cmd).expect("failed to spawn PTY session");
     session.set_expect_timeout(Some(Duration::from_secs(10)));
     session
 }


### PR DESCRIPTION
Upgrade two dependencies to their latest major versions:

**axum-server 0.7.3 -> 0.8.0**
- Replaces the unmaintained `rustls-pemfile` with `rustls-pki-types`, resolving RUSTSEC-2025-0134
- Server type is now generic over connections (no API change for our `bind_rustls` usage)
- Adds Unix domain socket support (not used by patchloom)

**expectrl 0.7.1 -> 0.9.0**
- `Session` is now generic (`Session<P, S>`); updated PTY tests to use `OsSession` type alias
- `Expect` trait must now be imported explicitly
- Primarily an `async-io` dependency bump internally

All 1,816 tests pass (1,056 unit + 750 integration + 10 PTY). Zero `cargo audit` advisories after upgrade.