### PR TITLE
refactor: add PathGuard to ExecuteOptions and execute_as_edit_result adapter

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -336,6 +336,124 @@ fn build_edit_result(
 }
 
 // ---------------------------------------------------------------------------
+// TX engine adapter (requires tx module: cli or files feature)
+// ---------------------------------------------------------------------------
+
+/// Execute a single `Operation` through the tx engine and return an `EditResult`.
+///
+/// This is the bridge between the library API (which uses `ApplyMode` and returns
+/// `EditResult`) and the tx engine (which uses `GlobalFlags` and returns
+/// `ExecutionResult`). All API write functions can delegate to this adapter
+/// instead of reimplementing read-transform-write-backup independently.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[allow(dead_code)] // Used by upcoming migration PRs (#1007)
+pub(crate) fn execute_as_edit_result(
+    op: crate::plan::Operation,
+    mode: ApplyMode,
+    cwd: &Path,
+    guard: Option<&PathGuard>,
+    action: &'static str,
+) -> anyhow::Result<EditResult> {
+    let global = mode_to_global_flags(mode);
+    let options = crate::tx::engine::ExecuteOptions {
+        cwd,
+        global: &global,
+        guard,
+    };
+    let result = crate::tx::engine::execute_single(op, options)?;
+    execution_result_to_edit_result(result, mode, cwd, action, None)
+}
+
+/// Like `execute_as_edit_result` but for cross-file operations (rename, move)
+/// where the destination path differs from the source.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[allow(dead_code)] // Used by upcoming migration PRs (#1007)
+pub(crate) fn execute_cross_file_as_edit_result(
+    op: crate::plan::Operation,
+    mode: ApplyMode,
+    cwd: &Path,
+    guard: Option<&PathGuard>,
+    action: &'static str,
+    dest_path: Option<String>,
+) -> anyhow::Result<EditResult> {
+    let global = mode_to_global_flags(mode);
+    let options = crate::tx::engine::ExecuteOptions {
+        cwd,
+        global: &global,
+        guard,
+    };
+    let result = crate::tx::engine::execute_single(op, options)?;
+    execution_result_to_edit_result(result, mode, cwd, action, dest_path)
+}
+
+/// Map `ApplyMode` to `GlobalFlags` with the appropriate apply/check settings.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[allow(dead_code)]
+fn mode_to_global_flags(mode: ApplyMode) -> crate::cli::global::GlobalFlags {
+    let mut flags = crate::cli::global::GlobalFlags::default();
+    match mode {
+        ApplyMode::Apply => flags.apply = true,
+        ApplyMode::Check => flags.check = true,
+        ApplyMode::Preview => {} // default: no apply, no check
+    }
+    flags
+}
+
+/// Convert an `ExecutionResult` into an `EditResult`.
+///
+/// Handles commit for Apply mode, extracts per-file data from the engine result.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[allow(dead_code)]
+fn execution_result_to_edit_result(
+    result: crate::tx::engine::ExecutionResult,
+    mode: ApplyMode,
+    cwd: &Path,
+    action: &'static str,
+    dest_path: Option<String>,
+) -> anyhow::Result<EditResult> {
+    let has_changes = result.has_changes;
+
+    // Extract path + content from the engine result before potentially consuming it.
+    let (path_str, original, new_content) =
+        if let Some((abs_path, orig, new)) = result.exec_result.changes.first() {
+            let rel = crate::files::relative_display(abs_path, cwd);
+            (rel.to_string_lossy().to_string(), orig.clone(), new.clone())
+        } else if let Some(abs_path) = result.exec_result.deletions.iter().next() {
+            // File deletion: content is in the pending map.
+            let rel = crate::files::relative_display(abs_path, cwd);
+            let original = result
+                .exec_result
+                .pending
+                .get(abs_path)
+                .map(|(orig, _)| orig.clone())
+                .unwrap_or_default();
+            (rel.to_string_lossy().to_string(), original, String::new())
+        } else {
+            // No changes at all (e.g., replace with no matches + if_exists).
+            // Return an unchanged result. We need the path from the operation,
+            // but we don't have it here. Use empty path as fallback.
+            (String::new(), String::new(), String::new())
+        };
+
+    // Commit for Apply mode.
+    let applied = if mode == ApplyMode::Apply && has_changes {
+        result.commit()?;
+        true
+    } else {
+        false
+    };
+
+    Ok(build_edit_result(
+        &path_str,
+        original,
+        new_content,
+        applied,
+        action,
+        dest_path,
+    ))
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1861,3 +1861,164 @@ fn make_write_policy_maps_crlf() {
         "should map EolMode::Crlf correctly"
     );
 }
