### PR TITLE
test: replace bare assert!(x.is_ok()) with .unwrap() in 19 test assertions

### DIFF
--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -2014,7 +2014,7 @@ mod tests {
 
     #[test]
     fn validate_content_size_accepts_small() {
-        assert!(validate_content_size("field", "hello").is_ok());
+        validate_content_size("field", "hello").unwrap();
     }
 
     #[test]
@@ -2028,7 +2028,7 @@ mod tests {
 
     #[test]
     fn validate_param_size_accepts_small() {
-        assert!(validate_param_size("selector", "a.b.c").is_ok());
+        validate_param_size("selector", "a.b.c").unwrap();
     }
 
     #[test]
@@ -2041,7 +2041,7 @@ mod tests {
 
     #[test]
     fn validate_batch_size_accepts_small() {
-        assert!(validate_batch_size("files", 5).is_ok());
+        validate_batch_size("files", 5).unwrap();
     }
 
     #[test]
@@ -2054,13 +2054,13 @@ mod tests {
     #[test]
     fn validate_json_depth_accepts_shallow() {
         let val = serde_json::json!({"a": {"b": "c"}});
-        assert!(validate_json_depth("value", &val).is_ok());
+        validate_json_depth("value", &val).unwrap();
     }
 
     #[test]
     fn validate_json_depth_accepts_scalar() {
         let val = serde_json::json!("hello");
-        assert!(validate_json_depth("value", &val).is_ok());
+        validate_json_depth("value", &val).unwrap();
     }
 
     #[test]

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -449,7 +449,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         fs::write(dir.path().join("file.txt"), "ok").unwrap();
         let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        assert!(guard.check_path("file.txt").is_ok());
+        guard.check_path("file.txt").unwrap();
     }
 
     #[test]
@@ -459,7 +459,7 @@ mod tests {
         fs::write(dir.path().join("Cargo.toml"), "ok").unwrap();
         let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
         // src/../Cargo.toml stays within workspace
-        assert!(guard.check_path("src/../Cargo.toml").is_ok());
+        guard.check_path("src/../Cargo.toml").unwrap();
     }
 
     #[test]
@@ -480,7 +480,7 @@ mod tests {
         )
         .unwrap();
         let abs = dir.path().join("inside.txt");
-        assert!(guard.check_path(abs.to_str().unwrap()).is_ok());
+        guard.check_path(abs.to_str().unwrap()).unwrap();
     }
 
     /// Return an absolute path string that is guaranteed outside any temp dir.
@@ -542,7 +542,7 @@ mod tests {
         let dir = tempfile::TempDir::new().unwrap();
         let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
         // Empty string resolves to cwd itself, which is contained.
-        assert!(guard.check_path("").is_ok());
+        guard.check_path("").unwrap();
     }
 
     #[test]
@@ -565,7 +565,7 @@ mod tests {
         fs::create_dir_all(dir.path().join("foo")).unwrap();
         fs::write(dir.path().join("foo/bar.json"), "{}").unwrap();
         let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        assert!(guard.check_path("./foo/bar.json").is_ok());
+        guard.check_path("./foo/bar.json").unwrap();
     }
 
     #[cfg(unix)]
@@ -681,7 +681,7 @@ mod tests {
         // create it
         std::fs::write(&tmp_file, "ok").unwrap();
         let res = guard.check_path(tmp_file.to_str().unwrap());
-        assert!(res.is_ok());
+        res.unwrap();
         // clean
         let _ = std::fs::remove_file(&tmp_file);
     }
@@ -708,7 +708,7 @@ mod tests {
         // should allow temp
         let temp = std::env::temp_dir().join("patchloom_builder_test.txt");
         std::fs::write(&temp, "ok").unwrap();
-        assert!(guard.check_path(temp.to_str().unwrap()).is_ok());
+        guard.check_path(temp.to_str().unwrap()).unwrap();
         let _ = std::fs::remove_file(&temp);
     }
 
@@ -768,7 +768,7 @@ mod tests {
         .unwrap();
         let temp = std::env::temp_dir().join("patchloom_awtd_std.txt");
         std::fs::write(&temp, "ok").unwrap();
-        assert!(guard.check_path(temp.to_str().unwrap()).is_ok());
+        guard.check_path(temp.to_str().unwrap()).unwrap();
         let _ = std::fs::remove_file(&temp);
     }
 
@@ -786,7 +786,7 @@ mod tests {
         let tmp_path = format!("/tmp/patchloom_781_awtd_{}.txt", std::process::id());
         let _ = std::fs::remove_file(&tmp_path);
         std::fs::write(&tmp_path, "data").unwrap();
-        assert!(guard.check_path(&tmp_path).is_ok());
+        guard.check_path(&tmp_path).unwrap();
         let _ = std::fs::remove_file(&tmp_path);
     }
 

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -323,17 +323,17 @@ mod tests {
 
         #[test]
         fn validate_mode_valid_to_only() {
-            assert!(validate_replace_mode(true, false, false).is_ok());
+            validate_replace_mode(true, false, false).unwrap();
         }
 
         #[test]
         fn validate_mode_valid_insert_before_only() {
-            assert!(validate_replace_mode(false, true, false).is_ok());
+            validate_replace_mode(false, true, false).unwrap();
         }
 
         #[test]
         fn validate_mode_valid_insert_after_only() {
-            assert!(validate_replace_mode(false, false, true).is_ok());
+            validate_replace_mode(false, false, true).unwrap();
         }
 
         #[test]

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -193,13 +193,13 @@ mod tests {
     #[test]
     fn replace_range_with_whole_line_accepted() {
         let op = replace_op(true, false, Some("10:50"));
-        assert!(validate_operation(&op).is_ok());
+        validate_operation(&op).unwrap();
     }
 
     #[test]
     fn replace_whole_line_without_multiline_accepted() {
         let op = replace_op(true, false, None);
-        assert!(validate_operation(&op).is_ok());
+        validate_operation(&op).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Replace `assert!(x.is_ok())` with `x.unwrap()` across 4 files (19 instances total):

- `src/containment.rs` (9 instances)
- `src/cmd/mcp/mod.rs` (5 instances)
- `src/ops/replace.rs` (3 instances)
- `src/tx/validate.rs` (2 instances)

The bare `assert!` pattern discards the error message on failure, producing `assertion failed: result.is_ok()` with zero context. Using `.unwrap()` shows the actual `Err(...)` value, making test failures immediately diagnosable.

This is the same class of issue fixed in PR #952 for `src/fallback.rs` (3 instances of `assert!(result.is_ok()); result.unwrap()` collapsed to `result.expect("msg")`). These 19 remaining instances were noticed during that fix but left untracked.

Closes #954