### PR TITLE
fix: multi-perspective improvement - tests, docs, and error context

### DIFF
--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -85,8 +85,8 @@ pub fn rename_in_file(
     lang_hint: Option<Language>,
 ) -> anyhow::Result<Option<RenameResult>> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
-    let source = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))?;
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     Ok(rename_in_source(&source, old_name, new_name, lang))
 }
 

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -3,6 +3,8 @@
 
 use std::path::Path;
 
+use anyhow::Context;
+
 use super::{Language, parse_source};
 
 /// Node kinds that represent identifier tokens (rename targets).
@@ -83,7 +85,8 @@ pub fn rename_in_file(
     lang_hint: Option<Language>,
 ) -> anyhow::Result<Option<RenameResult>> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
-    let source = std::fs::read_to_string(path)?;
+    let source = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
     Ok(rename_in_source(&source, old_name, new_name, lang))
 }
 

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -2,6 +2,8 @@
 
 use std::path::Path;
 
+use anyhow::Context;
+
 use super::Language;
 use super::symbols::{extract_symbols, find_symbol};
 
@@ -102,7 +104,8 @@ pub fn replace_in_symbol_file(
     if !lang.has_grammar() {
         return Ok(None);
     }
-    let source = std::fs::read_to_string(path)?;
+    let source = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
     replace_in_symbol(&source, symbol_name, from, to, regex, lang)
 }
 

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -104,8 +104,8 @@ pub fn replace_in_symbol_file(
     if !lang.has_grammar() {
         return Ok(None);
     }
-    let source = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))?;
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     replace_in_symbol(&source, symbol_name, from, to, regex, lang)
 }
 

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -5,6 +5,7 @@
 
 use std::path::Path;
 
+use anyhow::Context;
 use serde::Serialize;
 
 use tree_sitter_lib::StreamingIterator;
@@ -104,7 +105,8 @@ pub fn search_file(
     if !lang.has_grammar() {
         return Ok(Vec::new());
     }
-    let source = std::fs::read_to_string(path)?;
+    let source = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
     search_query(&source, query_str, lang, max_results)
 }
 

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -105,8 +105,8 @@ pub fn search_file(
     if !lang.has_grammar() {
         return Ok(Vec::new());
     }
-    let source = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))?;
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     search_query(&source, query_str, lang, max_results)
 }
 

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -52,8 +52,8 @@ pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result
     if !lang.has_grammar() {
         anyhow::bail!("no grammar available for {lang}");
     }
-    let source = std::fs::read_to_string(path)
-        .with_context(|| format!("reading {}", path.display()))?;
+    let source =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
     validate_source(&source, lang)
         .ok_or_else(|| anyhow::anyhow!("failed to parse {}", path.display()))
 }

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -2,6 +2,7 @@
 
 use std::path::Path;
 
+use anyhow::Context;
 use serde::Serialize;
 
 use super::{Language, parse_source};
@@ -51,7 +52,8 @@ pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result
     if !lang.has_grammar() {
         anyhow::bail!("no grammar available for {lang}");
     }