+
+// ---------------------------------------------------------------------------
+// TX engine adapter (execute_as_edit_result)
+// ---------------------------------------------------------------------------
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn adapter_preview_does_not_write() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"key": "old"}"#).unwrap();
+
+    let op = crate::plan::Operation::DocSet {
+        path: file.to_string_lossy().into(),
+        selector: "key".into(),
+        value: serde_json::json!("new"),
+    };
+
+    let result =
+        super::execute_as_edit_result(op, ApplyMode::Preview, dir.path(), None, "doc.set").unwrap();
+
+    assert!(result.changed, "content should differ");
+    assert!(!result.applied, "preview should not write");
+    assert!(result.new_content.contains("new"));
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("old"), "file should be unchanged on disk");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn adapter_apply_writes_to_disk() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"key": "old"}"#).unwrap();
+
+    let op = crate::plan::Operation::DocSet {
+        path: file.to_string_lossy().into(),
+        selector: "key".into(),
+        value: serde_json::json!("new"),
+    };
+
+    let result =
+        super::execute_as_edit_result(op, ApplyMode::Apply, dir.path(), None, "doc.set").unwrap();
+
+    assert!(result.changed);
+    assert!(result.applied);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("new"), "file should be updated on disk");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn adapter_check_does_not_write() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"key": "old"}"#).unwrap();
+
+    let op = crate::plan::Operation::DocSet {
+        path: file.to_string_lossy().into(),
+        selector: "key".into(),
+        value: serde_json::json!("new"),
+    };
+
+    let result =
+        super::execute_as_edit_result(op, ApplyMode::Check, dir.path(), None, "doc.set").unwrap();
+
+    assert!(result.changed);
+    assert!(!result.applied, "check should not write");
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("old"), "file should be unchanged on disk");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn adapter_respects_guard() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"key": "old"}"#).unwrap();
+
+    // Use AllowIfContained policy so absolute temp paths work with the guard.
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+
+    let op = crate::plan::Operation::DocSet {
+        path: file.to_string_lossy().into(),
+        selector: "key".into(),
+        value: serde_json::json!("new"),
+    };
+
+    let result =
+        super::execute_as_edit_result(op, ApplyMode::Apply, dir.path(), Some(&guard), "doc.set")
+            .unwrap();
+
+    assert!(result.applied);
+    assert!(result.changed);
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn adapter_guard_rejects_outside_path() {
+    let dir = TempDir::new().unwrap();
+    let other = TempDir::new().unwrap();
+    let file = other.path().join("test.json");
+    fs::write(&file, r#"{"key": "old"}"#).unwrap();
+
+    let guard = PathGuard::builder(dir.path().to_path_buf())
+        .build()
+        .unwrap();
+
+    let op = crate::plan::Operation::DocSet {
+        path: file.to_string_lossy().into(),
+        selector: "key".into(),
+        value: serde_json::json!("new"),
+    };
+
+    let err =
+        super::execute_as_edit_result(op, ApplyMode::Apply, dir.path(), Some(&guard), "doc.set");
+
+    assert!(err.is_err(), "guard should reject path outside workspace");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn adapter_unchanged_returns_no_diff() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    // Use a replace operation with a pattern that doesn't match
+    // to test the no-change path cleanly.
+    fs::write(&file, "hello world\n").unwrap();
+
+    let op = crate::plan::Operation::Replace {
+        path: Some(file.to_string_lossy().into()),
+        glob: None,
+        mode: None,
+        from: "nonexistent_pattern".into(),
+        to: Some("replacement".into()),
+        nth: None,
+        case_insensitive: false,
+        insert_before: None,
+        insert_after: None,
+        whole_line: false,
+        multiline: false,
+        range: None,
+        if_exists: true,
+        word_boundary: false,
+        before_context: None,
+        after_context: None,
+    };
+
+    let result =
+        super::execute_as_edit_result(op, ApplyMode::Preview, dir.path(), None, "replace").unwrap();
+
+    assert!(
+        !result.changed,
+        "should not be changed when pattern doesn't match"
+    );
+    assert!(!result.applied);
+}

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -356,7 +356,11 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     let files_changed = operations.len();
-    let options = ExecuteOptions { cwd: &cwd, global };
+    let options = ExecuteOptions {
+        cwd: &cwd,
+        global,
+        guard: None,
+    };
     let result = crate::tx::engine::execute_operations(operations, options)?;
 
     if global.check {

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -278,7 +278,11 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             // to avoid execute_via_engine's JSON emission (which would conflict
             // with the removed-headings output already emitted above).
             let op = Operation::MdDedupeHeadings { path: file.clone() };
-            let options = crate::tx::engine::ExecuteOptions { cwd: &cwd, global };
+            let options = crate::tx::engine::ExecuteOptions {
+                cwd: &cwd,
+                global,
+                guard: None,
+            };
             let result = crate::tx::engine::execute_single(op, options)?;
 
             if global.check {

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -68,7 +68,11 @@ fn execute_via_engine_inner<T: Serialize>(
     preview_diffs: bool,
 ) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
-    let options = ExecuteOptions { cwd: &cwd, global };
+    let options = ExecuteOptions {
+        cwd: &cwd,
+        global,
+        guard: None,
+    };
 
     let result = execute_single(op, options)?;
 

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -326,7 +326,11 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         allow_conflicts: apply_options.allow_conflicts,
     };
 
-    let options = ExecuteOptions { cwd: &cwd, global };
+    let options = ExecuteOptions {
+        cwd: &cwd,
+        global,
+        guard: None,
+    };
     let result = match execute_single(op, options) {
         Ok(r) => r,
         Err(e) => {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -271,7 +271,11 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         })
         .collect();
 
-    let options = ExecuteOptions { cwd: &cwd, global };
+    let options = ExecuteOptions {
+        cwd: &cwd,
+        global,
+        guard: None,
+    };
     let result = execute_precomputed(precomputed, options);
 
     // Phase 3: Render output based on mode (check/apply/diff/confirm).

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -226,7 +226,11 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 })
                 .collect();
 
