### PR TITLE
feat: pre/post-operation symbol verification for tx plans

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -855,6 +855,16 @@ Use these when newline and whitespace correctness is the main concern.
 - **Failure behavior:** `required: true` makes the step gate transaction success. `required: false` still reports the validation problem to stderr. Error output reports the failing step number, exit status, the lifecycle working directory (`cwd`), and a truncated snippet of the command's stderr when available.
 - **Prefer instead:** Use standalone verification outside `tx` when the mutation and the validation lifecycle should stay separate.
 
+<!-- ref:tx-field:verify -->
+### `verify`
+
+- **What it does:** Runs pre/post-operation symbol verification checks to ensure structural safety.
+- **Use when:** A refactoring plan must preserve the number of functions, test methods, or other AST symbols.
+- **Field value:** Array of check objects. Each is either `{"kind": "function", "attr": "test"}` (symbol count) or `{"check": "unique_names"}` (named check).
+- **CLI equivalent:** `--verify="kind=function,attr=test"` (repeatable).
+- **Failure behavior:** When a check fails, the transaction rolls back and exits with `VALIDATION_FAILED` (6).
+- **Prefer instead:** Omit when the plan only touches configuration files or non-code content.
+
 ### Transaction operations
 
 The operations below are the building blocks inside `operations`.

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -628,6 +628,31 @@ fn extract_generic(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolK
     None
 }
 
+/// Parse a comma-separated kind filter string into a list of `SymbolKind`s.
+pub fn parse_kind_filter(kind_arg: &Option<String>) -> Vec<SymbolKind> {
+    match kind_arg {
+        Some(s) => s
+            .split(',')
+            .filter_map(|k| SymbolKind::from_str_loose(k.trim()))
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+/// Filter symbols by kind. Returns all symbols if filter is empty.
+pub fn filter_symbols<'a>(
+    symbols: &'a [SymbolDef],
+    kind_filter: &[SymbolKind],
+) -> Vec<&'a SymbolDef> {
+    if kind_filter.is_empty() {
+        return symbols.iter().collect();
+    }
+    symbols
+        .iter()
+        .filter(|s| kind_filter.contains(&s.kind))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1,7 +1,7 @@
 //! AST-aware subcommands: `patchloom ast list|read|rename|validate|search|refs|deps|map|replace|impact|diff`.
 
 use crate::ast::Language;
-use crate::ast::symbols::{self, SymbolDef, SymbolKind};
+use crate::ast::symbols::{self, SymbolDef};
 use crate::cli::global::GlobalFlags;
 use crate::cmd::output::WritePhase;
 use crate::cmd::output::execute_via_engine;
@@ -1066,28 +1066,7 @@ pub fn lang_from_str(s: &str) -> Language {
     Language::from_extension(s)
 }
 
-pub fn parse_kind_filter(kind_arg: &Option<String>) -> Vec<SymbolKind> {
-    match kind_arg {
-        Some(s) => s
-            .split(',')
-            .filter_map(|k| SymbolKind::from_str_loose(k.trim()))
-            .collect(),
-        None => Vec::new(),
-    }
-}
-
-pub fn filter_symbols<'a>(
-    symbols: &'a [SymbolDef],
-    kind_filter: &[SymbolKind],
-) -> Vec<&'a SymbolDef> {
-    if kind_filter.is_empty() {
-        return symbols.iter().collect();
-    }
-    symbols
-        .iter()
-        .filter(|s| kind_filter.contains(&s.kind))
-        .collect()
-}
+pub use symbols::{filter_symbols, parse_kind_filter};
 
 pub fn collect_source_files(
     dir: &std::path::Path,
@@ -1170,6 +1149,7 @@ pub fn symbol_to_json(sym: &SymbolDef, path: &str) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ast::symbols::SymbolKind;
 
     #[test]
     fn parse_kind_filter_works() {

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -415,6 +415,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             operations,
             format: None,
             validate: None,
+            verify: None,
         };
         serde_json::to_string(&plan)?
     };
@@ -431,6 +432,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             .to_string(),
         plan_format: None,
         no_strict: false,
