### PR TITLE
fix: setext heading body offset and CRLF bare CR normalization

### DIFF
--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -8,6 +8,10 @@ pub struct HeadingInfo {
     pub level: usize,
     pub text: String,
     pub line_start: usize,
+    /// First line of the section body (after the heading and any underline).
+    /// For ATX headings: `line_start + 1`.
+    /// For setext headings: `line_start + 2` (text line + underline).
+    pub body_line: usize,
     pub line_end: usize,
 }
 
@@ -89,6 +93,7 @@ pub fn parse_headings(content: &str) -> Vec<HeadingInfo> {
                 level: hashes,
                 text: line[hashes + 1..].to_string(),
                 line_start: idx,
+                body_line: idx + 1,
                 line_end: 0,
             });
             continue;
@@ -112,6 +117,7 @@ pub fn parse_headings(content: &str) -> Vec<HeadingInfo> {
                         level,
                         text: prev_trimmed.to_string(),
                         line_start: prev_idx,
+                        body_line: idx + 1, // after the underline
                         line_end: 0,
                     });
                 }
@@ -165,8 +171,8 @@ pub fn find_section(content: &str, heading: &str) -> Option<(usize, usize)> {
 
     for h in &headings {
         if h.text.trim() == query {
-            let body_start = if h.line_start + 1 < offsets.len() {
-                offsets[h.line_start + 1]
+            let body_start = if h.body_line < offsets.len() {
+                offsets[h.body_line]
             } else {
                 content.len()
             };
@@ -741,15 +747,46 @@ mod tests {
         #[test]
         fn parse_headings_setext_section_operations() {
             // Verify that section-based operations work with setext headings.
-            let content =
-                "Title\n=====\n\nBody of title\n\nSubtitle\n--------\n\nBody of subtitle\n";
+            // Body must NOT include the underline.
+            // Use two h1 setext headings so the first section is bounded.
+            let content = "Title\n=====\n\nBody of title\n\nSubtitle\n=====\n\nBody of subtitle\n";
             let (start, end) = find_section(content, "Title").unwrap();
             let body = &content[start..end];
-            assert!(body.contains("Body of title"), "body: {:?}", body);
+            assert_eq!(body, "\nBody of title\n\n", "Title body: {:?}", body);
 
             let (start2, end2) = find_section(content, "Subtitle").unwrap();
             let body2 = &content[start2..end2];
-            assert!(body2.contains("Body of subtitle"), "body: {:?}", body2);
+            assert_eq!(body2, "\nBody of subtitle\n", "Subtitle body: {:?}", body2);
+        }
+
+        #[test]
+        fn replace_section_setext_preserves_underline() {
+            // Use same-level headings so the section is bounded.
+            let content = "Title\n=====\n\nOld body\n\nNext\n=====\nKeep\n";
+            let result = replace_section_in(content, "Title", "New body").unwrap();
+            assert_eq!(
+                result, "Title\n=====\nNew body\nNext\n=====\nKeep\n",
+                "underline must be preserved: {result}"
+            );
+        }
+
+        #[test]
+        fn upsert_bullet_setext_heading() {
+            let content = "List\n----\n\n- item1\n";
+            let result = upsert_bullet_in(content, "List", "- item2").unwrap();
+            assert!(
+                result.contains("----\n"),
+                "underline must be preserved: {result}"
+            );
+            assert!(
+                result.contains("- item1\n- item2\n"),
+                "bullet should be appended: {result}"
+            );
+            // Underline must NOT appear in the body match
+            assert!(
+                !result.contains("- ----"),
+                "underline must not be treated as bullet content: {result}"
+            );
         }
 
         #[test]
@@ -978,6 +1015,19 @@ mod tests {
         fn section_range_missing() {
             let content = "# A\nbody\n";
             assert!(section_range(content, "Missing").is_none());
+        }
+
+        #[test]
+        fn section_range_setext_includes_text_and_underline() {
+            // Use same-level heading to bound the section.
+            let content = "Title\n=====\nbody\nNext\n=====\nmore\n";
+            let (start, end) = section_range(content, "Title").unwrap();
+            // section_range should include the text line + underline + body
+            assert_eq!(
+                &content[start..end],
+                "Title\n=====\nbody\n",
+                "setext section_range should include text line and underline"
+            );
         }
 
         #[test]

--- a/src/write.rs
+++ b/src/write.rs
@@ -144,28 +144,37 @@ pub fn normalize_eol(content: &str, mode: EolMode) -> std::borrow::Cow<'_, str> 
         }
         EolMode::Crlf => {
             let bytes = content.as_bytes();
-            let has_bare_lf =
-                memchr::memchr_iter(b'\n', bytes).any(|i| i == 0 || bytes[i - 1] != b'\r');
-            if !has_bare_lf {
-                Cow::Borrowed(content)
+            // Check for bare \r (not followed by \n) in addition to bare \n.
+            let has_bare_cr = memchr::memchr_iter(b'\r', bytes)
+                .any(|i| i + 1 >= bytes.len() || bytes[i + 1] != b'\n');
+            if has_bare_cr {
+                // Normalize all line endings to \n first, then convert to \r\n.
+                let lf_first = content.replace("\r\n", "\n").replace('\r', "\n");
+                Cow::Owned(lf_first.replace('\n', "\r\n"))
             } else {
-                // Single-pass: copy slices between \n positions, inserting
-                // \r before bare \n characters.
-                let mut result = String::with_capacity(content.len() + content.len() / 10);
-                let mut last = 0;
-                for i in memchr::memchr_iter(b'\n', bytes) {
-                    if i == 0 || bytes[i - 1] != b'\r' {
-                        result.push_str(&content[last..i]);
-                        result.push_str("\r\n");
-                    } else {
-                        result.push_str(&content[last..=i]);
+                let has_bare_lf =
+                    memchr::memchr_iter(b'\n', bytes).any(|i| i == 0 || bytes[i - 1] != b'\r');
+                if !has_bare_lf {
+                    Cow::Borrowed(content)
+                } else {
+                    // Single-pass: copy slices between \n positions, inserting
+                    // \r before bare \n characters.
+                    let mut result = String::with_capacity(content.len() + content.len() / 10);
+                    let mut last = 0;
+                    for i in memchr::memchr_iter(b'\n', bytes) {
+                        if i == 0 || bytes[i - 1] != b'\r' {
+                            result.push_str(&content[last..i]);
+                            result.push_str("\r\n");
+                        } else {
+                            result.push_str(&content[last..=i]);
+                        }
+                        last = i + 1;
                     }
-                    last = i + 1;
+                    if last < content.len() {
+                        result.push_str(&content[last..]);
+                    }
+                    Cow::Owned(result)
                 }
-                if last < content.len() {
-                    result.push_str(&content[last..]);
-                }
-                Cow::Owned(result)
             }
         }
         EolMode::Cr => {
@@ -596,6 +605,21 @@ mod tests {
     fn normalize_eol_lf_also_strips_bare_cr() {
         // LF mode should convert both \r\n and bare \r to \n.
         assert_eq!(normalize_eol("a\rb\r\nc\n", EolMode::Lf), "a\nb\nc\n");
+    }
+
+    #[test]
+    fn normalize_eol_crlf_converts_bare_cr() {
+        // Bare \r (classic Mac) should become \r\n.
+        assert_eq!(normalize_eol("a\rb\r", EolMode::Crlf), "a\r\nb\r\n");
+    }
+
+    #[test]
+    fn normalize_eol_crlf_mixed_with_bare_cr() {
+        // Mix of bare \r, \r\n, and bare \n should all become \r\n.
+        assert_eq!(
+            normalize_eol("a\rb\r\nc\n", EolMode::Crlf),
+            "a\r\nb\r\nc\r\n"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two bugs discovered during the #985-#989 session, tracked immediately as issues.

| Issue | Fix |
|-------|-----|
| #991 | Setext heading body offset included the underline (`===`/`---`) in the section body |
| #992 | CRLF normalization did not convert bare `\r` to `\r\n` |

## Details

**#991 Setext body offset**: `find_section()` used `line_start + 1` to compute body start. For ATX headings that is correct (body starts after `# Heading`). For setext headings, `line_start` is the text line, so `line_start + 1` pointed to the underline, including it in the body. Fix adds a `body_line` field to `HeadingInfo`: ATX sets it to `line_start + 1`, setext sets it to `line_start + 2` (text + underline). `find_section()` now uses `body_line` instead of `line_start + 1`. `section_range()` is unaffected (still uses `line_start` for the full section).

**#992 CRLF bare CR**: `normalize_eol()` with `EolMode::Crlf` only scanned for bare `\n` and inserted `\r`. Bare `\r` (classic Mac endings) were left untouched. Fix detects bare `\r` first; when present, normalizes all endings to `\n` then converts to `\r\n`. This matches the symmetry with `EolMode::Lf` which was fixed in #985 to handle both `\r\n` and bare `\r`.

## Test coverage

- Setext section tests updated from `contains` to `eq` (would have caught #991 originally)
- New tests: `replace_section_setext_preserves_underline`, `upsert_bullet_setext_heading`, `section_range_setext_includes_text_and_underline`
- New tests: `normalize_eol_crlf_converts_bare_cr`, `normalize_eol_crlf_mixed_with_bare_cr`

`make check-fast` passes (1376 unit + 750 integration + 10 PTY).

Closes #991
Closes #992