-    let source = std::fs::read_to_string(path)?;
+    let source = std::fs::read_to_string(path)
+        .with_context(|| format!("reading {}", path.display()))?;
     validate_source(&source, lang)
         .ok_or_else(|| anyhow::anyhow!("failed to parse {}", path.display()))
 }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -238,7 +238,8 @@ pub fn list_sessions(project_root: &Path) -> anyhow::Result<Vec<Manifest>> {
     for entry in entries {
         let manifest_path = entry.path().join("manifest.json");
         if manifest_path.exists() {
-            let content = std::fs::read_to_string(&manifest_path)?;
+            let content = std::fs::read_to_string(&manifest_path)
+                .with_context(|| format!("reading {}", manifest_path.display()))?;
             if let Ok(manifest) = serde_json::from_str::<Manifest>(&content) {
                 sessions.push(manifest);
             }

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -3,7 +3,7 @@ use crate::cli::global::GlobalFlags;
 use crate::cmd::write_dispatch::{WriteMessages, WritePhase, execute_write};
 use crate::diff::{DiffResult, format_diff_result_colored, unified_diff};
 use crate::write::{atomic_write, policy_from_flags};
-use anyhow::bail;
+use anyhow::{Context, bail};
 use clap::Args;
 use serde::Serialize;
 use std::fs;
@@ -61,7 +61,8 @@ pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         bail!("target is not a file: {}", args.file);
     }
 
-    let existing = fs::read_to_string(&path)?;
+    let existing = fs::read_to_string(&path)
+        .with_context(|| format!("reading {}", args.file))?;
     let combined = crate::ops::file::append_content(&existing, &append_content);
 
     let diff_fn = |color: bool| {

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -61,8 +61,7 @@ pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         bail!("target is not a file: {}", args.file);
     }
 
-    let existing = fs::read_to_string(&path)
-        .with_context(|| format!("reading {}", args.file))?;
+    let existing = fs::read_to_string(&path).with_context(|| format!("reading {}", args.file))?;
     let combined = crate::ops::file::append_content(&existing, &append_content);
 
     let diff_fn = |color: bool| {

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1,4 +1,4 @@
-//! AST-aware subcommands: `patchloom ast list|read|rename|validate|search|refs|deps`.
+//! AST-aware subcommands: `patchloom ast list|read|rename|validate|search|refs|deps|map|replace|impact|diff`.
 
 use crate::ast::Language;
 use crate::ast::symbols::{self, SymbolDef, SymbolKind};

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1,11 +1,11 @@
 //! AST-aware subcommands: `patchloom ast list|read|rename|validate|search|refs|deps|map|replace|impact|diff`.
 
-use anyhow::Context;
 use crate::ast::Language;
 use crate::ast::symbols::{self, SymbolDef, SymbolKind};
 use crate::backup::BackupSession;
 use crate::cli::global::GlobalFlags;
 use crate::exit;
+use anyhow::Context;
 use clap::{Args, Subcommand};
 use std::path::Path;
 
@@ -198,8 +198,8 @@ fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.path,
         args.symbol
     );
-    let source = std::fs::read_to_string(&target)
-        .with_context(|| format!("reading {}", args.path))?;
+    let source =
+        std::fs::read_to_string(&target).with_context(|| format!("reading {}", args.path))?;
     let all_symbols = symbols::extract_symbols(&source, lang);
     let sym = symbols::find_symbol(&all_symbols, &args.symbol)
         .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in {}", args.symbol, args.path))?;
@@ -360,8 +360,8 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     for path in &paths {
         let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
-        let source = std::fs::read_to_string(path)
-            .with_context(|| format!("reading {}", path.display()))?;
+        let source =
+            std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
         let result = if lang.has_grammar() {
             crate::ast::rename::rename_in_source(&source, &args.old_name, &args.new_name, lang)
         } else {
@@ -889,8 +889,8 @@ fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.regex
     );
 
-    let source = std::fs::read_to_string(&target)
-        .with_context(|| format!("reading {}", args.path))?;
+    let source =
+        std::fs::read_to_string(&target).with_context(|| format!("reading {}", args.path))?;
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
     crate::verbose!("ast replace: lang={lang}, file={}", args.path);
 
@@ -1066,8 +1066,7 @@ fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let new_source = if let Some(ref to_ref) = args.to {
         get_git_file_content(&cwd, &args.path, to_ref)?
     } else {
-        std::fs::read_to_string(&target)
-            .with_context(|| format!("reading {}", args.path))?
+        std::fs::read_to_string(&target).with_context(|| format!("reading {}", args.path))?
     };
 
     let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1,5 +1,6 @@
 //! AST-aware subcommands: `patchloom ast list|read|rename|validate|search|refs|deps|map|replace|impact|diff`.
 
+use anyhow::Context;
 use crate::ast::Language;
 use crate::ast::symbols::{self, SymbolDef, SymbolKind};
 use crate::backup::BackupSession;
@@ -197,7 +198,8 @@ fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.path,
         args.symbol
     );
-    let source = std::fs::read_to_string(&target)?;
+    let source = std::fs::read_to_string(&target)
+        .with_context(|| format!("reading {}", args.path))?;
     let all_symbols = symbols::extract_symbols(&source, lang);
     let sym = symbols::find_symbol(&all_symbols, &args.symbol)
         .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in {}", args.symbol, args.path))?;
@@ -358,7 +360,8 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     for path in &paths {
         let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
-        let source = std::fs::read_to_string(path)?;
+        let source = std::fs::read_to_string(path)
+            .with_context(|| format!("reading {}", path.display()))?;
         let result = if lang.has_grammar() {
             crate::ast::rename::rename_in_source(&source, &args.old_name, &args.new_name, lang)
         } else {
@@ -886,7 +889,8 @@ fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.regex
     );
 
-    let source = std::fs::read_to_string(&target)?;
+    let source = std::fs::read_to_string(&target)
+        .with_context(|| format!("reading {}", args.path))?;
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(&target));
     crate::verbose!("ast replace: lang={lang}, file={}", args.path);
 
@@ -1062,7 +1066,8 @@ fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let new_source = if let Some(ref to_ref) = args.to {
         get_git_file_content(&cwd, &args.path, to_ref)?
     } else {
-        std::fs::read_to_string(&target)?
+        std::fs::read_to_string(&target)
+            .with_context(|| format!("reading {}", args.path))?
     };
 
     let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -70,7 +70,7 @@ pub enum Command {
     Md(md::MdArgs),
 
     // -- AST Operations (display_order 40-49) --
-    /// AST-aware operations: list, read, rename, validate.
+    /// AST-aware operations: list, read, rename, validate, search, refs, deps, map, replace, impact, diff.
     #[cfg(feature = "ast")]
     #[command(display_order = 40)]
     Ast(ast::AstArgs),

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -34,8 +34,6 @@ pub fn navigate_mut<'a>(
     Ok(current)
 }
 
-
-
 /// Returns the parent path and the final segment (for use by set/delete/move).
 fn split_last(segments: &[selector::Segment]) -> (&[selector::Segment], &selector::Segment) {
     let (parent, last) = segments.split_at(segments.len() - 1);

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -34,6 +34,8 @@ pub fn navigate_mut<'a>(
     Ok(current)
 }
 
+
+
 /// Returns the parent path and the final segment (for use by set/delete/move).
 fn split_last(segments: &[selector::Segment]) -> (&[selector::Segment], &selector::Segment) {
     let (parent, last) = segments.split_at(segments.len() - 1);
@@ -280,5 +282,146 @@ pub fn update_matching(
             }
             count
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn segs(path: &str) -> Vec<selector::Segment> {
+        selector::parse(path).unwrap()
+    }
+
+    #[test]
+    fn navigate_mut_key() {
+        let mut root = json!({"a": {"b": 1}});
+        let val = navigate_mut(&mut root, &segs("a.b"), false).unwrap();
+        assert_eq!(val, &json!(1));
+    }
+
+    #[test]
+    fn navigate_mut_index() {
+        let mut root = json!({"items": [10, 20, 30]});
+        let val = navigate_mut(&mut root, &segs("items[1]"), false).unwrap();
+        assert_eq!(val, &json!(20));
+    }
+
+    #[test]
+    fn navigate_mut_missing_key_errors() {
+        let mut root = json!({"a": 1});
+        let result = navigate_mut(&mut root, &segs("b"), false);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("key not found"));
+    }
+
+    #[test]
+    fn navigate_mut_create_intermediate() {
+        let mut root = json!({"a": {}});
+        let val = navigate_mut(&mut root, &segs("a.b"), true).unwrap();
+        assert!(val.is_object(), "should create intermediate object");
+    }
+
+    #[test]
+    fn set_at_path_creates_key() {
+        let mut root = json!({"x": {}});
+        set_at_path(&mut root, &segs("x.y"), json!("hello")).unwrap();
+        assert_eq!(root["x"]["y"], json!("hello"));
+    }
+
+    #[test]
+    fn set_at_path_empty_selector_errors() {
+        let mut root = json!({});
+        let result = set_at_path(&mut root, &[], json!(1));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn set_at_path_index_replaces_element() {
+        let mut root = json!({"arr": [1, 2, 3]});
+        set_at_path(&mut root, &segs("arr[1]"), json!(99)).unwrap();
+        assert_eq!(root["arr"][1], json!(99));
+    }
+
+    #[test]
+    fn delete_at_selector_removes_key() {
+        let mut root = json!({"a": 1, "b": 2});
+        let removed = delete_at_selector(&mut root, &segs("b")).unwrap();
+        assert!(removed);
+        assert!(root.get("b").is_none());
+    }
+
+    #[test]
+    fn delete_at_selector_missing_returns_false() {
+        let mut root = json!({"a": 1});
+        let removed = delete_at_selector(&mut root, &segs("z")).unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    fn delete_at_selector_empty_segments() {
+        let mut root = json!({"a": 1});
+        let removed = delete_at_selector(&mut root, &[]).unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    fn delete_where_removes_matching_items() {
+        let mut root = json!({"items": [{"name": "a"}, {"name": "b"}, {"name": "a"}]});
+        let count = delete_where(&mut root, &segs("items"), "name=a").unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(root["items"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn delete_where_invalid_predicate() {
+        let mut root = json!({"items": []});
+        let result = delete_where(&mut root, &segs("items"), "noequalssign");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn delete_where_empty_key_errors() {
+        let mut root = json!({"items": []});
+        let result = delete_where(&mut root, &segs("items"), "=val");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("key is empty"));
+    }
+
+    #[test]
+    fn delete_where_double_equals_errors() {
+        let mut root = json!({"items": []});
+        let result = delete_where(&mut root, &segs("items"), "k==v");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("=="));
+    }
+
+    #[test]
+    fn move_at_path_moves_value() {
+        let mut root = json!({"src": 42, "dst": {}});
+        move_at_path(&mut root, &segs("src"), &segs("dst.moved")).unwrap();
+        assert!(root.get("src").is_none());
+        assert_eq!(root["dst"]["moved"], json!(42));
+    }
+
+    #[test]
+    fn deep_merge_overlays_objects() {
+        let mut base = json!({"a": 1, "b": {"c": 2}});
+        let other = json!({"b": {"d": 3}, "e": 4});
+        deep_merge(&mut base, &other);
+        assert_eq!(base["a"], json!(1));
+        assert_eq!(base["b"]["c"], json!(2));
+        assert_eq!(base["b"]["d"], json!(3));
+        assert_eq!(base["e"], json!(4));
+    }
+
+    #[test]
+    fn update_matching_wildcard() {
+        let mut root = json!({"items": [{"v": 1}, {"v": 2}]});
+        let count = update_matching(&mut root, &segs("items[*].v"), &json!(0));
+        assert_eq!(count, 2);
+        assert_eq!(root["items"][0]["v"], json!(0));
+        assert_eq!(root["items"][1]["v"], json!(0));
     }
 }

--- a/src/ops/doc/preserve.rs
+++ b/src/ops/doc/preserve.rs
@@ -20,3 +20,51 @@ pub(crate) fn hoist_comments(original: &str, body: &str) -> String {
         body.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hoist_comments_prepends_comment_block() {
+        let original = "# top comment\nkey = \"val\"\n";
+        let body = "key = \"new\"\n";
+        let result = hoist_comments(original, body);
+        assert!(
+            result.starts_with("# top comment"),
+            "should prepend comment: {result}"
+        );
+        assert!(result.contains("key = \"new\""));
+    }
+
+    #[test]
+    fn hoist_comments_returns_body_when_no_comments() {
+        let original = "key = \"val\"\nother = 1\n";
+        let body = "key = \"new\"\n";
+        assert_eq!(hoist_comments(original, body), body);
+    }
+
+    #[test]
+    fn hoist_comments_preserves_blank_lines_between_comments() {
+        let original = "# group A\n\n# group B\nkey = 1\n";
+        let body = "key = 2\n";
+        let result = hoist_comments(original, body);
+        assert!(
+            result.contains("# group A\n\n# group B"),
+            "blank line between comment groups should be preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn hoist_comments_adds_separator_when_needed() {
+        let original = "# comment\nkey = 1\n";
+        let body = "key = 2";
+        let result = hoist_comments(original, body);
+        // The comment does not end with \n, and body does not start with \n,
+        // so a separator newline should be inserted.
+        assert!(
+            result.contains("# comment\nkey = 2"),
+            "separator newline between comment and body: {result}"
+        );
+    }
+}

--- a/src/ops/doc/toml_preserve.rs
+++ b/src/ops/doc/toml_preserve.rs
@@ -146,3 +146,100 @@ fn json_to_toml_item(val: &serde_json::Value) -> toml_edit::Item {
         _ => toml_edit::Item::Value(json_to_toml_value(val)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_toml(s: &str) -> toml_edit::DocumentMut {
+        s.parse::<toml_edit::DocumentMut>().unwrap()
+    }
+
+    fn json(s: &str) -> serde_json::Value {
+        serde_json::from_str(s).unwrap()
+    }
+
+    #[test]
+    fn apply_value_diff_updates_scalar() {
+        let mut doc = parse_toml("key = \"old\"\n");
+        let old = json(r#"{"key": "old"}"#);
+        let new = json(r#"{"key": "new"}"#);
+        apply_value_diff(doc.as_item_mut(), &old, &new);
+        let result = doc.to_string();
+        assert!(
+            result.contains("\"new\""),
+            "scalar should be updated: {result}"
+        );
+    }
+
+    #[test]
+    fn apply_value_diff_removes_deleted_key() {
+        let mut doc = parse_toml("a = 1\nb = 2\n");
+        let old = json(r#"{"a": 1, "b": 2}"#);
+        let new = json(r#"{"a": 1}"#);
+        apply_value_diff(doc.as_item_mut(), &old, &new);
+        let result = doc.to_string();
+        assert!(!result.contains("b ="), "removed key should be gone: {result}");
+        assert!(result.contains("a = 1"));
+    }
+
+    #[test]
+    fn apply_value_diff_adds_new_key() {
+        let mut doc = parse_toml("a = 1\n");
+        let old = json(r#"{"a": 1}"#);
+        let new = json(r#"{"a": 1, "c": 3}"#);
+        apply_value_diff(doc.as_item_mut(), &old, &new);
+        let result = doc.to_string();
+        assert!(result.contains("c"), "new key should appear: {result}");
+    }
+
+    #[test]
+    fn apply_value_diff_noop_on_equal() {
+        let original = "key = \"same\"\n";
+        let mut doc = parse_toml(original);
+        let val = json(r#"{"key": "same"}"#);
+        apply_value_diff(doc.as_item_mut(), &val, &val);
+        assert_eq!(doc.to_string(), original);
+    }
+
+    #[test]
+    fn apply_value_diff_same_length_array() {
+        let mut doc = parse_toml("arr = [1, 2, 3]\n");
+        let old = json(r#"{"arr": [1, 2, 3]}"#);
+        let new = json(r#"{"arr": [1, 99, 3]}"#);
+        apply_value_diff(doc.as_item_mut(), &old, &new);
+        let result = doc.to_string();
+        assert!(result.contains("99"), "array element should be updated: {result}");
+    }
+
+    #[test]
+    fn apply_value_diff_different_length_array_replaces() {
+        let mut doc = parse_toml("arr = [1, 2]\n");
+        let old = json(r#"{"arr": [1, 2]}"#);
+        let new = json(r#"{"arr": [1, 2, 3]}"#);
+        apply_value_diff(doc.as_item_mut(), &old, &new);
+        let result = doc.to_string();
+        assert!(result.contains("3"), "longer array should be applied: {result}");
+    }
+
+    #[test]
+    fn json_to_toml_value_handles_null() {
+        let val = json_to_toml_value(&serde_json::Value::Null);
+        assert_eq!(val.as_str(), Some(""), "null should map to empty string");
+    }
+
+    #[test]
+    fn json_to_toml_item_object_becomes_table() {
+        let item = json_to_toml_item(&json(r#"{"k": "v"}"#));
+        assert!(item.is_table(), "object should become a table");
+    }
+
+    #[test]
+    fn json_to_toml_item_array_of_objects_becomes_aot() {
+        let item = json_to_toml_item(&json(r#"[{"a": 1}, {"b": 2}]"#));
+        assert!(
+            item.is_array_of_tables(),
+            "array of objects should become array-of-tables"
+        );
+    }
+}

--- a/src/ops/doc/toml_preserve.rs
+++ b/src/ops/doc/toml_preserve.rs
@@ -179,7 +179,10 @@ mod tests {
         let new = json(r#"{"a": 1}"#);
         apply_value_diff(doc.as_item_mut(), &old, &new);
         let result = doc.to_string();
-        assert!(!result.contains("b ="), "removed key should be gone: {result}");
+        assert!(
+            !result.contains("b ="),
+            "removed key should be gone: {result}"
+        );
         assert!(result.contains("a = 1"));
     }
 
@@ -209,7 +212,10 @@ mod tests {
         let new = json(r#"{"arr": [1, 99, 3]}"#);
         apply_value_diff(doc.as_item_mut(), &old, &new);
         let result = doc.to_string();
-        assert!(result.contains("99"), "array element should be updated: {result}");
+        assert!(
+            result.contains("99"),
+            "array element should be updated: {result}"
+        );
     }
 
     #[test]
@@ -219,7 +225,10 @@ mod tests {
         let new = json(r#"{"arr": [1, 2, 3]}"#);
         apply_value_diff(doc.as_item_mut(), &old, &new);
         let result = doc.to_string();
-        assert!(result.contains("3"), "longer array should be applied: {result}");
+        assert!(
+            result.contains("3"),
+            "longer array should be applied: {result}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Multi-perspective improvement rotation (14 perspectives) producing 3 concrete fixes:

### Changes

1. **30 unit tests** for 3 previously untested modules (`ops/doc/navigate`, `ops/doc/preserve`, `ops/doc/toml_preserve`)
2. **Updated ast subcommand description** to list all 11 subcommands (was only listing 4)
3. **Added .with_context() to 9 bare read_to_string() calls** in ast and file operation modules for better error diagnostics
4. **Applied cargo fmt** to align new code with project formatting

### Perspectives results

| # | Perspective | Result |
|---|------------|--------|
| 1 | QA Engineer | Fixed: 30 tests for 3 untested modules |
| 2 | Developer | No-op: zero convention violations |
| 3 | End User | Fixed: ast subcommand description |
| 4 | Maintainer | No-op: all deps current |
| 5 | Ops/SRE | No-op: CI well-configured |
| 6 | Security | No-op: PathGuard enforced |
| 7 | Product Manager | No-op: features complete |
| 8 | Spec/Contract | No-op: exit codes match docs |
| 9 | Performance | No-op: efficient patterns |
| 10 | Backward Compat | No-op: proper alias/deprecation |
| 11 | Adversarial | No-op: robust error handling |
| 12 | Architecture | No-op: clean layering |
| 13 | New Contributor | No-op: docs match Makefile |
| 14 | Observability | Fixed: 9 bare read_to_string calls got .with_context() |

### Verification

`make check` passes locally (1847 total tests passing).