+        verify: Vec::new(),
         write: args.write,
     };
     // Delegate to tx, which handles --apply / --confirm / --format / plan lifecycle.

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -491,6 +491,7 @@ mod tests {
             ],
             format: None,
             validate: None,
+            verify: None,
         };
         // Just ensure it doesn't panic.
         print_human_summary(&plan, true);
@@ -515,6 +516,7 @@ mod tests {
                 required: Some(true),
                 timeout: None,
             }]),
+            verify: None,
         };
         let json = build_json_summary(&plan, false);
         assert_eq!(json["operation_count"], 1);

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -326,6 +326,7 @@ fn make_plan_strict(operations: Vec<Operation>, strict: Option<bool>) -> Plan {
         operations,
         format: None,
         validate: None,
+        verify: None,
     }
 }
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -282,6 +282,43 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::PARSE_ERROR);
     }
 
+    // 3b. Merge --verify CLI args with plan's verify field.
+    #[cfg(feature = "ast")]
+    let verify_checks = {
+        use crate::plan::VerifyCheck;
+        let mut checks: Vec<VerifyCheck> = plan.verify.clone().unwrap_or_default();
+        for raw in &args.verify {
+            match VerifyCheck::parse(raw) {
+                Ok(c) => checks.push(c),
+                Err(e) => {
+                    let msg = format!("invalid --verify spec '{raw}': {e}");
+                    if structured {
+                        emit_error_json("parse_error", &msg, None, compact);
+                    } else {
+                        eprintln!("tx: {msg}");
+                    }
+                    return Ok(exit::PARSE_ERROR);
+                }
+            }
+        }
+        checks
+    };
+
+    // 3c. Take pre-execution symbol snapshot for verification.
+    #[cfg(feature = "ast")]
+    let verify_before = if !verify_checks.is_empty() {
+        let affected = crate::tx::verify::affected_file_paths(&plan, &cwd);
+        verify_checks
+            .iter()
+            .map(|check| {
+                let snap = crate::tx::verify::snapshot_symbols(&affected, check);
+                (check.clone(), snap)
+            })
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
     // 4. Execute all operations, collecting changes in memory (no writes).
     let mut result =
         match crate::tx::execute_and_collect(&plan, &cwd, global, global.quiet, structured) {
@@ -296,6 +333,38 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 return Ok(exit::OPERATION_FAILED);
             }
         };
