### PR TITLE
feat(tidy): add --dedent and --indent flags to tidy fix

### DIFF
--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -10,13 +10,42 @@ use crate::write::EolMode;
 
 use super::{ApplyMode, EditResult, WritePolicyOptions};
 
+/// Options for indentation transforms (separate from write policy).
+#[derive(Debug, Clone, Default)]
+pub struct TidyIndentOptions {
+    /// Dedent specification: `"auto"`, `"tab"`, or a numeric string (e.g. `"4"`).
+    pub dedent: Option<String>,
+    /// Indent specification: `"tab"` or a numeric string (e.g. `"4"`).
+    pub indent: Option<String>,
+    /// Line range restriction: `"10:50"` (1-based inclusive).
+    pub lines: Option<String>,
+}
+
 /// Apply whitespace normalization to a file using the given write policy.
 ///
 /// Normalizes final newlines, line endings, trailing whitespace, and
-/// consecutive blank lines according to the policy options.
+/// consecutive blank lines according to the policy options. Optionally
+/// applies dedent/indent transforms via `indent_opts`.
 pub fn tidy(
     path: &Path,
     policy_opts: &WritePolicyOptions,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    tidy_with_indent(
+        path,
+        policy_opts,
+        &TidyIndentOptions::default(),
+        mode,
+        guard,
+    )
+}
+
+/// Apply whitespace normalization with optional dedent/indent transforms.
+pub fn tidy_with_indent(
+    path: &Path,
+    policy_opts: &WritePolicyOptions,
+    indent_opts: &TidyIndentOptions,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
@@ -36,6 +65,9 @@ pub fn tidy(
         ensure_final_newline: Some(policy_opts.ensure_final_newline),
         trim_trailing_whitespace: Some(policy_opts.trim_trailing_whitespace),
         normalize_eol: eol_str,
+        dedent: indent_opts.dedent.clone(),
+        indent: indent_opts.indent.clone(),
+        lines: indent_opts.lines.clone(),
     };
     tidy_write(op, path, mode, guard)
 }
