### PR TITLE
refactor: consolidate label/needs_doc_flush/declared_paths onto Operation

### DIFF
--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -68,7 +68,7 @@ fn validate_operation_paths(
     )
     .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
     for op in operations {
-        for path in crate::plan::declared_paths(op) {
+        for path in op.declared_paths() {
             guard
                 .check_path(path)
                 .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
@@ -253,7 +253,7 @@ impl PatchloomService {
 
     /// Validate paths for a single operation (including embedded paths for PatchApply).
     fn validate_op_paths(&self, op: &Operation) -> Result<(), McpError> {
-        for declared in crate::plan::declared_paths(op) {
+        for declared in op.declared_paths() {
             self.check_path(declared)?;
         }
         if let Operation::PatchApply { diff, .. } = op {

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -278,6 +278,87 @@ pub enum Operation {
     },
 }
 
+impl Operation {
+    /// Human-readable label for this operation (matches the serde tag name).
+    pub fn label(&self) -> &'static str {
+        match self {
+            Operation::Replace { .. } => "replace",
+            Operation::DocSet { .. } => "doc.set",
+            Operation::DocDelete { .. } => "doc.delete",
+            Operation::DocMerge { .. } => "doc.merge",
+            Operation::DocAppend { .. } => "doc.append",
+            Operation::DocPrepend { .. } => "doc.prepend",
+            Operation::DocUpdate { .. } => "doc.update",
+            Operation::DocMove { .. } => "doc.move",
+            Operation::DocEnsure { .. } => "doc.ensure",
+            Operation::DocDeleteWhere { .. } => "doc.delete_where",
+            Operation::MdReplaceSection { .. } => "md.replace_section",
+            Operation::MdInsertAfterHeading { .. } => "md.insert_after_heading",
+            Operation::MdInsertBeforeHeading { .. } => "md.insert_before_heading",
+            Operation::MdUpsertBullet { .. } => "md.upsert_bullet",
+            Operation::MdTableAppend { .. } => "md.table_append",
+            Operation::MdMoveSection { .. } => "md.move_section",
+            Operation::MdDedupeHeadings { .. } => "md.dedupe_headings",
+            Operation::TidyFix { .. } => "tidy.fix",
+            Operation::FileAppend { .. } => "file.append",
+            Operation::FileCreate { .. } => "file.create",
+            Operation::FileDelete { .. } => "file.delete",
+            Operation::FileRename { .. } => "file.rename",
+            Operation::PatchApply { .. } => "patch.apply",
+            Operation::Read { .. } => "read",
+            Operation::Search { .. } => "search",
+            Operation::MdLintAgents { .. } => "md.lint_agents",
+            #[cfg(feature = "ast")]
+            Operation::AstRename { .. } => "ast.rename",
+            #[cfg(feature = "ast")]
+            Operation::AstReplace { .. } => "ast.replace",
+        }
+    }
+
+    /// Whether this operation requires flushing the doc cache before execution.
+    ///
+    /// Non-doc operations (replace, md, file, patch, read, search, tidy, ast)
+    /// need the doc cache flushed because they read/write files directly and
+    /// would see stale content if doc mutations are still buffered.
+    pub fn needs_doc_flush(&self) -> bool {
+        matches!(
+            self,
+            Operation::Replace { .. }
+                | Operation::MdReplaceSection { .. }
+                | Operation::MdInsertAfterHeading { .. }
+                | Operation::MdInsertBeforeHeading { .. }
+                | Operation::MdUpsertBullet { .. }
+                | Operation::MdTableAppend { .. }
+                | Operation::MdMoveSection { .. }
+                | Operation::MdDedupeHeadings { .. }
+                | Operation::PatchApply { .. }
+                | Operation::FileAppend { .. }
+                | Operation::Read { .. }
+                | Operation::Search { .. }
+                | Operation::MdLintAgents { .. }
+                | Operation::TidyFix { .. }
+        ) || {
+            #[cfg(feature = "ast")]
+            {
+                matches!(
+                    self,
+                    Operation::AstRename { .. } | Operation::AstReplace { .. }
+                )
+            }
+            #[cfg(not(feature = "ast"))]
+            {
+                false
+            }
+        }
+    }
+
+    /// Returns the file paths declared by this operation for containment
+    /// validation. See [`declared_paths`] for details.
+    pub fn declared_paths(&self) -> Vec<&str> {
+        declared_paths(self)
+    }
+}
+
 /// Convert a doc-family `Operation` into a `(path, DocMutation)` pair.
 ///
 /// Returns `None` for non-doc operations. This is the single source of truth

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -275,36 +275,9 @@ pub(crate) use super::search_op::execute_search_op;
 
 /// Returns true if the operation works on raw text and needs any cached
 /// doc values flushed (serialized) back to the pending text map first.
+/// Delegates to [`Operation::needs_doc_flush()`].
 fn op_needs_doc_flush(op: &Operation) -> bool {
-    matches!(
-        op,
-        Operation::Replace { .. }
-            | Operation::MdReplaceSection { .. }
-            | Operation::MdInsertAfterHeading { .. }
-            | Operation::MdInsertBeforeHeading { .. }
-            | Operation::MdUpsertBullet { .. }
-            | Operation::MdTableAppend { .. }
-            | Operation::MdMoveSection { .. }
-            | Operation::MdDedupeHeadings { .. }
-            | Operation::PatchApply { .. }
-            | Operation::FileAppend { .. }
-            | Operation::Read { .. }
-            | Operation::Search { .. }
-            | Operation::MdLintAgents { .. }
-            | Operation::TidyFix { .. }
-    ) || {
-        #[cfg(feature = "ast")]
-        {
-            matches!(
-                op,
-                Operation::AstRename { .. } | Operation::AstReplace { .. }
-            )
-        }
-        #[cfg(not(feature = "ast"))]
-        {
-            false
-        }
-    }
+    op.needs_doc_flush()
 }
 
 pub(crate) fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -385,7 +385,7 @@ pub fn execute_plan_direct(
     // patterns, patch embedded paths) are best-effort or handled by loaders.
     if let Some(g) = guard {
         for op in &plan.operations {
-            for p in crate::plan::declared_paths(op) {
+            for p in op.declared_paths() {
                 g.check_path(p)
                     .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
             }

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -2,39 +2,9 @@ use crate::ops::replace::{ReplaceValidationParams, validate_replace_args};
 use crate::plan::{Operation, Plan};
 
 /// Short label for an operation, used in error messages.
+/// Delegates to [`Operation::label()`].
 pub(super) fn op_label(op: &Operation) -> &'static str {
-    match op {
-        Operation::Replace { .. } => "replace",
-        Operation::DocSet { .. } => "doc.set",
-        Operation::DocDelete { .. } => "doc.delete",
-        Operation::DocMerge { .. } => "doc.merge",
-        Operation::DocAppend { .. } => "doc.append",
-        Operation::DocPrepend { .. } => "doc.prepend",
-        Operation::DocUpdate { .. } => "doc.update",
-        Operation::DocMove { .. } => "doc.move",
-        Operation::DocEnsure { .. } => "doc.ensure",
-        Operation::DocDeleteWhere { .. } => "doc.delete_where",
-        Operation::MdReplaceSection { .. } => "md.replace_section",
-        Operation::MdInsertAfterHeading { .. } => "md.insert_after_heading",
-        Operation::MdInsertBeforeHeading { .. } => "md.insert_before_heading",
-        Operation::MdUpsertBullet { .. } => "md.upsert_bullet",
-        Operation::MdTableAppend { .. } => "md.table_append",
-        Operation::MdMoveSection { .. } => "md.move_section",
-        Operation::MdDedupeHeadings { .. } => "md.dedupe_headings",
-        Operation::TidyFix { .. } => "tidy.fix",
-        Operation::FileAppend { .. } => "file.append",
-        Operation::FileCreate { .. } => "file.create",
-        Operation::FileDelete { .. } => "file.delete",
-        Operation::FileRename { .. } => "file.rename",
-        Operation::PatchApply { .. } => "patch.apply",
-        Operation::Read { .. } => "read",
-        Operation::Search { .. } => "search",
-        Operation::MdLintAgents { .. } => "md.lint_agents",
-        #[cfg(feature = "ast")]
-        Operation::AstRename { .. } => "ast.rename",
-        #[cfg(feature = "ast")]
-        Operation::AstReplace { .. } => "ast.replace",
-    }
+    op.label()
 }
 
 pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {


### PR DESCRIPTION
Move scattered free functions (`op_label` in tx/validate.rs, `op_needs_doc_flush` in tx/execute.rs, `declared_paths` in plan.rs) into methods on the `Operation` enum. The free functions now delegate to the methods, keeping the internal API stable while making the methods available to all callers.

Update direct callers in lifecycle.rs and mcp/mod.rs to use `op.declared_paths()` instead of the free function.

## Changes

- `src/plan.rs`: Add `impl Operation { label(), needs_doc_flush(), declared_paths() }`
- `src/tx/validate.rs`: `op_label()` delegates to `op.label()`
- `src/tx/execute.rs`: `op_needs_doc_flush()` delegates to `op.needs_doc_flush()`
- `src/tx/lifecycle.rs`: Use `op.declared_paths()` instead of free function
- `src/cmd/mcp/mod.rs`: Use `op.declared_paths()` instead of free function (2 call sites)

## Verification

`make check-fast` passes: 752 tests, 10 PTY tests, clippy clean, fmt clean.

Closes #1001