+
+    // 4b. Post-execution verification against pending content.
+    #[cfg(feature = "ast")]
+    if !verify_before.is_empty() {
+        let affected = crate::tx::verify::affected_file_paths(&plan, &cwd);
+        let mut any_failed = false;
+        let mut messages = Vec::new();
+        for (check, before_snap) in &verify_before {
+            let after_snap =
+                crate::tx::verify::snapshot_symbols_from_pending(&affected, &result.pending, check);
+            let vr = crate::tx::verify::compare_snapshots(before_snap, &after_snap, check, &cwd);
+            messages.push(vr.message.clone());
+            if !vr.passed {
+                any_failed = true;
+            }
+        }
+        let summary = messages.join("\n");
+        if any_failed {
+            let msg = format!("verification failed, changes not applied:\n{summary}");
+            if structured {
+                emit_error_json("verification_failed", &msg, None, compact);
+            } else {
+                eprintln!("tx: {msg}");
+            }
+            return Ok(exit::VALIDATION_FAILED);
+        }
+        if !global.quiet {
+            for m in &messages {
+                eprintln!("tx: {m}");
+            }
+        }
+    }
 
     // Deletions of empty files won't appear in `changes` (original == final == ""),
     // but they still count as changes for --check reporting.

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -141,6 +141,7 @@ mod basic {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -197,6 +198,7 @@ mod basic {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -252,6 +254,7 @@ mod basic {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -287,6 +290,7 @@ mod basic {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -326,6 +330,7 @@ mod basic {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -366,6 +371,7 @@ mod basic {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -450,6 +456,7 @@ mod basic {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -479,6 +486,7 @@ mod basic {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -542,6 +550,7 @@ mod edge_cases {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -575,6 +584,7 @@ mod edge_cases {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -613,6 +623,7 @@ mod edge_cases {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -645,6 +656,7 @@ mod edge_cases {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -680,6 +692,7 @@ mod edge_cases {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -712,6 +725,7 @@ mod edge_cases {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -737,6 +751,7 @@ mod error_handling {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let global = GlobalFlags::test_default();
@@ -834,6 +849,7 @@ mod error_handling {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -954,6 +970,7 @@ mod error_handling {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let global = GlobalFlags::test_default();
@@ -996,6 +1013,7 @@ mod error_handling {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1029,6 +1047,7 @@ mod error_handling {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1077,6 +1096,7 @@ mod integrity {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1113,6 +1133,7 @@ mod integrity {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1176,6 +1197,7 @@ mod integrity {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1211,6 +1233,7 @@ mod integrity {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1246,6 +1269,7 @@ mod integrity {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1285,6 +1309,7 @@ mod integrity {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1393,6 +1418,7 @@ mod integrity {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1437,6 +1463,7 @@ mod integrity {
             plan: plan_file.to_str().unwrap().to_string(),
             plan_format: None,
             no_strict: false,
+            verify: Vec::new(),
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -38,6 +38,57 @@ pub struct Plan {
     pub operations: Vec<Operation>,
     pub format: Option<Vec<FormatStep>>,
     pub validate: Option<Vec<ValidationStep>>,
+    /// Pre/post-operation symbol verification checks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verify: Option<Vec<VerifyCheck>>,
+}
+
+/// A single verification check parsed from `--verify` or plan `verify` field.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum VerifyCheck {
+    /// `{"kind": "function", "attr": "test"}` or `{"kind": "function"}`
+    SymbolCount {
+        kind: String,
+        #[serde(default)]
+        attr: Option<String>,
+    },
+    /// `{"check": "unique_names"}` or `{"check": "no_orphans"}`
+    Named { check: String },
+}
+
+impl VerifyCheck {
+    /// Parse a CLI `--verify` value like `kind=function,attr=test` or `unique_names`.
+    #[cfg(feature = "cli")]
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        if s == "unique_names" || s == "no_orphans" {
+            return Ok(VerifyCheck::Named {
+                check: s.to_string(),
+            });
+        }
+        let mut kind = None;
+        let mut attr = None;
+        for part in s.split(',') {
+            let part = part.trim();
+            if let Some((k, v)) = part.split_once('=') {
+                match k.trim() {
+                    "kind" => kind = Some(v.trim().to_string()),
+                    "attr" => attr = Some(v.trim().to_string()),
+                    other => anyhow::bail!("unknown verify key: {other}"),
+                }
+            } else {
+                // Bare word like "function" treated as kind
+                kind = Some(part.to_string());
+            }
+        }
+        if let Some(kind) = kind {
+            Ok(VerifyCheck::SymbolCount { kind, attr })
+        } else {
+            anyhow::bail!(
+                "verify spec must contain 'kind=<type>' or a named check (unique_names, no_orphans)"
+            )
+        }
+    }
 }
 
 /// A format step to run after applying operations but before validation.

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -215,6 +215,7 @@ fn execute_plan_inner(
         operations,
         format: None,
         validate: None,
+        verify: None,
         cwd: None,
         strict: None,
         write_policy: None,

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -392,6 +392,25 @@ pub fn execute_plan_direct(
         }
     }
 
+    // Pre-execution verification snapshot.
+    #[cfg(feature = "ast")]
+    let verify_before = if let Some(ref checks) = plan.verify {
+        if !checks.is_empty() {
+            let affected = super::verify::affected_file_paths(&plan, &effective_cwd);
+            checks
+                .iter()
+                .map(|check| {
+                    let snap = super::verify::snapshot_symbols(&affected, check);
+                    (check.clone(), snap)
+                })
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        }
+    } else {
+        Vec::new()
+    };
+
     // Execute operations and collect changes in memory.
     let mut result = match execute_and_collect(&plan, &effective_cwd, &global, true, true) {
         Ok(r) => r,
@@ -418,6 +437,34 @@ pub fn execute_plan_direct(
     if result.no_effective_changes {
         let output = build_full_tx_output("success", &mut result, &effective_cwd);
         return Ok(output);
+    }
+
+    // Post-execution verification against pending content.
+    #[cfg(feature = "ast")]
+    if !verify_before.is_empty() {
+        let affected = super::verify::affected_file_paths(&plan, &effective_cwd);
+        let mut messages = Vec::new();
+        let mut any_failed = false;
+        for (check, before_snap) in &verify_before {
+            let after_snap =
+                super::verify::snapshot_symbols_from_pending(&affected, &result.pending, check);
+            let vr =
+                super::verify::compare_snapshots(before_snap, &after_snap, check, &effective_cwd);
+            messages.push(vr.message.clone());
+            if !vr.passed {
+                any_failed = true;
+            }
+        }
+        if any_failed {
+            let summary = messages.join("\n");
+            let msg = format!("verification failed, changes not applied:\n{summary}");
+            return Ok(build_error_output(
+                "verification_failed",
+                "verification_failed",
+                &msg,
+                None,
+            ));
+        }
     }
 
     // Apply: back up originals, write files.
@@ -568,6 +615,7 @@ mod tests {
             operations: Vec::new(),
             format: None,
             validate: None,
+            verify: None,
             cwd: None,
             strict: None,
             write_policy: None,

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -7,6 +7,7 @@ mod output;
 mod replace_op;
 mod search_op;
 mod validate;
+pub(crate) mod verify;
 
 // Re-export all pub and pub(crate) items so `crate::tx::*` paths continue to work.
 
@@ -57,6 +58,11 @@ pub struct TxArgs {
     /// Disable strict rollback on format/validate failure.
     #[arg(long)]
     pub no_strict: bool,
+
+    /// Verify symbol counts before and after execution. Repeatable.
+    /// Examples: `--verify="kind=function,attr=test"`, `--verify=unique_names`.
+    #[arg(long)]
+    pub verify: Vec<String>,
 
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -1,0 +1,596 @@
+//! Pre/post-operation symbol count verification for structural safety.
+//!
+//! When `--verify` is used, the tx engine captures a symbol snapshot before
+//! executing operations and compares it against a post-execution snapshot.
+//! Mismatches trigger rollback with a descriptive error.
+
+#[cfg(feature = "ast")]
+use crate::ast::{Language, symbols};
+use crate::plan::VerifyCheck;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// Snapshot of symbol counts per file, keyed by file path.
+#[cfg(feature = "ast")]
+#[derive(Debug, Clone)]
+pub(crate) struct SymbolSnapshot {
+    /// Per-file symbol lists (only files matching the criteria).
+    pub(crate) files: HashMap<PathBuf, Vec<SnappedSymbol>>,
+    /// Total count of matching symbols.
+    pub(crate) total: usize,
+}
+
+/// A symbol captured in a snapshot.
+#[cfg(feature = "ast")]
+#[derive(Debug, Clone)]
+pub(crate) struct SnappedSymbol {
+    pub(crate) name: String,
+    /// Retained for diagnostic messages in compare_snapshots.
+    #[allow(dead_code)]
+    pub(crate) kind: symbols::SymbolKind,
+}
+
+/// Collect all file paths declared by operations in a plan.
+pub(crate) fn affected_file_paths(plan: &crate::plan::Plan, cwd: &Path) -> Vec<PathBuf> {
+    let mut paths = HashSet::new();
+    for op in &plan.operations {
+        for p in op.declared_paths() {
+            let full = cwd.join(p);
+            if full.is_file() {
+                paths.insert(full);
+            } else if full.is_dir() {
+                // For directory targets (e.g. glob replace), scan for source files
+                #[cfg(all(feature = "ast", feature = "cli"))]
+                if let Ok(files) = crate::cmd::ast::collect_source_files(
+                    &full,
+                    &crate::cli::global::GlobalFlags::default(),
+                ) {
+                    for f in files {
+                        paths.insert(f);
+                    }
+                }
+            }
+        }
+    }
+    paths.into_iter().collect()
+}
+
+/// Take a symbol snapshot of the given files for a specific verify check.
+#[cfg(feature = "ast")]
+pub(crate) fn snapshot_symbols(files: &[PathBuf], check: &VerifyCheck) -> SymbolSnapshot {
+    use symbols::{filter_symbols, parse_kind_filter};
+
+    let mut result = SymbolSnapshot {
+        files: HashMap::new(),
+        total: 0,
+    };
+
+    let (kind_filter, attr_filter) = match check {
+        VerifyCheck::SymbolCount { kind, attr } => {
+            (parse_kind_filter(&Some(kind.clone())), attr.clone())
+        }
+        VerifyCheck::Named { check } if check == "unique_names" || check == "no_orphans" => {
+            // For named checks, capture all symbols
+            (Vec::new(), None)
+        }
+        _ => return result,
+    };
+
+    for path in files {
+        let lang = Language::from_path(path);
+        if !lang.has_grammar() {
+            continue;
+        }
+        let all_symbols = symbols::extract_symbols_from_file(path, Some(lang));
+        let filtered = filter_symbols(&all_symbols, &kind_filter);
+
+        // If attr filter is set, further filter by checking the source for the attribute
+        let matched: Vec<SnappedSymbol> = if let Some(ref attr) = attr_filter {
+            let source = std::fs::read_to_string(path).unwrap_or_default();
+            filtered
+                .into_iter()
+                .filter(|sym| symbol_has_attr(&source, sym, attr))
+                .map(|sym| SnappedSymbol {
+                    name: sym.name.clone(),
+                    kind: sym.kind,
+                })
+                .collect()
+        } else {
+            filtered
+                .into_iter()
+                .map(|sym| SnappedSymbol {
+                    name: sym.name.clone(),
+                    kind: sym.kind,
+                })
+                .collect()
+        };
+
+        result.total += matched.len();
+        if !matched.is_empty() {
+            result.files.insert(path.clone(), matched);
+        }
+    }
+
+    result
+}
+
+/// Take a snapshot from in-memory pending content (post-execution, before commit).
+#[cfg(feature = "ast")]
+pub(crate) fn snapshot_symbols_from_pending(
+    files: &[PathBuf],
+    pending: &HashMap<PathBuf, (String, String)>,
+    check: &VerifyCheck,
+) -> SymbolSnapshot {
+    use symbols::{filter_symbols, parse_kind_filter};
+
+    let mut result = SymbolSnapshot {
+        files: HashMap::new(),
+        total: 0,
+    };
+
+    let (kind_filter, attr_filter) = match check {
+        VerifyCheck::SymbolCount { kind, attr } => {
+            (parse_kind_filter(&Some(kind.clone())), attr.clone())
+        }
+        VerifyCheck::Named { check } if check == "unique_names" || check == "no_orphans" => {
+            (Vec::new(), None)
+        }
+        _ => return result,
+    };
+
+    for path in files {
+        let lang = Language::from_path(path);
+        if !lang.has_grammar() {
+            continue;
+        }
+
+        // Use pending content (post-edit) if available, otherwise read from disk
+        let source = if let Some((_, current)) = pending.get(path) {
+            current.clone()
+        } else if let Ok(s) = std::fs::read_to_string(path) {
+            s
+        } else {
+            continue;
+        };
+
+        let all_symbols = symbols::extract_symbols(&source, lang);
+        let filtered = filter_symbols(&all_symbols, &kind_filter);
+
+        let matched: Vec<SnappedSymbol> = if let Some(ref attr) = attr_filter {
+            filtered
+                .into_iter()
+                .filter(|sym| symbol_has_attr(&source, sym, attr))
+                .map(|sym| SnappedSymbol {
+                    name: sym.name.clone(),
+                    kind: sym.kind,
+                })
+                .collect()
+        } else {
+            filtered
+                .into_iter()
+                .map(|sym| SnappedSymbol {
+                    name: sym.name.clone(),
+                    kind: sym.kind,
+                })
+                .collect()
+        };
+
+        result.total += matched.len();
+        if !matched.is_empty() {
+            result.files.insert(path.clone(), matched);
+        }
+    }
+
+    result
+}
+
+/// Check if a symbol has a specific attribute (e.g., `#[test]` for Rust).
+#[cfg(feature = "ast")]
+fn symbol_has_attr(source: &str, sym: &symbols::SymbolDef, attr: &str) -> bool {
+    // Look at lines before the symbol's start line for the attribute
+    let lines: Vec<&str> = source.lines().collect();
+    if sym.start_line == 0 || sym.start_line > lines.len() {
+        return false;
+    }
+    // Search up to 10 lines before the symbol for the attribute
+    let start = sym.start_line.saturating_sub(11); // 0-indexed, start_line is 1-based
+    let end = sym.start_line - 1; // line just before the symbol definition
+    for i in start..end {
+        if i < lines.len() {
+            let line = lines[i].trim();
+            // Match #[test], #[cfg(test)], #[tokio::test], @test, @Test, etc.
+            if line.contains(&format!("#[{attr}]"))
+                || line.contains(&format!("#[{attr}("))
+                || line.contains(&format!("#[tokio::{attr}]"))
+                || line.contains(&format!("@{attr}"))
+                || line.contains(&format!("@{}", capitalize(attr)))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+#[cfg(feature = "ast")]
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().to_string() + chars.as_str(),
+    }
+}
+
+/// Result of a verification comparison.
+#[derive(Debug)]
+pub(crate) struct VerifyResult {
+    pub(crate) passed: bool,
+    pub(crate) message: String,
+}
+
+/// Compare pre and post snapshots for a SymbolCount check.
+#[cfg(feature = "ast")]
+pub(crate) fn compare_snapshots(
+    before: &SymbolSnapshot,
+    after: &SymbolSnapshot,
+    check: &VerifyCheck,
+    cwd: &Path,
+) -> VerifyResult {
+    match check {
+        VerifyCheck::SymbolCount { kind, attr } => {
+            let label = if let Some(a) = attr {
+                format!("{kind} (attr={a})")
+            } else {
+                kind.clone()
+            };
+
+            if before.total == after.total {
+                VerifyResult {
+                    passed: true,
+                    message: format!(
+                        "verify {label}: before={}, after={} \u{2713}",
+                        before.total, after.total
+                    ),
+                }
+            } else {
+                // Find which files lost or gained symbols
+                let mut details = Vec::new();
+                let all_files: HashSet<&PathBuf> =
+                    before.files.keys().chain(after.files.keys()).collect();
+
+                for path in all_files {
+                    let b = before.files.get(path).map_or(0, |v| v.len());
+                    let a = after.files.get(path).map_or(0, |v| v.len());
+                    if b != a {
+                        let display = path.strip_prefix(cwd).unwrap_or(path).display();
+                        let diff = a as isize - b as isize;
+                        details.push(format!("  {display}: {b} -> {a} ({diff:+})"));
+                    }
+                }
+
+                let detail_str = if details.is_empty() {
+                    String::new()
+                } else {
+                    format!("\n{}", details.join("\n"))
+                };
+
+                let diff = after.total as isize - before.total as isize;
+                VerifyResult {
+                    passed: false,
+                    message: format!(
+                        "verify {label}: before={}, after={} ({diff:+}) \u{2717}{detail_str}",
+                        before.total, after.total
+                    ),
+                }
+            }
+        }
+        VerifyCheck::Named { check } if check == "unique_names" => check_unique_names(after, cwd),
+        VerifyCheck::Named { check } if check == "no_orphans" => {
+            check_no_orphans(before, after, cwd)
+        }
+        _ => VerifyResult {
+            passed: true,
+            message: "unknown check (skipped)".to_string(),
+        },
+    }
+}
+
+/// Check that no file has duplicate symbol names.
+#[cfg(feature = "ast")]
+fn check_unique_names(snapshot: &SymbolSnapshot, cwd: &Path) -> VerifyResult {
+    let mut duplicates = Vec::new();
+    for (path, syms) in &snapshot.files {
+        let mut seen = HashMap::new();
+        for sym in syms {
+            *seen.entry(sym.name.as_str()).or_insert(0usize) += 1;
+        }
+        for (name, count) in &seen {
+            if *count > 1 {
+                let display = path.strip_prefix(cwd).unwrap_or(path).display();
+                duplicates.push(format!("  {display}: '{name}' appears {count} times"));
+            }
+        }
+    }
+
+    if duplicates.is_empty() {
+        VerifyResult {
+            passed: true,
+            message: "verify unique_names: no duplicates found \u{2713}".to_string(),
+        }
+    } else {
+        VerifyResult {
+            passed: false,
+            message: format!(
+                "verify unique_names: duplicate symbols found \u{2717}\n{}",
+                duplicates.join("\n")
+            ),
+        }
+    }
+}
+
+/// Check that every symbol from `before` appears in `after` (no orphans).
+#[cfg(feature = "ast")]
+fn check_no_orphans(before: &SymbolSnapshot, after: &SymbolSnapshot, cwd: &Path) -> VerifyResult {
+    let after_names: HashSet<&str> = after
+        .files
+        .values()
+        .flat_map(|syms| syms.iter().map(|s| s.name.as_str()))
+        .collect();
+
+    let mut orphans = Vec::new();
+    for (path, syms) in &before.files {
+        for sym in syms {
+            if !after_names.contains(sym.name.as_str()) {
+                let display = path.strip_prefix(cwd).unwrap_or(path).display();
+                orphans.push(format!(
+                    "  {display}: '{}' not found in any target",
+                    sym.name
+                ));
+            }
+        }
+    }
+
+    if orphans.is_empty() {
+        VerifyResult {
+            passed: true,
+            message: "verify no_orphans: all symbols preserved \u{2713}".to_string(),
+        }
+    } else {
+        VerifyResult {
+            passed: false,
+            message: format!(
+                "verify no_orphans: {} symbol(s) lost \u{2717}\n{}",
+                orphans.len(),
+                orphans.join("\n")
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn parse_verify_kind_only() {
+        let check = VerifyCheck::parse("kind=function").unwrap();
+        match check {
+            VerifyCheck::SymbolCount { kind, attr } => {
+                assert_eq!(kind, "function");
+                assert!(attr.is_none());
+            }
+            _ => panic!("expected SymbolCount"),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn parse_verify_kind_and_attr() {
+        let check = VerifyCheck::parse("kind=function,attr=test").unwrap();
+        match check {
+            VerifyCheck::SymbolCount { kind, attr } => {
+                assert_eq!(kind, "function");
+                assert_eq!(attr.as_deref(), Some("test"));
+            }
+            _ => panic!("expected SymbolCount"),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn parse_verify_named_check() {
+        let check = VerifyCheck::parse("unique_names").unwrap();
+        match check {
+            VerifyCheck::Named { check } => assert_eq!(check, "unique_names"),
+            _ => panic!("expected Named"),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn parse_verify_bare_kind() {
+        let check = VerifyCheck::parse("function").unwrap();
+        match check {
+            VerifyCheck::SymbolCount { kind, attr } => {
+                assert_eq!(kind, "function");
+                assert!(attr.is_none());
+            }
+            _ => panic!("expected SymbolCount"),
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn parse_verify_unknown_key_errors() {
+        assert!(VerifyCheck::parse("foo=bar").is_err());
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn symbol_has_test_attr() {
+        let source = r#"
+#[test]
+fn my_test() {
+    assert!(true);
+}
+"#;
+        let syms = symbols::extract_symbols(source, Language::Rust);
+        assert!(!syms.is_empty());
+        assert!(symbol_has_attr(source, &syms[0], "test"));
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn symbol_without_attr() {
+        let source = "fn normal() { }\n";
+        let syms = symbols::extract_symbols(source, Language::Rust);
+        assert!(!syms.is_empty());
+        assert!(!symbol_has_attr(source, &syms[0], "test"));
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn compare_snapshots_equal() {
+        let check = VerifyCheck::SymbolCount {
+            kind: "function".to_string(),
+            attr: None,
+        };
+        let before = SymbolSnapshot {
+            files: HashMap::new(),
+            total: 5,
+        };
+        let after = SymbolSnapshot {
+            files: HashMap::new(),
+            total: 5,
+        };
+        let result = compare_snapshots(&before, &after, &check, Path::new("/tmp"));
+        assert!(result.passed);
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn compare_snapshots_mismatch() {
+        let check = VerifyCheck::SymbolCount {
+            kind: "function".to_string(),
+            attr: Some("test".to_string()),
+        };
+        let before = SymbolSnapshot {
+            files: HashMap::new(),
+            total: 10,
+        };
+        let after = SymbolSnapshot {
+            files: HashMap::new(),
+            total: 8,
+        };
+        let result = compare_snapshots(&before, &after, &check, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert!(result.message.contains("-2"));
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn unique_names_no_duplicates() {
+        let snapshot = SymbolSnapshot {
+            files: HashMap::from([(
+                PathBuf::from("/tmp/test.rs"),
+                vec![
+                    SnappedSymbol {
+                        name: "a".into(),
+                        kind: symbols::SymbolKind::Function,
+                    },
+                    SnappedSymbol {
+                        name: "b".into(),
+                        kind: symbols::SymbolKind::Function,
+                    },
+                ],
+            )]),
+            total: 2,
+        };
+        let result = check_unique_names(&snapshot, Path::new("/tmp"));
+        assert!(result.passed);
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn unique_names_with_duplicates() {
+        let snapshot = SymbolSnapshot {
+            files: HashMap::from([(
+                PathBuf::from("/tmp/test.rs"),
+                vec![
+                    SnappedSymbol {
+                        name: "foo".into(),
+                        kind: symbols::SymbolKind::Function,
+                    },
+                    SnappedSymbol {
+                        name: "foo".into(),
+                        kind: symbols::SymbolKind::Function,
+                    },
+                ],
+            )]),
+            total: 2,
+        };
+        let result = check_unique_names(&snapshot, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert!(result.message.contains("'foo' appears 2 times"));
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn no_orphans_all_present() {
+        let syms = vec![
+            SnappedSymbol {
+                name: "a".into(),
+                kind: symbols::SymbolKind::Function,
+            },
+            SnappedSymbol {
+                name: "b".into(),
+                kind: symbols::SymbolKind::Function,
+            },
+        ];
+        let before = SymbolSnapshot {
+            files: HashMap::from([(PathBuf::from("/tmp/old.rs"), syms.clone())]),
+            total: 2,
+        };
+        let after = SymbolSnapshot {
+            files: HashMap::from([(PathBuf::from("/tmp/new.rs"), syms)]),
+            total: 2,
+        };
+        let result = check_no_orphans(&before, &after, Path::new("/tmp"));
+        assert!(result.passed);
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn no_orphans_missing_symbol() {
+        let before = SymbolSnapshot {
+            files: HashMap::from([(
+                PathBuf::from("/tmp/old.rs"),
+                vec![
+                    SnappedSymbol {
+                        name: "a".into(),
+                        kind: symbols::SymbolKind::Function,
+                    },
+                    SnappedSymbol {
+                        name: "b".into(),
+                        kind: symbols::SymbolKind::Function,
+                    },
+                ],
+            )]),
+            total: 2,
+        };
+        let after = SymbolSnapshot {
+            files: HashMap::from([(
+                PathBuf::from("/tmp/new.rs"),
+                vec![SnappedSymbol {
+                    name: "a".into(),
+                    kind: symbols::SymbolKind::Function,
+                }],
+            )]),
+            total: 1,
+        };
+        let result = check_no_orphans(&before, &after, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert!(result.message.contains("'b' not found"));
+    }
+}


### PR DESCRIPTION
Add `--verify` flag and plan `verify` field that captures AST symbol
snapshots before and after transaction execution. Mismatches trigger
rollback with `VALIDATION_FAILED` (exit 6) and detailed per-file diffs.

**Supported checks:**
- `SymbolCount`: `--verify="kind=function,attr=test"` (count preservation)
- `Named`: `unique_names` (no duplicate symbols), `no_orphans` (no lost symbols)

Works in both CLI (`--verify`) and MCP (plan `verify` field) paths.

`VerifyCheck` lives in `plan.rs` (unconditional) so it compiles without
`cli`/`files` feature gates. Verification logic in `tx/verify.rs` is
behind appropriate feature gates (`ast`, `cli`).

14 unit tests covering parsing, attr detection, snapshot comparison,
unique names, and orphan detection.

Closes #1019