### PR TITLE
refactor: organize tests by concern category with nested modules

### DIFF
--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -1,454 +1,293 @@
 use super::*;
 
-#[test]
-fn max_batch_operations_limit_is_enforced() {
-    let dir = tempfile::TempDir::new().unwrap();
-    // Build input with MAX+1 lines.
-    let lines: String = (0..=MAX_BATCH_OPERATIONS)
-        .map(|i| format!("doc.set f.json key{i} \"v\""))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let input_file = dir.path().join("ops.txt");
-    std::fs::write(&input_file, &lines).unwrap();
+mod basic {
+    use super::*;
 
-    let args = BatchArgs {
-        input: input_file.to_str().unwrap().to_string(),
-        write: Default::default(),
-    };
-    let global = GlobalFlags::test_with_cwd(dir.path());
-    let err = run(args, &global).unwrap_err();
-    assert!(
-        err.to_string().contains("too many operations"),
-        "expected limit error: {err}"
-    );
-}
+    #[test]
+    fn tokenize_simple() {
+        let tokens = tokenize("doc.set config.json version 42").unwrap();
+        assert_eq!(tokens, vec!["doc.set", "config.json", "version", "42"]);
+    }
 
-#[test]
-fn tokenize_simple() {
-    let tokens = tokenize("doc.set config.json version 42").unwrap();
-    assert_eq!(tokens, vec!["doc.set", "config.json", "version", "42"]);
-}
+    #[test]
+    fn tokenize_quoted() {
+        let tokens = tokenize(r#"doc.set config.json key "hello world""#).unwrap();
+        assert_eq!(tokens, vec!["doc.set", "config.json", "key", "hello world"]);
+    }
 
-#[test]
-fn tokenize_quoted() {
-    let tokens = tokenize(r#"doc.set config.json key "hello world""#).unwrap();
-    assert_eq!(tokens, vec!["doc.set", "config.json", "key", "hello world"]);
-}
-
-#[test]
-fn tokenize_escaped_quote() {
-    let tokens = tokenize(r#"replace f.txt "say \"hi\"" "say \"bye\"""#).unwrap();
-    assert_eq!(
-        tokens,
-        vec!["replace", "f.txt", r#"say "hi""#, r#"say "bye""#]
-    );
-}
-
-#[test]
-fn tokenize_json_value_unquoted() {
-    // Unquoted JSON without internal quotes works fine.
-    let tokens = tokenize("doc.set f.json key 42").unwrap();
-    assert_eq!(tokens, vec!["doc.set", "f.json", "key", "42"]);
-}
-
-#[test]
-fn tokenize_empty_quoted_string() {
-    let tokens = tokenize(r#"doc.set f.json key """#).unwrap();
-    assert_eq!(tokens, vec!["doc.set", "f.json", "key", ""]);
-}
-
-#[test]
-fn tokenize_empty_quoted_string_mid_line() {
-    let tokens = tokenize(r#"replace f.txt "" "new""#).unwrap();
-    assert_eq!(tokens, vec!["replace", "f.txt", "", "new"]);
-}
-
-#[test]
-fn tokenize_json_value_quoted() {
-    // JSON objects with internal quotes must be double-quoted.
-    let tokens = tokenize(r#"doc.merge f.json "{\"nested\":\"value\",\"num\":42}""#).unwrap();
-    assert_eq!(
-        tokens,
-        vec!["doc.merge", "f.json", r#"{"nested":"value","num":42}"#]
-    );
-}
-
-#[test]
-fn parse_json_value_number() {
-    let v = parse_json_value("42").unwrap();
-    assert_eq!(v, serde_json::json!(42));
-}
-
-#[test]
-fn parse_json_value_string_fallback() {
-    let v = parse_json_value("hello").unwrap();
-    assert_eq!(v, serde_json::json!("hello"));
-}
-
-#[test]
-fn parse_json_value_object() {
-    let v = parse_json_value(r#"{"a":1}"#).unwrap();
-    assert_eq!(v, serde_json::json!({"a": 1}));
-}
-
-#[test]
-fn tokenize_trailing_backslash_error() {
-    let err = tokenize(r#"doc.set f.json key "trail\"#).unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("unexpected end of line after backslash"),
-        "expected backslash error, got: {err}"
-    );
-}
-
-#[test]
-fn tokenize_unterminated_quote_error() {
-    let err = tokenize(r#"doc.set f.json key "no close"#).unwrap_err();
-    assert!(
-        err.to_string().contains("unterminated double quote"),
-        "expected unterminated quote error, got: {err}"
-    );
-}
-
-#[test]
-fn parse_json_value_quoted_string() {
-    let v = parse_json_value(r#""2.0.0""#).unwrap();
-    assert_eq!(v, serde_json::json!("2.0.0"));
-}
-
-#[test]
-fn parse_line_doc_set() {
-    let op = parse_line("doc.set config.json version 42", 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::DocSet { path, selector, value }
-        if path == "config.json" && selector == "version" && value == serde_json::json!(42)
-    ));
-}
-
-#[test]
-fn parse_line_doc_set_string_value() {
-    let op = parse_line(r#"doc.set config.json name "my app""#, 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::DocSet { path, selector, value }
-        if path == "config.json" && selector == "name" && value == serde_json::json!("my app")
-    ));
-}
-
-#[test]
-fn parse_line_replace() {
-    let op = parse_line(r#"replace src/main.rs "old text" "new text""#, 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::Replace { path: Some(p), from, to: Some(t), .. }
-        if p == "src/main.rs" && from == "old text" && t == "new text"
-    ));
-}
-
-#[test]
-fn parse_line_file_create() {
-    let op = parse_line(r#"file.create hello.txt "Hello, World!""#, 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::FileCreate { path, content, .. }
-        if path == "hello.txt" && content == "Hello, World!"
-    ));
-}
-
-#[test]
-fn parse_line_file_delete() {
-    let op = parse_line("file.delete old.txt", 1).unwrap();
-    assert!(matches!(op, Operation::FileDelete { path } if path == "old.txt"));
-}
-
-#[test]
-fn parse_line_tidy_fix() {
-    let op = parse_line("tidy.fix src/lib.rs", 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::TidyFix { path, ensure_final_newline, trim_trailing_whitespace, normalize_eol }
-        if path == "src/lib.rs"
-            && ensure_final_newline.is_none()
-            && trim_trailing_whitespace.is_none()
-            && normalize_eol.is_none()
-    ));
-}
-
-#[test]
-fn parse_line_md_upsert_bullet() {
-    let input = "md.upsert_bullet AGENTS.md \"## Rules\" \"- New rule\"";
-    let op = parse_line(input, 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::MdUpsertBullet { path, heading, bullet }
-        if path == "AGENTS.md" && heading == "## Rules" && bullet == "- New rule"
-    ));
-}
-
-#[test]
-fn parse_line_doc_update() {
-    // JSON objects with internal quotes must be escaped inside double quotes
-    // in batch format (see tokenize_json_value_quoted test).
-    let op = parse_line(r#"doc.update config.json items[*] "{\"active\":true}""#, 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::DocUpdate { path, selector, value }
-        if path == "config.json" && selector == "items[*]" && value == serde_json::json!({"active": true})
-    ));
-}
-
-#[test]
-fn parse_line_doc_move() {
-    let op = parse_line(r#"doc.move config.json old_key new_key"#, 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::DocMove { path, from, to }
-        if path == "config.json" && from == "old_key" && to == "new_key"
-    ));
-}
-
-#[test]
-fn parse_line_doc_delete_where() {
-    let op = parse_line(r#"doc.delete_where config.json items "status=obsolete""#, 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::DocDeleteWhere { path, selector, predicate }
-        if path == "config.json" && selector == "items" && predicate == "status=obsolete"
-    ));
-}
-
-#[test]
-fn parse_line_md_replace_section() {
-    let op = parse_line("md.replace_section README.md \"## API\" \"New content\"", 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::MdReplaceSection { path, heading, content }
-        if path == "README.md" && heading == "## API" && content == "New content"
-    ));
-}
-
-#[test]
-fn parse_line_md_insert_after_heading() {
-    let op = parse_line(
-        "md.insert_after_heading README.md \"## Rules\" \"New paragraph\"",
-        1,
-    )
-    .unwrap();
-    assert!(matches!(
-        op,
-        Operation::MdInsertAfterHeading { path, heading, content }
-        if path == "README.md" && heading == "## Rules" && content == "New paragraph"
-    ));
-}
-
-#[test]
-fn parse_line_md_insert_before_heading() {
-    let op = parse_line(
-        "md.insert_before_heading README.md \"## Rules\" \"Preamble\"",
-        1,
-    )
-    .unwrap();
-    assert!(matches!(
-        op,
-        Operation::MdInsertBeforeHeading { path, heading, content }
-        if path == "README.md" && heading == "## Rules" && content == "Preamble"
-    ));
-}
-
-#[test]
-fn parse_line_md_dedupe_headings() {
-    let op = parse_line("md.dedupe_headings CHANGELOG.md", 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::MdDedupeHeadings { path }
-        if path == "CHANGELOG.md"
-    ));
-}
-
-#[test]
-fn parse_line_md_lint_agents() {
-    let op = parse_line("md.lint_agents AGENTS.md", 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::MdLintAgents { path }
-        if path == "AGENTS.md"
-    ));
-}
-
-#[test]
-fn parse_line_doc_delete() {
-    let op = parse_line("doc.delete config.json old_key", 1).unwrap();
-    assert!(matches!(op, Operation::DocDelete { ref path, ref selector }
-        if path == "config.json" && selector == "old_key"));
-}
-
-#[test]
-fn parse_line_doc_merge() {
-    let op = parse_line(r#"doc.merge config.json "{\"debug\":true}""#, 1).unwrap();
-    assert!(matches!(op, Operation::DocMerge { ref path, ref value }
-            if path == "config.json" && value == &serde_json::json!({"debug": true})));
-}
-
-#[test]
-fn parse_line_doc_ensure() {
-    let op = parse_line(r#"doc.ensure config.json version "beta""#, 1).unwrap();
-    assert!(
-        matches!(op, Operation::DocEnsure { ref path, ref selector, ref value }
-        if path == "config.json" && selector == "version" && value == &serde_json::json!("beta"))
-    );
-}
-
-#[test]
-fn parse_line_doc_append() {
-    let op = parse_line(r#"doc.append config.json tags "new""#, 1).unwrap();
-    assert!(
-        matches!(op, Operation::DocAppend { ref path, ref selector, ref value }
-        if path == "config.json" && selector == "tags" && value == &serde_json::json!("new"))
-    );
-}
-
-#[test]
-fn parse_line_doc_prepend() {
-    let op = parse_line(r#"doc.prepend config.json items "first""#, 1).unwrap();
-    assert!(
-        matches!(op, Operation::DocPrepend { ref path, ref selector, ref value }
-        if path == "config.json" && selector == "items" && value == &serde_json::json!("first"))
-    );
-}
-
-#[test]
-fn parse_line_md_table_append() {
-    let input = "md.table_append README.md \"## Commands\" \"| new | desc |\"";
-    let op = parse_line(input, 1).unwrap();
-    assert!(
-        matches!(op, Operation::MdTableAppend { ref path, ref heading, ref row }
-        if path == "README.md" && heading == "## Commands" && row == "| new | desc |")
-    );
-}
-
-#[test]
-fn parse_line_file_rename() {
-    let op = parse_line("file.rename old.txt new.txt", 1).unwrap();
-    assert!(
-        matches!(op, Operation::FileRename { ref from, ref to, force }
-        if from == "old.txt" && to == "new.txt" && !force)
-    );
-}
-
-#[test]
-fn parse_line_unknown_op() {
-    let err = parse_line("unknown.op foo bar", 1).unwrap_err();
-    assert!(err.to_string().contains("unknown operation"));
-}
-
-// Batch intentionally does not support read, search, and patch.apply.
-// These are tx-only operations. The tests below document this as deliberate.
-
-#[test]
-fn parse_line_rejects_read() {
-    let err = parse_line("read path.txt", 1).unwrap_err();
-    assert!(err.to_string().contains("unknown operation"));
-}
-
-#[test]
-fn parse_line_rejects_search() {
-    let err = parse_line("search path.txt hello", 1).unwrap_err();
-    assert!(err.to_string().contains("unknown operation"));
-}
-
-#[test]
-fn parse_line_rejects_patch_apply() {
-    let err = parse_line("patch.apply diff-text", 1).unwrap_err();
-    assert!(err.to_string().contains("unknown operation"));
-}
-
-#[test]
-fn parse_line_too_few_args() {
-    let err = parse_line("doc.set config.json", 1).unwrap_err();
-    assert!(err.to_string().contains("requires exactly 3 arguments"));
-}
-
-#[test]
-fn parse_line_extra_args_rejected() {
-    let err = parse_line(r#"file.delete old.txt extra"#, 1).unwrap_err();
-    assert!(err.to_string().contains("requires exactly 1 arguments"));
-}
-
-#[test]
-fn parse_line_extra_args_rejected_all_operations() {
-    // 2-arg operations (require exactly 2)
-    let two_arg_ops = [
-        r#"doc.delete f.json sel extra"#,
-        r#"doc.merge f.json "{}" extra"#,
-        r#"file.create f.txt content extra"#,
-        r#"file.rename old.txt new.txt extra"#,
-    ];
-    for line in &two_arg_ops {
-        let err = parse_line(line, 1).unwrap_err();
-        assert!(
-            err.to_string().contains("requires exactly 2 arguments"),
-            "expected rejection for '{line}', got: {err}"
+    #[test]
+    fn tokenize_escaped_quote() {
+        let tokens = tokenize(r#"replace f.txt "say \"hi\"" "say \"bye\"""#).unwrap();
+        assert_eq!(
+            tokens,
+            vec!["replace", "f.txt", r#"say "hi""#, r#"say "bye""#]
         );
     }
 
-    // 3-arg operations (require exactly 3)
-    let three_arg_ops = [
-        r#"doc.set f.json sel "v" extra"#,
-        r#"doc.ensure f.json sel "v" extra"#,
-        r#"doc.append f.json sel "v" extra"#,
-        r#"doc.prepend f.json sel "v" extra"#,
-        r#"doc.update f.json sel "v" extra"#,
-        r#"doc.move f.json from to extra"#,
-        r#"doc.delete_where f.json sel "k=v" extra"#,
-        r#"replace f.txt old new extra"#,
-        r##"md.upsert_bullet f.md "# H" "- b" extra"##,
-        r##"md.table_append f.md "# H" "| r |" extra"##,
-        r##"md.replace_section f.md "# H" body extra"##,
-        r##"md.insert_after_heading f.md "# H" text extra"##,
-        r##"md.insert_before_heading f.md "# H" text extra"##,
-    ];
-    for line in &three_arg_ops {
-        let err = parse_line(line, 1).unwrap_err();
-        assert!(
-            err.to_string().contains("requires exactly 3 arguments"),
-            "expected rejection for '{line}', got: {err}"
+    #[test]
+    fn tokenize_json_value_unquoted() {
+        // Unquoted JSON without internal quotes works fine.
+        let tokens = tokenize("doc.set f.json key 42").unwrap();
+        assert_eq!(tokens, vec!["doc.set", "f.json", "key", "42"]);
+    }
+
+    #[test]
+    fn tokenize_json_value_quoted() {
+        // JSON objects with internal quotes must be double-quoted.
+        let tokens = tokenize(r#"doc.merge f.json "{\"nested\":\"value\",\"num\":42}""#).unwrap();
+        assert_eq!(
+            tokens,
+            vec!["doc.merge", "f.json", r#"{"nested":"value","num":42}"#]
         );
     }
 
-    // 1-arg operations (require exactly 1)
-    let one_arg_ops = [
-        "md.dedupe_headings f.md extra",
-        "md.lint_agents f.md extra",
-        "tidy.fix f.txt extra",
-    ];
-    for line in &one_arg_ops {
-        let err = parse_line(line, 1).unwrap_err();
+    #[test]
+    fn parse_json_value_number() {
+        let v = parse_json_value("42").unwrap();
+        assert_eq!(v, serde_json::json!(42));
+    }
+
+    #[test]
+    fn parse_json_value_string_fallback() {
+        let v = parse_json_value("hello").unwrap();
+        assert_eq!(v, serde_json::json!("hello"));
+    }
+
+    #[test]
+    fn parse_json_value_object() {
+        let v = parse_json_value(r#"{"a":1}"#).unwrap();
+        assert_eq!(v, serde_json::json!({"a": 1}));
+    }
+
+    #[test]
+    fn parse_json_value_quoted_string() {
+        let v = parse_json_value(r#""2.0.0""#).unwrap();
+        assert_eq!(v, serde_json::json!("2.0.0"));
+    }
+
+    #[test]
+    fn parse_line_doc_set() {
+        let op = parse_line("doc.set config.json version 42", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::DocSet { path, selector, value }
+            if path == "config.json" && selector == "version" && value == serde_json::json!(42)
+        ));
+    }
+
+    #[test]
+    fn parse_line_doc_set_string_value() {
+        let op = parse_line(r#"doc.set config.json name "my app""#, 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::DocSet { path, selector, value }
+            if path == "config.json" && selector == "name" && value == serde_json::json!("my app")
+        ));
+    }
+
+    #[test]
+    fn parse_line_replace() {
+        let op = parse_line(r#"replace src/main.rs "old text" "new text""#, 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::Replace { path: Some(p), from, to: Some(t), .. }
+            if p == "src/main.rs" && from == "old text" && t == "new text"
+        ));
+    }
+
+    #[test]
+    fn parse_line_file_create() {
+        let op = parse_line(r#"file.create hello.txt "Hello, World!""#, 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::FileCreate { path, content, .. }
+            if path == "hello.txt" && content == "Hello, World!"
+        ));
+    }
+
+    #[test]
+    fn parse_line_file_delete() {
+        let op = parse_line("file.delete old.txt", 1).unwrap();
+        assert!(matches!(op, Operation::FileDelete { path } if path == "old.txt"));
+    }
+
+    #[test]
+    fn parse_line_tidy_fix() {
+        let op = parse_line("tidy.fix src/lib.rs", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::TidyFix { path, ensure_final_newline, trim_trailing_whitespace, normalize_eol }
+            if path == "src/lib.rs"
+                && ensure_final_newline.is_none()
+                && trim_trailing_whitespace.is_none()
+                && normalize_eol.is_none()
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_upsert_bullet() {
+        let input = "md.upsert_bullet AGENTS.md \"## Rules\" \"- New rule\"";
+        let op = parse_line(input, 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdUpsertBullet { path, heading, bullet }
+            if path == "AGENTS.md" && heading == "## Rules" && bullet == "- New rule"
+        ));
+    }
+
+    #[test]
+    fn parse_line_doc_update() {
+        // JSON objects with internal quotes must be escaped inside double quotes
+        // in batch format (see tokenize_json_value_quoted test).
+        let op = parse_line(r#"doc.update config.json items[*] "{\"active\":true}""#, 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::DocUpdate { path, selector, value }
+            if path == "config.json" && selector == "items[*]" && value == serde_json::json!({"active": true})
+        ));
+    }
+
+    #[test]
+    fn parse_line_doc_move() {
+        let op = parse_line(r#"doc.move config.json old_key new_key"#, 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::DocMove { path, from, to }
+            if path == "config.json" && from == "old_key" && to == "new_key"
+        ));
+    }
+
+    #[test]
+    fn parse_line_doc_delete_where() {
+        let op = parse_line(r#"doc.delete_where config.json items "status=obsolete""#, 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::DocDeleteWhere { path, selector, predicate }
+            if path == "config.json" && selector == "items" && predicate == "status=obsolete"
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_replace_section() {
+        let op = parse_line("md.replace_section README.md \"## API\" \"New content\"", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdReplaceSection { path, heading, content }
+            if path == "README.md" && heading == "## API" && content == "New content"
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_insert_after_heading() {
+        let op = parse_line(
+            "md.insert_after_heading README.md \"## Rules\" \"New paragraph\"",
+            1,
+        )
+        .unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdInsertAfterHeading { path, heading, content }
+            if path == "README.md" && heading == "## Rules" && content == "New paragraph"
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_insert_before_heading() {
+        let op = parse_line(
+            "md.insert_before_heading README.md \"## Rules\" \"Preamble\"",
+            1,
+        )
+        .unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdInsertBeforeHeading { path, heading, content }
+            if path == "README.md" && heading == "## Rules" && content == "Preamble"
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_dedupe_headings() {
+        let op = parse_line("md.dedupe_headings CHANGELOG.md", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdDedupeHeadings { path }
+            if path == "CHANGELOG.md"
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_lint_agents() {
+        let op = parse_line("md.lint_agents AGENTS.md", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdLintAgents { path }
+            if path == "AGENTS.md"
+        ));
+    }
+
+    #[test]
+    fn parse_line_doc_delete() {
+        let op = parse_line("doc.delete config.json old_key", 1).unwrap();
+        assert!(matches!(op, Operation::DocDelete { ref path, ref selector }
+            if path == "config.json" && selector == "old_key"));
+    }
+
+    #[test]
+    fn parse_line_doc_merge() {
+        let op = parse_line(r#"doc.merge config.json "{\"debug\":true}""#, 1).unwrap();
+        assert!(matches!(op, Operation::DocMerge { ref path, ref value }
+                if path == "config.json" && value == &serde_json::json!({"debug": true})));
+    }
+
+    #[test]
+    fn parse_line_doc_ensure() {
+        let op = parse_line(r#"doc.ensure config.json version "beta""#, 1).unwrap();
         assert!(
-            err.to_string().contains("requires exactly 1 arguments"),
-            "expected rejection for '{line}', got: {err}"
+            matches!(op, Operation::DocEnsure { ref path, ref selector, ref value }
+            if path == "config.json" && selector == "version" && value == &serde_json::json!("beta"))
         );
     }
-}
 
-#[test]
-fn tokenize_error_includes_line_number() {
-    // Unterminated quote should include the line number from parse_line.
-    let err = parse_line(r#"doc.set f.json key "unterminated"#, 7).unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("line 7"),
-        "expected line number in error: {msg}"
-    );
-    assert!(
-        msg.contains("unterminated double quote"),
-        "expected tokenize message in error: {msg}"
-    );
-}
+    #[test]
+    fn parse_line_doc_append() {
+        let op = parse_line(r#"doc.append config.json tags "new""#, 1).unwrap();
+        assert!(
+            matches!(op, Operation::DocAppend { ref path, ref selector, ref value }
+            if path == "config.json" && selector == "tags" && value == &serde_json::json!("new"))
+        );
+    }
 
-#[test]
-fn full_batch_parse() {
-    let input = r#"
+    #[test]
+    fn parse_line_doc_prepend() {
+        let op = parse_line(r#"doc.prepend config.json items "first""#, 1).unwrap();
+        assert!(
+            matches!(op, Operation::DocPrepend { ref path, ref selector, ref value }
+            if path == "config.json" && selector == "items" && value == &serde_json::json!("first"))
+        );
+    }
+
+    #[test]
+    fn parse_line_md_table_append() {
+        let input = "md.table_append README.md \"## Commands\" \"| new | desc |\"";
+        let op = parse_line(input, 1).unwrap();
+        assert!(
+            matches!(op, Operation::MdTableAppend { ref path, ref heading, ref row }
+            if path == "README.md" && heading == "## Commands" && row == "| new | desc |")
+        );
+    }
+
+    #[test]
+    fn parse_line_file_rename() {
+        let op = parse_line("file.rename old.txt new.txt", 1).unwrap();
+        assert!(
+            matches!(op, Operation::FileRename { ref from, ref to, force }
+            if from == "old.txt" && to == "new.txt" && !force)
+        );
+    }
+
+    #[test]
+    fn full_batch_parse() {
+        let input = r#"
 # Update versions across the project
 doc.set package.json version "2.0.0"
 doc.set config.yaml app.version "2.0.0"
@@ -457,52 +296,230 @@ replace README.md "1.0.0" "2.0.0"
 # Create a new file
 file.create hello.txt "Hello, World!"
 "#;
-    let mut operations = Vec::new();
-    for (i, line) in input.lines().enumerate() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() || trimmed.starts_with('#') {
-            continue;
+        let mut operations = Vec::new();
+        for (i, line) in input.lines().enumerate() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            operations.push(parse_line(trimmed, i + 1).unwrap());
         }
-        operations.push(parse_line(trimmed, i + 1).unwrap());
+        assert_eq!(operations.len(), 4);
     }
-    assert_eq!(operations.len(), 4);
+
+    #[test]
+    fn parse_line_md_move_section_same_file() {
+        let op = parse_line("md.move_section README.md \"FAQ\" before \"License\"", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdMoveSection { path, heading, to, before, after }
+            if path == "README.md" && heading == "FAQ" && to.is_none()
+               && before.as_deref() == Some("License") && after.is_none()
+        ));
+    }
+
+    #[test]
+    fn parse_line_md_move_section_cross_file() {
+        let op = parse_line(
+            "md.move_section spec.md \"Appendix\" dest.md after \"Layer 4\"",
+            1,
+        )
+        .unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdMoveSection { path, heading, to, before, after }
+            if path == "spec.md" && heading == "Appendix"
+               && to.as_deref() == Some("dest.md")
+               && before.is_none() && after.as_deref() == Some("Layer 4")
+        ));
+    }
 }
 
-#[test]
-fn parse_line_md_move_section_same_file() {
-    let op = parse_line("md.move_section README.md \"FAQ\" before \"License\"", 1).unwrap();
-    assert!(matches!(
-        op,
-        Operation::MdMoveSection { path, heading, to, before, after }
-        if path == "README.md" && heading == "FAQ" && to.is_none()
-           && before.as_deref() == Some("License") && after.is_none()
-    ));
+mod edge_cases {
+    use super::*;
+
+    #[test]
+    fn tokenize_empty_quoted_string() {
+        let tokens = tokenize(r#"doc.set f.json key """#).unwrap();
+        assert_eq!(tokens, vec!["doc.set", "f.json", "key", ""]);
+    }
+
+    #[test]
+    fn tokenize_empty_quoted_string_mid_line() {
+        let tokens = tokenize(r#"replace f.txt "" "new""#).unwrap();
+        assert_eq!(tokens, vec!["replace", "f.txt", "", "new"]);
+    }
 }
 
-#[test]
-fn parse_line_md_move_section_cross_file() {
-    let op = parse_line(
-        "md.move_section spec.md \"Appendix\" dest.md after \"Layer 4\"",
-        1,
-    )
-    .unwrap();
-    assert!(matches!(
-        op,
-        Operation::MdMoveSection { path, heading, to, before, after }
-        if path == "spec.md" && heading == "Appendix"
-           && to.as_deref() == Some("dest.md")
-           && before.is_none() && after.as_deref() == Some("Layer 4")
-    ));
+mod error_handling {
+    use super::*;
+
+    #[test]
+    fn tokenize_trailing_backslash_error() {
+        let err = tokenize(r#"doc.set f.json key "trail\"#).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("unexpected end of line after backslash"),
+            "expected backslash error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn tokenize_unterminated_quote_error() {
+        let err = tokenize(r#"doc.set f.json key "no close"#).unwrap_err();
+        assert!(
+            err.to_string().contains("unterminated double quote"),
+            "expected unterminated quote error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_line_unknown_op() {
+        let err = parse_line("unknown.op foo bar", 1).unwrap_err();
+        assert!(err.to_string().contains("unknown operation"));
+    }
+
+    // Batch intentionally does not support read, search, and patch.apply.
+    // These are tx-only operations. The tests below document this as deliberate.
+
+    #[test]
+    fn parse_line_rejects_read() {
+        let err = parse_line("read path.txt", 1).unwrap_err();
+        assert!(err.to_string().contains("unknown operation"));
+    }
+
+    #[test]
+    fn parse_line_rejects_search() {
+        let err = parse_line("search path.txt hello", 1).unwrap_err();
+        assert!(err.to_string().contains("unknown operation"));
+    }
+
+    #[test]
+    fn parse_line_rejects_patch_apply() {
+        let err = parse_line("patch.apply diff-text", 1).unwrap_err();
+        assert!(err.to_string().contains("unknown operation"));
+    }
+
+    #[test]
+    fn parse_line_too_few_args() {
+        let err = parse_line("doc.set config.json", 1).unwrap_err();
+        assert!(err.to_string().contains("requires exactly 3 arguments"));
+    }
+
+    #[test]
+    fn parse_line_extra_args_rejected() {
+        let err = parse_line(r#"file.delete old.txt extra"#, 1).unwrap_err();
+        assert!(err.to_string().contains("requires exactly 1 arguments"));
+    }
+
+    #[test]
+    fn parse_line_extra_args_rejected_all_operations() {
+        // 2-arg operations (require exactly 2)
+        let two_arg_ops = [
+            r#"doc.delete f.json sel extra"#,
+            r#"doc.merge f.json "{}" extra"#,
+            r#"file.create f.txt content extra"#,
+            r#"file.rename old.txt new.txt extra"#,
+        ];
+        for line in &two_arg_ops {
+            let err = parse_line(line, 1).unwrap_err();
+            assert!(
+                err.to_string().contains("requires exactly 2 arguments"),
+                "expected rejection for '{line}', got: {err}"
+            );
+        }
+
+        // 3-arg operations (require exactly 3)
+        let three_arg_ops = [
+            r#"doc.set f.json sel "v" extra"#,
+            r#"doc.ensure f.json sel "v" extra"#,
+            r#"doc.append f.json sel "v" extra"#,
+            r#"doc.prepend f.json sel "v" extra"#,
+            r#"doc.update f.json sel "v" extra"#,
+            r#"doc.move f.json from to extra"#,
+            r#"doc.delete_where f.json sel "k=v" extra"#,
+            r#"replace f.txt old new extra"#,
+            r##"md.upsert_bullet f.md "# H" "- b" extra"##,
+            r##"md.table_append f.md "# H" "| r |" extra"##,
+            r##"md.replace_section f.md "# H" body extra"##,
+            r##"md.insert_after_heading f.md "# H" text extra"##,
+            r##"md.insert_before_heading f.md "# H" text extra"##,
+        ];
+        for line in &three_arg_ops {
+            let err = parse_line(line, 1).unwrap_err();
+            assert!(
+                err.to_string().contains("requires exactly 3 arguments"),
+                "expected rejection for '{line}', got: {err}"
+            );
+        }
+
+        // 1-arg operations (require exactly 1)
+        let one_arg_ops = [
+            "md.dedupe_headings f.md extra",
+            "md.lint_agents f.md extra",
+            "tidy.fix f.txt extra",
+        ];
+        for line in &one_arg_ops {
+            let err = parse_line(line, 1).unwrap_err();
+            assert!(
+                err.to_string().contains("requires exactly 1 arguments"),
+                "expected rejection for '{line}', got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn tokenize_error_includes_line_number() {
+        // Unterminated quote should include the line number from parse_line.
+        let err = parse_line(r#"doc.set f.json key "unterminated"#, 7).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("line 7"),
+            "expected line number in error: {msg}"
+        );
+        assert!(
+            msg.contains("unterminated double quote"),
+            "expected tokenize message in error: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_line_md_move_section_bad_keyword() {
+        let err =
+            parse_line("md.move_section README.md \"FAQ\" between \"License\"", 1).unwrap_err();
+        assert!(err.to_string().contains("expected 'before' or 'after'"));
+    }
+
+    #[test]
+    fn parse_line_md_move_section_wrong_arg_count() {
+        let err = parse_line("md.move_section README.md", 1).unwrap_err();
+        assert!(err.to_string().contains("requires 4 args"));
+    }
 }
 
-#[test]
-fn parse_line_md_move_section_bad_keyword() {
-    let err = parse_line("md.move_section README.md \"FAQ\" between \"License\"", 1).unwrap_err();
-    assert!(err.to_string().contains("expected 'before' or 'after'"));
-}
+mod security {
+    use super::*;
 
-#[test]
-fn parse_line_md_move_section_wrong_arg_count() {
-    let err = parse_line("md.move_section README.md", 1).unwrap_err();
-    assert!(err.to_string().contains("requires 4 args"));
+    #[test]
+    fn max_batch_operations_limit_is_enforced() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Build input with MAX+1 lines.
+        let lines: String = (0..=MAX_BATCH_OPERATIONS)
+            .map(|i| format!("doc.set f.json key{i} \"v\""))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let input_file = dir.path().join("ops.txt");
+        std::fs::write(&input_file, &lines).unwrap();
+
+        let args = BatchArgs {
+            input: input_file.to_str().unwrap().to_string(),
+            write: Default::default(),
+        };
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let err = run(args, &global).unwrap_err();
+        assert!(
+            err.to_string().contains("too many operations"),
+            "expected limit error: {err}"
+        );
+    }
 }

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -9,156 +9,6 @@ fn write_file(dir: &TempDir, name: &str, content: &str) -> String {
     path.to_str().unwrap().to_string()
 }
 
-// -- get ----------------------------------------------------------------
-
-#[test]
-fn get_returns_value_from_json() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello", "count": 42}"#);
-    let action = DocAction::Get {
-        file: path,
-        selector: "name".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(output, "hello");
-}
-
-#[test]
-fn get_returns_value_from_yaml() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.yaml", "name: hello\ncount: 42\n");
-    let action = DocAction::Get {
-        file: path,
-        selector: "name".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(output, "hello");
-}
-
-#[test]
-fn get_returns_value_from_toml() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.toml", "name = \"hello\"\ncount = 42\n");
-    let action = DocAction::Get {
-        file: path,
-        selector: "name".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(output, "hello");
-}
-
-// -- has ----------------------------------------------------------------
-
-#[test]
-fn has_returns_true_for_existing_key() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Has {
-        file: path,
-        selector: "name".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(output, "true");
-}
-
-#[test]
-fn has_returns_false_for_missing_key() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Has {
-        file: path,
-        selector: "missing".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(output, "false");
-}
-
-// -- keys ---------------------------------------------------------------
-
-#[test]
-fn keys_lists_object_keys() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(
-        &dir,
-        "test.json",
-        r#"{"scripts": {"build": "tsc", "lint": "eslint", "test": "jest"}}"#,
-    );
-    let action = DocAction::Keys {
-        file: path,
-        selector: "scripts".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let keys: Vec<&str> = output.split('\n').collect();
-    assert_eq!(keys.len(), 3);
-    assert!(keys.contains(&"build"));
-    assert!(keys.contains(&"lint"));
-    assert!(keys.contains(&"test"));
-}
-
-// -- len ----------------------------------------------------------------
-
-#[test]
-fn len_counts_array_elements() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"items": [1, 2, 3, 4, 5]}"#);
-    let action = DocAction::Len {
-        file: path,
-        selector: "items".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(output, "5");
-}
-
-// -- missing selector ---------------------------------------------------
-
-#[test]
-fn get_missing_selector_returns_exit_3() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Get {
-        file: path,
-        selector: "nonexistent".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::NO_MATCHES);
-    assert!(output.is_empty());
-}
-
-// -- parse_value --------------------------------------------------------
-
-#[test]
-fn parse_value_bare_string() {
-    assert_eq!(parse_value("hello"), serde_json::json!("hello"));
-}
-
-#[test]
-fn parse_value_integer() {
-    assert_eq!(parse_value("42"), serde_json::json!(42));
-}
-
-#[test]
-fn parse_value_bool() {
-    assert_eq!(parse_value("true"), serde_json::json!(true));
-}
-
-#[test]
-fn parse_value_null() {
-    assert_eq!(parse_value("null"), serde_json::Value::Null);
-}
-
-#[test]
-fn parse_value_json_object() {
-    let v = parse_value(r#"{"a":1}"#);
-    assert_eq!(v, serde_json::json!({"a": 1}));
-}
-
 // -- Helper to run a doc write action through run() -------------------
 
 fn run_doc(action: DocAction, global: &GlobalFlags) -> anyhow::Result<u8> {
@@ -171,520 +21,699 @@ fn run_doc(action: DocAction, global: &GlobalFlags) -> anyhow::Result<u8> {
     )
 }
 
-// -- set ----------------------------------------------------------------
+mod basic {
+    use super::*;
 
-#[test]
-fn set_creates_new_key() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Set {
-        file: path.clone(),
-        selector: "age".into(),
-        value: "42".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["age"], serde_json::json!(42));
-}
+    // -- get ----------------------------------------------------------------
 
-#[test]
-fn set_updates_existing_key() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Set {
-        file: path.clone(),
-        selector: "name".into(),
-        value: "world".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["name"], serde_json::json!("world"));
-}
-
-// -- delete -------------------------------------------------------------
-
-#[test]
-fn delete_removes_key() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello", "age": 42}"#);
-    let action = DocAction::Delete {
-        file: path.clone(),
-        selector: "age".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert!(val.get("age").is_none());
-}
-
-// -- delete-where -------------------------------------------------------
-
-#[test]
-fn delete_where_removes_matching_items() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(
-        &dir,
-        "test.json",
-        r#"{"users": [{"name": "alice"}, {"name": "bob"}, {"name": "carol"}]}"#,
-    );
-    let action = DocAction::DeleteWhere {
-        file: path.clone(),
-        selector: "users".into(),
-        predicate: "name=bob".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    let arr = val["users"].as_array().unwrap();
-    assert_eq!(arr.len(), 2);
-    assert_eq!(arr[0]["name"], serde_json::json!("alice"));
-    assert_eq!(arr[1]["name"], serde_json::json!("carol"));
-}
-
-#[test]
-fn delete_where_no_match_is_idempotent() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(
-        &dir,
-        "test.json",
-        r#"{"users": [{"name": "alice"}, {"name": "bob"}]}"#,
-    );
-    let action = DocAction::DeleteWhere {
-        file: path,
-        selector: "users".into(),
-        predicate: "name=nobody".into(),
-    };
-    let global = GlobalFlags::test_with_cwd(dir.path());
-    // Engine treats delete-where no-match as success (idempotent).
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-#[test]
-fn delete_where_removes_multiple_matches() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(
-        &dir,
-        "test.json",
-        r#"{"items": [{"status": "done"}, {"status": "pending"}, {"status": "done"}]}"#,
-    );
-    let action = DocAction::DeleteWhere {
-        file: path.clone(),
-        selector: "items".into(),
-        predicate: "status=done".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    let arr = val["items"].as_array().unwrap();
-    assert_eq!(arr.len(), 1);
-    assert_eq!(arr[0]["status"], serde_json::json!("pending"));
-}
-
-#[test]
-fn delete_missing_key_is_idempotent() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Delete {
-        file: path,
-        selector: "nonexistent".into(),
-    };
-    let global = GlobalFlags::test_with_cwd(dir.path());
-    // Engine treats delete no-match as success (idempotent).
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-// -- append / prepend ---------------------------------------------------
-
-#[test]
-fn append_adds_to_array() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"items": [1, 2, 3]}"#);
-    let action = DocAction::Append {
-        file: path.clone(),
-        selector: "items".into(),
-        value: "4".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["items"], serde_json::json!([1, 2, 3, 4]));
-}
-
-#[test]
-fn prepend_adds_to_beginning_of_array() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"items": [1, 2, 3]}"#);
-    let action = DocAction::Prepend {
-        file: path.clone(),
-        selector: "items".into(),
-        value: "0".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["items"], serde_json::json!([0, 1, 2, 3]));
-}
-
-// -- merge --------------------------------------------------------------
-
-#[test]
-fn deep_merge_depth_guard_caps_recursion() {
-    use crate::ops::doc::deep_merge;
-    // Build a JSON tree nested 200 levels deep (exceeds MAX_MERGE_DEPTH of 128).
-    // The guard stops recursing at depth 128 and overwrites with the
-    // remaining subtree, preventing stack overflow on adversarial input.
-    let mut base = serde_json::json!(null);
-    let mut other = serde_json::json!({"leaf": true});
-    for _ in 0..200 {
-        other = serde_json::json!({"nested": other});
+    #[test]
+    fn get_returns_value_from_json() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello", "count": 42}"#);
+        let action = DocAction::Get {
+            file: path,
+            selector: "name".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(output, "hello");
     }
-    deep_merge(&mut base, &other);
-    // Verify the result is a valid object (not a crash) and the
-    // top-level structure was preserved.
-    assert!(base.is_object());
-    assert!(
-        base.get("nested").is_some(),
-        "top-level 'nested' key must exist"
-    );
-    // Walk down to verify nesting was preserved (not just top level).
-    let mut cursor = &base;
-    for _ in 0..10 {
-        cursor = cursor
-            .get("nested")
-            .expect("nesting should be at least 10 levels deep");
+
+    #[test]
+    fn get_returns_value_from_yaml() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.yaml", "name: hello\ncount: 42\n");
+        let action = DocAction::Get {
+            file: path,
+            selector: "name".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(output, "hello");
     }
-    assert!(cursor.is_object());
+
+    #[test]
+    fn get_returns_value_from_toml() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.toml", "name = \"hello\"\ncount = 42\n");
+        let action = DocAction::Get {
+            file: path,
+            selector: "name".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(output, "hello");
+    }
+
+    // -- has ----------------------------------------------------------------
+
+    #[test]
+    fn has_returns_true_for_existing_key() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Has {
+            file: path,
+            selector: "name".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(output, "true");
+    }
+
+    #[test]
+    fn has_returns_false_for_missing_key() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Has {
+            file: path,
+            selector: "missing".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(output, "false");
+    }
+
+    // -- keys ---------------------------------------------------------------
+
+    #[test]
+    fn keys_lists_object_keys() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "test.json",
+            r#"{"scripts": {"build": "tsc", "lint": "eslint", "test": "jest"}}"#,
+        );
+        let action = DocAction::Keys {
+            file: path,
+            selector: "scripts".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let keys: Vec<&str> = output.split('\n').collect();
+        assert_eq!(keys.len(), 3);
+        assert!(keys.contains(&"build"));
+        assert!(keys.contains(&"lint"));
+        assert!(keys.contains(&"test"));
+    }
+
+    // -- len ----------------------------------------------------------------
+
+    #[test]
+    fn len_counts_array_elements() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"items": [1, 2, 3, 4, 5]}"#);
+        let action = DocAction::Len {
+            file: path,
+            selector: "items".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(output, "5");
+    }
+
+    // -- parse_value --------------------------------------------------------
+
+    #[test]
+    fn parse_value_bare_string() {
+        assert_eq!(parse_value("hello"), serde_json::json!("hello"));
+    }
+
+    #[test]
+    fn parse_value_integer() {
+        assert_eq!(parse_value("42"), serde_json::json!(42));
+    }
+
+    #[test]
+    fn parse_value_bool() {
+        assert_eq!(parse_value("true"), serde_json::json!(true));
+    }
+
+    #[test]
+    fn parse_value_null() {
+        assert_eq!(parse_value("null"), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn parse_value_json_object() {
+        let v = parse_value(r#"{"a":1}"#);
+        assert_eq!(v, serde_json::json!({"a": 1}));
+    }
+
+    // -- set ----------------------------------------------------------------
+
+    #[test]
+    fn set_creates_new_key() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Set {
+            file: path.clone(),
+            selector: "age".into(),
+            value: "42".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["age"], serde_json::json!(42));
+    }
+
+    #[test]
+    fn set_updates_existing_key() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Set {
+            file: path.clone(),
+            selector: "name".into(),
+            value: "world".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["name"], serde_json::json!("world"));
+    }
+
+    // -- delete -------------------------------------------------------------
+
+    #[test]
+    fn delete_removes_key() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello", "age": 42}"#);
+        let action = DocAction::Delete {
+            file: path.clone(),
+            selector: "age".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert!(val.get("age").is_none());
+    }
+
+    // -- delete-where -------------------------------------------------------
+
+    #[test]
+    fn delete_where_removes_matching_items() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "test.json",
+            r#"{"users": [{"name": "alice"}, {"name": "bob"}, {"name": "carol"}]}"#,
+        );
+        let action = DocAction::DeleteWhere {
+            file: path.clone(),
+            selector: "users".into(),
+            predicate: "name=bob".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let arr = val["users"].as_array().unwrap();
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["name"], serde_json::json!("alice"));
+        assert_eq!(arr[1]["name"], serde_json::json!("carol"));
+    }
+
+    #[test]
+    fn delete_where_removes_multiple_matches() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "test.json",
+            r#"{"items": [{"status": "done"}, {"status": "pending"}, {"status": "done"}]}"#,
+        );
+        let action = DocAction::DeleteWhere {
+            file: path.clone(),
+            selector: "items".into(),
+            predicate: "status=done".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let arr = val["items"].as_array().unwrap();
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["status"], serde_json::json!("pending"));
+    }
+
+    // -- append / prepend ---------------------------------------------------
+
+    #[test]
+    fn append_adds_to_array() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"items": [1, 2, 3]}"#);
+        let action = DocAction::Append {
+            file: path.clone(),
+            selector: "items".into(),
+            value: "4".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["items"], serde_json::json!([1, 2, 3, 4]));
+    }
+
+    #[test]
+    fn prepend_adds_to_beginning_of_array() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"items": [1, 2, 3]}"#);
+        let action = DocAction::Prepend {
+            file: path.clone(),
+            selector: "items".into(),
+            value: "0".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["items"], serde_json::json!([0, 1, 2, 3]));
+    }
+
+    #[test]
+    fn merge_combines_objects() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Merge {
+            file: path.clone(),
+            stdin: false,
+            value: Some(r#"{"age": 42}"#.into()),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["name"], serde_json::json!("hello"));
+        assert_eq!(val["age"], serde_json::json!(42));
+    }
+
+    #[test]
+    fn ensure_creates_missing_key() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Ensure {
+            file: path.clone(),
+            selector: "age".into(),
+            value: "30".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["age"], serde_json::json!(30));
+        assert_eq!(val["name"], serde_json::json!("hello"));
+    }
+
+    // -- move ---------------------------------------------------------------
+
+    #[test]
+    fn move_renames_key() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"old_name": "value"}"#);
+        let action = DocAction::Move {
+            file: path.clone(),
+            from: "old_name".into(),
+            to: "new_name".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["new_name"], serde_json::json!("value"));
+        assert!(val.get("old_name").is_none());
+    }
+
+    // -- apply writes file --------------------------------------------------
+
+    #[test]
+    fn set_with_apply_writes_file() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Set {
+            file: path.clone(),
+            selector: "name".into(),
+            value: "world".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["name"], serde_json::json!("world"));
+    }
+
+    // -- check mode ---------------------------------------------------------
+
+    #[test]
+    fn set_with_check_reports_changes() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Set {
+            file: path,
+            selector: "name".into(),
+            value: "world".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.check = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    #[test]
+    fn diff_detects_added_removed_changed() {
+        let dir = TempDir::new().unwrap();
+        let a = write_file(
+            &dir,
+            "a.json",
+            r#"{"name":"old","version":1,"removed":true}"#,
+        );
+        let b = write_file(
+            &dir,
+            "b.json",
+            r#"{"name":"new","version":1,"added":"yes"}"#,
+        );
+        let action = DocAction::Diff {
+            file_a: a,
+            file_b: b,
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(output.contains("~ name"), "should show changed: {output}");
+        assert!(
+            output.contains("- removed"),
+            "should show removed: {output}"
+        );
+        assert!(output.contains("+ added"), "should show added: {output}");
+        assert!(
+            !output.contains("version"),
+            "unchanged key should not appear: {output}"
+        );
+    }
+
+    #[test]
+    fn len_counts_object_keys() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"a": 1, "b": 2, "c": 3}"#);
+        let action = DocAction::Len {
+            file: path,
+            selector: String::new(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(output, "3");
+    }
+
+    // -- flatten ------------------------------------------------------------
+
+    #[test]
+    fn set_apply_creates_backup_session() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"version": "1.0"}"#);
+        let action = DocAction::Set {
+            file: path.clone(),
+            selector: "version".into(),
+            value: "\"2.0\"".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let backup_dir = dir.path().join(".patchloom/backups");
+        assert!(
+            backup_dir.exists(),
+            "backup directory should exist after doc set --apply"
+        );
+        let sessions: Vec<_> = fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert!(
+            !sessions.is_empty(),
+            "at least one backup session should be created"
+        );
+    }
+
+    #[test]
+    fn flatten_enumerates_leaf_paths() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "test.json",
+            r#"{"a":1,"b":{"c":2,"d":3},"e":[10,20]}"#,
+        );
+        let action = DocAction::Flatten { file: path };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(output.contains("a = 1"), "missing a: {output}");
+        assert!(output.contains("b.c = 2"), "missing b.c: {output}");
+        assert!(output.contains("b.d = 3"), "missing b.d: {output}");
+        assert!(output.contains("e[0] = 10"), "missing e[0]: {output}");
+        assert!(output.contains("e[1] = 20"), "missing e[1]: {output}");
+    }
 }
 
-#[test]
-fn merge_combines_objects() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Merge {
-        file: path.clone(),
-        stdin: false,
-        value: Some(r#"{"age": 42}"#.into()),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["name"], serde_json::json!("hello"));
-    assert_eq!(val["age"], serde_json::json!(42));
+mod edge_cases {
+    use super::*;
+
+    #[test]
+    fn delete_where_no_match_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "test.json",
+            r#"{"users": [{"name": "alice"}, {"name": "bob"}]}"#,
+        );
+        let action = DocAction::DeleteWhere {
+            file: path,
+            selector: "users".into(),
+            predicate: "name=nobody".into(),
+        };
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        // Engine treats delete-where no-match as success (idempotent).
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn delete_missing_key_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Delete {
+            file: path,
+            selector: "nonexistent".into(),
+        };
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        // Engine treats delete no-match as success (idempotent).
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    // -- ensure -------------------------------------------------------------
+
+    #[test]
+    fn ensure_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "original"}"#);
+        // Ensure on an existing key should not overwrite.
+        let action = DocAction::Ensure {
+            file: path.clone(),
+            selector: "name".into(),
+            value: "overwritten".into(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        // Value should remain "original" (not overwritten).
+        let val: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(val["name"], serde_json::json!("original"));
+    }
+
+    #[test]
+    fn diff_identical_files() {
+        let dir = TempDir::new().unwrap();
+        let a = write_file(&dir, "a.json", r#"{"k":1}"#);
+        let b = write_file(&dir, "b.json", r#"{"k":1}"#);
+        let action = DocAction::Diff {
+            file_a: a,
+            file_b: b,
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(output, "identical\n");
+    }
+
+    #[test]
+    fn flatten_includes_empty_arrays() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"tags":[],"name":"foo","items":[1]}"#);
+        let action = DocAction::Flatten { file: path };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["tags"], serde_json::json!([]));
+        assert_eq!(parsed["name"], serde_json::json!("foo"));
+        assert_eq!(parsed["items[0]"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn flatten_includes_empty_objects() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"config":{},"name":"bar"}"#);
+        let action = DocAction::Flatten { file: path };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["config"], serde_json::json!({}));
+        assert_eq!(parsed["name"], serde_json::json!("bar"));
+    }
+
+    #[test]
+    fn flatten_includes_nested_empty_containers() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"a":{"b":[],"c":{}},"d":[1]}"#);
+        let action = DocAction::Flatten { file: path };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["a.b"], serde_json::json!([]));
+        assert_eq!(parsed["a.c"], serde_json::json!({}));
+        assert_eq!(parsed["d[0]"], serde_json::json!(1));
+    }
 }
 
-// -- ensure -------------------------------------------------------------
+mod error_handling {
+    use super::*;
 
-#[test]
-fn ensure_is_idempotent() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "original"}"#);
-    // Ensure on an existing key should not overwrite.
-    let action = DocAction::Ensure {
-        file: path.clone(),
-        selector: "name".into(),
-        value: "overwritten".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    // Value should remain "original" (not overwritten).
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["name"], serde_json::json!("original"));
+    // -- missing selector ---------------------------------------------------
+
+    #[test]
+    fn get_missing_selector_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Get {
+            file: path,
+            selector: "nonexistent".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+        assert!(output.is_empty());
+    }
+
+    // -- error path tests ---------------------------------------------------
+
+    #[test]
+    fn keys_on_scalar_returns_failure() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Keys {
+            file: path,
+            selector: "name".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::FAILURE);
+        assert!(output.contains("not an object"));
+    }
+
+    #[test]
+    fn len_on_scalar_returns_failure() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Len {
+            file: path,
+            selector: "name".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        assert_eq!(code, exit::FAILURE);
+        assert!(output.contains("not an array or object"));
+    }
+
+    #[test]
+    fn append_to_non_array_returns_failure() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Append {
+            file: path,
+            selector: "name".into(),
+            value: "42".into(),
+        };
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
+    }
+
+    #[test]
+    fn prepend_to_non_array_returns_failure() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Prepend {
+            file: path,
+            selector: "name".into(),
+            value: "42".into(),
+        };
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
+    }
 }
 
-#[test]
-fn ensure_creates_missing_key() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Ensure {
-        file: path.clone(),
-        selector: "age".into(),
-        value: "30".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["age"], serde_json::json!(30));
-    assert_eq!(val["name"], serde_json::json!("hello"));
-}
+mod security {
+    #[allow(unused_imports)]
+    use super::*;
 
-// -- move ---------------------------------------------------------------
+    // -- merge --------------------------------------------------------------
 
-#[test]
-fn move_renames_key() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"old_name": "value"}"#);
-    let action = DocAction::Move {
-        file: path.clone(),
-        from: "old_name".into(),
-        to: "new_name".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["new_name"], serde_json::json!("value"));
-    assert!(val.get("old_name").is_none());
-}
-
-// -- apply writes file --------------------------------------------------
-
-#[test]
-fn set_with_apply_writes_file() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Set {
-        file: path.clone(),
-        selector: "name".into(),
-        value: "world".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let val: serde_json::Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
-    assert_eq!(val["name"], serde_json::json!("world"));
-}
-
-// -- check mode ---------------------------------------------------------
-
-#[test]
-fn set_with_check_reports_changes() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Set {
-        file: path,
-        selector: "name".into(),
-        value: "world".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.check = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::CHANGES_DETECTED);
-}
-
-#[test]
-fn diff_detects_added_removed_changed() {
-    let dir = TempDir::new().unwrap();
-    let a = write_file(
-        &dir,
-        "a.json",
-        r#"{"name":"old","version":1,"removed":true}"#,
-    );
-    let b = write_file(
-        &dir,
-        "b.json",
-        r#"{"name":"new","version":1,"added":"yes"}"#,
-    );
-    let action = DocAction::Diff {
-        file_a: a,
-        file_b: b,
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert!(output.contains("~ name"), "should show changed: {output}");
-    assert!(
-        output.contains("- removed"),
-        "should show removed: {output}"
-    );
-    assert!(output.contains("+ added"), "should show added: {output}");
-    assert!(
-        !output.contains("version"),
-        "unchanged key should not appear: {output}"
-    );
-}
-
-#[test]
-fn diff_identical_files() {
-    let dir = TempDir::new().unwrap();
-    let a = write_file(&dir, "a.json", r#"{"k":1}"#);
-    let b = write_file(&dir, "b.json", r#"{"k":1}"#);
-    let action = DocAction::Diff {
-        file_a: a,
-        file_b: b,
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(output, "identical\n");
-}
-
-// -- error path tests ---------------------------------------------------
-
-#[test]
-fn keys_on_scalar_returns_failure() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Keys {
-        file: path,
-        selector: "name".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::FAILURE);
-    assert!(output.contains("not an object"));
-}
-
-#[test]
-fn len_on_scalar_returns_failure() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Len {
-        file: path,
-        selector: "name".into(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::FAILURE);
-    assert!(output.contains("not an array or object"));
-}
-
-#[test]
-fn len_counts_object_keys() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"a": 1, "b": 2, "c": 3}"#);
-    let action = DocAction::Len {
-        file: path,
-        selector: String::new(),
-    };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(output, "3");
-}
-
-#[test]
-fn append_to_non_array_returns_failure() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Append {
-        file: path,
-        selector: "name".into(),
-        value: "42".into(),
-    };
-    let global = GlobalFlags::test_with_cwd(dir.path());
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::FAILURE);
-}
-
-#[test]
-fn prepend_to_non_array_returns_failure() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-    let action = DocAction::Prepend {
-        file: path,
-        selector: "name".into(),
-        value: "42".into(),
-    };
-    let global = GlobalFlags::test_with_cwd(dir.path());
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::FAILURE);
-}
-
-// -- flatten ------------------------------------------------------------
-
-#[test]
-fn set_apply_creates_backup_session() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"version": "1.0"}"#);
-    let action = DocAction::Set {
-        file: path.clone(),
-        selector: "version".into(),
-        value: "\"2.0\"".into(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
-    let code = run_doc(action, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let backup_dir = dir.path().join(".patchloom/backups");
-    assert!(
-        backup_dir.exists(),
-        "backup directory should exist after doc set --apply"
-    );
-    let sessions: Vec<_> = fs::read_dir(&backup_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .collect();
-    assert!(
-        !sessions.is_empty(),
-        "at least one backup session should be created"
-    );
-}
-
-#[test]
-fn flatten_enumerates_leaf_paths() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(
-        &dir,
-        "test.json",
-        r#"{"a":1,"b":{"c":2,"d":3},"e":[10,20]}"#,
-    );
-    let action = DocAction::Flatten { file: path };
-    let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert!(output.contains("a = 1"), "missing a: {output}");
-    assert!(output.contains("b.c = 2"), "missing b.c: {output}");
-    assert!(output.contains("b.d = 3"), "missing b.d: {output}");
-    assert!(output.contains("e[0] = 10"), "missing e[0]: {output}");
-    assert!(output.contains("e[1] = 20"), "missing e[1]: {output}");
-}
-
-#[test]
-fn flatten_includes_empty_arrays() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"tags":[],"name":"foo","items":[1]}"#);
-    let action = DocAction::Flatten { file: path };
-    let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-    assert_eq!(parsed["tags"], serde_json::json!([]));
-    assert_eq!(parsed["name"], serde_json::json!("foo"));
-    assert_eq!(parsed["items[0]"], serde_json::json!(1));
-}
-
-#[test]
-fn flatten_includes_empty_objects() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"config":{},"name":"bar"}"#);
-    let action = DocAction::Flatten { file: path };
-    let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-    assert_eq!(parsed["config"], serde_json::json!({}));
-    assert_eq!(parsed["name"], serde_json::json!("bar"));
-}
-
-#[test]
-fn flatten_includes_nested_empty_containers() {
-    let dir = TempDir::new().unwrap();
-    let path = write_file(&dir, "test.json", r#"{"a":{"b":[],"c":{}},"d":[1]}"#);
-    let action = DocAction::Flatten { file: path };
-    let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-    assert_eq!(parsed["a.b"], serde_json::json!([]));
-    assert_eq!(parsed["a.c"], serde_json::json!({}));
-    assert_eq!(parsed["d[0]"], serde_json::json!(1));
+    #[test]
+    fn deep_merge_depth_guard_caps_recursion() {
+        use crate::ops::doc::deep_merge;
+        // Build a JSON tree nested 200 levels deep (exceeds MAX_MERGE_DEPTH of 128).
+        // The guard stops recursing at depth 128 and overwrites with the
+        // remaining subtree, preventing stack overflow on adversarial input.
+        let mut base = serde_json::json!(null);
+        let mut other = serde_json::json!({"leaf": true});
+        for _ in 0..200 {
+            other = serde_json::json!({"nested": other});
+        }
+        deep_merge(&mut base, &other);
+        // Verify the result is a valid object (not a crash) and the
+        // top-level structure was preserved.
+        assert!(base.is_object());
+        assert!(
+            base.get("nested").is_some(),
+            "top-level 'nested' key must exist"
+        );
+        // Walk down to verify nesting was preserved (not just top level).
+        let mut cursor = &base;
+        for _ in 0..10 {
+            cursor = cursor
+                .get("nested")
+                .expect("nesting should be at least 10 levels deep");
+        }
+        assert!(cursor.is_object());
+    }
 }

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -15,324 +15,6 @@ async fn spawn_test_client(
     ().serve(client_transport).await.unwrap()
 }
 
-#[tokio::test]
-async fn mcp_lists_expected_tools() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-    let tools = client.peer().list_all_tools().await.unwrap();
-    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
-    let descriptions = tools
-        .iter()
-        .map(|t| (t.name.as_ref(), t.description.as_deref().unwrap_or("")))
-        .collect::<std::collections::BTreeMap<_, _>>();
-    assert!(names.contains(&"doc_set"), "missing doc_set tool");
-    assert!(names.contains(&"doc_get"), "missing doc_get tool");
-    assert!(names.contains(&"doc_query"), "missing doc_query tool");
-    assert!(names.contains(&"doc_diff"), "missing doc_diff tool");
-    assert!(names.contains(&"read_file"), "missing read_file tool");
-    assert!(names.contains(&"search_files"), "missing search_files tool");
-    assert_eq!(
-        descriptions.get("search_files"),
-        Some(
-            &"Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for Bline parity: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .blineignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".blineignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
-        ),
-        "search_files description drifted"
-    );
-    assert!(names.contains(&"git_status"), "missing git_status tool");
-    assert!(names.contains(&"replace_text"), "missing replace_text tool");
-    assert_eq!(
-        descriptions.get("replace_text"),
-        Some(
-            &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
-        ),
-        "replace_text description drifted"
-    );
-    assert!(
-        names.contains(&"fix_whitespace"),
-        "missing fix_whitespace tool"
-    );
-    assert_eq!(
-        descriptions.get("fix_whitespace"),
-        Some(
-            &"Fix whitespace in a file: trims trailing spaces and ensures final newline. Safe to call on any file (no-op if already clean). Example: {\"path\": \"dirty.txt\"}"
-        ),
-        "fix_whitespace description drifted"
-    );
-    assert!(names.contains(&"move_file"), "missing move_file tool");
-    assert!(names.contains(&"create_file"), "missing create_file tool");
-    assert!(names.contains(&"delete_file"), "missing delete_file tool");
-    assert!(names.contains(&"apply_patch"), "missing apply_patch tool");
-    assert!(
-        names.contains(&"batch_replace"),
-        "missing batch_replace tool"
-    );
-    assert!(names.contains(&"batch_tidy"), "missing batch_tidy tool");
-    assert!(names.contains(&"execute_plan"), "missing execute_plan tool");
-    assert!(
-        names.contains(&"md_insert_after_heading"),
-        "missing md_insert_after_heading tool"
-    );
-    assert!(
-        names.contains(&"md_insert_before_heading"),
-        "missing md_insert_before_heading tool"
-    );
-    assert!(
-        names.contains(&"md_move_section"),
-        "missing md_move_section tool"
-    );
-    assert!(names.contains(&"append_file"), "missing append_file tool");
-    // 32 base tools + 11 AST tools = 43
-    assert_eq!(names.len(), 43, "expected 43 tools, got {}", names.len());
-    client.cancel().await.unwrap();
-}
-
-#[test]
-fn mcp_search_params_accept_new_bline_ignore_fields() {
-    // Ensures schemars/serde accept the new fields added for #821 parity.
-    let json = r#"{
-        "pattern": "TODO",
-        "paths": ["src/"],
-        "globs": ["*.rs"],
-        "exclude_patterns": ["target/**"],
-        "custom_ignore_filenames": [".blineignore"],
-        "max_results": 10,
-        "literal": true
-    }"#;
-    let p: SearchParams =
-        serde_json::from_str(json).expect("SearchParams deserial with new ignore/max fields");
-    assert_eq!(p.globs.len(), 1);
-    assert_eq!(p.max_results, 10);
-}
-
-#[tokio::test]
-async fn mcp_server_info_has_correct_name() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-    let info = client.peer_info().expect("peer info should be set");
-    assert_eq!(info.server_info.name, "patchloom");
-    client.cancel().await.unwrap();
-}
-
-#[tokio::test]
-async fn mcp_path_traversal_rejected_via_protocol() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-    let params = rmcp::model::CallToolRequestParams::new("doc_set").with_arguments(
-        serde_json::from_value(serde_json::json!({
-            "path": "../../etc/passwd",
-            "selector": "root",
-            "value": "hacked"
-        }))
-        .unwrap(),
-    );
-    let result = client.peer().call_tool(params).await;
-    assert!(result.is_err(), "path traversal should be rejected");
-    client.cancel().await.unwrap();
-}
-
-#[test]
-fn patch_apply_path_containment_validation() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let evil_diff =
-        "--- a/../../etc/passwd\n+++ b/../../etc/passwd\n@@ -1,1 +1,1 @@\n-root\n+hacked\n";
-    let ops = vec![Operation::PatchApply {
-        diff: evil_diff.to_string(),
-        on_stale: crate::ops::patch::OnStale::Fail,
-        allow_conflicts: false,
-    }];
-    let result = validate_operation_paths(&ops, dir.path());
-    assert!(
-        result.is_err(),
-        "PatchApply with escaping paths should be rejected"
-    );
-}
-
-#[test]
-fn patch_apply_safe_paths_pass_containment() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let safe_diff = "--- a/src/main.rs\n+++ b/src/main.rs\n@@ -1,1 +1,1 @@\n-old\n+new\n";
-    let ops = vec![Operation::PatchApply {
-        diff: safe_diff.to_string(),
-        on_stale: crate::ops::patch::OnStale::Fail,
-        allow_conflicts: false,
-    }];
-    let result = validate_operation_paths(&ops, dir.path());
-    assert!(result.is_ok(), "PatchApply with safe paths should pass");
-}
-
-#[tokio::test]
-async fn mcp_example_argument_keys_match_schemas() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-    let tools = client.peer().list_all_tools().await.unwrap();
-
-    // Build map of tool_name -> set of valid property keys from schemas
-    let mut schema_keys: std::collections::HashMap<String, std::collections::HashSet<String>> =
-        std::collections::HashMap::new();
-    for tool in &tools {
-        if let Some(props) = tool
-            .input_schema
-            .get("properties")
-            .and_then(|p| p.as_object())
-        {
-            schema_keys.insert(tool.name.to_string(), props.keys().cloned().collect());
-        }
-    }
-
-    // Read and validate the example file
-    let example_path =
-        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/08-mcp-tool-call.json");
-    let example_content = std::fs::read_to_string(&example_path)
-        .expect("failed to read examples/08-mcp-tool-call.json");
-    let example_json: serde_json::Value = serde_json::from_str(&example_content)
-        .expect("failed to parse examples/08-mcp-tool-call.json");
-
-    let examples = example_json["examples"]
-        .as_array()
-        .expect("examples should be an array");
-
-    let mut errors = Vec::new();
-    for entry in examples {
-        let tool_name = entry["tool"].as_str().expect("tool should be a string");
-        let arguments = entry["arguments"]
-            .as_object()
-            .expect("arguments should be an object");
-
-        if let Some(valid_keys) = schema_keys.get(tool_name) {
-            for key in arguments.keys() {
-                if !valid_keys.contains(key) {
-                    errors.push(format!(
-                        "tool '{}': unknown argument '{}' (valid: {:?})",
-                        tool_name, key, valid_keys
-                    ));
-                }
-            }
-        } else {
-            errors.push(format!("tool '{}': not found in MCP tool list", tool_name));
-        }
-    }
-
-    assert!(
-        errors.is_empty(),
-        "MCP example validation errors:\n{}",
-        errors.join("\n")
-    );
-    client.cancel().await.unwrap();
-}
-
-/// Verify field drift between hand-written MCP params structs and Operation variants.
-///
-/// Auto-generated tools (registered via MCP_TOOL_REGISTRY) are drift-proof by
-/// construction since they use the Operation variant's schema directly. This test
-/// only covers hand-written handlers that maintain their own params structs.
-#[test]
-fn mcp_params_fields_match_operation_variants() {
-    use crate::schema::operation_variant_schema;
-
-    fn schema_keys_for<T: schemars::JsonSchema>() -> std::collections::BTreeSet<String> {
-        let generator = schemars::generate::SchemaSettings::default().into_generator();
-        let root = generator.into_root_schema_for::<T>();
-        let v = serde_json::to_value(root).unwrap();
-        v.get("properties")
-            .and_then(|p| p.as_object())
-            .map(|o| o.keys().cloned().collect())
-            .unwrap_or_default()
-    }
-
-    fn op_schema_keys(op_name: &str) -> std::collections::BTreeSet<String> {
-        let schema = operation_variant_schema(op_name);
-        schema
-            .get("properties")
-            .and_then(|p| p.as_object())
-            .map(|o| o.keys().cloned().collect())
-            .unwrap_or_default()
-    }
-
-    struct Check {
-        op_name: &'static str,
-        mcp_keys: std::collections::BTreeSet<String>,
-        mcp_only_allowed: &'static [&'static str],
-        op_only_allowed: &'static [&'static str],
-    }
-
-    // Only hand-written handlers need drift checking.
-    let checks = vec![
-        Check {
-            op_name: "replace",
-            mcp_keys: schema_keys_for::<ReplaceParams>(),
-            mcp_only_allowed: &["strict", "regex"],
-            op_only_allowed: &["glob", "mode"],
-        },
-        Check {
-            op_name: "tidy.fix",
-            mcp_keys: schema_keys_for::<TidyParams>(),
-            mcp_only_allowed: &[],
-            op_only_allowed: &[
-                "ensure_final_newline",
-                "trim_trailing_whitespace",
-                "normalize_eol",
-            ],
-        },
-        Check {
-            op_name: "patch.apply",
-            mcp_keys: schema_keys_for::<PatchParams>(),
-            mcp_only_allowed: &["strict"],
-            op_only_allowed: &[],
-        },
-        Check {
-            op_name: "md.move_section",
-            mcp_keys: schema_keys_for::<MdMoveSectionParams>(),
-            mcp_only_allowed: &[],
-            op_only_allowed: &[],
-        },
-        Check {
-            op_name: "md.lint_agents",
-            mcp_keys: schema_keys_for::<MdLintAgentsParams>(),
-            mcp_only_allowed: &[],
-            op_only_allowed: &[],
-        },
-        Check {
-            op_name: "search",
-            mcp_keys: schema_keys_for::<SearchParams>(),
-            mcp_only_allowed: &["paths", "files_with_matches", "count", "literal"],
-            op_only_allowed: &["path", "regex"],
-        },
-    ];
-
-    let mut errors = Vec::new();
-    for check in &checks {
-        let op_keys = op_schema_keys(check.op_name);
-        let mcp_only_allowed: std::collections::BTreeSet<&str> =
-            check.mcp_only_allowed.iter().copied().collect();
-        let op_only_allowed: std::collections::BTreeSet<&str> =
-            check.op_only_allowed.iter().copied().collect();
-
-        for key in &check.mcp_keys {
-            if !op_keys.contains(key) && !mcp_only_allowed.contains(key.as_str()) {
-                errors.push(format!(
-                    "{}: MCP param '{}' not in Operation (add to op_only_allowed if intentional)",
-                    check.op_name, key
-                ));
-            }
-        }
-
-        for key in &op_keys {
-            if !check.mcp_keys.contains(key) && !op_only_allowed.contains(key.as_str()) {
-                errors.push(format!(
-                    "{}: Operation field '{}' not in MCP params (add to mcp_only_allowed if intentional)",
-                    check.op_name, key
-                ));
-            }
-        }
-    }
-
-    assert!(
-        errors.is_empty(),
-        "MCP params / Operation field drift detected:\n  {}",
-        errors.join("\n  ")
-    );
-}
-
 // Path containment unit tests (validate_path_contained, validate_path_resolved)
 // have been moved to crate::containment::tests. The MCP-level integration test
 // `mcp_path_traversal_rejected_via_protocol` above verifies the end-to-end
@@ -353,305 +35,637 @@ async fn spawn_test_client_with_log(
     ().serve(client_transport).await.unwrap()
 }
 
-#[tokio::test]
-async fn mcp_log_writes_jsonl_on_tool_call() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let log_file = dir.path().join("mcp.log");
-    std::fs::write(dir.path().join("test.txt"), "hello world").unwrap();
-    let client = spawn_test_client_with_log(dir.path().to_path_buf(), log_file.clone()).await;
+mod basic {
+    use super::*;
 
-    // Call read_file to trigger a log entry.
-    let params = rmcp::model::CallToolRequestParams::new("read_file").with_arguments(
-        serde_json::from_value(serde_json::json!({
-            "path": "test.txt",
-        }))
-        .unwrap(),
-    );
-    let result = client.peer().call_tool(params).await.unwrap();
-    assert!(
-        result.is_error != Some(true),
-        "read_file should succeed: {result:?}"
-    );
-    client.cancel().await.unwrap();
-
-    // Verify the log file contains a valid JSONL entry.
-    let log_content = std::fs::read_to_string(&log_file).expect("log file should exist");
-    let lines: Vec<&str> = log_content.trim().lines().collect();
-    assert_eq!(lines.len(), 1, "expected exactly 1 log line");
-    let entry: serde_json::Value =
-        serde_json::from_str(lines[0]).expect("log line should be valid JSON");
-    assert_eq!(entry["tool"], "read_file");
-    assert_eq!(entry["ok"], true);
-    assert!(entry["ts"].is_number(), "ts should be a number");
-    assert!(
-        entry["duration_ms"].is_number(),
-        "duration_ms should be a number"
-    );
-}
-
-#[tokio::test]
-async fn mcp_log_records_error_on_failure() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let log_file = dir.path().join("mcp.log");
-    let client = spawn_test_client_with_log(dir.path().to_path_buf(), log_file.clone()).await;
-
-    // Call doc_set on a non-existent file to trigger an error result.
-    let params = rmcp::model::CallToolRequestParams::new("doc_set").with_arguments(
-        serde_json::from_value(serde_json::json!({
-            "path": "nonexistent.json",
-            "selector": "key",
-            "value": "val",
-        }))
-        .unwrap(),
-    );
-    let _result = client.peer().call_tool(params).await;
-    client.cancel().await.unwrap();
-
-    let log_content = std::fs::read_to_string(&log_file).expect("log file should exist");
-    let lines: Vec<&str> = log_content.trim().lines().collect();
-    assert_eq!(lines.len(), 1, "expected exactly 1 log line");
-    let entry: serde_json::Value =
-        serde_json::from_str(lines[0]).expect("log line should be valid JSON");
-    assert_eq!(entry["tool"], "doc_set");
-    assert_eq!(entry["ok"], false);
-}
-
-#[test]
-fn validate_content_size_accepts_small() {
-    validate_content_size("field", "hello").unwrap();
-}
-
-#[test]
-fn validate_content_size_rejects_oversized() {
-    let big = "x".repeat(MAX_CONTENT_BYTES + 1);
-    let err = validate_content_size("content", &big).unwrap_err();
-    let msg = format!("{err}");
-    assert!(msg.contains("content"), "error should name the field");
-    assert!(msg.contains("exceeds"), "error should say exceeds");
-}
-
-#[test]
-fn validate_param_size_accepts_small() {
-    validate_param_size("selector", "a.b.c").unwrap();
-}
-
-#[test]
-fn validate_param_size_rejects_oversized() {
-    let big = "x".repeat(MAX_PARAM_BYTES + 1);
-    let err = validate_param_size("pattern", &big).unwrap_err();
-    let msg = format!("{err}");
-    assert!(msg.contains("pattern"), "error should name the field");
-}
-
-#[test]
-fn validate_batch_size_accepts_small() {
-    validate_batch_size("files", 5).unwrap();
-}
-
-#[test]
-fn validate_batch_size_rejects_oversized() {
-    let err = validate_batch_size("files", MAX_BATCH_FILES + 1).unwrap_err();
-    let msg = format!("{err}");
-    assert!(msg.contains("files"), "error should name the field");
-}
-
-#[test]
-fn validate_json_depth_accepts_shallow() {
-    let val = serde_json::json!({"a": {"b": "c"}});
-    validate_json_depth("value", &val).unwrap();
-}
-
-#[test]
-fn validate_json_depth_accepts_scalar() {
-    let val = serde_json::json!("hello");
-    validate_json_depth("value", &val).unwrap();
-}
-
-#[test]
-fn validate_json_depth_rejects_deeply_nested() {
-    // Build a value nested deeper than MAX_JSON_DEPTH.
-    let mut val = serde_json::json!("leaf");
-    for _ in 0..MAX_JSON_DEPTH + 1 {
-        val = serde_json::json!([val]);
+    #[tokio::test]
+    async fn mcp_lists_expected_tools() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let tools = client.peer().list_all_tools().await.unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        let descriptions = tools
+            .iter()
+            .map(|t| (t.name.as_ref(), t.description.as_deref().unwrap_or("")))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert!(names.contains(&"doc_set"), "missing doc_set tool");
+        assert!(names.contains(&"doc_get"), "missing doc_get tool");
+        assert!(names.contains(&"doc_query"), "missing doc_query tool");
+        assert!(names.contains(&"doc_diff"), "missing doc_diff tool");
+        assert!(names.contains(&"read_file"), "missing read_file tool");
+        assert!(names.contains(&"search_files"), "missing search_files tool");
+        assert_eq!(
+            descriptions.get("search_files"),
+            Some(
+                &"Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for Bline parity: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .blineignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".blineignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
+            ),
+            "search_files description drifted"
+        );
+        assert!(names.contains(&"git_status"), "missing git_status tool");
+        assert!(names.contains(&"replace_text"), "missing replace_text tool");
+        assert_eq!(
+            descriptions.get("replace_text"),
+            Some(
+                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with to=\"\" to delete lines). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"README.md\", \"from\": \"1.0.0\", \"to\": \"2.0.0\"}"
+            ),
+            "replace_text description drifted"
+        );
+        assert!(
+            names.contains(&"fix_whitespace"),
+            "missing fix_whitespace tool"
+        );
+        assert_eq!(
+            descriptions.get("fix_whitespace"),
+            Some(
+                &"Fix whitespace in a file: trims trailing spaces and ensures final newline. Safe to call on any file (no-op if already clean). Example: {\"path\": \"dirty.txt\"}"
+            ),
+            "fix_whitespace description drifted"
+        );
+        assert!(names.contains(&"move_file"), "missing move_file tool");
+        assert!(names.contains(&"create_file"), "missing create_file tool");
+        assert!(names.contains(&"delete_file"), "missing delete_file tool");
+        assert!(names.contains(&"apply_patch"), "missing apply_patch tool");
+        assert!(
+            names.contains(&"batch_replace"),
+            "missing batch_replace tool"
+        );
+        assert!(names.contains(&"batch_tidy"), "missing batch_tidy tool");
+        assert!(names.contains(&"execute_plan"), "missing execute_plan tool");
+        assert!(
+            names.contains(&"md_insert_after_heading"),
+            "missing md_insert_after_heading tool"
+        );
+        assert!(
+            names.contains(&"md_insert_before_heading"),
+            "missing md_insert_before_heading tool"
+        );
+        assert!(
+            names.contains(&"md_move_section"),
+            "missing md_move_section tool"
+        );
+        assert!(names.contains(&"append_file"), "missing append_file tool");
+        // 32 base tools + 11 AST tools = 43
+        assert_eq!(names.len(), 43, "expected 43 tools, got {}", names.len());
+        client.cancel().await.unwrap();
     }
-    let err = validate_json_depth("value", &val).unwrap_err();
-    let msg = format!("{err}");
-    assert!(msg.contains("nesting depth"), "error should mention depth");
-}
 
-#[tokio::test]
-async fn mcp_rejects_oversized_content_via_protocol() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-    let big_content = "x".repeat(MAX_CONTENT_BYTES + 1);
-    let params = rmcp::model::CallToolRequestParams::new("create_file").with_arguments(
-        serde_json::from_value(serde_json::json!({
-            "path": "big.txt",
-            "content": big_content,
-        }))
-        .unwrap(),
-    );
-    let result = client.peer().call_tool(params).await;
-    assert!(result.is_err(), "oversized content should be rejected");
-    client.cancel().await.unwrap();
-}
+    #[test]
+    fn mcp_search_params_accept_new_bline_ignore_fields() {
+        // Ensures schemars/serde accept the new fields added for #821 parity.
+        let json = r#"{
+            "pattern": "TODO",
+            "paths": ["src/"],
+            "globs": ["*.rs"],
+            "exclude_patterns": ["target/**"],
+            "custom_ignore_filenames": [".blineignore"],
+            "max_results": 10,
+            "literal": true
+        }"#;
+        let p: SearchParams =
+            serde_json::from_str(json).expect("SearchParams deserial with new ignore/max fields");
+        assert_eq!(p.globs.len(), 1);
+        assert_eq!(p.max_results, 10);
+    }
 
-#[tokio::test]
-async fn mcp_rejects_oversized_batch() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-    let files: Vec<String> = (0..MAX_BATCH_FILES + 1)
-        .map(|i| format!("file{i}.txt"))
-        .collect();
-    let params = rmcp::model::CallToolRequestParams::new("batch_tidy").with_arguments(
-        serde_json::from_value(serde_json::json!({
-            "files": files,
-        }))
-        .unwrap(),
-    );
-    let result = client.peer().call_tool(params).await;
-    assert!(result.is_err(), "oversized batch should be rejected");
-    client.cancel().await.unwrap();
-}
+    #[tokio::test]
+    async fn mcp_server_info_has_correct_name() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let info = client.peer_info().expect("peer info should be set");
+        assert_eq!(info.server_info.name, "patchloom");
+        client.cancel().await.unwrap();
+    }
 
-#[tokio::test]
-async fn mcp_rejects_oversized_doc_query_selector() {
-    let dir = tempfile::TempDir::new().unwrap();
-    std::fs::write(dir.path().join("data.json"), r#"{"a":1}"#).unwrap();
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-    let big_selector = "x".repeat(MAX_PARAM_BYTES + 1);
-    let params = rmcp::model::CallToolRequestParams::new("doc_query").with_arguments(
-        serde_json::from_value(serde_json::json!({
-            "action": "has",
-            "path": "data.json",
-            "selector": big_selector,
-        }))
-        .unwrap(),
-    );
-    let result = client.peer().call_tool(params).await;
-    assert!(result.is_err(), "oversized selector should be rejected");
-    client.cancel().await.unwrap();
-}
+    #[tokio::test]
+    async fn mcp_example_argument_keys_match_schemas() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let tools = client.peer().list_all_tools().await.unwrap();
 
-#[tokio::test]
-async fn mcp_no_log_without_flag() {
-    let dir = tempfile::TempDir::new().unwrap();
-    let log_file = dir.path().join("mcp.log");
-    std::fs::write(dir.path().join("test.txt"), "hello").unwrap();
-    // Use default client (no log flag).
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-
-    let params = rmcp::model::CallToolRequestParams::new("read_file").with_arguments(
-        serde_json::from_value(serde_json::json!({
-            "path": "test.txt",
-        }))
-        .unwrap(),
-    );
-    let _result = client.peer().call_tool(params).await.unwrap();
-    client.cancel().await.unwrap();
-
-    // Log file should not exist since no log path was configured.
-    assert!(
-        !log_file.exists(),
-        "log file should not exist without --log"
-    );
-}
-
-#[tokio::test]
-async fn mcp_execute_plan_mixed_ops_atomic() {
-    // Test the new execute_plan tool with a mixed plan (doc + replace + create).
-    // This is the core of #827: one call for atomic multi-op instead of many parallel/serial.
-    let dir = tempfile::TempDir::new().unwrap();
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
-
-    // Prepare initial file
-    std::fs::write(dir.path().join("package.json"), r#"{"version":"1.0.0"}"#).unwrap();
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "strict": true,
-        "operations": [
+        // Build map of tool_name -> set of valid property keys from schemas
+        let mut schema_keys: std::collections::HashMap<String, std::collections::HashSet<String>> =
+            std::collections::HashMap::new();
+        for tool in &tools {
+            if let Some(props) = tool
+                .input_schema
+                .get("properties")
+                .and_then(|p| p.as_object())
             {
-                "op": "doc.set",
-                "path": "package.json",
-                "selector": "version",
-                "value": "2.0.0"
-            },
-            {
-                "op": "replace",
-                "path": "package.json",
-                "from": "2.0.0",
-                "to": "2.1.0"
-            },
-            {
-                "op": "file.create",
-                "path": "CREATED.md",
-                "content": "# Created via plan\n"
+                schema_keys.insert(tool.name.to_string(), props.keys().cloned().collect());
             }
-        ]
-    });
+        }
 
-    let params = rmcp::model::CallToolRequestParams::new("execute_plan")
-        .with_arguments(serde_json::from_value(serde_json::json!({ "plan": plan_json })).unwrap());
+        // Read and validate the example file
+        let example_path =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/08-mcp-tool-call.json");
+        let example_content = std::fs::read_to_string(&example_path)
+            .expect("failed to read examples/08-mcp-tool-call.json");
+        let example_json: serde_json::Value = serde_json::from_str(&example_content)
+            .expect("failed to parse examples/08-mcp-tool-call.json");
 
-    let result = client.peer().call_tool(params).await.unwrap();
-    assert!(
-        !result.is_error.unwrap_or(false),
-        "execute_plan should succeed: {:?}",
-        result
-    );
+        let examples = example_json["examples"]
+            .as_array()
+            .expect("examples should be an array");
 
-    // Verify results
-    let pkg = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
-    assert!(
-        pkg.contains("2.1.0"),
-        "doc.set + replace should have updated to 2.1.0"
-    );
+        let mut errors = Vec::new();
+        for entry in examples {
+            let tool_name = entry["tool"].as_str().expect("tool should be a string");
+            let arguments = entry["arguments"]
+                .as_object()
+                .expect("arguments should be an object");
 
-    let created = std::fs::read_to_string(dir.path().join("CREATED.md")).unwrap();
-    assert!(created.contains("Created via plan"));
+            if let Some(valid_keys) = schema_keys.get(tool_name) {
+                for key in arguments.keys() {
+                    if !valid_keys.contains(key) {
+                        errors.push(format!(
+                            "tool '{}': unknown argument '{}' (valid: {:?})",
+                            tool_name, key, valid_keys
+                        ));
+                    }
+                }
+            } else {
+                errors.push(format!("tool '{}': not found in MCP tool list", tool_name));
+            }
+        }
 
-    client.cancel().await.unwrap();
+        assert!(
+            errors.is_empty(),
+            "MCP example validation errors:\n{}",
+            errors.join("\n")
+        );
+        client.cancel().await.unwrap();
+    }
+
+    /// Verify field drift between hand-written MCP params structs and Operation variants.
+    ///
+    /// Auto-generated tools (registered via MCP_TOOL_REGISTRY) are drift-proof by
+    /// construction since they use the Operation variant's schema directly. This test
+    /// only covers hand-written handlers that maintain their own params structs.
+    #[test]
+    fn mcp_params_fields_match_operation_variants() {
+        use crate::schema::operation_variant_schema;
+
+        fn schema_keys_for<T: schemars::JsonSchema>() -> std::collections::BTreeSet<String> {
+            let generator = schemars::generate::SchemaSettings::default().into_generator();
+            let root = generator.into_root_schema_for::<T>();
+            let v = serde_json::to_value(root).unwrap();
+            v.get("properties")
+                .and_then(|p| p.as_object())
+                .map(|o| o.keys().cloned().collect())
+                .unwrap_or_default()
+        }
+
+        fn op_schema_keys(op_name: &str) -> std::collections::BTreeSet<String> {
+            let schema = operation_variant_schema(op_name);
+            schema
+                .get("properties")
+                .and_then(|p| p.as_object())
+                .map(|o| o.keys().cloned().collect())
+                .unwrap_or_default()
+        }
+
+        struct Check {
+            op_name: &'static str,
+            mcp_keys: std::collections::BTreeSet<String>,
+            mcp_only_allowed: &'static [&'static str],
+            op_only_allowed: &'static [&'static str],
+        }
+
+        // Only hand-written handlers need drift checking.
+        let checks = vec![
+            Check {
+                op_name: "replace",
+                mcp_keys: schema_keys_for::<ReplaceParams>(),
+                mcp_only_allowed: &["strict", "regex"],
+                op_only_allowed: &["glob", "mode"],
+            },
+            Check {
+                op_name: "tidy.fix",
+                mcp_keys: schema_keys_for::<TidyParams>(),
+                mcp_only_allowed: &[],
+                op_only_allowed: &[
+                    "ensure_final_newline",
+                    "trim_trailing_whitespace",
+                    "normalize_eol",
+                ],
+            },
+            Check {
+                op_name: "patch.apply",
+                mcp_keys: schema_keys_for::<PatchParams>(),
+                mcp_only_allowed: &["strict"],
+                op_only_allowed: &[],
+            },
+            Check {
+                op_name: "md.move_section",
+                mcp_keys: schema_keys_for::<MdMoveSectionParams>(),
+                mcp_only_allowed: &[],
+                op_only_allowed: &[],
+            },
+            Check {
+                op_name: "md.lint_agents",
+                mcp_keys: schema_keys_for::<MdLintAgentsParams>(),
+                mcp_only_allowed: &[],
+                op_only_allowed: &[],
+            },
+            Check {
+                op_name: "search",
+                mcp_keys: schema_keys_for::<SearchParams>(),
+                mcp_only_allowed: &["paths", "files_with_matches", "count", "literal"],
+                op_only_allowed: &["path", "regex"],
+            },
+        ];
+
+        let mut errors = Vec::new();
+        for check in &checks {
+            let op_keys = op_schema_keys(check.op_name);
+            let mcp_only_allowed: std::collections::BTreeSet<&str> =
+                check.mcp_only_allowed.iter().copied().collect();
+            let op_only_allowed: std::collections::BTreeSet<&str> =
+                check.op_only_allowed.iter().copied().collect();
+
+            for key in &check.mcp_keys {
+                if !op_keys.contains(key) && !mcp_only_allowed.contains(key.as_str()) {
+                    errors.push(format!(
+                        "{}: MCP param '{}' not in Operation (add to op_only_allowed if intentional)",
+                        check.op_name, key
+                    ));
+                }
+            }
+
+            for key in &op_keys {
+                if !check.mcp_keys.contains(key) && !op_only_allowed.contains(key.as_str()) {
+                    errors.push(format!(
+                        "{}: Operation field '{}' not in MCP params (add to mcp_only_allowed if intentional)",
+                        check.op_name, key
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            errors.is_empty(),
+            "MCP params / Operation field drift detected:\n  {}",
+            errors.join("\n  ")
+        );
+    }
+
+    #[test]
+    fn patch_apply_safe_paths_pass_containment() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let safe_diff = "--- a/src/main.rs\n+++ b/src/main.rs\n@@ -1,1 +1,1 @@\n-old\n+new\n";
+        let ops = vec![Operation::PatchApply {
+            diff: safe_diff.to_string(),
+            on_stale: crate::ops::patch::OnStale::Fail,
+            allow_conflicts: false,
+        }];
+        let result = validate_operation_paths(&ops, dir.path());
+        assert!(result.is_ok(), "PatchApply with safe paths should pass");
+    }
+
+    #[tokio::test]
+    async fn mcp_log_writes_jsonl_on_tool_call() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let log_file = dir.path().join("mcp.log");
+        std::fs::write(dir.path().join("test.txt"), "hello world").unwrap();
+        let client = spawn_test_client_with_log(dir.path().to_path_buf(), log_file.clone()).await;
+
+        // Call read_file to trigger a log entry.
+        let params = rmcp::model::CallToolRequestParams::new("read_file").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "path": "test.txt",
+            }))
+            .unwrap(),
+        );
+        let result = client.peer().call_tool(params).await.unwrap();
+        assert!(
+            result.is_error != Some(true),
+            "read_file should succeed: {result:?}"
+        );
+        client.cancel().await.unwrap();
+
+        // Verify the log file contains a valid JSONL entry.
+        let log_content = std::fs::read_to_string(&log_file).expect("log file should exist");
+        let lines: Vec<&str> = log_content.trim().lines().collect();
+        assert_eq!(lines.len(), 1, "expected exactly 1 log line");
+        let entry: serde_json::Value =
+            serde_json::from_str(lines[0]).expect("log line should be valid JSON");
+        assert_eq!(entry["tool"], "read_file");
+        assert_eq!(entry["ok"], true);
+        assert!(entry["ts"].is_number(), "ts should be a number");
+        assert!(
+            entry["duration_ms"].is_number(),
+            "duration_ms should be a number"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_log_records_error_on_failure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let log_file = dir.path().join("mcp.log");
+        let client = spawn_test_client_with_log(dir.path().to_path_buf(), log_file.clone()).await;
+
+        // Call doc_set on a non-existent file to trigger an error result.
+        let params = rmcp::model::CallToolRequestParams::new("doc_set").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "path": "nonexistent.json",
+                "selector": "key",
+                "value": "val",
+            }))
+            .unwrap(),
+        );
+        let _result = client.peer().call_tool(params).await;
+        client.cancel().await.unwrap();
+
+        let log_content = std::fs::read_to_string(&log_file).expect("log file should exist");
+        let lines: Vec<&str> = log_content.trim().lines().collect();
+        assert_eq!(lines.len(), 1, "expected exactly 1 log line");
+        let entry: serde_json::Value =
+            serde_json::from_str(lines[0]).expect("log line should be valid JSON");
+        assert_eq!(entry["tool"], "doc_set");
+        assert_eq!(entry["ok"], false);
+    }
+
+    #[test]
+    fn validate_content_size_accepts_small() {
+        validate_content_size("field", "hello").unwrap();
+    }
+
+    #[test]
+    fn validate_param_size_accepts_small() {
+        validate_param_size("selector", "a.b.c").unwrap();
+    }
+
+    #[test]
+    fn validate_batch_size_accepts_small() {
+        validate_batch_size("files", 5).unwrap();
+    }
+
+    #[test]
+    fn validate_json_depth_accepts_shallow() {
+        let val = serde_json::json!({"a": {"b": "c"}});
+        validate_json_depth("value", &val).unwrap();
+    }
+
+    #[test]
+    fn validate_json_depth_accepts_scalar() {
+        let val = serde_json::json!("hello");
+        validate_json_depth("value", &val).unwrap();
+    }
+
+    #[tokio::test]
+    async fn mcp_no_log_without_flag() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let log_file = dir.path().join("mcp.log");
+        std::fs::write(dir.path().join("test.txt"), "hello").unwrap();
+        // Use default client (no log flag).
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+
+        let params = rmcp::model::CallToolRequestParams::new("read_file").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "path": "test.txt",
+            }))
+            .unwrap(),
+        );
+        let _result = client.peer().call_tool(params).await.unwrap();
+        client.cancel().await.unwrap();
+
+        // Log file should not exist since no log path was configured.
+        assert!(
+            !log_file.exists(),
+            "log file should not exist without --log"
+        );
+    }
+
+    #[tokio::test]
+    async fn mcp_execute_plan_mixed_ops_atomic() {
+        // Test the new execute_plan tool with a mixed plan (doc + replace + create).
+        // This is the core of #827: one call for atomic multi-op instead of many parallel/serial.
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+
+        // Prepare initial file
+        std::fs::write(dir.path().join("package.json"), r#"{"version":"1.0.0"}"#).unwrap();
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "strict": true,
+            "operations": [
+                {
+                    "op": "doc.set",
+                    "path": "package.json",
+                    "selector": "version",
+                    "value": "2.0.0"
+                },
+                {
+                    "op": "replace",
+                    "path": "package.json",
+                    "from": "2.0.0",
+                    "to": "2.1.0"
+                },
+                {
+                    "op": "file.create",
+                    "path": "CREATED.md",
+                    "content": "# Created via plan\n"
+                }
+            ]
+        });
+
+        let params = rmcp::model::CallToolRequestParams::new("execute_plan").with_arguments(
+            serde_json::from_value(serde_json::json!({ "plan": plan_json })).unwrap(),
+        );
+
+        let result = client.peer().call_tool(params).await.unwrap();
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "execute_plan should succeed: {:?}",
+            result
+        );
+
+        // Verify results
+        let pkg = std::fs::read_to_string(dir.path().join("package.json")).unwrap();
+        assert!(
+            pkg.contains("2.1.0"),
+            "doc.set + replace should have updated to 2.1.0"
+        );
+
+        let created = std::fs::read_to_string(dir.path().join("CREATED.md")).unwrap();
+        assert!(created.contains("Created via plan"));
+
+        client.cancel().await.unwrap();
+    }
 }
 
-#[tokio::test]
-async fn mcp_execute_plan_strict_rollback_on_error() {
-    // Verify that strict plan rolls back on failure (e.g. invalid op mid-plan).
-    let dir = tempfile::TempDir::new().unwrap();
-    std::fs::write(dir.path().join("test.txt"), "original").unwrap();
+mod security {
+    use super::*;
 
-    let client = spawn_test_client(dir.path().to_path_buf()).await;
+    #[tokio::test]
+    async fn mcp_path_traversal_rejected_via_protocol() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let params = rmcp::model::CallToolRequestParams::new("doc_set").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "path": "../../etc/passwd",
+                "selector": "root",
+                "value": "hacked"
+            }))
+            .unwrap(),
+        );
+        let result = client.peer().call_tool(params).await;
+        assert!(result.is_err(), "path traversal should be rejected");
+        client.cancel().await.unwrap();
+    }
 
-    // Plan that will fail on second op (bad replace or non-existing for safety, but use doc on non structured? Use a replace that requires mode or simply a bad path? Better: use a plan that succeeds first, fails second.
-    // For simplicity, use a plan with an op that causes parse/validate fail, but since plan itself is valid, use a mid failure like delete non existing in strict?
-    // Simpler: a plan that does create (ok), then a replace that is invalid (no mode).
-    // But to trigger runtime fail in tx, easier: use doc.set on a file that will cause later validate fail, but to keep simple use a non-existent for a delete in plan?
-    // Actually for this, do two creates, then a doc.set on bad structured that may not rollback file create? File creates are part of tx.
-    // Use a plan that the second op fails (e.g. move non-existing source).
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "strict": true,
-        "operations": [
-            { "op": "file.create", "path": "first.txt", "content": "one" },
-            { "op": "file.delete", "path": "does-not-exist.txt" }  // will fail
-        ]
-    });
+    #[test]
+    fn patch_apply_path_containment_validation() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let evil_diff =
+            "--- a/../../etc/passwd\n+++ b/../../etc/passwd\n@@ -1,1 +1,1 @@\n-root\n+hacked\n";
+        let ops = vec![Operation::PatchApply {
+            diff: evil_diff.to_string(),
+            on_stale: crate::ops::patch::OnStale::Fail,
+            allow_conflicts: false,
+        }];
+        let result = validate_operation_paths(&ops, dir.path());
+        assert!(
+            result.is_err(),
+            "PatchApply with escaping paths should be rejected"
+        );
+    }
 
-    let params = rmcp::model::CallToolRequestParams::new("execute_plan")
-        .with_arguments(serde_json::from_value(serde_json::json!({ "plan": plan_json })).unwrap());
+    #[test]
+    fn validate_content_size_rejects_oversized() {
+        let big = "x".repeat(MAX_CONTENT_BYTES + 1);
+        let err = validate_content_size("content", &big).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("content"), "error should name the field");
+        assert!(msg.contains("exceeds"), "error should say exceeds");
+    }
 
-    let result = client.peer().call_tool(params).await.unwrap();
-    // Should report error
-    assert!(
-        result.is_error.unwrap_or(false),
-        "plan with failing op under strict should error"
-    );
+    #[test]
+    fn validate_param_size_rejects_oversized() {
+        let big = "x".repeat(MAX_PARAM_BYTES + 1);
+        let err = validate_param_size("pattern", &big).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("pattern"), "error should name the field");
+    }
 
-    // first.txt should NOT exist (rollback)
-    assert!(
-        !dir.path().join("first.txt").exists(),
-        "strict plan should have rolled back the first create"
-    );
+    #[test]
+    fn validate_batch_size_rejects_oversized() {
+        let err = validate_batch_size("files", MAX_BATCH_FILES + 1).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("files"), "error should name the field");
+    }
 
-    client.cancel().await.unwrap();
+    #[test]
+    fn validate_json_depth_rejects_deeply_nested() {
+        // Build a value nested deeper than MAX_JSON_DEPTH.
+        let mut val = serde_json::json!("leaf");
+        for _ in 0..MAX_JSON_DEPTH + 1 {
+            val = serde_json::json!([val]);
+        }
+        let err = validate_json_depth("value", &val).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("nesting depth"), "error should mention depth");
+    }
+
+    #[tokio::test]
+    async fn mcp_rejects_oversized_content_via_protocol() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let big_content = "x".repeat(MAX_CONTENT_BYTES + 1);
+        let params = rmcp::model::CallToolRequestParams::new("create_file").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "path": "big.txt",
+                "content": big_content,
+            }))
+            .unwrap(),
+        );
+        let result = client.peer().call_tool(params).await;
+        assert!(result.is_err(), "oversized content should be rejected");
+        client.cancel().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn mcp_rejects_oversized_batch() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let files: Vec<String> = (0..MAX_BATCH_FILES + 1)
+            .map(|i| format!("file{i}.txt"))
+            .collect();
+        let params = rmcp::model::CallToolRequestParams::new("batch_tidy").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "files": files,
+            }))
+            .unwrap(),
+        );
+        let result = client.peer().call_tool(params).await;
+        assert!(result.is_err(), "oversized batch should be rejected");
+        client.cancel().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn mcp_rejects_oversized_doc_query_selector() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("data.json"), r#"{"a":1}"#).unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let big_selector = "x".repeat(MAX_PARAM_BYTES + 1);
+        let params = rmcp::model::CallToolRequestParams::new("doc_query").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "action": "has",
+                "path": "data.json",
+                "selector": big_selector,
+            }))
+            .unwrap(),
+        );
+        let result = client.peer().call_tool(params).await;
+        assert!(result.is_err(), "oversized selector should be rejected");
+        client.cancel().await.unwrap();
+    }
+}
+
+mod integrity {
+    use super::*;
+
+    #[tokio::test]
+    async fn mcp_execute_plan_strict_rollback_on_error() {
+        // Verify that strict plan rolls back on failure (e.g. invalid op mid-plan).
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("test.txt"), "original").unwrap();
+
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+
+        // Plan that will fail on second op (bad replace or non-existing for safety, but use doc on non structured? Use a replace that requires mode or simply a bad path? Better: use a plan that succeeds first, fails second.
+        // For simplicity, use a plan with an op that causes parse/validate fail, but since plan itself is valid, use a mid failure like delete non existing in strict?
+        // Simpler: a plan that does create (ok), then a replace that is invalid (no mode).
+        // But to trigger runtime fail in tx, easier: use doc.set on a file that will cause later validate fail, but to keep simple use a non-existent for a delete in plan?
+        // Actually for this, do two creates, then a doc.set on bad structured that may not rollback file create? File creates are part of tx.
+        // Use a plan that the second op fails (e.g. move non-existing source).
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "strict": true,
+            "operations": [
+                { "op": "file.create", "path": "first.txt", "content": "one" },
+                { "op": "file.delete", "path": "does-not-exist.txt" }  // will fail
+            ]
+        });
+
+        let params = rmcp::model::CallToolRequestParams::new("execute_plan").with_arguments(
+            serde_json::from_value(serde_json::json!({ "plan": plan_json })).unwrap(),
+        );
+
+        let result = client.peer().call_tool(params).await.unwrap();
+        // Should report error
+        assert!(
+            result.is_error.unwrap_or(false),
+            "plan with failing op under strict should error"
+        );
+
+        // first.txt should NOT exist (rollback)
+        assert!(
+            !dir.path().join("first.txt").exists(),
+            "strict plan should have rolled back the first create"
+        );
+
+        client.cancel().await.unwrap();
+    }
 }

--- a/src/cmd/md_tests.rs
+++ b/src/cmd/md_tests.rs
@@ -3,763 +3,783 @@ use crate::ops::md::{find_section, has_dangerous_git_add_dot, strip_inline_code}
 use std::fs;
 use tempfile::TempDir;
 
-// -- backup ------------------------------------------------------------
+mod basic {
+    use super::*;
 
-#[test]
-fn replace_section_apply_creates_backup_session() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\nold content\n# Other\nkept\n").unwrap();
+    // -- backup ------------------------------------------------------------
 
-    let args = MdArgs {
-        action: MdAction::ReplaceSection {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Title".into(),
-            stdin: false,
-            content: Some("new content".into()),
-        },
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_with_cwd(dir.path());
-    global.apply = true;
+    #[test]
+    fn replace_section_apply_creates_backup_session() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\nold content\n# Other\nkept\n").unwrap();
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
+        let args = MdArgs {
+            action: MdAction::ReplaceSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Title".into(),
+                stdin: false,
+                content: Some("new content".into()),
+            },
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
 
-    let backup_dir = dir.path().join(".patchloom/backups");
-    assert!(
-        backup_dir.exists(),
-        "backup directory should exist after md replace-section --apply"
-    );
-    let sessions: Vec<_> = fs::read_dir(&backup_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().is_dir())
-        .collect();
-    assert!(
-        !sessions.is_empty(),
-        "at least one backup session should be created"
-    );
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let backup_dir = dir.path().join(".patchloom/backups");
+        assert!(
+            backup_dir.exists(),
+            "backup directory should exist after md replace-section --apply"
+        );
+        let sessions: Vec<_> = fs::read_dir(&backup_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert!(
+            !sessions.is_empty(),
+            "at least one backup session should be created"
+        );
+    }
+
+    // -- replace-section ----------------------------------------------------
+
+    #[test]
+    fn replace_section_replaces_correct_content() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\nold content\n# Other\nkept\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::ReplaceSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Title".into(),
+                stdin: false,
+                content: Some("new content".into()),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        assert!(result.contains("new content"), "missing new content");
+        assert!(!result.contains("old content"), "old content still present");
+        assert!(
+            result.contains("# Other\nkept\n"),
+            "adjacent section damaged"
+        );
+    }
+
+    // -- insert-after-heading -----------------------------------------------
+
+    #[test]
+    fn insert_after_heading_inserts_at_correct_position() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\nexisting\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::InsertAfterHeading {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Title".into(),
+                stdin: false,
+                content: Some("inserted".into()),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        assert!(
+            result.starts_with("# Title\ninserted\n"),
+            "insertion not at correct position: {result}"
+        );
+        assert!(result.contains("existing"), "existing content lost");
+    }
+
+    // -- upsert-bullet ------------------------------------------------------
+
+    #[test]
+    fn upsert_bullet_adds_new_bullet() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# List\n- item1\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::UpsertBullet {
+                file: file.to_str().unwrap().to_string(),
+                heading: "List".into(),
+                bullet: "item2".into(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        assert!(result.contains("- item2"), "new bullet missing");
+        assert!(result.contains("- item1"), "existing bullet lost");
+    }
+
+    // -- dedupe-headings ----------------------------------------------------
+
+    #[test]
+    fn dedupe_headings_removes_duplicate_headings() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(
+            &file,
+            "# Section\nfirst\n# Section\nsecond\n# Other\nkept\n",
+        )
+        .unwrap();
+
+        let args = MdArgs {
+            action: MdAction::DedupeHeadings {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        assert_eq!(
+            result.matches("# Section").count(),
+            1,
+            "duplicate not removed: {result}"
+        );
+        assert!(result.contains("first"), "first occurrence body lost");
+        assert!(!result.contains("second"), "duplicate body remains");
+        assert!(
+            result.contains("# Other\nkept\n"),
+            "unrelated section damaged"
+        );
+    }
+
+    #[test]
+    fn lint_agents_finds_missing_final_newline() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(&file, "# Rules\nNo trailing newline").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    #[test]
+    fn strip_inline_code_removes_backtick_spans() {
+        assert_eq!(
+            strip_inline_code("use `git add .` carefully"),
+            "use  carefully"
+        );
+        assert_eq!(strip_inline_code("no backticks here"), "no backticks here");
+        assert_eq!(strip_inline_code("`all code`"), "");
+        assert_eq!(strip_inline_code("a `b` c `d` e"), "a  c  e");
+    }
+
+    // -- parser unit tests --------------------------------------------------
+
+    #[test]
+    fn parse_headings_basic() {
+        let content = "# A\ntext\n## B\nmore\n# C\n";
+        let h = crate::ops::md::parse_headings(content);
+        assert_eq!(h.len(), 3);
+        assert_eq!(h[0].level, 1);
+        assert_eq!(h[0].text, "A");
+        assert_eq!(h[1].level, 2);
+        assert_eq!(h[1].text, "B");
+        assert_eq!(h[2].level, 1);
+        assert_eq!(h[2].text, "C");
+        // A ends at C (level 1 <= 1).
+        assert_eq!(h[0].line_end, 4);
+        // B ends at C (level 1 <= 2).
+        assert_eq!(h[1].line_end, 4);
+        // C ends at EOF.
+        assert_eq!(h[2].line_end, 5);
+    }
+
+    #[test]
+    fn find_section_returns_correct_body() {
+        let content = "# A\nbody a\n# B\nbody b\n";
+        let (start, end) = find_section(content, "A").unwrap();
+        assert_eq!(&content[start..end], "body a\n");
+
+        let (start, end) = find_section(content, "B").unwrap();
+        assert_eq!(&content[start..end], "body b\n");
+    }
+
+    // -- table-append -------------------------------------------------------
+
+    #[test]
+    fn table_append_adds_row() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Table\n| H1 | H2 |\n|---|---|\n| A | B |\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::TableAppend {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Table".into(),
+                row: "| C | D |".into(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        assert!(result.contains("| C | D |"), "new row missing");
+        let a_pos = result.find("| A | B |").unwrap();
+        let c_pos = result.find("| C | D |").unwrap();
+        assert!(c_pos > a_pos, "new row not after existing data row");
+    }
+
+    // -- move-section -------------------------------------------------------
+
+    #[test]
+    fn move_section_same_file_reorder_before() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\na-content\n# B\nb-content\n# C\nc-content\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "C".into(),
+                to: None,
+                before: Some("B".into()),
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        let a_pos = result.find("# A").unwrap();
+        let c_pos = result.find("# C").unwrap();
+        let b_pos = result.find("# B").unwrap();
+        assert!(a_pos < c_pos, "A should come before C");
+        assert!(c_pos < b_pos, "C should come before B after move");
+        assert!(result.contains("a-content"), "A content lost");
+        assert!(result.contains("b-content"), "B content lost");
+        assert!(result.contains("c-content"), "C content lost");
+    }
+
+    #[test]
+    fn move_section_same_file_reorder_after() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\na-content\n# B\nb-content\n# C\nc-content\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "A".into(),
+                to: None,
+                before: None,
+                after: Some("B".into()),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        let b_pos = result.find("# B").unwrap();
+        let a_pos = result.find("# A").unwrap();
+        let c_pos = result.find("# C").unwrap();
+        assert!(b_pos < a_pos, "B should come before A after move");
+        assert!(a_pos < c_pos, "A should come before C");
+    }
+
+    #[test]
+    fn move_section_cross_file() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("source.md");
+        let dst = dir.path().join("dest.md");
+        fs::write(
+            &src,
+            "# Keep\nkept\n# Move Me\nmoved content\n# Also Keep\nalso\n",
+        )
+        .unwrap();
+        fs::write(&dst, "# Intro\nintro text\n# End\nend text\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: src.to_str().unwrap().to_string(),
+                heading: "Move Me".into(),
+                to: Some(dst.to_str().unwrap().to_string()),
+                before: Some("End".into()),
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let src_result = fs::read_to_string(&src).unwrap();
+        assert!(
+            !src_result.contains("# Move Me"),
+            "section not removed from source"
+        );
+        assert!(
+            !src_result.contains("moved content"),
+            "section body not removed from source"
+        );
+        assert!(src_result.contains("# Keep"), "kept section lost");
+        assert!(src_result.contains("# Also Keep"), "other section lost");
+
+        let dst_result = fs::read_to_string(&dst).unwrap();
+        assert!(
+            dst_result.contains("# Move Me"),
+            "section not added to dest"
+        );
+        assert!(
+            dst_result.contains("moved content"),
+            "section body not in dest"
+        );
+        let move_pos = dst_result.find("# Move Me").unwrap();
+        let end_pos = dst_result.find("# End").unwrap();
+        assert!(move_pos < end_pos, "section not inserted before End");
+    }
 }
 
-// -- replace-section ----------------------------------------------------
+mod edge_cases {
+    use super::*;
 
-#[test]
-fn replace_section_replaces_correct_content() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\nold content\n# Other\nkept\n").unwrap();
+    #[test]
+    fn upsert_bullet_is_idempotent_when_bullet_exists() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# List\n- item1\n").unwrap();
 
-    let args = MdArgs {
-        action: MdAction::ReplaceSection {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Title".into(),
-            stdin: false,
-            content: Some("new content".into()),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
+        let args = MdArgs {
+            action: MdAction::UpsertBullet {
+                file: file.to_str().unwrap().to_string(),
+                heading: "List".into(),
+                bullet: "- item1".into(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
 
-    let result = fs::read_to_string(&file).unwrap();
-    assert!(result.contains("new content"), "missing new content");
-    assert!(!result.contains("old content"), "old content still present");
-    assert!(
-        result.contains("# Other\nkept\n"),
-        "adjacent section damaged"
-    );
+        let result = fs::read_to_string(&file).unwrap();
+        assert_eq!(
+            result.matches("- item1").count(),
+            1,
+            "bullet duplicated: {result}"
+        );
+    }
+
+    #[test]
+    fn find_section_accepts_hash_prefixed_query() {
+        let content = "## Sub\ndata\n";
+        let (start, end) = find_section(content, "## Sub").unwrap();
+        assert_eq!(&content[start..end], "data\n");
+    }
+
+    #[test]
+    fn move_section_explicit_to_same_file_reorders_not_duplicates() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\na-content\n# B\nb-content\n# C\nc-content\n").unwrap();
+
+        let path_str = file.to_str().unwrap().to_string();
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: path_str.clone(),
+                heading: "C".into(),
+                to: Some(path_str),
+                before: Some("B".into()),
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        let a_pos = result.find("# A").unwrap();
+        let c_pos = result.find("# C").unwrap();
+        let b_pos = result.find("# B").unwrap();
+        assert!(a_pos < c_pos, "A should come before C");
+        assert!(c_pos < b_pos, "C should come before B after move");
+        assert_eq!(
+            result.matches("# C").count(),
+            1,
+            "section C must appear exactly once (not duplicated)"
+        );
+        assert_eq!(
+            result.matches("c-content").count(),
+            1,
+            "content must not be duplicated"
+        );
+    }
 }
 
-#[test]
-fn replace_section_missing_heading_returns_exit_3() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\ncontent\n").unwrap();
+mod error_handling {
+    use super::*;
 
-    let args = MdArgs {
-        action: MdAction::ReplaceSection {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Missing".into(),
-            stdin: false,
-            content: Some("new".into()),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::NO_MATCHES);
+    #[test]
+    fn replace_section_missing_heading_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\ncontent\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::ReplaceSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Missing".into(),
+                stdin: false,
+                content: Some("new".into()),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn insert_after_heading_missing_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\ncontent\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::InsertAfterHeading {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Missing".into(),
+                stdin: false,
+                content: Some("inserted".into()),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn upsert_bullet_missing_heading_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\ncontent\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::UpsertBullet {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Missing".into(),
+                bullet: "new item".into(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn table_append_heading_not_found_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\n| H1 |\n|---|\n| A |\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::TableAppend {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Missing".into(),
+                row: "| X |".into(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn table_append_no_table_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\nsome text but no table\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::TableAppend {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Title".into(),
+                row: "| X |".into(),
+            },
+            write: Default::default(),
+        };
+        let result = run(args, &GlobalFlags::test_apply());
+        assert!(result.is_err(), "expected error when no table is present");
+    }
+
+    #[test]
+    fn find_section_none_for_missing() {
+        assert!(find_section("# X\n", "Y").is_none());
+    }
+
+    #[test]
+    fn move_section_missing_heading_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\ncontent\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Missing".into(),
+                to: None,
+                before: Some("A".into()),
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn move_section_no_before_or_after_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# A\ncontent\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::MoveSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "A".into(),
+                to: None,
+                before: None,
+                after: None,
+            },
+            write: Default::default(),
+        };
+        let result = run(args, &GlobalFlags::test_apply());
+        assert!(
+            result.is_err(),
+            "expected error when neither --before nor --after is provided"
+        );
+    }
 }
 
-// -- insert-after-heading -----------------------------------------------
+mod security {
+    use super::*;
 
-#[test]
-fn insert_after_heading_inserts_at_correct_position() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\nexisting\n").unwrap();
+    // -- lint-agents --------------------------------------------------------
 
-    let args = MdArgs {
-        action: MdAction::InsertAfterHeading {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Title".into(),
-            stdin: false,
-            content: Some("inserted".into()),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
+    #[test]
+    fn lint_agents_finds_duplicate_headings() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(&file, "# Rules\nfoo\n# Rules\nbar\n").unwrap();
 
-    let result = fs::read_to_string(&file).unwrap();
-    assert!(
-        result.starts_with("# Title\ninserted\n"),
-        "insertion not at correct position: {result}"
-    );
-    assert!(result.contains("existing"), "existing content lost");
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    #[test]
+    fn lint_agents_finds_dangerous_git_add_dot() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(&file, "# Rules\nRun git add . to stage\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    #[test]
+    fn lint_agents_finds_dangerous_git_add_all_long_form() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(&file, "# Rules\nRun git add --all to stage\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    #[test]
+    fn lint_agents_skips_dangerous_cmd_in_code_fence() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(
+            &file,
+            "# Rules\n\n```bash\n# BAD example\ngit add .\n```\n\nStage explicitly.\n",
+        )
+        .unwrap();
+
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn lint_agents_skips_dangerous_cmd_in_tilde_fence() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(
+            &file,
+            "# Rules\n\n~~~bash\n# BAD example\ngit add .\n~~~\n\nStage explicitly.\n",
+        )
+        .unwrap();
+
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn lint_agents_skips_dangerous_cmd_in_inline_code() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(&file, "# Rules\nNever use `git add .` or `git add -A`.\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn has_dangerous_git_add_dot_true_cases() {
+        assert!(has_dangerous_git_add_dot("git add ."));
+        assert!(has_dangerous_git_add_dot("run git add . first"));
+        assert!(has_dangerous_git_add_dot("git add . && git commit"));
+    }
+
+    #[test]
+    fn has_dangerous_git_add_dot_false_for_dotfiles() {
+        assert!(!has_dangerous_git_add_dot("git add .gitignore"));
+        assert!(!has_dangerous_git_add_dot("git add .editorconfig"));
+        assert!(!has_dangerous_git_add_dot(
+            "git add .github/workflows/ci.yml"
+        ));
+    }
+
+    #[test]
+    fn lint_agents_allows_git_add_dotfile() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("AGENTS.md");
+        fs::write(&file, "# Rules\nRun git add .gitignore to stage\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::LintAgents {
+                file: file.to_str().unwrap().to_string(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
 }
 
-#[test]
-fn insert_after_heading_missing_returns_exit_3() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\ncontent\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::InsertAfterHeading {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Missing".into(),
-            stdin: false,
-            content: Some("inserted".into()),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::NO_MATCHES);
-}
-
-// -- upsert-bullet ------------------------------------------------------
-
-#[test]
-fn upsert_bullet_adds_new_bullet() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# List\n- item1\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::UpsertBullet {
-            file: file.to_str().unwrap().to_string(),
-            heading: "List".into(),
-            bullet: "item2".into(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    assert!(result.contains("- item2"), "new bullet missing");
-    assert!(result.contains("- item1"), "existing bullet lost");
-}
-
-#[test]
-fn upsert_bullet_is_idempotent_when_bullet_exists() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# List\n- item1\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::UpsertBullet {
-            file: file.to_str().unwrap().to_string(),
-            heading: "List".into(),
-            bullet: "- item1".into(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    assert_eq!(
-        result.matches("- item1").count(),
-        1,
-        "bullet duplicated: {result}"
-    );
-}
-
-#[test]
-fn upsert_bullet_missing_heading_returns_exit_3() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\ncontent\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::UpsertBullet {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Missing".into(),
-            bullet: "new item".into(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::NO_MATCHES);
-}
-
-// -- dedupe-headings ----------------------------------------------------
-
-#[test]
-fn dedupe_headings_removes_duplicate_headings() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(
-        &file,
-        "# Section\nfirst\n# Section\nsecond\n# Other\nkept\n",
-    )
-    .unwrap();
-
-    let args = MdArgs {
-        action: MdAction::DedupeHeadings {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    assert_eq!(
-        result.matches("# Section").count(),
-        1,
-        "duplicate not removed: {result}"
-    );
-    assert!(result.contains("first"), "first occurrence body lost");
-    assert!(!result.contains("second"), "duplicate body remains");
-    assert!(
-        result.contains("# Other\nkept\n"),
-        "unrelated section damaged"
-    );
-}
-
-// -- lint-agents --------------------------------------------------------
-
-#[test]
-fn lint_agents_finds_duplicate_headings() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("AGENTS.md");
-    fs::write(&file, "# Rules\nfoo\n# Rules\nbar\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::LintAgents {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::CHANGES_DETECTED);
-}
-
-#[test]
-fn lint_agents_finds_dangerous_git_add_dot() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("AGENTS.md");
-    fs::write(&file, "# Rules\nRun git add . to stage\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::LintAgents {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::CHANGES_DETECTED);
-}
-
-#[test]
-fn lint_agents_finds_dangerous_git_add_all_long_form() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("AGENTS.md");
-    fs::write(&file, "# Rules\nRun git add --all to stage\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::LintAgents {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::CHANGES_DETECTED);
-}
-
-#[test]
-fn lint_agents_finds_missing_final_newline() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("AGENTS.md");
-    fs::write(&file, "# Rules\nNo trailing newline").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::LintAgents {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::CHANGES_DETECTED);
-}
-
-#[test]
-fn lint_agents_skips_dangerous_cmd_in_code_fence() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("AGENTS.md");
-    fs::write(
-        &file,
-        "# Rules\n\n```bash\n# BAD example\ngit add .\n```\n\nStage explicitly.\n",
-    )
-    .unwrap();
-
-    let args = MdArgs {
-        action: MdAction::LintAgents {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-#[test]
-fn lint_agents_skips_dangerous_cmd_in_tilde_fence() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("AGENTS.md");
-    fs::write(
-        &file,
-        "# Rules\n\n~~~bash\n# BAD example\ngit add .\n~~~\n\nStage explicitly.\n",
-    )
-    .unwrap();
-
-    let args = MdArgs {
-        action: MdAction::LintAgents {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-#[test]
-fn lint_agents_skips_dangerous_cmd_in_inline_code() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("AGENTS.md");
-    fs::write(&file, "# Rules\nNever use `git add .` or `git add -A`.\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::LintAgents {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-#[test]
-fn strip_inline_code_removes_backtick_spans() {
-    assert_eq!(
-        strip_inline_code("use `git add .` carefully"),
-        "use  carefully"
-    );
-    assert_eq!(strip_inline_code("no backticks here"), "no backticks here");
-    assert_eq!(strip_inline_code("`all code`"), "");
-    assert_eq!(strip_inline_code("a `b` c `d` e"), "a  c  e");
-}
-
-#[test]
-fn has_dangerous_git_add_dot_true_cases() {
-    assert!(has_dangerous_git_add_dot("git add ."));
-    assert!(has_dangerous_git_add_dot("run git add . first"));
-    assert!(has_dangerous_git_add_dot("git add . && git commit"));
-}
-
-#[test]
-fn has_dangerous_git_add_dot_false_for_dotfiles() {
-    assert!(!has_dangerous_git_add_dot("git add .gitignore"));
-    assert!(!has_dangerous_git_add_dot("git add .editorconfig"));
-    assert!(!has_dangerous_git_add_dot(
-        "git add .github/workflows/ci.yml"
-    ));
-}
-
-#[test]
-fn lint_agents_allows_git_add_dotfile() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("AGENTS.md");
-    fs::write(&file, "# Rules\nRun git add .gitignore to stage\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::LintAgents {
-            file: file.to_str().unwrap().to_string(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-// -- final newline ------------------------------------------------------
-
-#[test]
-fn final_newline_is_preserved_on_write() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\ncontent\n").unwrap();
-
-    let mut global = GlobalFlags::test_apply();
-    global.ensure_final_newline = true;
-
-    let args = MdArgs {
-        action: MdAction::ReplaceSection {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Title".into(),
-            stdin: false,
-            content: Some("replaced".into()),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    assert!(result.ends_with('\n'), "final newline missing: {result:?}");
-}
-
-// -- parser unit tests --------------------------------------------------
-
-#[test]
-fn parse_headings_basic() {
-    let content = "# A\ntext\n## B\nmore\n# C\n";
-    let h = crate::ops::md::parse_headings(content);
-    assert_eq!(h.len(), 3);
-    assert_eq!(h[0].level, 1);
-    assert_eq!(h[0].text, "A");
-    assert_eq!(h[1].level, 2);
-    assert_eq!(h[1].text, "B");
-    assert_eq!(h[2].level, 1);
-    assert_eq!(h[2].text, "C");
-    // A ends at C (level 1 <= 1).
-    assert_eq!(h[0].line_end, 4);
-    // B ends at C (level 1 <= 2).
-    assert_eq!(h[1].line_end, 4);
-    // C ends at EOF.
-    assert_eq!(h[2].line_end, 5);
-}
-
-#[test]
-fn find_section_returns_correct_body() {
-    let content = "# A\nbody a\n# B\nbody b\n";
-    let (start, end) = find_section(content, "A").unwrap();
-    assert_eq!(&content[start..end], "body a\n");
-
-    let (start, end) = find_section(content, "B").unwrap();
-    assert_eq!(&content[start..end], "body b\n");
-}
-
-#[test]
-fn find_section_none_for_missing() {
-    assert!(find_section("# X\n", "Y").is_none());
-}
-
-#[test]
-fn find_section_accepts_hash_prefixed_query() {
-    let content = "## Sub\ndata\n";
-    let (start, end) = find_section(content, "## Sub").unwrap();
-    assert_eq!(&content[start..end], "data\n");
-}
-
-// -- table-append -------------------------------------------------------
-
-#[test]
-fn table_append_adds_row() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Table\n| H1 | H2 |\n|---|---|\n| A | B |\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::TableAppend {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Table".into(),
-            row: "| C | D |".into(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    assert!(result.contains("| C | D |"), "new row missing");
-    let a_pos = result.find("| A | B |").unwrap();
-    let c_pos = result.find("| C | D |").unwrap();
-    assert!(c_pos > a_pos, "new row not after existing data row");
-}
-
-#[test]
-fn table_append_heading_not_found_returns_exit_3() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\n| H1 |\n|---|\n| A |\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::TableAppend {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Missing".into(),
-            row: "| X |".into(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::NO_MATCHES);
-}
-
-#[test]
-fn table_append_no_table_returns_error() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# Title\nsome text but no table\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::TableAppend {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Title".into(),
-            row: "| X |".into(),
-        },
-        write: Default::default(),
-    };
-    let result = run(args, &GlobalFlags::test_apply());
-    assert!(result.is_err(), "expected error when no table is present");
-}
-
-#[test]
-fn table_append_preserves_surrounding_content() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(
-        &file,
-        "# Before\npre-content\n# Table\n| H1 |\n|---|\n| A |\n\nAfter table text.\n# After\npost-content\n",
-    )
-    .unwrap();
-
-    let args = MdArgs {
-        action: MdAction::TableAppend {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Table".into(),
-            row: "| B |".into(),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    assert!(
-        result.contains("# Before\npre-content\n"),
-        "content before heading damaged"
-    );
-    assert!(
-        result.contains("After table text.\n"),
-        "content after table damaged"
-    );
-    assert!(
-        result.contains("# After\npost-content\n"),
-        "next section damaged"
-    );
-    assert!(result.contains("| B |"), "new row missing");
-}
-
-// -- move-section -------------------------------------------------------
-
-#[test]
-fn move_section_same_file_reorder_before() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# A\na-content\n# B\nb-content\n# C\nc-content\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::MoveSection {
-            file: file.to_str().unwrap().to_string(),
-            heading: "C".into(),
-            to: None,
-            before: Some("B".into()),
-            after: None,
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    let a_pos = result.find("# A").unwrap();
-    let c_pos = result.find("# C").unwrap();
-    let b_pos = result.find("# B").unwrap();
-    assert!(a_pos < c_pos, "A should come before C");
-    assert!(c_pos < b_pos, "C should come before B after move");
-    assert!(result.contains("a-content"), "A content lost");
-    assert!(result.contains("b-content"), "B content lost");
-    assert!(result.contains("c-content"), "C content lost");
-}
-
-#[test]
-fn move_section_same_file_reorder_after() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# A\na-content\n# B\nb-content\n# C\nc-content\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::MoveSection {
-            file: file.to_str().unwrap().to_string(),
-            heading: "A".into(),
-            to: None,
-            before: None,
-            after: Some("B".into()),
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    let b_pos = result.find("# B").unwrap();
-    let a_pos = result.find("# A").unwrap();
-    let c_pos = result.find("# C").unwrap();
-    assert!(b_pos < a_pos, "B should come before A after move");
-    assert!(a_pos < c_pos, "A should come before C");
-}
-
-#[test]
-fn move_section_explicit_to_same_file_reorders_not_duplicates() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# A\na-content\n# B\nb-content\n# C\nc-content\n").unwrap();
-
-    let path_str = file.to_str().unwrap().to_string();
-    let args = MdArgs {
-        action: MdAction::MoveSection {
-            file: path_str.clone(),
-            heading: "C".into(),
-            to: Some(path_str),
-            before: Some("B".into()),
-            after: None,
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let result = fs::read_to_string(&file).unwrap();
-    let a_pos = result.find("# A").unwrap();
-    let c_pos = result.find("# C").unwrap();
-    let b_pos = result.find("# B").unwrap();
-    assert!(a_pos < c_pos, "A should come before C");
-    assert!(c_pos < b_pos, "C should come before B after move");
-    assert_eq!(
-        result.matches("# C").count(),
-        1,
-        "section C must appear exactly once (not duplicated)"
-    );
-    assert_eq!(
-        result.matches("c-content").count(),
-        1,
-        "content must not be duplicated"
-    );
-}
-
-#[test]
-fn move_section_cross_file() {
-    let dir = TempDir::new().unwrap();
-    let src = dir.path().join("source.md");
-    let dst = dir.path().join("dest.md");
-    fs::write(
-        &src,
-        "# Keep\nkept\n# Move Me\nmoved content\n# Also Keep\nalso\n",
-    )
-    .unwrap();
-    fs::write(&dst, "# Intro\nintro text\n# End\nend text\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::MoveSection {
-            file: src.to_str().unwrap().to_string(),
-            heading: "Move Me".into(),
-            to: Some(dst.to_str().unwrap().to_string()),
-            before: Some("End".into()),
-            after: None,
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let src_result = fs::read_to_string(&src).unwrap();
-    assert!(
-        !src_result.contains("# Move Me"),
-        "section not removed from source"
-    );
-    assert!(
-        !src_result.contains("moved content"),
-        "section body not removed from source"
-    );
-    assert!(src_result.contains("# Keep"), "kept section lost");
-    assert!(src_result.contains("# Also Keep"), "other section lost");
-
-    let dst_result = fs::read_to_string(&dst).unwrap();
-    assert!(
-        dst_result.contains("# Move Me"),
-        "section not added to dest"
-    );
-    assert!(
-        dst_result.contains("moved content"),
-        "section body not in dest"
-    );
-    let move_pos = dst_result.find("# Move Me").unwrap();
-    let end_pos = dst_result.find("# End").unwrap();
-    assert!(move_pos < end_pos, "section not inserted before End");
-}
-
-#[test]
-fn move_section_missing_heading_returns_exit_3() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# A\ncontent\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::MoveSection {
-            file: file.to_str().unwrap().to_string(),
-            heading: "Missing".into(),
-            to: None,
-            before: Some("A".into()),
-            after: None,
-        },
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_apply()).unwrap();
-    assert_eq!(code, exit::NO_MATCHES);
-}
-
-#[test]
-fn move_section_no_before_or_after_returns_error() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.md");
-    fs::write(&file, "# A\ncontent\n").unwrap();
-
-    let args = MdArgs {
-        action: MdAction::MoveSection {
-            file: file.to_str().unwrap().to_string(),
-            heading: "A".into(),
-            to: None,
-            before: None,
-            after: None,
-        },
-        write: Default::default(),
-    };
-    let result = run(args, &GlobalFlags::test_apply());
-    assert!(
-        result.is_err(),
-        "expected error when neither --before nor --after is provided"
-    );
+mod format_preservation {
+    use super::*;
+
+    // -- final newline ------------------------------------------------------
+
+    #[test]
+    fn final_newline_is_preserved_on_write() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\ncontent\n").unwrap();
+
+        let mut global = GlobalFlags::test_apply();
+        global.ensure_final_newline = true;
+
+        let args = MdArgs {
+            action: MdAction::ReplaceSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Title".into(),
+                stdin: false,
+                content: Some("replaced".into()),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        assert!(result.ends_with('\n'), "final newline missing: {result:?}");
+    }
+
+    #[test]
+    fn table_append_preserves_surrounding_content() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(
+            &file,
+            "# Before\npre-content\n# Table\n| H1 |\n|---|\n| A |\n\nAfter table text.\n# After\npost-content\n",
+        )
+        .unwrap();
+
+        let args = MdArgs {
+            action: MdAction::TableAppend {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Table".into(),
+                row: "| B |".into(),
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let result = fs::read_to_string(&file).unwrap();
+        assert!(
+            result.contains("# Before\npre-content\n"),
+            "content before heading damaged"
+        );
+        assert!(
+            result.contains("After table text.\n"),
+            "content after table damaged"
+        );
+        assert!(
+            result.contains("# After\npost-content\n"),
+            "next section damaged"
+        );
+        assert!(result.contains("| B |"), "new row missing");
+    }
 }

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -22,752 +22,764 @@ fn make_args(from: &str, to: &str, paths: Vec<String>) -> ReplaceArgs {
     }
 }
 
-#[test]
-fn literal_replace_works() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\nhello again\n").unwrap();
+mod basic {
+    use super::*;
 
-    let args = make_args(
-        "hello",
-        "hi",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+    #[test]
+    fn literal_replace_works() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\nhello again\n").unwrap();
 
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(replacements[0].match_count, 2);
-    assert_eq!(replacements[0].replaced, "hi world\nhi again\n");
+        let args = make_args(
+            "hello",
+            "hi",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 2);
+        assert_eq!(replacements[0].replaced, "hi world\nhi again\n");
+    }
+
+    #[test]
+    fn regex_replace_works() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "foo123bar\nfoo456baz\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: r"foo\d+".to_string(),
+            to: Some("replaced".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: false,
+            regex: true,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 2);
+        assert_eq!(replacements[0].replaced, "replacedbar\nreplacedbaz\n");
+    }
+
+    #[test]
+    fn regex_capture_groups_in_replacement() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "version = \"1.2.3\"\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: r#"version = "(\d+)\.(\d+)\.(\d+)""#.to_string(),
+            to: Some(r#"version = "$1.$2.99""#.to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: false,
+            regex: true,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(
+            replacements[0].replaced, "version = \"1.2.99\"\n",
+            "capture groups $1/$2 should work in replacement text"
+        );
+    }
+
+    #[test]
+    fn diff_mode_produces_unified_diff() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "old line\n").unwrap();
+
+        let args = make_args(
+            "old",
+            "new",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(replacements.len(), 1);
+
+        // Verify the replacement content produces a valid diff.
+        let diff = crate::diff::unified_diff(
+            &replacements[0].display_path,
+            &replacements[0].original,
+            &replacements[0].replaced,
+        );
+        let diff_str = crate::diff::format_diff_result_colored(
+            &crate::diff::DiffResult { diffs: vec![diff] },
+            false,
+        );
+        assert!(diff_str.contains("--- a/"));
+        assert!(diff_str.contains("+++ b/"));
+        assert!(diff_str.contains("-old line"));
+        assert!(diff_str.contains("+new line"));
+    }
+
+    #[test]
+    fn apply_mode_writes_replacement() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = make_args(
+            "hello",
+            "hi",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let content = fs::read_to_string(&file).unwrap();
+        assert_eq!(content, "hi world\n");
+    }
+
+    #[test]
+    fn multi_file_replace() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("a.txt"), "hello from a\n").unwrap();
+        fs::write(dir.path().join("b.txt"), "hello from b\n").unwrap();
+
+        let args = make_args(
+            "hello",
+            "hi",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 2);
+        let total: usize = replacements.iter().map(|r| r.match_count).sum();
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn if_exists_still_replaces_when_found() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "hello".to_string(),
+            to: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: true,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let content = fs::read_to_string(&file).unwrap();
+        assert_eq!(content, "hi world\n");
+    }
+
+    #[test]
+    fn write_policy_ensure_final_newline_applied() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world").unwrap();
+
+        let args = make_args(
+            "hello",
+            "hi",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+        global.ensure_final_newline = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let content = fs::read_to_string(&file).unwrap();
+        assert_eq!(content, "hi world\n");
+    }
+
+    #[test]
+    fn multiline_regex_spans_newlines() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "start\nmiddle\nend\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: r"start.*end".to_string(),
+            to: Some("replaced".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: false,
+            regex: true,
+            if_exists: false,
+            multiline: true,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 1);
+        assert_eq!(replacements[0].replaced, "replaced\n");
+    }
+
+    #[test]
+    fn check_mode_returns_changes_detected() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = make_args(
+            "hello",
+            "hi",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let mut global = GlobalFlags::test_default();
+        global.check = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+
+        // File must not be modified in check mode.
+        let content = fs::read_to_string(&file).unwrap();
+        assert_eq!(content, "hello world\n");
+    }
+
+    #[test]
+    fn whole_line_deletes_matching_lines() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        fs::write(
+            &file,
+            "fn main() {\n    let _x = foo();\n    let y = bar();\n    let _z = baz();\n}\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            from: "let _".to_string(),
+            to: Some(String::new()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 2);
+        assert_eq!(
+            replacements[0].replaced,
+            "fn main() {\n    let y = bar();\n}\n"
+        );
+    }
+
+    #[test]
+    fn whole_line_regex_deletes_matching_lines() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        fs::write(
+            &file,
+            "use std::io;\nuse std::fmt;\nuse crate::foo;\nuse crate::bar;\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            from: r"use crate::".to_string(),
+            to: Some(String::new()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: false,
+            regex: true,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 2);
+        assert_eq!(replacements[0].replaced, "use std::io;\nuse std::fmt;\n");
+    }
+
+    #[test]
+    fn whole_line_replaces_entire_line() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "alpha\nbeta match\ngamma\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "match".to_string(),
+            to: Some("replaced line".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].replaced, "alpha\nreplaced line\ngamma\n");
+    }
+
+    #[test]
+    fn whole_line_with_range_restricts_matches() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "aaa\nbbb\nccc\nbbb\neee\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "bbb".to_string(),
+            to: Some(String::new()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: true,
+            range: Some("1:3".to_string()),
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        // Only the bbb on line 2 should be deleted; the one on line 4 is outside range.
+        assert_eq!(replacements[0].match_count, 1);
+        assert_eq!(replacements[0].replaced, "aaa\nccc\nbbb\neee\n");
+    }
+
+    #[test]
+    fn whole_line_nth_only_removes_nth_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "aaa\nbbb\nccc\nbbb\neee\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "bbb".to_string(),
+            to: Some(String::new()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: Some(2),
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 1);
+        // Second occurrence of bbb (line 4) is deleted.
+        assert_eq!(replacements[0].replaced, "aaa\nbbb\nccc\neee\n");
+    }
+
+    #[test]
+    fn word_boundary_prevents_partial_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        fs::write(
+            &file,
+            "struct SetupFile {}\nstruct BenchSetupFile {}\nlet x: SetupFile = todo!();\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            from: "SetupFile".to_string(),
+            to: Some("NewFile".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: true,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 2);
+        assert_eq!(
+            replacements[0].replaced,
+            "struct NewFile {}\nstruct BenchSetupFile {}\nlet x: NewFile = todo!();\n",
+            "word_boundary should rename standalone SetupFile but not inside BenchSetupFile"
+        );
+    }
 }
 
-#[test]
-fn regex_replace_works() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "foo123bar\nfoo456baz\n").unwrap();
+mod edge_cases {
+    use super::*;
 
-    let args = ReplaceArgs {
-        from: r"foo\d+".to_string(),
-        to: Some("replaced".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: false,
-        regex: true,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+    #[test]
+    fn if_exists_returns_success_on_no_matches() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
 
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(replacements[0].match_count, 2);
-    assert_eq!(replacements[0].replaced, "replacedbar\nreplacedbaz\n");
+        let args = ReplaceArgs {
+            from: "zzz_no_match_zzz".to_string(),
+            to: Some("replacement".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: true,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn binary_files_are_skipped() {
+        let dir = TempDir::new().unwrap();
+        let bin_file = dir.path().join("data.bin");
+        // Write a file with NUL bytes (binary content).
+        fs::write(&bin_file, b"hello\x00world").unwrap();
+
+        let args = make_args(
+            "hello",
+            "replaced",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        assert!(
+            replacements.is_empty(),
+            "binary files should be skipped, got {} matches",
+            replacements.len()
+        );
+    }
+
+    #[test]
+    fn multiline_false_does_not_span_newlines() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "start\nmiddle\nend\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: r"start.*end".to_string(),
+            to: Some("replaced".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: false,
+            regex: true,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert!(
+            replacements.is_empty(),
+            "without multiline, dot should not match newlines"
+        );
+    }
+
+    #[test]
+    fn identity_replacement_treated_as_no_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        // Replacing "hello" with "hello" should produce no change.
+        let args = make_args(
+            "hello",
+            "hello",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        assert!(
+            replacements.is_empty(),
+            "identity replacement must be filtered out"
+        );
+    }
+
+    #[test]
+    fn identity_replacement_check_returns_no_matches() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = make_args(
+            "hello",
+            "hello",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let mut global = GlobalFlags::test_default();
+        global.check = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::NO_MATCHES,
+            "--check with identity replacement must not report changes"
+        );
+    }
+
+    #[test]
+    fn word_boundary_with_metacharacters() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        fs::write(&file, "type A = Option<SetupFile>;\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "SetupFile".to_string(),
+            to: Some("NewFile".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: true,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(
+            replacements[0].replaced, "type A = Option<NewFile>;\n",
+            "word_boundary should match at angle bracket boundaries"
+        );
+    }
+
+    #[test]
+    fn word_boundary_does_not_match_in_string() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.rs");
+        // In a string, SetupFile is still at word boundaries (quotes are non-word chars)
+        // so word_boundary alone won't skip strings -- that needs AST (#647).
+        // But it WILL prevent matching inside compound identifiers.
+        fs::write(
+            &file,
+            "let name = \"SetupFile\";\nlet x: SetupFileConfig = todo!();\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            from: "SetupFile".to_string(),
+            to: Some("NewFile".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: true,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+
+        assert_eq!(replacements.len(), 1);
+        // SetupFile in the string IS matched (word boundaries don't know about strings)
+        // SetupFileConfig is NOT matched (no word boundary between SetupFile and Config)
+        assert_eq!(
+            replacements[0].replaced,
+            "let name = \"NewFile\";\nlet x: SetupFileConfig = todo!();\n",
+        );
+    }
 }
 
-#[test]
-fn regex_capture_groups_in_replacement() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "version = \"1.2.3\"\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: r#"version = "(\d+)\.(\d+)\.(\d+)""#.to_string(),
-        to: Some(r#"version = "$1.$2.99""#.to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: false,
-        regex: true,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(
-        replacements[0].replaced, "version = \"1.2.99\"\n",
-        "capture groups $1/$2 should work in replacement text"
-    );
-}
-
-#[test]
-fn no_matches_returns_exit_3() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\n").unwrap();
-
-    let args = make_args(
-        "zzz_no_match_zzz",
-        "replacement",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let code = run(args, &GlobalFlags::test_default()).unwrap();
-    assert_eq!(code, exit::NO_MATCHES);
-}
-
-#[test]
-fn diff_mode_produces_unified_diff() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "old line\n").unwrap();
-
-    let args = make_args(
-        "old",
-        "new",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-    assert_eq!(replacements.len(), 1);
-
-    // Verify the replacement content produces a valid diff.
-    let diff = crate::diff::unified_diff(
-        &replacements[0].display_path,
-        &replacements[0].original,
-        &replacements[0].replaced,
-    );
-    let diff_str = crate::diff::format_diff_result_colored(
-        &crate::diff::DiffResult { diffs: vec![diff] },
-        false,
-    );
-    assert!(diff_str.contains("--- a/"));
-    assert!(diff_str.contains("+++ b/"));
-    assert!(diff_str.contains("-old line"));
-    assert!(diff_str.contains("+new line"));
-}
-
-#[test]
-fn apply_mode_writes_replacement() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\n").unwrap();
-
-    let args = make_args(
-        "hello",
-        "hi",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let content = fs::read_to_string(&file).unwrap();
-    assert_eq!(content, "hi world\n");
-}
-
-#[test]
-fn multi_file_replace() {
-    let dir = TempDir::new().unwrap();
-    fs::write(dir.path().join("a.txt"), "hello from a\n").unwrap();
-    fs::write(dir.path().join("b.txt"), "hello from b\n").unwrap();
-
-    let args = make_args(
-        "hello",
-        "hi",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 2);
-    let total: usize = replacements.iter().map(|r| r.match_count).sum();
-    assert_eq!(total, 2);
-}
-
-#[test]
-fn if_exists_returns_success_on_no_matches() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "zzz_no_match_zzz".to_string(),
-        to: Some("replacement".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: true,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let code = run(args, &GlobalFlags::test_default()).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-#[test]
-fn if_exists_still_replaces_when_found() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "hello".to_string(),
-        to: Some("hi".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: true,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let content = fs::read_to_string(&file).unwrap();
-    assert_eq!(content, "hi world\n");
-}
-
-#[test]
-fn binary_files_are_skipped() {
-    let dir = TempDir::new().unwrap();
-    let bin_file = dir.path().join("data.bin");
-    // Write a file with NUL bytes (binary content).
-    fs::write(&bin_file, b"hello\x00world").unwrap();
-
-    let args = make_args(
-        "hello",
-        "replaced",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-    assert!(
-        replacements.is_empty(),
-        "binary files should be skipped, got {} matches",
-        replacements.len()
-    );
-}
-
-#[test]
-fn write_policy_ensure_final_newline_applied() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world").unwrap();
-
-    let args = make_args(
-        "hello",
-        "hi",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-    global.ensure_final_newline = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    let content = fs::read_to_string(&file).unwrap();
-    assert_eq!(content, "hi world\n");
-}
-
-#[test]
-fn multiline_regex_spans_newlines() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "start\nmiddle\nend\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: r"start.*end".to_string(),
-        to: Some("replaced".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: false,
-        regex: true,
-        if_exists: false,
-        multiline: true,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(replacements[0].match_count, 1);
-    assert_eq!(replacements[0].replaced, "replaced\n");
-}
-
-#[test]
-fn multiline_false_does_not_span_newlines() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "start\nmiddle\nend\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: r"start.*end".to_string(),
-        to: Some("replaced".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: false,
-        regex: true,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert!(
-        replacements.is_empty(),
-        "without multiline, dot should not match newlines"
-    );
-}
-
-#[test]
-fn check_mode_returns_changes_detected() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\n").unwrap();
-
-    let args = make_args(
-        "hello",
-        "hi",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let mut global = GlobalFlags::test_default();
-    global.check = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::CHANGES_DETECTED);
-
-    // File must not be modified in check mode.
-    let content = fs::read_to_string(&file).unwrap();
-    assert_eq!(content, "hello world\n");
-}
-
-#[test]
-fn identity_replacement_treated_as_no_match() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\n").unwrap();
-
-    // Replacing "hello" with "hello" should produce no change.
-    let args = make_args(
-        "hello",
-        "hello",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-    assert!(
-        replacements.is_empty(),
-        "identity replacement must be filtered out"
-    );
-}
-
-#[test]
-fn identity_replacement_check_returns_no_matches() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\n").unwrap();
-
-    let args = make_args(
-        "hello",
-        "hello",
-        vec![dir.path().to_string_lossy().into_owned()],
-    );
-    let mut global = GlobalFlags::test_default();
-    global.check = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::NO_MATCHES,
-        "--check with identity replacement must not report changes"
-    );
-}
-
-#[test]
-fn nth_zero_is_rejected() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello world\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "hello".to_string(),
-        to: Some("hi".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: Some(0),
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let err = run(args, &GlobalFlags::test_default()).unwrap_err();
-    assert!(err.to_string().contains("1-based"), "{err}");
-}
-
-#[test]
-fn whole_line_deletes_matching_lines() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.rs");
-    fs::write(
-        &file,
-        "fn main() {\n    let _x = foo();\n    let y = bar();\n    let _z = baz();\n}\n",
-    )
-    .unwrap();
-
-    let args = ReplaceArgs {
-        from: "let _".to_string(),
-        to: Some(String::new()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: true,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(replacements[0].match_count, 2);
-    assert_eq!(
-        replacements[0].replaced,
-        "fn main() {\n    let y = bar();\n}\n"
-    );
-}
-
-#[test]
-fn whole_line_regex_deletes_matching_lines() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.rs");
-    fs::write(
-        &file,
-        "use std::io;\nuse std::fmt;\nuse crate::foo;\nuse crate::bar;\n",
-    )
-    .unwrap();
-
-    let args = ReplaceArgs {
-        from: r"use crate::".to_string(),
-        to: Some(String::new()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: false,
-        regex: true,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: true,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(replacements[0].match_count, 2);
-    assert_eq!(replacements[0].replaced, "use std::io;\nuse std::fmt;\n");
-}
-
-#[test]
-fn whole_line_replaces_entire_line() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "alpha\nbeta match\ngamma\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "match".to_string(),
-        to: Some("replaced line".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: true,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(replacements[0].replaced, "alpha\nreplaced line\ngamma\n");
-}
-
-#[test]
-fn whole_line_with_range_restricts_matches() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "aaa\nbbb\nccc\nbbb\neee\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "bbb".to_string(),
-        to: Some(String::new()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: true,
-        range: Some("1:3".to_string()),
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    // Only the bbb on line 2 should be deleted; the one on line 4 is outside range.
-    assert_eq!(replacements[0].match_count, 1);
-    assert_eq!(replacements[0].replaced, "aaa\nccc\nbbb\neee\n");
-}
-
-#[test]
-fn whole_line_nth_only_removes_nth_match() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "aaa\nbbb\nccc\nbbb\neee\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "bbb".to_string(),
-        to: Some(String::new()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: Some(2),
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: true,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(replacements[0].match_count, 1);
-    // Second occurrence of bbb (line 4) is deleted.
-    assert_eq!(replacements[0].replaced, "aaa\nbbb\nccc\neee\n");
-}
-
-#[test]
-fn range_requires_whole_line() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "hello".to_string(),
-        to: Some("hi".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: false,
-        range: Some("1:5".to_string()),
-        write: Default::default(),
-    };
-    let err = run(args, &GlobalFlags::test_default()).unwrap_err();
-    assert!(
-        err.to_string().contains("range requires whole_line"),
-        "{err}"
-    );
-}
-
-#[test]
-fn whole_line_and_multiline_conflict() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "hello\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "hello".to_string(),
-        to: Some("hi".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: false,
-        regex: true,
-        if_exists: false,
-        multiline: true,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: false,
-        whole_line: true,
-        range: None,
-        write: Default::default(),
-    };
-    let err = run(args, &GlobalFlags::test_default()).unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("whole_line and multiline cannot be combined"),
-        "{err}"
-    );
-}
-
-#[test]
-fn word_boundary_prevents_partial_match() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.rs");
-    fs::write(
-        &file,
-        "struct SetupFile {}\nstruct BenchSetupFile {}\nlet x: SetupFile = todo!();\n",
-    )
-    .unwrap();
-
-    let args = ReplaceArgs {
-        from: "SetupFile".to_string(),
-        to: Some("NewFile".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: true,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(replacements[0].match_count, 2);
-    assert_eq!(
-        replacements[0].replaced,
-        "struct NewFile {}\nstruct BenchSetupFile {}\nlet x: NewFile = todo!();\n",
-        "word_boundary should rename standalone SetupFile but not inside BenchSetupFile"
-    );
-}
-
-#[test]
-fn word_boundary_with_metacharacters() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.rs");
-    fs::write(&file, "type A = Option<SetupFile>;\n").unwrap();
-
-    let args = ReplaceArgs {
-        from: "SetupFile".to_string(),
-        to: Some("NewFile".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: true,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    assert_eq!(
-        replacements[0].replaced, "type A = Option<NewFile>;\n",
-        "word_boundary should match at angle bracket boundaries"
-    );
-}
-
-#[test]
-fn word_boundary_does_not_match_in_string() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("test.rs");
-    // In a string, SetupFile is still at word boundaries (quotes are non-word chars)
-    // so word_boundary alone won't skip strings -- that needs AST (#647).
-    // But it WILL prevent matching inside compound identifiers.
-    fs::write(
-        &file,
-        "let name = \"SetupFile\";\nlet x: SetupFileConfig = todo!();\n",
-    )
-    .unwrap();
-
-    let args = ReplaceArgs {
-        from: "SetupFile".to_string(),
-        to: Some("NewFile".to_string()),
-        insert_before: None,
-        insert_after: None,
-        paths: vec![dir.path().to_string_lossy().into_owned()],
-        literal: true,
-        regex: false,
-        if_exists: false,
-        multiline: false,
-        nth: None,
-        case_insensitive: false,
-        word_boundary: true,
-        whole_line: false,
-        range: None,
-        write: Default::default(),
-    };
-    let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-
-    assert_eq!(replacements.len(), 1);
-    // SetupFile in the string IS matched (word boundaries don't know about strings)
-    // SetupFileConfig is NOT matched (no word boundary between SetupFile and Config)
-    assert_eq!(
-        replacements[0].replaced,
-        "let name = \"NewFile\";\nlet x: SetupFileConfig = todo!();\n",
-    );
+mod error_handling {
+    use super::*;
+
+    #[test]
+    fn no_matches_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = make_args(
+            "zzz_no_match_zzz",
+            "replacement",
+            vec![dir.path().to_string_lossy().into_owned()],
+        );
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn nth_zero_is_rejected() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "hello".to_string(),
+            to: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: Some(0),
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let err = run(args, &GlobalFlags::test_default()).unwrap_err();
+        assert!(err.to_string().contains("1-based"), "{err}");
+    }
+
+    #[test]
+    fn range_requires_whole_line() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "hello".to_string(),
+            to: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: Some("1:5".to_string()),
+            write: Default::default(),
+        };
+        let err = run(args, &GlobalFlags::test_default()).unwrap_err();
+        assert!(
+            err.to_string().contains("range requires whole_line"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn whole_line_and_multiline_conflict() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "hello".to_string(),
+            to: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: false,
+            regex: true,
+            if_exists: false,
+            multiline: true,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: true,
+            range: None,
+            write: Default::default(),
+        };
+        let err = run(args, &GlobalFlags::test_default()).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("whole_line and multiline cannot be combined"),
+            "{err}"
+        );
+    }
 }

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -46,1067 +46,1229 @@ fn portable_path_str(p: &std::path::Path) -> String {
     p.to_str().unwrap().replace('\\', "/")
 }
 
-#[test]
-fn read_file_content_populates_pending_from_disk() {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("existing.txt");
-    fs::write(&path, "hello from disk\n").unwrap();
-    let mut pending = HashMap::new();
-    let mut existed = HashSet::new();
-
-    let content = read_file_content(&mut pending, &mut existed, &path).unwrap();
-
-    assert_eq!(content, "hello from disk\n");
-    assert_eq!(
-        pending.get(&path),
-        Some(&(
-            "hello from disk\n".to_string(),
-            "hello from disk\n".to_string()
-        ))
-    );
-}
-
-#[test]
-fn read_and_probe_returns_true_for_text() {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("text.rs");
-    fs::write(&path, "fn main() {}\n").unwrap();
-    let mut pending = HashMap::new();
-    let mut existed = HashSet::new();
-
-    assert!(read_and_probe(&mut pending, &mut existed, &path).unwrap());
-    assert!(pending.contains_key(&path));
-    assert_eq!(pending[&path].1, "fn main() {}\n");
-}
-
-#[test]
-fn read_and_probe_returns_false_for_binary() {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("data.bin");
-    fs::write(&path, b"ELF\x00\x01\x02\x03").unwrap();
-    let mut pending = HashMap::new();
-    let mut existed = HashSet::new();
-
-    assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
-    assert!(!pending.contains_key(&path));
-}
-
-#[test]
-fn read_and_probe_returns_false_for_invalid_utf8() {
-    let dir = TempDir::new().unwrap();
-    let path = dir.path().join("bad.txt");
-    // Bare continuation bytes: invalid UTF-8 but no NUL (passes binary check)
-    fs::write(&path, [0x80, 0x81, 0x82]).unwrap();
-    let mut pending = HashMap::new();
-    let mut existed = HashSet::new();
-
-    // Should skip gracefully (false) instead of erroring,
-    // matching standalone search/replace behavior.
-    assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
-    assert!(!pending.contains_key(&path));
-}
-
-#[test]
-fn update_file_content_inserts_missing_pending_entry() {
-    let mut pending = HashMap::new();
-    let mut deletions = HashSet::new();
-    let path = PathBuf::from("created.txt");
-
-    update_file_content(&mut pending, &mut deletions, &path, "brand new".to_string());
-
-    assert_eq!(
-        pending.get(&path),
-        Some(&(String::new(), "brand new".to_string()))
-    );
-}
-
-#[test]
-fn multi_op_plan() {
-    let dir = TempDir::new().unwrap();
-
-    // Create test files.
-    let txt = dir.path().join("test.txt");
-    fs::write(&txt, "hello world\n").unwrap();
-
-    let json_file = dir.path().join("config.json");
-    fs::write(&json_file, r#"{"name": "old"}"#).unwrap();
-
-    let no_nl = dir.path().join("no_nl.txt");
-    fs::write(&no_nl, "content").unwrap();
-
-    // Build plan with replace + doc.set + tidy.fix.
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [
-            {
-                "op": "replace",
-                "path": txt.to_str().unwrap(),
-                "from": "hello",
-                "to": "hi"
-            },
-            {
-                "op": "doc.set",
-                "path": json_file.to_str().unwrap(),
-                "selector": "name",
-                "value": "new"
-            },
-            {
-                "op": "tidy.fix",
-                "path": no_nl.to_str().unwrap(),
-                "ensure_final_newline": true
-            }
-        ]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    // Verify replace.
-    assert_eq!(fs::read_to_string(&txt).unwrap(), "hi world\n");
-
-    // Verify doc.set.
-    let config: serde_json::Value =
-        serde_json::from_str(&fs::read_to_string(&json_file).unwrap()).unwrap();
-    assert_eq!(config["name"], serde_json::json!("new"));
-
-    // Verify tidy.fix.
-    assert!(fs::read_to_string(&no_nl).unwrap().ends_with('\n'));
-}
-
-#[test]
-fn create_then_delete_in_same_tx_becomes_noop() {
-    let dir = TempDir::new().unwrap();
-    let new_file = dir.path().join("new.txt");
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [
-            {"op": "file.create", "path": new_file.to_str().unwrap(), "content": "hello"},
-            {"op": "file.delete", "path": new_file.to_str().unwrap()}
-        ]
-    });
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.check = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert!(!new_file.exists());
-}
-
-#[test]
-fn rollback_on_failure() {
-    let dir = TempDir::new().unwrap();
-
-    let txt = dir.path().join("test.txt");
-    fs::write(&txt, "hello world\n").unwrap();
-
-    let nonexistent = dir.path().join("nonexistent.json");
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [
-            {
-                "op": "replace",
-                "path": txt.to_str().unwrap(),
-                "from": "hello",
-                "to": "hi"
-            },
-            {
-                "op": "doc.set",
-                "path": nonexistent.to_str().unwrap(),
-                "selector": "name",
-                "value": "test"
-            }
-        ]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::OPERATION_FAILED);
-
-    // Verify no files were modified.
-    assert_eq!(fs::read_to_string(&txt).unwrap(), "hello world\n");
-}
-
-#[test]
-fn legacy_error_prefix_maps_format_failed() {
-    assert_eq!(legacy_error_prefix("format_failed"), "validation_failed");
-    assert_eq!(legacy_error_prefix("rollback"), "rollback");
-    assert_eq!(legacy_error_prefix("parse_error"), "parse_error");
-}
-
-#[test]
-fn build_error_output_produces_expected_shape() {
-    let output = build_error_output("rollback", "rollback", "disk full", None);
-    assert!(!output.ok);
-    assert_eq!(output.status, "error".to_string());
-    assert_eq!(output.error_kind, Some("rollback".to_string()));
-    assert_eq!(output.error, Some("rollback: disk full".to_string()));
-    assert_eq!(output.files_changed, 0);
-}
-
-#[test]
-fn validation_pass() {
-    let dir = TempDir::new().unwrap();
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [],
-        "validate": [
-            {"cmd": shell_true(), "required": true}
-        ]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-    global.cwd = Some(dir.path().to_string_lossy().into_owned());
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-#[test]
-fn validation_fail_required() {
-    let dir = TempDir::new().unwrap();
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "strict": false,
-        "operations": [],
-        "validate": [
-            {"cmd": shell_false(), "required": true}
-        ]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-    global.cwd = Some(dir.path().to_string_lossy().into_owned());
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::VALIDATION_FAILED);
-}
-
-#[test]
-fn validation_pass_with_large_stderr_output() {
-    let dir = TempDir::new().unwrap();
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [],
-        "validate": [
-            {"cmd": shell_stderr_spam(), "required": true, "timeout": 10}
-        ]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-    global.cwd = Some(dir.path().to_string_lossy().into_owned());
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-}
-
-#[test]
-fn parse_plan_json_string() {
-    let plan_json = r#"{"version": "1", "operations": [{"op": "replace", "path": "test.txt", "from": "a", "to": "b"}]}"#;
-    let plan = plan::parse_plan(plan_json).unwrap();
-    assert_eq!(plan.operations.len(), 1);
-}
-
-#[test]
-fn malformed_plan_returns_parse_error() {
-    let dir = TempDir::new().unwrap();
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, "not json at all {{{").unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let global = GlobalFlags::test_default();
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::PARSE_ERROR);
-}
-
-#[test]
-fn replace_requires_replacement_mode() {
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "replace",
-            "path": "test.txt",
-            "from": "hello"
-        }]
-    })
-    .to_string();
-    let plan = plan::parse_plan(&plan_json).unwrap();
-
-    let err = validate_operation(&plan.operations[0]).unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "replace: one of 'to', 'insert_before', or 'insert_after' must be provided"
-    );
-}
-
-#[test]
-fn replace_conflicting_insert_fields_return_parse_error() {
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "replace",
-            "path": "test.txt",
-            "from": "hello",
-            "insert_before": "X",
-            "insert_after": "Y"
-        }]
-    })
-    .to_string();
-    let plan = plan::parse_plan(&plan_json).unwrap();
-
-    let err = validate_operation(&plan.operations[0]).unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "replace: 'insert_before' and 'insert_after' cannot be combined"
-    );
-}
-
-#[test]
-fn regex_insert_before_uses_match_anchor_in_replacement_text() {
-    let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true);
-
-    assert_eq!(text, "X${0}");
-}
-
-#[test]
-fn regex_insert_after_uses_match_anchor_in_replacement_text() {
-    let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true);
-
-    assert_eq!(text, "${0}X");
-}
-
-#[test]
-fn replace_to_with_insert_returns_parse_error() {
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "replace",
-            "path": "test.txt",
-            "from": "hello",
-            "to": "world",
-            "insert_before": "X"
-        }]
-    })
-    .to_string();
-    let plan = plan::parse_plan(&plan_json).unwrap();
-
-    let err = validate_operation(&plan.operations[0]).unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "replace: 'to' cannot be combined with 'insert_before' or 'insert_after'"
-    );
-}
-
-#[test]
-fn tx_file_create_in_plan() {
-    let dir = TempDir::new().unwrap();
-
-    let new_file = dir.path().join("created.txt");
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [
-            {
-                "op": "file.create",
-                "path": new_file.to_str().unwrap(),
-                "content": "brand new file\n"
-            }
-        ]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    // Verify the file was created with the correct content.
-    assert!(new_file.exists());
-    assert_eq!(fs::read_to_string(&new_file).unwrap(), "brand new file\n");
-}
-
-#[test]
-fn tx_file_create_existing_fails() {
-    let dir = TempDir::new().unwrap();
-
-    let existing = dir.path().join("existing.txt");
-    fs::write(&existing, "original content\n").unwrap();
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [
-            {
-                "op": "file.create",
-                "path": existing.to_str().unwrap(),
-                "content": "should not overwrite\n"
-            }
-        ]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::OPERATION_FAILED);
-
-    // Verify the original file was NOT modified.
-    assert_eq!(fs::read_to_string(&existing).unwrap(), "original content\n");
-}
-
-#[test]
-fn validate_operation_rejects_empty_from() {
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "replace",
-            "path": "test.txt",
-            "from": "",
-            "to": "x"
-        }]
-    })
-    .to_string();
-    let plan = plan::parse_plan(&plan_json).unwrap();
-
-    let err = validate_operation(&plan.operations[0]).unwrap_err();
-    assert!(
-        err.to_string().contains("search pattern must not be empty"),
-        "expected 'search pattern must not be empty' error, got: {}",
-        err
-    );
-}
-
-#[test]
-fn validate_operation_rejects_nth_zero() {
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "replace",
-            "path": "test.txt",
-            "from": "hello",
-            "to": "world",
-            "nth": 0
-        }]
-    })
-    .to_string();
-    let plan = plan::parse_plan(&plan_json).unwrap();
-
-    let err = validate_operation(&plan.operations[0]).unwrap_err();
-    assert!(
-        err.to_string().contains("1-based"),
-        "expected '1-based' error, got: {}",
-        err
-    );
-}
-
-#[test]
-fn validate_operation_rejects_invert_match_with_multiline() {
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "search",
-            "path": "test.txt",
-            "pattern": "foo",
-            "invert_match": true,
-            "multiline": true
-        }]
-    })
-    .to_string();
-    let plan = plan::parse_plan(&plan_json).unwrap();
-
-    let err = validate_operation(&plan.operations[0]).unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("invert_match and multiline cannot be combined"),
-        "unexpected error: {}",
-        err
-    );
-}
-
-#[test]
-fn validate_operation_rejects_literal_with_regex() {
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "search",
-            "path": "test.txt",
-            "pattern": "foo",
-            "literal": true,
-            "regex": true
-        }]
-    })
-    .to_string();
-    let plan = plan::parse_plan(&plan_json).unwrap();
-
-    let err = validate_operation(&plan.operations[0]).unwrap_err();
-    assert!(
-        err.to_string()
-            .contains("literal and regex cannot be combined"),
-        "unexpected error: {}",
-        err
-    );
-}
-
-#[test]
-fn tx_file_rename_basic() {
-    let dir = TempDir::new().unwrap();
-    let src = dir.path().join("old.txt");
-    fs::write(&src, "content\n").unwrap();
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "file.rename",
-            "from": portable_path_str(&src),
-            "to": portable_path_str(&dir.path().join("new.txt"))
-        }]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert!(!src.exists());
-    assert_eq!(
-        fs::read_to_string(dir.path().join("new.txt")).unwrap(),
-        "content\n"
-    );
-}
-
-#[test]
-fn tx_file_rename_same_path_noop() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("same.txt");
-    fs::write(&f, "data\n").unwrap();
-
-    let path_str = portable_path_str(&f);
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "file.rename",
-            "from": path_str,
-            "to": path_str
-        }]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(fs::read_to_string(&f).unwrap(), "data\n");
-}
-
-#[test]
-fn tx_file_rename_dst_exists_without_force_rolls_back() {
-    let dir = TempDir::new().unwrap();
-    let src = dir.path().join("src.txt");
-    let dst = dir.path().join("dst.txt");
-    fs::write(&src, "source\n").unwrap();
-    fs::write(&dst, "dest\n").unwrap();
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "file.rename",
-            "from": portable_path_str(&src),
-            "to": portable_path_str(&dst)
-        }]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::OPERATION_FAILED);
-    // Both files unchanged.
-    assert_eq!(fs::read_to_string(&src).unwrap(), "source\n");
-    assert_eq!(fs::read_to_string(&dst).unwrap(), "dest\n");
-}
-
-#[test]
-fn tx_file_rename_dst_exists_with_force() {
-    let dir = TempDir::new().unwrap();
-    let src = dir.path().join("src.txt");
-    let dst = dir.path().join("dst.txt");
-    fs::write(&src, "source\n").unwrap();
-    fs::write(&dst, "dest\n").unwrap();
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [{
-            "op": "file.rename",
-            "from": portable_path_str(&src),
-            "to": portable_path_str(&dst),
-            "force": true
-        }]
-    });
-
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert!(!src.exists());
-    assert_eq!(fs::read_to_string(&dst).unwrap(), "source\n");
-}
-
-#[test]
-fn tx_create_then_rename() {
-    let dir = TempDir::new().unwrap();
-    let created = dir.path().join("created.txt");
-    let renamed = dir.path().join("renamed.txt");
-
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [
-            {
-                "op": "file.create",
-                "path": portable_path_str(&created),
-                "content": "new file\n"
-            },
-            {
+mod basic {
+    use super::*;
+
+    #[test]
+    fn read_file_content_populates_pending_from_disk() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("existing.txt");
+        fs::write(&path, "hello from disk\n").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        let content = read_file_content(&mut pending, &mut existed, &path).unwrap();
+
+        assert_eq!(content, "hello from disk\n");
+        assert_eq!(
+            pending.get(&path),
+            Some(&(
+                "hello from disk\n".to_string(),
+                "hello from disk\n".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn read_and_probe_returns_true_for_text() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("text.rs");
+        fs::write(&path, "fn main() {}\n").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
+
+        assert!(read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(pending.contains_key(&path));
+        assert_eq!(pending[&path].1, "fn main() {}\n");
+    }
+
+    #[test]
+    fn update_file_content_inserts_missing_pending_entry() {
+        let mut pending = HashMap::new();
+        let mut deletions = HashSet::new();
+        let path = PathBuf::from("created.txt");
+
+        update_file_content(&mut pending, &mut deletions, &path, "brand new".to_string());
+
+        assert_eq!(
+            pending.get(&path),
+            Some(&(String::new(), "brand new".to_string()))
+        );
+    }
+
+    #[test]
+    fn multi_op_plan() {
+        let dir = TempDir::new().unwrap();
+
+        // Create test files.
+        let txt = dir.path().join("test.txt");
+        fs::write(&txt, "hello world\n").unwrap();
+
+        let json_file = dir.path().join("config.json");
+        fs::write(&json_file, r#"{"name": "old"}"#).unwrap();
+
+        let no_nl = dir.path().join("no_nl.txt");
+        fs::write(&no_nl, "content").unwrap();
+
+        // Build plan with replace + doc.set + tidy.fix.
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [
+                {
+                    "op": "replace",
+                    "path": txt.to_str().unwrap(),
+                    "from": "hello",
+                    "to": "hi"
+                },
+                {
+                    "op": "doc.set",
+                    "path": json_file.to_str().unwrap(),
+                    "selector": "name",
+                    "value": "new"
+                },
+                {
+                    "op": "tidy.fix",
+                    "path": no_nl.to_str().unwrap(),
+                    "ensure_final_newline": true
+                }
+            ]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        // Verify replace.
+        assert_eq!(fs::read_to_string(&txt).unwrap(), "hi world\n");
+
+        // Verify doc.set.
+        let config: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&json_file).unwrap()).unwrap();
+        assert_eq!(config["name"], serde_json::json!("new"));
+
+        // Verify tidy.fix.
+        assert!(fs::read_to_string(&no_nl).unwrap().ends_with('\n'));
+    }
+
+    #[test]
+    fn legacy_error_prefix_maps_format_failed() {
+        assert_eq!(legacy_error_prefix("format_failed"), "validation_failed");
+        assert_eq!(legacy_error_prefix("rollback"), "rollback");
+        assert_eq!(legacy_error_prefix("parse_error"), "parse_error");
+    }
+
+    #[test]
+    fn build_error_output_produces_expected_shape() {
+        let output = build_error_output("rollback", "rollback", "disk full", None);
+        assert!(!output.ok);
+        assert_eq!(output.status, "error".to_string());
+        assert_eq!(output.error_kind, Some("rollback".to_string()));
+        assert_eq!(output.error, Some("rollback: disk full".to_string()));
+        assert_eq!(output.files_changed, 0);
+    }
+
+    #[test]
+    fn validation_pass() {
+        let dir = TempDir::new().unwrap();
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [],
+            "validate": [
+                {"cmd": shell_true(), "required": true}
+            ]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+        global.cwd = Some(dir.path().to_string_lossy().into_owned());
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn parse_plan_json_string() {
+        let plan_json = r#"{"version": "1", "operations": [{"op": "replace", "path": "test.txt", "from": "a", "to": "b"}]}"#;
+        let plan = plan::parse_plan(plan_json).unwrap();
+        assert_eq!(plan.operations.len(), 1);
+    }
+
+    #[test]
+    fn regex_insert_before_uses_match_anchor_in_replacement_text() {
+        let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true);
+
+        assert_eq!(text, "X${0}");
+    }
+
+    #[test]
+    fn regex_insert_after_uses_match_anchor_in_replacement_text() {
+        let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true);
+
+        assert_eq!(text, "${0}X");
+    }
+
+    #[test]
+    fn tx_file_create_in_plan() {
+        let dir = TempDir::new().unwrap();
+
+        let new_file = dir.path().join("created.txt");
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [
+                {
+                    "op": "file.create",
+                    "path": new_file.to_str().unwrap(),
+                    "content": "brand new file\n"
+                }
+            ]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        // Verify the file was created with the correct content.
+        assert!(new_file.exists());
+        assert_eq!(fs::read_to_string(&new_file).unwrap(), "brand new file\n");
+    }
+
+    #[test]
+    fn tx_file_rename_basic() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("old.txt");
+        fs::write(&src, "content\n").unwrap();
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
                 "op": "file.rename",
-                "from": portable_path_str(&created),
-                "to": portable_path_str(&renamed)
-            }
-        ]
-    });
+                "from": portable_path_str(&src),
+                "to": portable_path_str(&dir.path().join("new.txt"))
+            }]
+        });
 
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert!(!created.exists());
-    assert_eq!(fs::read_to_string(&renamed).unwrap(), "new file\n");
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(!src.exists());
+        assert_eq!(
+            fs::read_to_string(dir.path().join("new.txt")).unwrap(),
+            "content\n"
+        );
+    }
+
+    #[test]
+    fn tx_file_rename_dst_exists_with_force() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src.txt");
+        let dst = dir.path().join("dst.txt");
+        fs::write(&src, "source\n").unwrap();
+        fs::write(&dst, "dest\n").unwrap();
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "file.rename",
+                "from": portable_path_str(&src),
+                "to": portable_path_str(&dst),
+                "force": true
+            }]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(!src.exists());
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "source\n");
+    }
+
+    #[test]
+    fn tx_create_then_rename() {
+        let dir = TempDir::new().unwrap();
+        let created = dir.path().join("created.txt");
+        let renamed = dir.path().join("renamed.txt");
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [
+                {
+                    "op": "file.create",
+                    "path": portable_path_str(&created),
+                    "content": "new file\n"
+                },
+                {
+                    "op": "file.rename",
+                    "from": portable_path_str(&created),
+                    "to": portable_path_str(&renamed)
+                }
+            ]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(!created.exists());
+        assert_eq!(fs::read_to_string(&renamed).unwrap(), "new file\n");
+    }
+
+    #[test]
+    fn undo_list_json_output() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("a.txt");
+        fs::write(&file, "v1").unwrap();
+        let mut session = crate::backup::BackupSession::new(dir.path()).unwrap();
+        session.save_before_write(&file).unwrap();
+        session.finalize().unwrap().unwrap();
+
+        let args = crate::cmd::undo::UndoArgs {
+            list: true,
+            session: None,
+            apply: false,
+        };
+        let global = GlobalFlags::with_cwd_and_json(dir.path());
+        let code = crate::cmd::undo::run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        // Also test JSONL mode.
+        let global = GlobalFlags::with_cwd_and_jsonl(dir.path());
+        let args2 = crate::cmd::undo::UndoArgs {
+            list: true,
+            session: None,
+            apply: false,
+        };
+        let code2 = crate::cmd::undo::run(args2, &global).unwrap();
+        assert_eq!(code2, exit::SUCCESS);
+    }
+
+    #[test]
+    fn undo_dry_run_json_output() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("b.txt");
+        fs::write(&file, "v1").unwrap();
+        let mut session = crate::backup::BackupSession::new(dir.path()).unwrap();
+        session.save_before_write(&file).unwrap();
+        let ts = session.finalize().unwrap().unwrap();
+
+        // Modify file so dry-run shows changes.
+        fs::write(&file, "v2").unwrap();
+
+        let args = crate::cmd::undo::UndoArgs {
+            list: false,
+            session: Some(ts),
+            apply: false,
+        };
+        let global = GlobalFlags::with_cwd_and_json(dir.path());
+        let code = crate::cmd::undo::run(args, &global).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    #[test]
+    fn path_err_formats_flat_error_with_path_prefix() {
+        let err = crate::tx::path_err("config.toml")(anyhow::anyhow!("key not found"));
+        let msg = err.to_string();
+        assert_eq!(msg, "config.toml: key not found");
+    }
+
+    #[test]
+    fn tx_yaml_plan_format() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test_file.txt");
+        let plan_yaml = format!(
+            "version: \"1\"\noperations:\n  - op: file.create\n    path: \"{}\"\n    content: \"hello from yaml plan\"\n",
+            portable_path_str(&target)
+        );
+        let plan_file = dir.path().join("plan.yaml");
+        fs::write(&plan_file, &plan_yaml).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS, "YAML plan should succeed");
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "hello from yaml plan",
+            "file should contain content from YAML plan"
+        );
+    }
+
+    #[test]
+    fn tx_toml_plan_format() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("test_file.txt");
+        let plan_toml = format!(
+            "version = \"1\"\n\n[[operations]]\nop = \"file.create\"\npath = \"{}\"\ncontent = \"hello from toml plan\"\n",
+            portable_path_str(&target)
+        );
+        let plan_file = dir.path().join("plan.toml");
+        fs::write(&plan_file, &plan_toml).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS, "TOML plan should succeed");
+        assert_eq!(
+            fs::read_to_string(&target).unwrap(),
+            "hello from toml plan",
+            "file should contain content from TOML plan"
+        );
+    }
 }
 
-#[test]
-fn tx_unsupported_plan_version() {
-    let dir = TempDir::new().unwrap();
-    let plan_json = serde_json::json!({
-        "version": "99",
-        "operations": []
-    });
+mod edge_cases {
+    use super::*;
 
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+    #[test]
+    fn read_and_probe_returns_false_for_binary() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("data.bin");
+        fs::write(&path, b"ELF\x00\x01\x02\x03").unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let global = GlobalFlags::test_default();
+        assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(!pending.contains_key(&path));
+    }
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::PARSE_ERROR);
-}
+    #[test]
+    fn read_and_probe_returns_false_for_invalid_utf8() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.txt");
+        // Bare continuation bytes: invalid UTF-8 but no NUL (passes binary check)
+        fs::write(&path, [0x80, 0x81, 0x82]).unwrap();
+        let mut pending = HashMap::new();
+        let mut existed = HashSet::new();
 
-#[test]
-fn tx_delete_then_create_without_force_succeeds() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("target.txt");
-    fs::write(&f, "original\n").unwrap();
+        // Should skip gracefully (false) instead of erroring,
+        // matching standalone search/replace behavior.
+        assert!(!read_and_probe(&mut pending, &mut existed, &path).unwrap());
+        assert!(!pending.contains_key(&path));
+    }
 
-    let plan_json = serde_json::json!({
-        "version": "1",
-        "operations": [
-            {
-                "op": "file.delete",
-                "path": portable_path_str(&f)
-            },
-            {
-                "op": "file.create",
-                "path": portable_path_str(&f),
-                "content": "recreated\n"
-            }
-        ]
-    });
+    #[test]
+    fn create_then_delete_in_same_tx_becomes_noop() {
+        let dir = TempDir::new().unwrap();
+        let new_file = dir.path().join("new.txt");
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [
+                {"op": "file.create", "path": new_file.to_str().unwrap(), "content": "hello"},
+                {"op": "file.delete", "path": new_file.to_str().unwrap()}
+            ]
+        });
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
 
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.check = true;
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(!new_file.exists());
+    }
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-    assert_eq!(fs::read_to_string(&f).unwrap(), "recreated\n");
-}
+    #[test]
+    fn tx_file_rename_same_path_noop() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("same.txt");
+        fs::write(&f, "data\n").unwrap();
 
-// -----------------------------------------------------------------------
-// #387: Medium-priority test gaps
-// -----------------------------------------------------------------------
+        let path_str = portable_path_str(&f);
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "file.rename",
+                "from": path_str,
+                "to": path_str
+            }]
+        });
 
-#[test]
-fn parse_eol_mode_invalid_value_returns_error() {
-    let result = crate::write::parse_eol_mode("bogus");
-    let msg = result
-        .expect_err("invalid eol value should fail")
-        .to_string();
-    assert!(
-        msg.contains("invalid normalize_eol"),
-        "error should name the field: {msg}"
-    );
-}
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
 
-#[test]
-fn rollback_strict_restores_modified_files() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("a.txt");
-    fs::write(&f, "original").unwrap();
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
 
-    let mut pending = HashMap::new();
-    pending.insert(f.clone(), ("original".to_string(), "changed".to_string()));
-    let deletions = HashSet::new();
-    let existed_before: HashSet<PathBuf> = [f.clone()].into();
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(fs::read_to_string(&f).unwrap(), "data\n");
+    }
 
-    // Simulate the apply phase: write the new content.
-    crate::write::atomic_write(&f, "changed", &WritePolicy::default()).unwrap();
-    assert_eq!(fs::read_to_string(&f).unwrap(), "changed");
+    #[test]
+    fn tx_delete_then_create_without_force_succeeds() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("target.txt");
+        fs::write(&f, "original\n").unwrap();
 
-    // Rollback should restore to original.
-    crate::tx::rollback_strict(
-        &[(f.clone(), "original".to_string(), "changed".to_string())],
-        &pending,
-        &deletions,
-        &existed_before,
-    );
-    assert_eq!(
-        fs::read_to_string(&f).unwrap(),
-        "original",
-        "rollback_strict should restore the original content"
-    );
-}
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [
+                {
+                    "op": "file.delete",
+                    "path": portable_path_str(&f)
+                },
+                {
+                    "op": "file.create",
+                    "path": portable_path_str(&f),
+                    "content": "recreated\n"
+                }
+            ]
+        });
 
-#[test]
-fn tx_doc_append_to_non_array_rolls_back() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("data.json");
-    fs::write(&f, r#"{"items": "not-an-array"}"#).unwrap();
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
 
-    let plan = format!(
-        r#"{{
-  "version": "1",
-  "operations": [
-{{"op": "doc.append", "path": "{}", "selector": "items", "value": 42}}
-  ]
-}}"#,
-        portable_path_str(&f)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(fs::read_to_string(&f).unwrap(), "recreated\n");
+    }
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::OPERATION_FAILED,
-        "doc.append to non-array should fail before commit"
-    );
-}
+    #[test]
+    fn tx_doc_delete_missing_key_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("data.json");
+        fs::write(&f, r#"{"a": 1}"#).unwrap();
 
-#[test]
-fn tx_doc_prepend_to_non_array_rolls_back() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("data.json");
-    fs::write(&f, r#"{"items": "not-an-array"}"#).unwrap();
-
-    let plan = format!(
-        r#"{{
-  "version": "1",
-  "operations": [
-{{"op": "doc.prepend", "path": "{}", "selector": "items", "value": 99}}
-  ]
-}}"#,
-        portable_path_str(&f)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::OPERATION_FAILED,
-        "doc.prepend to non-array should fail before commit"
-    );
-}
-
-#[test]
-fn tx_doc_delete_where_on_non_array_rolls_back() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("data.json");
-    fs::write(&f, r#"{"items": "not-an-array"}"#).unwrap();
-
-    let plan = format!(
-        r#"{{
-  "version": "1",
-  "operations": [
-{{"op": "doc.delete_where", "path": "{}", "selector": "items", "predicate": "x=1"}}
-  ]
-}}"#,
-        portable_path_str(&f)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::OPERATION_FAILED,
-        "doc.delete_where on non-array should fail before commit"
-    );
-}
-
-#[test]
-fn tx_doc_delete_missing_key_is_idempotent() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("data.json");
-    fs::write(&f, r#"{"a": 1}"#).unwrap();
-
-    let plan = format!(
-        r#"{{
+        let plan = format!(
+            r#"{{
   "version": "1",
   "operations": [
 {{"op": "doc.delete", "path": "{}", "selector": "nonexistent"}}
   ]
 }}"#,
-        portable_path_str(&f)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::SUCCESS,
-        "doc.delete on missing key should succeed (idempotent)"
-    );
-}
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::SUCCESS,
+            "doc.delete on missing key should succeed (idempotent)"
+        );
+    }
 
-#[test]
-fn tx_doc_delete_where_no_match_is_idempotent() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("data.json");
-    fs::write(&f, r#"{"items": [{"name": "a"}]}"#).unwrap();
+    #[test]
+    fn tx_doc_delete_where_no_match_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("data.json");
+        fs::write(&f, r#"{"items": [{"name": "a"}]}"#).unwrap();
 
-    let plan = format!(
-        r#"{{
+        let plan = format!(
+            r#"{{
   "version": "1",
   "operations": [
 {{"op": "doc.delete_where", "path": "{}", "selector": "items", "predicate": "name=nonexistent"}}
   ]
 }}"#,
-        portable_path_str(&f)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::SUCCESS,
-        "doc.delete_where with zero matches should succeed (idempotent)"
-    );
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::SUCCESS,
+            "doc.delete_where with zero matches should succeed (idempotent)"
+        );
+    }
+
+    #[test]
+    fn validation_pass_with_large_stderr_output() {
+        let dir = TempDir::new().unwrap();
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [],
+            "validate": [
+                {"cmd": shell_stderr_spam(), "required": true, "timeout": 10}
+            ]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+        global.cwd = Some(dir.path().to_string_lossy().into_owned());
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
 }
 
-#[test]
-fn tx_strict_mode_rollback_on_operation_failure() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("data.txt");
-    fs::write(&f, "original content").unwrap();
+mod error_handling {
+    use super::*;
 
-    // Operation 1 succeeds (replace), operation 2 fails (read nonexistent).
-    // Strict mode should revert operation 1's changes.
-    let plan = format!(
-        r#"{{
+    #[test]
+    fn malformed_plan_returns_parse_error() {
+        let dir = TempDir::new().unwrap();
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, "not json at all {{{").unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let global = GlobalFlags::test_default();
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::PARSE_ERROR);
+    }
+
+    #[test]
+    fn replace_requires_replacement_mode() {
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "hello"
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "replace: one of 'to', 'insert_before', or 'insert_after' must be provided"
+        );
+    }
+
+    #[test]
+    fn replace_conflicting_insert_fields_return_parse_error() {
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "hello",
+                "insert_before": "X",
+                "insert_after": "Y"
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "replace: 'insert_before' and 'insert_after' cannot be combined"
+        );
+    }
+
+    #[test]
+    fn replace_to_with_insert_returns_parse_error() {
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "hello",
+                "to": "world",
+                "insert_before": "X"
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "replace: 'to' cannot be combined with 'insert_before' or 'insert_after'"
+        );
+    }
+
+    #[test]
+    fn tx_file_create_existing_fails() {
+        let dir = TempDir::new().unwrap();
+
+        let existing = dir.path().join("existing.txt");
+        fs::write(&existing, "original content\n").unwrap();
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [
+                {
+                    "op": "file.create",
+                    "path": existing.to_str().unwrap(),
+                    "content": "should not overwrite\n"
+                }
+            ]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::OPERATION_FAILED);
+
+        // Verify the original file was NOT modified.
+        assert_eq!(fs::read_to_string(&existing).unwrap(), "original content\n");
+    }
+
+    #[test]
+    fn validate_operation_rejects_empty_from() {
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "",
+                "to": "x"
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert!(
+            err.to_string().contains("search pattern must not be empty"),
+            "expected 'search pattern must not be empty' error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validate_operation_rejects_nth_zero() {
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "replace",
+                "path": "test.txt",
+                "from": "hello",
+                "to": "world",
+                "nth": 0
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert!(
+            err.to_string().contains("1-based"),
+            "expected '1-based' error, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validate_operation_rejects_invert_match_with_multiline() {
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "search",
+                "path": "test.txt",
+                "pattern": "foo",
+                "invert_match": true,
+                "multiline": true
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("invert_match and multiline cannot be combined"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn validate_operation_rejects_literal_with_regex() {
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "search",
+                "path": "test.txt",
+                "pattern": "foo",
+                "literal": true,
+                "regex": true
+            }]
+        })
+        .to_string();
+        let plan = plan::parse_plan(&plan_json).unwrap();
+
+        let err = validate_operation(&plan.operations[0]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("literal and regex cannot be combined"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn tx_unsupported_plan_version() {
+        let dir = TempDir::new().unwrap();
+        let plan_json = serde_json::json!({
+            "version": "99",
+            "operations": []
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let global = GlobalFlags::test_default();
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::PARSE_ERROR);
+    }
+
+    #[test]
+    fn parse_eol_mode_invalid_value_returns_error() {
+        let result = crate::write::parse_eol_mode("bogus");
+        let msg = result
+            .expect_err("invalid eol value should fail")
+            .to_string();
+        assert!(
+            msg.contains("invalid normalize_eol"),
+            "error should name the field: {msg}"
+        );
+    }
+
+    #[test]
+    fn tx_invalid_normalize_eol_in_plan() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("file.txt");
+        fs::write(&f, "hello\n").unwrap();
+
+        let plan = format!(
+            r#"{{
+  "version": "1",
+  "operations": [
+{{"op": "tidy.fix", "path": "{}", "normalize_eol": "bogus"}}
+  ]
+}}"#,
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::OPERATION_FAILED,
+            "invalid normalize_eol should fail before commit"
+        );
+    }
+
+    #[test]
+    fn validation_fail_required() {
+        let dir = TempDir::new().unwrap();
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "strict": false,
+            "operations": [],
+            "validate": [
+                {"cmd": shell_false(), "required": true}
+            ]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+        global.cwd = Some(dir.path().to_string_lossy().into_owned());
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::VALIDATION_FAILED);
+    }
+}
+
+mod integrity {
+    use super::*;
+
+    #[test]
+    fn rollback_on_failure() {
+        let dir = TempDir::new().unwrap();
+
+        let txt = dir.path().join("test.txt");
+        fs::write(&txt, "hello world\n").unwrap();
+
+        let nonexistent = dir.path().join("nonexistent.json");
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [
+                {
+                    "op": "replace",
+                    "path": txt.to_str().unwrap(),
+                    "from": "hello",
+                    "to": "hi"
+                },
+                {
+                    "op": "doc.set",
+                    "path": nonexistent.to_str().unwrap(),
+                    "selector": "name",
+                    "value": "test"
+                }
+            ]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::OPERATION_FAILED);
+
+        // Verify no files were modified.
+        assert_eq!(fs::read_to_string(&txt).unwrap(), "hello world\n");
+    }
+
+    #[test]
+    fn tx_file_rename_dst_exists_without_force_rolls_back() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src.txt");
+        let dst = dir.path().join("dst.txt");
+        fs::write(&src, "source\n").unwrap();
+        fs::write(&dst, "dest\n").unwrap();
+
+        let plan_json = serde_json::json!({
+            "version": "1",
+            "operations": [{
+                "op": "file.rename",
+                "from": portable_path_str(&src),
+                "to": portable_path_str(&dst)
+            }]
+        });
+
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, serde_json::to_string(&plan_json).unwrap()).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::OPERATION_FAILED);
+        // Both files unchanged.
+        assert_eq!(fs::read_to_string(&src).unwrap(), "source\n");
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "dest\n");
+    }
+
+    #[test]
+    fn rollback_strict_restores_modified_files() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("a.txt");
+        fs::write(&f, "original").unwrap();
+
+        let mut pending = HashMap::new();
+        pending.insert(f.clone(), ("original".to_string(), "changed".to_string()));
+        let deletions = HashSet::new();
+        let existed_before: HashSet<PathBuf> = [f.clone()].into();
+
+        // Simulate the apply phase: write the new content.
+        crate::write::atomic_write(&f, "changed", &WritePolicy::default()).unwrap();
+        assert_eq!(fs::read_to_string(&f).unwrap(), "changed");
+
+        // Rollback should restore to original.
+        crate::tx::rollback_strict(
+            &[(f.clone(), "original".to_string(), "changed".to_string())],
+            &pending,
+            &deletions,
+            &existed_before,
+        );
+        assert_eq!(
+            fs::read_to_string(&f).unwrap(),
+            "original",
+            "rollback_strict should restore the original content"
+        );
+    }
+
+    #[test]
+    fn tx_doc_append_to_non_array_rolls_back() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("data.json");
+        fs::write(&f, r#"{"items": "not-an-array"}"#).unwrap();
+
+        let plan = format!(
+            r#"{{
+  "version": "1",
+  "operations": [
+{{"op": "doc.append", "path": "{}", "selector": "items", "value": 42}}
+  ]
+}}"#,
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::OPERATION_FAILED,
+            "doc.append to non-array should fail before commit"
+        );
+    }
+
+    #[test]
+    fn tx_doc_prepend_to_non_array_rolls_back() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("data.json");
+        fs::write(&f, r#"{"items": "not-an-array"}"#).unwrap();
+
+        let plan = format!(
+            r#"{{
+  "version": "1",
+  "operations": [
+{{"op": "doc.prepend", "path": "{}", "selector": "items", "value": 99}}
+  ]
+}}"#,
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::OPERATION_FAILED,
+            "doc.prepend to non-array should fail before commit"
+        );
+    }
+
+    #[test]
+    fn tx_doc_delete_where_on_non_array_rolls_back() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("data.json");
+        fs::write(&f, r#"{"items": "not-an-array"}"#).unwrap();
+
+        let plan = format!(
+            r#"{{
+  "version": "1",
+  "operations": [
+{{"op": "doc.delete_where", "path": "{}", "selector": "items", "predicate": "x=1"}}
+  ]
+}}"#,
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
+
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::OPERATION_FAILED,
+            "doc.delete_where on non-array should fail before commit"
+        );
+    }
+
+    #[test]
+    fn tx_strict_mode_rollback_on_operation_failure() {
+        let dir = TempDir::new().unwrap();
+        let f = dir.path().join("data.txt");
+        fs::write(&f, "original content").unwrap();
+
+        // Operation 1 succeeds (replace), operation 2 fails (read nonexistent).
+        // Strict mode should revert operation 1's changes.
+        let plan = format!(
+            r#"{{
   "version": "1",
   "strict": true,
   "operations": [
@@ -1114,258 +1276,107 @@ fn tx_strict_mode_rollback_on_operation_failure() {
 {{"op": "read", "path": "nonexistent-file.txt"}}
   ]
 }}"#,
-        portable_path_str(&f)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
+            portable_path_str(&f)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::OPERATION_FAILED,
-        "strict plan with failing op should fail before commit"
-    );
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::OPERATION_FAILED,
+            "strict plan with failing op should fail before commit"
+        );
 
-    // File should remain untouched because execution failed before any writes.
-    let content = fs::read_to_string(&f).unwrap();
-    assert_eq!(content, "original content", "file should remain unchanged");
-}
+        // File should remain untouched because execution failed before any writes.
+        let content = fs::read_to_string(&f).unwrap();
+        assert_eq!(content, "original content", "file should remain unchanged");
+    }
 
-#[test]
-fn tx_invalid_normalize_eol_in_plan() {
-    let dir = TempDir::new().unwrap();
-    let f = dir.path().join("file.txt");
-    fs::write(&f, "hello\n").unwrap();
+    #[test]
+    fn handle_commit_error_rollback_failed_exits_failure() {
+        let err = CommitError {
+            message: "write failed".into(),
+            rollback_ok: false,
+            backup_session: Some("1234567890".into()),
+        };
+        let code = handle_commit_error(err, true, false).unwrap();
+        assert_eq!(code, exit::FAILURE);
+    }
 
-    let plan = format!(
-        r#"{{
-  "version": "1",
-  "operations": [
-{{"op": "tidy.fix", "path": "{}", "normalize_eol": "bogus"}}
-  ]
-}}"#,
-        portable_path_str(&f)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
+    #[test]
+    fn commit_changes_reports_rollback_failed_when_restore_fails() {
+        let dir = TempDir::new().unwrap();
+        let f1 = dir.path().join("a.txt");
+        let blocker = dir.path().join("blocker");
+        fs::write(&f1, "original-a").unwrap();
+        fs::write(&blocker, "blocker-is-file").unwrap();
+        let f2 = blocker.join("b.txt");
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let changes = vec![
+            (f1.clone(), "original-a".to_string(), "new-a".to_string()),
+            (f2.clone(), String::new(), "new-b".to_string()),
+        ];
+        let deletions = HashSet::new();
+        let existed_before: HashSet<_> = [f1.clone()].into();
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::OPERATION_FAILED,
-        "invalid normalize_eol should fail before commit"
-    );
-}
+        let _guard = RestoreFailGuard::engage();
+        let err = crate::tx::commit_changes(&changes, &deletions, &existed_before, dir.path())
+            .unwrap_err();
 
-#[test]
-fn handle_commit_error_rollback_failed_exits_failure() {
-    let err = CommitError {
-        message: "write failed".into(),
-        rollback_ok: false,
-        backup_session: Some("1234567890".into()),
-    };
-    let code = handle_commit_error(err, true, false).unwrap();
-    assert_eq!(code, exit::FAILURE);
-}
+        assert!(!err.rollback_ok, "restore should be reported as failed");
+        let _session = err
+            .backup_session
+            .expect("backup session should be present on failure");
+        assert_eq!(fs::read_to_string(&f1).unwrap(), "new-a");
+    }
 
-#[test]
-fn commit_changes_reports_rollback_failed_when_restore_fails() {
-    let dir = TempDir::new().unwrap();
-    let f1 = dir.path().join("a.txt");
-    let blocker = dir.path().join("blocker");
-    fs::write(&f1, "original-a").unwrap();
-    fs::write(&blocker, "blocker-is-file").unwrap();
-    let f2 = blocker.join("b.txt");
+    #[test]
+    fn commit_changes_rolls_back_on_mid_write_failure() {
+        let dir = TempDir::new().unwrap();
+        let f1 = dir.path().join("a.txt");
+        let blocker = dir.path().join("blocker");
+        fs::write(&f1, "original-a").unwrap();
+        fs::write(&blocker, "blocker-is-file").unwrap();
+        let f2 = blocker.join("b.txt");
 
-    let changes = vec![
-        (f1.clone(), "original-a".to_string(), "new-a".to_string()),
-        (f2.clone(), String::new(), "new-b".to_string()),
-    ];
-    let deletions = HashSet::new();
-    let existed_before: HashSet<_> = [f1.clone()].into();
+        let changes = vec![
+            (f1.clone(), "original-a".to_string(), "new-a".to_string()),
+            (f2.clone(), String::new(), "new-b".to_string()),
+        ];
+        let deletions = HashSet::new();
+        let existed_before: HashSet<_> = [f1.clone()].into();
 
-    let _guard = RestoreFailGuard::engage();
-    let err =
-        crate::tx::commit_changes(&changes, &deletions, &existed_before, dir.path()).unwrap_err();
+        let err = crate::tx::commit_changes(&changes, &deletions, &existed_before, dir.path())
+            .unwrap_err();
+        assert!(err.rollback_ok, "rollback should succeed");
+        assert!(
+            err.backup_session.is_some(),
+            "backup session should be recorded"
+        );
+        assert_eq!(fs::read_to_string(&f1).unwrap(), "original-a");
+        assert!(!f2.exists());
+    }
 
-    assert!(!err.rollback_ok, "restore should be reported as failed");
-    let _session = err
-        .backup_session
-        .expect("backup session should be present on failure");
-    assert_eq!(fs::read_to_string(&f1).unwrap(), "new-a");
-}
+    #[test]
+    fn tx_strict_rollback_removes_created_file() {
+        let dir = TempDir::new().unwrap();
+        let created = dir.path().join("new_file.txt");
 
-#[test]
-fn commit_changes_rolls_back_on_mid_write_failure() {
-    let dir = TempDir::new().unwrap();
-    let f1 = dir.path().join("a.txt");
-    let blocker = dir.path().join("blocker");
-    fs::write(&f1, "original-a").unwrap();
-    fs::write(&blocker, "blocker-is-file").unwrap();
-    let f2 = blocker.join("b.txt");
-
-    let changes = vec![
-        (f1.clone(), "original-a".to_string(), "new-a".to_string()),
-        (f2.clone(), String::new(), "new-b".to_string()),
-    ];
-    let deletions = HashSet::new();
-    let existed_before: HashSet<_> = [f1.clone()].into();
-
-    let err =
-        crate::tx::commit_changes(&changes, &deletions, &existed_before, dir.path()).unwrap_err();
-    assert!(err.rollback_ok, "rollback should succeed");
-    assert!(
-        err.backup_session.is_some(),
-        "backup session should be recorded"
-    );
-    assert_eq!(fs::read_to_string(&f1).unwrap(), "original-a");
-    assert!(!f2.exists());
-}
-
-#[test]
-fn undo_list_json_output() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("a.txt");
-    fs::write(&file, "v1").unwrap();
-    let mut session = crate::backup::BackupSession::new(dir.path()).unwrap();
-    session.save_before_write(&file).unwrap();
-    session.finalize().unwrap().unwrap();
-
-    let args = crate::cmd::undo::UndoArgs {
-        list: true,
-        session: None,
-        apply: false,
-    };
-    let global = GlobalFlags::with_cwd_and_json(dir.path());
-    let code = crate::cmd::undo::run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS);
-
-    // Also test JSONL mode.
-    let global = GlobalFlags::with_cwd_and_jsonl(dir.path());
-    let args2 = crate::cmd::undo::UndoArgs {
-        list: true,
-        session: None,
-        apply: false,
-    };
-    let code2 = crate::cmd::undo::run(args2, &global).unwrap();
-    assert_eq!(code2, exit::SUCCESS);
-}
-
-#[test]
-fn undo_dry_run_json_output() {
-    let dir = TempDir::new().unwrap();
-    let file = dir.path().join("b.txt");
-    fs::write(&file, "v1").unwrap();
-    let mut session = crate::backup::BackupSession::new(dir.path()).unwrap();
-    session.save_before_write(&file).unwrap();
-    let ts = session.finalize().unwrap().unwrap();
-
-    // Modify file so dry-run shows changes.
-    fs::write(&file, "v2").unwrap();
-
-    let args = crate::cmd::undo::UndoArgs {
-        list: false,
-        session: Some(ts),
-        apply: false,
-    };
-    let global = GlobalFlags::with_cwd_and_json(dir.path());
-    let code = crate::cmd::undo::run(args, &global).unwrap();
-    assert_eq!(code, exit::CHANGES_DETECTED);
-}
-
-#[test]
-fn path_err_formats_flat_error_with_path_prefix() {
-    let err = crate::tx::path_err("config.toml")(anyhow::anyhow!("key not found"));
-    let msg = err.to_string();
-    assert_eq!(msg, "config.toml: key not found");
-}
-
-#[test]
-fn tx_yaml_plan_format() {
-    let dir = TempDir::new().unwrap();
-    let target = dir.path().join("test_file.txt");
-    let plan_yaml = format!(
-        "version: \"1\"\noperations:\n  - op: file.create\n    path: \"{}\"\n    content: \"hello from yaml plan\"\n",
-        portable_path_str(&target)
-    );
-    let plan_file = dir.path().join("plan.yaml");
-    fs::write(&plan_file, &plan_yaml).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS, "YAML plan should succeed");
-    assert_eq!(
-        fs::read_to_string(&target).unwrap(),
-        "hello from yaml plan",
-        "file should contain content from YAML plan"
-    );
-}
-
-#[test]
-fn tx_toml_plan_format() {
-    let dir = TempDir::new().unwrap();
-    let target = dir.path().join("test_file.txt");
-    let plan_toml = format!(
-        "version = \"1\"\n\n[[operations]]\nop = \"file.create\"\npath = \"{}\"\ncontent = \"hello from toml plan\"\n",
-        portable_path_str(&target)
-    );
-    let plan_file = dir.path().join("plan.toml");
-    fs::write(&plan_file, &plan_toml).unwrap();
-
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
-
-    let code = run(args, &global).unwrap();
-    assert_eq!(code, exit::SUCCESS, "TOML plan should succeed");
-    assert_eq!(
-        fs::read_to_string(&target).unwrap(),
-        "hello from toml plan",
-        "file should contain content from TOML plan"
-    );
-}
-
-#[test]
-fn tx_strict_rollback_removes_created_file() {
-    let dir = TempDir::new().unwrap();
-    let created = dir.path().join("new_file.txt");
-
-    // Operation 1: create a new file (succeeds).
-    // Operation 2: read a nonexistent file (fails).
-    // Strict mode should roll back the created file.
-    let plan = format!(
-        r#"{{
+        // Operation 1: create a new file (succeeds).
+        // Operation 2: read a nonexistent file (fails).
+        // Strict mode should roll back the created file.
+        let plan = format!(
+            r#"{{
   "version": "1",
   "strict": true,
   "operations": [
@@ -1373,43 +1384,43 @@ fn tx_strict_rollback_removes_created_file() {
 {{"op": "read", "path": "nonexistent-file.txt"}}
   ]
 }}"#,
-        portable_path_str(&created)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
+            portable_path_str(&created)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::OPERATION_FAILED,
-        "strict plan with failing op should fail"
-    );
-    assert!(
-        !created.exists(),
-        "created file should be removed after rollback"
-    );
-}
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::OPERATION_FAILED,
+            "strict plan with failing op should fail"
+        );
+        assert!(
+            !created.exists(),
+            "created file should be removed after rollback"
+        );
+    }
 
-#[test]
-fn tx_strict_rollback_restores_deleted_file() {
-    let dir = TempDir::new().unwrap();
-    let victim = dir.path().join("victim.txt");
-    fs::write(&victim, "precious content").unwrap();
+    #[test]
+    fn tx_strict_rollback_restores_deleted_file() {
+        let dir = TempDir::new().unwrap();
+        let victim = dir.path().join("victim.txt");
+        fs::write(&victim, "precious content").unwrap();
 
-    // Operation 1: delete victim.txt (succeeds).
-    // Operation 2: read a nonexistent file (fails).
-    // Strict mode should restore the deleted file.
-    let plan = format!(
-        r#"{{
+        // Operation 1: delete victim.txt (succeeds).
+        // Operation 2: read a nonexistent file (fails).
+        // Strict mode should restore the deleted file.
+        let plan = format!(
+            r#"{{
   "version": "1",
   "strict": true,
   "operations": [
@@ -1417,33 +1428,34 @@ fn tx_strict_rollback_restores_deleted_file() {
 {{"op": "read", "path": "nonexistent-file.txt"}}
   ]
 }}"#,
-        portable_path_str(&victim)
-    );
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, &plan).unwrap();
+            portable_path_str(&victim)
+        );
+        let plan_file = dir.path().join("plan.json");
+        fs::write(&plan_file, &plan).unwrap();
 
-    let args = TxArgs {
-        plan: plan_file.to_str().unwrap().to_string(),
-        plan_format: None,
-        no_strict: false,
-        write: Default::default(),
-    };
-    let mut global = GlobalFlags::test_default();
-    global.apply = true;
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
 
-    let code = run(args, &global).unwrap();
-    assert_eq!(
-        code,
-        exit::OPERATION_FAILED,
-        "strict plan with failing op should fail"
-    );
-    assert!(
-        victim.exists(),
-        "deleted file should be restored after rollback"
-    );
-    assert_eq!(
-        fs::read_to_string(&victim).unwrap(),
-        "precious content",
-        "restored file should have original content"
-    );
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::OPERATION_FAILED,
+            "strict plan with failing op should fail"
+        );
+        assert!(
+            victim.exists(),
+            "deleted file should be restored after rollback"
+        );
+        assert_eq!(
+            fs::read_to_string(&victim).unwrap(),
+            "precious content",
+            "restored file should have original content"
+        );
+    }
 }

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1,66 +1,10 @@
 // ── doc module tests ──────────────────────────────────────────────
-mod doc_tests {
-    use crate::ops::doc::*;
-    use crate::selector;
-    use serde_json::json;
+use crate::ops::doc::*;
+use crate::selector;
+use serde_json::json;
 
-    // ── gap closing regressions (#824/#825 style fidelity) ───────────
-    #[test]
-    fn yaml_deep_nested_object_creation() {
-        // Deep (2+) new intermediates: in-memory always correct.
-        // Preserving serialize may use fallback for some >1-level cases
-        // (data correct, comments may be hoisted). We assert in-memory +
-        // plain serialize roundtrip.
-        let mut v = json!({"root": 1});
-        set_at_path(&mut v, &crate::selector::parse("a.b.c").unwrap(), json!(42)).unwrap();
-        assert_eq!(v, json!({"root":1, "a":{"b":{"c":42}}}));
-
-        let plain = serialize_value(&v, &FileFormat::Yaml).unwrap();
-        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&plain).unwrap();
-        assert_eq!(reparsed, json!({"root":1, "a":{"b":{"c":42}}}));
-    }
-
-    #[test]
-    fn yaml_new_key_in_existing_nested_preserves_sibling_comment() {
-        let yaml = "server:\n  # keep host\n  host: localhost\n";
-        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
-        let mut newv = old.clone();
-        set_at_path(
-            &mut newv,
-            &crate::selector::parse("server.port").unwrap(),
-            json!(9090),
-        )
-        .unwrap();
-        let result = serialize_value_preserving(yaml, &old, &newv, &FileFormat::Yaml).unwrap();
-        assert!(result.contains("# keep host"));
-        assert!(
-            result.contains("9090") || result.contains("port"),
-            "new port value missing"
-        );
-        // Note: when adding a brand-new key inside a sub, current CST may
-        // place it at wrong level (fallback produces correct data). Full
-        // attachment for new siblings inside subs is a remaining gap.
-    }
-
-    #[test]
-    fn toml_deep_nested_table_creation() {
-        let toml = "# header\n[app]\nname = \"x\"\n";
-        let old = parse_doc(toml, &FileFormat::Toml).unwrap();
-        let mut newv = old.clone();
-        set_at_path(
-            &mut newv,
-            &crate::selector::parse("app.server.tls.port").unwrap(),
-            json!(9443),
-        )
-        .unwrap();
-        let result = serialize_value_preserving(toml, &old, &newv, &FileFormat::Toml).unwrap();
-        let reparsed: serde_json::Value = toml_edit::de::from_str(&result).expect("valid");
-        assert_eq!(
-            reparsed,
-            json!({"app":{"name":"x","server":{"tls":{"port":9443}}}})
-        );
-        assert!(result.contains("# header"));
-    }
+mod basic {
+    use super::*;
 
     #[test]
     fn detect_format_json() {
@@ -101,6 +45,403 @@ mod doc_tests {
     }
 
     #[test]
+    fn parse_and_serialize_json_roundtrip() {
+        let input = "{\n  \"a\": 1\n}\n";
+        let val = parse_doc(input, &FileFormat::Json).unwrap();
+        assert_eq!(val, json!({"a": 1}));
+        let out = serialize_value(&val, &FileFormat::Json).unwrap();
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn parse_and_serialize_yaml_roundtrip() {
+        let input = "a: 1\n";
+        let val = parse_doc(input, &crate::ops::doc::FileFormat::Yaml).unwrap();
+        assert_eq!(val, json!({"a": 1}));
+        let out = serialize_value(&val, &crate::ops::doc::FileFormat::Yaml).unwrap();
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn parse_and_serialize_toml_roundtrip() {
+        let input = "a = 1\n";
+        let val = parse_doc(input, &FileFormat::Toml).unwrap();
+        assert_eq!(val, json!({"a": 1}));
+        // TOML pretty serialization may differ slightly; just ensure it parses back
+        let out = serialize_value(&val, &FileFormat::Toml).unwrap();
+        let reparsed = parse_doc(&out, &FileFormat::Toml).unwrap();
+        assert_eq!(reparsed, json!({"a": 1}));
+    }
+
+    #[test]
+    fn navigate_mut_existing_key() {
+        let mut val = json!({"a": {"b": 42}});
+        let seg = crate::selector::parse("a.b").unwrap();
+        let found = navigate_mut(&mut val, &seg, false).unwrap();
+        assert_eq!(*found, json!(42));
+    }
+
+    #[test]
+    fn navigate_mut_create_missing_key() {
+        let mut val = json!({"a": 1});
+        let seg = crate::selector::parse("b.c").unwrap();
+        let found = navigate_mut(&mut val, &seg, true).unwrap();
+        // created as empty object, then descended into "c" which was also created
+        assert!(found.is_object());
+    }
+
+    #[test]
+    fn navigate_mut_array_index() {
+        let mut val = json!({"items": [10, 20, 30]});
+        let seg = crate::selector::parse("items[1]").unwrap();
+        let found = navigate_mut(&mut val, &seg, false).unwrap();
+        assert_eq!(*found, json!(20));
+    }
+
+    #[test]
+    fn deep_merge_objects() {
+        let mut base = json!({"a": 1, "b": {"c": 2}});
+        let other = json!({"b": {"d": 3}, "e": 4});
+        deep_merge(&mut base, &other);
+        assert_eq!(base, json!({"a": 1, "b": {"c": 2, "d": 3}, "e": 4}));
+    }
+
+    #[test]
+    fn set_at_path_simple_key() {
+        let mut root = json!({"a": 1});
+        let sel = crate::selector::parse("b").unwrap();
+        set_at_path(&mut root, &sel, json!(2)).unwrap();
+        assert_eq!(root, json!({"a": 1, "b": 2}));
+    }
+
+    #[test]
+    fn set_at_path_nested_creates_intermediates() {
+        let mut root = json!({});
+        let sel = crate::selector::parse("a.b.c").unwrap();
+        set_at_path(&mut root, &sel, json!("deep")).unwrap();
+        assert_eq!(root, json!({"a": {"b": {"c": "deep"}}}));
+    }
+
+    #[test]
+    fn set_at_path_array_index() {
+        let mut root = json!({"items": [10, 20, 30]});
+        let sel = crate::selector::parse("items[1]").unwrap();
+        set_at_path(&mut root, &sel, json!(99)).unwrap();
+        assert_eq!(root, json!({"items": [10, 99, 30]}));
+    }
+
+    #[test]
+    fn delete_where_removes_matching_items() {
+        let mut root = json!({"items": [{"name": "a"}, {"name": "b"}, {"name": "c"}]});
+        let sel = crate::selector::parse("items").unwrap();
+        let removed = delete_where(&mut root, &sel, "name=b").unwrap();
+        assert_eq!(removed, 1);
+        assert_eq!(root["items"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn delete_at_selector_removes_key() {
+        let mut root = json!({"a": 1, "b": 2});
+        let sel = crate::selector::parse("b").unwrap();
+        assert!(delete_at_selector(&mut root, &sel).unwrap());
+        assert_eq!(root, json!({"a": 1}));
+    }
+
+    #[test]
+    fn delete_at_selector_array_index() {
+        let mut root = json!({"items": [10, 20, 30]});
+        let sel = crate::selector::parse("items[1]").unwrap();
+        assert!(delete_at_selector(&mut root, &sel).unwrap());
+        assert_eq!(root, json!({"items": [10, 30]}));
+    }
+
+    #[test]
+    fn move_at_path_renames_key() {
+        let mut root = json!({"old_name": "value", "other": 1});
+        let from = crate::selector::parse("old_name").unwrap();
+        let to = crate::selector::parse("new_name").unwrap();
+        move_at_path(&mut root, &from, &to).unwrap();
+        assert_eq!(root, json!({"other": 1, "new_name": "value"}));
+    }
+
+    #[test]
+    fn move_at_path_to_nested_creates_intermediates() {
+        let mut root = json!({"src": 42});
+        let from = crate::selector::parse("src").unwrap();
+        let to = crate::selector::parse("a.b.dst").unwrap();
+        move_at_path(&mut root, &from, &to).unwrap();
+        assert_eq!(root, json!({"a": {"b": {"dst": 42}}}));
+    }
+
+    #[test]
+    fn update_matching_by_key() {
+        let mut val = json!({"a": {"b": "old"}});
+        let seg = crate::selector::parse("a.b").unwrap();
+        let count = update_matching(&mut val, &seg, &json!("new"));
+        assert_eq!(count, 1);
+        assert_eq!(val, json!({"a": {"b": "new"}}));
+    }
+
+    #[test]
+    fn update_matching_wildcard() {
+        let mut val = json!({"items": [{"v": 1}, {"v": 2}]});
+        let seg = crate::selector::parse("items[*].v").unwrap();
+        let count = update_matching(&mut val, &seg, &json!(99));
+        assert_eq!(count, 2);
+        assert_eq!(val, json!({"items": [{"v": 99}, {"v": 99}]}));
+    }
+
+    #[test]
+    fn update_matching_predicate() {
+        let mut val = json!({"items": [
+            {"name": "a", "v": 1},
+            {"name": "b", "v": 2}
+        ]});
+        let seg = crate::selector::parse("items[name=b].v").unwrap();
+        let count = update_matching(&mut val, &seg, &json!(42));
+        assert_eq!(count, 1);
+        assert_eq!(val["items"][1]["v"], json!(42));
+        // First item unchanged
+        assert_eq!(val["items"][0]["v"], json!(1));
+    }
+
+    #[test]
+    fn toml_deep_nested_table_creation() {
+        let toml = "# header\n[app]\nname = \"x\"\n";
+        let old = parse_doc(toml, &FileFormat::Toml).unwrap();
+        let mut newv = old.clone();
+        set_at_path(
+            &mut newv,
+            &crate::selector::parse("app.server.tls.port").unwrap(),
+            json!(9443),
+        )
+        .unwrap();
+        let result = serialize_value_preserving(toml, &old, &newv, &FileFormat::Toml).unwrap();
+        let reparsed: serde_json::Value = toml_edit::de::from_str(&result).expect("valid");
+        assert_eq!(
+            reparsed,
+            json!({"app":{"name":"x","server":{"tls":{"port":9443}}}})
+        );
+        assert!(result.contains("# header"));
+    }
+
+    #[test]
+    fn mutation_set() {
+        let mut root = json!({"a": 1});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Set {
+                selector: "b".into(),
+                value: json!(2),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root, json!({"a": 1, "b": 2}));
+    }
+
+    #[test]
+    fn mutation_delete_existing() {
+        let mut root = json!({"a": 1, "b": 2});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Delete {
+                selector: "b".into(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root, json!({"a": 1}));
+    }
+
+    #[test]
+    fn mutation_merge() {
+        let mut root = json!({"a": 1});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Merge {
+                value: json!({"b": 2}),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root, json!({"a": 1, "b": 2}));
+    }
+
+    #[test]
+    fn mutation_append_to_array() {
+        let mut root = json!({"items": [1, 2]});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Append {
+                selector: "items".into(),
+                value: json!(3),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root["items"], json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn mutation_prepend_to_array() {
+        let mut root = json!({"items": [2, 3]});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Prepend {
+                selector: "items".into(),
+                value: json!(1),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root["items"], json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn mutation_update_matching() {
+        let mut root = json!({"items": [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}]});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Update {
+                selector: "items[id=1]".into(),
+                value: json!({"id": 1, "v": "updated"}),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root["items"][0]["v"], "updated");
+    }
+
+    #[test]
+    fn mutation_move_key() {
+        let mut root = json!({"src": 42, "dst": {}});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Move {
+                from: "src".into(),
+                to: "dst.val".into(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root, json!({"dst": {"val": 42}}));
+    }
+
+    #[test]
+    fn mutation_ensure_missing() {
+        let mut root = json!({"a": 1});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Ensure {
+                selector: "b".into(),
+                value: json!(2),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root, json!({"a": 1, "b": 2}));
+    }
+
+    #[test]
+    fn mutation_delete_where_matching() {
+        let mut root = json!({"items": [{"k": "a"}, {"k": "b"}]});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::DeleteWhere {
+                selector: "items".into(),
+                predicate: "k=a".into(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::Applied));
+        assert_eq!(root["items"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn parse_value_bare_string() {
+        assert_eq!(parse_value("hello"), json!("hello"));
+    }
+
+    #[test]
+    fn parse_value_integer() {
+        assert_eq!(parse_value("42"), json!(42));
+    }
+
+    #[test]
+    fn parse_value_bool() {
+        assert_eq!(parse_value("true"), json!(true));
+    }
+
+    #[test]
+    fn parse_value_null() {
+        assert_eq!(parse_value("null"), serde_json::Value::Null);
+    }
+
+    #[test]
+    fn parse_value_json_object() {
+        assert_eq!(parse_value(r#"{"a":1}"#), json!({"a": 1}));
+    }
+
+    #[test]
+    fn parse_value_plain_string() {
+        let result = parse_value("hello");
+        assert_eq!(result, json!("hello"));
+        assert!(result.is_string());
+    }
+
+    #[test]
+    fn parse_value_true_is_bool() {
+        // "true" is recognized as boolean, not left as a string.
+        let result = parse_value("true");
+        assert_eq!(result, json!(true));
+        assert!(result.is_boolean());
+    }
+
+    #[test]
+    fn parse_value_false_is_bool() {
+        let result = parse_value("false");
+        assert_eq!(result, json!(false));
+        assert!(result.is_boolean());
+    }
+
+    #[test]
+    fn flatten_value_nested() {
+        let val = json!({"a": {"b": 1}, "c": [2, 3]});
+        let mut buf = String::new();
+        let mut out = Vec::new();
+        flatten_value(&val, &mut buf, &mut out);
+        let paths: Vec<&str> = out.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.contains(&"a.b"));
+        assert!(paths.contains(&"c[0]"));
+        assert!(paths.contains(&"c[1]"));
+    }
+
+    #[test]
+    fn diff_values_detects_changes() {
+        let a = json!({"x": 1, "y": 2});
+        let b = json!({"x": 1, "y": 3, "z": 4});
+        let mut buf = String::new();
+        let mut out = Vec::new();
+        diff_values(&a, &b, &mut buf, &mut out);
+        assert_eq!(out.len(), 2); // y changed, z added
+        assert!(out.iter().any(|e| e.path == "y" && e.kind == "changed"));
+        assert!(out.iter().any(|e| e.path == "z" && e.kind == "added"));
+    }
+
+    #[test]
+    fn yaml_plain_strings_do_not_need_quoting() {
+        assert!(!needs_yaml_quoting("hello"));
+        assert!(!needs_yaml_quoting("foo-bar"));
+        assert!(!needs_yaml_quoting("some_value_123"));
+        assert!(!needs_yaml_quoting("v1.2.3"));
+    }
+}
+
+mod edge_cases {
+    use super::*;
+
+    #[test]
     fn yaml_merge_key_existing_wins() {
         let yaml = "base: &b\n  x: 1\nchild:\n  <<: *b\n  x: 99\n";
         let val = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
@@ -116,8 +457,598 @@ mod doc_tests {
     }
 
     #[test]
+    fn deep_merge_overwrites_non_object() {
+        let mut base = json!({"a": "string"});
+        let other = json!({"a": {"nested": true}});
+        deep_merge(&mut base, &other);
+        assert_eq!(base, json!({"a": {"nested": true}}));
+    }
+
+    #[test]
+    fn delete_where_no_match_returns_zero() {
+        let mut root = json!({"items": [{"name": "a"}]});
+        let sel = crate::selector::parse("items").unwrap();
+        let removed = delete_where(&mut root, &sel, "name=zzz").unwrap();
+        assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn delete_where_trims_whitespace() {
+        let mut root = json!({"items": [{"name": "a"}, {"name": "b"}]});
+        let sel = crate::selector::parse("items").unwrap();
+        // Spaces around key and value should be trimmed.
+        let removed = delete_where(&mut root, &sel, " name = a ").unwrap();
+        assert_eq!(removed, 1);
+        assert_eq!(root["items"].as_array().unwrap().len(), 1);
+        assert_eq!(root["items"][0]["name"], "b");
+    }
+
+    #[test]
+    fn delete_at_selector_missing_returns_false() {
+        let mut root = json!({"a": 1});
+        let sel = crate::selector::parse("nonexistent").unwrap();
+        assert!(!delete_at_selector(&mut root, &sel).unwrap());
+    }
+
+    #[test]
+    fn delete_at_selector_empty_returns_false() {
+        let mut root = json!({"a": 1});
+        let sel: Vec<crate::selector::Segment> = vec![];
+        assert!(!delete_at_selector(&mut root, &sel).unwrap());
+    }
+
+    #[test]
+    fn move_at_path_to_array_index() {
+        let mut root = json!({"src": "x", "arr": [1, 2, 3]});
+        let from = crate::selector::parse("src").unwrap();
+        let to = crate::selector::parse("arr[1]").unwrap();
+        move_at_path(&mut root, &from, &to).unwrap();
+        let arr = root["arr"].as_array().unwrap();
+        assert_eq!(arr.len(), 4);
+        assert_eq!(arr[1], json!("x"));
+    }
+
+    #[test]
+    fn update_matching_missing_key_returns_zero() {
+        let mut val = json!({"a": 1});
+        let seg = crate::selector::parse("b.c").unwrap();
+        let count = update_matching(&mut val, &seg, &json!("x"));
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn yaml_sequence_root_mutation_not_lost() {
+        let yaml = "- item1\n- item2\n";
+        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new.as_array_mut().unwrap().push(json!("item3"));
+
+        let result =
+            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
+                .unwrap();
+        assert!(result.contains("item3"), "appended item missing: {result}");
+        assert!(result.contains("item1"), "item1 missing: {result}");
+        assert!(result.contains("item2"), "item2 missing: {result}");
+    }
+
+    #[test]
+    fn yaml_mapping_to_scalar_root_type_change_not_lost() {
+        let yaml = "name: app\nversion: 1\n";
+        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
+        let new = json!("overridden");
+
+        let result =
+            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
+                .unwrap();
+        assert!(
+            result.contains("overridden"),
+            "root type change lost: {result}"
+        );
+    }
+
+    #[test]
+    fn yaml_mapping_to_array_root_type_change_not_lost() {
+        let yaml = "name: app\nversion: 1\n";
+        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
+        let new = json!(["a", "b"]);
+
+        let result =
+            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
+                .unwrap();
+        assert!(result.contains("- a"), "array item '- a' missing: {result}");
+        assert!(result.contains("- b"), "array item '- b' missing: {result}");
+    }
+
+    #[test]
+    fn yaml_single_document_marker_accepted() {
+        // A single document with an explicit `---` marker is valid and parses fine.
+        let yaml = "---\nname: only\n";
+        let val = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        assert_eq!(val, json!({"name": "only"}));
+
+        let mut new = val.clone();
+        new["name"] = json!("updated");
+        let result = serialize_value_preserving(yaml, &val, &new, &FileFormat::Yaml).unwrap();
+        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
+        assert_eq!(reparsed, json!({"name": "updated"}));
+    }
+
+    #[test]
+    fn mutation_delete_missing() {
+        let mut root = json!({"a": 1});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Delete {
+                selector: "z".into(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::NoMatch));
+    }
+
+    #[test]
+    fn mutation_update_no_match() {
+        let mut root = json!({"items": [{"id": 1}]});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Update {
+                selector: "items[id=99]".into(),
+                value: json!({"id": 99}),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::NoMatch));
+    }
+
+    #[test]
+    fn mutation_ensure_existing() {
+        let mut root = json!({"a": 1});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Ensure {
+                selector: "a".into(),
+                value: json!(99),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::AlreadyExists));
+        assert_eq!(root["a"], 1); // unchanged
+    }
+
+    #[test]
+    fn mutation_delete_where_no_match() {
+        let mut root = json!({"items": [{"k": "a"}]});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::DeleteWhere {
+                selector: "items".into(),
+                predicate: "k=z".into(),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::NoMatch));
+    }
+
+    #[test]
+    fn yaml_empty_string_needs_quoting() {
+        assert!(needs_yaml_quoting(""));
+    }
+
+    // -- parse_value edge cases (#978) -----------------------------------
+
+    #[test]
+    fn parse_value_float() {
+        assert_eq!(parse_value("1.5"), json!(1.5));
+    }
+
+    #[test]
+    fn parse_value_negative_integer() {
+        assert_eq!(parse_value("-42"), json!(-42));
+    }
+
+    #[test]
+    fn parse_value_json_array() {
+        assert_eq!(parse_value("[1,2,3]"), json!([1, 2, 3]));
+    }
+
+    #[test]
+    fn parse_value_json_object_with_spaces() {
+        assert_eq!(parse_value(r#"{"a": 1}"#), json!({"a": 1}));
+    }
+
+    #[test]
+    fn parse_value_quoted_string_with_escapes() {
+        // JSON-escaped inner quotes: the input is a valid JSON string literal.
+        let result = parse_value(r#""hello\"world""#);
+        assert_eq!(result, json!("hello\"world"));
+        assert!(result.is_string());
+    }
+}
+
+mod error_handling {
+    use super::*;
+
+    #[test]
     fn detect_format_unsupported() {
         assert!(detect_format("readme.txt").is_err());
+    }
+
+    #[test]
+    fn detect_format_no_extension() {
+        assert!(detect_format("Makefile").is_err());
+    }
+
+    #[test]
+    fn navigate_mut_missing_key_no_create() {
+        let mut val = json!({"a": 1});
+        let seg = crate::selector::parse("b").unwrap();
+        assert!(navigate_mut(&mut val, &seg, false).is_err());
+    }
+
+    #[test]
+    fn navigate_mut_index_out_of_bounds() {
+        let mut val = json!({"items": [10]});
+        let seg = crate::selector::parse("items[5]").unwrap();
+        assert!(navigate_mut(&mut val, &seg, false).is_err());
+    }
+
+    #[test]
+    fn set_at_path_out_of_bounds_index_fails() {
+        let mut root = json!({"items": [1]});
+        let sel = crate::selector::parse("items[5]").unwrap();
+        assert!(set_at_path(&mut root, &sel, json!(99)).is_err());
+    }
+
+    #[test]
+    fn set_at_path_empty_selector_fails() {
+        let mut root = json!({});
+        let sel: Vec<crate::selector::Segment> = vec![];
+        assert!(set_at_path(&mut root, &sel, json!(1)).is_err());
+    }
+
+    #[test]
+    fn delete_where_invalid_predicate_fails() {
+        let mut root = json!({"items": [{"name": "a"}]});
+        let sel = crate::selector::parse("items").unwrap();
+        assert!(delete_where(&mut root, &sel, "no-equals-sign").is_err());
+    }
+
+    #[test]
+    fn delete_where_non_array_fails() {
+        let mut root = json!({"items": "not-an-array"});
+        let sel = crate::selector::parse("items").unwrap();
+        assert!(delete_where(&mut root, &sel, "k=v").is_err());
+    }
+
+    #[test]
+    fn delete_where_double_equals_rejected() {
+        let mut root =
+            json!({"items": [{"name": "a", "keep": false}, {"name": "b", "keep": true}]});
+        let sel = crate::selector::parse("items").unwrap();
+        let err = delete_where(&mut root, &sel, "keep == false").unwrap_err();
+        assert!(
+            err.to_string().contains("'=='"),
+            "expected == rejection, got: {err}"
+        );
+        // Array must be unchanged (no silent removal).
+        assert_eq!(root["items"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn delete_where_empty_key_rejected() {
+        let mut root = json!({"items": [{"name": "a"}]});
+        let sel = crate::selector::parse("items").unwrap();
+        let err = delete_where(&mut root, &sel, "=value").unwrap_err();
+        assert!(
+            err.to_string().contains("empty"),
+            "expected empty-key error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn move_at_path_missing_source_fails() {
+        let mut root = json!({"a": 1});
+        let from = crate::selector::parse("nonexistent").unwrap();
+        let to = crate::selector::parse("b").unwrap();
+        assert!(move_at_path(&mut root, &from, &to).is_err());
+    }
+
+    #[test]
+    fn move_at_path_empty_from_selector_fails() {
+        let mut root = json!({"a": 1});
+        let from: Vec<crate::selector::Segment> = vec![];
+        let to = crate::selector::parse("b").unwrap();
+        assert!(move_at_path(&mut root, &from, &to).is_err());
+    }
+
+    #[test]
+    fn yaml_multi_document_rejected_by_parser() {
+        // Multi-document YAML (--- separated) is rejected by serde_yaml_ng.
+        // This test documents the current behavior: parse_doc returns an error
+        // rather than silently dropping documents.
+        let yaml = "---\nname: first\n---\nname: second\n";
+        let err = parse_doc(yaml, &FileFormat::Yaml).unwrap_err();
+        assert!(
+            err.to_string().contains("more than one document"),
+            "expected multi-document rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn mutation_append_to_non_array() {
+        let mut root = json!({"items": "not-array"});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Append {
+                selector: "items".into(),
+                value: json!(1),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::TypeError(_)));
+    }
+
+    #[test]
+    fn mutation_move_missing_source() {
+        let mut root = json!({"a": 1});
+        let err = apply_doc_mutation(
+            &mut root,
+            DocMutation::Move {
+                from: "nonexistent".into(),
+                to: "b".into(),
+            },
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("source key 'nonexistent' not found")
+        );
+    }
+
+    #[test]
+    fn mutation_prepend_to_non_array() {
+        let mut root = json!({"items": "not-array"});
+        let result = apply_doc_mutation(
+            &mut root,
+            DocMutation::Prepend {
+                selector: "items".into(),
+                value: json!(1),
+            },
+        )
+        .unwrap();
+        assert!(matches!(result, MutationResult::TypeError(_)));
+    }
+}
+
+mod security {
+    use super::*;
+
+    #[test]
+    fn deep_merge_depth_limit() {
+        // Build a deeply nested structure beyond MAX_MERGE_DEPTH (128)
+        let mut deep_val = json!("leaf");
+        for _ in 0..130 {
+            deep_val = json!({"n": deep_val});
+        }
+        let mut base = json!({});
+        deep_merge(&mut base, &deep_val);
+        // Should not panic; at depth 128 it clones instead of recursing
+        assert!(base.is_object());
+    }
+}
+
+mod regression {
+    use super::*;
+
+    // ── gap closing regressions (#824/#825 style fidelity) ───────────
+    #[test]
+    fn yaml_deep_nested_object_creation() {
+        // Deep (2+) new intermediates: in-memory always correct.
+        // Preserving serialize may use fallback for some >1-level cases
+        // (data correct, comments may be hoisted). We assert in-memory +
+        // plain serialize roundtrip.
+        let mut v = json!({"root": 1});
+        set_at_path(&mut v, &crate::selector::parse("a.b.c").unwrap(), json!(42)).unwrap();
+        assert_eq!(v, json!({"root":1, "a":{"b":{"c":42}}}));
+
+        let plain = serialize_value(&v, &FileFormat::Yaml).unwrap();
+        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&plain).unwrap();
+        assert_eq!(reparsed, json!({"root":1, "a":{"b":{"c":42}}}));
+    }
+
+    #[test]
+    fn yaml_nested_keys_create_correct_structure() {
+        // Regression for #824: new nested via set/ensure/merge must produce
+        // valid indented mappings, not "key:\nleaf: " (null parent + sibling).
+        let yaml = "a: 1\n";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut newv = old.clone();
+        set_at_path(
+            &mut newv,
+            &crate::selector::parse("server.port").unwrap(),
+            json!(9090),
+        )
+        .unwrap();
+        let result = serialize_value_preserving(yaml, &old, &newv, &FileFormat::Yaml).unwrap();
+        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
+        assert_eq!(reparsed, json!({"a":1, "server":{"port":9090}}));
+        // Also for ensure path (no-op if exists, but create case)
+        let mut new2 = old.clone();
+        // simulate ensure by set since not exist
+        set_at_path(
+            &mut new2,
+            &crate::selector::parse("settings.debug").unwrap(),
+            json!(false),
+        )
+        .unwrap();
+        let r2 = serialize_value_preserving(yaml, &old, &new2, &FileFormat::Yaml).unwrap();
+        let p2: serde_json::Value = serde_yaml_ng::from_str(&r2).unwrap();
+        assert_eq!(p2, json!({"a":1, "settings":{"debug":false}}));
+        // merge case
+        let mut new3 = old.clone();
+        deep_merge(&mut new3, &json!({"server": {"port": 9090}}));
+        let r3 = serialize_value_preserving(yaml, &old, &new3, &FileFormat::Yaml).unwrap();
+        let p3: serde_json::Value = serde_yaml_ng::from_str(&r3).unwrap();
+        assert_eq!(p3, json!({"a":1, "server":{"port":9090}}));
+    }
+
+    #[test]
+    fn yaml_array_shrink_with_modification_not_lost() {
+        // Regression: complex array shrinkage (shrink + modify remaining
+        // elements) must not be silently dropped. The CST path cannot
+        // handle this case, so it should fall through to serialize_value.
+        let yaml = "# Config\nname: app\ntags:\n  - alpha\n  - beta\n  - gamma\n";
+        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
+        let new = json!({"name": "app", "tags": ["MODIFIED"]});
+
+        let result =
+            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
+                .unwrap();
+        let parsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
+        assert_eq!(
+            parsed, new,
+            "serialized YAML must match target value: {result}"
+        );
+    }
+
+    #[test]
+    fn yaml_nested_complex_shrinkage_in_same_length_outer() {
+        // Regression: same-length outer array with complex inner array
+        // shrinkage (not a subsequence). apply_yaml_sequence_diff must
+        // propagate the failure flag from the nested mapping diff.
+        let yaml = "# Comment\nitems:\n  - name: a\n    tags:\n      - x\n      - y\n  - name: b\n";
+        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
+        let new = json!({"items": [{"name": "a", "tags": ["MODIFIED"]}, {"name": "b"}]});
+
+        let result =
+            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
+                .unwrap();
+        let parsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
+        assert_eq!(
+            parsed, new,
+            "nested complex shrinkage must not be silently dropped: {result}"
+        );
+    }
+
+    #[test]
+    fn yaml_nested_array_growth_detected() {
+        // Regression: has_array_growth_diffs must recurse into same-length
+        // array elements to detect nested growth (e.g., adding a port to
+        // the first server's ports array while the outer array stays the
+        // same length).
+        let yaml = "# config comment\nservers:\n  - name: web\n    ports:\n      - 80\n";
+        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["servers"][0]["ports"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!(443));
+
+        let result =
+            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
+                .unwrap();
+        assert!(
+            result.contains("443"),
+            "nested array growth should not be silently dropped: {result}"
+        );
+        assert!(
+            result.contains("# config comment"),
+            "comments should be preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn yaml_nested_array_append_produces_yaml_edit_parseable_output() {
+        // Regression for #972: doc_append on a deeply nested array (e.g., K8s
+        // env vars inside a container) could produce YAML with altered indentation.
+        // serde_yaml_ng accepted the result, but yaml_edit (CST parser) rejected it,
+        // causing subsequent doc_set calls to fail with "did not find expected key".
+        //
+        // Uses realistic K8s-style indentation: containers at 8 spaces, entries
+        // at 10 spaces (the exact pattern from the bug report).
+        let yaml = concat!(
+            "apiVersion: apps/v1\n",
+            "kind: Deployment\n",
+            "metadata:\n",
+            "  name: my-app\n",
+            "spec:\n",
+            "  replicas: 1\n",
+            "  template:\n",
+            "    spec:\n",
+            "      containers:\n",
+            "        - name: main\n",
+            "          image: my-app:latest\n",
+            "          env:\n",
+            "            - name: DB_HOST\n",
+            "              value: postgres.default:5432\n",
+            "            - name: API_URL\n",
+            "              valueFrom:\n",
+            "                configMapKeyRef:\n",
+            "                  name: config\n",
+            "                  key: api-url\n",
+            "          resources:\n",
+            "            limits:\n",
+            "              cpu: \"1\"\n",
+            "              memory: 512Mi\n",
+        );
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        // Append a new env var with a URL value (the original bug trigger).
+        new["spec"]["template"]["spec"]["containers"][0]["env"]
+            .as_array_mut()
+            .unwrap()
+            .push(
+                json!({"name": "OTEL_ENDPOINT", "value": "http://otel-collector.monitoring:4317"}),
+            );
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        // Must round-trip through serde_yaml_ng.
+        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
+        assert_eq!(reparsed, new, "serialized YAML must match target: {result}");
+        // Must also be parseable by yaml_edit (the CST library used by doc_set).
+        assert!(
+            result.parse::<yaml_edit::YamlFile>().is_ok(),
+            "result must be parseable by yaml_edit for subsequent doc_set: {result}"
+        );
+        // After the append, a subsequent set on a different path must succeed.
+        // This simulates the #972 scenario: doc_append then doc_set.
+        let mut final_val = new.clone();
+        final_val["spec"]["template"]["spec"]["containers"][0]["resources"]["limits"]["cpu"] =
+            json!("2");
+        let result2 = serialize_value_preserving(&result, &new, &final_val, &FileFormat::Yaml)
+            .expect("doc_set after doc_append must not fail");
+        let reparsed2: serde_json::Value = serde_yaml_ng::from_str(&result2).unwrap();
+        assert_eq!(
+            reparsed2, final_val,
+            "second operation must produce correct output: {result2}"
+        );
+    }
+}
+
+mod format_preservation {
+    use super::*;
+    use ::proptest::prelude::*;
+
+    #[test]
+    fn yaml_new_key_in_existing_nested_preserves_sibling_comment() {
+        let yaml = "server:\n  # keep host\n  host: localhost\n";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut newv = old.clone();
+        set_at_path(
+            &mut newv,
+            &crate::selector::parse("server.port").unwrap(),
+            json!(9090),
+        )
+        .unwrap();
+        let result = serialize_value_preserving(yaml, &old, &newv, &FileFormat::Yaml).unwrap();
+        assert!(result.contains("# keep host"));
+        assert!(
+            result.contains("9090") || result.contains("port"),
+            "new port value missing"
+        );
+        // Note: when adding a brand-new key inside a sub, current CST may
+        // place it at wrong level (fallback produces correct data). Full
+        // attachment for new siblings inside subs is a remaining gap.
     }
 
     // -- TOML comment preservation ----------------------------------------
@@ -311,42 +1242,6 @@ mod doc_tests {
     }
 
     #[test]
-    fn yaml_nested_keys_create_correct_structure() {
-        // Regression for #824: new nested via set/ensure/merge must produce
-        // valid indented mappings, not "key:\nleaf: " (null parent + sibling).
-        let yaml = "a: 1\n";
-        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
-        let mut newv = old.clone();
-        set_at_path(
-            &mut newv,
-            &crate::selector::parse("server.port").unwrap(),
-            json!(9090),
-        )
-        .unwrap();
-        let result = serialize_value_preserving(yaml, &old, &newv, &FileFormat::Yaml).unwrap();
-        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
-        assert_eq!(reparsed, json!({"a":1, "server":{"port":9090}}));
-        // Also for ensure path (no-op if exists, but create case)
-        let mut new2 = old.clone();
-        // simulate ensure by set since not exist
-        set_at_path(
-            &mut new2,
-            &crate::selector::parse("settings.debug").unwrap(),
-            json!(false),
-        )
-        .unwrap();
-        let r2 = serialize_value_preserving(yaml, &old, &new2, &FileFormat::Yaml).unwrap();
-        let p2: serde_json::Value = serde_yaml_ng::from_str(&r2).unwrap();
-        assert_eq!(p2, json!({"a":1, "settings":{"debug":false}}));
-        // merge case
-        let mut new3 = old.clone();
-        deep_merge(&mut new3, &json!({"server": {"port": 9090}}));
-        let r3 = serialize_value_preserving(yaml, &old, &new3, &FileFormat::Yaml).unwrap();
-        let p3: serde_json::Value = serde_yaml_ng::from_str(&r3).unwrap();
-        assert_eq!(p3, json!({"a":1, "server":{"port":9090}}));
-    }
-
-    #[test]
     fn yaml_ensure_nested_in_existing_subobject_preserves_top_comments() {
         // Mirrors the integration test_doc_ensure_yaml_preserves_comments
         // server.port ensure when "server" key already exists as object.
@@ -393,208 +1288,6 @@ mod doc_tests {
     }
 
     #[test]
-    fn yaml_array_shrink_with_modification_not_lost() {
-        // Regression: complex array shrinkage (shrink + modify remaining
-        // elements) must not be silently dropped. The CST path cannot
-        // handle this case, so it should fall through to serialize_value.
-        let yaml = "# Config\nname: app\ntags:\n  - alpha\n  - beta\n  - gamma\n";
-        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
-        let new = json!({"name": "app", "tags": ["MODIFIED"]});
-
-        let result =
-            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
-                .unwrap();
-        let parsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
-        assert_eq!(
-            parsed, new,
-            "serialized YAML must match target value: {result}"
-        );
-    }
-
-    #[test]
-    fn yaml_nested_complex_shrinkage_in_same_length_outer() {
-        // Regression: same-length outer array with complex inner array
-        // shrinkage (not a subsequence). apply_yaml_sequence_diff must
-        // propagate the failure flag from the nested mapping diff.
-        let yaml = "# Comment\nitems:\n  - name: a\n    tags:\n      - x\n      - y\n  - name: b\n";
-        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
-        let new = json!({"items": [{"name": "a", "tags": ["MODIFIED"]}, {"name": "b"}]});
-
-        let result =
-            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
-                .unwrap();
-        let parsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
-        assert_eq!(
-            parsed, new,
-            "nested complex shrinkage must not be silently dropped: {result}"
-        );
-    }
-
-    #[test]
-    fn yaml_nested_array_growth_detected() {
-        // Regression: has_array_growth_diffs must recurse into same-length
-        // array elements to detect nested growth (e.g., adding a port to
-        // the first server's ports array while the outer array stays the
-        // same length).
-        let yaml = "# config comment\nservers:\n  - name: web\n    ports:\n      - 80\n";
-        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
-        let mut new = old.clone();
-        new["servers"][0]["ports"]
-            .as_array_mut()
-            .unwrap()
-            .push(json!(443));
-
-        let result =
-            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
-                .unwrap();
-        assert!(
-            result.contains("443"),
-            "nested array growth should not be silently dropped: {result}"
-        );
-        assert!(
-            result.contains("# config comment"),
-            "comments should be preserved: {result}"
-        );
-    }
-
-    #[test]
-    fn yaml_nested_array_append_produces_yaml_edit_parseable_output() {
-        // Regression for #972: doc_append on a deeply nested array (e.g., K8s
-        // env vars inside a container) could produce YAML with altered indentation.
-        // serde_yaml_ng accepted the result, but yaml_edit (CST parser) rejected it,
-        // causing subsequent doc_set calls to fail with "did not find expected key".
-        //
-        // Uses realistic K8s-style indentation: containers at 8 spaces, entries
-        // at 10 spaces (the exact pattern from the bug report).
-        let yaml = concat!(
-            "apiVersion: apps/v1\n",
-            "kind: Deployment\n",
-            "metadata:\n",
-            "  name: my-app\n",
-            "spec:\n",
-            "  replicas: 1\n",
-            "  template:\n",
-            "    spec:\n",
-            "      containers:\n",
-            "        - name: main\n",
-            "          image: my-app:latest\n",
-            "          env:\n",
-            "            - name: DB_HOST\n",
-            "              value: postgres.default:5432\n",
-            "            - name: API_URL\n",
-            "              valueFrom:\n",
-            "                configMapKeyRef:\n",
-            "                  name: config\n",
-            "                  key: api-url\n",
-            "          resources:\n",
-            "            limits:\n",
-            "              cpu: \"1\"\n",
-            "              memory: 512Mi\n",
-        );
-        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
-        let mut new = old.clone();
-        // Append a new env var with a URL value (the original bug trigger).
-        new["spec"]["template"]["spec"]["containers"][0]["env"]
-            .as_array_mut()
-            .unwrap()
-            .push(
-                json!({"name": "OTEL_ENDPOINT", "value": "http://otel-collector.monitoring:4317"}),
-            );
-
-        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
-        // Must round-trip through serde_yaml_ng.
-        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
-        assert_eq!(reparsed, new, "serialized YAML must match target: {result}");
-        // Must also be parseable by yaml_edit (the CST library used by doc_set).
-        assert!(
-            result.parse::<yaml_edit::YamlFile>().is_ok(),
-            "result must be parseable by yaml_edit for subsequent doc_set: {result}"
-        );
-        // After the append, a subsequent set on a different path must succeed.
-        // This simulates the #972 scenario: doc_append then doc_set.
-        let mut final_val = new.clone();
-        final_val["spec"]["template"]["spec"]["containers"][0]["resources"]["limits"]["cpu"] =
-            json!("2");
-        let result2 = serialize_value_preserving(&result, &new, &final_val, &FileFormat::Yaml)
-            .expect("doc_set after doc_append must not fail");
-        let reparsed2: serde_json::Value = serde_yaml_ng::from_str(&result2).unwrap();
-        assert_eq!(
-            reparsed2, final_val,
-            "second operation must produce correct output: {result2}"
-        );
-    }
-
-    #[test]
-    fn yaml_sequence_root_mutation_not_lost() {
-        let yaml = "- item1\n- item2\n";
-        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
-        let mut new = old.clone();
-        new.as_array_mut().unwrap().push(json!("item3"));
-
-        let result =
-            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
-                .unwrap();
-        assert!(result.contains("item3"), "appended item missing: {result}");
-        assert!(result.contains("item1"), "item1 missing: {result}");
-        assert!(result.contains("item2"), "item2 missing: {result}");
-    }
-
-    #[test]
-    fn yaml_mapping_to_scalar_root_type_change_not_lost() {
-        let yaml = "name: app\nversion: 1\n";
-        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
-        let new = json!("overridden");
-
-        let result =
-            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
-                .unwrap();
-        assert!(
-            result.contains("overridden"),
-            "root type change lost: {result}"
-        );
-    }
-
-    #[test]
-    fn yaml_mapping_to_array_root_type_change_not_lost() {
-        let yaml = "name: app\nversion: 1\n";
-        let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
-        let new = json!(["a", "b"]);
-
-        let result =
-            serialize_value_preserving(yaml, &old, &new, &crate::ops::doc::FileFormat::Yaml)
-                .unwrap();
-        assert!(result.contains("- a"), "array item '- a' missing: {result}");
-        assert!(result.contains("- b"), "array item '- b' missing: {result}");
-    }
-
-    #[test]
-    fn yaml_multi_document_rejected_by_parser() {
-        // Multi-document YAML (--- separated) is rejected by serde_yaml_ng.
-        // This test documents the current behavior: parse_doc returns an error
-        // rather than silently dropping documents.
-        let yaml = "---\nname: first\n---\nname: second\n";
-        let err = parse_doc(yaml, &FileFormat::Yaml).unwrap_err();
-        assert!(
-            err.to_string().contains("more than one document"),
-            "expected multi-document rejection, got: {err}"
-        );
-    }
-
-    #[test]
-    fn yaml_single_document_marker_accepted() {
-        // A single document with an explicit `---` marker is valid and parses fine.
-        let yaml = "---\nname: only\n";
-        let val = parse_doc(yaml, &FileFormat::Yaml).unwrap();
-        assert_eq!(val, json!({"name": "only"}));
-
-        let mut new = val.clone();
-        new["name"] = json!("updated");
-        let result = serialize_value_preserving(yaml, &val, &new, &FileFormat::Yaml).unwrap();
-        let reparsed: serde_json::Value = serde_yaml_ng::from_str(&result).unwrap();
-        assert_eq!(reparsed, json!({"name": "updated"}));
-    }
-
-    #[test]
     fn yaml_sequence_root_noop_preserves_content() {
         let yaml = "- item1\n- item2\n";
         let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
@@ -603,333 +1296,6 @@ mod doc_tests {
                 .unwrap();
         assert_eq!(result, yaml, "no-op roundtrip should be identical");
     }
-
-    #[test]
-    fn detect_format_no_extension() {
-        assert!(detect_format("Makefile").is_err());
-    }
-
-    #[test]
-    fn parse_and_serialize_json_roundtrip() {
-        let input = "{\n  \"a\": 1\n}\n";
-        let val = parse_doc(input, &FileFormat::Json).unwrap();
-        assert_eq!(val, json!({"a": 1}));
-        let out = serialize_value(&val, &FileFormat::Json).unwrap();
-        assert_eq!(out, input);
-    }
-
-    #[test]
-    fn parse_and_serialize_yaml_roundtrip() {
-        let input = "a: 1\n";
-        let val = parse_doc(input, &crate::ops::doc::FileFormat::Yaml).unwrap();
-        assert_eq!(val, json!({"a": 1}));
-        let out = serialize_value(&val, &crate::ops::doc::FileFormat::Yaml).unwrap();
-        assert_eq!(out, input);
-    }
-
-    #[test]
-    fn parse_and_serialize_toml_roundtrip() {
-        let input = "a = 1\n";
-        let val = parse_doc(input, &FileFormat::Toml).unwrap();
-        assert_eq!(val, json!({"a": 1}));
-        // TOML pretty serialization may differ slightly; just ensure it parses back
-        let out = serialize_value(&val, &FileFormat::Toml).unwrap();
-        let reparsed = parse_doc(&out, &FileFormat::Toml).unwrap();
-        assert_eq!(reparsed, json!({"a": 1}));
-    }
-
-    #[test]
-    fn navigate_mut_existing_key() {
-        let mut val = json!({"a": {"b": 42}});
-        let seg = crate::selector::parse("a.b").unwrap();
-        let found = navigate_mut(&mut val, &seg, false).unwrap();
-        assert_eq!(*found, json!(42));
-    }
-
-    #[test]
-    fn navigate_mut_missing_key_no_create() {
-        let mut val = json!({"a": 1});
-        let seg = crate::selector::parse("b").unwrap();
-        assert!(navigate_mut(&mut val, &seg, false).is_err());
-    }
-
-    #[test]
-    fn navigate_mut_create_missing_key() {
-        let mut val = json!({"a": 1});
-        let seg = crate::selector::parse("b.c").unwrap();
-        let found = navigate_mut(&mut val, &seg, true).unwrap();
-        // created as empty object, then descended into "c" which was also created
-        assert!(found.is_object());
-    }
-
-    #[test]
-    fn navigate_mut_array_index() {
-        let mut val = json!({"items": [10, 20, 30]});
-        let seg = crate::selector::parse("items[1]").unwrap();
-        let found = navigate_mut(&mut val, &seg, false).unwrap();
-        assert_eq!(*found, json!(20));
-    }
-
-    #[test]
-    fn navigate_mut_index_out_of_bounds() {
-        let mut val = json!({"items": [10]});
-        let seg = crate::selector::parse("items[5]").unwrap();
-        assert!(navigate_mut(&mut val, &seg, false).is_err());
-    }
-
-    #[test]
-    fn deep_merge_objects() {
-        let mut base = json!({"a": 1, "b": {"c": 2}});
-        let other = json!({"b": {"d": 3}, "e": 4});
-        deep_merge(&mut base, &other);
-        assert_eq!(base, json!({"a": 1, "b": {"c": 2, "d": 3}, "e": 4}));
-    }
-
-    #[test]
-    fn deep_merge_overwrites_non_object() {
-        let mut base = json!({"a": "string"});
-        let other = json!({"a": {"nested": true}});
-        deep_merge(&mut base, &other);
-        assert_eq!(base, json!({"a": {"nested": true}}));
-    }
-
-    #[test]
-    fn deep_merge_depth_limit() {
-        // Build a deeply nested structure beyond MAX_MERGE_DEPTH (128)
-        let mut deep_val = json!("leaf");
-        for _ in 0..130 {
-            deep_val = json!({"n": deep_val});
-        }
-        let mut base = json!({});
-        deep_merge(&mut base, &deep_val);
-        // Should not panic; at depth 128 it clones instead of recursing
-        assert!(base.is_object());
-    }
-
-    #[test]
-    fn set_at_path_simple_key() {
-        let mut root = json!({"a": 1});
-        let sel = crate::selector::parse("b").unwrap();
-        set_at_path(&mut root, &sel, json!(2)).unwrap();
-        assert_eq!(root, json!({"a": 1, "b": 2}));
-    }
-
-    #[test]
-    fn set_at_path_nested_creates_intermediates() {
-        let mut root = json!({});
-        let sel = crate::selector::parse("a.b.c").unwrap();
-        set_at_path(&mut root, &sel, json!("deep")).unwrap();
-        assert_eq!(root, json!({"a": {"b": {"c": "deep"}}}));
-    }
-
-    #[test]
-    fn set_at_path_array_index() {
-        let mut root = json!({"items": [10, 20, 30]});
-        let sel = crate::selector::parse("items[1]").unwrap();
-        set_at_path(&mut root, &sel, json!(99)).unwrap();
-        assert_eq!(root, json!({"items": [10, 99, 30]}));
-    }
-
-    #[test]
-    fn set_at_path_out_of_bounds_index_fails() {
-        let mut root = json!({"items": [1]});
-        let sel = crate::selector::parse("items[5]").unwrap();
-        assert!(set_at_path(&mut root, &sel, json!(99)).is_err());
-    }
-
-    #[test]
-    fn set_at_path_empty_selector_fails() {
-        let mut root = json!({});
-        let sel: Vec<crate::selector::Segment> = vec![];
-        assert!(set_at_path(&mut root, &sel, json!(1)).is_err());
-    }
-
-    #[test]
-    fn delete_where_removes_matching_items() {
-        let mut root = json!({"items": [{"name": "a"}, {"name": "b"}, {"name": "c"}]});
-        let sel = crate::selector::parse("items").unwrap();
-        let removed = delete_where(&mut root, &sel, "name=b").unwrap();
-        assert_eq!(removed, 1);
-        assert_eq!(root["items"].as_array().unwrap().len(), 2);
-    }
-
-    #[test]
-    fn delete_where_no_match_returns_zero() {
-        let mut root = json!({"items": [{"name": "a"}]});
-        let sel = crate::selector::parse("items").unwrap();
-        let removed = delete_where(&mut root, &sel, "name=zzz").unwrap();
-        assert_eq!(removed, 0);
-    }
-
-    #[test]
-    fn delete_where_invalid_predicate_fails() {
-        let mut root = json!({"items": [{"name": "a"}]});
-        let sel = crate::selector::parse("items").unwrap();
-        assert!(delete_where(&mut root, &sel, "no-equals-sign").is_err());
-    }
-
-    #[test]
-    fn delete_where_non_array_fails() {
-        let mut root = json!({"items": "not-an-array"});
-        let sel = crate::selector::parse("items").unwrap();
-        assert!(delete_where(&mut root, &sel, "k=v").is_err());
-    }
-
-    #[test]
-    fn delete_where_double_equals_rejected() {
-        let mut root =
-            json!({"items": [{"name": "a", "keep": false}, {"name": "b", "keep": true}]});
-        let sel = crate::selector::parse("items").unwrap();
-        let err = delete_where(&mut root, &sel, "keep == false").unwrap_err();
-        assert!(
-            err.to_string().contains("'=='"),
-            "expected == rejection, got: {err}"
-        );
-        // Array must be unchanged (no silent removal).
-        assert_eq!(root["items"].as_array().unwrap().len(), 2);
-    }
-
-    #[test]
-    fn delete_where_empty_key_rejected() {
-        let mut root = json!({"items": [{"name": "a"}]});
-        let sel = crate::selector::parse("items").unwrap();
-        let err = delete_where(&mut root, &sel, "=value").unwrap_err();
-        assert!(
-            err.to_string().contains("empty"),
-            "expected empty-key error, got: {err}"
-        );
-    }
-
-    #[test]
-    fn delete_where_trims_whitespace() {
-        let mut root = json!({"items": [{"name": "a"}, {"name": "b"}]});
-        let sel = crate::selector::parse("items").unwrap();
-        // Spaces around key and value should be trimmed.
-        let removed = delete_where(&mut root, &sel, " name = a ").unwrap();
-        assert_eq!(removed, 1);
-        assert_eq!(root["items"].as_array().unwrap().len(), 1);
-        assert_eq!(root["items"][0]["name"], "b");
-    }
-
-    #[test]
-    fn delete_at_selector_removes_key() {
-        let mut root = json!({"a": 1, "b": 2});
-        let sel = crate::selector::parse("b").unwrap();
-        assert!(delete_at_selector(&mut root, &sel).unwrap());
-        assert_eq!(root, json!({"a": 1}));
-    }
-
-    #[test]
-    fn delete_at_selector_missing_returns_false() {
-        let mut root = json!({"a": 1});
-        let sel = crate::selector::parse("nonexistent").unwrap();
-        assert!(!delete_at_selector(&mut root, &sel).unwrap());
-    }
-
-    #[test]
-    fn delete_at_selector_array_index() {
-        let mut root = json!({"items": [10, 20, 30]});
-        let sel = crate::selector::parse("items[1]").unwrap();
-        assert!(delete_at_selector(&mut root, &sel).unwrap());
-        assert_eq!(root, json!({"items": [10, 30]}));
-    }
-
-    #[test]
-    fn delete_at_selector_empty_returns_false() {
-        let mut root = json!({"a": 1});
-        let sel: Vec<crate::selector::Segment> = vec![];
-        assert!(!delete_at_selector(&mut root, &sel).unwrap());
-    }
-
-    #[test]
-    fn move_at_path_renames_key() {
-        let mut root = json!({"old_name": "value", "other": 1});
-        let from = crate::selector::parse("old_name").unwrap();
-        let to = crate::selector::parse("new_name").unwrap();
-        move_at_path(&mut root, &from, &to).unwrap();
-        assert_eq!(root, json!({"other": 1, "new_name": "value"}));
-    }
-
-    #[test]
-    fn move_at_path_to_nested_creates_intermediates() {
-        let mut root = json!({"src": 42});
-        let from = crate::selector::parse("src").unwrap();
-        let to = crate::selector::parse("a.b.dst").unwrap();
-        move_at_path(&mut root, &from, &to).unwrap();
-        assert_eq!(root, json!({"a": {"b": {"dst": 42}}}));
-    }
-
-    #[test]
-    fn move_at_path_missing_source_fails() {
-        let mut root = json!({"a": 1});
-        let from = crate::selector::parse("nonexistent").unwrap();
-        let to = crate::selector::parse("b").unwrap();
-        assert!(move_at_path(&mut root, &from, &to).is_err());
-    }
-
-    #[test]
-    fn move_at_path_empty_from_selector_fails() {
-        let mut root = json!({"a": 1});
-        let from: Vec<crate::selector::Segment> = vec![];
-        let to = crate::selector::parse("b").unwrap();
-        assert!(move_at_path(&mut root, &from, &to).is_err());
-    }
-
-    #[test]
-    fn move_at_path_to_array_index() {
-        let mut root = json!({"src": "x", "arr": [1, 2, 3]});
-        let from = crate::selector::parse("src").unwrap();
-        let to = crate::selector::parse("arr[1]").unwrap();
-        move_at_path(&mut root, &from, &to).unwrap();
-        let arr = root["arr"].as_array().unwrap();
-        assert_eq!(arr.len(), 4);
-        assert_eq!(arr[1], json!("x"));
-    }
-
-    #[test]
-    fn update_matching_by_key() {
-        let mut val = json!({"a": {"b": "old"}});
-        let seg = crate::selector::parse("a.b").unwrap();
-        let count = update_matching(&mut val, &seg, &json!("new"));
-        assert_eq!(count, 1);
-        assert_eq!(val, json!({"a": {"b": "new"}}));
-    }
-
-    #[test]
-    fn update_matching_wildcard() {
-        let mut val = json!({"items": [{"v": 1}, {"v": 2}]});
-        let seg = crate::selector::parse("items[*].v").unwrap();
-        let count = update_matching(&mut val, &seg, &json!(99));
-        assert_eq!(count, 2);
-        assert_eq!(val, json!({"items": [{"v": 99}, {"v": 99}]}));
-    }
-
-    #[test]
-    fn update_matching_predicate() {
-        let mut val = json!({"items": [
-            {"name": "a", "v": 1},
-            {"name": "b", "v": 2}
-        ]});
-        let seg = crate::selector::parse("items[name=b].v").unwrap();
-        let count = update_matching(&mut val, &seg, &json!(42));
-        assert_eq!(count, 1);
-        assert_eq!(val["items"][1]["v"], json!(42));
-        // First item unchanged
-        assert_eq!(val["items"][0]["v"], json!(1));
-    }
-
-    #[test]
-    fn update_matching_missing_key_returns_zero() {
-        let mut val = json!({"a": 1});
-        let seg = crate::selector::parse("b.c").unwrap();
-        let count = update_matching(&mut val, &seg, &json!("x"));
-        assert_eq!(count, 0);
-    }
-}
-
-// ── needs_yaml_quoting tests ─────────────────────────────────────
-mod yaml_quoting_tests {
-    use crate::ops::doc::needs_yaml_quoting;
 
     #[test]
     fn yaml_booleans_need_quoting() {
@@ -959,11 +1325,6 @@ mod yaml_quoting_tests {
         assert!(needs_yaml_quoting("3.14"));
         assert!(needs_yaml_quoting("-1"));
         assert!(needs_yaml_quoting("0"));
-    }
-
-    #[test]
-    fn yaml_empty_string_needs_quoting() {
-        assert!(needs_yaml_quoting(""));
     }
 
     #[test]
@@ -1003,21 +1364,38 @@ mod yaml_quoting_tests {
         assert!(needs_yaml_quoting("hello #comment"));
     }
 
-    #[test]
-    fn yaml_plain_strings_do_not_need_quoting() {
-        assert!(!needs_yaml_quoting("hello"));
-        assert!(!needs_yaml_quoting("foo-bar"));
-        assert!(!needs_yaml_quoting("some_value_123"));
-        assert!(!needs_yaml_quoting("v1.2.3"));
+    ::proptest::proptest! {
+        /// JSON preserving round-trip: set a key, serialize preserving, reparse.
+                #[test]
+                fn json_preserving_set_round_trip(
+                    key in "[a-zA-Z_][a-zA-Z0-9_]{0,10}",
+                    set_value in prop_oneof![
+                        any::<bool>().prop_map(|b| json!(b)),
+                        any::<i64>().prop_map(|n| json!(n)),
+                        "[a-zA-Z0-9_]{0,20}".prop_map(|s| json!(s)),
+                    ],
+                ) {
+                    let original_content = "{\"existing\": 1}";
+                    let original_value = parse_doc(original_content, &FileFormat::Json).unwrap();
+                    let mut new_value = original_value.clone();
+                    let sel = selector::parse(&key).unwrap();
+                    set_at_path(&mut new_value, &sel, set_value.clone()).unwrap();
+
+                    let serialized = serialize_value_preserving(
+                        original_content,
+                        &original_value,
+                        &new_value,
+                        &FileFormat::Json,
+                    ).unwrap();
+                    let reparsed = parse_doc(&serialized, &FileFormat::Json).unwrap();
+                    prop_assert_eq!(&new_value, &reparsed);
+                }
     }
 }
 
-// ── proptest: doc round-trip ─────────────────────────────────────
-mod proptest_doc {
-    use crate::ops::doc::*;
-    use crate::selector;
-    use proptest::prelude::*;
-    use serde_json::json;
+mod proptest {
+    use super::*;
+    use ::proptest::prelude::*;
 
     /// Generate an arbitrary JSON value (limited depth to keep tests fast).
     fn arb_json_value() -> impl Strategy<Value = serde_json::Value> {
@@ -1043,441 +1421,68 @@ mod proptest_doc {
 
     proptest! {
         /// JSON round-trip: serialize then reparse must produce the same value.
-        #[test]
-        fn json_round_trip(value in arb_json_value()) {
-            let serialized = serialize_value(&value, &FileFormat::Json).unwrap();
-            let reparsed = parse_doc(&serialized, &FileFormat::Json).unwrap();
-            prop_assert_eq!(&value, &reparsed);
-        }
+                #[test]
+                fn json_round_trip(value in arb_json_value()) {
+                    let serialized = serialize_value(&value, &FileFormat::Json).unwrap();
+                    let reparsed = parse_doc(&serialized, &FileFormat::Json).unwrap();
+                    prop_assert_eq!(&value, &reparsed);
+                }
 
         /// TOML round-trip for object values (TOML root must be a table).
-        #[test]
-        fn toml_round_trip(entries in prop::collection::vec(
-            ("[a-zA-Z_][a-zA-Z0-9_]{0,10}", prop_oneof![
-                any::<bool>().prop_map(|b| json!(b)),
-                any::<i64>().prop_map(|n| json!(n)),
-                "[a-zA-Z0-9_]{0,20}".prop_map(|s| json!(s)),
-            ]),
-            0..8
-        )) {
-            let map: serde_json::Map<String, serde_json::Value> =
-                entries.into_iter().collect();
-            let value = serde_json::Value::Object(map);
-            let serialized = serialize_value(&value, &FileFormat::Toml).unwrap();
-            let reparsed = parse_doc(&serialized, &FileFormat::Toml).unwrap();
-            prop_assert_eq!(&value, &reparsed);
-        }
+                #[test]
+                fn toml_round_trip(entries in prop::collection::vec(
+                    ("[a-zA-Z_][a-zA-Z0-9_]{0,10}", prop_oneof![
+                        any::<bool>().prop_map(|b| json!(b)),
+                        any::<i64>().prop_map(|n| json!(n)),
+                        "[a-zA-Z0-9_]{0,20}".prop_map(|s| json!(s)),
+                    ]),
+                    0..8
+                )) {
+                    let map: serde_json::Map<String, serde_json::Value> =
+                        entries.into_iter().collect();
+                    let value = serde_json::Value::Object(map);
+                    let serialized = serialize_value(&value, &FileFormat::Toml).unwrap();
+                    let reparsed = parse_doc(&serialized, &FileFormat::Toml).unwrap();
+                    prop_assert_eq!(&value, &reparsed);
+                }
 
         /// YAML round-trip: serialize then reparse must produce the same value.
-        #[test]
-        fn yaml_round_trip(value in arb_json_value()) {
-            let serialized = serialize_value(&value, &crate::ops::doc::FileFormat::Yaml).unwrap();
-            let reparsed = parse_doc(&serialized, &crate::ops::doc::FileFormat::Yaml).unwrap();
-            prop_assert_eq!(&value, &reparsed);
-        }
+                #[test]
+                fn yaml_round_trip(value in arb_json_value()) {
+                    let serialized = serialize_value(&value, &crate::ops::doc::FileFormat::Yaml).unwrap();
+                    let reparsed = parse_doc(&serialized, &crate::ops::doc::FileFormat::Yaml).unwrap();
+                    prop_assert_eq!(&value, &reparsed);
+                }
 
         /// JSON set-then-get: setting a key and retrieving it must return the set value.
-        #[test]
-        fn json_set_then_get(
-            key in "[a-zA-Z_][a-zA-Z0-9_]{0,10}",
-            set_value in prop_oneof![
-                any::<bool>().prop_map(|b| json!(b)),
-                any::<i64>().prop_map(|n| json!(n)),
-                "[a-zA-Z0-9_]{0,20}".prop_map(|s| json!(s)),
-            ],
-        ) {
-            let mut root = json!({});
-            let sel = selector::parse(&key).unwrap();
-            set_at_path(&mut root, &sel, set_value.clone()).unwrap();
-            let results = selector::eval(&root, &sel);
-            prop_assert_eq!(results.len(), 1);
-            prop_assert_eq!(results[0], &set_value);
-        }
+                #[test]
+                fn json_set_then_get(
+                    key in "[a-zA-Z_][a-zA-Z0-9_]{0,10}",
+                    set_value in prop_oneof![
+                        any::<bool>().prop_map(|b| json!(b)),
+                        any::<i64>().prop_map(|n| json!(n)),
+                        "[a-zA-Z0-9_]{0,20}".prop_map(|s| json!(s)),
+                    ],
+                ) {
+                    let mut root = json!({});
+                    let sel = selector::parse(&key).unwrap();
+                    set_at_path(&mut root, &sel, set_value.clone()).unwrap();
+                    let results = selector::eval(&root, &sel);
+                    prop_assert_eq!(results.len(), 1);
+                    prop_assert_eq!(results[0], &set_value);
+                }
 
         /// JSON delete-then-has: deleting a key means it no longer exists.
-        #[test]
-        fn json_delete_then_has(
-            key in "[a-zA-Z_][a-zA-Z0-9_]{0,10}",
-        ) {
-            let mut root = json!({ &key: "value" });
-            let sel = selector::parse(&key).unwrap();
-            let deleted = delete_at_selector(&mut root, &sel).unwrap();
-            prop_assert!(deleted);
-            let results = selector::eval(&root, &sel);
-            prop_assert!(results.is_empty());
-        }
-
-        /// JSON preserving round-trip: set a key, serialize preserving, reparse.
-        #[test]
-        fn json_preserving_set_round_trip(
-            key in "[a-zA-Z_][a-zA-Z0-9_]{0,10}",
-            set_value in prop_oneof![
-                any::<bool>().prop_map(|b| json!(b)),
-                any::<i64>().prop_map(|n| json!(n)),
-                "[a-zA-Z0-9_]{0,20}".prop_map(|s| json!(s)),
-            ],
-        ) {
-            let original_content = "{\"existing\": 1}";
-            let original_value = parse_doc(original_content, &FileFormat::Json).unwrap();
-            let mut new_value = original_value.clone();
-            let sel = selector::parse(&key).unwrap();
-            set_at_path(&mut new_value, &sel, set_value.clone()).unwrap();
-
-            let serialized = serialize_value_preserving(
-                original_content,
-                &original_value,
-                &new_value,
-                &FileFormat::Json,
-            ).unwrap();
-            let reparsed = parse_doc(&serialized, &FileFormat::Json).unwrap();
-            prop_assert_eq!(&new_value, &reparsed);
-        }
-    }
-}
-
-// ── DocMutation / apply_doc_mutation tests ────────────────────────
-mod mutation_tests {
-    use super::super::*;
-    use serde_json::json;
-
-    #[test]
-    fn mutation_set() {
-        let mut root = json!({"a": 1});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Set {
-                selector: "b".into(),
-                value: json!(2),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root, json!({"a": 1, "b": 2}));
-    }
-
-    #[test]
-    fn mutation_delete_existing() {
-        let mut root = json!({"a": 1, "b": 2});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Delete {
-                selector: "b".into(),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root, json!({"a": 1}));
-    }
-
-    #[test]
-    fn mutation_delete_missing() {
-        let mut root = json!({"a": 1});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Delete {
-                selector: "z".into(),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::NoMatch));
-    }
-
-    #[test]
-    fn mutation_merge() {
-        let mut root = json!({"a": 1});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Merge {
-                value: json!({"b": 2}),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root, json!({"a": 1, "b": 2}));
-    }
-
-    #[test]
-    fn mutation_append_to_array() {
-        let mut root = json!({"items": [1, 2]});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Append {
-                selector: "items".into(),
-                value: json!(3),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root["items"], json!([1, 2, 3]));
-    }
-
-    #[test]
-    fn mutation_append_to_non_array() {
-        let mut root = json!({"items": "not-array"});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Append {
-                selector: "items".into(),
-                value: json!(1),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::TypeError(_)));
-    }
-
-    #[test]
-    fn mutation_prepend_to_array() {
-        let mut root = json!({"items": [2, 3]});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Prepend {
-                selector: "items".into(),
-                value: json!(1),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root["items"], json!([1, 2, 3]));
-    }
-
-    #[test]
-    fn mutation_update_matching() {
-        let mut root = json!({"items": [{"id": 1, "v": "a"}, {"id": 2, "v": "b"}]});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Update {
-                selector: "items[id=1]".into(),
-                value: json!({"id": 1, "v": "updated"}),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root["items"][0]["v"], "updated");
-    }
-
-    #[test]
-    fn mutation_update_no_match() {
-        let mut root = json!({"items": [{"id": 1}]});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Update {
-                selector: "items[id=99]".into(),
-                value: json!({"id": 99}),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::NoMatch));
-    }
-
-    #[test]
-    fn mutation_move_key() {
-        let mut root = json!({"src": 42, "dst": {}});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Move {
-                from: "src".into(),
-                to: "dst.val".into(),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root, json!({"dst": {"val": 42}}));
-    }
-
-    #[test]
-    fn mutation_move_missing_source() {
-        let mut root = json!({"a": 1});
-        let err = apply_doc_mutation(
-            &mut root,
-            DocMutation::Move {
-                from: "nonexistent".into(),
-                to: "b".into(),
-            },
-        )
-        .unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("source key 'nonexistent' not found")
-        );
-    }
-
-    #[test]
-    fn mutation_prepend_to_non_array() {
-        let mut root = json!({"items": "not-array"});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Prepend {
-                selector: "items".into(),
-                value: json!(1),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::TypeError(_)));
-    }
-
-    #[test]
-    fn mutation_ensure_missing() {
-        let mut root = json!({"a": 1});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Ensure {
-                selector: "b".into(),
-                value: json!(2),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root, json!({"a": 1, "b": 2}));
-    }
-
-    #[test]
-    fn mutation_ensure_existing() {
-        let mut root = json!({"a": 1});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::Ensure {
-                selector: "a".into(),
-                value: json!(99),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::AlreadyExists));
-        assert_eq!(root["a"], 1); // unchanged
-    }
-
-    #[test]
-    fn mutation_delete_where_matching() {
-        let mut root = json!({"items": [{"k": "a"}, {"k": "b"}]});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::DeleteWhere {
-                selector: "items".into(),
-                predicate: "k=a".into(),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
-        assert_eq!(root["items"].as_array().unwrap().len(), 1);
-    }
-
-    #[test]
-    fn mutation_delete_where_no_match() {
-        let mut root = json!({"items": [{"k": "a"}]});
-        let result = apply_doc_mutation(
-            &mut root,
-            DocMutation::DeleteWhere {
-                selector: "items".into(),
-                predicate: "k=z".into(),
-            },
-        )
-        .unwrap();
-        assert!(matches!(result, MutationResult::NoMatch));
-    }
-}
-
-// ── pure data helper tests ───────────────────────────────────────
-mod data_helper_tests {
-    use super::super::*;
-    use serde_json::json;
-
-    #[test]
-    fn parse_value_bare_string() {
-        assert_eq!(parse_value("hello"), json!("hello"));
-    }
-
-    #[test]
-    fn parse_value_integer() {
-        assert_eq!(parse_value("42"), json!(42));
-    }
-
-    #[test]
-    fn parse_value_bool() {
-        assert_eq!(parse_value("true"), json!(true));
-    }
-
-    #[test]
-    fn parse_value_null() {
-        assert_eq!(parse_value("null"), serde_json::Value::Null);
-    }
-
-    #[test]
-    fn parse_value_json_object() {
-        assert_eq!(parse_value(r#"{"a":1}"#), json!({"a": 1}));
-    }
-
-    // -- parse_value edge cases (#978) -----------------------------------
-
-    #[test]
-    fn parse_value_float() {
-        assert_eq!(parse_value("1.5"), json!(1.5));
-    }
-
-    #[test]
-    fn parse_value_negative_integer() {
-        assert_eq!(parse_value("-42"), json!(-42));
-    }
-
-    #[test]
-    fn parse_value_json_array() {
-        assert_eq!(parse_value("[1,2,3]"), json!([1, 2, 3]));
-    }
-
-    #[test]
-    fn parse_value_json_object_with_spaces() {
-        assert_eq!(parse_value(r#"{"a": 1}"#), json!({"a": 1}));
-    }
-
-    #[test]
-    fn parse_value_quoted_string_with_escapes() {
-        // JSON-escaped inner quotes: the input is a valid JSON string literal.
-        let result = parse_value(r#""hello\"world""#);
-        assert_eq!(result, json!("hello\"world"));
-        assert!(result.is_string());
-    }
-
-    #[test]
-    fn parse_value_plain_string() {
-        let result = parse_value("hello");
-        assert_eq!(result, json!("hello"));
-        assert!(result.is_string());
-    }
-
-    #[test]
-    fn parse_value_true_is_bool() {
-        // "true" is recognized as boolean, not left as a string.
-        let result = parse_value("true");
-        assert_eq!(result, json!(true));
-        assert!(result.is_boolean());
-    }
-
-    #[test]
-    fn parse_value_false_is_bool() {
-        let result = parse_value("false");
-        assert_eq!(result, json!(false));
-        assert!(result.is_boolean());
-    }
-
-    #[test]
-    fn flatten_value_nested() {
-        let val = json!({"a": {"b": 1}, "c": [2, 3]});
-        let mut buf = String::new();
-        let mut out = Vec::new();
-        flatten_value(&val, &mut buf, &mut out);
-        let paths: Vec<&str> = out.iter().map(|(p, _)| p.as_str()).collect();
-        assert!(paths.contains(&"a.b"));
-        assert!(paths.contains(&"c[0]"));
-        assert!(paths.contains(&"c[1]"));
-    }
-
-    #[test]
-    fn diff_values_detects_changes() {
-        let a = json!({"x": 1, "y": 2});
-        let b = json!({"x": 1, "y": 3, "z": 4});
-        let mut buf = String::new();
-        let mut out = Vec::new();
-        diff_values(&a, &b, &mut buf, &mut out);
-        assert_eq!(out.len(), 2); // y changed, z added
-        assert!(out.iter().any(|e| e.path == "y" && e.kind == "changed"));
-        assert!(out.iter().any(|e| e.path == "z" && e.kind == "added"));
+                #[test]
+                fn json_delete_then_has(
+                    key in "[a-zA-Z_][a-zA-Z0-9_]{0,10}",
+                ) {
+                    let mut root = json!({ &key: "value" });
+                    let sel = selector::parse(&key).unwrap();
+                    let deleted = delete_at_selector(&mut root, &sel).unwrap();
+                    prop_assert!(deleted);
+                    let results = selector::eval(&root, &sel);
+                    prop_assert!(results.is_empty());
+                }
     }
 }

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1,6 +1,8 @@
 // ── md module tests ───────────────────────────────────────────────
-mod md_tests {
-    use crate::ops::md::*;
+use crate::ops::md::*;
+
+mod basic {
+    use super::*;
 
     #[test]
     fn parse_headings_basic() {
@@ -14,6 +16,393 @@ mod md_tests {
         assert_eq!(headings[2].level, 1);
         assert_eq!(headings[2].text, "H1b");
     }
+
+    #[test]
+    fn parse_headings_section_boundaries() {
+        // ## B (level 2) does NOT end # A (level 1); only same-or-higher level ends it
+        let content = "# A\nline1\nline2\n## B\nline3\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings[0].line_start, 0);
+        assert_eq!(headings[0].line_end, 5); // # A owns everything (no same-level heading)
+        assert_eq!(headings[1].line_start, 3);
+        assert_eq!(headings[1].line_end, 5); // ## B to end of content
+
+        // Two same-level headings: second ends first
+        let content2 = "# A\nbody\n# B\nmore\n";
+        let h2 = parse_headings(content2);
+        assert_eq!(h2[0].line_end, 2); // # A ends at # B
+        assert_eq!(h2[1].line_end, 4); // # B to end
+    }
+
+    #[test]
+    fn parse_headings_setext_h1() {
+        let content = "Title\n=====\n\nSome content\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].level, 1);
+        assert_eq!(headings[0].text, "Title");
+        assert_eq!(headings[0].line_start, 0);
+    }
+
+    #[test]
+    fn parse_headings_setext_h2() {
+        let content = "Subtitle\n--------\n\nMore content\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].level, 2);
+        assert_eq!(headings[0].text, "Subtitle");
+        assert_eq!(headings[0].line_start, 0);
+    }
+
+    #[test]
+    fn parse_headings_setext_mixed_with_atx() {
+        let content = "Title\n=====\n\nSome content\n\n## ATX Heading\n\nMore text\n\nSubtitle\n--------\n\nEnd\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 3);
+        assert_eq!(headings[0].text, "Title");
+        assert_eq!(headings[0].level, 1);
+        assert_eq!(headings[1].text, "ATX Heading");
+        assert_eq!(headings[1].level, 2);
+        assert_eq!(headings[2].text, "Subtitle");
+        assert_eq!(headings[2].level, 2);
+    }
+
+    #[test]
+    fn parse_headings_setext_section_operations() {
+        // Verify that section-based operations work with setext headings.
+        // Body must NOT include the underline.
+        // Use two h1 setext headings so the first section is bounded.
+        let content = "Title\n=====\n\nBody of title\n\nSubtitle\n=====\n\nBody of subtitle\n";
+        let (start, end) = find_section(content, "Title").unwrap();
+        let body = &content[start..end];
+        assert_eq!(body, "\nBody of title\n\n", "Title body: {:?}", body);
+
+        let (start2, end2) = find_section(content, "Subtitle").unwrap();
+        let body2 = &content[start2..end2];
+        assert_eq!(body2, "\nBody of subtitle\n", "Subtitle body: {:?}", body2);
+    }
+
+    #[test]
+    fn find_section_returns_body_bytes() {
+        // ## Next is deeper than # Title, so it's part of the section body
+        let content = "# Title\nBody line 1\nBody line 2\n## Next\n";
+        let (start, end) = find_section(content, "Title").unwrap();
+        let body = &content[start..end];
+        assert_eq!(body, "Body line 1\nBody line 2\n## Next\n");
+
+        // Same-level heading ends the section
+        let content2 = "# Title\nBody\n# Other\nKeep\n";
+        let (s2, e2) = find_section(content2, "Title").unwrap();
+        assert_eq!(&content2[s2..e2], "Body\n");
+    }
+
+    #[test]
+    fn replace_section_basic() {
+        // Use same-level heading so section boundary is clear
+        let content = "# Title\nOld body\n# Next\nKeep\n";
+        let result = replace_section_in(content, "Title", "New body").unwrap();
+        assert_eq!(result, "# Title\nNew body\n# Next\nKeep\n");
+    }
+
+    #[test]
+    fn insert_after_heading() {
+        let content = "# Title\nExisting\n";
+        let result = insert_after_heading_in(content, "Title", "Inserted\n").unwrap();
+        assert_eq!(result, "# Title\nInserted\nExisting\n");
+    }
+
+    #[test]
+    fn insert_before_heading() {
+        let content = "# First\nBody\n## Second\nMore\n";
+        let result = insert_before_heading_in(content, "Second", "Inserted").unwrap();
+        assert!(result.contains("Inserted\n\n## Second"));
+    }
+
+    #[test]
+    fn upsert_bullet_adds_new() {
+        let content = "# List\n- item1\n";
+        let result = upsert_bullet_in(content, "List", "- item2").unwrap();
+        assert!(result.contains("- item1\n- item2\n"));
+    }
+
+    #[test]
+    fn upsert_bullet_dedup_existing() {
+        let content = "# List\n- item1\n";
+        let result = upsert_bullet_in(content, "List", "- item1").unwrap();
+        // Should return content unchanged (no duplicate)
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn upsert_bullet_auto_prefix() {
+        let content = "# List\n- a\n";
+        let result = upsert_bullet_in(content, "List", "new item").unwrap();
+        assert!(result.contains("- new item\n"));
+    }
+
+    #[test]
+    fn dedupe_headings_removes_duplicate() {
+        let content = "# Title\nFirst\n# Title\nSecond\n";
+        let (result, removed) = dedupe_headings_in(content);
+        assert_eq!(removed, vec!["# Title"]);
+        // First occurrence kept, second removed
+        assert!(result.contains("First"));
+        assert!(!result.contains("Second"));
+    }
+
+    #[test]
+    fn table_append_basic() {
+        let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n## Next\n";
+        let (start, end) = find_section(content, "API").unwrap();
+        let result = table_append_in(content, start, end, "| b | 2 |").unwrap();
+        assert!(result.contains("| a | 1 |\n| b | 2 |\n## Next"));
+    }
+
+    #[test]
+    fn table_append_for_tx_basic() {
+        let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n";
+        let result = table_append_for_tx(content, "API", "| b | 2 |").unwrap();
+        assert!(result.contains("| a | 1 |\n| b | 2 |\n"));
+    }
+
+    #[test]
+    fn section_range_includes_heading() {
+        let content = "# A\nbody a\n# B\nbody b\n";
+        let (start, end) = section_range(content, "A").unwrap();
+        assert_eq!(&content[start..end], "# A\nbody a\n");
+    }
+
+    #[test]
+    fn section_range_last_section() {
+        let content = "# A\nbody a\n# B\nbody b\n";
+        let (start, end) = section_range(content, "B").unwrap();
+        assert_eq!(&content[start..end], "# B\nbody b\n");
+    }
+
+    #[test]
+    fn move_section_same_file_before() {
+        let content = "# A\na body\n# B\nb body\n# C\nc body\n";
+        let (result, _) = move_section_in(content, "C", content, ("before", "B"), true).unwrap();
+        let a_pos = result.find("# A").unwrap();
+        let c_pos = result.find("# C").unwrap();
+        let b_pos = result.find("# B").unwrap();
+        assert!(a_pos < c_pos);
+        assert!(c_pos < b_pos);
+        assert!(result.contains("a body"));
+        assert!(result.contains("b body"));
+        assert!(result.contains("c body"));
+    }
+
+    #[test]
+    fn move_section_same_file_after() {
+        let content = "# A\na body\n# B\nb body\n# C\nc body\n";
+        let (result, _) = move_section_in(content, "A", content, ("after", "B"), true).unwrap();
+        let b_pos = result.find("# B").unwrap();
+        let a_pos = result.find("# A").unwrap();
+        let c_pos = result.find("# C").unwrap();
+        assert!(b_pos < a_pos);
+        assert!(a_pos < c_pos);
+    }
+
+    #[test]
+    fn move_section_cross_file() {
+        let source = "# Keep\nkept\n# Move\nmoved\n# Stay\nstayed\n";
+        let dest = "# Intro\nintro\n# End\nend\n";
+        let (new_src, new_dst) =
+            move_section_in(source, "Move", dest, ("before", "End"), false).unwrap();
+        assert!(!new_src.contains("# Move"));
+        assert!(!new_src.contains("moved"));
+        assert!(new_src.contains("# Keep"));
+        assert!(new_src.contains("# Stay"));
+        assert!(new_dst.contains("# Move\nmoved"));
+        let move_pos = new_dst.find("# Move").unwrap();
+        let end_pos = new_dst.find("# End").unwrap();
+        assert!(move_pos < end_pos);
+    }
+
+    #[test]
+    fn move_section_preserves_sub_headings() {
+        let content = "# A\n## A1\na1 content\n## A2\na2 content\n# B\nb content\n";
+        let (result, _) = move_section_in(content, "A", content, ("after", "B"), true).unwrap();
+        // A should now come after B, with both sub-headings preserved.
+        let b_pos = result.find("# B").unwrap();
+        let a_pos = result.find("# A").unwrap();
+        assert!(b_pos < a_pos, "A should be after B");
+        assert!(
+            result.contains("## A1\na1 content"),
+            "sub-heading A1 should be preserved: {result}"
+        );
+        assert!(
+            result.contains("## A2\na2 content"),
+            "sub-heading A2 should be preserved: {result}"
+        );
+        assert!(
+            result.contains("b content"),
+            "B body should be preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn move_section_cross_file_preserves_sub_headings() {
+        let source = "# A\n## A1\na1 content\n## A2\na2 content\n# B\nb content\n";
+        let dest = "# X\nx content\n# Y\ny content\n";
+        let (new_src, new_dst) =
+            move_section_in(source, "A", dest, ("before", "Y"), false).unwrap();
+        // Source should no longer have A or its sub-headings.
+        assert!(!new_src.contains("# A"));
+        assert!(!new_src.contains("## A1"));
+        assert!(!new_src.contains("## A2"));
+        assert!(new_src.contains("# B\nb content"));
+        // Dest should have A with its sub-headings before Y.
+        let a_pos = new_dst.find("# A").unwrap();
+        let y_pos = new_dst.find("# Y").unwrap();
+        assert!(a_pos < y_pos);
+        assert!(new_dst.contains("## A1\na1 content"));
+        assert!(new_dst.contains("## A2\na2 content"));
+    }
+
+    // ── strip_inline_code ─────────────────────────────────────────
+
+    #[test]
+    fn strip_inline_code_basic() {
+        assert_eq!(strip_inline_code("use `foo` here"), "use  here");
+    }
+
+    #[test]
+    fn strip_inline_code_multiple_spans() {
+        assert_eq!(strip_inline_code("`a` and `b`"), " and ");
+    }
+
+    #[test]
+    fn strip_inline_code_no_backticks_returns_borrowed() {
+        let result = strip_inline_code("no backticks");
+        assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(result, "no backticks");
+    }
+
+    #[test]
+    fn strip_inline_code_text_around_spans() {
+        assert_eq!(strip_inline_code("start `mid` end"), "start  end");
+    }
+
+    #[test]
+    fn upsert_bullet_star_dedup_same_style() {
+        // Upserting "* existing item" when body already has "* existing item"
+        // should dedup (same style, same text).
+        let content = "# List\n\n* existing item\n";
+        let result = upsert_bullet_in(content, "List", "* existing item").unwrap();
+        assert_eq!(result, content, "same-style duplicate should be deduped");
+    }
+
+    #[test]
+    fn upsert_bullet_dash_appends_after_star_items() {
+        // "- new item" appended correctly after existing "* " items.
+        let content = "# List\n\n* alpha\n* beta\n";
+        let result = upsert_bullet_in(content, "List", "- new item").unwrap();
+        assert!(
+            result.contains("* beta\n- new item\n"),
+            "new dash bullet should follow existing star bullets: {:?}",
+            result
+        );
+    }
+}
+
+mod line_endings {
+    use super::*;
+
+    // ── CRLF handling in table_append_in ──────────────────────────
+
+    #[test]
+    fn table_append_crlf_content_finds_correct_position() {
+        // CRLF content: the byte-offset tracking in table_append_in
+        // must correctly advance past \r\n (2 bytes) per line.
+        let content = "# T\r\n| H |\r\n|---|\r\n| v |\r\n";
+        let (start, end) = find_section(content, "T").unwrap();
+        let result = table_append_in(content, start, end, "| new |").unwrap();
+        // The new row must appear after the last data row.
+        assert!(
+            result.contains("| v |\r\n| new |"),
+            "row should be appended after existing data row in CRLF content: {:?}",
+            result
+        );
+        // The content before the insertion should be preserved.
+        assert!(
+            result.contains("| H |\r\n|---|\r\n| v |\r\n"),
+            "original CRLF table should be intact: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn table_append_crlf_header_only() {
+        // Table with only header + separator in CRLF content.
+        let content = "# T\r\n| H |\r\n|---|\r\n";
+        let (start, end) = find_section(content, "T").unwrap();
+        let result = table_append_in(content, start, end, "| a |").unwrap();
+        assert!(
+            result.contains("|---|\r\n| a |"),
+            "row should be appended after separator in CRLF content: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn table_append_crlf_multiple_data_rows() {
+        // Multiple data rows with CRLF; new row goes after the last one.
+        let content = "# T\r\n| H |\r\n|---|\r\n| a |\r\n| b |\r\n";
+        let (start, end) = find_section(content, "T").unwrap();
+        let result = table_append_in(content, start, end, "| c |").unwrap();
+        assert!(
+            result.contains("| b |\r\n| c |"),
+            "row should be appended after the last data row: {:?}",
+            result
+        );
+    }
+
+    // ── CRLF in parse_headings ────────────────────────────────────
+
+    #[test]
+    fn parse_headings_crlf_strips_carriage_return() {
+        // .lines() strips \r, so heading text should not contain \r.
+        let content = "## Heading One\r\n\r\nBody text.\r\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].text, "Heading One");
+        assert!(
+            !headings[0].text.contains('\r'),
+            "heading text must not contain \\r"
+        );
+        assert_eq!(headings[0].level, 2);
+    }
+
+    #[test]
+    fn parse_headings_crlf_multiple_headings() {
+        let content = "# First\r\nBody 1\r\n## Second\r\nBody 2\r\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 2);
+        assert_eq!(headings[0].text, "First");
+        assert_eq!(headings[1].text, "Second");
+        // Verify section boundaries are correct.
+        assert_eq!(headings[0].line_start, 0);
+        assert_eq!(headings[1].line_start, 2);
+    }
+
+    #[test]
+    fn find_section_crlf_returns_correct_body() {
+        let content = "## Heading One\r\n\r\nBody text.\r\n## Next\r\n";
+        let (start, end) = find_section(content, "Heading One").unwrap();
+        let body = &content[start..end];
+        // Body should include the blank line and body text between headings.
+        assert!(
+            body.contains("Body text."),
+            "body should contain body text: {:?}",
+            body
+        );
+    }
+}
+
+mod edge_cases {
+    use super::*;
 
     #[test]
     fn parse_headings_skips_fenced_code_blocks() {
@@ -85,107 +474,12 @@ mod md_tests {
     }
 
     #[test]
-    fn parse_headings_section_boundaries() {
-        // ## B (level 2) does NOT end # A (level 1); only same-or-higher level ends it
-        let content = "# A\nline1\nline2\n## B\nline3\n";
-        let headings = parse_headings(content);
-        assert_eq!(headings[0].line_start, 0);
-        assert_eq!(headings[0].line_end, 5); // # A owns everything (no same-level heading)
-        assert_eq!(headings[1].line_start, 3);
-        assert_eq!(headings[1].line_end, 5); // ## B to end of content
-
-        // Two same-level headings: second ends first
-        let content2 = "# A\nbody\n# B\nmore\n";
-        let h2 = parse_headings(content2);
-        assert_eq!(h2[0].line_end, 2); // # A ends at # B
-        assert_eq!(h2[1].line_end, 4); // # B to end
-    }
-
-    #[test]
-    fn parse_headings_setext_h1() {
-        let content = "Title\n=====\n\nSome content\n";
-        let headings = parse_headings(content);
-        assert_eq!(headings.len(), 1);
-        assert_eq!(headings[0].level, 1);
-        assert_eq!(headings[0].text, "Title");
-        assert_eq!(headings[0].line_start, 0);
-    }
-
-    #[test]
-    fn parse_headings_setext_h2() {
-        let content = "Subtitle\n--------\n\nMore content\n";
-        let headings = parse_headings(content);
-        assert_eq!(headings.len(), 1);
-        assert_eq!(headings[0].level, 2);
-        assert_eq!(headings[0].text, "Subtitle");
-        assert_eq!(headings[0].line_start, 0);
-    }
-
-    #[test]
-    fn parse_headings_setext_mixed_with_atx() {
-        let content = "Title\n=====\n\nSome content\n\n## ATX Heading\n\nMore text\n\nSubtitle\n--------\n\nEnd\n";
-        let headings = parse_headings(content);
-        assert_eq!(headings.len(), 3);
-        assert_eq!(headings[0].text, "Title");
-        assert_eq!(headings[0].level, 1);
-        assert_eq!(headings[1].text, "ATX Heading");
-        assert_eq!(headings[1].level, 2);
-        assert_eq!(headings[2].text, "Subtitle");
-        assert_eq!(headings[2].level, 2);
-    }
-
-    #[test]
     fn parse_headings_setext_inside_fenced_code_block_ignored() {
         let content = "# Real\n```\nFake\n====\n```\n## Also Real\n";
         let headings = parse_headings(content);
         assert_eq!(headings.len(), 2);
         assert_eq!(headings[0].text, "Real");
         assert_eq!(headings[1].text, "Also Real");
-    }
-
-    #[test]
-    fn parse_headings_setext_section_operations() {
-        // Verify that section-based operations work with setext headings.
-        // Body must NOT include the underline.
-        // Use two h1 setext headings so the first section is bounded.
-        let content = "Title\n=====\n\nBody of title\n\nSubtitle\n=====\n\nBody of subtitle\n";
-        let (start, end) = find_section(content, "Title").unwrap();
-        let body = &content[start..end];
-        assert_eq!(body, "\nBody of title\n\n", "Title body: {:?}", body);
-
-        let (start2, end2) = find_section(content, "Subtitle").unwrap();
-        let body2 = &content[start2..end2];
-        assert_eq!(body2, "\nBody of subtitle\n", "Subtitle body: {:?}", body2);
-    }
-
-    #[test]
-    fn replace_section_setext_preserves_underline() {
-        // Use same-level headings so the section is bounded.
-        let content = "Title\n=====\n\nOld body\n\nNext\n=====\nKeep\n";
-        let result = replace_section_in(content, "Title", "New body").unwrap();
-        assert_eq!(
-            result, "Title\n=====\nNew body\nNext\n=====\nKeep\n",
-            "underline must be preserved: {result}"
-        );
-    }
-
-    #[test]
-    fn upsert_bullet_setext_heading() {
-        let content = "List\n----\n\n- item1\n";
-        let result = upsert_bullet_in(content, "List", "- item2").unwrap();
-        assert!(
-            result.contains("----\n"),
-            "underline must be preserved: {result}"
-        );
-        assert!(
-            result.contains("- item1\n- item2\n"),
-            "bullet should be appended: {result}"
-        );
-        // Underline must NOT appear in the body match
-        assert!(
-            !result.contains("- ----"),
-            "underline must not be treated as bullet content: {result}"
-        );
     }
 
     #[test]
@@ -223,20 +517,6 @@ mod md_tests {
     }
 
     #[test]
-    fn find_section_returns_body_bytes() {
-        // ## Next is deeper than # Title, so it's part of the section body
-        let content = "# Title\nBody line 1\nBody line 2\n## Next\n";
-        let (start, end) = find_section(content, "Title").unwrap();
-        let body = &content[start..end];
-        assert_eq!(body, "Body line 1\nBody line 2\n## Next\n");
-
-        // Same-level heading ends the section
-        let content2 = "# Title\nBody\n# Other\nKeep\n";
-        let (s2, e2) = find_section(content2, "Title").unwrap();
-        assert_eq!(&content2[s2..e2], "Body\n");
-    }
-
-    #[test]
     fn find_section_with_hashes_in_query() {
         let content = "## API\nsome text\n";
         let (start, end) = find_section(content, "## API").unwrap();
@@ -244,44 +524,10 @@ mod md_tests {
     }
 
     #[test]
-    fn find_section_missing() {
-        let content = "# Title\nBody\n";
-        assert!(find_section(content, "Nonexistent").is_none());
-    }
-
-    #[test]
-    fn replace_section_basic() {
-        // Use same-level heading so section boundary is clear
-        let content = "# Title\nOld body\n# Next\nKeep\n";
-        let result = replace_section_in(content, "Title", "New body").unwrap();
-        assert_eq!(result, "# Title\nNew body\n# Next\nKeep\n");
-    }
-
-    #[test]
     fn replace_section_empty_replacement() {
         let content = "# Title\nOld body\n# Next\nKeep\n";
         let result = replace_section_in(content, "Title", "").unwrap();
         assert_eq!(result, "# Title\n# Next\nKeep\n");
-    }
-
-    #[test]
-    fn replace_section_missing_heading() {
-        let content = "# Title\nBody\n";
-        assert!(replace_section_in(content, "Missing", "x").is_none());
-    }
-
-    #[test]
-    fn insert_after_heading() {
-        let content = "# Title\nExisting\n";
-        let result = insert_after_heading_in(content, "Title", "Inserted\n").unwrap();
-        assert_eq!(result, "# Title\nInserted\nExisting\n");
-    }
-
-    #[test]
-    fn insert_before_heading() {
-        let content = "# First\nBody\n## Second\nMore\n";
-        let result = insert_before_heading_in(content, "Second", "Inserted").unwrap();
-        assert!(result.contains("Inserted\n\n## Second"));
     }
 
     #[test]
@@ -301,74 +547,11 @@ mod md_tests {
     }
 
     #[test]
-    fn upsert_bullet_adds_new() {
-        let content = "# List\n- item1\n";
-        let result = upsert_bullet_in(content, "List", "- item2").unwrap();
-        assert!(result.contains("- item1\n- item2\n"));
-    }
-
-    #[test]
-    fn upsert_bullet_dedup_existing() {
-        let content = "# List\n- item1\n";
-        let result = upsert_bullet_in(content, "List", "- item1").unwrap();
-        // Should return content unchanged (no duplicate)
-        assert_eq!(result, content);
-    }
-
-    #[test]
-    fn upsert_bullet_auto_prefix() {
-        let content = "# List\n- a\n";
-        let result = upsert_bullet_in(content, "List", "new item").unwrap();
-        assert!(result.contains("- new item\n"));
-    }
-
-    #[test]
-    fn upsert_bullet_preserves_blank_line_before_next_heading() {
-        // Regression test for #973: upsert_bullet consumed the blank line
-        // separating the section body from the next heading.
-        let content = "## Section A\n\n- Bullet one\n- Bullet two\n\n## Section B\n\nContent B.\n";
-        let result = upsert_bullet_in(content, "Section A", "- Bullet three").unwrap();
-        assert!(
-            result.contains("- Bullet three\n\n## Section B"),
-            "blank line before next heading must be preserved: {result}"
-        );
-    }
-
-    #[test]
-    fn upsert_bullet_preserves_blank_before_sub_heading() {
-        // #973 variant: subsection headings (###) also need blank line preservation.
-        let content = "### Bug Fixes\n\n- Fix one\n\n### Dependencies\n\nDep content.\n";
-        let result = upsert_bullet_in(content, "Bug Fixes", "- Fix two").unwrap();
-        assert!(
-            result.contains("- Fix two\n\n### Dependencies"),
-            "blank line before sub-heading must be preserved: {result}"
-        );
-    }
-
-    #[test]
-    fn dedupe_headings_removes_duplicate() {
-        let content = "# Title\nFirst\n# Title\nSecond\n";
-        let (result, removed) = dedupe_headings_in(content);
-        assert_eq!(removed, vec!["# Title"]);
-        // First occurrence kept, second removed
-        assert!(result.contains("First"));
-        assert!(!result.contains("Second"));
-    }
-
-    #[test]
     fn dedupe_headings_no_duplicates() {
         let content = "# A\n## B\n# C\n";
         let (result, removed) = dedupe_headings_in(content);
         assert!(removed.is_empty());
         assert_eq!(result, content);
-    }
-
-    #[test]
-    fn table_append_basic() {
-        let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n## Next\n";
-        let (start, end) = find_section(content, "API").unwrap();
-        let result = table_append_in(content, start, end, "| b | 2 |").unwrap();
-        assert!(result.contains("| a | 1 |\n| b | 2 |\n## Next"));
     }
 
     #[test]
@@ -380,126 +563,6 @@ mod md_tests {
             result,
             "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n## Next\n"
         );
-    }
-
-    #[test]
-    fn table_append_no_table() {
-        let content = "# API\nJust text\n";
-        let (start, end) = find_section(content, "API").unwrap();
-        assert!(table_append_in(content, start, end, "| b | 2 |").is_none());
-    }
-
-    #[test]
-    fn table_append_for_tx_basic() {
-        let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n";
-        let result = table_append_for_tx(content, "API", "| b | 2 |").unwrap();
-        assert!(result.contains("| a | 1 |\n| b | 2 |\n"));
-    }
-
-    #[test]
-    fn section_range_includes_heading() {
-        let content = "# A\nbody a\n# B\nbody b\n";
-        let (start, end) = section_range(content, "A").unwrap();
-        assert_eq!(&content[start..end], "# A\nbody a\n");
-    }
-
-    #[test]
-    fn section_range_last_section() {
-        let content = "# A\nbody a\n# B\nbody b\n";
-        let (start, end) = section_range(content, "B").unwrap();
-        assert_eq!(&content[start..end], "# B\nbody b\n");
-    }
-
-    #[test]
-    fn section_range_missing() {
-        let content = "# A\nbody\n";
-        assert!(section_range(content, "Missing").is_none());
-    }
-
-    #[test]
-    fn section_range_setext_includes_text_and_underline() {
-        // Use same-level heading to bound the section.
-        let content = "Title\n=====\nbody\nNext\n=====\nmore\n";
-        let (start, end) = section_range(content, "Title").unwrap();
-        // section_range should include the text line + underline + body
-        assert_eq!(
-            &content[start..end],
-            "Title\n=====\nbody\n",
-            "setext section_range should include text line and underline"
-        );
-    }
-
-    #[test]
-    fn move_section_same_file_before() {
-        let content = "# A\na body\n# B\nb body\n# C\nc body\n";
-        let (result, _) = move_section_in(content, "C", content, ("before", "B"), true).unwrap();
-        let a_pos = result.find("# A").unwrap();
-        let c_pos = result.find("# C").unwrap();
-        let b_pos = result.find("# B").unwrap();
-        assert!(a_pos < c_pos);
-        assert!(c_pos < b_pos);
-        assert!(result.contains("a body"));
-        assert!(result.contains("b body"));
-        assert!(result.contains("c body"));
-    }
-
-    #[test]
-    fn move_section_same_file_after() {
-        let content = "# A\na body\n# B\nb body\n# C\nc body\n";
-        let (result, _) = move_section_in(content, "A", content, ("after", "B"), true).unwrap();
-        let b_pos = result.find("# B").unwrap();
-        let a_pos = result.find("# A").unwrap();
-        let c_pos = result.find("# C").unwrap();
-        assert!(b_pos < a_pos);
-        assert!(a_pos < c_pos);
-    }
-
-    #[test]
-    fn move_section_after_preserves_dest_table_body() {
-        // Regression for #825: moving a section "after" a dest that owns a
-        // table must keep the table under the dest heading.
-        let content = "# T\n\n## Commands\n\ncmd body\n\n## Rules\n\n- rule1\n\n## Features\n\n| Name | Status |\n|------|--------|\n| search | done |\n";
-        let (result, _) =
-            move_section_in(content, "## Rules", content, ("after", "## Features"), true).unwrap();
-        // Features heading should still be followed (eventually) by its table,
-        // and Rules after the table.
-        let features_pos = result.find("## Features").unwrap();
-        let rules_pos = result.find("## Rules").unwrap();
-        let table_pos = result.find("| search | done |").unwrap();
-        assert!(
-            features_pos < table_pos,
-            "table should still be after Features"
-        );
-        assert!(table_pos < rules_pos, "Rules should be after the table");
-        assert!(result.contains("- rule1"));
-    }
-
-    #[test]
-    fn move_section_cross_file() {
-        let source = "# Keep\nkept\n# Move\nmoved\n# Stay\nstayed\n";
-        let dest = "# Intro\nintro\n# End\nend\n";
-        let (new_src, new_dst) =
-            move_section_in(source, "Move", dest, ("before", "End"), false).unwrap();
-        assert!(!new_src.contains("# Move"));
-        assert!(!new_src.contains("moved"));
-        assert!(new_src.contains("# Keep"));
-        assert!(new_src.contains("# Stay"));
-        assert!(new_dst.contains("# Move\nmoved"));
-        let move_pos = new_dst.find("# Move").unwrap();
-        let end_pos = new_dst.find("# End").unwrap();
-        assert!(move_pos < end_pos);
-    }
-
-    #[test]
-    fn move_section_missing_source_heading() {
-        let content = "# A\nbody\n";
-        assert!(move_section_in(content, "Missing", content, ("before", "A"), true).is_none());
-    }
-
-    #[test]
-    fn move_section_missing_target_heading() {
-        let content = "# A\nbody\n# B\nbody\n";
-        assert!(move_section_in(content, "A", content, ("before", "Missing"), true).is_none());
     }
 
     #[test]
@@ -528,71 +591,6 @@ mod md_tests {
     }
 
     #[test]
-    fn move_section_preserves_sub_headings() {
-        let content = "# A\n## A1\na1 content\n## A2\na2 content\n# B\nb content\n";
-        let (result, _) = move_section_in(content, "A", content, ("after", "B"), true).unwrap();
-        // A should now come after B, with both sub-headings preserved.
-        let b_pos = result.find("# B").unwrap();
-        let a_pos = result.find("# A").unwrap();
-        assert!(b_pos < a_pos, "A should be after B");
-        assert!(
-            result.contains("## A1\na1 content"),
-            "sub-heading A1 should be preserved: {result}"
-        );
-        assert!(
-            result.contains("## A2\na2 content"),
-            "sub-heading A2 should be preserved: {result}"
-        );
-        assert!(
-            result.contains("b content"),
-            "B body should be preserved: {result}"
-        );
-    }
-
-    #[test]
-    fn move_section_cross_file_preserves_sub_headings() {
-        let source = "# A\n## A1\na1 content\n## A2\na2 content\n# B\nb content\n";
-        let dest = "# X\nx content\n# Y\ny content\n";
-        let (new_src, new_dst) =
-            move_section_in(source, "A", dest, ("before", "Y"), false).unwrap();
-        // Source should no longer have A or its sub-headings.
-        assert!(!new_src.contains("# A"));
-        assert!(!new_src.contains("## A1"));
-        assert!(!new_src.contains("## A2"));
-        assert!(new_src.contains("# B\nb content"));
-        // Dest should have A with its sub-headings before Y.
-        let a_pos = new_dst.find("# A").unwrap();
-        let y_pos = new_dst.find("# Y").unwrap();
-        assert!(a_pos < y_pos);
-        assert!(new_dst.contains("## A1\na1 content"));
-        assert!(new_dst.contains("## A2\na2 content"));
-    }
-}
-
-// ── Issue #976: lint helper tests ──────────────────────────────────
-mod lint_helper_tests {
-    use crate::ops::md::*;
-
-    // ── strip_inline_code ─────────────────────────────────────────
-
-    #[test]
-    fn strip_inline_code_basic() {
-        assert_eq!(strip_inline_code("use `foo` here"), "use  here");
-    }
-
-    #[test]
-    fn strip_inline_code_multiple_spans() {
-        assert_eq!(strip_inline_code("`a` and `b`"), " and ");
-    }
-
-    #[test]
-    fn strip_inline_code_no_backticks_returns_borrowed() {
-        let result = strip_inline_code("no backticks");
-        assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
-        assert_eq!(result, "no backticks");
-    }
-
-    #[test]
     fn strip_inline_code_unmatched_backtick() {
         assert_eq!(strip_inline_code("before `after"), "before after");
     }
@@ -615,69 +613,40 @@ mod lint_helper_tests {
     }
 
     #[test]
-    fn strip_inline_code_text_around_spans() {
-        assert_eq!(strip_inline_code("start `mid` end"), "start  end");
-    }
-
-    // ── has_dangerous_git_add_dot ─────────────────────────────────
-
-    #[test]
-    fn git_add_dot_at_eol() {
-        assert!(has_dangerous_git_add_dot("git add ."));
-    }
-
-    #[test]
-    fn git_add_dot_followed_by_space() {
-        assert!(has_dangerous_git_add_dot("git add . && git commit"));
-    }
-
-    #[test]
-    fn git_add_dot_followed_by_tab() {
-        assert!(has_dangerous_git_add_dot("git add .\tnext"));
-    }
-
-    #[test]
-    fn git_add_dotgitignore_is_safe() {
-        assert!(!has_dangerous_git_add_dot("git add .gitignore"));
-    }
-
-    #[test]
-    fn git_add_dot_slash_is_safe() {
-        assert!(!has_dangerous_git_add_dot("git add ./file"));
-    }
-
-    #[test]
-    fn git_add_dot_mid_line() {
-        assert!(has_dangerous_git_add_dot("run git add . now"));
-    }
-
-    #[test]
-    fn git_add_dot_no_match() {
-        assert!(!has_dangerous_git_add_dot("no match here"));
-    }
-
-    #[test]
     fn git_add_dot_empty_string() {
         assert!(!has_dangerous_git_add_dot(""));
     }
 
     #[test]
-    fn git_add_dot_multiple_occurrences_first_safe() {
-        // First "git add .gitignore" is safe, second "git add ." is dangerous
-        assert!(has_dangerous_git_add_dot("git add .gitignore && git add ."));
+    fn upsert_bullet_cross_style_dash_into_star_dedup() {
+        // Upserting "- existing item" when body has "* existing item":
+        // cross-style dedup should recognize them as the same item.
+        let content = "# List\n\n* existing item\n";
+        let result = upsert_bullet_in(content, "List", "- existing item").unwrap();
+        assert_eq!(result, content, "cross-style bullets should dedup");
     }
 
     #[test]
-    fn git_add_dot_multiple_occurrences_all_safe() {
-        assert!(!has_dangerous_git_add_dot(
-            "git add .gitignore && git add .env"
-        ));
+    fn upsert_bullet_no_prefix_into_star_content_dedup() {
+        // Upserting "existing item" (no prefix) normalizes to "- existing item"
+        // which should dedup against body's "* existing item".
+        let content = "# List\n\n* existing item\n";
+        let result = upsert_bullet_in(content, "List", "existing item").unwrap();
+        assert_eq!(
+            result, content,
+            "auto-prefixed dash should dedup against star bullet"
+        );
     }
-}
 
-// ── Issue #975: empty section boundary tests ──────────────────────
-mod empty_section_tests {
-    use crate::ops::md::*;
+    #[test]
+    fn upsert_bullet_plus_prefix_dedup_against_dash() {
+        let content = "# List\n\n- existing item\n";
+        let result = upsert_bullet_in(content, "List", "+ existing item").unwrap();
+        assert_eq!(
+            result, content,
+            "plus-prefixed bullet should dedup against dash"
+        );
+    }
 
     #[test]
     fn find_section_empty_body() {
@@ -807,97 +776,144 @@ mod empty_section_tests {
     }
 }
 
-// ── Issue #974: CRLF handling and mixed bullet styles ─────────────
-mod crlf_and_bullet_tests {
-    use crate::ops::md::*;
-
-    // ── CRLF handling in table_append_in ──────────────────────────
+mod error_handling {
+    use super::*;
 
     #[test]
-    fn table_append_crlf_content_finds_correct_position() {
-        // CRLF content: the byte-offset tracking in table_append_in
-        // must correctly advance past \r\n (2 bytes) per line.
-        let content = "# T\r\n| H |\r\n|---|\r\n| v |\r\n";
-        let (start, end) = find_section(content, "T").unwrap();
-        let result = table_append_in(content, start, end, "| new |").unwrap();
-        // The new row must appear after the last data row.
-        assert!(
-            result.contains("| v |\r\n| new |"),
-            "row should be appended after existing data row in CRLF content: {:?}",
-            result
-        );
-        // The content before the insertion should be preserved.
-        assert!(
-            result.contains("| H |\r\n|---|\r\n| v |\r\n"),
-            "original CRLF table should be intact: {:?}",
-            result
+    fn find_section_missing() {
+        let content = "# Title\nBody\n";
+        assert!(find_section(content, "Nonexistent").is_none());
+    }
+
+    #[test]
+    fn replace_section_missing_heading() {
+        let content = "# Title\nBody\n";
+        assert!(replace_section_in(content, "Missing", "x").is_none());
+    }
+
+    #[test]
+    fn table_append_no_table() {
+        let content = "# API\nJust text\n";
+        let (start, end) = find_section(content, "API").unwrap();
+        assert!(table_append_in(content, start, end, "| b | 2 |").is_none());
+    }
+
+    #[test]
+    fn section_range_missing() {
+        let content = "# A\nbody\n";
+        assert!(section_range(content, "Missing").is_none());
+    }
+
+    #[test]
+    fn move_section_missing_source_heading() {
+        let content = "# A\nbody\n";
+        assert!(move_section_in(content, "Missing", content, ("before", "A"), true).is_none());
+    }
+
+    #[test]
+    fn move_section_missing_target_heading() {
+        let content = "# A\nbody\n# B\nbody\n";
+        assert!(move_section_in(content, "A", content, ("before", "Missing"), true).is_none());
+    }
+}
+
+mod security {
+    use super::*;
+
+    // ── has_dangerous_git_add_dot ─────────────────────────────────
+
+    #[test]
+    fn git_add_dot_at_eol() {
+        assert!(has_dangerous_git_add_dot("git add ."));
+    }
+
+    #[test]
+    fn git_add_dot_followed_by_space() {
+        assert!(has_dangerous_git_add_dot("git add . && git commit"));
+    }
+
+    #[test]
+    fn git_add_dot_followed_by_tab() {
+        assert!(has_dangerous_git_add_dot("git add .\tnext"));
+    }
+
+    #[test]
+    fn git_add_dotgitignore_is_safe() {
+        assert!(!has_dangerous_git_add_dot("git add .gitignore"));
+    }
+
+    #[test]
+    fn git_add_dot_slash_is_safe() {
+        assert!(!has_dangerous_git_add_dot("git add ./file"));
+    }
+
+    #[test]
+    fn git_add_dot_mid_line() {
+        assert!(has_dangerous_git_add_dot("run git add . now"));
+    }
+
+    #[test]
+    fn git_add_dot_no_match() {
+        assert!(!has_dangerous_git_add_dot("no match here"));
+    }
+
+    #[test]
+    fn git_add_dot_multiple_occurrences_first_safe() {
+        // First "git add .gitignore" is safe, second "git add ." is dangerous
+        assert!(has_dangerous_git_add_dot("git add .gitignore && git add ."));
+    }
+
+    #[test]
+    fn git_add_dot_multiple_occurrences_all_safe() {
+        assert!(!has_dangerous_git_add_dot(
+            "git add .gitignore && git add .env"
+        ));
+    }
+}
+
+mod format_preservation {
+    use super::*;
+
+    #[test]
+    fn replace_section_setext_preserves_underline() {
+        // Use same-level headings so the section is bounded.
+        let content = "Title\n=====\n\nOld body\n\nNext\n=====\nKeep\n";
+        let result = replace_section_in(content, "Title", "New body").unwrap();
+        assert_eq!(
+            result, "Title\n=====\nNew body\nNext\n=====\nKeep\n",
+            "underline must be preserved: {result}"
         );
     }
 
     #[test]
-    fn table_append_crlf_header_only() {
-        // Table with only header + separator in CRLF content.
-        let content = "# T\r\n| H |\r\n|---|\r\n";
-        let (start, end) = find_section(content, "T").unwrap();
-        let result = table_append_in(content, start, end, "| a |").unwrap();
+    fn upsert_bullet_setext_heading() {
+        let content = "List\n----\n\n- item1\n";
+        let result = upsert_bullet_in(content, "List", "- item2").unwrap();
         assert!(
-            result.contains("|---|\r\n| a |"),
-            "row should be appended after separator in CRLF content: {:?}",
-            result
+            result.contains("----\n"),
+            "underline must be preserved: {result}"
+        );
+        assert!(
+            result.contains("- item1\n- item2\n"),
+            "bullet should be appended: {result}"
+        );
+        // Underline must NOT appear in the body match
+        assert!(
+            !result.contains("- ----"),
+            "underline must not be treated as bullet content: {result}"
         );
     }
 
     #[test]
-    fn table_append_crlf_multiple_data_rows() {
-        // Multiple data rows with CRLF; new row goes after the last one.
-        let content = "# T\r\n| H |\r\n|---|\r\n| a |\r\n| b |\r\n";
-        let (start, end) = find_section(content, "T").unwrap();
-        let result = table_append_in(content, start, end, "| c |").unwrap();
-        assert!(
-            result.contains("| b |\r\n| c |"),
-            "row should be appended after the last data row: {:?}",
-            result
-        );
-    }
-
-    // ── CRLF in parse_headings ────────────────────────────────────
-
-    #[test]
-    fn parse_headings_crlf_strips_carriage_return() {
-        // .lines() strips \r, so heading text should not contain \r.
-        let content = "## Heading One\r\n\r\nBody text.\r\n";
-        let headings = parse_headings(content);
-        assert_eq!(headings.len(), 1);
-        assert_eq!(headings[0].text, "Heading One");
-        assert!(
-            !headings[0].text.contains('\r'),
-            "heading text must not contain \\r"
-        );
-        assert_eq!(headings[0].level, 2);
-    }
-
-    #[test]
-    fn parse_headings_crlf_multiple_headings() {
-        let content = "# First\r\nBody 1\r\n## Second\r\nBody 2\r\n";
-        let headings = parse_headings(content);
-        assert_eq!(headings.len(), 2);
-        assert_eq!(headings[0].text, "First");
-        assert_eq!(headings[1].text, "Second");
-        // Verify section boundaries are correct.
-        assert_eq!(headings[0].line_start, 0);
-        assert_eq!(headings[1].line_start, 2);
-    }
-
-    #[test]
-    fn find_section_crlf_returns_correct_body() {
-        let content = "## Heading One\r\n\r\nBody text.\r\n## Next\r\n";
-        let (start, end) = find_section(content, "Heading One").unwrap();
-        let body = &content[start..end];
-        // Body should include the blank line and body text between headings.
-        assert!(
-            body.contains("Body text."),
-            "body should contain body text: {:?}",
-            body
+    fn section_range_setext_includes_text_and_underline() {
+        // Use same-level heading to bound the section.
+        let content = "Title\n=====\nbody\nNext\n=====\nmore\n";
+        let (start, end) = section_range(content, "Title").unwrap();
+        // section_range should include the text line + underline + body
+        assert_eq!(
+            &content[start..end],
+            "Title\n=====\nbody\n",
+            "setext section_range should include text line and underline"
         );
     }
 
@@ -916,46 +932,6 @@ mod crlf_and_bullet_tests {
     }
 
     #[test]
-    fn upsert_bullet_star_dedup_same_style() {
-        // Upserting "* existing item" when body already has "* existing item"
-        // should dedup (same style, same text).
-        let content = "# List\n\n* existing item\n";
-        let result = upsert_bullet_in(content, "List", "* existing item").unwrap();
-        assert_eq!(result, content, "same-style duplicate should be deduped");
-    }
-
-    #[test]
-    fn upsert_bullet_cross_style_dash_into_star_dedup() {
-        // Upserting "- existing item" when body has "* existing item":
-        // cross-style dedup should recognize them as the same item.
-        let content = "# List\n\n* existing item\n";
-        let result = upsert_bullet_in(content, "List", "- existing item").unwrap();
-        assert_eq!(result, content, "cross-style bullets should dedup");
-    }
-
-    #[test]
-    fn upsert_bullet_no_prefix_into_star_content_dedup() {
-        // Upserting "existing item" (no prefix) normalizes to "- existing item"
-        // which should dedup against body's "* existing item".
-        let content = "# List\n\n* existing item\n";
-        let result = upsert_bullet_in(content, "List", "existing item").unwrap();
-        assert_eq!(
-            result, content,
-            "auto-prefixed dash should dedup against star bullet"
-        );
-    }
-
-    #[test]
-    fn upsert_bullet_plus_prefix_dedup_against_dash() {
-        let content = "# List\n\n- existing item\n";
-        let result = upsert_bullet_in(content, "List", "+ existing item").unwrap();
-        assert_eq!(
-            result, content,
-            "plus-prefixed bullet should dedup against dash"
-        );
-    }
-
-    #[test]
     fn upsert_bullet_plus_prefix_preserved() {
         // When inserting a new bullet with +, the prefix is kept.
         let content = "# List\n\n- other item\n";
@@ -966,16 +942,51 @@ mod crlf_and_bullet_tests {
             result
         );
     }
+}
+
+mod regression {
+    use super::*;
 
     #[test]
-    fn upsert_bullet_dash_appends_after_star_items() {
-        // "- new item" appended correctly after existing "* " items.
-        let content = "# List\n\n* alpha\n* beta\n";
-        let result = upsert_bullet_in(content, "List", "- new item").unwrap();
+    fn upsert_bullet_preserves_blank_line_before_next_heading() {
+        // Regression test for #973: upsert_bullet consumed the blank line
+        // separating the section body from the next heading.
+        let content = "## Section A\n\n- Bullet one\n- Bullet two\n\n## Section B\n\nContent B.\n";
+        let result = upsert_bullet_in(content, "Section A", "- Bullet three").unwrap();
         assert!(
-            result.contains("* beta\n- new item\n"),
-            "new dash bullet should follow existing star bullets: {:?}",
-            result
+            result.contains("- Bullet three\n\n## Section B"),
+            "blank line before next heading must be preserved: {result}"
         );
+    }
+
+    #[test]
+    fn upsert_bullet_preserves_blank_before_sub_heading() {
+        // #973 variant: subsection headings (###) also need blank line preservation.
+        let content = "### Bug Fixes\n\n- Fix one\n\n### Dependencies\n\nDep content.\n";
+        let result = upsert_bullet_in(content, "Bug Fixes", "- Fix two").unwrap();
+        assert!(
+            result.contains("- Fix two\n\n### Dependencies"),
+            "blank line before sub-heading must be preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn move_section_after_preserves_dest_table_body() {
+        // Regression for #825: moving a section "after" a dest that owns a
+        // table must keep the table under the dest heading.
+        let content = "# T\n\n## Commands\n\ncmd body\n\n## Rules\n\n- rule1\n\n## Features\n\n| Name | Status |\n|------|--------|\n| search | done |\n";
+        let (result, _) =
+            move_section_in(content, "## Rules", content, ("after", "## Features"), true).unwrap();
+        // Features heading should still be followed (eventually) by its table,
+        // and Rules after the table.
+        let features_pos = result.find("## Features").unwrap();
+        let rules_pos = result.find("## Rules").unwrap();
+        let table_pos = result.find("| search | done |").unwrap();
+        assert!(
+            features_pos < table_pos,
+            "table should still be after Features"
+        );
+        assert!(table_pos < rules_pos, "Rules should be after the table");
+        assert!(result.contains("- rule1"));
     }
 }

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1,6 +1,44 @@
-// ── patch module tests ────────────────────────────────────────────
-mod patch_tests {
-    use crate::ops::patch::*;
+use crate::ops::patch::*;
+
+/// Helper: build a hunk with prefix context, removes, adds, suffix context.
+fn make_hunk(
+    old_start: usize,
+    prefix: &[&str],
+    removes: &[&str],
+    adds: &[&str],
+    suffix: &[&str],
+) -> Hunk {
+    let mut lines = Vec::new();
+    for s in prefix {
+        lines.push(PatchLine::Context(s.to_string()));
+    }
+    for s in removes {
+        lines.push(PatchLine::Remove(s.to_string()));
+    }
+    for s in adds {
+        lines.push(PatchLine::Add(s.to_string()));
+    }
+    for s in suffix {
+        lines.push(PatchLine::Context(s.to_string()));
+    }
+    let old_count = prefix.len() + removes.len() + suffix.len();
+    let new_count = prefix.len() + adds.len() + suffix.len();
+    Hunk {
+        old_start,
+        old_count,
+        new_start: old_start,
+        new_count,
+        lines,
+    }
+}
+
+/// Shorthand: `&[&str]` → `Vec<String>`.
+fn s(strings: &[&str]) -> Vec<String> {
+    strings.iter().map(|s| s.to_string()).collect()
+}
+
+mod basic {
+    use super::*;
 
     #[test]
     fn parse_patch_single_file() {
@@ -39,18 +77,6 @@ mod patch_tests {
         assert_eq!(files.len(), 2);
         assert_eq!(files[0].path, "a.txt");
         assert_eq!(files[1].path, "b.txt");
-    }
-
-    #[test]
-    fn parse_patch_no_files() {
-        let diff = "just some text\n";
-        assert!(parse_patch(diff).is_err());
-    }
-
-    #[test]
-    fn parse_patch_no_hunks() {
-        let diff = "--- a/f.txt\n+++ b/f.txt\n";
-        assert!(parse_patch(diff).is_err());
     }
 
     #[test]
@@ -106,38 +132,6 @@ mod patch_tests {
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, "a\nb\n");
-    }
-
-    #[test]
-    fn apply_hunks_stale_context_fails() {
-        let original = "a\nb\nc\n";
-        let hunks = vec![Hunk {
-            old_start: 1,
-            old_count: 1,
-            new_start: 1,
-            new_count: 1,
-            lines: vec![
-                PatchLine::Remove("wrong_context".into()),
-                PatchLine::Add("x".into()),
-            ],
-        }];
-        assert!(apply_hunks(original, &hunks).is_err());
-    }
-
-    #[test]
-    fn apply_hunks_fuzz_match() {
-        // The hunk header says line 2, but the actual match is at line 3
-        // (1 line off). Should still apply within FUZZ_RANGE=3.
-        let original = "a\nb\nc\nd\n";
-        let hunks = vec![Hunk {
-            old_start: 2,
-            old_count: 1,
-            new_start: 2,
-            new_count: 1,
-            lines: vec![PatchLine::Remove("c".into()), PatchLine::Add("C".into())],
-        }];
-        let result = apply_hunks(original, &hunks).unwrap();
-        assert_eq!(result, "a\nb\nC\nd\n");
     }
 
     #[test]
@@ -199,126 +193,12 @@ mod patch_tests {
     }
 
     #[test]
-    fn apply_hunks_pure_addition_on_empty() {
-        // A patch that creates a file from scratch: old_start=0, old_count=0,
-        // hunk contains only additions.
-        let original = "";
-        let hunks = vec![Hunk {
-            old_start: 0,
-            old_count: 0,
-            new_start: 1,
-            new_count: 2,
-            lines: vec![
-                PatchLine::Add("new_line1".into()),
-                PatchLine::Add("new_line2".into()),
-            ],
-        }];
-        let result = apply_hunks(original, &hunks).unwrap();
-        // Empty original is treated as having a final newline, so the
-        // output also gets one.
-        assert_eq!(result, "new_line1\nnew_line2\n");
-    }
-
-    #[test]
-    fn apply_hunks_preserves_no_final_newline() {
-        let original = "line1\nline2";
-        let hunks = vec![Hunk {
-            old_start: 2,
-            old_count: 1,
-            new_start: 2,
-            new_count: 1,
-            lines: vec![
-                PatchLine::Remove("line2".into()),
-                PatchLine::Add("LINE2".into()),
-            ],
-        }];
-        let result = apply_hunks(original, &hunks).unwrap();
-        assert_eq!(result, "line1\nLINE2");
-    }
-
-    /// Regression: apply_hunks must not panic on huge old_start values
-    /// that would overflow isize when cast from usize. Found by fuzzing.
-    #[test]
-    fn apply_hunks_huge_old_start_does_not_panic() {
-        let hunks = vec![Hunk {
-            old_start: usize::MAX,
-            old_count: 1,
-            new_start: 1,
-            new_count: 1,
-            lines: vec![PatchLine::Context("x".into())],
-        }];
-        // Must return Err, never panic.
-        assert!(apply_hunks("x\n", &hunks).is_err());
-    }
-
-    /// Regression: find_match must not panic when delta * sign overflows.
-    /// Found by fuzzing.
-    #[test]
-    fn apply_hunks_huge_fuzz_range_does_not_panic() {
-        let hunks = vec![Hunk {
-            old_start: 1,
-            old_count: 0,
-            new_start: 1,
-            new_count: 1,
-            lines: vec![PatchLine::Add("new".into())],
-        }];
-        // apply_hunks uses a fuzz of 2 internally; the regression was
-        // in find_match when delta values caused isize overflow. Just
-        // verify it doesn't panic.
-        let _ = apply_hunks("original\n", &hunks);
-    }
-}
-
-// ── merge / conflict path tests ──────────────────────────────
-mod merge_tests {
-    use crate::ops::patch::*;
-
-    /// Helper: build a hunk with prefix context, removes, adds, suffix context.
-    fn make_hunk(
-        old_start: usize,
-        prefix: &[&str],
-        removes: &[&str],
-        adds: &[&str],
-        suffix: &[&str],
-    ) -> Hunk {
-        let mut lines = Vec::new();
-        for s in prefix {
-            lines.push(PatchLine::Context(s.to_string()));
-        }
-        for s in removes {
-            lines.push(PatchLine::Remove(s.to_string()));
-        }
-        for s in adds {
-            lines.push(PatchLine::Add(s.to_string()));
-        }
-        for s in suffix {
-            lines.push(PatchLine::Context(s.to_string()));
-        }
-        let old_count = prefix.len() + removes.len() + suffix.len();
-        let new_count = prefix.len() + adds.len() + suffix.len();
-        Hunk {
-            old_start,
-            old_count,
-            new_start: old_start,
-            new_count,
-            lines,
-        }
-    }
-
-    /// Shorthand: `&[&str]` → `Vec<String>`.
-    fn s(strings: &[&str]) -> Vec<String> {
-        strings.iter().map(|s| s.to_string()).collect()
-    }
-
-    // ── merge_three_way_lines ────────────────────────────────
-
-    #[test]
     fn merge_three_way_lines_theirs_wins() {
         // ours == base for the differing line → take theirs
         let base = s(&["same", "base_val", "same"]);
         let ours = s(&["same", "base_val", "same"]);
         let theirs = s(&["same", "theirs_val", "same"]);
-        let (result, conflicts) = super::super::merge_three_way_lines(&base, &ours, &theirs, 1);
+        let (result, conflicts) = merge_three_way_lines(&base, &ours, &theirs, 1);
         assert_eq!(result, s(&["same", "theirs_val", "same"]));
         assert!(conflicts.is_empty());
     }
@@ -329,7 +209,7 @@ mod merge_tests {
         let base = s(&["A", "base", "C"]);
         let ours = s(&["A", "ours", "C"]);
         let theirs = s(&["A", "base", "C"]);
-        let (result, conflicts) = super::super::merge_three_way_lines(&base, &ours, &theirs, 1);
+        let (result, conflicts) = merge_three_way_lines(&base, &ours, &theirs, 1);
         assert_eq!(result, s(&["A", "ours", "C"]));
         assert!(conflicts.is_empty());
     }
@@ -340,7 +220,7 @@ mod merge_tests {
         let base = s(&["X"]);
         let ours = s(&["Z"]);
         let theirs = s(&["Z"]);
-        let (result, conflicts) = super::super::merge_three_way_lines(&base, &ours, &theirs, 1);
+        let (result, conflicts) = merge_three_way_lines(&base, &ours, &theirs, 1);
         assert_eq!(result, s(&["Z"]));
         assert!(conflicts.is_empty());
     }
@@ -351,27 +231,16 @@ mod merge_tests {
         let base = s(&["base"]);
         let ours = s(&["ours"]);
         let theirs = s(&["theirs"]);
-        let (result, conflicts) = super::super::merge_three_way_lines(&base, &ours, &theirs, 1);
+        let (result, conflicts) = merge_three_way_lines(&base, &ours, &theirs, 1);
         assert_eq!(result.len(), 5);
-        assert_eq!(result[0], super::super::CONFLICT_OURS);
+        assert_eq!(result[0], CONFLICT_OURS);
         assert_eq!(result[1], "ours");
-        assert_eq!(result[2], super::super::CONFLICT_SEP);
+        assert_eq!(result[2], CONFLICT_SEP);
         assert_eq!(result[3], "theirs");
-        assert_eq!(result[4], super::super::CONFLICT_THEIRS);
+        assert_eq!(result[4], CONFLICT_THEIRS);
         assert_eq!(conflicts.len(), 1);
         assert_eq!(conflicts[0].start_line, 1);
         assert_eq!(conflicts[0].end_line, 5);
-    }
-
-    #[test]
-    fn merge_three_way_lines_all_unchanged() {
-        // all three identical → no change, no conflict
-        let base = s(&["A", "B"]);
-        let ours = s(&["A", "B"]);
-        let theirs = s(&["A", "B"]);
-        let (result, conflicts) = super::super::merge_three_way_lines(&base, &ours, &theirs, 1);
-        assert_eq!(result, s(&["A", "B"]));
-        assert!(conflicts.is_empty());
     }
 
     #[test]
@@ -381,12 +250,10 @@ mod merge_tests {
         let base = s(&["B1", "B2"]);
         let ours = s(&["O1", "B2"]);
         let theirs = s(&["B1", "T2"]);
-        let (result, conflicts) = super::super::merge_three_way_lines(&base, &ours, &theirs, 1);
+        let (result, conflicts) = merge_three_way_lines(&base, &ours, &theirs, 1);
         assert_eq!(result, s(&["O1", "T2"]));
         assert!(conflicts.is_empty());
     }
-
-    // ── merge_three_way_block ────────────────────────────────
 
     #[test]
     fn merge_three_way_block_theirs_wins() {
@@ -394,7 +261,7 @@ mod merge_tests {
         let base = s(&["A", "B"]);
         let ours = s(&["A", "B"]);
         let theirs = s(&["A", "B", "C"]);
-        let (result, conflicts) = super::super::merge_three_way_block(&base, &ours, &theirs, 1);
+        let (result, conflicts) = merge_three_way_block(&base, &ours, &theirs, 1);
         assert_eq!(result, s(&["A", "B", "C"]));
         assert!(conflicts.is_empty());
     }
@@ -405,19 +272,8 @@ mod merge_tests {
         let base = s(&["A", "B"]);
         let ours = s(&["A", "B", "new"]);
         let theirs = s(&["A", "B"]);
-        let (result, conflicts) = super::super::merge_three_way_block(&base, &ours, &theirs, 1);
+        let (result, conflicts) = merge_three_way_block(&base, &ours, &theirs, 1);
         assert_eq!(result, s(&["A", "B", "new"]));
-        assert!(conflicts.is_empty());
-    }
-
-    #[test]
-    fn merge_three_way_block_ours_equals_theirs() {
-        // ours == theirs, both differ from base → take ours, no conflict
-        let base = s(&["old"]);
-        let ours = s(&["new1", "new2"]);
-        let theirs = s(&["new1", "new2"]);
-        let (result, conflicts) = super::super::merge_three_way_block(&base, &ours, &theirs, 1);
-        assert_eq!(result, s(&["new1", "new2"]));
         assert!(conflicts.is_empty());
     }
 
@@ -427,61 +283,43 @@ mod merge_tests {
         let base = s(&["B1", "B2"]);
         let ours = s(&["O1", "O2", "O3"]);
         let theirs = s(&["T1", "T2", "T3", "T4"]);
-        let (result, conflicts) = super::super::merge_three_way_block(&base, &ours, &theirs, 1);
-        assert_eq!(result[0], super::super::CONFLICT_OURS);
+        let (result, conflicts) = merge_three_way_block(&base, &ours, &theirs, 1);
+        assert_eq!(result[0], CONFLICT_OURS);
         assert_eq!(result[1], "O1");
         assert_eq!(result[2], "O2");
         assert_eq!(result[3], "O3");
-        assert_eq!(result[4], super::super::CONFLICT_SEP);
+        assert_eq!(result[4], CONFLICT_SEP);
         assert_eq!(result[5], "T1");
         assert_eq!(result[6], "T2");
         assert_eq!(result[7], "T3");
         assert_eq!(result[8], "T4");
-        assert_eq!(result[9], super::super::CONFLICT_THEIRS);
+        assert_eq!(result[9], CONFLICT_THEIRS);
         assert_eq!(result.len(), 10);
         assert_eq!(conflicts.len(), 1);
         assert_eq!(conflicts[0].start_line, 1);
         assert_eq!(conflicts[0].end_line, 10);
     }
 
-    // ── find_match_global ────────────────────────────────────
-
     #[test]
     fn find_match_global_finds_at_start() {
         let haystack: Vec<&str> = vec!["A", "B", "C", "D"];
         let needle: Vec<&str> = vec!["A", "B"];
-        assert_eq!(super::super::find_match_global(&haystack, &needle), Some(0));
+        assert_eq!(find_match_global(&haystack, &needle), Some(0));
     }
 
     #[test]
     fn find_match_global_finds_in_middle() {
         let haystack: Vec<&str> = vec!["X", "A", "B", "Y"];
         let needle: Vec<&str> = vec!["A", "B"];
-        assert_eq!(super::super::find_match_global(&haystack, &needle), Some(1));
+        assert_eq!(find_match_global(&haystack, &needle), Some(1));
     }
 
     #[test]
     fn find_match_global_finds_at_end() {
         let haystack: Vec<&str> = vec!["X", "Y", "A", "B"];
         let needle: Vec<&str> = vec!["A", "B"];
-        assert_eq!(super::super::find_match_global(&haystack, &needle), Some(2));
+        assert_eq!(find_match_global(&haystack, &needle), Some(2));
     }
-
-    #[test]
-    fn find_match_global_empty_needle() {
-        let haystack: Vec<&str> = vec!["A", "B"];
-        let needle: Vec<&str> = vec![];
-        assert_eq!(super::super::find_match_global(&haystack, &needle), Some(0));
-    }
-
-    #[test]
-    fn find_match_global_no_match() {
-        let haystack: Vec<&str> = vec!["A", "B", "C"];
-        let needle: Vec<&str> = vec!["X", "Y"];
-        assert_eq!(super::super::find_match_global(&haystack, &needle), None);
-    }
-
-    // ── locate_by_context_anchors ────────────────────────────
 
     #[test]
     fn locate_by_context_anchors_prefix_only() {
@@ -499,7 +337,7 @@ mod merge_tests {
             ],
         };
         let haystack: Vec<&str> = vec!["ctx1", "ctx2", "modified"];
-        let result = super::super::locate_by_context_anchors(&haystack, &hunk, 0);
+        let result = locate_by_context_anchors(&haystack, &hunk, 0);
         assert_eq!(result, Some(0));
     }
 
@@ -518,7 +356,7 @@ mod merge_tests {
             ],
         };
         let haystack: Vec<&str> = vec!["modified", "suffix"];
-        let result = super::super::locate_by_context_anchors(&haystack, &hunk, 0);
+        let result = locate_by_context_anchors(&haystack, &hunk, 0);
         assert_eq!(result, Some(0));
     }
 
@@ -538,29 +376,9 @@ mod merge_tests {
             ],
         };
         let haystack: Vec<&str> = vec!["prefix", "modified", "suffix"];
-        let result = super::super::locate_by_context_anchors(&haystack, &hunk, 0);
+        let result = locate_by_context_anchors(&haystack, &hunk, 0);
         assert_eq!(result, Some(0));
     }
-
-    #[test]
-    fn locate_by_context_anchors_no_context_returns_none() {
-        // Hunk has no context lines at all → cannot locate
-        let hunk = Hunk {
-            old_start: 1,
-            old_count: 1,
-            new_start: 1,
-            new_count: 1,
-            lines: vec![
-                PatchLine::Remove("old".into()),
-                PatchLine::Add("new".into()),
-            ],
-        };
-        let haystack: Vec<&str> = vec!["modified"];
-        let result = super::super::locate_by_context_anchors(&haystack, &hunk, 0);
-        assert_eq!(result, None);
-    }
-
-    // ── merge_hunks ─────────────────────────────────────────
 
     #[test]
     fn merge_hunks_clean_apply() {
@@ -585,10 +403,10 @@ mod merge_tests {
         )];
         let result = merge_hunks(ours, &hunks).unwrap();
         assert!(!result.conflicts.is_empty());
-        assert!(result.content.contains(super::super::CONFLICT_OURS));
+        assert!(result.content.contains(CONFLICT_OURS));
         assert!(result.content.contains("ours_modified"));
         assert!(result.content.contains("theirs_val"));
-        assert!(result.content.contains(super::super::CONFLICT_THEIRS));
+        assert!(result.content.contains(CONFLICT_THEIRS));
     }
 
     #[test]
@@ -615,25 +433,6 @@ mod merge_tests {
         assert_eq!(result.content, "ctx1\nours_val\npatched\nctx2\n");
         assert!(result.conflicts.is_empty());
     }
-
-    #[test]
-    fn merge_hunks_preserves_final_newline() {
-        let ours = "ctx1\nold\nctx2\n";
-        let hunks = vec![make_hunk(1, &["ctx1"], &["old"], &["new"], &["ctx2"])];
-        let result = merge_hunks(ours, &hunks).unwrap();
-        assert!(result.content.ends_with('\n'));
-    }
-
-    #[test]
-    fn merge_hunks_no_final_newline() {
-        let ours = "ctx1\nold\nctx2";
-        let hunks = vec![make_hunk(1, &["ctx1"], &["old"], &["new"], &["ctx2"])];
-        let result = merge_hunks(ours, &hunks).unwrap();
-        assert!(!result.content.ends_with('\n'));
-        assert_eq!(result.content, "ctx1\nnew\nctx2");
-    }
-
-    // ── apply_hunks_with_options ─────────────────────────────
 
     #[test]
     fn apply_with_options_merge_clean() {
@@ -690,43 +489,142 @@ mod merge_tests {
         let result = apply_hunks_with_options(ours, &hunks, opts).unwrap();
         assert_eq!(result.status, ApplyHunksStatus::Conflict);
         assert!(!result.conflicts.is_empty());
-        assert!(result.content.contains(super::super::CONFLICT_OURS));
+        assert!(result.content.contains(CONFLICT_OURS));
         assert!(result.content.contains("ours_mod"));
         assert!(result.content.contains("theirs"));
-        assert!(result.content.contains(super::super::CONFLICT_THEIRS));
+        assert!(result.content.contains(CONFLICT_THEIRS));
     }
 
     #[test]
-    fn apply_with_options_merge_conflict_disallowed() {
-        // Stale content, conflicting merge, allow_conflicts = false → Err
-        let ours = "ctx1\nours_mod\nctx2\n";
-        let hunks = vec![make_hunk(1, &["ctx1"], &["base"], &["theirs"], &["ctx2"])];
-        let opts = ApplyHunksOptions {
-            on_stale: OnStale::Merge,
-            allow_conflicts: false,
-        };
-        let result = apply_hunks_with_options(ours, &hunks, opts);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("conflict"));
-    }
-
-    #[test]
-    fn apply_with_options_fail_on_stale() {
-        // OnStale::Fail with stale content → Err
-        let ours = "ctx1\nmodified\nctx2\n";
-        let hunks = vec![make_hunk(1, &["ctx1"], &["original"], &["new"], &["ctx2"])];
-        let opts = ApplyHunksOptions {
-            on_stale: OnStale::Fail,
-            allow_conflicts: false,
-        };
-        let result = apply_hunks_with_options(ours, &hunks, opts);
-        assert!(result.is_err());
+    fn parse_patch_with_diff_git_headers() {
+        let diff = "\
+diff --git a/src/hello.rs b/src/hello.rs
+index 1234567..abcdefg 100644
+--- a/src/hello.rs
++++ b/src/hello.rs
+@@ -1,3 +1,3 @@
+ fn main() {
+-    println!(\"hello\");
++    println!(\"Hello, world!\");
+ }
+";
+        let files = parse_patch(diff).unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "src/hello.rs");
+        assert_eq!(files[0].hunks.len(), 1);
+        assert_eq!(files[0].hunks[0].old_start, 1);
+        assert_eq!(files[0].hunks[0].old_count, 3);
+        assert_eq!(files[0].hunks[0].new_count, 3);
+        assert_eq!(files[0].hunks[0].lines.len(), 4);
+        assert_eq!(
+            files[0].hunks[0].lines[0],
+            PatchLine::Context("fn main() {".into())
+        );
+        assert_eq!(
+            files[0].hunks[0].lines[1],
+            PatchLine::Remove("    println!(\"hello\");".into())
+        );
+        assert_eq!(
+            files[0].hunks[0].lines[2],
+            PatchLine::Add("    println!(\"Hello, world!\");".into())
+        );
+        assert_eq!(files[0].hunks[0].lines[3], PatchLine::Context("}".into()));
     }
 }
 
-// ── fuzz boundary and edge case tests ────────────────────────
-mod fuzz_and_edge_tests {
-    use crate::ops::patch::*;
+mod edge_cases {
+    use super::*;
+
+    #[test]
+    fn apply_hunks_fuzz_match() {
+        // The hunk header says line 2, but the actual match is at line 3
+        // (1 line off). Should still apply within FUZZ_RANGE=3.
+        let original = "a\nb\nc\nd\n";
+        let hunks = vec![Hunk {
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 1,
+            lines: vec![PatchLine::Remove("c".into()), PatchLine::Add("C".into())],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "a\nb\nC\nd\n");
+    }
+
+    #[test]
+    fn apply_hunks_pure_addition_on_empty() {
+        // A patch that creates a file from scratch: old_start=0, old_count=0,
+        // hunk contains only additions.
+        let original = "";
+        let hunks = vec![Hunk {
+            old_start: 0,
+            old_count: 0,
+            new_start: 1,
+            new_count: 2,
+            lines: vec![
+                PatchLine::Add("new_line1".into()),
+                PatchLine::Add("new_line2".into()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        // Empty original is treated as having a final newline, so the
+        // output also gets one.
+        assert_eq!(result, "new_line1\nnew_line2\n");
+    }
+
+    #[test]
+    fn merge_three_way_lines_all_unchanged() {
+        // all three identical → no change, no conflict
+        let base = s(&["A", "B"]);
+        let ours = s(&["A", "B"]);
+        let theirs = s(&["A", "B"]);
+        let (result, conflicts) = merge_three_way_lines(&base, &ours, &theirs, 1);
+        assert_eq!(result, s(&["A", "B"]));
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn merge_three_way_block_ours_equals_theirs() {
+        // ours == theirs, both differ from base → take ours, no conflict
+        let base = s(&["old"]);
+        let ours = s(&["new1", "new2"]);
+        let theirs = s(&["new1", "new2"]);
+        let (result, conflicts) = merge_three_way_block(&base, &ours, &theirs, 1);
+        assert_eq!(result, s(&["new1", "new2"]));
+        assert!(conflicts.is_empty());
+    }
+
+    #[test]
+    fn find_match_global_empty_needle() {
+        let haystack: Vec<&str> = vec!["A", "B"];
+        let needle: Vec<&str> = vec![];
+        assert_eq!(find_match_global(&haystack, &needle), Some(0));
+    }
+
+    #[test]
+    fn find_match_global_no_match() {
+        let haystack: Vec<&str> = vec!["A", "B", "C"];
+        let needle: Vec<&str> = vec!["X", "Y"];
+        assert_eq!(find_match_global(&haystack, &needle), None);
+    }
+
+    #[test]
+    fn locate_by_context_anchors_no_context_returns_none() {
+        // Hunk has no context lines at all → cannot locate
+        let hunk = Hunk {
+            old_start: 1,
+            old_count: 1,
+            new_start: 1,
+            new_count: 1,
+            lines: vec![
+                PatchLine::Remove("old".into()),
+                PatchLine::Add("new".into()),
+            ],
+        };
+        let haystack: Vec<&str> = vec!["modified"];
+        let result = locate_by_context_anchors(&haystack, &hunk, 0);
+        assert_eq!(result, None);
+    }
 
     #[test]
     fn fuzz_at_maximum_boundary_delta_3() {
@@ -830,41 +728,102 @@ mod fuzz_and_edge_tests {
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, original);
     }
+}
+
+mod error_handling {
+    use super::*;
 
     #[test]
-    fn parse_patch_with_diff_git_headers() {
-        let diff = "\
-diff --git a/src/hello.rs b/src/hello.rs
-index 1234567..abcdefg 100644
---- a/src/hello.rs
-+++ b/src/hello.rs
-@@ -1,3 +1,3 @@
- fn main() {
--    println!(\"hello\");
-+    println!(\"Hello, world!\");
- }
-";
-        let files = parse_patch(diff).unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].path, "src/hello.rs");
-        assert_eq!(files[0].hunks.len(), 1);
-        assert_eq!(files[0].hunks[0].old_start, 1);
-        assert_eq!(files[0].hunks[0].old_count, 3);
-        assert_eq!(files[0].hunks[0].new_count, 3);
-        assert_eq!(files[0].hunks[0].lines.len(), 4);
-        assert_eq!(
-            files[0].hunks[0].lines[0],
-            PatchLine::Context("fn main() {".into())
-        );
-        assert_eq!(
-            files[0].hunks[0].lines[1],
-            PatchLine::Remove("    println!(\"hello\");".into())
-        );
-        assert_eq!(
-            files[0].hunks[0].lines[2],
-            PatchLine::Add("    println!(\"Hello, world!\");".into())
-        );
-        assert_eq!(files[0].hunks[0].lines[3], PatchLine::Context("}".into()));
+    fn parse_patch_no_files() {
+        let diff = "just some text\n";
+        assert!(parse_patch(diff).is_err());
+    }
+
+    #[test]
+    fn parse_patch_no_hunks() {
+        let diff = "--- a/f.txt\n+++ b/f.txt\n";
+        assert!(parse_patch(diff).is_err());
+    }
+
+    #[test]
+    fn apply_hunks_stale_context_fails() {
+        let original = "a\nb\nc\n";
+        let hunks = vec![Hunk {
+            old_start: 1,
+            old_count: 1,
+            new_start: 1,
+            new_count: 1,
+            lines: vec![
+                PatchLine::Remove("wrong_context".into()),
+                PatchLine::Add("x".into()),
+            ],
+        }];
+        assert!(apply_hunks(original, &hunks).is_err());
+    }
+
+    #[test]
+    fn apply_with_options_merge_conflict_disallowed() {
+        // Stale content, conflicting merge, allow_conflicts = false → Err
+        let ours = "ctx1\nours_mod\nctx2\n";
+        let hunks = vec![make_hunk(1, &["ctx1"], &["base"], &["theirs"], &["ctx2"])];
+        let opts = ApplyHunksOptions {
+            on_stale: OnStale::Merge,
+            allow_conflicts: false,
+        };
+        let result = apply_hunks_with_options(ours, &hunks, opts);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("conflict"));
+    }
+
+    #[test]
+    fn apply_with_options_fail_on_stale() {
+        // OnStale::Fail with stale content → Err
+        let ours = "ctx1\nmodified\nctx2\n";
+        let hunks = vec![make_hunk(1, &["ctx1"], &["original"], &["new"], &["ctx2"])];
+        let opts = ApplyHunksOptions {
+            on_stale: OnStale::Fail,
+            allow_conflicts: false,
+        };
+        let result = apply_hunks_with_options(ours, &hunks, opts);
+        assert!(result.is_err());
+    }
+}
+
+mod format_preservation {
+    use super::*;
+
+    #[test]
+    fn apply_hunks_preserves_no_final_newline() {
+        let original = "line1\nline2";
+        let hunks = vec![Hunk {
+            old_start: 2,
+            old_count: 1,
+            new_start: 2,
+            new_count: 1,
+            lines: vec![
+                PatchLine::Remove("line2".into()),
+                PatchLine::Add("LINE2".into()),
+            ],
+        }];
+        let result = apply_hunks(original, &hunks).unwrap();
+        assert_eq!(result, "line1\nLINE2");
+    }
+
+    #[test]
+    fn merge_hunks_preserves_final_newline() {
+        let ours = "ctx1\nold\nctx2\n";
+        let hunks = vec![make_hunk(1, &["ctx1"], &["old"], &["new"], &["ctx2"])];
+        let result = merge_hunks(ours, &hunks).unwrap();
+        assert!(result.content.ends_with('\n'));
+    }
+
+    #[test]
+    fn merge_hunks_no_final_newline() {
+        let ours = "ctx1\nold\nctx2";
+        let hunks = vec![make_hunk(1, &["ctx1"], &["old"], &["new"], &["ctx2"])];
+        let result = merge_hunks(ours, &hunks).unwrap();
+        assert!(!result.content.ends_with('\n'));
+        assert_eq!(result.content, "ctx1\nnew\nctx2");
     }
 
     #[test]
@@ -889,5 +848,41 @@ index 1234567..abcdefg 100644
         );
         assert_eq!(files[0].hunks[0].lines[1], PatchLine::Remove("old".into()));
         assert_eq!(files[0].hunks[0].lines[2], PatchLine::Add("new".into()));
+    }
+}
+
+mod regression {
+    use super::*;
+
+    /// Regression: apply_hunks must not panic on huge old_start values
+    /// that would overflow isize when cast from usize. Found by fuzzing.
+    #[test]
+    fn apply_hunks_huge_old_start_does_not_panic() {
+        let hunks = vec![Hunk {
+            old_start: usize::MAX,
+            old_count: 1,
+            new_start: 1,
+            new_count: 1,
+            lines: vec![PatchLine::Context("x".into())],
+        }];
+        // Must return Err, never panic.
+        assert!(apply_hunks("x\n", &hunks).is_err());
+    }
+
+    /// Regression: find_match must not panic when delta * sign overflows.
+    /// Found by fuzzing.
+    #[test]
+    fn apply_hunks_huge_fuzz_range_does_not_panic() {
+        let hunks = vec![Hunk {
+            old_start: 1,
+            old_count: 0,
+            new_start: 1,
+            new_count: 1,
+            lines: vec![PatchLine::Add("new".into())],
+        }];
+        // apply_hunks uses a fuzz of 2 internally; the regression was
+        // in find_match when delta values caused isize overflow. Just
+        // verify it doesn't panic.
+        let _ = apply_hunks("original\n", &hunks);
     }
 }

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -2,51 +2,6 @@
 mod replace_tests {
     use crate::ops::replace::*;
 
-    #[test]
-    fn validate_mode_missing() {
-        assert_eq!(
-            validate_replace_mode(false, false, false),
-            Err(ReplaceModeError::MissingMode)
-        );
-    }
-
-    #[test]
-    fn validate_mode_both_inserts() {
-        assert_eq!(
-            validate_replace_mode(false, true, true),
-            Err(ReplaceModeError::BothInsertModes)
-        );
-    }
-
-    #[test]
-    fn validate_mode_to_with_insert() {
-        assert_eq!(
-            validate_replace_mode(true, true, false),
-            Err(ReplaceModeError::ToWithInsert)
-        );
-        assert_eq!(
-            validate_replace_mode(true, false, true),
-            Err(ReplaceModeError::ToWithInsert)
-        );
-    }
-
-    #[test]
-    fn validate_mode_valid_to_only() {
-        validate_replace_mode(true, false, false).unwrap();
-    }
-
-    #[test]
-    fn validate_mode_valid_insert_before_only() {
-        validate_replace_mode(false, true, false).unwrap();
-    }
-
-    #[test]
-    fn validate_mode_valid_insert_after_only() {
-        validate_replace_mode(false, false, true).unwrap();
-    }
-
-    // ── validate_replace_args tests ───────────────────────────────
-
     fn valid_params() -> ReplaceValidationParams<'static> {
         ReplaceValidationParams {
             pattern: "needle",
@@ -60,505 +15,566 @@ mod replace_tests {
         }
     }
 
-    #[test]
-    fn validate_args_valid_basic() {
-        validate_replace_args(&valid_params()).unwrap();
+    mod basic {
+        use super::*;
+
+        #[test]
+        fn validate_mode_valid_to_only() {
+            validate_replace_mode(true, false, false).unwrap();
+        }
+
+        #[test]
+        fn validate_mode_valid_insert_before_only() {
+            validate_replace_mode(false, true, false).unwrap();
+        }
+
+        #[test]
+        fn validate_mode_valid_insert_after_only() {
+            validate_replace_mode(false, false, true).unwrap();
+        }
+
+        #[test]
+        fn validate_args_valid_basic() {
+            validate_replace_args(&valid_params()).unwrap();
+        }
+
+        #[test]
+        fn validate_args_nth_one_ok() {
+            let mut p = valid_params();
+            p.nth = Some(1);
+            validate_replace_args(&p).unwrap();
+        }
+
+        #[test]
+        fn validate_args_range_with_whole_line_ok() {
+            let mut p = valid_params();
+            p.has_range = true;
+            p.whole_line = true;
+            validate_replace_args(&p).unwrap();
+        }
+
+        #[test]
+        fn validate_args_display_messages() {
+            // Verify Display impl produces expected human-readable messages.
+            assert!(
+                ReplaceValidationError::EmptyPattern
+                    .to_string()
+                    .contains("search pattern must not be empty")
+            );
+            assert!(ReplaceValidationError::NthZero.to_string().contains("nth"));
+            assert!(
+                ReplaceValidationError::RangeRequiresWholeLine
+                    .to_string()
+                    .contains("range requires whole_line")
+            );
+            assert!(
+                ReplaceValidationError::WholeLineMultilineConflict
+                    .to_string()
+                    .contains("whole_line and multiline")
+            );
+            assert!(
+                ReplaceValidationError::Mode(ReplaceModeError::MissingMode)
+                    .to_string()
+                    .contains("'to', 'insert_before', or 'insert_after'")
+            );
+        }
+
+        #[test]
+        fn replacement_text_with_to() {
+            let result = replacement_text("from", &Some("to".into()), &None, &None, false);
+            assert_eq!(result, "to");
+        }
+
+        #[test]
+        fn replacement_text_insert_before_literal() {
+            let result =
+                replacement_text("original", &None, &Some("PREFIX\n".into()), &None, false);
+            assert_eq!(result, "PREFIX\noriginal");
+        }
+
+        #[test]
+        fn replacement_text_insert_after_literal() {
+            let result =
+                replacement_text("original", &None, &None, &Some("\nSUFFIX".into()), false);
+            assert_eq!(result, "original\nSUFFIX");
+        }
+
+        #[test]
+        fn replacement_text_insert_before_regex_anchor() {
+            let result = replacement_text("ignored", &None, &Some("PREFIX\n".into()), &None, true);
+            assert_eq!(result, "PREFIX\n${0}");
+        }
+
+        #[test]
+        fn replacement_text_insert_after_regex_anchor() {
+            let result = replacement_text("ignored", &None, &None, &Some("\nSUFFIX".into()), true);
+            assert_eq!(result, "${0}\nSUFFIX");
+        }
+
+        #[test]
+        fn replace_content_literal_all() {
+            let (out, count) = replace_content("aXbXc", "X", "Y", None, None);
+            assert_eq!(out, "aYbYc");
+            assert_eq!(count, 2);
+        }
+
+        #[test]
+        fn replace_content_literal_nth() {
+            let (out, count) = replace_content("aXbXcX", "X", "Y", None, Some(2));
+            assert_eq!(out, "aXbYcX");
+            assert_eq!(count, 1);
+        }
+
+        #[test]
+        fn replace_content_regex_all() {
+            let re = regex::Regex::new(r"\d+").unwrap();
+            let (out, count) = replace_content("a1b22c333", "unused", "N", Some(&re), None);
+            assert_eq!(out, "aNbNcN");
+            assert_eq!(count, 3);
+        }
+
+        #[test]
+        fn replace_content_regex_nth() {
+            let re = regex::Regex::new(r"\d+").unwrap();
+            let (out, count) = replace_content("a1b22c333", "unused", "N", Some(&re), Some(2));
+            assert_eq!(out, "a1bNc333");
+            assert_eq!(count, 1);
+        }
+
+        #[test]
+        fn replace_content_regex_capture_group() {
+            let re = regex::Regex::new(r"(\w+)@(\w+)").unwrap();
+            let (out, count) = replace_content("user@host", "unused", "$2=$1", Some(&re), None);
+            assert_eq!(out, "host=user");
+            assert_eq!(count, 1);
+        }
+
+        #[test]
+        fn compile_regex_mode_returns_some() {
+            let re = compile_replace_regex(r"\d+", true, false, false, false)
+                .unwrap()
+                .expect("regex mode should return Some");
+            assert!(re.is_match("abc123"));
+        }
+
+        #[test]
+        fn compile_regex_multiline_dot_matches_newline() {
+            let re = compile_replace_regex("a.b", true, false, true, false)
+                .unwrap()
+                .unwrap();
+            assert!(
+                re.is_match("a\nb"),
+                "multiline should make dot match newline"
+            );
+        }
+
+        #[test]
+        fn compile_literal_case_insensitive_returns_some() {
+            let re = compile_replace_regex("hello", false, true, false, false)
+                .unwrap()
+                .expect("case-insensitive literal should return Some");
+            assert!(re.is_match("HELLO"));
+        }
+
+        #[test]
+        fn compile_plain_literal_returns_none() {
+            let re = compile_replace_regex("hello", false, false, false, false).unwrap();
+            assert!(re.is_none());
+        }
+
+        #[test]
+        fn compile_word_boundary_literal() {
+            let re = compile_replace_regex("SetupFile", false, false, false, true)
+                .unwrap()
+                .expect("word_boundary should return Some");
+            assert!(re.is_match("SetupFile"), "should match standalone word");
+            assert!(
+                re.is_match("use crate::SetupFile;"),
+                "should match at word boundary"
+            );
+            assert!(
+                !re.is_match("BenchSetupFile"),
+                "should NOT match inside a longer word"
+            );
+            assert!(
+                !re.is_match("SetupFileConfig"),
+                "should NOT match when followed by more word chars"
+            );
+        }
+
+        #[test]
+        fn compile_word_boundary_case_insensitive() {
+            let re = compile_replace_regex("setupfile", false, true, false, true)
+                .unwrap()
+                .expect("word_boundary + case_insensitive should return Some");
+            assert!(re.is_match("SetupFile"));
+            assert!(!re.is_match("BenchSetupFile"));
+        }
+
+        #[test]
+        fn whole_lines_delete_literal() {
+            let content = "aaa\nbbb\nccc\nbbb\neee\n";
+            let (result, count) = replace_whole_lines(content, "bbb", "", None, None, None);
+            assert_eq!(count, 2);
+            assert_eq!(&*result, "aaa\nccc\neee\n");
+        }
+
+        #[test]
+        fn whole_lines_delete_regex() {
+            let re = compile_replace_regex(r"let _\w+", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "fn main() {\n    let _x = foo();\n    let y = bar();\n}\n";
+            let (result, count) = replace_whole_lines(content, "", "", Some(&re), None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "fn main() {\n    let y = bar();\n}\n");
+        }
+
+        #[test]
+        fn whole_lines_replace_with_text() {
+            let content = "alpha\nbeta\ngamma\n";
+            let (result, count) =
+                replace_whole_lines(content, "beta", "REPLACED", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "alpha\nREPLACED\ngamma\n");
+        }
+
+        #[test]
+        fn whole_lines_range_restriction() {
+            let content = "aaa\nbbb\nccc\nbbb\neee\n";
+            // Range 1:3 means lines 1-3 only. Second bbb is on line 4.
+            let (result, count) =
+                replace_whole_lines(content, "bbb", "", None, None, Some((1, Some(3))));
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\nccc\nbbb\neee\n");
+        }
+
+        #[test]
+        fn whole_lines_nth() {
+            let content = "aaa\nbbb\nccc\nbbb\neee\n";
+            let (result, count) = replace_whole_lines(content, "bbb", "", None, Some(2), None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\nbbb\nccc\neee\n");
+        }
+
+        #[test]
+        fn whole_lines_regex_capture_groups() {
+            let re = compile_replace_regex(r"version = (\d+)", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "name = foo\nversion = 3\nrelease = true\n";
+            let (result, count) =
+                replace_whole_lines(content, "", "version = ${1}00", Some(&re), None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "name = foo\nversion = 300\nrelease = true\n");
+        }
     }
 
-    #[test]
-    fn validate_args_empty_pattern() {
-        let mut p = valid_params();
-        p.pattern = "";
-        assert_eq!(
-            validate_replace_args(&p),
-            Err(ReplaceValidationError::EmptyPattern)
-        );
+    mod line_endings {
+        use super::*;
+
+        #[test]
+        fn whole_lines_cr_endings_literal() {
+            let content = "aaa\rbbb\rccc\r";
+            let (result, count) = replace_whole_lines(content, "bbb", "REPLACED", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\rREPLACED\rccc\r");
+        }
+
+        #[test]
+        fn whole_lines_cr_endings_delete() {
+            let content = "aaa\rbbb\rccc\rbbb\reee\r";
+            let (result, count) = replace_whole_lines(content, "bbb", "", None, None, None);
+            assert_eq!(count, 2);
+            assert_eq!(&*result, "aaa\rccc\reee\r");
+        }
+
+        #[test]
+        fn whole_lines_cr_no_match_returns_borrowed() {
+            let content = "aaa\rbbb\rccc\r";
+            let (result, count) = replace_whole_lines(content, "zzz", "", None, None, None);
+            assert_eq!(count, 0);
+            assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+        }
+
+        #[test]
+        fn whole_lines_crlf_preserves_ending() {
+            let content = "aaa\r\nbbb\r\nccc\r\n";
+            let (result, count) = replace_whole_lines(content, "bbb", "REPLACED", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\r\nREPLACED\r\nccc\r\n");
+        }
+
+        #[test]
+        fn whole_lines_crlf_delete() {
+            let content = "aaa\r\nbbb\r\nccc\r\n";
+            let (result, count) = replace_whole_lines(content, "bbb", "", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\r\nccc\r\n");
+        }
+
+        #[test]
+        fn whole_lines_crlf_line_content_excludes_cr() {
+            // Verify that line_content does NOT include the \r from CRLF,
+            // so exact-match patterns work without trailing \r.
+            let content = "hello\r\nworld\r\n";
+            let (result, count) =
+                replace_whole_lines(content, "hello", "MATCHED", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "MATCHED\r\nworld\r\n");
+        }
+
+        #[test]
+        fn whole_lines_crlf_regex_dollar_matches() {
+            // Regex $ should match at end of line_content (before \r\n),
+            // not fail because \r is included in line_content.
+            let re = compile_replace_regex(r"hello$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "hello\r\nworld\r\n";
+            let (result, count) =
+                replace_whole_lines(content, "", "MATCHED", Some(&re), None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "MATCHED\r\nworld\r\n");
+        }
+
+        #[test]
+        fn whole_lines_cr_regex_capture_groups() {
+            let re = compile_replace_regex(r"v(\d+)", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "name=foo\rv3\rrelease=true\r";
+            let (result, count) =
+                replace_whole_lines(content, "", "v${1}00", Some(&re), None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "name=foo\rv300\rrelease=true\r");
+        }
+
+        #[test]
+        fn whole_lines_cr_last_line_no_ending() {
+            let content = "aaa\rbbb\rccc";
+            let (result, count) = replace_whole_lines(content, "ccc", "", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\rbbb\r");
+        }
+
+        #[test]
+        fn whole_lines_mixed_endings_each_preserved() {
+            // Lines with different endings: LF, CRLF, CR, no-ending.
+            let content = "aaa\nbbb\r\nccc\rddd";
+            let (result, count) = replace_whole_lines(content, "aaa", "A", None, None, None);
+            assert_eq!(count, 1);
+            // Only the first line is replaced; its \n ending is preserved.
+            assert_eq!(&*result, "A\nbbb\r\nccc\rddd");
+
+            let (result2, count2) = replace_whole_lines(content, "bbb", "B", None, None, None);
+            assert_eq!(count2, 1);
+            // Second line replaced; its \r\n ending is preserved.
+            assert_eq!(&*result2, "aaa\nB\r\nccc\rddd");
+
+            let (result3, count3) = replace_whole_lines(content, "ccc", "C", None, None, None);
+            assert_eq!(count3, 1);
+            // Third line replaced; its \r ending is preserved.
+            assert_eq!(&*result3, "aaa\nbbb\r\nC\rddd");
+        }
+
+        #[test]
+        fn whole_lines_cr_range_restriction() {
+            let content = "aaa\rbbb\rccc\rbbb\reee\r";
+            // Range 1:3 means lines 1-3. Second bbb is on line 4.
+            let (result, count) =
+                replace_whole_lines(content, "bbb", "", None, None, Some((1, Some(3))));
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\rccc\rbbb\reee\r");
+        }
+
+        #[test]
+        fn whole_lines_cr_nth() {
+            let content = "aaa\rbbb\rccc\rbbb\reee\r";
+            let (result, count) = replace_whole_lines(content, "bbb", "", None, Some(2), None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\rbbb\rccc\reee\r");
+        }
     }
 
-    #[test]
-    fn validate_args_nth_zero() {
-        let mut p = valid_params();
-        p.nth = Some(0);
-        assert_eq!(
-            validate_replace_args(&p),
-            Err(ReplaceValidationError::NthZero)
-        );
+    mod edge_cases {
+        use super::*;
+
+        #[test]
+        fn replace_content_literal_no_match() {
+            let (out, count) = replace_content("hello", "zzz", "y", None, None);
+            assert_eq!(out, "hello");
+            assert_eq!(count, 0);
+            // Cow optimization: no-match must return Borrowed, not a cloned String.
+            assert!(
+                matches!(out, std::borrow::Cow::Borrowed(_)),
+                "expected Cow::Borrowed for no-match, got Owned"
+            );
+        }
+
+        #[test]
+        fn replace_content_literal_nth_out_of_range() {
+            let (out, count) = replace_content("aXb", "X", "Y", None, Some(5));
+            assert_eq!(out, "aXb");
+            assert_eq!(count, 0);
+            assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
+        }
+
+        #[test]
+        fn replace_content_regex_no_match_returns_borrowed() {
+            let re = regex::Regex::new(r"\d+").unwrap();
+            let (out, count) = replace_content("no digits here", "unused", "N", Some(&re), None);
+            assert_eq!(out, "no digits here");
+            assert_eq!(count, 0);
+            assert!(
+                matches!(out, std::borrow::Cow::Borrowed(_)),
+                "regex no-match should return Cow::Borrowed"
+            );
+        }
+
+        #[test]
+        fn replace_content_empty_from_returns_borrowed() {
+            let (out, count) = replace_content("hello", "", "y", None, None);
+            assert_eq!(out, "hello");
+            assert_eq!(count, 0);
+            assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
+        }
+
+        #[test]
+        fn replace_content_regex_nth_no_match_returns_borrowed() {
+            let re = regex::Regex::new(r"\d+").unwrap();
+            let (out, count) = replace_content("no digits here", "unused", "N", Some(&re), Some(1));
+            assert_eq!(out, "no digits here");
+            assert_eq!(count, 0);
+            assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
+        }
+
+        #[test]
+        fn compile_word_boundary_escapes_metacharacters() {
+            // Test that regex metacharacters in the pattern are properly escaped.
+            // Use a pattern with dots and parens that would be regex-special.
+            let re = compile_replace_regex("foo.bar()", false, false, false, true)
+                .unwrap()
+                .expect("word_boundary with metacharacters should return Some");
+            // The escaped pattern should NOT match "fooXbar()" (dot is literal)
+            assert!(
+                !re.is_match("fooXbarX"),
+                "dot should be literal, not wildcard"
+            );
+        }
+
+        #[test]
+        fn whole_lines_no_match_returns_borrowed() {
+            let content = "aaa\nbbb\nccc\n";
+            let (result, count) = replace_whole_lines(content, "zzz", "", None, None, None);
+            assert_eq!(count, 0);
+            assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
+        }
+
+        #[test]
+        fn whole_lines_last_line_no_newline() {
+            let content = "aaa\nbbb\nccc";
+            let (result, count) = replace_whole_lines(content, "ccc", "", None, None, None);
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "aaa\nbbb\n");
+        }
     }
 
-    #[test]
-    fn validate_args_nth_one_ok() {
-        let mut p = valid_params();
-        p.nth = Some(1);
-        validate_replace_args(&p).unwrap();
-    }
+    mod error_handling {
+        use super::*;
 
-    #[test]
-    fn validate_args_range_requires_whole_line() {
-        let mut p = valid_params();
-        p.has_range = true;
-        p.whole_line = false;
-        assert_eq!(
-            validate_replace_args(&p),
-            Err(ReplaceValidationError::RangeRequiresWholeLine)
-        );
-    }
+        #[test]
+        fn validate_mode_missing() {
+            assert_eq!(
+                validate_replace_mode(false, false, false),
+                Err(ReplaceModeError::MissingMode)
+            );
+        }
 
-    #[test]
-    fn validate_args_range_with_whole_line_ok() {
-        let mut p = valid_params();
-        p.has_range = true;
-        p.whole_line = true;
-        validate_replace_args(&p).unwrap();
-    }
+        #[test]
+        fn validate_mode_both_inserts() {
+            assert_eq!(
+                validate_replace_mode(false, true, true),
+                Err(ReplaceModeError::BothInsertModes)
+            );
+        }
 
-    #[test]
-    fn validate_args_whole_line_multiline_conflict() {
-        let mut p = valid_params();
-        p.whole_line = true;
-        p.multiline = true;
-        assert_eq!(
-            validate_replace_args(&p),
-            Err(ReplaceValidationError::WholeLineMultilineConflict)
-        );
-    }
+        #[test]
+        fn validate_mode_to_with_insert() {
+            assert_eq!(
+                validate_replace_mode(true, true, false),
+                Err(ReplaceModeError::ToWithInsert)
+            );
+            assert_eq!(
+                validate_replace_mode(true, false, true),
+                Err(ReplaceModeError::ToWithInsert)
+            );
+        }
 
-    #[test]
-    fn validate_args_mode_error_propagated() {
-        let p = ReplaceValidationParams {
-            pattern: "needle",
-            has_to: false,
-            has_insert_before: false,
-            has_insert_after: false,
-            nth: None,
-            whole_line: false,
-            multiline: false,
-            has_range: false,
-        };
-        assert_eq!(
-            validate_replace_args(&p),
-            Err(ReplaceValidationError::Mode(ReplaceModeError::MissingMode))
-        );
-    }
+        #[test]
+        fn validate_args_empty_pattern() {
+            let mut p = valid_params();
+            p.pattern = "";
+            assert_eq!(
+                validate_replace_args(&p),
+                Err(ReplaceValidationError::EmptyPattern)
+            );
+        }
 
-    #[test]
-    fn validate_args_display_messages() {
-        // Verify Display impl produces expected human-readable messages.
-        assert!(
-            ReplaceValidationError::EmptyPattern
-                .to_string()
-                .contains("search pattern must not be empty")
-        );
-        assert!(ReplaceValidationError::NthZero.to_string().contains("nth"));
-        assert!(
-            ReplaceValidationError::RangeRequiresWholeLine
-                .to_string()
-                .contains("range requires whole_line")
-        );
-        assert!(
-            ReplaceValidationError::WholeLineMultilineConflict
-                .to_string()
-                .contains("whole_line and multiline")
-        );
-        assert!(
-            ReplaceValidationError::Mode(ReplaceModeError::MissingMode)
-                .to_string()
-                .contains("'to', 'insert_before', or 'insert_after'")
-        );
-    }
+        #[test]
+        fn validate_args_nth_zero() {
+            let mut p = valid_params();
+            p.nth = Some(0);
+            assert_eq!(
+                validate_replace_args(&p),
+                Err(ReplaceValidationError::NthZero)
+            );
+        }
 
-    #[test]
-    fn replacement_text_with_to() {
-        let result = replacement_text("from", &Some("to".into()), &None, &None, false);
-        assert_eq!(result, "to");
-    }
+        #[test]
+        fn validate_args_range_requires_whole_line() {
+            let mut p = valid_params();
+            p.has_range = true;
+            p.whole_line = false;
+            assert_eq!(
+                validate_replace_args(&p),
+                Err(ReplaceValidationError::RangeRequiresWholeLine)
+            );
+        }
 
-    #[test]
-    fn replacement_text_insert_before_literal() {
-        let result = replacement_text("original", &None, &Some("PREFIX\n".into()), &None, false);
-        assert_eq!(result, "PREFIX\noriginal");
-    }
+        #[test]
+        fn validate_args_whole_line_multiline_conflict() {
+            let mut p = valid_params();
+            p.whole_line = true;
+            p.multiline = true;
+            assert_eq!(
+                validate_replace_args(&p),
+                Err(ReplaceValidationError::WholeLineMultilineConflict)
+            );
+        }
 
-    #[test]
-    fn replacement_text_insert_after_literal() {
-        let result = replacement_text("original", &None, &None, &Some("\nSUFFIX".into()), false);
-        assert_eq!(result, "original\nSUFFIX");
-    }
+        #[test]
+        fn validate_args_mode_error_propagated() {
+            let p = ReplaceValidationParams {
+                pattern: "needle",
+                has_to: false,
+                has_insert_before: false,
+                has_insert_after: false,
+                nth: None,
+                whole_line: false,
+                multiline: false,
+                has_range: false,
+            };
+            assert_eq!(
+                validate_replace_args(&p),
+                Err(ReplaceValidationError::Mode(ReplaceModeError::MissingMode))
+            );
+        }
 
-    #[test]
-    fn replacement_text_insert_before_regex_anchor() {
-        let result = replacement_text("ignored", &None, &Some("PREFIX\n".into()), &None, true);
-        assert_eq!(result, "PREFIX\n${0}");
-    }
-
-    #[test]
-    fn replacement_text_insert_after_regex_anchor() {
-        let result = replacement_text("ignored", &None, &None, &Some("\nSUFFIX".into()), true);
-        assert_eq!(result, "${0}\nSUFFIX");
-    }
-
-    #[test]
-    fn replace_content_literal_all() {
-        let (out, count) = replace_content("aXbXc", "X", "Y", None, None);
-        assert_eq!(out, "aYbYc");
-        assert_eq!(count, 2);
-    }
-
-    #[test]
-    fn replace_content_literal_no_match() {
-        let (out, count) = replace_content("hello", "zzz", "y", None, None);
-        assert_eq!(out, "hello");
-        assert_eq!(count, 0);
-        // Cow optimization: no-match must return Borrowed, not a cloned String.
-        assert!(
-            matches!(out, std::borrow::Cow::Borrowed(_)),
-            "expected Cow::Borrowed for no-match, got Owned"
-        );
-    }
-
-    #[test]
-    fn replace_content_literal_nth() {
-        let (out, count) = replace_content("aXbXcX", "X", "Y", None, Some(2));
-        assert_eq!(out, "aXbYcX");
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn replace_content_literal_nth_out_of_range() {
-        let (out, count) = replace_content("aXb", "X", "Y", None, Some(5));
-        assert_eq!(out, "aXb");
-        assert_eq!(count, 0);
-        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn replace_content_regex_all() {
-        let re = regex::Regex::new(r"\d+").unwrap();
-        let (out, count) = replace_content("a1b22c333", "unused", "N", Some(&re), None);
-        assert_eq!(out, "aNbNcN");
-        assert_eq!(count, 3);
-    }
-
-    #[test]
-    fn replace_content_regex_nth() {
-        let re = regex::Regex::new(r"\d+").unwrap();
-        let (out, count) = replace_content("a1b22c333", "unused", "N", Some(&re), Some(2));
-        assert_eq!(out, "a1bNc333");
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn replace_content_regex_capture_group() {
-        let re = regex::Regex::new(r"(\w+)@(\w+)").unwrap();
-        let (out, count) = replace_content("user@host", "unused", "$2=$1", Some(&re), None);
-        assert_eq!(out, "host=user");
-        assert_eq!(count, 1);
-    }
-
-    #[test]
-    fn replace_content_regex_no_match_returns_borrowed() {
-        let re = regex::Regex::new(r"\d+").unwrap();
-        let (out, count) = replace_content("no digits here", "unused", "N", Some(&re), None);
-        assert_eq!(out, "no digits here");
-        assert_eq!(count, 0);
-        assert!(
-            matches!(out, std::borrow::Cow::Borrowed(_)),
-            "regex no-match should return Cow::Borrowed"
-        );
-    }
-
-    #[test]
-    fn replace_content_empty_from_returns_borrowed() {
-        let (out, count) = replace_content("hello", "", "y", None, None);
-        assert_eq!(out, "hello");
-        assert_eq!(count, 0);
-        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn replace_content_regex_nth_no_match_returns_borrowed() {
-        let re = regex::Regex::new(r"\d+").unwrap();
-        let (out, count) = replace_content("no digits here", "unused", "N", Some(&re), Some(1));
-        assert_eq!(out, "no digits here");
-        assert_eq!(count, 0);
-        assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn compile_regex_mode_returns_some() {
-        let re = compile_replace_regex(r"\d+", true, false, false, false)
-            .unwrap()
-            .expect("regex mode should return Some");
-        assert!(re.is_match("abc123"));
-    }
-
-    #[test]
-    fn compile_regex_multiline_dot_matches_newline() {
-        let re = compile_replace_regex("a.b", true, false, true, false)
-            .unwrap()
-            .unwrap();
-        assert!(
-            re.is_match("a\nb"),
-            "multiline should make dot match newline"
-        );
-    }
-
-    #[test]
-    fn compile_invalid_regex_returns_error() {
-        let result = compile_replace_regex("(unclosed", true, false, false, false);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn compile_literal_case_insensitive_returns_some() {
-        let re = compile_replace_regex("hello", false, true, false, false)
-            .unwrap()
-            .expect("case-insensitive literal should return Some");
-        assert!(re.is_match("HELLO"));
-    }
-
-    #[test]
-    fn compile_plain_literal_returns_none() {
-        let re = compile_replace_regex("hello", false, false, false, false).unwrap();
-        assert!(re.is_none());
-    }
-
-    #[test]
-    fn compile_word_boundary_literal() {
-        let re = compile_replace_regex("SetupFile", false, false, false, true)
-            .unwrap()
-            .expect("word_boundary should return Some");
-        assert!(re.is_match("SetupFile"), "should match standalone word");
-        assert!(
-            re.is_match("use crate::SetupFile;"),
-            "should match at word boundary"
-        );
-        assert!(
-            !re.is_match("BenchSetupFile"),
-            "should NOT match inside a longer word"
-        );
-        assert!(
-            !re.is_match("SetupFileConfig"),
-            "should NOT match when followed by more word chars"
-        );
-    }
-
-    #[test]
-    fn compile_word_boundary_escapes_metacharacters() {
-        // Test that regex metacharacters in the pattern are properly escaped.
-        // Use a pattern with dots and parens that would be regex-special.
-        let re = compile_replace_regex("foo.bar()", false, false, false, true)
-            .unwrap()
-            .expect("word_boundary with metacharacters should return Some");
-        // The escaped pattern should NOT match "fooXbar()" (dot is literal)
-        assert!(
-            !re.is_match("fooXbarX"),
-            "dot should be literal, not wildcard"
-        );
-    }
-
-    #[test]
-    fn compile_word_boundary_case_insensitive() {
-        let re = compile_replace_regex("setupfile", false, true, false, true)
-            .unwrap()
-            .expect("word_boundary + case_insensitive should return Some");
-        assert!(re.is_match("SetupFile"));
-        assert!(!re.is_match("BenchSetupFile"));
-    }
-
-    // ── replace_whole_lines tests ─────────────────────────────────
-
-    #[test]
-    fn whole_lines_delete_literal() {
-        let content = "aaa\nbbb\nccc\nbbb\neee\n";
-        let (result, count) = replace_whole_lines(content, "bbb", "", None, None, None);
-        assert_eq!(count, 2);
-        assert_eq!(&*result, "aaa\nccc\neee\n");
-    }
-
-    #[test]
-    fn whole_lines_delete_regex() {
-        let re = compile_replace_regex(r"let _\w+", true, false, false, false)
-            .unwrap()
-            .unwrap();
-        let content = "fn main() {\n    let _x = foo();\n    let y = bar();\n}\n";
-        let (result, count) = replace_whole_lines(content, "", "", Some(&re), None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "fn main() {\n    let y = bar();\n}\n");
-    }
-
-    #[test]
-    fn whole_lines_replace_with_text() {
-        let content = "alpha\nbeta\ngamma\n";
-        let (result, count) = replace_whole_lines(content, "beta", "REPLACED", None, None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "alpha\nREPLACED\ngamma\n");
-    }
-
-    #[test]
-    fn whole_lines_range_restriction() {
-        let content = "aaa\nbbb\nccc\nbbb\neee\n";
-        // Range 1:3 means lines 1-3 only. Second bbb is on line 4.
-        let (result, count) =
-            replace_whole_lines(content, "bbb", "", None, None, Some((1, Some(3))));
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\nccc\nbbb\neee\n");
-    }
-
-    #[test]
-    fn whole_lines_nth() {
-        let content = "aaa\nbbb\nccc\nbbb\neee\n";
-        let (result, count) = replace_whole_lines(content, "bbb", "", None, Some(2), None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\nbbb\nccc\neee\n");
-    }
-
-    #[test]
-    fn whole_lines_no_match_returns_borrowed() {
-        let content = "aaa\nbbb\nccc\n";
-        let (result, count) = replace_whole_lines(content, "zzz", "", None, None, None);
-        assert_eq!(count, 0);
-        assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn whole_lines_regex_capture_groups() {
-        let re = compile_replace_regex(r"version = (\d+)", true, false, false, false)
-            .unwrap()
-            .unwrap();
-        let content = "name = foo\nversion = 3\nrelease = true\n";
-        let (result, count) =
-            replace_whole_lines(content, "", "version = ${1}00", Some(&re), None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "name = foo\nversion = 300\nrelease = true\n");
-    }
-
-    #[test]
-    fn whole_lines_last_line_no_newline() {
-        let content = "aaa\nbbb\nccc";
-        let (result, count) = replace_whole_lines(content, "ccc", "", None, None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\nbbb\n");
-    }
-
-    // -- CR/CRLF line ending tests (#999) ──────────────────────────
-
-    #[test]
-    fn whole_lines_cr_endings_literal() {
-        let content = "aaa\rbbb\rccc\r";
-        let (result, count) = replace_whole_lines(content, "bbb", "REPLACED", None, None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\rREPLACED\rccc\r");
-    }
-
-    #[test]
-    fn whole_lines_cr_endings_delete() {
-        let content = "aaa\rbbb\rccc\rbbb\reee\r";
-        let (result, count) = replace_whole_lines(content, "bbb", "", None, None, None);
-        assert_eq!(count, 2);
-        assert_eq!(&*result, "aaa\rccc\reee\r");
-    }
-
-    #[test]
-    fn whole_lines_cr_no_match_returns_borrowed() {
-        let content = "aaa\rbbb\rccc\r";
-        let (result, count) = replace_whole_lines(content, "zzz", "", None, None, None);
-        assert_eq!(count, 0);
-        assert!(matches!(result, std::borrow::Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn whole_lines_crlf_preserves_ending() {
-        let content = "aaa\r\nbbb\r\nccc\r\n";
-        let (result, count) = replace_whole_lines(content, "bbb", "REPLACED", None, None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\r\nREPLACED\r\nccc\r\n");
-    }
-
-    #[test]
-    fn whole_lines_crlf_delete() {
-        let content = "aaa\r\nbbb\r\nccc\r\n";
-        let (result, count) = replace_whole_lines(content, "bbb", "", None, None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\r\nccc\r\n");
-    }
-
-    #[test]
-    fn whole_lines_crlf_line_content_excludes_cr() {
-        // Verify that line_content does NOT include the \r from CRLF,
-        // so exact-match patterns work without trailing \r.
-        let content = "hello\r\nworld\r\n";
-        let (result, count) = replace_whole_lines(content, "hello", "MATCHED", None, None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "MATCHED\r\nworld\r\n");
-    }
-
-    #[test]
-    fn whole_lines_crlf_regex_dollar_matches() {
-        // Regex $ should match at end of line_content (before \r\n),
-        // not fail because \r is included in line_content.
-        let re = compile_replace_regex(r"hello$", true, false, false, false)
-            .unwrap()
-            .unwrap();
-        let content = "hello\r\nworld\r\n";
-        let (result, count) = replace_whole_lines(content, "", "MATCHED", Some(&re), None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "MATCHED\r\nworld\r\n");
-    }
-
-    #[test]
-    fn whole_lines_cr_regex_capture_groups() {
-        let re = compile_replace_regex(r"v(\d+)", true, false, false, false)
-            .unwrap()
-            .unwrap();
-        let content = "name=foo\rv3\rrelease=true\r";
-        let (result, count) = replace_whole_lines(content, "", "v${1}00", Some(&re), None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "name=foo\rv300\rrelease=true\r");
-    }
-
-    #[test]
-    fn whole_lines_cr_last_line_no_ending() {
-        let content = "aaa\rbbb\rccc";
-        let (result, count) = replace_whole_lines(content, "ccc", "", None, None, None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\rbbb\r");
-    }
-
-    #[test]
-    fn whole_lines_mixed_endings_each_preserved() {
-        // Lines with different endings: LF, CRLF, CR, no-ending.
-        let content = "aaa\nbbb\r\nccc\rddd";
-        let (result, count) = replace_whole_lines(content, "aaa", "A", None, None, None);
-        assert_eq!(count, 1);
-        // Only the first line is replaced; its \n ending is preserved.
-        assert_eq!(&*result, "A\nbbb\r\nccc\rddd");
-
-        let (result2, count2) = replace_whole_lines(content, "bbb", "B", None, None, None);
-        assert_eq!(count2, 1);
-        // Second line replaced; its \r\n ending is preserved.
-        assert_eq!(&*result2, "aaa\nB\r\nccc\rddd");
-
-        let (result3, count3) = replace_whole_lines(content, "ccc", "C", None, None, None);
-        assert_eq!(count3, 1);
-        // Third line replaced; its \r ending is preserved.
-        assert_eq!(&*result3, "aaa\nbbb\r\nC\rddd");
-    }
-
-    #[test]
-    fn whole_lines_cr_range_restriction() {
-        let content = "aaa\rbbb\rccc\rbbb\reee\r";
-        // Range 1:3 means lines 1-3. Second bbb is on line 4.
-        let (result, count) =
-            replace_whole_lines(content, "bbb", "", None, None, Some((1, Some(3))));
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\rccc\rbbb\reee\r");
-    }
-
-    #[test]
-    fn whole_lines_cr_nth() {
-        let content = "aaa\rbbb\rccc\rbbb\reee\r";
-        let (result, count) = replace_whole_lines(content, "bbb", "", None, Some(2), None);
-        assert_eq!(count, 1);
-        assert_eq!(&*result, "aaa\rbbb\rccc\reee\r");
+        #[test]
+        fn compile_invalid_regex_returns_error() {
+            let result = compile_replace_regex("(unclosed", true, false, false, false);
+            assert!(result.is_err());
+        }
     }
 }

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -1,545 +1,555 @@
 use super::*;
 
-#[test]
-fn version_compatibility() {
-    assert!(is_compatible_version("1"));
-    assert!(!is_compatible_version("0"));
-    assert!(!is_compatible_version("2"));
-}
+mod basic {
+    use super::*;
 
-#[test]
-fn tier_ordering() {
-    assert!(Tier::Weak < Tier::Medium);
-    assert!(Tier::Medium < Tier::Strong);
-}
-
-#[test]
-fn tier_parse_roundtrip() {
-    for tier in [Tier::Weak, Tier::Medium, Tier::Strong] {
-        let s = tier.to_string();
-        let parsed: Tier = s.parse().unwrap();
-        assert_eq!(parsed, tier);
+    #[test]
+    fn version_compatibility() {
+        assert!(is_compatible_version("1"));
+        assert!(!is_compatible_version("0"));
+        assert!(!is_compatible_version("2"));
     }
-}
 
-#[test]
-fn tier_parse_case_insensitive() {
-    assert_eq!("WEAK".parse::<Tier>().unwrap(), Tier::Weak);
-    assert_eq!("Medium".parse::<Tier>().unwrap(), Tier::Medium);
-    assert_eq!("STRONG".parse::<Tier>().unwrap(), Tier::Strong);
-}
-
-#[test]
-fn tier_parse_invalid() {
-    assert!("unknown".parse::<Tier>().is_err());
-}
-
-#[test]
-fn operation_schemas_non_empty() {
-    let schemas = operation_schemas();
-    assert!(!schemas.is_empty());
-    // Every schema must have a name, description, and valid JSON parameters.
-    for schema in &schemas {
-        assert!(!schema.name.is_empty(), "schema name is empty");
-        assert!(
-            !schema.description.is_empty(),
-            "schema {}: description is empty",
-            schema.name
-        );
-        assert!(
-            schema.parameters.is_object(),
-            "schema {}: parameters is not an object",
-            schema.name
-        );
+    #[test]
+    fn tier_ordering() {
+        assert!(Tier::Weak < Tier::Medium);
+        assert!(Tier::Medium < Tier::Strong);
     }
-}
 
-#[test]
-fn operation_schemas_have_unique_names() {
-    let schemas = operation_schemas();
-    let mut names: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
-    names.sort();
-    let original_len = names.len();
-    names.dedup();
-    assert_eq!(names.len(), original_len, "duplicate operation names found");
-}
-
-#[test]
-fn weak_tier_returns_subset() {
-    let all = operation_schemas();
-    let weak = operations_for_tier(Tier::Weak);
-    assert!(
-        weak.len() < all.len(),
-        "weak should be a proper subset of all"
-    );
-    for op in &weak {
-        assert_eq!(
-            op.min_tier,
-            Tier::Weak,
-            "weak tier should only contain weak ops, got {:?} for {}",
-            op.min_tier,
-            op.name
-        );
+    #[test]
+    fn tier_parse_roundtrip() {
+        for tier in [Tier::Weak, Tier::Medium, Tier::Strong] {
+            let s = tier.to_string();
+            let parsed: Tier = s.parse().unwrap();
+            assert_eq!(parsed, tier);
+        }
     }
-}
 
-#[test]
-fn medium_tier_includes_weak() {
-    let weak = operations_for_tier(Tier::Weak);
-    let medium = operations_for_tier(Tier::Medium);
-    assert!(medium.len() >= weak.len());
-    let weak_names: Vec<&str> = weak.iter().map(|o| o.name.as_str()).collect();
-    for name in &weak_names {
-        assert!(
-            medium.iter().any(|o| o.name == *name),
-            "medium tier should include weak op: {name}"
-        );
+    #[test]
+    fn tier_parse_case_insensitive() {
+        assert_eq!("WEAK".parse::<Tier>().unwrap(), Tier::Weak);
+        assert_eq!("Medium".parse::<Tier>().unwrap(), Tier::Medium);
+        assert_eq!("STRONG".parse::<Tier>().unwrap(), Tier::Strong);
     }
-}
 
-#[test]
-fn strong_tier_returns_all() {
-    let all = operation_schemas();
-    let strong = operations_for_tier(Tier::Strong);
-    assert_eq!(
-        strong.len(),
-        all.len(),
-        "strong tier should include all operations"
-    );
-}
-
-#[test]
-fn weak_tier_has_expected_ops() {
-    let weak = operations_for_tier(Tier::Weak);
-    let names: Vec<&str> = weak.iter().map(|o| o.name.as_str()).collect();
-    assert!(names.contains(&"replace"), "weak tier must include replace");
-    assert!(
-        names.contains(&"file.create"),
-        "weak tier must include file.create"
-    );
-    assert!(
-        names.contains(&"file.delete"),
-        "weak tier must include file.delete"
-    );
-    assert!(
-        names.contains(&"tidy.fix"),
-        "weak tier must include tidy.fix"
-    );
-}
-
-#[test]
-fn medium_tier_has_expected_ops() {
-    let medium = operations_for_tier(Tier::Medium);
-    let names: Vec<&str> = medium.iter().map(|o| o.name.as_str()).collect();
-    assert!(
-        names.contains(&"doc.set"),
-        "medium tier must include doc.set"
-    );
-    assert!(
-        names.contains(&"md.replace_section"),
-        "medium tier must include md.replace_section"
-    );
-    assert!(
-        names.contains(&"doc.merge"),
-        "medium tier must include doc.merge"
-    );
-}
-
-#[test]
-fn strong_tier_has_expected_ops() {
-    let strong = operations_for_tier(Tier::Strong);
-    let names: Vec<&str> = strong.iter().map(|o| o.name.as_str()).collect();
-    assert!(names.contains(&"search"), "strong tier must include search");
-    assert!(
-        names.contains(&"doc.delete_where"),
-        "strong tier must include doc.delete_where"
-    );
-}
-
-#[test]
-fn system_prompt_for_weak_tier() {
-    let prompt = system_prompt_for_tier(Tier::Weak);
-    assert!(prompt.contains("tier: weak"));
-    assert!(prompt.contains("replace"));
-    assert!(prompt.contains("file.create"));
-    // Should NOT contain medium/strong ops.
-    assert!(!prompt.contains("## `doc.set`"));
-    assert!(!prompt.contains("## `search`"));
-}
-
-#[test]
-fn system_prompt_for_strong_tier() {
-    let prompt = system_prompt_for_tier(Tier::Strong);
-    assert!(prompt.contains("tier: strong"));
-    assert!(prompt.contains("replace"));
-    assert!(prompt.contains("doc.set"));
-    assert!(prompt.contains("search"));
-}
-
-#[test]
-fn plan_write_policy_schema_has_all_fields() {
-    let schema = plan_write_policy_schema();
-    let props = schema.get("properties").unwrap().as_object().unwrap();
-    assert!(props.contains_key("ensure_final_newline"));
-    assert!(props.contains_key("normalize_eol"));
-    assert!(props.contains_key("trim_trailing_whitespace"));
-    assert!(props.contains_key("collapse_blanks"));
-}
-
-#[test]
-fn system_prompt_includes_write_policy() {
-    let prompt = system_prompt_for_tier(Tier::Strong);
-    assert!(prompt.contains("write_policy"));
-    assert!(prompt.contains("collapse_blanks"));
-    assert!(prompt.contains("ensure_final_newline"));
-}
-
-#[test]
-fn system_prompt_includes_version() {
-    let prompt = system_prompt_for_tier(Tier::Medium);
-    assert!(prompt.contains(&format!("format version: {INTENT_FORMAT_VERSION}")));
-}
-
-#[test]
-fn schemas_have_required_fields() {
-    let schemas = operation_schemas();
-    for schema in &schemas {
-        let required = schema.parameters.get("required");
-        assert!(
-            required.is_some(),
-            "schema {}: must have 'required' field",
-            schema.name
-        );
-    }
-}
-
-#[test]
-fn operation_examples_include_op_field() {
-    for schema in operation_schemas() {
-        for ex in &schema.examples {
-            let op = ex
-                .args
-                .get("op")
-                .and_then(|v| v.as_str())
-                .unwrap_or_else(|| {
-                    panic!(
-                        "schema {} example {:?}: missing 'op' field",
-                        schema.name, ex.description
-                    )
-                });
-            assert_eq!(
-                op, schema.name,
-                "schema {} example {:?}: op must match operation name",
-                schema.name, ex.description
+    #[test]
+    fn operation_schemas_non_empty() {
+        let schemas = operation_schemas();
+        assert!(!schemas.is_empty());
+        // Every schema must have a name, description, and valid JSON parameters.
+        for schema in &schemas {
+            assert!(!schema.name.is_empty(), "schema name is empty");
+            assert!(
+                !schema.description.is_empty(),
+                "schema {}: description is empty",
+                schema.name
+            );
+            assert!(
+                schema.parameters.is_object(),
+                "schema {}: parameters is not an object",
+                schema.name
             );
         }
     }
-}
 
-#[test]
-fn operation_schema_serializes_to_json() {
-    let schemas = operation_schemas();
-    let json = serde_json::to_string_pretty(&schemas).unwrap();
-    assert!(!json.is_empty());
-    // Roundtrip: deserialize back.
-    let deserialized: Vec<OperationSchema> = serde_json::from_str(&json).unwrap();
-    assert_eq!(deserialized.len(), schemas.len());
-}
-
-/// Verify that every field accepted by `plan::Operation` for a given op
-/// name has a corresponding entry in the hand-written schema `properties`.
-/// This catches drift when new fields are added to the serde-based
-/// `Operation` enum but not to the JSON Schema export.
-#[test]
-fn schema_properties_cover_plan_operation_fields() {
-    use crate::plan::Operation;
-
-    // Build representative Operation values for each schema op name.
-    // Only the field names matter; values are dummies.
-    let mut ops: Vec<(&str, Operation)> = vec![
-        (
-            "replace",
-            Operation::Replace {
-                glob: Some("*.rs".into()),
-                path: Some("f.rs".into()),
-                mode: Some("literal".into()),
-                from: "a".into(),
-                to: Some("b".into()),
-                nth: Some(1),
-                insert_before: Some("x".into()),
-                insert_after: Some("y".into()),
-                case_insensitive: false,
-                multiline: false,
-                if_exists: false,
-                whole_line: false,
-                range: Some("1:10".into()),
-                word_boundary: false,
-                before_context: Some("ctx".into()),
-                after_context: Some("ctx".into()),
-            },
-        ),
-        (
-            "file.create",
-            Operation::FileCreate {
-                path: "f".into(),
-                content: "c".into(),
-                force: Some(true),
-            },
-        ),
-        (
-            "file.append",
-            Operation::FileAppend {
-                path: "f".into(),
-                content: "c".into(),
-            },
-        ),
-        ("file.delete", Operation::FileDelete { path: "f".into() }),
-        (
-            "file.rename",
-            Operation::FileRename {
-                from: "a".into(),
-                to: "b".into(),
-                force: true,
-            },
-        ),
-        (
-            "tidy.fix",
-            Operation::TidyFix {
-                path: "f".into(),
-                ensure_final_newline: Some(true),
-                trim_trailing_whitespace: Some(true),
-                normalize_eol: Some("lf".into()),
-            },
-        ),
-        (
-            "doc.set",
-            Operation::DocSet {
-                path: "f".into(),
-                selector: "s".into(),
-                value: serde_json::json!("v"),
-            },
-        ),
-        (
-            "doc.delete",
-            Operation::DocDelete {
-                path: "f".into(),
-                selector: "s".into(),
-            },
-        ),
-        (
-            "doc.merge",
-            Operation::DocMerge {
-                path: "f".into(),
-                value: serde_json::json!({}),
-            },
-        ),
-        (
-            "doc.append",
-            Operation::DocAppend {
-                path: "f".into(),
-                selector: "s".into(),
-                value: serde_json::json!([]),
-            },
-        ),
-        (
-            "doc.prepend",
-            Operation::DocPrepend {
-                path: "f".into(),
-                selector: "s".into(),
-                value: serde_json::json!([]),
-            },
-        ),
-        (
-            "doc.update",
-            Operation::DocUpdate {
-                path: "f".into(),
-                selector: "s".into(),
-                value: serde_json::json!({}),
-            },
-        ),
-        (
-            "doc.move",
-            Operation::DocMove {
-                path: "f".into(),
-                from: "a".into(),
-                to: "b".into(),
-            },
-        ),
-        (
-            "doc.ensure",
-            Operation::DocEnsure {
-                path: "f".into(),
-                selector: "s".into(),
-                value: serde_json::json!(1),
-            },
-        ),
-        (
-            "doc.delete_where",
-            Operation::DocDeleteWhere {
-                path: "f".into(),
-                selector: "s".into(),
-                predicate: "p".into(),
-            },
-        ),
-        (
-            "md.replace_section",
-            Operation::MdReplaceSection {
-                path: "f".into(),
-                heading: "h".into(),
-                content: "c".into(),
-            },
-        ),
-        (
-            "md.insert_after_heading",
-            Operation::MdInsertAfterHeading {
-                path: "f".into(),
-                heading: "h".into(),
-                content: "c".into(),
-            },
-        ),
-        (
-            "md.insert_before_heading",
-            Operation::MdInsertBeforeHeading {
-                path: "f".into(),
-                heading: "h".into(),
-                content: "c".into(),
-            },
-        ),
-        (
-            "md.upsert_bullet",
-            Operation::MdUpsertBullet {
-                path: "f".into(),
-                heading: "h".into(),
-                bullet: "b".into(),
-            },
-        ),
-        (
-            "md.table_append",
-            Operation::MdTableAppend {
-                path: "f".into(),
-                heading: "h".into(),
-                row: "r".into(),
-            },
-        ),
-        (
-            "md.move_section",
-            Operation::MdMoveSection {
-                path: "f".into(),
-                heading: "h".into(),
-                to: None,
-                before: None,
-                after: None,
-            },
-        ),
-        (
-            "md.dedupe_headings",
-            Operation::MdDedupeHeadings { path: "f".into() },
-        ),
-        (
-            "md.lint_agents",
-            Operation::MdLintAgents { path: "f".into() },
-        ),
-        (
-            "patch.apply",
-            Operation::PatchApply {
-                diff: "d".into(),
-                on_stale: Default::default(),
-                allow_conflicts: false,
-            },
-        ),
-        (
-            "search",
-            Operation::Search {
-                path: "f".into(),
-                pattern: "p".into(),
-                regex: false,
-                case_insensitive: false,
-                multiline: false,
-                invert_match: false,
-                context: None,
-                before_context: None,
-                after_context: None,
-                assert_count: None,
-                literal: false,
-                globs: vec![],
-                max_results: 0,
-                exclude_patterns: vec![],
-                custom_ignore_filenames: vec![],
-            },
-        ),
-        (
-            "read",
-            Operation::Read {
-                path: "f".into(),
-                lines: None,
-            },
-        ),
-    ];
-
-    #[cfg(feature = "ast")]
-    {
-        ops.push((
-            "ast.rename",
-            Operation::AstRename {
-                path: "f.rs".into(),
-                old_name: "old".into(),
-                new_name: "new".into(),
-                lang: None,
-            },
-        ));
-        ops.push((
-            "ast.replace",
-            Operation::AstReplace {
-                path: "f.rs".into(),
-                symbol: "s".into(),
-                from: "a".into(),
-                to: "b".into(),
-                regex: false,
-                lang: None,
-            },
-        ));
+    #[test]
+    fn operation_schemas_have_unique_names() {
+        let schemas = operation_schemas();
+        let mut names: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
+        names.sort();
+        let original_len = names.len();
+        names.dedup();
+        assert_eq!(names.len(), original_len, "duplicate operation names found");
     }
 
-    let schemas = operation_schemas();
-    let schema_map: std::collections::HashMap<&str, &OperationSchema> =
-        schemas.iter().map(|s| (s.name.as_str(), s)).collect();
+    #[test]
+    fn weak_tier_returns_subset() {
+        let all = operation_schemas();
+        let weak = operations_for_tier(Tier::Weak);
+        assert!(
+            weak.len() < all.len(),
+            "weak should be a proper subset of all"
+        );
+        for op in &weak {
+            assert_eq!(
+                op.min_tier,
+                Tier::Weak,
+                "weak tier should only contain weak ops, got {:?} for {}",
+                op.min_tier,
+                op.name
+            );
+        }
+    }
 
-    let mut missing: Vec<String> = Vec::new();
+    #[test]
+    fn medium_tier_includes_weak() {
+        let weak = operations_for_tier(Tier::Weak);
+        let medium = operations_for_tier(Tier::Medium);
+        assert!(medium.len() >= weak.len());
+        let weak_names: Vec<&str> = weak.iter().map(|o| o.name.as_str()).collect();
+        for name in &weak_names {
+            assert!(
+                medium.iter().any(|o| o.name == *name),
+                "medium tier should include weak op: {name}"
+            );
+        }
+    }
 
-    for (op_name, op_value) in &ops {
-        let schema = match schema_map.get(op_name) {
-            Some(s) => s,
-            None => {
-                missing.push(format!("{op_name}: no schema found"));
-                continue;
-            }
-        };
-        let props = schema
-            .parameters
-            .get("properties")
-            .and_then(|v| v.as_object())
-            .unwrap_or_else(|| panic!("schema {op_name}: parameters.properties is not an object"));
+    #[test]
+    fn strong_tier_returns_all() {
+        let all = operation_schemas();
+        let strong = operations_for_tier(Tier::Strong);
+        assert_eq!(
+            strong.len(),
+            all.len(),
+            "strong tier should include all operations"
+        );
+    }
 
-        // Serialize the Operation to get its field names.
-        let serialized = serde_json::to_value(op_value).unwrap();
-        let obj = serialized.as_object().unwrap();
-        for key in obj.keys() {
-            if key == "op" {
-                continue; // tag field, not a parameter
-            }
-            if !props.contains_key(key) {
-                missing.push(format!(
-                    "{op_name}: plan.rs field '{key}' missing from schema properties"
-                ));
+    #[test]
+    fn weak_tier_has_expected_ops() {
+        let weak = operations_for_tier(Tier::Weak);
+        let names: Vec<&str> = weak.iter().map(|o| o.name.as_str()).collect();
+        assert!(names.contains(&"replace"), "weak tier must include replace");
+        assert!(
+            names.contains(&"file.create"),
+            "weak tier must include file.create"
+        );
+        assert!(
+            names.contains(&"file.delete"),
+            "weak tier must include file.delete"
+        );
+        assert!(
+            names.contains(&"tidy.fix"),
+            "weak tier must include tidy.fix"
+        );
+    }
+
+    #[test]
+    fn medium_tier_has_expected_ops() {
+        let medium = operations_for_tier(Tier::Medium);
+        let names: Vec<&str> = medium.iter().map(|o| o.name.as_str()).collect();
+        assert!(
+            names.contains(&"doc.set"),
+            "medium tier must include doc.set"
+        );
+        assert!(
+            names.contains(&"md.replace_section"),
+            "medium tier must include md.replace_section"
+        );
+        assert!(
+            names.contains(&"doc.merge"),
+            "medium tier must include doc.merge"
+        );
+    }
+
+    #[test]
+    fn strong_tier_has_expected_ops() {
+        let strong = operations_for_tier(Tier::Strong);
+        let names: Vec<&str> = strong.iter().map(|o| o.name.as_str()).collect();
+        assert!(names.contains(&"search"), "strong tier must include search");
+        assert!(
+            names.contains(&"doc.delete_where"),
+            "strong tier must include doc.delete_where"
+        );
+    }
+
+    #[test]
+    fn system_prompt_for_weak_tier() {
+        let prompt = system_prompt_for_tier(Tier::Weak);
+        assert!(prompt.contains("tier: weak"));
+        assert!(prompt.contains("replace"));
+        assert!(prompt.contains("file.create"));
+        // Should NOT contain medium/strong ops.
+        assert!(!prompt.contains("## `doc.set`"));
+        assert!(!prompt.contains("## `search`"));
+    }
+
+    #[test]
+    fn system_prompt_for_strong_tier() {
+        let prompt = system_prompt_for_tier(Tier::Strong);
+        assert!(prompt.contains("tier: strong"));
+        assert!(prompt.contains("replace"));
+        assert!(prompt.contains("doc.set"));
+        assert!(prompt.contains("search"));
+    }
+
+    #[test]
+    fn plan_write_policy_schema_has_all_fields() {
+        let schema = plan_write_policy_schema();
+        let props = schema.get("properties").unwrap().as_object().unwrap();
+        assert!(props.contains_key("ensure_final_newline"));
+        assert!(props.contains_key("normalize_eol"));
+        assert!(props.contains_key("trim_trailing_whitespace"));
+        assert!(props.contains_key("collapse_blanks"));
+    }
+
+    #[test]
+    fn system_prompt_includes_write_policy() {
+        let prompt = system_prompt_for_tier(Tier::Strong);
+        assert!(prompt.contains("write_policy"));
+        assert!(prompt.contains("collapse_blanks"));
+        assert!(prompt.contains("ensure_final_newline"));
+    }
+
+    #[test]
+    fn system_prompt_includes_version() {
+        let prompt = system_prompt_for_tier(Tier::Medium);
+        assert!(prompt.contains(&format!("format version: {INTENT_FORMAT_VERSION}")));
+    }
+
+    #[test]
+    fn schemas_have_required_fields() {
+        let schemas = operation_schemas();
+        for schema in &schemas {
+            let required = schema.parameters.get("required");
+            assert!(
+                required.is_some(),
+                "schema {}: must have 'required' field",
+                schema.name
+            );
+        }
+    }
+
+    #[test]
+    fn operation_examples_include_op_field() {
+        for schema in operation_schemas() {
+            for ex in &schema.examples {
+                let op = ex
+                    .args
+                    .get("op")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "schema {} example {:?}: missing 'op' field",
+                            schema.name, ex.description
+                        )
+                    });
+                assert_eq!(
+                    op, schema.name,
+                    "schema {} example {:?}: op must match operation name",
+                    schema.name, ex.description
+                );
             }
         }
     }
 
-    assert!(
-        missing.is_empty(),
-        "schema/plan drift detected:\n  {}",
-        missing.join("\n  ")
-    );
+    #[test]
+    fn operation_schema_serializes_to_json() {
+        let schemas = operation_schemas();
+        let json = serde_json::to_string_pretty(&schemas).unwrap();
+        assert!(!json.is_empty());
+        // Roundtrip: deserialize back.
+        let deserialized: Vec<OperationSchema> = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.len(), schemas.len());
+    }
+
+    /// Verify that every field accepted by `plan::Operation` for a given op
+    /// name has a corresponding entry in the hand-written schema `properties`.
+    /// This catches drift when new fields are added to the serde-based
+    /// `Operation` enum but not to the JSON Schema export.
+    #[test]
+    fn schema_properties_cover_plan_operation_fields() {
+        use crate::plan::Operation;
+
+        // Build representative Operation values for each schema op name.
+        // Only the field names matter; values are dummies.
+        let mut ops: Vec<(&str, Operation)> = vec![
+            (
+                "replace",
+                Operation::Replace {
+                    glob: Some("*.rs".into()),
+                    path: Some("f.rs".into()),
+                    mode: Some("literal".into()),
+                    from: "a".into(),
+                    to: Some("b".into()),
+                    nth: Some(1),
+                    insert_before: Some("x".into()),
+                    insert_after: Some("y".into()),
+                    case_insensitive: false,
+                    multiline: false,
+                    if_exists: false,
+                    whole_line: false,
+                    range: Some("1:10".into()),
+                    word_boundary: false,
+                    before_context: Some("ctx".into()),
+                    after_context: Some("ctx".into()),
+                },
+            ),
+            (
+                "file.create",
+                Operation::FileCreate {
+                    path: "f".into(),
+                    content: "c".into(),
+                    force: Some(true),
+                },
+            ),
+            (
+                "file.append",
+                Operation::FileAppend {
+                    path: "f".into(),
+                    content: "c".into(),
+                },
+            ),
+            ("file.delete", Operation::FileDelete { path: "f".into() }),
+            (
+                "file.rename",
+                Operation::FileRename {
+                    from: "a".into(),
+                    to: "b".into(),
+                    force: true,
+                },
+            ),
+            (
+                "tidy.fix",
+                Operation::TidyFix {
+                    path: "f".into(),
+                    ensure_final_newline: Some(true),
+                    trim_trailing_whitespace: Some(true),
+                    normalize_eol: Some("lf".into()),
+                },
+            ),
+            (
+                "doc.set",
+                Operation::DocSet {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!("v"),
+                },
+            ),
+            (
+                "doc.delete",
+                Operation::DocDelete {
+                    path: "f".into(),
+                    selector: "s".into(),
+                },
+            ),
+            (
+                "doc.merge",
+                Operation::DocMerge {
+                    path: "f".into(),
+                    value: serde_json::json!({}),
+                },
+            ),
+            (
+                "doc.append",
+                Operation::DocAppend {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!([]),
+                },
+            ),
+            (
+                "doc.prepend",
+                Operation::DocPrepend {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!([]),
+                },
+            ),
+            (
+                "doc.update",
+                Operation::DocUpdate {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!({}),
+                },
+            ),
+            (
+                "doc.move",
+                Operation::DocMove {
+                    path: "f".into(),
+                    from: "a".into(),
+                    to: "b".into(),
+                },
+            ),
+            (
+                "doc.ensure",
+                Operation::DocEnsure {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    value: serde_json::json!(1),
+                },
+            ),
+            (
+                "doc.delete_where",
+                Operation::DocDeleteWhere {
+                    path: "f".into(),
+                    selector: "s".into(),
+                    predicate: "p".into(),
+                },
+            ),
+            (
+                "md.replace_section",
+                Operation::MdReplaceSection {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    content: "c".into(),
+                },
+            ),
+            (
+                "md.insert_after_heading",
+                Operation::MdInsertAfterHeading {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    content: "c".into(),
+                },
+            ),
+            (
+                "md.insert_before_heading",
+                Operation::MdInsertBeforeHeading {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    content: "c".into(),
+                },
+            ),
+            (
+                "md.upsert_bullet",
+                Operation::MdUpsertBullet {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    bullet: "b".into(),
+                },
+            ),
+            (
+                "md.table_append",
+                Operation::MdTableAppend {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    row: "r".into(),
+                },
+            ),
+            (
+                "md.move_section",
+                Operation::MdMoveSection {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    to: None,
+                    before: None,
+                    after: None,
+                },
+            ),
+            (
+                "md.dedupe_headings",
+                Operation::MdDedupeHeadings { path: "f".into() },
+            ),
+            (
+                "md.lint_agents",
+                Operation::MdLintAgents { path: "f".into() },
+            ),
+            (
+                "patch.apply",
+                Operation::PatchApply {
+                    diff: "d".into(),
+                    on_stale: Default::default(),
+                    allow_conflicts: false,
+                },
+            ),
+            (
+                "search",
+                Operation::Search {
+                    path: "f".into(),
+                    pattern: "p".into(),
+                    regex: false,
+                    case_insensitive: false,
+                    multiline: false,
+                    invert_match: false,
+                    context: None,
+                    before_context: None,
+                    after_context: None,
+                    assert_count: None,
+                    literal: false,
+                    globs: vec![],
+                    max_results: 0,
+                    exclude_patterns: vec![],
+                    custom_ignore_filenames: vec![],
+                },
+            ),
+            (
+                "read",
+                Operation::Read {
+                    path: "f".into(),
+                    lines: None,
+                },
+            ),
+        ];
+
+        #[cfg(feature = "ast")]
+        {
+            ops.push((
+                "ast.rename",
+                Operation::AstRename {
+                    path: "f.rs".into(),
+                    old_name: "old".into(),
+                    new_name: "new".into(),
+                    lang: None,
+                },
+            ));
+            ops.push((
+                "ast.replace",
+                Operation::AstReplace {
+                    path: "f.rs".into(),
+                    symbol: "s".into(),
+                    from: "a".into(),
+                    to: "b".into(),
+                    regex: false,
+                    lang: None,
+                },
+            ));
+        }
+
+        let schemas = operation_schemas();
+        let schema_map: std::collections::HashMap<&str, &OperationSchema> =
+            schemas.iter().map(|s| (s.name.as_str(), s)).collect();
+
+        let mut missing: Vec<String> = Vec::new();
+
+        for (op_name, op_value) in &ops {
+            let schema = match schema_map.get(op_name) {
+                Some(s) => s,
+                None => {
+                    missing.push(format!("{op_name}: no schema found"));
+                    continue;
+                }
+            };
+            let props = schema
+                .parameters
+                .get("properties")
+                .and_then(|v| v.as_object())
+                .unwrap_or_else(|| {
+                    panic!("schema {op_name}: parameters.properties is not an object")
+                });
+
+            // Serialize the Operation to get its field names.
+            let serialized = serde_json::to_value(op_value).unwrap();
+            let obj = serialized.as_object().unwrap();
+            for key in obj.keys() {
+                if key == "op" {
+                    continue; // tag field, not a parameter
+                }
+                if !props.contains_key(key) {
+                    missing.push(format!(
+                        "{op_name}: plan.rs field '{key}' missing from schema properties"
+                    ));
+                }
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "schema/plan drift detected:\n  {}",
+            missing.join("\n  ")
+        );
+    }
+}
+
+mod error_handling {
+    use super::*;
+
+    #[test]
+    fn tier_parse_invalid() {
+        assert!("unknown".parse::<Tier>().is_err());
+    }
 }
 
 // Static assertion: types must be Send + Sync.

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -3,654 +3,670 @@ use super::*;
 use crate::cli::global::GlobalFlags;
 use std::fs;
 
-#[test]
-fn ensure_final_newline_adds_when_missing() {
-    assert_eq!(ensure_final_newline("hello", EolMode::Keep), "hello\n");
-}
-
-#[test]
-fn ensure_final_newline_empty_stays_empty() {
-    assert_eq!(ensure_final_newline("", EolMode::Keep), "");
-}
-
-#[test]
-fn ensure_final_newline_no_double_add() {
-    assert_eq!(ensure_final_newline("hello\n", EolMode::Keep), "hello\n");
-}
-
-#[test]
-fn ensure_final_newline_cr_mode_appends_cr() {
-    assert_eq!(ensure_final_newline("hello\r", EolMode::Cr), "hello\r");
-    assert_eq!(ensure_final_newline("hello", EolMode::Cr), "hello\r");
-}
-
-#[test]
-fn ensure_final_newline_cr_mode_does_not_append_lf() {
-    // Content ending with \r should NOT get a \n appended
-    let result = ensure_final_newline("line1\rline2\r", EolMode::Cr);
-    assert!(result.ends_with('\r'));
-    assert!(!result.ends_with('\n'));
-}
-
-#[test]
-fn ensure_final_newline_crlf_mode_appends_crlf() {
-    assert_eq!(
-        ensure_final_newline("hello\r\n", EolMode::Crlf),
-        "hello\r\n"
-    );
-    assert_eq!(ensure_final_newline("hello", EolMode::Crlf), "hello\r\n");
-}
-
-#[test]
-fn ensure_final_newline_crlf_mode_bare_lf_gets_crlf() {
-    // Content ending with bare \n should get \r\n appended (not kept as-is)
-    assert_eq!(
-        ensure_final_newline("hello\n", EolMode::Crlf),
-        "hello\n\r\n"
-    );
-}
-
-#[test]
-fn ensure_final_newline_lf_mode_unchanged() {
-    assert_eq!(ensure_final_newline("hello", EolMode::Lf), "hello\n");
-    assert_eq!(ensure_final_newline("hello\n", EolMode::Lf), "hello\n");
-}
-
-#[test]
-fn normalize_eol_lf_converts_crlf() {
-    assert_eq!(normalize_eol("a\r\nb\r\n", EolMode::Lf), "a\nb\n");
-}
-
-#[test]
-fn normalize_eol_crlf_converts_lf() {
-    assert_eq!(normalize_eol("a\nb\n", EolMode::Crlf), "a\r\nb\r\n");
-}
-
-#[test]
-fn normalize_eol_crlf_bare_lf_at_position_zero() {
-    // Exercises the `i == 0` branch in the memchr single-pass scan.
-    assert_eq!(normalize_eol("\na\n", EolMode::Crlf), "\r\na\r\n");
-}
-
-#[test]
-fn normalize_eol_crlf_mixed_content() {
-    // Some lines already CRLF, some bare LF — only bare LFs get \r.
-    assert_eq!(
-        normalize_eol("a\r\nb\nc\r\n", EolMode::Crlf),
-        "a\r\nb\r\nc\r\n"
-    );
-}
-
-#[test]
-fn normalize_eol_crlf_already_correct_returns_borrowed() {
-    use std::borrow::Cow;
-    let content = "a\r\nb\r\n";
-    let result = normalize_eol(content, EolMode::Crlf);
-    assert!(
-        matches!(result, Cow::Borrowed(_)),
-        "all-CRLF content should return Cow::Borrowed"
-    );
-}
-
-#[test]
-fn normalize_eol_keep_unchanged() {
-    let content = "a\r\nb\nc\n";
-    assert_eq!(normalize_eol(content, EolMode::Keep), content);
-}
-
-#[test]
-fn normalize_eol_cr_converts_lf() {
-    assert_eq!(normalize_eol("a\nb\n", EolMode::Cr), "a\rb\r");
-}
-
-#[test]
-fn normalize_eol_cr_converts_crlf() {
-    assert_eq!(normalize_eol("a\r\nb\r\n", EolMode::Cr), "a\rb\r");
-}
-
-#[test]
-fn normalize_eol_cr_mixed_input() {
-    assert_eq!(normalize_eol("a\r\nb\nc\r\n", EolMode::Cr), "a\rb\rc\r");
-}
-
-#[test]
-fn normalize_eol_cr_already_correct_returns_borrowed() {
-    use std::borrow::Cow;
-    let content = "a\rb\r";
-    let result = normalize_eol(content, EolMode::Cr);
-    assert!(
-        matches!(result, Cow::Borrowed(_)),
-        "all-CR content should return Cow::Borrowed"
-    );
-}
-
-#[test]
-fn normalize_eol_lf_also_strips_bare_cr() {
-    // LF mode should convert both \r\n and bare \r to \n.
-    assert_eq!(normalize_eol("a\rb\r\nc\n", EolMode::Lf), "a\nb\nc\n");
-}
-
-#[test]
-fn normalize_eol_crlf_converts_bare_cr() {
-    // Bare \r (classic Mac) should become \r\n.
-    assert_eq!(normalize_eol("a\rb\r", EolMode::Crlf), "a\r\nb\r\n");
-}
-
-#[test]
-fn normalize_eol_crlf_mixed_with_bare_cr() {
-    // Mix of bare \r, \r\n, and bare \n should all become \r\n.
-    assert_eq!(
-        normalize_eol("a\rb\r\nc\n", EolMode::Crlf),
-        "a\r\nb\r\nc\r\n"
-    );
-}
-
-#[test]
-fn parse_eol_mode_cr() {
-    assert!(matches!(parse_eol_mode("cr").unwrap(), EolMode::Cr));
-}
-
-#[test]
-fn trim_trailing_whitespace_removes_spaces() {
-    let result = trim_trailing_whitespace("hello   \nworld\t\n");
-    assert_eq!(result, "hello\nworld\n");
-    assert!(
-        matches!(result, std::borrow::Cow::Owned(_)),
-        "trimmed content should be Cow::Owned"
-    );
-}
-
-#[test]
-fn trim_trailing_whitespace_clean_returns_borrowed() {
-    let result = trim_trailing_whitespace("hello\nworld\n");
-    assert_eq!(result, "hello\nworld\n");
-    assert!(
-        matches!(result, std::borrow::Cow::Borrowed(_)),
-        "clean content should return Cow::Borrowed, not allocate"
-    );
-}
-
-#[test]
-fn noop_policy_returns_borrowed() {
-    let policy = WritePolicy::default();
-    let input = "hello\nworld\n";
-    let result = apply_policy(input, &policy);
-    assert!(
-        matches!(result, std::borrow::Cow::Borrowed(_)),
-        "no-op policy should return Cow::Borrowed"
-    );
-    assert_eq!(&*result, input);
-}
-
-#[test]
-fn apply_policy_chains_all() {
-    let policy = WritePolicy {
-        trim_trailing_whitespace: true,
-        normalize_eol: EolMode::Lf,
-        ensure_final_newline: true,
-        ..Default::default()
-    };
-    // Trailing whitespace, CRLF endings, no final newline.
-    let input = "hello  \r\nworld\t\r\n";
-    let result = apply_policy(input, &policy);
-    // After trim: "hello\r\nworld\r\n"
-    // After LF:   "hello\nworld\n"
-    // After final newline: already ends with \n → unchanged.
-    assert_eq!(result, "hello\nworld\n");
-}
-
-#[test]
-fn atomic_write_writes_correct_content() {
-    let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("output.txt");
-
-    let policy = WritePolicy {
-        ensure_final_newline: true,
-        normalize_eol: EolMode::Lf,
-        trim_trailing_whitespace: true,
-        ..Default::default()
-    };
-
-    atomic_write(&target, "foo  \r\nbar", &policy).unwrap();
-
-    let got = fs::read_to_string(&target).unwrap();
-    assert_eq!(got, "foo\nbar\n");
-}
-
 #[cfg(feature = "cli")]
 fn test_global_flags() -> GlobalFlags {
     GlobalFlags::test_default()
 }
 
-#[test]
-#[cfg(feature = "cli")]
-fn policy_from_flags_explicit_flags_win() {
-    let dir = tempfile::tempdir().unwrap();
-    let ec_path = dir.path().join(".editorconfig");
-    fs::write(
-        &ec_path,
-        "root = true\n\n[*]\ninsert_final_newline = false\nend_of_line = crlf\ntrim_trailing_whitespace = false\n",
-    )
-    .unwrap();
+mod basic {
+    use super::*;
 
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "content\n").unwrap();
+    #[test]
+    fn ensure_final_newline_adds_when_missing() {
+        assert_eq!(ensure_final_newline("hello", EolMode::Keep), "hello\n");
+    }
 
-    let mut global = test_global_flags();
-    global.respect_editorconfig = true;
-    global.ensure_final_newline = true;
-    global.normalize_eol = Some(EolMode::Lf);
-    global.trim_trailing_whitespace = true;
+    #[test]
+    fn parse_eol_mode_cr() {
+        assert!(matches!(parse_eol_mode("cr").unwrap(), EolMode::Cr));
+    }
 
-    let policy = policy_from_flags(&global, Some(&file));
-    // Explicit flags should win over EditorConfig values.
-    assert!(policy.ensure_final_newline);
-    assert!(matches!(policy.normalize_eol, EolMode::Lf));
-    assert!(policy.trim_trailing_whitespace);
+    #[test]
+    fn trim_trailing_whitespace_removes_spaces() {
+        let result = trim_trailing_whitespace("hello   \nworld\t\n");
+        assert_eq!(result, "hello\nworld\n");
+        assert!(
+            matches!(result, std::borrow::Cow::Owned(_)),
+            "trimmed content should be Cow::Owned"
+        );
+    }
+
+    #[test]
+    fn trim_trailing_whitespace_clean_returns_borrowed() {
+        let result = trim_trailing_whitespace("hello\nworld\n");
+        assert_eq!(result, "hello\nworld\n");
+        assert!(
+            matches!(result, std::borrow::Cow::Borrowed(_)),
+            "clean content should return Cow::Borrowed, not allocate"
+        );
+    }
+
+    #[test]
+    fn noop_policy_returns_borrowed() {
+        let policy = WritePolicy::default();
+        let input = "hello\nworld\n";
+        let result = apply_policy(input, &policy);
+        assert!(
+            matches!(result, std::borrow::Cow::Borrowed(_)),
+            "no-op policy should return Cow::Borrowed"
+        );
+        assert_eq!(&*result, input);
+    }
+
+    #[test]
+    fn apply_policy_chains_all() {
+        let policy = WritePolicy {
+            trim_trailing_whitespace: true,
+            normalize_eol: EolMode::Lf,
+            ensure_final_newline: true,
+            ..Default::default()
+        };
+        // Trailing whitespace, CRLF endings, no final newline.
+        let input = "hello  \r\nworld\t\r\n";
+        let result = apply_policy(input, &policy);
+        // After trim: "hello\r\nworld\r\n"
+        // After LF:   "hello\nworld\n"
+        // After final newline: already ends with \n → unchanged.
+        assert_eq!(result, "hello\nworld\n");
+    }
+
+    #[test]
+    fn atomic_write_writes_correct_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("output.txt");
+
+        let policy = WritePolicy {
+            ensure_final_newline: true,
+            normalize_eol: EolMode::Lf,
+            trim_trailing_whitespace: true,
+            ..Default::default()
+        };
+
+        atomic_write(&target, "foo  \r\nbar", &policy).unwrap();
+
+        let got = fs::read_to_string(&target).unwrap();
+        assert_eq!(got, "foo\nbar\n");
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn policy_from_flags_explicit_flags_win() {
+        let dir = tempfile::tempdir().unwrap();
+        let ec_path = dir.path().join(".editorconfig");
+        fs::write(
+            &ec_path,
+            "root = true\n\n[*]\ninsert_final_newline = false\nend_of_line = crlf\ntrim_trailing_whitespace = false\n",
+        )
+        .unwrap();
+
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "content\n").unwrap();
+
+        let mut global = test_global_flags();
+        global.respect_editorconfig = true;
+        global.ensure_final_newline = true;
+        global.normalize_eol = Some(EolMode::Lf);
+        global.trim_trailing_whitespace = true;
+
+        let policy = policy_from_flags(&global, Some(&file));
+        // Explicit flags should win over EditorConfig values.
+        assert!(policy.ensure_final_newline);
+        assert!(matches!(policy.normalize_eol, EolMode::Lf));
+        assert!(policy.trim_trailing_whitespace);
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn policy_from_flags_editorconfig_provides_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let ec_path = dir.path().join(".editorconfig");
+        fs::write(
+            &ec_path,
+            "root = true\n\n[*]\ninsert_final_newline = true\nend_of_line = lf\ntrim_trailing_whitespace = true\n",
+        )
+        .unwrap();
+
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "content\n").unwrap();
+
+        let mut global = test_global_flags();
+        global.respect_editorconfig = true;
+
+        let policy = policy_from_flags(&global, Some(&file));
+        assert!(policy.ensure_final_newline);
+        assert!(matches!(policy.normalize_eol, EolMode::Lf));
+        assert!(policy.trim_trailing_whitespace);
+    }
+
+    #[test]
+    fn noop_policy_detected() {
+        assert!(WritePolicy::default().is_noop());
+    }
+
+    #[test]
+    fn non_noop_policy_detected() {
+        let p = WritePolicy {
+            ensure_final_newline: true,
+            ..Default::default()
+        };
+        assert!(!p.is_noop());
+
+        let p2 = WritePolicy {
+            normalize_eol: EolMode::Lf,
+            ..Default::default()
+        };
+        assert!(!p2.is_noop());
+
+        let p3 = WritePolicy {
+            trim_trailing_whitespace: true,
+            ..Default::default()
+        };
+        assert!(!p3.is_noop());
+    }
+
+    #[test]
+    fn atomic_create_new_writes_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("new.txt");
+
+        let policy = WritePolicy {
+            ensure_final_newline: true,
+            normalize_eol: EolMode::Lf,
+            trim_trailing_whitespace: false,
+            ..Default::default()
+        };
+
+        atomic_create_new(&target, "hello", &policy).unwrap();
+        let got = fs::read_to_string(&target).unwrap();
+        assert_eq!(got, "hello\n");
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn policy_from_flags_no_editorconfig_uses_defaults() {
+        let global = test_global_flags();
+
+        let policy = policy_from_flags(&global, None);
+        assert!(!policy.ensure_final_newline);
+        assert!(matches!(policy.normalize_eol, EolMode::Keep));
+        assert!(!policy.trim_trailing_whitespace);
+    }
+
+    #[test]
+    fn collapse_blanks_reduces_consecutive_blanks() {
+        let input = "line1\n\n\n\nline2\n\n\nline3\n";
+        let result = collapse_blanks(input);
+        assert_eq!(result, "line1\n\nline2\n\nline3\n");
+    }
+
+    #[test]
+    fn collapse_blanks_no_change_returns_borrowed() {
+        let input = "line1\n\nline2\nline3\n";
+        let result = collapse_blanks(input);
+        assert_eq!(result, input);
+        assert!(
+            matches!(result, std::borrow::Cow::Borrowed(_)),
+            "no-change should return Cow::Borrowed"
+        );
+    }
+
+    #[test]
+    fn apply_policy_collapse_blanks() {
+        let policy = WritePolicy {
+            collapse_blanks: true,
+            ..Default::default()
+        };
+        let input = "a\n\n\nb\n";
+        let result = apply_policy(input, &policy);
+        assert_eq!(result, "a\n\nb\n");
+    }
+
+    #[test]
+    fn write_policy_override_full() {
+        let mut policy = WritePolicy::default();
+        let ov = WritePolicyOverride {
+            ensure_final_newline: Some(true),
+            normalize_eol: Some("lf".to_string()),
+            trim_trailing_whitespace: Some(true),
+            collapse_blanks: Some(true),
+            respect_editorconfig: Some(true),
+        };
+        policy.apply_override(&ov).unwrap();
+        assert!(policy.ensure_final_newline);
+        assert!(matches!(policy.normalize_eol, EolMode::Lf));
+        assert!(policy.trim_trailing_whitespace);
+        assert!(policy.collapse_blanks);
+    }
+
+    #[test]
+    fn write_policy_override_partial() {
+        let mut policy = WritePolicy::default();
+        let ov = WritePolicyOverride {
+            ensure_final_newline: Some(true),
+            ..Default::default()
+        };
+        policy.apply_override(&ov).unwrap();
+        assert!(policy.ensure_final_newline);
+        // Other fields stay at defaults.
+        assert!(matches!(policy.normalize_eol, EolMode::Keep));
+        assert!(!policy.trim_trailing_whitespace);
+        assert!(!policy.collapse_blanks);
+    }
+
+    #[test]
+    fn write_policy_override_lf() {
+        let mut policy = WritePolicy::default();
+        let ov = WritePolicyOverride {
+            normalize_eol: Some("lf".to_string()),
+            ..Default::default()
+        };
+        policy.apply_override(&ov).unwrap();
+        assert!(matches!(policy.normalize_eol, EolMode::Lf));
+    }
+
+    #[test]
+    fn write_policy_override_crlf() {
+        let mut policy = WritePolicy::default();
+        let ov = WritePolicyOverride {
+            normalize_eol: Some("crlf".to_string()),
+            ..Default::default()
+        };
+        policy.apply_override(&ov).unwrap();
+        assert!(matches!(policy.normalize_eol, EolMode::Crlf));
+    }
+
+    #[test]
+    fn write_policy_override_cr() {
+        let mut policy = WritePolicy::default();
+        let ov = WritePolicyOverride {
+            normalize_eol: Some("cr".to_string()),
+            ..Default::default()
+        };
+        policy.apply_override(&ov).unwrap();
+        assert!(matches!(policy.normalize_eol, EolMode::Cr));
+    }
 }
 
-#[test]
-#[cfg(feature = "cli")]
-fn policy_from_flags_editorconfig_provides_defaults() {
-    let dir = tempfile::tempdir().unwrap();
-    let ec_path = dir.path().join(".editorconfig");
-    fs::write(
-        &ec_path,
-        "root = true\n\n[*]\ninsert_final_newline = true\nend_of_line = lf\ntrim_trailing_whitespace = true\n",
-    )
-    .unwrap();
+mod line_endings {
+    use super::*;
 
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "content\n").unwrap();
+    #[test]
+    fn ensure_final_newline_cr_mode_appends_cr() {
+        assert_eq!(ensure_final_newline("hello\r", EolMode::Cr), "hello\r");
+        assert_eq!(ensure_final_newline("hello", EolMode::Cr), "hello\r");
+    }
 
-    let mut global = test_global_flags();
-    global.respect_editorconfig = true;
+    #[test]
+    fn ensure_final_newline_cr_mode_does_not_append_lf() {
+        // Content ending with \r should NOT get a \n appended
+        let result = ensure_final_newline("line1\rline2\r", EolMode::Cr);
+        assert!(result.ends_with('\r'));
+        assert!(!result.ends_with('\n'));
+    }
 
-    let policy = policy_from_flags(&global, Some(&file));
-    assert!(policy.ensure_final_newline);
-    assert!(matches!(policy.normalize_eol, EolMode::Lf));
-    assert!(policy.trim_trailing_whitespace);
+    #[test]
+    fn ensure_final_newline_crlf_mode_appends_crlf() {
+        assert_eq!(
+            ensure_final_newline("hello\r\n", EolMode::Crlf),
+            "hello\r\n"
+        );
+        assert_eq!(ensure_final_newline("hello", EolMode::Crlf), "hello\r\n");
+    }
+
+    #[test]
+    fn ensure_final_newline_crlf_mode_bare_lf_gets_crlf() {
+        // Content ending with bare \n should get \r\n appended (not kept as-is)
+        assert_eq!(
+            ensure_final_newline("hello\n", EolMode::Crlf),
+            "hello\n\r\n"
+        );
+    }
+
+    #[test]
+    fn ensure_final_newline_lf_mode_unchanged() {
+        assert_eq!(ensure_final_newline("hello", EolMode::Lf), "hello\n");
+        assert_eq!(ensure_final_newline("hello\n", EolMode::Lf), "hello\n");
+    }
+
+    #[test]
+    fn normalize_eol_lf_converts_crlf() {
+        assert_eq!(normalize_eol("a\r\nb\r\n", EolMode::Lf), "a\nb\n");
+    }
+
+    #[test]
+    fn normalize_eol_crlf_converts_lf() {
+        assert_eq!(normalize_eol("a\nb\n", EolMode::Crlf), "a\r\nb\r\n");
+    }
+
+    #[test]
+    fn normalize_eol_crlf_bare_lf_at_position_zero() {
+        // Exercises the `i == 0` branch in the memchr single-pass scan.
+        assert_eq!(normalize_eol("\na\n", EolMode::Crlf), "\r\na\r\n");
+    }
+
+    #[test]
+    fn normalize_eol_crlf_mixed_content() {
+        // Some lines already CRLF, some bare LF — only bare LFs get \r.
+        assert_eq!(
+            normalize_eol("a\r\nb\nc\r\n", EolMode::Crlf),
+            "a\r\nb\r\nc\r\n"
+        );
+    }
+
+    #[test]
+    fn normalize_eol_crlf_already_correct_returns_borrowed() {
+        use std::borrow::Cow;
+        let content = "a\r\nb\r\n";
+        let result = normalize_eol(content, EolMode::Crlf);
+        assert!(
+            matches!(result, Cow::Borrowed(_)),
+            "all-CRLF content should return Cow::Borrowed"
+        );
+    }
+
+    #[test]
+    fn normalize_eol_keep_unchanged() {
+        let content = "a\r\nb\nc\n";
+        assert_eq!(normalize_eol(content, EolMode::Keep), content);
+    }
+
+    #[test]
+    fn normalize_eol_cr_converts_lf() {
+        assert_eq!(normalize_eol("a\nb\n", EolMode::Cr), "a\rb\r");
+    }
+
+    #[test]
+    fn normalize_eol_cr_converts_crlf() {
+        assert_eq!(normalize_eol("a\r\nb\r\n", EolMode::Cr), "a\rb\r");
+    }
+
+    #[test]
+    fn normalize_eol_cr_mixed_input() {
+        assert_eq!(normalize_eol("a\r\nb\nc\r\n", EolMode::Cr), "a\rb\rc\r");
+    }
+
+    #[test]
+    fn normalize_eol_cr_already_correct_returns_borrowed() {
+        use std::borrow::Cow;
+        let content = "a\rb\r";
+        let result = normalize_eol(content, EolMode::Cr);
+        assert!(
+            matches!(result, Cow::Borrowed(_)),
+            "all-CR content should return Cow::Borrowed"
+        );
+    }
+
+    #[test]
+    fn normalize_eol_lf_also_strips_bare_cr() {
+        // LF mode should convert both \r\n and bare \r to \n.
+        assert_eq!(normalize_eol("a\rb\r\nc\n", EolMode::Lf), "a\nb\nc\n");
+    }
+
+    #[test]
+    fn normalize_eol_crlf_converts_bare_cr() {
+        // Bare \r (classic Mac) should become \r\n.
+        assert_eq!(normalize_eol("a\rb\r", EolMode::Crlf), "a\r\nb\r\n");
+    }
+
+    #[test]
+    fn normalize_eol_crlf_mixed_with_bare_cr() {
+        // Mix of bare \r, \r\n, and bare \n should all become \r\n.
+        assert_eq!(
+            normalize_eol("a\rb\r\nc\n", EolMode::Crlf),
+            "a\r\nb\r\nc\r\n"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn policy_from_flags_editorconfig_cr() {
+        let dir = tempfile::tempdir().unwrap();
+        let ec_path = dir.path().join(".editorconfig");
+        fs::write(&ec_path, "root = true\n\n[*]\nend_of_line = cr\n").unwrap();
+
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "content\n").unwrap();
+
+        let mut global = test_global_flags();
+        global.respect_editorconfig = true;
+
+        let policy = policy_from_flags(&global, Some(&file));
+        assert!(
+            matches!(policy.normalize_eol, EolMode::Cr),
+            "end_of_line = cr should map to EolMode::Cr"
+        );
+    }
+
+    #[test]
+    fn trim_trailing_whitespace_crlf_endings() {
+        let result = trim_trailing_whitespace("hello  \r\nworld\t\r\n");
+        assert_eq!(result, "hello\r\nworld\r\n");
+    }
+
+    #[test]
+    fn trim_trailing_whitespace_cr_endings() {
+        let result = trim_trailing_whitespace("hello   \rworld\t\r");
+        assert_eq!(result, "hello\rworld\r");
+        assert!(matches!(result, std::borrow::Cow::Owned(_)));
+    }
+
+    #[test]
+    fn trim_trailing_whitespace_cr_clean_returns_borrowed() {
+        let result = trim_trailing_whitespace("hello\rworld\r");
+        assert_eq!(result, "hello\rworld\r");
+        assert!(
+            matches!(result, std::borrow::Cow::Borrowed(_)),
+            "clean CR content should return Cow::Borrowed"
+        );
+    }
+
+    #[test]
+    fn trim_trailing_whitespace_cr_mixed_whitespace() {
+        // Tabs and spaces before CR endings.
+        let result = trim_trailing_whitespace("a \t\rb  \r");
+        assert_eq!(result, "a\rb\r");
+    }
+
+    #[test]
+    fn trim_trailing_whitespace_cr_no_trailing_newline() {
+        // Last line with trailing whitespace, no line ending.
+        let result = trim_trailing_whitespace("hello\rworld  ");
+        assert_eq!(result, "hello\rworld");
+    }
+
+    #[test]
+    fn collapse_blanks_cr_endings() {
+        let input = "line1\r\r\r\rline2\r\r\rline3\r";
+        let result = collapse_blanks(input);
+        assert_eq!(result, "line1\r\rline2\r\rline3\r");
+    }
+
+    #[test]
+    fn collapse_blanks_cr_no_change_returns_borrowed() {
+        let input = "line1\r\rline2\rline3\r";
+        let result = collapse_blanks(input);
+        assert_eq!(result, input);
+        assert!(
+            matches!(result, std::borrow::Cow::Borrowed(_)),
+            "no-change CR content should return Cow::Borrowed"
+        );
+    }
+
+    #[test]
+    fn collapse_blanks_crlf_endings() {
+        let input = "line1\r\n\r\n\r\n\r\nline2\r\n";
+        let result = collapse_blanks(input);
+        assert_eq!(result, "line1\r\n\r\nline2\r\n");
+    }
+
+    #[test]
+    fn collapse_blanks_cr_whitespace_only_lines_are_blank() {
+        let input = "line1\r  \r\t\r\rline2\r";
+        let result = collapse_blanks(input);
+        // "  " and "\t" and "" are all blank; three consecutive blanks become one.
+        assert_eq!(result, "line1\r  \rline2\r");
+    }
+
+    #[test]
+    fn apply_policy_cr_mode_final_newline_is_cr() {
+        let policy = WritePolicy {
+            ensure_final_newline: true,
+            normalize_eol: EolMode::Cr,
+            ..Default::default()
+        };
+        // Content without a trailing newline: should get \r appended.
+        let result = apply_policy("hello", &policy);
+        assert_eq!(result, "hello\r");
+        assert!(!result.ends_with('\n'), "CR mode must not append \\n");
+    }
+
+    #[test]
+    fn apply_policy_crlf_mode_final_newline_is_crlf() {
+        let policy = WritePolicy {
+            ensure_final_newline: true,
+            normalize_eol: EolMode::Crlf,
+            ..Default::default()
+        };
+        let result = apply_policy("hello", &policy);
+        assert_eq!(result, "hello\r\n");
+    }
+
+    #[test]
+    fn apply_policy_cr_mode_multiline_final_newline() {
+        let policy = WritePolicy {
+            ensure_final_newline: true,
+            normalize_eol: EolMode::Cr,
+            ..Default::default()
+        };
+        // Input has LF line endings; normalize converts to CR, then final \r appended.
+        let result = apply_policy("a\nb", &policy);
+        assert_eq!(result, "a\rb\r");
+    }
+
+    #[test]
+    fn apply_policy_cr_mode_collapse_blanks() {
+        let policy = WritePolicy {
+            collapse_blanks: true,
+            normalize_eol: EolMode::Cr,
+            ..Default::default()
+        };
+        // Input with LF endings; after normalize_eol they become CR.
+        // Then collapse_blanks must still detect and collapse consecutive blank lines.
+        let input = "a\n\n\nb\n";
+        let result = apply_policy(input, &policy);
+        assert_eq!(result, "a\r\rb\r");
+    }
+
+    #[test]
+    fn apply_policy_cr_mode_trim_and_collapse() {
+        let policy = WritePolicy {
+            trim_trailing_whitespace: true,
+            collapse_blanks: true,
+            normalize_eol: EolMode::Cr,
+            ensure_final_newline: true,
+        };
+        // Full pipeline: trim trailing ws, normalize to CR, collapse blanks, ensure final \r.
+        let input = "hello  \n\n\nworld\t\n";
+        let result = apply_policy(input, &policy);
+        // After trim: "hello\n\n\nworld\n"
+        // After CR normalize: "hello\r\r\rworld\r"
+        // After collapse: "hello\r\rworld\r"
+        // After final newline: already ends with \r
+        assert_eq!(result, "hello\r\rworld\r");
+    }
 }
 
-#[test]
-#[cfg(feature = "cli")]
-fn policy_from_flags_editorconfig_cr() {
-    let dir = tempfile::tempdir().unwrap();
-    let ec_path = dir.path().join(".editorconfig");
-    fs::write(&ec_path, "root = true\n\n[*]\nend_of_line = cr\n").unwrap();
+mod edge_cases {
+    use super::*;
 
-    let file = dir.path().join("test.txt");
-    fs::write(&file, "content\n").unwrap();
+    #[test]
+    fn ensure_final_newline_empty_stays_empty() {
+        assert_eq!(ensure_final_newline("", EolMode::Keep), "");
+    }
 
-    let mut global = test_global_flags();
-    global.respect_editorconfig = true;
+    #[test]
+    fn ensure_final_newline_no_double_add() {
+        assert_eq!(ensure_final_newline("hello\n", EolMode::Keep), "hello\n");
+    }
 
-    let policy = policy_from_flags(&global, Some(&file));
-    assert!(
-        matches!(policy.normalize_eol, EolMode::Cr),
-        "end_of_line = cr should map to EolMode::Cr"
-    );
+    #[test]
+    fn trim_trailing_whitespace_eof_without_newline() {
+        let result = trim_trailing_whitespace("hello  ");
+        assert_eq!(result, "hello");
+    }
+
+    #[test]
+    fn collapse_blanks_whitespace_only_lines_are_blank() {
+        let input = "line1\n  \n\t\n\nline2\n";
+        let result = collapse_blanks(input);
+        // "  " and "\t" and "" are all blank; three consecutive blanks become one.
+        assert_eq!(result, "line1\n  \nline2\n");
+    }
+
+    #[test]
+    fn collapse_blanks_no_blanks() {
+        let input = "line1\nline2\nline3\n";
+        let result = collapse_blanks(input);
+        assert_eq!(result, input);
+    }
 }
 
-#[test]
-#[cfg(unix)]
-fn atomic_write_preserves_file_permissions() {
-    use std::os::unix::fs::PermissionsExt;
+mod error_handling {
+    use super::*;
 
-    let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("script.sh");
-    fs::write(&target, "#!/bin/sh\necho old\n").unwrap();
+    #[test]
+    fn atomic_create_new_fails_if_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("existing.txt");
+        fs::write(&target, "old").unwrap();
 
-    // Set executable permission (0o755).
-    fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let policy = WritePolicy::default();
+        let err = atomic_create_new(&target, "new", &policy).unwrap_err();
+        assert!(
+            err.to_string().contains("already exists"),
+            "error should mention 'already exists': {err}"
+        );
+    }
 
-    let policy = WritePolicy::default();
-    atomic_write(&target, "#!/bin/sh\necho new\n", &policy).unwrap();
-
-    let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
-    assert_eq!(
-        mode, 0o755,
-        "permissions should be preserved after atomic_write"
-    );
+    #[test]
+    fn write_policy_override_invalid_normalize_eol() {
+        let mut policy = WritePolicy::default();
+        let ov = WritePolicyOverride {
+            normalize_eol: Some("invalid".to_string()),
+            ..Default::default()
+        };
+        let err = policy.apply_override(&ov).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid normalize_eol value"),
+            "expected invalid eol error, got: {err}"
+        );
+        // Policy should not have been partially mutated before the error.
+        assert!(matches!(policy.normalize_eol, EolMode::Keep));
+    }
 }
 
-#[test]
-fn trim_trailing_whitespace_crlf_endings() {
-    let result = trim_trailing_whitespace("hello  \r\nworld\t\r\n");
-    assert_eq!(result, "hello\r\nworld\r\n");
-}
+mod format_preservation {
+    use super::*;
 
-#[test]
-fn trim_trailing_whitespace_eof_without_newline() {
-    let result = trim_trailing_whitespace("hello  ");
-    assert_eq!(result, "hello");
-}
+    #[test]
+    #[cfg(unix)]
+    fn atomic_write_preserves_file_permissions() {
+        use std::os::unix::fs::PermissionsExt;
 
-#[test]
-fn noop_policy_detected() {
-    assert!(WritePolicy::default().is_noop());
-}
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("script.sh");
+        fs::write(&target, "#!/bin/sh\necho old\n").unwrap();
 
-#[test]
-fn non_noop_policy_detected() {
-    let p = WritePolicy {
-        ensure_final_newline: true,
-        ..Default::default()
-    };
-    assert!(!p.is_noop());
+        // Set executable permission (0o755).
+        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o755)).unwrap();
 
-    let p2 = WritePolicy {
-        normalize_eol: EolMode::Lf,
-        ..Default::default()
-    };
-    assert!(!p2.is_noop());
+        let policy = WritePolicy::default();
+        atomic_write(&target, "#!/bin/sh\necho new\n", &policy).unwrap();
 
-    let p3 = WritePolicy {
-        trim_trailing_whitespace: true,
-        ..Default::default()
-    };
-    assert!(!p3.is_noop());
-}
-
-#[test]
-fn atomic_create_new_writes_content() {
-    let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("new.txt");
-
-    let policy = WritePolicy {
-        ensure_final_newline: true,
-        normalize_eol: EolMode::Lf,
-        trim_trailing_whitespace: false,
-        ..Default::default()
-    };
-
-    atomic_create_new(&target, "hello", &policy).unwrap();
-    let got = fs::read_to_string(&target).unwrap();
-    assert_eq!(got, "hello\n");
-}
-
-#[test]
-fn atomic_create_new_fails_if_exists() {
-    let dir = tempfile::tempdir().unwrap();
-    let target = dir.path().join("existing.txt");
-    fs::write(&target, "old").unwrap();
-
-    let policy = WritePolicy::default();
-    let err = atomic_create_new(&target, "new", &policy).unwrap_err();
-    assert!(
-        err.to_string().contains("already exists"),
-        "error should mention 'already exists': {err}"
-    );
-}
-
-#[test]
-#[cfg(feature = "cli")]
-fn policy_from_flags_no_editorconfig_uses_defaults() {
-    let global = test_global_flags();
-
-    let policy = policy_from_flags(&global, None);
-    assert!(!policy.ensure_final_newline);
-    assert!(matches!(policy.normalize_eol, EolMode::Keep));
-    assert!(!policy.trim_trailing_whitespace);
-}
-
-#[test]
-fn collapse_blanks_reduces_consecutive_blanks() {
-    let input = "line1\n\n\n\nline2\n\n\nline3\n";
-    let result = collapse_blanks(input);
-    assert_eq!(result, "line1\n\nline2\n\nline3\n");
-}
-
-#[test]
-fn collapse_blanks_no_change_returns_borrowed() {
-    let input = "line1\n\nline2\nline3\n";
-    let result = collapse_blanks(input);
-    assert_eq!(result, input);
-    assert!(
-        matches!(result, std::borrow::Cow::Borrowed(_)),
-        "no-change should return Cow::Borrowed"
-    );
-}
-
-#[test]
-fn collapse_blanks_whitespace_only_lines_are_blank() {
-    let input = "line1\n  \n\t\n\nline2\n";
-    let result = collapse_blanks(input);
-    // "  " and "\t" and "" are all blank; three consecutive blanks become one.
-    assert_eq!(result, "line1\n  \nline2\n");
-}
-
-#[test]
-fn collapse_blanks_no_blanks() {
-    let input = "line1\nline2\nline3\n";
-    let result = collapse_blanks(input);
-    assert_eq!(result, input);
-}
-
-#[test]
-fn apply_policy_collapse_blanks() {
-    let policy = WritePolicy {
-        collapse_blanks: true,
-        ..Default::default()
-    };
-    let input = "a\n\n\nb\n";
-    let result = apply_policy(input, &policy);
-    assert_eq!(result, "a\n\nb\n");
-}
-
-#[test]
-fn apply_policy_cr_mode_final_newline_is_cr() {
-    let policy = WritePolicy {
-        ensure_final_newline: true,
-        normalize_eol: EolMode::Cr,
-        ..Default::default()
-    };
-    // Content without a trailing newline: should get \r appended.
-    let result = apply_policy("hello", &policy);
-    assert_eq!(result, "hello\r");
-    assert!(!result.ends_with('\n'), "CR mode must not append \\n");
-}
-
-#[test]
-fn apply_policy_crlf_mode_final_newline_is_crlf() {
-    let policy = WritePolicy {
-        ensure_final_newline: true,
-        normalize_eol: EolMode::Crlf,
-        ..Default::default()
-    };
-    let result = apply_policy("hello", &policy);
-    assert_eq!(result, "hello\r\n");
-}
-
-#[test]
-fn apply_policy_cr_mode_multiline_final_newline() {
-    let policy = WritePolicy {
-        ensure_final_newline: true,
-        normalize_eol: EolMode::Cr,
-        ..Default::default()
-    };
-    // Input has LF line endings; normalize converts to CR, then final \r appended.
-    let result = apply_policy("a\nb", &policy);
-    assert_eq!(result, "a\rb\r");
-}
-
-// -- WritePolicyOverride tests (#980) -----------------------------------
-
-#[test]
-fn write_policy_override_full() {
-    let mut policy = WritePolicy::default();
-    let ov = WritePolicyOverride {
-        ensure_final_newline: Some(true),
-        normalize_eol: Some("lf".to_string()),
-        trim_trailing_whitespace: Some(true),
-        collapse_blanks: Some(true),
-        respect_editorconfig: Some(true),
-    };
-    policy.apply_override(&ov).unwrap();
-    assert!(policy.ensure_final_newline);
-    assert!(matches!(policy.normalize_eol, EolMode::Lf));
-    assert!(policy.trim_trailing_whitespace);
-    assert!(policy.collapse_blanks);
-}
-
-#[test]
-fn write_policy_override_partial() {
-    let mut policy = WritePolicy::default();
-    let ov = WritePolicyOverride {
-        ensure_final_newline: Some(true),
-        ..Default::default()
-    };
-    policy.apply_override(&ov).unwrap();
-    assert!(policy.ensure_final_newline);
-    // Other fields stay at defaults.
-    assert!(matches!(policy.normalize_eol, EolMode::Keep));
-    assert!(!policy.trim_trailing_whitespace);
-    assert!(!policy.collapse_blanks);
-}
-
-#[test]
-fn write_policy_override_invalid_normalize_eol() {
-    let mut policy = WritePolicy::default();
-    let ov = WritePolicyOverride {
-        normalize_eol: Some("invalid".to_string()),
-        ..Default::default()
-    };
-    let err = policy.apply_override(&ov).unwrap_err();
-    assert!(
-        err.to_string().contains("invalid normalize_eol value"),
-        "expected invalid eol error, got: {err}"
-    );
-    // Policy should not have been partially mutated before the error.
-    assert!(matches!(policy.normalize_eol, EolMode::Keep));
-}
-
-#[test]
-fn write_policy_override_lf() {
-    let mut policy = WritePolicy::default();
-    let ov = WritePolicyOverride {
-        normalize_eol: Some("lf".to_string()),
-        ..Default::default()
-    };
-    policy.apply_override(&ov).unwrap();
-    assert!(matches!(policy.normalize_eol, EolMode::Lf));
-}
-
-#[test]
-fn write_policy_override_crlf() {
-    let mut policy = WritePolicy::default();
-    let ov = WritePolicyOverride {
-        normalize_eol: Some("crlf".to_string()),
-        ..Default::default()
-    };
-    policy.apply_override(&ov).unwrap();
-    assert!(matches!(policy.normalize_eol, EolMode::Crlf));
-}
-
-#[test]
-fn write_policy_override_cr() {
-    let mut policy = WritePolicy::default();
-    let ov = WritePolicyOverride {
-        normalize_eol: Some("cr".to_string()),
-        ..Default::default()
-    };
-    policy.apply_override(&ov).unwrap();
-    assert!(matches!(policy.normalize_eol, EolMode::Cr));
-}
-
-// -- CR line ending support tests (#996) --------------------------------
-
-#[test]
-fn trim_trailing_whitespace_cr_endings() {
-    let result = trim_trailing_whitespace("hello   \rworld\t\r");
-    assert_eq!(result, "hello\rworld\r");
-    assert!(matches!(result, std::borrow::Cow::Owned(_)));
-}
-
-#[test]
-fn trim_trailing_whitespace_cr_clean_returns_borrowed() {
-    let result = trim_trailing_whitespace("hello\rworld\r");
-    assert_eq!(result, "hello\rworld\r");
-    assert!(
-        matches!(result, std::borrow::Cow::Borrowed(_)),
-        "clean CR content should return Cow::Borrowed"
-    );
-}
-
-#[test]
-fn trim_trailing_whitespace_cr_mixed_whitespace() {
-    // Tabs and spaces before CR endings.
-    let result = trim_trailing_whitespace("a \t\rb  \r");
-    assert_eq!(result, "a\rb\r");
-}
-
-#[test]
-fn trim_trailing_whitespace_cr_no_trailing_newline() {
-    // Last line with trailing whitespace, no line ending.
-    let result = trim_trailing_whitespace("hello\rworld  ");
-    assert_eq!(result, "hello\rworld");
-}
-
-#[test]
-fn collapse_blanks_cr_endings() {
-    let input = "line1\r\r\r\rline2\r\r\rline3\r";
-    let result = collapse_blanks(input);
-    assert_eq!(result, "line1\r\rline2\r\rline3\r");
-}
-
-#[test]
-fn collapse_blanks_cr_no_change_returns_borrowed() {
-    let input = "line1\r\rline2\rline3\r";
-    let result = collapse_blanks(input);
-    assert_eq!(result, input);
-    assert!(
-        matches!(result, std::borrow::Cow::Borrowed(_)),
-        "no-change CR content should return Cow::Borrowed"
-    );
-}
-
-#[test]
-fn collapse_blanks_crlf_endings() {
-    let input = "line1\r\n\r\n\r\n\r\nline2\r\n";
-    let result = collapse_blanks(input);
-    assert_eq!(result, "line1\r\n\r\nline2\r\n");
-}
-
-#[test]
-fn collapse_blanks_cr_whitespace_only_lines_are_blank() {
-    let input = "line1\r  \r\t\r\rline2\r";
-    let result = collapse_blanks(input);
-    // "  " and "\t" and "" are all blank; three consecutive blanks become one.
-    assert_eq!(result, "line1\r  \rline2\r");
-}
-
-#[test]
-fn apply_policy_cr_mode_collapse_blanks() {
-    let policy = WritePolicy {
-        collapse_blanks: true,
-        normalize_eol: EolMode::Cr,
-        ..Default::default()
-    };
-    // Input with LF endings; after normalize_eol they become CR.
-    // Then collapse_blanks must still detect and collapse consecutive blank lines.
-    let input = "a\n\n\nb\n";
-    let result = apply_policy(input, &policy);
-    assert_eq!(result, "a\r\rb\r");
-}
-
-#[test]
-fn apply_policy_cr_mode_trim_and_collapse() {
-    let policy = WritePolicy {
-        trim_trailing_whitespace: true,
-        collapse_blanks: true,
-        normalize_eol: EolMode::Cr,
-        ensure_final_newline: true,
-    };
-    // Full pipeline: trim trailing ws, normalize to CR, collapse blanks, ensure final \r.
-    let input = "hello  \n\n\nworld\t\n";
-    let result = apply_policy(input, &policy);
-    // After trim: "hello\n\n\nworld\n"
-    // After CR normalize: "hello\r\r\rworld\r"
-    // After collapse: "hello\r\rworld\r"
-    // After final newline: already ends with \r
-    assert_eq!(result, "hello\r\rworld\r");
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o755,
+            "permissions should be preserved after atomic_write"
+        );
+    }
 }

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -646,6 +646,7 @@ mod error_handling {
 }
 
 mod format_preservation {
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Summary

Reorganizes all 12 companion test files (from PR #1010) into nested modules by concern category, enabling cross-cutting test filters like `cargo test security` (30 tests), `cargo test line_endings` (52 tests), `cargo test edge_cases`, etc.

## Changes

Each test companion file now groups its test functions into nested modules:

| File | Modules |
|------|---------|
| `src/write_tests.rs` | basic(21), line_endings(33), edge_cases(5), error_handling(2), format_preservation(1) |
| `src/ops/replace_tests.rs` | basic(29), line_endings(12), edge_cases(8), error_handling(9) |
| `src/cmd/replace_tests.rs` | basic(16), edge_cases(7), error_handling(4) |
| `src/schema_tests.rs` | basic(21), error_handling(1) |
| `src/ops/doc/tests.rs` | basic(41), edge_cases(23), error_handling(16), security(1), regression(6), format_preservation(24), proptest(5) |
| `src/cmd/doc_tests.rs` | basic(28), edge_cases(7), error_handling(5), security(1) |
| `src/ops/md_tests.rs` | basic(28), line_endings(6), edge_cases(32), error_handling(6), security(9), format_preservation(5), regression(3) |
| `src/cmd/md_tests.rs` | basic(13), edge_cases(3), error_handling(8), security(9), format_preservation(2) |
| `src/ops/patch_tests.rs` | basic(27), edge_cases(12), error_handling(5), format_preservation(4), regression(2) |
| `src/cmd/tx_tests.rs` | basic(19), edge_cases(8), error_handling(13), integrity(12) |
| `src/cmd/batch_tests.rs` | basic(34), edge_cases(2), error_handling(12), security(1) |
| `src/cmd/mcp/tests.rs` | basic(15), security(9), integrity(1) |

### Taxonomy

- **basic**: Core functionality, happy-path behavior
- **line_endings**: CR/LF/CRLF handling and preservation
- **edge_cases**: Empty input, unusual formatting, boundary conditions
- **error_handling**: Invalid input, missing files, parse failures
- **security**: Path traversal, injection, sandbox escapes
- **integrity**: Atomicity, rollback, crash recovery
- **format_preservation**: Round-trip fidelity of structured formats
- **regression**: Tests for specific past bugs
- **proptest**: Property-based / fuzz-style tests

All 2168 tests pass. No behavioral changes.

Closes #1009