@@ -94,6 +126,9 @@ fn tidy_write(
         ensure_final_newline,
         trim_trailing_whitespace,
         normalize_eol,
+        dedent,
+        indent,
+        lines,
         ..
     } = _op
     {
@@ -116,7 +151,19 @@ fn tidy_write(
             trim_trailing_whitespace: trim_trailing_whitespace.unwrap_or(false),
             collapse_blanks: false,
         };
-        let new_content = crate::write::apply_policy(&original, &policy).into_owned();
+        let mut new_content = crate::write::apply_policy(&original, &policy).into_owned();
+
+        // Apply dedent/indent after policy normalization.
+        let line_range = lines
+            .as_deref()
+            .map(crate::write::parse_line_range)
+            .transpose()?;
+        if let Some(ref spec) = dedent {
+            new_content = crate::write::dedent_content(&new_content, spec, line_range);
+        }
+        if let Some(ref spec) = indent {
+            new_content = crate::write::indent_content(&new_content, spec, line_range);
+        }
 
         let noop_policy = crate::write::WritePolicy::default();
         let applied = super::write_if_apply(path, &new_content, mode, &noop_policy, guard)?;

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -254,6 +254,9 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
                 ensure_final_newline: None,
                 trim_trailing_whitespace: None,
                 normalize_eol: None,
+                dedent: None,
+                indent: None,
+                lines: None,
             })
         }
 

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -116,7 +116,7 @@ mod basic {
         let op = parse_line("tidy.fix src/lib.rs", 1).unwrap();
         assert!(matches!(
             op,
-            Operation::TidyFix { path, ensure_final_newline, trim_trailing_whitespace, normalize_eol }
+            Operation::TidyFix { path, ensure_final_newline, trim_trailing_whitespace, normalize_eol, .. }
             if path == "src/lib.rs"
                 && ensure_final_newline.is_none()
                 && trim_trailing_whitespace.is_none()

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -260,8 +260,19 @@ fn describe_operation(op: &Operation) -> String {
         Operation::MdDedupeHeadings { path } => {
             format!("Deduplicate headings in {path}")
         }
-        Operation::TidyFix { path, .. } => {
-            format!("Normalize whitespace in {path}")
+        Operation::TidyFix {
+            path,
+            dedent,
+            indent,
+            ..
+        } => {
+            if dedent.is_some() {
+                format!("Dedent and normalize whitespace in {path}")
+            } else if indent.is_some() {
+                format!("Indent and normalize whitespace in {path}")
+            } else {
+                format!("Normalize whitespace in {path}")
+            }
         }
         Operation::FileAppend { path, .. } => {
             format!("Append content to {path}")

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -495,6 +495,9 @@ impl PatchloomService {
                     ensure_final_newline: Some(true),
                     trim_trailing_whitespace: Some(true),
                     normalize_eol: None,
+                    dedent: None,
+                    indent: None,
+                    lines: None,
                 })
                 .collect();
             svc.run_ops(ops, Some(p.strict))
@@ -548,7 +551,7 @@ impl PatchloomService {
     // from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
 
     #[tool(
-        description = "Fix whitespace in a file: trims trailing spaces and ensures final newline. Safe to call on any file (no-op if already clean). Example: {\"path\": \"dirty.txt\"}"
+        description = "Fix whitespace in a file: trims trailing spaces, ensures final newline. Optionally dedent (\"auto\", \"tab\", \"4\") or indent (\"tab\", \"4\") with optional line range. Example: {\"path\": \"dirty.txt\"} or {\"path\": \"src/main.rs\", \"dedent\": \"auto\", \"lines\": \"10:50\"}"
     )]
     async fn fix_whitespace(
         &self,
@@ -562,6 +565,9 @@ impl PatchloomService {
                     ensure_final_newline: Some(true),
                     trim_trailing_whitespace: Some(true),
                     normalize_eol: None,
+                    dedent: p.dedent,
+                    indent: p.indent,
+                    lines: p.lines,
                 }],
                 None,
             )

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -102,6 +102,15 @@ pub(crate) struct MdMoveSectionParams {
 pub(crate) struct TidyParams {
     /// File path to normalize.
     pub path: String,
+    /// Dedent: remove leading whitespace. Values: "auto", "tab", or a number (e.g. "4").
+    #[serde(default)]
+    pub dedent: Option<String>,
+    /// Indent: add leading whitespace. Values: "tab" or a number (e.g. "4").
+    #[serde(default)]
+    pub indent: Option<String>,
+    /// Restrict dedent/indent to a line range (1-based inclusive, e.g. "10:50").
+    #[serde(default)]
+    pub lines: Option<String>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -77,7 +77,7 @@ mod basic {
         assert_eq!(
             descriptions.get("fix_whitespace"),
             Some(
-                &"Fix whitespace in a file: trims trailing spaces and ensures final newline. Safe to call on any file (no-op if already clean). Example: {\"path\": \"dirty.txt\"}"
+                &"Fix whitespace in a file: trims trailing spaces, ensures final newline. Optionally dedent (\"auto\", \"tab\", \"4\") or indent (\"tab\", \"4\") with optional line range. Example: {\"path\": \"dirty.txt\"} or {\"path\": \"src/main.rs\", \"dedent\": \"auto\", \"lines\": \"10:50\"}"
             ),
             "fix_whitespace description drifted"
         );

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -26,7 +26,18 @@ pub enum TidyAction {
     /// Report newline, EOL, and whitespace issues in text files.
     Check { paths: Vec<String> },
     /// Apply normalization fixes to text files.
-    Fix { paths: Vec<String> },
+    Fix {
+        paths: Vec<String>,
+        /// Dedent: remove leading whitespace. Values: "auto", "tab", or a number (e.g. "4").
+        #[arg(long)]
+        dedent: Option<String>,
+        /// Indent: add leading whitespace. Values: "tab" or a number (e.g. "4").
+        #[arg(long)]
+        indent: Option<String>,
+        /// Restrict dedent/indent to a line range (1-based inclusive, e.g. "10:50").
+        #[arg(long)]
+        lines: Option<String>,
+    },
 }
 
 /// A single tidy issue found in a file.
@@ -172,17 +183,34 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 Ok(exit::CHANGES_DETECTED)
             }
         }
-        TidyAction::Fix { paths } => {
+        TidyAction::Fix {
+            paths,
+            dedent,
+            indent,
+            lines,
+        } => {
+            if dedent.is_some() && indent.is_some() {
+                anyhow::bail!("--dedent and --indent cannot both be set");
+            }
+
             let cwd = global.resolve_cwd()?;
             let glob_matcher = crate::build_glob_matcher_from_global(global)?;
             let fix_file_paths = crate::collect_file_paths_opts(&paths, global, true, Some(&cwd))?;
             let glob_roots = crate::collect_glob_roots_from_global(&paths, global, Some(&cwd))?;
+
+            // Parse line range once (shared across all files).
+            let line_range = lines
+                .as_deref()
+                .map(crate::write::parse_line_range)
+                .transpose()?;
 
             // Parallel read+compute phase: identify which files need fixing.
             // This preserves the performance-critical parallel scan; only
             // files that actually differ after policy application are
             // included in the engine execution.
             let quiet = global.quiet;
+            let dedent_ref = dedent.as_deref();
+            let indent_ref = indent.as_deref();
             let dirty_rel_paths: Vec<String> = crate::par_process_files(
                 &fix_file_paths,
                 glob_matcher.as_ref(),
@@ -194,7 +222,13 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                             None => return None,
                         };
                     let policy = policy_from_flags(global, Some(file_path));
-                    let fixed = apply_policy(&original, &policy);
+                    let mut fixed = apply_policy(&original, &policy).into_owned();
+                    if let Some(spec) = dedent_ref {
+                        fixed = crate::write::dedent_content(&fixed, spec, line_range);
+                    }
+                    if let Some(spec) = indent_ref {
+                        fixed = crate::write::indent_content(&fixed, spec, line_range);
+                    }
                     if fixed == *original {
                         return None;
                     }
@@ -223,6 +257,9 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     ensure_final_newline: Some(global.ensure_final_newline),
                     trim_trailing_whitespace: Some(global.trim_trailing_whitespace),
                     normalize_eol: eol_str.map(String::from),
+                    dedent: dedent.clone(),
+                    indent: indent.clone(),
+                    lines: lines.clone(),
                 })
                 .collect();
 
@@ -516,6 +553,9 @@ mod tests {
         let args = TidyArgs {
             action: TidyAction::Fix {
                 paths: vec![".".to_string()],
+                dedent: None,
+                indent: None,
+                lines: None,
             },
             write: Default::default(),
         };
@@ -542,6 +582,9 @@ mod tests {
         let args = TidyArgs {
             action: TidyAction::Fix {
                 paths: vec![".".to_string()],
+                dedent: None,
+                indent: None,
+                lines: None,
             },
             write: Default::default(),
         };
@@ -568,6 +611,9 @@ mod tests {
         let args = TidyArgs {
             action: TidyAction::Fix {
                 paths: vec![".".to_string()],
+                dedent: None,
+                indent: None,
+                lines: None,
             },
             write: Default::default(),
         };
@@ -593,6 +639,9 @@ mod tests {
         let args = TidyArgs {
             action: TidyAction::Fix {
                 paths: vec![".".to_string()],
+                dedent: None,
+                indent: None,
+                lines: None,
             },
             write: Default::default(),
         };
@@ -616,6 +665,9 @@ mod tests {
         let args = TidyArgs {
             action: TidyAction::Fix {
                 paths: vec![".".to_string()],
+                dedent: None,
+                indent: None,
+                lines: None,
             },
             write: Default::default(),
         };
@@ -640,6 +692,9 @@ mod tests {
         let args = TidyArgs {
             action: TidyAction::Fix {
                 paths: vec![".".to_string()],
+                dedent: None,
+                indent: None,
+                lines: None,
             },
             write: Default::default(),
         };
@@ -660,6 +715,9 @@ mod tests {
         let args = TidyArgs {
             action: TidyAction::Fix {
                 paths: vec![".".to_string()],
+                dedent: None,
+                indent: None,
+                lines: None,
             },
             write: Default::default(),
         };

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -190,6 +190,12 @@ pub enum Operation {
         ensure_final_newline: Option<bool>,
         trim_trailing_whitespace: Option<bool>,
         normalize_eol: Option<String>,
+        /// Dedent specification: "4", "tab", or "auto".
+        dedent: Option<String>,
+        /// Indent specification: "4", "tab".
+        indent: Option<String>,
+        /// Line range restriction for dedent/indent: "10:50" (1-based inclusive).
+        lines: Option<String>,
     },
     #[serde(rename = "file.create", alias = "create_file")]
     FileCreate {

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -307,6 +307,9 @@ mod basic {
                     ensure_final_newline: Some(true),
                     trim_trailing_whitespace: Some(true),
                     normalize_eol: Some("lf".into()),
+                    dedent: None,
+                    indent: None,
+                    lines: None,
                 },
             ),
             (

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -190,6 +190,16 @@ fn execute_plan_inner(
     operations: Vec<Operation>,
     options: ExecuteOptions<'_>,
 ) -> anyhow::Result<ExecutionResult> {
+    // Validate TidyFix-specific constraints (dedent + indent mutual exclusion).
+    for op in &operations {
+        if let Operation::TidyFix { dedent, indent, .. } = op
+            && dedent.is_some()
+            && indent.is_some()
+        {
+            anyhow::bail!("tidy.fix: 'dedent' and 'indent' cannot both be set");
+        }
+    }
+
     // PathGuard enforcement (same pattern as lifecycle.rs execute_plan_direct).
     if let Some(g) = options.guard {
         for op in &operations {

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -552,6 +552,9 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             ensure_final_newline,
             trim_trailing_whitespace,
             normalize_eol,
+            dedent,
+            indent,
+            lines,
         } => {
             let file_path = tx.cwd.join(path);
             let content = read_file_content(tx.pending, tx.existed_before, &file_path)?.to_owned();
@@ -565,9 +568,22 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                 },
                 collapse_blanks: false,
             };
-            let new = crate::write::apply_policy(&content, &policy);
-            if content != *new {
-                update_file_content(tx.pending, tx.deletions, &file_path, new.into_owned());
+            let mut new = crate::write::apply_policy(&content, &policy).into_owned();
+
+            // Apply dedent/indent after policy normalization.
+            let line_range = lines
+                .as_deref()
+                .map(crate::write::parse_line_range)
+                .transpose()?;
+            if let Some(spec) = dedent {
+                new = crate::write::dedent_content(&new, spec, line_range);
+            }
+            if let Some(spec) = indent {
+                new = crate::write::indent_content(&new, spec, line_range);
+            }
+
+            if content != new {
+                update_file_content(tx.pending, tx.deletions, &file_path, new);
             }
         }
 

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -47,7 +47,6 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
         | Operation::MdUpsertBullet { .. }
         | Operation::MdTableAppend { .. }
         | Operation::MdDedupeHeadings { .. }
-        | Operation::TidyFix { .. }
         | Operation::FileAppend { .. }
         | Operation::FileCreate { .. }
         | Operation::FileDelete { .. }
@@ -57,6 +56,12 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
         | Operation::PatchApply { .. } => Ok(()),
         #[cfg(feature = "ast")]
         Operation::AstRename { .. } | Operation::AstReplace { .. } => Ok(()),
+        Operation::TidyFix { dedent, indent, .. } => {
+            if dedent.is_some() && indent.is_some() {
+                anyhow::bail!("tidy.fix: 'dedent' and 'indent' cannot both be set");
+            }
+            Ok(())
+        }
         Operation::MdMoveSection { before, after, .. } => {
             if before.is_none() && after.is_none() {
                 anyhow::bail!("md.move_section requires either 'before' or 'after'");

--- a/src/write.rs
+++ b/src/write.rs
@@ -324,6 +324,168 @@ pub fn collapse_blanks(content: &str) -> std::borrow::Cow<'_, str> {
     Cow::Owned(result)
 }
 
+/// Dedent content by removing leading whitespace.
+///
+/// `spec` accepts:
+/// - A numeric string (e.g. `"4"`) — remove up to N leading spaces per line.
+/// - `"tab"` — remove one leading tab per line.
+/// - `"auto"` — find the minimum non-zero indentation and remove that much.
+///
+/// If `line_range` is `Some((start, end))`, only lines in that 1-based inclusive
+/// range are affected. Blank lines are never modified.
+pub fn dedent_content(
+    content: &str,
+    spec: &str,
+    line_range: Option<(usize, Option<usize>)>,
+) -> String {
+    let lines: Vec<&str> = content.split('\n').collect();
+
+    let (start, end) = match line_range {
+        Some((s, e)) => (s.max(1), e.unwrap_or(lines.len())),
+        None => (1, lines.len()),
+    };
+
+    let in_range = |i: usize| {
+        let line_num = i + 1; // 1-based
+        line_num >= start && line_num <= end
+    };
+
+    match spec {
+        "auto" => {
+            // Find minimum non-zero indentation in the range.
+            let min_indent = lines
+                .iter()
+                .enumerate()
+                .filter(|&(i, _)| in_range(i))
+                .filter(|&(_, line)| !line.trim().is_empty())
+                .map(|(_, line)| line.len() - line.trim_start().len())
+                .filter(|&n| n > 0)
+                .min()
+                .unwrap_or(0);
+
+            if min_indent == 0 {
+                return content.to_string();
+            }
+
+            dedent_by_n(&lines, min_indent, &in_range)
+        }
+        "tab" => {
+            let result: Vec<String> = lines
+                .iter()
+                .enumerate()
+                .map(|(i, line)| {
+                    if !in_range(i) || line.trim().is_empty() {
+                        line.to_string()
+                    } else if let Some(rest) = line.strip_prefix('\t') {
+                        rest.to_string()
+                    } else {
+                        line.to_string()
+                    }
+                })
+                .collect();
+            result.join("\n")
+        }
+        n => {
+            let count: usize = n.parse().unwrap_or(0);
+            if count == 0 {
+                return content.to_string();
+            }
+            dedent_by_n(&lines, count, &in_range)
+        }
+    }
+}
+
+fn dedent_by_n(lines: &[&str], n: usize, in_range: &dyn Fn(usize) -> bool) -> String {
+    let result: Vec<String> = lines
+        .iter()
+        .enumerate()
+        .map(|(i, line)| {
+            if !in_range(i) || line.trim().is_empty() {
+                line.to_string()
+            } else {
+                let leading_spaces = line.len() - line.trim_start_matches(' ').len();
+                let strip = n.min(leading_spaces);
+                line[strip..].to_string()
+            }
+        })
+        .collect();
+    result.join("\n")
+}
+
+/// Parse a line range specification like `"10:50"` into `(start, Option<end>)`.
+///
+/// Both start and end are 1-based inclusive. Examples:
+/// - `"10:50"` → `(10, Some(50))`
+/// - `"5:"` → `(5, None)` (open-ended)
+/// - `"3"` → `(3, Some(3))` (single line)
+pub fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usize>)> {
+    if let Some((left, right)) = spec.split_once(':') {
+        let start: usize = left
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid line range start: '{left}'"))?;
+        if right.is_empty() {
+            Ok((start, None))
+        } else {
+            let end: usize = right
+                .parse()
+                .map_err(|_| anyhow::anyhow!("invalid line range end: '{right}'"))?;
+            Ok((start, Some(end)))
+        }
+    } else {
+        let line: usize = spec
+            .parse()
+            .map_err(|_| anyhow::anyhow!("invalid line number: '{spec}'"))?;
+        Ok((line, Some(line)))
+    }
+}
+
+/// Indent content by adding leading whitespace.
+///
+/// `spec` accepts:
+/// - A numeric string (e.g. `"4"`) — add N leading spaces to each non-blank line.
+/// - `"tab"` — add one leading tab to each non-blank line.
+///
+/// If `line_range` is `Some((start, end))`, only lines in that 1-based inclusive
+/// range are affected. Blank lines are never modified.
+pub fn indent_content(
+    content: &str,
+    spec: &str,
+    line_range: Option<(usize, Option<usize>)>,
+) -> String {
+    let lines: Vec<&str> = content.split('\n').collect();
+
+    let (start, end) = match line_range {
+        Some((s, e)) => (s.max(1), e.unwrap_or(lines.len())),
+        None => (1, lines.len()),
+    };
+
+    let prefix = match spec {
+        "tab" => "\t".to_string(),
+        n => {
+            let count: usize = n.parse().unwrap_or(0);
+            " ".repeat(count)
+        }
+    };
+
+    if prefix.is_empty() {
+        return content.to_string();
+    }
+
+    let result: Vec<String> = lines
+        .iter()
+        .enumerate()
+        .map(|(i, line)| {
+            let line_num = i + 1;
+            if line_num < start || line_num > end || line.trim().is_empty() {
+                line.to_string()
+            } else {
+                format!("{prefix}{line}")
+            }
+        })
+        .collect();
+    result.join("\n")
+}
+
 /// Apply a [`WritePolicy`] to `content`: trim, then EOL normalise, then final newline.
 ///
 /// Returns `Cow::Borrowed` when the policy is a no-op, avoiding allocation.

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -611,6 +611,137 @@ mod edge_cases {
     }
 }
 
+mod dedent_indent {
+    use super::*;
+
+    #[test]
+    fn dedent_auto_removes_minimum_indent() {
+        let input = "    line1\n        line2\n    line3\n";
+        let result = dedent_content(input, "auto", None);
+        assert_eq!(result, "line1\n    line2\nline3\n");
+    }
+
+    #[test]
+    fn dedent_auto_skips_blank_lines() {
+        let input = "    line1\n\n    line2\n";
+        let result = dedent_content(input, "auto", None);
+        assert_eq!(result, "line1\n\nline2\n");
+    }
+
+    #[test]
+    fn dedent_auto_no_indent_returns_unchanged() {
+        let input = "line1\nline2\n";
+        let result = dedent_content(input, "auto", None);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn dedent_numeric_removes_n_spaces() {
+        let input = "        line1\n    line2\n";
+        let result = dedent_content(input, "4", None);
+        assert_eq!(result, "    line1\nline2\n");
+    }
+
+    #[test]
+    fn dedent_numeric_stops_at_available_indent() {
+        let input = "  line1\n      line2\n";
+        let result = dedent_content(input, "4", None);
+        assert_eq!(result, "line1\n  line2\n");
+    }
+
+    #[test]
+    fn dedent_tab_removes_one_tab() {
+        let input = "\tline1\n\t\tline2\nline3\n";
+        let result = dedent_content(input, "tab", None);
+        assert_eq!(result, "line1\n\tline2\nline3\n");
+    }
+
+    #[test]
+    fn dedent_tab_no_tab_unchanged() {
+        let input = "    line1\n";
+        let result = dedent_content(input, "tab", None);
+        assert_eq!(result, "    line1\n");
+    }
+
+    #[test]
+    fn dedent_with_line_range() {
+        let input = "    line1\n    line2\n    line3\n    line4\n";
+        let result = dedent_content(input, "4", Some((2, Some(3))));
+        assert_eq!(result, "    line1\nline2\nline3\n    line4\n");
+    }
+
+    #[test]
+    fn indent_numeric_adds_spaces() {
+        let input = "line1\nline2\n";
+        let result = indent_content(input, "4", None);
+        assert_eq!(result, "    line1\n    line2\n");
+    }
+
+    #[test]
+    fn indent_tab_adds_tab() {
+        let input = "line1\nline2\n";
+        let result = indent_content(input, "tab", None);
+        assert_eq!(result, "\tline1\n\tline2\n");
+    }
+
+    #[test]
+    fn indent_skips_blank_lines() {
+        let input = "line1\n\nline2\n";
+        let result = indent_content(input, "4", None);
+        assert_eq!(result, "    line1\n\n    line2\n");
+    }
+
+    #[test]
+    fn indent_with_line_range() {
+        let input = "line1\nline2\nline3\nline4\n";
+        let result = indent_content(input, "4", Some((2, Some(3))));
+        assert_eq!(result, "line1\n    line2\n    line3\nline4\n");
+    }
+
+    #[test]
+    fn indent_zero_returns_unchanged() {
+        let input = "line1\nline2\n";
+        let result = indent_content(input, "0", None);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn parse_line_range_full() {
+        let (start, end) = parse_line_range("10:50").unwrap();
+        assert_eq!(start, 10);
+        assert_eq!(end, Some(50));
+    }
+
+    #[test]
+    fn parse_line_range_open_ended() {
+        let (start, end) = parse_line_range("5:").unwrap();
+        assert_eq!(start, 5);
+        assert_eq!(end, None);
+    }
+
+    #[test]
+    fn parse_line_range_single_line() {
+        let (start, end) = parse_line_range("3").unwrap();
+        assert_eq!(start, 3);
+        assert_eq!(end, Some(3));
+    }
+
+    #[test]
+    fn parse_line_range_invalid() {
+        assert!(parse_line_range("abc").is_err());
+        assert!(parse_line_range("1:xyz").is_err());
+    }
+
+    #[test]
+    fn dedent_auto_line_range() {
+        // Only dedent lines 2-3; leave lines 1 and 4 alone.
+        let input = "    a\n        b\n        c\n    d\n";
+        let result = dedent_content(input, "auto", Some((2, Some(3))));
+        // min indent in range (lines 2-3) is 8 spaces, so remove 8.
+        assert_eq!(result, "    a\nb\nc\n    d\n");
+    }
+}
+
 mod error_handling {
     use super::*;
 

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -381,3 +381,129 @@ fn test_tidy_apply_readonly_dir_fails_gracefully() {
 
     fs::set_permissions(&sub, fs::Permissions::from_mode(0o755)).unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// tidy fix --dedent / --indent
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tidy_fix_dedent_auto_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("indented.txt");
+    fs::write(&file, "    line1\n        line2\n    line3\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["tidy", "fix", ".", "--dedent", "auto", "--apply"])
+        .current_dir(dir.path())
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, "line1\n    line2\nline3\n");
+}
+
+#[test]
+fn test_tidy_fix_dedent_numeric_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("indented.txt");
+    fs::write(&file, "        line1\n    line2\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["tidy", "fix", ".", "--dedent", "4", "--apply"])
+        .current_dir(dir.path())
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, "    line1\nline2\n");
+}
+
+#[test]
+fn test_tidy_fix_indent_numeric_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("flat.txt");
+    fs::write(&file, "line1\nline2\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["tidy", "fix", ".", "--indent", "4", "--apply"])
+        .current_dir(dir.path())
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, "    line1\n    line2\n");
+}
+
+#[test]
+fn test_tidy_fix_indent_tab_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("flat.txt");
+    fs::write(&file, "line1\nline2\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["tidy", "fix", ".", "--indent", "tab", "--apply"])
+        .current_dir(dir.path())
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, "\tline1\n\tline2\n");
+}
+
+#[test]
+fn test_tidy_fix_dedent_with_line_range() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("ranged.txt");
+    fs::write(&file, "    line1\n    line2\n    line3\n    line4\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "tidy", "fix", ".", "--dedent", "4", "--lines", "2:3", "--apply",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, "    line1\nline2\nline3\n    line4\n");
+}
+
+#[test]
+fn test_tidy_fix_dedent_and_indent_rejects() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "    line1\n").unwrap();
+
+    // Both --dedent and --indent should fail validation.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "tidy", "fix", ".", "--dedent", "auto", "--indent", "4", "--apply",
+        ])
+        .current_dir(dir.path())
+        .assert()
+        .code(1);
+}
+
+#[test]
+fn test_tidy_fix_dedent_dry_run_no_modify() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("indented.txt");
+    let original = "    line1\n    line2\n";
+    fs::write(&file, original).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["tidy", "fix", ".", "--dedent", "auto"])
+        .current_dir(dir.path())
+        .assert()
+        .code(2);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, original, "file should not be modified in dry-run");
+}


### PR DESCRIPTION
## Summary

Add dedent and indent capabilities to the `tidy fix` command, enabling LLM agents to normalize indentation as part of whitespace cleanup operations.

### New CLI flags

- `--dedent <spec>`: remove leading whitespace. Values: `auto` (remove common indent), `tab`, or a number (e.g. `4`)
- `--indent <spec>`: add leading whitespace. Values: `tab` or a number (e.g. `4`)
- `--lines <range>`: restrict dedent/indent to a 1-based line range (e.g. `10:50`, `5:`, `3`)

`--dedent` and `--indent` are mutually exclusive. Validation is enforced at CLI argument parsing, tx engine, and plan validation layers.

### Changes

- `src/write.rs`: add `dedent_content()`, `dedent_by_n()`, `indent_content()`, `parse_line_range()`
- `src/plan.rs`: extend `Operation::TidyFix` with `dedent`, `indent`, `lines` fields
- `src/cmd/tidy.rs`: add CLI args and early validation
- `src/tx/execute.rs`: wire dedent/indent into TidyFix handler
- `src/tx/engine.rs`, `src/tx/validate.rs`: mutual exclusion validation
- `src/cmd/mcp/handlers.rs`, `src/cmd/mcp/params.rs`: extend MCP `fix_whitespace` tool
- `src/api/tidy.rs`: add `TidyIndentOptions` and `tidy_with_indent()` public API
- `src/cmd/explain.rs`: human-readable descriptions for dedent/indent
- `src/cmd/batch.rs`, `src/schema_tests.rs`: update TidyFix constructions

### Tests

- 18 unit tests in `src/write_tests.rs`: auto/numeric/tab dedent, numeric/tab/zero indent, line ranges, parse_line_range edge cases
- 7 integration tests in `tests/integration/tidy_tests.rs`: dedent auto/numeric apply, indent numeric/tab apply, line range, mutual exclusion rejection, dry-run no-modify

Closes #1021