### PR TITLE
refactor: route file, replace, tidy, patch API functions through tx engine

### DIFF
--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -1,16 +1,164 @@
 //! File-level operations (create, delete, rename, append, prepend) for the library API.
+//!
+//! Standard file operations delegate to the tx engine via `execute_as_edit_result`.
+//! `file_prepend` retains a direct implementation (no `Operation::FilePrepend` variant).
 
 use std::path::Path;
 
 use anyhow::{Context, bail};
 
 use crate::containment::PathGuard;
-use crate::write::{WritePolicy, atomic_create_new, atomic_write};
+use crate::plan::Operation;
 
-use super::{
-    ApplyMode, EditResult, apply_cross_file_mutation, apply_mutation, build_edit_result,
-    write_if_apply,
-};
+use super::{ApplyMode, EditResult};
+
+/// Derive cwd from a file path (its parent directory).
+fn cwd_from_path(path: &Path) -> &Path {
+    path.parent().unwrap_or_else(|| Path::new("."))
+}
+
+/// Unified write path for standard file operations.
+#[cfg(any(feature = "cli", feature = "files"))]
+fn file_write(
+    op: Operation,
+    path: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+    action: &'static str,
+) -> anyhow::Result<EditResult> {
+    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action)
+}
+
+#[cfg(not(any(feature = "cli", feature = "files")))]
+fn file_write(
+    op: Operation,
+    path: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+    action: &'static str,
+) -> anyhow::Result<EditResult> {
+    // Fallback for no-cli/files builds: delegate to the ops layer directly.
+    match op {
+        Operation::FileCreate { content, force, .. } => {
+            let path_str = path.to_string_lossy();
+            if path.exists() && !path.is_file() {
+                bail!("target is not a file: {}", path.display());
+            }
+            let original = if path.exists() {
+                std::fs::read_to_string(path)
+                    .with_context(|| format!("failed to read {}", path.display()))?
+            } else {
+                String::new()
+            };
+            let force = force.unwrap_or(false);
+            if !force && path.exists() && mode != ApplyMode::Preview {
+                bail!("file already exists: {}", path.display());
+            }
+            let policy = crate::write::WritePolicy::default();
+            let applied = super::write_if_apply(path, &content, mode, &policy, guard)?;
+            Ok(super::build_edit_result(
+                &path_str, original, content, applied, action, None,
+            ))
+        }
+        Operation::FileDelete { .. } => {
+            let path_str = path.to_string_lossy();
+            if !path.exists() {
+                bail!("file not found: {}", path.display());
+            }
+            let original = std::fs::read_to_string(path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            let applied = if mode == ApplyMode::Apply {
+                super::ensure_contained(guard, path)?;
+                std::fs::remove_file(path)
+                    .with_context(|| format!("failed to delete {}", path.display()))?;
+                true
+            } else {
+                false
+            };
+            Ok(super::build_edit_result(
+                &path_str,
+                original,
+                String::new(),
+                applied,
+                action,
+                None,
+            ))
+        }
+        Operation::FileAppend { content, .. } => {
+            let path_str = path.to_string_lossy();
+            if !path.exists() {
+                bail!("file does not exist: {}", path.display());
+            }
+            let original = std::fs::read_to_string(path)
+                .with_context(|| format!("failed to read {}", path.display()))?;
+            let combined = crate::ops::file::append_content(&original, &content);
+            let policy = crate::write::WritePolicy::default();
+            let applied = super::write_if_apply(path, &combined, mode, &policy, guard)?;
+            Ok(super::build_edit_result(
+                &path_str, original, combined, applied, action, None,
+            ))
+        }
+        _ => bail!("unsupported file operation"),
+    }
+}
+
+/// Unified cross-file write path (rename).
+#[cfg(any(feature = "cli", feature = "files"))]
+fn file_write_cross(
+    op: Operation,
+    src: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+    action: &'static str,
+    dest_path: Option<String>,
+) -> anyhow::Result<EditResult> {
+    super::execute_cross_file_as_edit_result(op, mode, cwd_from_path(src), guard, action, dest_path)
+}
+
+#[cfg(not(any(feature = "cli", feature = "files")))]
+fn file_write_cross(
+    _op: Operation,
+    src: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+    action: &'static str,
+    dest_path: Option<String>,
+) -> anyhow::Result<EditResult> {
+    // Fallback: rename directly.
+    if let Operation::FileRename { to, force, .. } = _op {
+        let dst = Path::new(&to);
+        let original = std::fs::read_to_string(src)
+            .with_context(|| format!("failed to read {}", src.display()))?;
+        let applied = super::apply_cross_file_mutation(
+            src,
+            Some(dst),
+            mode,
+            guard,
+            |backup| {
+                backup.save_before_write(src)?;
+                if dst.exists() && force {
+                    backup.save_before_write(dst)?;
+                }
+                Ok(())
+            },
+            || {
+                std::fs::rename(src, dst).with_context(|| {
+                    format!("failed to rename {} -> {}", src.display(), dst.display())
+                })
+            },
+        )?;
+        Ok(super::build_edit_result(
+            &src.to_string_lossy(),
+            original.clone(),
+            original,
+            applied,
+            action,
+            dest_path,
+        ))
+    } else {
+        bail!("unsupported cross-file operation")
+    }
+}
 
 /// Create a new file with the given content.
 ///
@@ -22,54 +170,12 @@ pub fn file_create(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy().to_string();
-
-    if path.exists() && !path.is_file() {
-        bail!("target is not a file: {}", path.display());
-    }
-
-    let original = if path.exists() {
-        std::fs::read_to_string(path)
-            .with_context(|| format!("failed to read existing file: {}", path.display()))?
-    } else {
-        String::new()
+    let op = Operation::FileCreate {
+        path: path.to_string_lossy().into(),
+        content: content.into(),
+        force: Some(force),
     };
-
-    if !force && path.exists() && mode != ApplyMode::Preview {
-        bail!("file already exists: {}", path.display());
-    }
-
-    let applied = apply_mutation(
-        path,
-        mode,
-        guard,
-        |backup| {
-            // Ensure parent directories exist for create.
-            if let Some(parent) = path.parent()
-                && !parent.as_os_str().is_empty()
-            {
-                std::fs::create_dir_all(parent)?;
-            }
-            backup.save_before_write(path)
-        },
-        || {
-            let policy = WritePolicy::default();
-            if force {
-                atomic_write(path, content, &policy)
-            } else {
-                atomic_create_new(path, content, &policy)
-            }
-        },
-    )?;
-
-    Ok(build_edit_result(
-        &path_str,
-        original,
-        content.to_string(),
-        applied,
-        "create",
-        None,
-    ))
+    file_write(op, path, mode, guard, "create")
 }
 
 /// Delete a file.
@@ -78,37 +184,10 @@ pub fn file_delete(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy().to_string();
-
-    if !path.exists() {
-        bail!("file not found: {}", path.display());
-    }
-    if !path.is_file() {
-        bail!("target is not a file: {}", path.display());
-    }
-
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-
-    let applied = apply_mutation(
-        path,
-        mode,
-        guard,
-        |backup| backup.save_before_delete(path),
-        || {
-            std::fs::remove_file(path)
-                .with_context(|| format!("failed to delete {}", path.display()))
-        },
-    )?;
-
-    Ok(build_edit_result(
-        &path_str,
-        original,
-        String::new(),
-        applied,
-        "delete",
-        None,
-    ))
+    let op = Operation::FileDelete {
+        path: path.to_string_lossy().into(),
+    };
+    file_write(op, path, mode, guard, "delete")
 }
 
 /// Rename (move) a file.
@@ -119,56 +198,13 @@ pub fn file_rename(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let src_str = src.to_string_lossy().to_string();
-
-    if !src.exists() {
-        bail!("source not found: {}", src.display());
-    }
-    if !src.is_file() {
-        bail!("source is not a file: {}", src.display());
-    }
-    if dst.exists() && !force {
-        bail!("destination already exists: {}", dst.display());
-    }
-    if dst.exists() && !dst.is_file() {
-        bail!("destination is not a file: {}", dst.display());
-    }
-
-    let original = std::fs::read_to_string(src)
-        .with_context(|| format!("failed to read {}", src.display()))?;
-
-    let applied = apply_cross_file_mutation(
-        src,
-        Some(dst),
-        mode,
-        guard,
-        |backup| {
-            backup.save_before_write(src)?;
-            if dst.exists() && force {
-                backup.save_before_write(dst)?;
-            }
-            // Ensure parent directory of destination exists.
-            if let Some(parent) = dst.parent()
-                && !parent.as_os_str().is_empty()
-            {
-                std::fs::create_dir_all(parent)?;
-            }
-            Ok(())
-        },
-        || {
-            std::fs::rename(src, dst)
-                .with_context(|| format!("failed to rename {} -> {}", src.display(), dst.display()))
-        },
-    )?;
-
-    Ok(build_edit_result(
-        &src_str,
-        original.clone(),
-        original,
-        applied,
-        "rename",
-        Some(dst.to_string_lossy().to_string()),
-    ))
+    let op = Operation::FileRename {
+        from: src.to_string_lossy().into(),
+        to: dst.to_string_lossy().into(),
+        force,
+    };
+    let dest_str = Some(dst.to_string_lossy().to_string());
+    file_write_cross(op, src, mode, guard, "rename", dest_str)
 }
 
 /// Append content to an existing file.
@@ -181,31 +217,17 @@ pub fn file_append(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy().to_string();
-
-    if !path.exists() {
-        bail!("file does not exist: {}", path.display());
-    }
-    if !path.is_file() {
-        bail!("target is not a file: {}", path.display());
-    }
-
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-
-    let combined = crate::ops::file::append_content(&original, content);
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &combined, mode, &policy, guard)?;
-
-    Ok(build_edit_result(
-        &path_str, original, combined, applied, "append", None,
-    ))
+    let op = Operation::FileAppend {
+        path: path.to_string_lossy().into(),
+        content: content.into(),
+    };
+    file_write(op, path, mode, guard, "append")
 }
 
 /// Prepend content to an existing file.
 ///
 /// The file must exist. Content is inserted at the beginning.
+/// Retains direct implementation (no `Operation::FilePrepend` variant).
 pub fn file_prepend(
     path: &Path,
     content: &str,
@@ -226,10 +248,10 @@ pub fn file_prepend(
 
     let combined = crate::ops::file::prepend_content(&original, content);
 
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &combined, mode, &policy, guard)?;
+    let policy = crate::write::WritePolicy::default();
+    let applied = super::write_if_apply(path, &combined, mode, &policy, guard)?;
 
-    Ok(build_edit_result(
+    Ok(super::build_edit_result(
         &path_str, original, combined, applied, "prepend", None,
     ))
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -346,7 +346,6 @@ fn build_edit_result(
 /// `ExecutionResult`). All API write functions can delegate to this adapter
 /// instead of reimplementing read-transform-write-backup independently.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(dead_code)] // Used by upcoming migration PRs (#1007)
 pub(crate) fn execute_as_edit_result(
     op: crate::plan::Operation,
     mode: ApplyMode,
@@ -367,7 +366,6 @@ pub(crate) fn execute_as_edit_result(
 /// Like `execute_as_edit_result` but for cross-file operations (rename, move)
 /// where the destination path differs from the source.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(dead_code)] // Used by upcoming migration PRs (#1007)
 pub(crate) fn execute_cross_file_as_edit_result(
     op: crate::plan::Operation,
     mode: ApplyMode,
@@ -388,7 +386,6 @@ pub(crate) fn execute_cross_file_as_edit_result(
 
 /// Map `ApplyMode` to `GlobalFlags` with the appropriate apply/check settings.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(dead_code)]
 fn mode_to_global_flags(mode: ApplyMode) -> crate::cli::global::GlobalFlags {
     let mut flags = crate::cli::global::GlobalFlags::default();
     match mode {
@@ -403,7 +400,6 @@ fn mode_to_global_flags(mode: ApplyMode) -> crate::cli::global::GlobalFlags {
 ///
 /// Handles commit for Apply mode, extracts per-file data from the engine result.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(dead_code)]
 fn execution_result_to_edit_result(
     result: crate::tx::engine::ExecutionResult,
     mode: ApplyMode,

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -1,14 +1,16 @@
 //! Patch (unified diff) apply operations for the library API.
+//!
+//! Single-file `apply_patch` delegates to the tx engine via `execute_as_edit_result`.
+//! Multi-file `apply_patch_file` retains a direct implementation.
 
 use std::path::Path;
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 
 use crate::containment::PathGuard;
-use crate::ops;
-use crate::write::WritePolicy;
+use crate::plan::Operation;
 
-use super::{ApplyMode, EditResult, build_edit_result, write_if_apply};
+use super::{ApplyMode, EditResult};
 
 /// Apply a unified diff patch to a file.
 ///
@@ -19,52 +21,78 @@ pub fn apply_patch(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
+    let op = Operation::PatchApply {
+        diff: patch_text.into(),
+        on_stale: Default::default(),
+        allow_conflicts: false,
+    };
+    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    patch_write(op, cwd, mode, guard)
+}
 
-    let patch_files = ops::patch::parse_patch(patch_text)
-        .map_err(|e| anyhow::anyhow!("patch parse error: {e}"))?;
+#[cfg(any(feature = "cli", feature = "files"))]
+fn patch_write(
+    op: Operation,
+    cwd: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    super::execute_as_edit_result(op, mode, cwd, guard, "patch")
+}
 
-    // Find the hunks for this file. The patch may contain hunks for multiple
-    // files; we only apply the ones matching the given path.
-    let path_str_ref: &str = &path_str;
-    let hunks: Vec<_> = patch_files
-        .iter()
-        .filter(|pf| {
-            pf.path == path_str_ref || std::path::Path::new(path_str_ref).ends_with(&pf.path)
-        })
-        .flat_map(|pf| pf.hunks.iter())
-        .collect();
+#[cfg(not(any(feature = "cli", feature = "files")))]
+fn patch_write(
+    _op: Operation,
+    cwd: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    use crate::ops;
 
-    if hunks.is_empty() {
-        bail!("no hunks found for path '{}'", path_str);
+    if let Operation::PatchApply { diff, .. } = _op {
+        let patch_files = ops::patch::parse_patch(&diff)
+            .map_err(|e| anyhow::anyhow!("patch parse error: {e}"))?;
+
+        if patch_files.is_empty() {
+            anyhow::bail!("no files in patch");
+        }
+
+        // Apply to the first file in the patch.
+        let pf = &patch_files[0];
+        let file_path = cwd.join(&pf.path);
+        let original = std::fs::read_to_string(&file_path)
+            .with_context(|| format!("failed to read {}", file_path.display()))?;
+
+        let new_content = ops::patch::apply_hunks(&original, &pf.hunks)
+            .map_err(|e| anyhow::anyhow!("patch apply error: {e}"))?;
+
+        let policy = crate::write::WritePolicy::default();
+        let applied = super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
+        Ok(super::build_edit_result(
+            &pf.path,
+            original,
+            new_content,
+            applied,
+            "patch",
+            None,
+        ))
+    } else {
+        anyhow::bail!("expected PatchApply operation")
     }
-
-    let owned_hunks: Vec<_> = hunks.into_iter().cloned().collect();
-    let new_content = ops::patch::apply_hunks(&original, &owned_hunks)
-        .map_err(|e| anyhow::anyhow!("patch apply error: {e}"))?;
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy, guard)?;
-    Ok(build_edit_result(
-        &path_str,
-        original,
-        new_content,
-        applied,
-        "patch",
-        None,
-    ))
 }
 
 /// Apply a multi-file patch. Returns one `EditResult` per affected file.
+///
+/// Retains direct implementation since it produces multiple `EditResult`s
+/// (one per file), which the single-op `execute_as_edit_result` adapter
+/// doesn't support.
 pub fn apply_patch_file(
     patch_text: &str,
     cwd: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<Vec<EditResult>> {
-    let patch_files = ops::patch::parse_patch(patch_text)
+    let patch_files = crate::ops::patch::parse_patch(patch_text)
         .map_err(|e| anyhow::anyhow!("patch parse error: {e}"))?;
 
     let mut results = Vec::new();
@@ -73,12 +101,12 @@ pub fn apply_patch_file(
         let original = std::fs::read_to_string(&file_path)
             .with_context(|| format!("failed to read {}", file_path.display()))?;
 
-        let new_content = ops::patch::apply_hunks(&original, &pf.hunks)
+        let new_content = crate::ops::patch::apply_hunks(&original, &pf.hunks)
             .map_err(|e| anyhow::anyhow!("patch apply error for {}: {e}", pf.path))?;
 
-        let policy = WritePolicy::default();
-        let applied = write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
-        results.push(build_edit_result(
+        let policy = crate::write::WritePolicy::default();
+        let applied = super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
+        results.push(super::build_edit_result(
             &pf.path,
             original,
             new_content,

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -1,14 +1,13 @@
 //! Text replacement operations for the public library API.
+//!
+//! Delegates to the tx engine via `execute_as_edit_result`.
 
 use std::path::Path;
 
-use anyhow::{Context, bail};
-
 use crate::containment::PathGuard;
-use crate::ops;
-use crate::write::WritePolicy;
+use crate::plan::Operation;
 
-use super::{ApplyMode, EditResult, ReplaceOptions, build_edit_result, write_if_apply};
+use super::{ApplyMode, EditResult, ReplaceOptions};
 
 /// Replace text in a file using literal or regex matching.
 ///
@@ -22,80 +21,164 @@ pub fn replace_text(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    let path_str = path.to_string_lossy();
-    let original = std::fs::read_to_string(path)
-        .with_context(|| format!("failed to read {}", path.display()))?;
-
+    // Pre-validate before building the Operation.
     if from.is_empty() && !opts.regex {
-        bail!("empty search pattern");
+        anyhow::bail!("empty search pattern");
     }
     if opts.range.is_some() && !opts.whole_line {
-        bail!("range requires whole_line to be true");
+        anyhow::bail!("range requires whole_line to be true");
     }
     if opts.whole_line && opts.multiline {
-        bail!("whole_line and multiline cannot be combined");
+        anyhow::bail!("whole_line and multiline cannot be combined");
     }
 
-    let compiled_re = ops::replace::compile_replace_regex(
-        from,
-        opts.regex,
-        opts.case_insensitive,
-        opts.multiline,
-        opts.word_boundary,
-    )?;
-
-    let direct_to = if opts.insert_before.is_none() && opts.insert_after.is_none() {
-        Some(to.to_string())
+    let mode_str = if opts.regex {
+        Some("regex".to_string())
     } else {
         None
     };
-    let replacement = ops::replace::replacement_text(
-        from,
-        &direct_to,
-        &opts.insert_before,
-        &opts.insert_after,
-        compiled_re.is_some(),
-    );
-
-    let (new_content, count) = if opts.whole_line {
-        ops::replace::replace_whole_lines(
-            &original,
-            from,
-            &replacement,
-            compiled_re.as_ref(),
-            opts.nth,
-            opts.range,
-        )
-    } else {
-        ops::replace::replace_content(
-            &original,
-            from,
-            &replacement,
-            compiled_re.as_ref(),
-            opts.nth,
-        )
+    let range_str = opts.range.map(|(start, end)| {
+        if let Some(e) = end {
+            format!("{start}:{e}")
+        } else {
+            format!("{start}:")
+        }
+    });
+    let op = Operation::Replace {
+        glob: None,
+        path: Some(path.to_string_lossy().into()),
+        mode: mode_str,
+        from: from.into(),
+        to: Some(to.into()),
+        nth: opts.nth,
+        insert_before: opts.insert_before.clone(),
+        insert_after: opts.insert_after.clone(),
+        case_insensitive: opts.case_insensitive,
+        multiline: opts.multiline,
+        if_exists: opts.if_exists,
+        whole_line: opts.whole_line,
+        range: range_str,
+        word_boundary: opts.word_boundary,
+        before_context: None,
+        after_context: None,
     };
-    let new_content = new_content.into_owned();
+    replace_write(op, path, mode, guard)
+}
 
-    if count == 0 && opts.if_exists {
-        return Ok(build_edit_result(
+/// Unified write path for replace operations.
+#[cfg(any(feature = "cli", feature = "files"))]
+fn replace_write(
+    op: Operation,
+    path: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    super::execute_as_edit_result(op, mode, cwd, guard, "replace")
+}
+
+#[cfg(not(any(feature = "cli", feature = "files")))]
+fn replace_write(
+    _op: Operation,
+    path: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    use crate::ops;
+    use anyhow::{Context, bail};
+
+    // Fallback for no-cli/files builds: delegate to ops layer directly.
+    if let Operation::Replace {
+        from,
+        to,
+        mode: mode_str,
+        insert_before,
+        insert_after,
+        case_insensitive,
+        multiline,
+        if_exists,
+        whole_line,
+        range,
+        word_boundary,
+        nth,
+        ..
+    } = _op
+    {
+        let path_str = path.to_string_lossy();
+        let original = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+
+        let is_regex = mode_str.as_deref() == Some("regex");
+        if from.is_empty() && !is_regex {
+            bail!("empty search pattern");
+        }
+
+        let compiled_re = ops::replace::compile_replace_regex(
+            &from,
+            is_regex,
+            case_insensitive,
+            multiline,
+            word_boundary,
+        )?;
+
+        let direct_to = if insert_before.is_none() && insert_after.is_none() {
+            to.clone()
+        } else {
+            None
+        };
+        let replacement = ops::replace::replacement_text(
+            &from,
+            &direct_to,
+            &insert_before,
+            &insert_after,
+            compiled_re.is_some(),
+        );
+
+        let parsed_range = range.as_deref().map(|r| {
+            let parts: Vec<&str> = r.splitn(2, ':').collect();
+            let start: usize = parts[0].parse().unwrap_or(1);
+            let end: Option<usize> = parts
+                .get(1)
+                .and_then(|s| if s.is_empty() { None } else { s.parse().ok() });
+            (start, end)
+        });
+
+        let (new_content, count) = if whole_line {
+            ops::replace::replace_whole_lines(
+                &original,
+                &from,
+                &replacement,
+                compiled_re.as_ref(),
+                nth,
+                parsed_range,
+            )
+        } else {
+            ops::replace::replace_content(&original, &from, &replacement, compiled_re.as_ref(), nth)
+        };
+        let new_content = new_content.into_owned();
+
+        if count == 0 && if_exists {
+            return Ok(super::build_edit_result(
+                &path_str,
+                original.clone(),
+                original,
+                false,
+                "replace",
+                None,
+            ));
+        }
+
+        let policy = crate::write::WritePolicy::default();
+        let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;
+        Ok(super::build_edit_result(
             &path_str,
-            original.clone(),
             original,
-            false,
+            new_content,
+            applied,
             "replace",
             None,
-        ));
+        ))
+    } else {
+        bail!("expected Replace operation")
     }
-
-    let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &policy, guard)?;
-    Ok(build_edit_result(
-        &path_str,
-        original,
-        new_content,
-        applied,
-        "replace",
-        None,
-    ))
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -295,7 +295,7 @@ fn file_create_force_propagates_read_error() {
     // Restore permissions so TempDir cleanup succeeds.
     fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
     assert!(
-        err.to_string().contains("failed to read existing file"),
+        err.to_string().contains("failed to read"),
         "expected read error, got: {err}"
     );
 }

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -1,15 +1,14 @@
 //! Tidy (whitespace normalization) operation for the library API.
+//!
+//! Delegates to the tx engine via `execute_as_edit_result`.
 
 use std::path::Path;
 
-use anyhow::Context;
-
 use crate::containment::PathGuard;
-use crate::write::WritePolicy;
+use crate::plan::Operation;
+use crate::write::EolMode;
 
-use super::{
-    ApplyMode, EditResult, WritePolicyOptions, build_edit_result, make_write_policy, write_if_apply,
-};
+use super::{ApplyMode, EditResult, WritePolicyOptions};
 
 /// Apply whitespace normalization to a file using the given write policy.
 ///
@@ -21,18 +20,46 @@ pub fn tidy(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    // Operation::TidyFix does not support collapse_blanks. When that option
+    // is set, use the direct implementation to apply the full policy.
+    if policy_opts.collapse_blanks {
+        return tidy_direct(path, policy_opts, mode, guard);
+    }
+    let eol_str = policy_opts.normalize_eol.map(|eol| match eol {
+        EolMode::Lf => "lf".to_string(),
+        EolMode::Crlf => "crlf".to_string(),
+        EolMode::Cr => "cr".to_string(),
+        EolMode::Keep => "keep".to_string(),
+    });
+    let op = Operation::TidyFix {
+        path: path.to_string_lossy().into(),
+        ensure_final_newline: Some(policy_opts.ensure_final_newline),
+        trim_trailing_whitespace: Some(policy_opts.trim_trailing_whitespace),
+        normalize_eol: eol_str,
+    };
+    tidy_write(op, path, mode, guard)
+}
+
+/// Direct tidy implementation for cases not supported by Operation::TidyFix
+/// (e.g., collapse_blanks).
+fn tidy_direct(
+    path: &Path,
+    policy_opts: &WritePolicyOptions,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    use anyhow::Context;
+
     let path_str = path.to_string_lossy();
     let original = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read {}", path.display()))?;
 
-    let policy = make_write_policy(policy_opts);
+    let policy = super::make_write_policy(policy_opts);
     let new_content = crate::write::apply_policy(&original, &policy).into_owned();
 
-    // Use a default (no-op) policy for writing since we already applied
-    // the transformations above.
-    let noop_policy = WritePolicy::default();
-    let applied = write_if_apply(path, &new_content, mode, &noop_policy, guard)?;
-    Ok(build_edit_result(
+    let noop_policy = crate::write::WritePolicy::default();
+    let applied = super::write_if_apply(path, &new_content, mode, &noop_policy, guard)?;
+    Ok(super::build_edit_result(
         &path_str,
         original,
         new_content,
@@ -40,4 +67,68 @@ pub fn tidy(
         "tidy",
         None,
     ))
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+fn tidy_write(
+    op: Operation,
+    path: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    super::execute_as_edit_result(op, mode, cwd, guard, "tidy")
+}
+
+#[cfg(not(any(feature = "cli", feature = "files")))]
+fn tidy_write(
+    _op: Operation,
+    path: &Path,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    use anyhow::Context;
+
+    // Fallback: apply policy directly through the write module.
+    if let Operation::TidyFix {
+        ensure_final_newline,
+        trim_trailing_whitespace,
+        normalize_eol,
+        ..
+    } = _op
+    {
+        let path_str = path.to_string_lossy();
+        let original = std::fs::read_to_string(path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+
+        let eol = normalize_eol
+            .as_deref()
+            .map(|s| match s {
+                "lf" => EolMode::Lf,
+                "crlf" => EolMode::Crlf,
+                "cr" => EolMode::Cr,
+                _ => EolMode::Keep,
+            })
+            .unwrap_or(EolMode::Keep);
+        let policy = crate::write::WritePolicy {
+            ensure_final_newline: ensure_final_newline.unwrap_or(false),
+            normalize_eol: eol,
+            trim_trailing_whitespace: trim_trailing_whitespace.unwrap_or(false),
+            collapse_blanks: false,
+        };
+        let new_content = crate::write::apply_policy(&original, &policy).into_owned();
+
+        let noop_policy = crate::write::WritePolicy::default();
+        let applied = super::write_if_apply(path, &new_content, mode, &noop_policy, guard)?;
+        Ok(super::build_edit_result(
+            &path_str,
+            original,
+            new_content,
+            applied,
+            "tidy",
+            None,
+        ))
+    } else {
+        anyhow::bail!("expected TidyFix operation")
+    }
 }


### PR DESCRIPTION
Migrate remaining API write functions to build Operation variants and delegate through execute_as_edit_result, unifying API and CLI write paths.

## Changes

### file.rs
- file_create, file_delete, file_append -> Operation variants via file_write()
- file_rename -> execute_cross_file_as_edit_result via file_write_cross()
- file_prepend retains direct implementation (no Operation::FilePrepend variant)

### replace.rs
- replace_text -> Operation::Replace via replace_write()
- Pre-validations (empty pattern, range+whole_line, whole_line+multiline) remain in the API layer

### tidy.rs
- tidy -> Operation::TidyFix via tidy_write()
- collapse_blanks falls back to tidy_direct() since Operation::TidyFix does not support it

### patch.rs
- apply_patch -> Operation::PatchApply via patch_write()
- apply_patch_file retains direct implementation (multi-EditResult)

All modules include cfg-gated fallbacks for no-cli/files builds.

## Part of #1007

PR 4 of 5 in the API-to-tx-engine migration series:
- PR 1: #1029 (merged) - guard + adapter
- PR 2: #1030 (merged) - doc migration
- PR 3: #1031 (merged) - md migration
- PR 4: this PR - file/replace/tidy/patch migration
- PR 5: dead code removal

Ref #1007