### PR TITLE
docs: add cr to normalize_eol documented values

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -44,7 +44,7 @@ These modes are mutually exclusive. Patchloom is safe by default: nothing is wri
 A write policy controls transformations applied to all content before it reaches disk:
 
 - `--ensure-final-newline` -- non-empty files always end with `\n`
-- `--normalize-eol <lf|crlf>` -- standardize line endings
+- `--normalize-eol <lf|crlf|cr>` -- standardize line endings
 - `--trim-trailing-whitespace` -- remove trailing spaces on every line
 - `--respect-editorconfig` -- read policy from `.editorconfig` if present
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -58,7 +58,7 @@ These flags shape how written content is normalized before it reaches disk.
 <!-- ref:write-flag:normalize-eol -->
 ### `--normalize-eol`
 
-- **What it does:** Normalizes written line endings to `keep`, `lf`, or `crlf`.
+- **What it does:** Normalizes written line endings to `keep`, `lf`, `crlf`, or `cr`.
 - **Use when:** A repo or downstream tool expects a specific line ending convention.
 - **Prefer instead:** Use `--respect-editorconfig` when the repo already declares the desired convention there.
 
@@ -819,7 +819,7 @@ Use these when newline and whitespace correctness is the main concern.
 
 - **What it does:** Applies newline, EOL, and whitespace normalization across all pending writes in the plan.
 - **Use when:** Every write in the transaction should share the same normalization policy.
-- **Fields:** Supports `ensure_final_newline` (bool), `normalize_eol` (`keep`, `lf`, or `crlf`), `trim_trailing_whitespace` (bool), and `collapse_blanks` (bool).
+- **Fields:** Supports `ensure_final_newline` (bool), `normalize_eol` (`keep`, `lf`, `crlf`, or `cr`), `trim_trailing_whitespace` (bool), and `collapse_blanks` (bool).
 - **Precedence:** Patchloom starts from the invocation's per-file write policy, including CLI flags and any `--respect-editorconfig` values, then overrides only the keys set here.
 - **Prefer instead:** Use CLI write flags when one invocation needs defaults, but the plan itself should stay generic.
 


### PR DESCRIPTION
## Summary

The CR line-ending mode was added in PR #990 but the documentation was not updated to list `cr` as a valid `normalize_eol` value.

## Changes

- **`docs/reference/README.md`**: Updated `--normalize-eol` description and `write_policy` fields to include `cr`
- **`docs/getting-started/concepts.md`**: Updated `--normalize-eol` usage example to include `cr`

## Context

This was found during a multi-perspective improvement rotation (End User perspective). Also filed [#996](https://github.com/patchloom/patchloom/issues/996) for `collapse_blanks`/`trim_trailing_whitespace` not handling CR-only content (QA perspective).