### PR TITLE
fix: resolve tech-debt issues #985-#989

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -198,7 +198,7 @@ pub struct WritePolicyOptions {
 /// Backward-compatible alias for [`EolMode`](crate::write::EolMode).
 #[deprecated(
     since = "0.6.0",
-    note = "use crate::write::EolMode instead (Lf, Crlf, Keep)"
+    note = "use crate::write::EolMode instead (Lf, Crlf, Cr, Keep)"
 )]
 pub type EolNormalization = EolMode;
 
@@ -220,8 +220,6 @@ pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
         normalize_eol: opts.normalize_eol.unwrap_or(EolMode::Keep),
         trim_trailing_whitespace: opts.trim_trailing_whitespace,
         collapse_blanks: opts.collapse_blanks,
-        indent_style: None,
-        indent_size: None,
     }
 }
 

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -239,6 +239,7 @@ fn eol_mode_to_str(mode: crate::cli::global::EolMode) -> &'static str {
     match mode {
         crate::cli::global::EolMode::Lf => "lf",
         crate::cli::global::EolMode::Crlf => "crlf",
+        crate::cli::global::EolMode::Cr => "cr",
         crate::cli::global::EolMode::Keep => "keep",
     }
 }
@@ -681,6 +682,7 @@ mod tests {
         use crate::cli::global::EolMode;
         assert_eq!(eol_mode_to_str(EolMode::Lf), "lf");
         assert_eq!(eol_mode_to_str(EolMode::Crlf), "crlf");
+        assert_eq!(eol_mode_to_str(EolMode::Cr), "cr");
         assert_eq!(eol_mode_to_str(EolMode::Keep), "keep");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,7 @@ pub fn apply_config(global: &mut crate::cli::global::GlobalFlags, config: &Proje
         match config.write_policy.normalize_eol.as_deref() {
             Some("lf") => global.normalize_eol = Some(crate::cli::global::EolMode::Lf),
             Some("crlf") => global.normalize_eol = Some(crate::cli::global::EolMode::Crlf),
+            Some("cr") => global.normalize_eol = Some(crate::cli::global::EolMode::Cr),
             Some(invalid) => {
                 eprintln!("{}", invalid_normalize_eol_warning(invalid));
             }

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -45,28 +45,83 @@ pub fn non_fenced_lines(content: &str) -> impl Iterator<Item = (usize, &str)> {
     })
 }
 
+/// Check if a line is a setext underline (`===` for h1, `---` for h2).
+/// Returns `Some(level)` if the line is a valid setext underline.
+/// CommonMark: the underline must be at least one `=` or `-` character,
+/// optionally preceded by up to 3 spaces and followed by trailing spaces.
+fn setext_underline_level(line: &str) -> Option<usize> {
+    let stripped = line.trim_start_matches(' ');
+    let indent = line.len() - stripped.len();
+    if indent > 3 {
+        return None;
+    }
+    let trimmed = stripped.trim_end();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.bytes().all(|b| b == b'=') {
+        Some(1)
+    } else if trimmed.bytes().all(|b| b == b'-') {
+        Some(2)
+    } else {
+        None
+    }
+}
+
 pub fn parse_headings(content: &str) -> Vec<HeadingInfo> {
     let mut headings = Vec::new();
     let total_lines = content.lines().count();
 
-    for (idx, line) in non_fenced_lines(content) {
-        if !line.starts_with('#') {
+    // Collect non-fenced lines into a vec so we can look ahead.
+    let nf_lines: Vec<(usize, &str)> = non_fenced_lines(content).collect();
+
+    for (pos, &(idx, line)) in nf_lines.iter().enumerate() {
+        // ATX heading: starts with #
+        if line.starts_with('#') {
+            let hashes = line.bytes().take_while(|&b| b == b'#').count();
+            if hashes > 6 || hashes >= line.len() {
+                continue;
+            }
+            if line.as_bytes()[hashes] != b' ' {
+                continue;
+            }
+            headings.push(HeadingInfo {
+                level: hashes,
+                text: line[hashes + 1..].to_string(),
+                line_start: idx,
+                line_end: 0,
+            });
             continue;
         }
-        let hashes = line.bytes().take_while(|&b| b == b'#').count();
-        if hashes > 6 || hashes >= line.len() {
-            continue;
+
+        // Setext heading: current line is the underline, previous
+        // non-fenced line is the heading text.
+        if let Some(level) = setext_underline_level(line)
+            && pos > 0
+        {
+            let (prev_idx, prev_line) = nf_lines[pos - 1];
+            // The text line must be non-empty and on the line
+            // immediately before the underline.
+            let prev_trimmed = prev_line.trim();
+            if !prev_trimmed.is_empty() && idx == prev_idx + 1 {
+                // Avoid treating the underline's text line as a
+                // heading if it was already parsed as an ATX heading.
+                let already_atx = headings.last().is_some_and(|h| h.line_start == prev_idx);
+                if !already_atx {
+                    headings.push(HeadingInfo {
+                        level,
+                        text: prev_trimmed.to_string(),
+                        line_start: prev_idx,
+                        line_end: 0,
+                    });
+                }
+            }
         }
-        if line.as_bytes()[hashes] != b' ' {
-            continue;
-        }
-        headings.push(HeadingInfo {
-            level: hashes,
-            text: line[hashes + 1..].to_string(),
-            line_start: idx,
-            line_end: 0,
-        });
     }
+
+    // Sort headings by line_start in case setext headings were
+    // interleaved with ATX headings (unlikely but safe).
+    headings.sort_by_key(|h| h.line_start);
 
     for i in 0..headings.len() {
         let lvl = headings[i].level;
@@ -285,19 +340,33 @@ pub fn insert_before_heading_in(content: &str, heading: &str, insertion: &str) -
     None
 }
 
+/// Strip a bullet prefix (`- `, `* `, `+ `) from a trimmed line,
+/// returning the text content for style-independent comparison.
+fn strip_bullet_prefix(s: &str) -> &str {
+    if s.starts_with("- ") || s.starts_with("* ") || s.starts_with("+ ") {
+        &s[2..]
+    } else {
+        s
+    }
+}
+
 pub fn upsert_bullet_in(content: &str, heading: &str, bullet: &str) -> Option<String> {
     let (body_start, body_end) = find_section(content, heading)?;
     let body = &content[body_start..body_end];
 
     let trimmed = bullet.trim();
-    let normalized = if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
-        trimmed.to_string()
-    } else {
-        format!("- {trimmed}")
-    };
+    let normalized =
+        if trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with("+ ") {
+            trimmed.to_string()
+        } else {
+            format!("- {trimmed}")
+        };
 
+    // Dedup across bullet styles: compare text content without prefix.
+    let new_text = strip_bullet_prefix(&normalized);
     for line in body.lines() {
-        if line.trim() == normalized {
+        let existing_text = strip_bullet_prefix(line.trim());
+        if existing_text == new_text {
             return Some(content.to_string());
         }
     }
@@ -628,6 +697,86 @@ mod tests {
         }
 
         #[test]
+        fn parse_headings_setext_h1() {
+            let content = "Title\n=====\n\nSome content\n";
+            let headings = parse_headings(content);
+            assert_eq!(headings.len(), 1);
+            assert_eq!(headings[0].level, 1);
+            assert_eq!(headings[0].text, "Title");
+            assert_eq!(headings[0].line_start, 0);
+        }
+
+        #[test]
+        fn parse_headings_setext_h2() {
+            let content = "Subtitle\n--------\n\nMore content\n";
+            let headings = parse_headings(content);
+            assert_eq!(headings.len(), 1);
+            assert_eq!(headings[0].level, 2);
+            assert_eq!(headings[0].text, "Subtitle");
+            assert_eq!(headings[0].line_start, 0);
+        }
+
+        #[test]
+        fn parse_headings_setext_mixed_with_atx() {
+            let content = "Title\n=====\n\nSome content\n\n## ATX Heading\n\nMore text\n\nSubtitle\n--------\n\nEnd\n";
+            let headings = parse_headings(content);
+            assert_eq!(headings.len(), 3);
+            assert_eq!(headings[0].text, "Title");
+            assert_eq!(headings[0].level, 1);
+            assert_eq!(headings[1].text, "ATX Heading");
+            assert_eq!(headings[1].level, 2);
+            assert_eq!(headings[2].text, "Subtitle");
+            assert_eq!(headings[2].level, 2);
+        }
+
+        #[test]
+        fn parse_headings_setext_inside_fenced_code_block_ignored() {
+            let content = "# Real\n```\nFake\n====\n```\n## Also Real\n";
+            let headings = parse_headings(content);
+            assert_eq!(headings.len(), 2);
+            assert_eq!(headings[0].text, "Real");
+            assert_eq!(headings[1].text, "Also Real");
+        }
+
+        #[test]
+        fn parse_headings_setext_section_operations() {
+            // Verify that section-based operations work with setext headings.
+            let content =
+                "Title\n=====\n\nBody of title\n\nSubtitle\n--------\n\nBody of subtitle\n";
+            let (start, end) = find_section(content, "Title").unwrap();
+            let body = &content[start..end];
+            assert!(body.contains("Body of title"), "body: {:?}", body);
+
+            let (start2, end2) = find_section(content, "Subtitle").unwrap();
+            let body2 = &content[start2..end2];
+            assert!(body2.contains("Body of subtitle"), "body: {:?}", body2);
+        }
+
+        #[test]
+        fn parse_headings_setext_single_char_underline() {
+            // CommonMark allows a single = or - as an underline.
+            let content = "H1\n=\n\nH2\n-\n";
+            let headings = parse_headings(content);
+            assert_eq!(headings.len(), 2);
+            assert_eq!(headings[0].level, 1);
+            assert_eq!(headings[0].text, "H1");
+            assert_eq!(headings[1].level, 2);
+            assert_eq!(headings[1].text, "H2");
+        }
+
+        #[test]
+        fn parse_headings_setext_not_triggered_by_blank_preceding_line() {
+            // A --- after a blank line is a thematic break, not a setext heading.
+            let content = "Some text\n\n---\n\nMore text\n";
+            let headings = parse_headings(content);
+            assert!(
+                headings.is_empty(),
+                "thematic break should not create a heading: {:?}",
+                headings
+            );
+        }
+
+        #[test]
         fn parse_headings_ignores_invalid() {
             let content = "#nospace\n##also\n# Valid\n###### Six\n####### Seven\n";
             let headings = parse_headings(content);
@@ -904,6 +1053,72 @@ mod tests {
         fn move_section_missing_target_heading() {
             let content = "# A\nbody\n# B\nbody\n";
             assert!(move_section_in(content, "A", content, ("before", "Missing"), true).is_none());
+        }
+
+        #[test]
+        fn move_section_self_move_before_returns_none() {
+            // Moving section A to before itself: after removing A, the
+            // destination heading no longer exists, so the move returns None.
+            let content = "# A\na body\n# B\nb body\n";
+            let result = move_section_in(content, "A", content, ("before", "A"), true);
+            assert!(
+                result.is_none(),
+                "self-move (before self) should return None: {:?}",
+                result
+            );
+        }
+
+        #[test]
+        fn move_section_self_move_after_returns_none() {
+            // Moving section A to after itself: same issue.
+            let content = "# A\na body\n# B\nb body\n";
+            let result = move_section_in(content, "A", content, ("after", "A"), true);
+            assert!(
+                result.is_none(),
+                "self-move (after self) should return None: {:?}",
+                result
+            );
+        }
+
+        #[test]
+        fn move_section_preserves_sub_headings() {
+            let content = "# A\n## A1\na1 content\n## A2\na2 content\n# B\nb content\n";
+            let (result, _) = move_section_in(content, "A", content, ("after", "B"), true).unwrap();
+            // A should now come after B, with both sub-headings preserved.
+            let b_pos = result.find("# B").unwrap();
+            let a_pos = result.find("# A").unwrap();
+            assert!(b_pos < a_pos, "A should be after B");
+            assert!(
+                result.contains("## A1\na1 content"),
+                "sub-heading A1 should be preserved: {result}"
+            );
+            assert!(
+                result.contains("## A2\na2 content"),
+                "sub-heading A2 should be preserved: {result}"
+            );
+            assert!(
+                result.contains("b content"),
+                "B body should be preserved: {result}"
+            );
+        }
+
+        #[test]
+        fn move_section_cross_file_preserves_sub_headings() {
+            let source = "# A\n## A1\na1 content\n## A2\na2 content\n# B\nb content\n";
+            let dest = "# X\nx content\n# Y\ny content\n";
+            let (new_src, new_dst) =
+                move_section_in(source, "A", dest, ("before", "Y"), false).unwrap();
+            // Source should no longer have A or its sub-headings.
+            assert!(!new_src.contains("# A"));
+            assert!(!new_src.contains("## A1"));
+            assert!(!new_src.contains("## A2"));
+            assert!(new_src.contains("# B\nb content"));
+            // Dest should have A with its sub-headings before Y.
+            let a_pos = new_dst.find("# A").unwrap();
+            let y_pos = new_dst.find("# Y").unwrap();
+            assert!(a_pos < y_pos);
+            assert!(new_dst.contains("## A1\na1 content"));
+            assert!(new_dst.contains("## A2\na2 content"));
         }
     }
 
@@ -1263,28 +1478,44 @@ mod tests {
         }
 
         #[test]
-        fn upsert_bullet_cross_style_dash_into_star_no_dedup() {
+        fn upsert_bullet_cross_style_dash_into_star_dedup() {
             // Upserting "- existing item" when body has "* existing item":
-            // normalized form is "- existing item" which does NOT match
-            // "* existing item", so it appends (no cross-style dedup).
+            // cross-style dedup should recognize them as the same item.
             let content = "# List\n\n* existing item\n";
             let result = upsert_bullet_in(content, "List", "- existing item").unwrap();
-            assert!(
-                result.contains("* existing item") && result.contains("- existing item"),
-                "cross-style bullets should not dedup: {:?}",
-                result
+            assert_eq!(result, content, "cross-style bullets should dedup");
+        }
+
+        #[test]
+        fn upsert_bullet_no_prefix_into_star_content_dedup() {
+            // Upserting "existing item" (no prefix) normalizes to "- existing item"
+            // which should dedup against body's "* existing item".
+            let content = "# List\n\n* existing item\n";
+            let result = upsert_bullet_in(content, "List", "existing item").unwrap();
+            assert_eq!(
+                result, content,
+                "auto-prefixed dash should dedup against star bullet"
             );
         }
 
         #[test]
-        fn upsert_bullet_no_prefix_into_star_content_no_dedup() {
-            // Upserting "existing item" (no prefix) normalizes to "- existing item"
-            // which does not match body's "* existing item".
-            let content = "# List\n\n* existing item\n";
-            let result = upsert_bullet_in(content, "List", "existing item").unwrap();
+        fn upsert_bullet_plus_prefix_dedup_against_dash() {
+            let content = "# List\n\n- existing item\n";
+            let result = upsert_bullet_in(content, "List", "+ existing item").unwrap();
+            assert_eq!(
+                result, content,
+                "plus-prefixed bullet should dedup against dash"
+            );
+        }
+
+        #[test]
+        fn upsert_bullet_plus_prefix_preserved() {
+            // When inserting a new bullet with +, the prefix is kept.
+            let content = "# List\n\n- other item\n";
+            let result = upsert_bullet_in(content, "List", "+ brand new").unwrap();
             assert!(
-                result.contains("* existing item") && result.contains("- existing item"),
-                "auto-prefixed dash should not dedup against star bullet: {:?}",
+                result.contains("+ brand new"),
+                "plus-prefixed bullet should be preserved: {:?}",
                 result
             );
         }

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -591,8 +591,6 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                     EolMode::Keep
                 },
                 collapse_blanks: false,
-                indent_style: None,
-                indent_size: None,
             };
             let new = crate::write::apply_policy(&content, &policy);
             if content != *new {

--- a/src/write.rs
+++ b/src/write.rs
@@ -19,13 +19,8 @@ pub enum EolMode {
     Lf,
     /// Normalize to CRLF.
     Crlf,
-}
-
-/// Indentation style read from EditorConfig.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum IndentStyle {
-    Space,
-    Tab,
+    /// Normalize to CR (classic Mac).
+    Cr,
 }
 
 /// Controls which transformations are applied before writing a file.
@@ -34,8 +29,6 @@ pub struct WritePolicy {
     pub normalize_eol: EolMode,
     pub trim_trailing_whitespace: bool,
     pub collapse_blanks: bool,
-    pub indent_style: Option<IndentStyle>,
-    pub indent_size: Option<usize>,
 }
 
 impl WritePolicy {
@@ -46,8 +39,6 @@ impl WritePolicy {
             && matches!(self.normalize_eol, EolMode::Keep)
             && !self.trim_trailing_whitespace
             && !self.collapse_blanks
-            && self.indent_style.is_none()
-            && self.indent_size.is_none()
     }
 
     /// Apply an override, setting only the fields that are `Some`.
@@ -75,8 +66,6 @@ impl Default for WritePolicy {
             normalize_eol: EolMode::Keep,
             trim_trailing_whitespace: false,
             collapse_blanks: false,
-            indent_style: None,
-            indent_size: None,
         }
     }
 }
@@ -102,9 +91,12 @@ pub fn parse_eol_mode(mode: &str) -> anyhow::Result<EolMode> {
     match mode {
         "lf" => Ok(EolMode::Lf),
         "crlf" => Ok(EolMode::Crlf),
+        "cr" => Ok(EolMode::Cr),
         "keep" => Ok(EolMode::Keep),
         _ => {
-            anyhow::bail!("invalid normalize_eol value '{mode}': expected 'lf', 'crlf', or 'keep'")
+            anyhow::bail!(
+                "invalid normalize_eol value '{mode}': expected 'lf', 'crlf', 'cr', or 'keep'"
+            )
         }
     }
 }
@@ -128,8 +120,9 @@ pub fn ensure_final_newline(content: &str) -> std::borrow::Cow<'_, str> {
 /// Normalize line endings according to `mode`.
 ///
 /// - `Keep`  – return content unchanged.
-/// - `Lf`    – replace every `\r\n` with `\n`.
+/// - `Lf`    – replace every `\r\n` with `\n`, and every bare `\r` with `\n`.
 /// - `Crlf`  – replace every lone `\n` (not preceded by `\r`) with `\r\n`.
+/// - `Cr`    – replace every `\r\n` with `\r`, and every bare `\n` with `\r`.
 ///
 /// Returns `Cow::Borrowed` when no change is needed, avoiding allocation.
 /// CRLF mode uses a single-pass scan with `memchr` instead of two
@@ -139,10 +132,14 @@ pub fn normalize_eol(content: &str, mode: EolMode) -> std::borrow::Cow<'_, str> 
     match mode {
         EolMode::Keep => Cow::Borrowed(content),
         EolMode::Lf => {
-            if memchr::memmem::find(content.as_bytes(), b"\r\n").is_none() {
+            let bytes = content.as_bytes();
+            let has_cr = memchr::memchr(b'\r', bytes).is_some();
+            if !has_cr {
                 Cow::Borrowed(content)
             } else {
-                Cow::Owned(content.replace("\r\n", "\n"))
+                // Replace \r\n with \n, then any remaining bare \r with \n.
+                let without_crlf = content.replace("\r\n", "\n");
+                Cow::Owned(without_crlf.replace('\r', "\n"))
             }
         }
         EolMode::Crlf => {
@@ -169,6 +166,17 @@ pub fn normalize_eol(content: &str, mode: EolMode) -> std::borrow::Cow<'_, str> 
                     result.push_str(&content[last..]);
                 }
                 Cow::Owned(result)
+            }
+        }
+        EolMode::Cr => {
+            let bytes = content.as_bytes();
+            let has_lf = memchr::memchr(b'\n', bytes).is_some();
+            if !has_lf {
+                Cow::Borrowed(content)
+            } else {
+                // Replace \r\n with \r, then any remaining bare \n with \r.
+                let without_crlf = content.replace("\r\n", "\r");
+                Cow::Owned(without_crlf.replace('\n', "\r"))
             }
         }
     }
@@ -341,11 +349,6 @@ pub fn policy_from_flags(
         false
     };
 
-    #[allow(unused_mut)]
-    let mut indent_style: Option<IndentStyle> = None;
-    #[allow(unused_mut)]
-    let mut indent_size: Option<usize> = None;
-
     let (efn, eol, ttw) = if respect_ec {
         #[cfg(feature = "cli")]
         if let Some(p) = file_path {
@@ -370,7 +373,7 @@ pub fn policy_from_flags(
                     new_eol = Some(match val {
                         ec4rs::property::EndOfLine::Lf => EolMode::Lf,
                         ec4rs::property::EndOfLine::CrLf => EolMode::Crlf,
-                        ec4rs::property::EndOfLine::Cr => EolMode::Keep,
+                        ec4rs::property::EndOfLine::Cr => EolMode::Cr,
                     });
                 }
 
@@ -380,21 +383,6 @@ pub fn policy_from_flags(
                         props.get::<ec4rs::property::TrimTrailingWs>()
                 {
                     new_ttw = true;
-                }
-
-                // indent_style
-                if let Ok(val) = props.get::<ec4rs::property::IndentStyle>() {
-                    indent_style = Some(match val {
-                        ec4rs::property::IndentStyle::Tabs => IndentStyle::Tab,
-                        ec4rs::property::IndentStyle::Spaces => IndentStyle::Space,
-                    });
-                }
-
-                // indent_size
-                if let Ok(ec4rs::property::IndentSize::Value(n)) =
-                    props.get::<ec4rs::property::IndentSize>()
-                {
-                    indent_size = Some(n);
                 }
 
                 (new_efn, new_eol, new_ttw)
@@ -417,8 +405,6 @@ pub fn policy_from_flags(
         normalize_eol: eol.unwrap_or(EolMode::Keep),
         trim_trailing_whitespace: ttw,
         collapse_blanks: global.collapse_blanks,
-        indent_style,
-        indent_size,
     }
 }
 
@@ -581,6 +567,43 @@ mod tests {
     }
 
     #[test]
+    fn normalize_eol_cr_converts_lf() {
+        assert_eq!(normalize_eol("a\nb\n", EolMode::Cr), "a\rb\r");
+    }
+
+    #[test]
+    fn normalize_eol_cr_converts_crlf() {
+        assert_eq!(normalize_eol("a\r\nb\r\n", EolMode::Cr), "a\rb\r");
+    }
+
+    #[test]
+    fn normalize_eol_cr_mixed_input() {
+        assert_eq!(normalize_eol("a\r\nb\nc\r\n", EolMode::Cr), "a\rb\rc\r");
+    }
+
+    #[test]
+    fn normalize_eol_cr_already_correct_returns_borrowed() {
+        use std::borrow::Cow;
+        let content = "a\rb\r";
+        let result = normalize_eol(content, EolMode::Cr);
+        assert!(
+            matches!(result, Cow::Borrowed(_)),
+            "all-CR content should return Cow::Borrowed"
+        );
+    }
+
+    #[test]
+    fn normalize_eol_lf_also_strips_bare_cr() {
+        // LF mode should convert both \r\n and bare \r to \n.
+        assert_eq!(normalize_eol("a\rb\r\nc\n", EolMode::Lf), "a\nb\nc\n");
+    }
+
+    #[test]
+    fn parse_eol_mode_cr() {
+        assert!(matches!(parse_eol_mode("cr").unwrap(), EolMode::Cr));
+    }
+
+    #[test]
     fn trim_trailing_whitespace_removes_spaces() {
         let result = trim_trailing_whitespace("hello   \nworld\t\n");
         assert_eq!(result, "hello\nworld\n");
@@ -704,52 +727,22 @@ mod tests {
 
     #[test]
     #[cfg(feature = "cli")]
-    fn policy_from_flags_editorconfig_reads_indent_properties() {
+    fn policy_from_flags_editorconfig_cr() {
         let dir = tempfile::tempdir().unwrap();
         let ec_path = dir.path().join(".editorconfig");
-        fs::write(
-            &ec_path,
-            "root = true\n\n[*]\nindent_style = space\nindent_size = 4\n",
-        )
-        .unwrap();
+        fs::write(&ec_path, "root = true\n\n[*]\nend_of_line = cr\n").unwrap();
 
-        let file = dir.path().join("test.rs");
-        fs::write(&file, "fn main() {}\n").unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "content\n").unwrap();
 
         let mut global = test_global_flags();
         global.respect_editorconfig = true;
 
         let policy = policy_from_flags(&global, Some(&file));
-        assert_eq!(policy.indent_style, Some(IndentStyle::Space));
-        assert_eq!(policy.indent_size, Some(4));
-    }
-
-    #[test]
-    #[cfg(feature = "cli")]
-    fn policy_from_flags_editorconfig_tab_indent() {
-        let dir = tempfile::tempdir().unwrap();
-        let ec_path = dir.path().join(".editorconfig");
-        fs::write(&ec_path, "root = true\n\n[*]\nindent_style = tab\n").unwrap();
-
-        let file = dir.path().join("test.go");
-        fs::write(&file, "package main\n").unwrap();
-
-        let mut global = test_global_flags();
-        global.respect_editorconfig = true;
-
-        let policy = policy_from_flags(&global, Some(&file));
-        assert_eq!(policy.indent_style, Some(IndentStyle::Tab));
-        assert_eq!(policy.indent_size, None);
-    }
-
-    #[test]
-    #[cfg(feature = "cli")]
-    fn policy_from_flags_no_editorconfig_indent_is_none() {
-        let global = test_global_flags();
-
-        let policy = policy_from_flags(&global, None);
-        assert_eq!(policy.indent_style, None);
-        assert_eq!(policy.indent_size, None);
+        assert!(
+            matches!(policy.normalize_eol, EolMode::Cr),
+            "end_of_line = cr should map to EolMode::Cr"
+        );
     }
 
     #[test]
@@ -968,5 +961,16 @@ mod tests {
         };
         policy.apply_override(&ov).unwrap();
         assert!(matches!(policy.normalize_eol, EolMode::Crlf));
+    }
+
+    #[test]
+    fn write_policy_override_cr() {
+        let mut policy = WritePolicy::default();
+        let ov = WritePolicyOverride {
+            normalize_eol: Some("cr".to_string()),
+            ..Default::default()
+        };
+        policy.apply_override(&ov).unwrap();
+        assert!(matches!(policy.normalize_eol, EolMode::Cr));
     }
 }


### PR DESCRIPTION
## Summary

Five tech-debt issues resolved in a single batch:

| Issue | Fix |
|-------|-----|
| #985 | Add `EolMode::Cr` variant, implement CR normalization, fix EditorConfig `end_of_line=cr` mapping. Also fixes LF mode to strip bare `\r` |
| #986 | Remove dead `indent_style`/`indent_size` fields from `WritePolicy` (populated but never consumed) |
| #987 | Fix `upsert_bullet_in` cross-style dedup across `-`, `*`, `+` bullet prefixes |
| #988 | Add setext heading support (`===` h1, `---` h2) to `parse_headings` |
| #989 | Add tests for `move_section_in` self-move and sub-heading preservation |

## Details

**#985 EolMode::Cr**: The `EolMode` enum lacked a `Cr` variant. EditorConfig `end_of_line = cr` was mapped to `EolMode::Keep` (no normalization), violating the spec. Fix adds the variant, implements CR normalization in `normalize_eol()`, and propagates to `parse_eol_mode()`, `config.rs`, `tidy.rs`, and `api/mod.rs`. Also fixes `EolMode::Lf` to convert bare `\r` to `\n` (previously only handled `\r\n`).

**#986 Dead indent fields**: `WritePolicy` had `indent_style` and `indent_size` fields populated from EditorConfig but never consumed by `apply_policy()`. Removed the fields, the `IndentStyle` enum, and the EditorConfig parsing code. Simpler and honest about current capability.

**#987 Cross-style bullet dedup**: `upsert_bullet_in` only checked exact match for dedup. Inserting `- item` when body had `* item` created duplicates. Fix strips bullet prefix before comparison. Also adds `+` as a recognized bullet prefix.

**#988 Setext headings**: `parse_headings` only recognized ATX-style (`#`) headings. Fix detects setext underlines (`===`/`---`) following text lines, handles fenced code block exclusion, thematic break discrimination, and single-char underlines.

**#989 move_section_in tests**: Documents self-move behavior (returns `None` since destination heading disappears after source removal) and verifies sub-heading preservation for both same-file and cross-file moves.

## Test coverage

20 new tests added across the fixes. `make check-fast` passes (1371 unit + 750 integration + 10 PTY + 933 library hygiene).

Closes #985
Closes #986
Closes #987
Closes #988
Closes #989