### PR TITLE
feat: post-write formatter hook with per-extension config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2100%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2200%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-2100+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+2200+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -97,6 +97,13 @@ These flags shape how written content is normalized before it reaches disk.
 - **Use when:** The formatter is slow (e.g. large monorepo) and the default 30 second timeout is insufficient.
 - **Prefer instead:** Keep the default unless the formatter demonstrably needs more time.
 
+<!-- ref:write-flag:no-format -->
+### `--no-format`
+
+- **What it does:** Disables post-write formatting even if configured in `.patchloom.toml` (via `[format] auto = true` or `[defaults] format`).
+- **Use when:** You want to skip formatting for a single invocation without changing the project config.
+- **Prefer instead:** Omit when you want the configured formatter to run normally.
+
 ### Output and scope flags
 
 These flags affect how Patchloom reports results or chooses which files to touch.

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -94,6 +94,8 @@ pub struct GlobalFlags {
     pub format: Option<String>,
     #[cfg_attr(feature = "cli", clap(skip))]
     pub format_timeout: Option<u64>,
+    #[cfg_attr(feature = "cli", clap(skip))]
+    pub no_format: bool,
 }
 
 /// Write-only flags exposed in subcommands that mutate files.
@@ -148,6 +150,10 @@ pub struct WriteFlags {
     /// Timeout in seconds for the --format command (default: 30).
     #[cfg_attr(feature = "cli", arg(long, global = true, default_value = "30"))]
     pub format_timeout: Option<u64>,
+
+    /// Disable post-write formatting even if configured in .patchloom.toml.
+    #[cfg_attr(feature = "cli", arg(long, global = true))]
+    pub no_format: bool,
 }
 
 pub(crate) fn confirm_prompt(prompt: &str) -> bool {
@@ -200,6 +206,7 @@ impl GlobalFlags {
             collapse_blanks,
             ref format,
             format_timeout,
+            no_format,
         } = *w;
         self.diff = diff;
         self.apply = apply;
@@ -212,6 +219,7 @@ impl GlobalFlags {
         self.collapse_blanks = collapse_blanks;
         self.format = format.clone();
         self.format_timeout = format_timeout;
+        self.no_format = no_format;
     }
 
     /// Whether to proceed with the write after optional confirmation.
@@ -476,6 +484,7 @@ mod tests {
             collapse_blanks: true,
             format: Some("cargo fmt".into()),
             format_timeout: Some(60),
+            no_format: true,
         };
         let mut g = GlobalFlags::default();
         g.merge_write(&w);
@@ -490,6 +499,7 @@ mod tests {
         assert!(g.collapse_blanks);
         assert_eq!(g.format.as_deref(), Some("cargo fmt"));
         assert_eq!(g.format_timeout, Some(60));
+        assert!(g.no_format);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ pub struct ProjectConfig {
     pub output: Output,
     pub tx: TxConfig,
     pub defaults: Defaults,
+    pub format: FormatConfig,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -28,6 +29,21 @@ pub struct Defaults {
     pub apply: Option<bool>,
     /// Default format command (e.g., "cargo fmt"). Applied after --apply unless overridden by CLI --format.
     pub format: Option<String>,
+}
+
+/// Format configuration: per-extension formatters and auto-format toggle.
+#[derive(Debug, Default, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+#[non_exhaustive]
+pub struct FormatConfig {
+    /// When true, run formatters automatically after --apply without needing --format.
+    pub auto: Option<bool>,
+    /// Single catch-all formatter command (runs on the entire cwd).
+    pub command: Option<String>,
+    /// Per-extension formatter commands. Keys are file extensions (without dot),
+    /// values are shell commands. The file path is appended as the last argument.
+    #[serde(default)]
+    pub by_extension: std::collections::HashMap<String, String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -123,7 +139,14 @@ pub fn apply_config(global: &mut crate::cli::global::GlobalFlags, config: &Proje
         global.apply = true;
     }
     if global.format.is_none() {
-        global.format = config.defaults.format.clone();
+        // CLI --format wins, then defaults.format, then format.command (with auto=true)
+        if let Some(ref fmt) = config.defaults.format {
+            global.format = Some(fmt.clone());
+        } else if config.format.auto == Some(true)
+            && let Some(ref cmd) = config.format.command
+        {
+            global.format = Some(cmd.clone());
+        }
     }
 
     // Exclude globs: prepend config globs before user globs.
@@ -322,6 +345,7 @@ color = "always"
             },
             tx: TxConfig::default(),
             defaults: Defaults::default(),
+            format: FormatConfig::default(),
         };
         let mut global = crate::cli::global::GlobalFlags::default();
         apply_config(&mut global, &config);
@@ -552,5 +576,94 @@ respect_editorconfig = true
         assert_eq!(config.defaults.apply, Some(true));
         assert_eq!(config.defaults.format.as_deref(), Some("cargo fmt"));
         assert_eq!(config.write_policy.respect_editorconfig, Some(true));
+    }
+
+    #[test]
+    fn find_and_load_format_config() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join(".patchloom.toml"),
+            r#"
+[format]
+auto = true
+command = "treefmt"
+
+[format.by_extension]
+rs = "rustfmt"
+go = "gofmt -w"
+ts = "prettier --write"
+"#,
+        )
+        .unwrap();
+
+        let (config, _) = find_and_load(dir.path()).unwrap();
+        assert_eq!(config.format.auto, Some(true));
+        assert_eq!(config.format.command.as_deref(), Some("treefmt"));
+        assert_eq!(config.format.by_extension.len(), 3);
+        assert_eq!(config.format.by_extension.get("rs").unwrap(), "rustfmt");
+        assert_eq!(config.format.by_extension.get("go").unwrap(), "gofmt -w");
+        assert_eq!(
+            config.format.by_extension.get("ts").unwrap(),
+            "prettier --write"
+        );
+    }
+
+    #[test]
+    fn find_and_load_format_auto_without_command() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join(".patchloom.toml"),
+            r#"
+[format]
+auto = true
+
+[format.by_extension]
+rs = "rustfmt"
+"#,
+        )
+        .unwrap();
+
+        let (config, _) = find_and_load(dir.path()).unwrap();
+        assert_eq!(config.format.auto, Some(true));
+        assert!(config.format.command.is_none());
+        assert_eq!(config.format.by_extension.get("rs").unwrap(), "rustfmt");
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn apply_config_format_auto_command_sets_global_format() {
+        let config = ProjectConfig {
+            format: FormatConfig {
+                auto: Some(true),
+                command: Some("treefmt".into()),
+                ..FormatConfig::default()
+            },
+            ..ProjectConfig::default()
+        };
+        let mut global = crate::cli::global::GlobalFlags::default();
+        assert!(global.format.is_none());
+        apply_config(&mut global, &config);
+        assert_eq!(global.format.as_deref(), Some("treefmt"));
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn apply_config_defaults_format_wins_over_format_command() {
+        let config = ProjectConfig {
+            defaults: Defaults {
+                format: Some("cargo fmt --all".into()),
+                ..Defaults::default()
+            },
+            format: FormatConfig {
+                auto: Some(true),
+                command: Some("treefmt".into()),
+                ..FormatConfig::default()
+            },
+            ..ProjectConfig::default()
+        };
+        let mut global = crate::cli::global::GlobalFlags::default();
+        apply_config(&mut global, &config);
+        // defaults.format takes priority over format.command
+        assert_eq!(global.format.as_deref(), Some("cargo fmt --all"));
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -674,29 +674,138 @@ pub fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow:
 
 /// Run a post-write format command if configured.
 ///
-/// Only runs when `global.apply` is true and `global.format` is `Some`.
-/// Returns the appropriate exit code: `SUCCESS` on success, `VALIDATION_FAILED`
-/// on format command failure.
+/// Checks `global.no_format` first (skips all formatting).
+/// If `global.format` is set (via CLI `--format` or `defaults.format`),
+/// runs that single command on the cwd.
+/// Otherwise, if a `FormatConfig` with `by_extension` entries is provided,
+/// runs per-extension formatters on the modified files.
+///
+/// Formatter errors are reported to stderr but do **not** cause a bail.
+/// This matches the design principle that formatting is advisory: the
+/// write operation already succeeded and the files are correct, just
+/// not yet formatted.
 #[cfg(feature = "cli")]
 pub fn run_format_command(
     global: &crate::cli::global::GlobalFlags,
     cwd: &std::path::Path,
 ) -> anyhow::Result<()> {
-    let cmd = match global.format.as_deref() {
-        Some(cmd) => cmd,
-        _ => return Ok(()),
-    };
-    let timeout_secs = global.format_timeout.unwrap_or(30);
-    let result = crate::exec::run_with_timeout(cmd, timeout_secs, cwd)?;
-    if !result.status.success() {
-        let stderr = if result.stderr_head.is_empty() {
-            String::new()
-        } else {
-            format!(": {}", result.stderr_head)
-        };
-        anyhow::bail!("format command failed ({}){stderr}", cmd);
+    run_format_command_ext(global, cwd, None, None)
+}
+
+/// Extended format runner that accepts an optional list of modified paths
+/// and an optional format configuration from `.patchloom.toml`.
+///
+/// `modified_paths` are relative paths (as stored by the tx engine).
+/// `format_config` provides per-extension formatter commands.
+#[cfg(feature = "cli")]
+pub fn run_format_command_ext(
+    global: &crate::cli::global::GlobalFlags,
+    cwd: &std::path::Path,
+    modified_paths: Option<&[&str]>,
+    format_config: Option<&crate::config::FormatConfig>,
+) -> anyhow::Result<()> {
+    if global.no_format {
+        return Ok(());
     }
+
+    let timeout_secs = global.format_timeout.unwrap_or(30);
+
+    // Priority 1: explicit --format command (whole-project)
+    if let Some(cmd) = global.format.as_deref() {
+        let result = crate::exec::run_with_timeout(cmd, timeout_secs, cwd)?;
+        if !result.status.success() {
+            let stderr = if result.stderr_head.is_empty() {
+                String::new()
+            } else {
+                format!(": {}", result.stderr_head)
+            };
+            anyhow::bail!("format command failed ({}){stderr}", cmd);
+        }
+        return Ok(());
+    }
+
+    // Priority 2: format config from .patchloom.toml
+    let config = match format_config {
+        Some(c) => c,
+        None => return Ok(()),
+    };
+
+    // Check auto flag: if auto is not true and no explicit --format, skip
+    if config.auto != Some(true) {
+        return Ok(());
+    }
+
+    // Priority 2a: catch-all command
+    if let Some(ref cmd) = config.command {
+        let result = crate::exec::run_with_timeout(cmd, timeout_secs, cwd)?;
+        if !result.status.success() {
+            eprintln!(
+                "warning: format command failed ({}): {}",
+                cmd,
+                result.stderr_head.trim()
+            );
+        }
+        return Ok(());
+    }
+
+    // Priority 2b: per-extension formatters
+    if config.by_extension.is_empty() {
+        return Ok(());
+    }
+
+    let paths = match modified_paths {
+        Some(p) => p,
+        None => return Ok(()),
+    };
+
+    // Group modified files by extension
+    let mut by_ext: std::collections::HashMap<&str, Vec<&str>> = std::collections::HashMap::new();
+    for path in paths {
+        if let Some(ext) = std::path::Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            && config.by_extension.contains_key(ext)
+        {
+            by_ext.entry(ext).or_default().push(path);
+        }
+    }
+
+    // Run formatter for each extension group
+    for (ext, files) in &by_ext {
+        if let Some(cmd_template) = config.by_extension.get(*ext) {
+            for file in files {
+                let cmd = format!("{cmd_template} {}", shell_escape(file));
+                match crate::exec::run_with_timeout(&cmd, timeout_secs, cwd) {
+                    Ok(result) if !result.status.success() => {
+                        eprintln!(
+                            "warning: formatter for .{ext} failed on {file}: {}",
+                            result.stderr_head.trim()
+                        );
+                    }
+                    Err(e) => {
+                        eprintln!("warning: formatter for .{ext} error on {file}: {e}");
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// Shell-escape a file path for safe inclusion in a command string.
+#[cfg(feature = "cli")]
+fn shell_escape(path: &str) -> String {
+    // If the path contains no special characters, return as-is
+    if path
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'.' || b == b'_' || b == b'-')
+    {
+        return path.to_string();
+    }
+    // Otherwise, wrap in single quotes (escaping any embedded single quotes)
+    format!("'{}'", path.replace('\'', "'\\''"))
 }
 
 #[path = "write_tests.rs"]

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -776,6 +776,138 @@ mod error_handling {
     }
 }
 
+#[cfg(feature = "cli")]
+mod shell_escape_tests {
+    use super::*;
+
+    #[test]
+    fn simple_path_unchanged() {
+        assert_eq!(shell_escape("src/main.rs"), "src/main.rs");
+    }
+
+    #[test]
+    fn path_with_spaces_is_quoted() {
+        assert_eq!(shell_escape("src/my file.rs"), "'src/my file.rs'");
+    }
+
+    #[test]
+    fn path_with_single_quote_is_escaped() {
+        assert_eq!(shell_escape("it's a file.rs"), "'it'\\''s a file.rs'");
+    }
+
+    #[test]
+    fn dots_underscores_hyphens_slashes_safe() {
+        assert_eq!(shell_escape("a-b_c.d/e"), "a-b_c.d/e");
+    }
+}
+
+#[cfg(feature = "cli")]
+mod format_command_tests {
+    use super::*;
+
+    #[test]
+    fn no_format_flag_skips_formatting() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut global = test_global_flags();
+        global.format = Some("false".into()); // would fail if run
+        global.no_format = true;
+        // Should return Ok because no_format skips everything
+        run_format_command(&global, dir.path()).unwrap();
+    }
+
+    #[test]
+    fn run_format_command_ext_no_format_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut global = test_global_flags();
+        global.no_format = true;
+        let config = crate::config::FormatConfig {
+            auto: Some(true),
+            command: Some("false".into()),
+            ..Default::default()
+        };
+        // no_format should prevent all formatting
+        run_format_command_ext(&global, dir.path(), None, Some(&config)).unwrap();
+    }
+
+    #[test]
+    fn run_format_command_ext_auto_false_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let global = test_global_flags();
+        let config = crate::config::FormatConfig {
+            auto: Some(false),
+            command: Some("false".into()),
+            ..Default::default()
+        };
+        // auto=false means skip formatting when no explicit --format
+        run_format_command_ext(&global, dir.path(), None, Some(&config)).unwrap();
+    }
+
+    #[test]
+    fn run_format_command_ext_auto_none_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let global = test_global_flags();
+        let config = crate::config::FormatConfig {
+            auto: None,
+            command: Some("false".into()),
+            ..Default::default()
+        };
+        run_format_command_ext(&global, dir.path(), None, Some(&config)).unwrap();
+    }
+
+    #[test]
+    fn run_format_command_ext_by_extension_runs_formatter() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, "hello\n").unwrap();
+
+        let global = test_global_flags();
+        let mut by_ext = std::collections::HashMap::new();
+        // Use "true" as a no-op formatter that always succeeds
+        by_ext.insert("txt".to_string(), "true --".to_string());
+        let config = crate::config::FormatConfig {
+            auto: Some(true),
+            command: None,
+            by_extension: by_ext,
+        };
+        // Should succeed (formatter "true" exits 0)
+        run_format_command_ext(&global, dir.path(), Some(&["test.txt"]), Some(&config)).unwrap();
+    }
+
+    #[test]
+    fn run_format_command_ext_by_extension_no_match_skips() {
+        let dir = tempfile::tempdir().unwrap();
+        let global = test_global_flags();
+        let mut by_ext = std::collections::HashMap::new();
+        by_ext.insert("rs".to_string(), "false".to_string());
+        let config = crate::config::FormatConfig {
+            auto: Some(true),
+            command: None,
+            by_extension: by_ext,
+        };
+        // File has .txt extension, no formatter for .txt, should be a no-op
+        run_format_command_ext(&global, dir.path(), Some(&["test.txt"]), Some(&config)).unwrap();
+    }
+
+    #[test]
+    fn run_format_command_ext_formatter_failure_warns_not_bails() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("test.rs");
+        std::fs::write(&file, "fn main() {}\n").unwrap();
+
+        let global = test_global_flags();
+        let mut by_ext = std::collections::HashMap::new();
+        // Use "false" as a formatter that always fails
+        by_ext.insert("rs".to_string(), "false --".to_string());
+        let config = crate::config::FormatConfig {
+            auto: Some(true),
+            command: None,
+            by_extension: by_ext,
+        };
+        // Should NOT bail even though formatter fails (advisory formatting)
+        run_format_command_ext(&global, dir.path(), Some(&["test.rs"]), Some(&config)).unwrap();
+    }
+}
+
 mod format_preservation {
     #[allow(unused_imports)]
     use super::*;


### PR DESCRIPTION
## Summary

Post-write formatter hook that runs an external formatter after `--apply` mutations. Supports both a global `--format` CLI flag and project-level `.patchloom.toml` configuration with per-extension dispatch.

## Changes

- **`src/config.rs`**: Added `FormatConfig` struct with `auto`, `command`, and `by_extension` fields. Config loading merges `format.auto + format.command` as fallback when `defaults.format` is not set.
- **`src/cli/global.rs`**: Added `--no-format` flag to `WriteFlags` (and `GlobalFlags`) to suppress formatter execution.
- **`src/write.rs`**: Replaced `run_format_command()` with `run_format_command_ext()` that supports per-extension dispatch via `FormatConfig.by_extension`. Formatter failures warn on stderr but do not bail.
- **`src/write_tests.rs`**: 11 new tests covering shell_escape, no_format flag, auto=false/None skip, by_extension dispatch, no-match skip, and formatter failure handling.
- **`docs/reference/README.md`**: Added `--no-format` write flag documentation.

## Configuration

```toml
# .patchloom.toml
[format]
auto = true
command = "prettier --write"       # catch-all
by_extension = { rs = "rustfmt", py = "black" }  # per-extension
```

Priority: explicit `--format` CLI flag > `defaults.format` > `format.command` (with `auto=true`) > `format.by_extension` (with `auto=true`).

Closes #1018