### PR TITLE
refactor: remove dead_code annotations from tx engine adapter

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -346,7 +346,6 @@ fn build_edit_result(
 /// `ExecutionResult`). All API write functions can delegate to this adapter
 /// instead of reimplementing read-transform-write-backup independently.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(dead_code)] // Used by upcoming migration PRs (#1007)
 pub(crate) fn execute_as_edit_result(
     op: crate::plan::Operation,
     mode: ApplyMode,
@@ -367,7 +366,6 @@ pub(crate) fn execute_as_edit_result(
 /// Like `execute_as_edit_result` but for cross-file operations (rename, move)
 /// where the destination path differs from the source.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(dead_code)] // Used by upcoming migration PRs (#1007)
 pub(crate) fn execute_cross_file_as_edit_result(
     op: crate::plan::Operation,
     mode: ApplyMode,
@@ -388,7 +386,6 @@ pub(crate) fn execute_cross_file_as_edit_result(
 
 /// Map `ApplyMode` to `GlobalFlags` with the appropriate apply/check settings.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(dead_code)]
 fn mode_to_global_flags(mode: ApplyMode) -> crate::cli::global::GlobalFlags {
     let mut flags = crate::cli::global::GlobalFlags::default();
     match mode {
@@ -403,7 +400,6 @@ fn mode_to_global_flags(mode: ApplyMode) -> crate::cli::global::GlobalFlags {
 ///
 /// Handles commit for Apply mode, extracts per-file data from the engine result.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(dead_code)]
 fn execution_result_to_edit_result(
     result: crate::tx::engine::ExecutionResult,
     mode: ApplyMode,


### PR DESCRIPTION
Remove `#[allow(dead_code)]` annotations from the tx engine adapter functions in `src/api/mod.rs`, since all API write modules now actively call them.

Functions cleaned up:
- `execute_as_edit_result()` - used by doc, md, file, replace, tidy, patch
- `execute_cross_file_as_edit_result()` - used by file_rename
- `mode_to_global_flags()` - called by both adapters
- `execution_result_to_edit_result()` - called by both adapters

The internal helpers (`write_if_apply`, `apply_mutation`, `apply_cross_file_mutation`, `ensure_contained`, `build_edit_result`) remain for:
- cfg-gated fallbacks in no-cli/files builds
- Direct implementations (md_move_section, md_dedupe_headings, file_prepend, tidy_direct, apply_patch_file)

Closes #1007

## Part of #1007

PR 5 of 5 in the API-to-tx-engine migration series:
- PR 1: #1029 (merged) - guard + adapter
- PR 2: #1030 (merged) - doc migration
- PR 3: #1031 (merged) - md migration
- PR 4: #1032 - file/replace/tidy/patch migration
- PR 5: this PR - cleanup