-            let options = ExecuteOptions { cwd: &cwd, global };
+            let options = ExecuteOptions {
+                cwd: &cwd,
+                global,
+                guard: None,
+            };
             let result = execute_operations(ops, options)?;
 
             tidy_fix_output(global, result, &dirty_rel_paths, &cwd)

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -22,6 +22,8 @@ pub struct ExecuteOptions<'a> {
     pub cwd: &'a Path,
     /// Global flags (apply mode, write policy, etc.).
     pub global: &'a GlobalFlags,
+    /// Optional path guard for containment validation.
+    pub guard: Option<&'a crate::containment::PathGuard>,
 }
 
 /// Result of a single-operation execution.
@@ -188,6 +190,16 @@ fn execute_plan_inner(
     operations: Vec<Operation>,
     options: ExecuteOptions<'_>,
 ) -> anyhow::Result<ExecutionResult> {
+    // PathGuard enforcement (same pattern as lifecycle.rs execute_plan_direct).
+    if let Some(g) = options.guard {
+        for op in &operations {
+            for p in op.declared_paths() {
+                g.check_path(p)
+                    .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
+            }
+        }
+    }
+
     let plan = Plan {
         version: SCHEMA_VERSION.to_string(),
         operations,
@@ -224,7 +236,11 @@ mod tests {
     use tempfile::TempDir;
 
     fn test_options<'a>(cwd: &'a Path, global: &'a GlobalFlags) -> ExecuteOptions<'a> {
-        ExecuteOptions { cwd, global }
+        ExecuteOptions {
+            cwd,
+            global,
+            guard: None,
+        }
     }
 
     #[test]


### PR DESCRIPTION
Add `guard: Option<&PathGuard>` to `ExecuteOptions` so the tx engine can enforce containment validation (same pattern as `execute_plan_direct` in lifecycle.rs). Update all 7 existing callers to pass `guard: None`.

Add `execute_as_edit_result()` and `execute_cross_file_as_edit_result()` adapter functions in `api/mod.rs` that bridge `ApplyMode`/`EditResult` to the tx engine's `ExecuteOptions`/`ExecutionResult`. This is the infrastructure foundation for migrating all API write functions to route through the tx engine.

## Changes

- `src/tx/engine.rs`: Add `guard` field to `ExecuteOptions`, wire guard checking into `execute_plan_inner()`
- `src/api/mod.rs`: Add `execute_as_edit_result()`, `execute_cross_file_as_edit_result()`, `mode_to_global_flags()`, `execution_result_to_edit_result()`
- `src/api/tests.rs`: 6 new adapter tests (preview, apply, check, guard allow, guard reject, no-change)
- `src/cmd/{ast,md,output,patch,replace,tidy}.rs`: Update `ExecuteOptions` construction to include `guard: None`

## Verification

`make check-fast` passes: 752 integration + PTY tests, 1408 unit tests, clippy clean, fmt clean.

Ref #1007