### PR TITLE
feat(ast): add ast.insert, ast.wrap, ast.imports operations

### DIFF
--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -18,6 +18,7 @@ use crate::plan::Operation;
 use super::{ApplyMode, EditResult};
 
 /// Derive cwd from a file path (its parent directory).
+#[cfg(any(feature = "cli", feature = "files"))]
 fn cwd_from_path(path: &Path) -> &Path {
     path.parent().unwrap_or_else(|| Path::new("."))
 }
@@ -52,7 +53,7 @@ fn doc_write(
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    use crate::ops::doc::{DocMutation, MutationResult};
+    use crate::ops::doc::MutationResult;
     use crate::write::WritePolicy;
 
     // Extract the mutation from the operation.

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -13,6 +13,7 @@ use crate::plan::Operation;
 use super::{ApplyMode, EditResult};
 
 /// Derive cwd from a file path (its parent directory).
+#[cfg(any(feature = "cli", feature = "files"))]
 fn cwd_from_path(path: &Path) -> &Path {
     path.parent().unwrap_or_else(|| Path::new("."))
 }

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -15,6 +15,7 @@ use crate::plan::Operation;
 use super::{ApplyMode, EditResult};
 
 /// Derive cwd from a file path (its parent directory).
+#[cfg(any(feature = "cli", feature = "files"))]
 fn cwd_from_path(path: &Path) -> &Path {
     path.parent().unwrap_or_else(|| Path::new("."))
 }

--- a/src/api/plan.rs
+++ b/src/api/plan.rs
@@ -1,7 +1,9 @@
 //! Plan parsing and execution (transaction) for the library API.
 
+#[cfg(any(feature = "cli", feature = "files"))]
 use std::path::Path;
 
+#[cfg(any(feature = "cli", feature = "files"))]
 use crate::containment::PathGuard;
 
 #[cfg(any(feature = "cli", feature = "files"))]

--- a/src/ast/imports.rs
+++ b/src/ast/imports.rs
@@ -1,0 +1,347 @@
+//! Import/use statement manipulation: add, remove, deduplicate.
+
+use super::Language;
+
+/// Result of an imports operation.
+#[derive(Debug)]
+pub struct ImportsResult {
+    /// The full file content after modification.
+    pub content: String,
+    /// Number of imports added.
+    pub added: usize,
+    /// Number of imports removed.
+    pub removed: usize,
+    /// Number of duplicates merged.
+    pub deduped: usize,
+}
+
+/// An import statement found in source code.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ImportStatement {
+    /// The full import text (e.g. "use std::io;").
+    pub text: String,
+    /// 1-based line number.
+    pub line: usize,
+}
+
+/// List all import/use statements in source code.
+pub fn list_imports(source: &str, lang: Language) -> Vec<ImportStatement> {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut imports = Vec::new();
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if is_import_line(trimmed, lang) {
+            imports.push(ImportStatement {
+                text: trimmed.to_string(),
+                line: i + 1,
+            });
+        }
+    }
+
+    imports
+}
+
+/// Add import statements idempotently to source code.
+///
+/// Skips imports that already exist. Inserts at the appropriate position
+/// (after existing imports, or after module doc comments).
+pub fn add_imports(source: &str, imports_to_add: &[String], lang: Language) -> ImportsResult {
+    let lines: Vec<&str> = source.lines().collect();
+    let existing = list_imports(source, lang);
+    let existing_texts: std::collections::HashSet<String> =
+        existing.iter().map(|i| normalize_import(&i.text)).collect();
+
+    let mut new_imports = Vec::new();
+    for imp in imports_to_add {
+        let normalized = normalize_import(imp);
+        if !existing_texts.contains(&normalized) {
+            new_imports.push(format_import(imp, lang));
+        }
+    }
+
+    if new_imports.is_empty() {
+        return ImportsResult {
+            content: source.to_string(),
+            added: 0,
+            removed: 0,
+            deduped: 0,
+        };
+    }
+
+    let added = new_imports.len();
+
+    // Find the insertion point: after the last existing import, or after
+    // leading comments/doc attributes.
+    let insert_after = find_import_insert_point(&lines, lang);
+
+    let mut result = String::new();
+    for (i, line) in lines.iter().enumerate() {
+        result.push_str(line);
+        result.push('\n');
+
+        if i == insert_after {
+            // If there were no imports before, add a blank line
+            if existing.is_empty() && !line.is_empty() {
+                result.push('\n');
+            }
+            for new_imp in &new_imports {
+                result.push_str(new_imp);
+                result.push('\n');
+            }
+        }
+    }
+
+    // Handle edge case: empty file or insert at line 0
+    if lines.is_empty() {
+        for new_imp in &new_imports {
+            result.push_str(new_imp);
+            result.push('\n');
+        }
+    }
+
+    // Preserve trailing newline behavior
+    if !source.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    ImportsResult {
+        content: result,
+        added,
+        removed: 0,
+        deduped: 0,
+    }
+}
+
+/// Remove specific import statements from source code.
+pub fn remove_imports(source: &str, imports_to_remove: &[String], lang: Language) -> ImportsResult {
+    let lines: Vec<&str> = source.lines().collect();
+    let remove_set: std::collections::HashSet<String> = imports_to_remove
+        .iter()
+        .map(|i| normalize_import(i))
+        .collect();
+
+    let mut result = String::new();
+    let mut removed = 0;
+
+    for line in &lines {
+        let trimmed = line.trim();
+        if is_import_line(trimmed, lang) && remove_set.contains(&normalize_import(trimmed)) {
+            removed += 1;
+            continue;
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Preserve trailing newline behavior
+    if !source.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    ImportsResult {
+        content: result,
+        added: 0,
+        removed,
+        deduped: 0,
+    }
+}
+
+/// Deduplicate import statements in source code.
+pub fn dedupe_imports(source: &str, lang: Language) -> ImportsResult {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut seen = std::collections::HashSet::new();
+    let mut result = String::new();
+    let mut deduped = 0;
+
+    for line in &lines {
+        let trimmed = line.trim();
+        if is_import_line(trimmed, lang) {
+            let normalized = normalize_import(trimmed);
+            if seen.contains(&normalized) {
+                deduped += 1;
+                continue;
+            }
+            seen.insert(normalized);
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Preserve trailing newline behavior
+    if !source.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    ImportsResult {
+        content: result,
+        added: 0,
+        removed: 0,
+        deduped,
+    }
+}
+
+/// Check if a line is an import/use statement for the given language.
+fn is_import_line(trimmed: &str, lang: Language) -> bool {
+    match lang {
+        Language::Rust => {
+            (trimmed.starts_with("use ")
+                || trimmed.starts_with("pub use ")
+                || trimmed.starts_with("pub(crate) use ")
+                || trimmed.starts_with("pub(super) use "))
+                && trimmed.ends_with(';')
+        }
+        Language::Python => trimmed.starts_with("import ") || trimmed.starts_with("from "),
+        Language::TypeScript | Language::JavaScript => trimmed.starts_with("import "),
+        Language::Go => {
+            trimmed.starts_with("import ") || (trimmed.starts_with('"') && trimmed.ends_with('"'))
+        }
+        Language::Java | Language::Kotlin => trimmed.starts_with("import "),
+        _ => trimmed.starts_with("import ") || trimmed.starts_with("use "),
+    }
+}
+
+/// Normalize an import statement for comparison (strip trailing semicolons, whitespace).
+fn normalize_import(import: &str) -> String {
+    import.trim().trim_end_matches(';').trim().to_string()
+}
+
+/// Format an import for insertion, ensuring it has proper syntax.
+fn format_import(import: &str, lang: Language) -> String {
+    let trimmed = import.trim();
+    match lang {
+        Language::Rust => {
+            if trimmed.ends_with(';') {
+                trimmed.to_string()
+            } else {
+                format!("{trimmed};")
+            }
+        }
+        _ => trimmed.to_string(),
+    }
+}
+
+/// Find the 0-based line index after which new imports should be inserted.
+fn find_import_insert_point(lines: &[&str], lang: Language) -> usize {
+    // Strategy: find the last import line. If none, find the end of leading
+    // comments/doc attributes.
+    let mut last_import_line = None;
+
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if is_import_line(trimmed, lang) {
+            last_import_line = Some(i);
+        }
+    }
+
+    if let Some(idx) = last_import_line {
+        return idx;
+    }
+
+    // No existing imports: insert after leading comments, doc strings, shebang,
+    // blank lines, and module-level attributes.
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with("//")
+            || trimmed.starts_with('#')
+            || trimmed.starts_with("/*")
+            || trimmed.starts_with('*')
+            || trimmed.starts_with("*/")
+            || trimmed.starts_with("\"\"\"")
+            || trimmed.starts_with("'''")
+        {
+            continue;
+        }
+        // First non-comment, non-blank line: insert before it
+        return if i > 0 { i - 1 } else { 0 };
+    }
+
+    // All comments/blank lines: insert at end
+    if lines.is_empty() { 0 } else { lines.len() - 1 }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_rust_imports() {
+        let source = "use std::io;\nuse std::fs;\n\nfn main() {}\n";
+        let imports = list_imports(source, Language::Rust);
+        assert_eq!(imports.len(), 2);
+        assert_eq!(imports[0].text, "use std::io;");
+        assert_eq!(imports[0].line, 1);
+        assert_eq!(imports[1].text, "use std::fs;");
+    }
+
+    #[test]
+    fn add_rust_import() {
+        let source = "use std::io;\n\nfn main() {}\n";
+        let result = add_imports(source, &["use std::fs".into()], Language::Rust);
+        assert_eq!(result.added, 1);
+        assert!(result.content.contains("use std::fs;"));
+        assert!(result.content.contains("use std::io;"));
+    }
+
+    #[test]
+    fn add_import_idempotent() {
+        let source = "use std::io;\n\nfn main() {}\n";
+        let result = add_imports(source, &["use std::io;".into()], Language::Rust);
+        assert_eq!(result.added, 0);
+        assert_eq!(result.content, source);
+    }
+
+    #[test]
+    fn remove_rust_import() {
+        let source = "use std::io;\nuse std::fs;\n\nfn main() {}\n";
+        let result = remove_imports(source, &["use std::io".into()], Language::Rust);
+        assert_eq!(result.removed, 1);
+        assert!(!result.content.contains("use std::io"));
+        assert!(result.content.contains("use std::fs;"));
+    }
+
+    #[test]
+    fn dedupe_rust_imports() {
+        let source = "use std::io;\nuse std::fs;\nuse std::io;\n\nfn main() {}\n";
+        let result = dedupe_imports(source, Language::Rust);
+        assert_eq!(result.deduped, 1);
+        let count = result.content.matches("use std::io;").count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn add_python_import() {
+        let source = "import os\n\ndef main():\n    pass\n";
+        let result = add_imports(source, &["import sys".into()], Language::Python);
+        assert_eq!(result.added, 1);
+        assert!(result.content.contains("import sys"));
+    }
+
+    #[test]
+    fn add_typescript_import() {
+        let source = "import { foo } from 'bar';\n\nconst x = 1;\n";
+        let result = add_imports(
+            source,
+            &["import { baz } from 'qux';".into()],
+            Language::TypeScript,
+        );
+        assert_eq!(result.added, 1);
+        assert!(result.content.contains("import { baz } from 'qux'"));
+    }
+
+    #[test]
+    fn add_import_to_empty_file() {
+        let source = "";
+        let result = add_imports(source, &["use std::io;".into()], Language::Rust);
+        assert_eq!(result.added, 1);
+        assert!(result.content.contains("use std::io;"));
+    }
+
+    #[test]
+    fn list_python_imports() {
+        let source = "import os\nfrom pathlib import Path\n\ndef main():\n    pass\n";
+        let imports = list_imports(source, Language::Python);
+        assert_eq!(imports.len(), 2);
+    }
+}

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -1,0 +1,485 @@
+//! AST-aware code insertion: insert code at structurally-defined positions.
+
+use super::Language;
+use super::symbols::{SymbolDef, extract_symbols, find_symbol};
+
+/// Result of an AST insert operation.
+#[derive(Debug)]
+pub struct InsertResult {
+    /// The full file content after insertion.
+    pub content: String,
+    /// 1-based line where insertion occurred.
+    pub inserted_at_line: usize,
+}
+
+/// Position within a container (module, impl, etc.) to insert code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertPosition {
+    Start,
+    End,
+}
+
+/// Insert code at a structurally-aware position in source code.
+///
+/// Exactly one of `inside`, `after`, or `before` must be `Some`.
+///
+/// - `inside` + `position`: insert content at start/end of the named block.
+/// - `after`: insert content after the named symbol.
+/// - `before`: insert content before the named symbol.
+pub fn insert_code(
+    source: &str,
+    content: &str,
+    inside: Option<&str>,
+    after: Option<&str>,
+    before: Option<&str>,
+    position: InsertPosition,
+    lang: Language,
+) -> anyhow::Result<InsertResult> {
+    let mode_count = inside.is_some() as u8 + after.is_some() as u8 + before.is_some() as u8;
+    if mode_count != 1 {
+        anyhow::bail!("exactly one of 'inside', 'after', or 'before' must be specified");
+    }
+
+    let symbols = extract_symbols(source, lang);
+    let lines: Vec<&str> = source.lines().collect();
+
+    if let Some(container_name) = inside {
+        insert_inside(source, content, container_name, position, &symbols, &lines)
+    } else if let Some(after_name) = after {
+        insert_adjacent(source, content, after_name, true, &symbols, &lines)
+    } else {
+        let before_name = before.unwrap();
+        insert_adjacent(source, content, before_name, false, &symbols, &lines)
+    }
+}
+
+/// Insert content inside a named container (mod, impl, struct, etc.).
+fn insert_inside(
+    source: &str,
+    content: &str,
+    container_name: &str,
+    position: InsertPosition,
+    symbols: &[SymbolDef],
+    lines: &[&str],
+) -> anyhow::Result<InsertResult> {
+    let sym = find_symbol(symbols, container_name)
+        .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", container_name))?;
+
+    let start_idx = sym.start_line.saturating_sub(1);
+    let end_idx = sym.end_line.min(lines.len());
+
+    // Detect the indentation level inside the container.
+    let container_indent = detect_indent(lines, start_idx, end_idx);
+    let adjusted = indent_content(content, &container_indent);
+
+    let mut result = String::new();
+
+    match position {
+        InsertPosition::End => {
+            // Insert before the closing brace of the container.
+            // The closing brace is typically on end_line (1-based), i.e. end_idx - 1 (0-based).
+            let close_line_idx = end_idx.saturating_sub(1);
+
+            for line in &lines[..close_line_idx] {
+                result.push_str(line);
+                result.push('\n');
+            }
+
+            // Add a blank line before if the previous content doesn't end with one
+            if close_line_idx > 0 && !lines[close_line_idx - 1].trim().is_empty() {
+                result.push('\n');
+            }
+            result.push_str(&adjusted);
+            if !adjusted.ends_with('\n') {
+                result.push('\n');
+            }
+
+            for line in &lines[close_line_idx..] {
+                result.push_str(line);
+                result.push('\n');
+            }
+
+            let inserted_at = close_line_idx + 1; // 1-based
+
+            // Preserve trailing newline behavior
+            if !source.ends_with('\n') && result.ends_with('\n') {
+                result.pop();
+            }
+
+            Ok(InsertResult {
+                content: result,
+                inserted_at_line: inserted_at,
+            })
+        }
+        InsertPosition::Start => {
+            // Insert after the opening brace/line of the container.
+            // We look for the first line after start_line that ends with '{' or ':'
+            let insert_after_idx = find_opening_line(lines, start_idx, end_idx);
+
+            for line in &lines[..=insert_after_idx] {
+                result.push_str(line);
+                result.push('\n');
+            }
+
+            result.push_str(&adjusted);
+            if !adjusted.ends_with('\n') {
+                result.push('\n');
+            }
+
+            // Add blank line if next line is not blank
+            if insert_after_idx + 1 < lines.len() && !lines[insert_after_idx + 1].trim().is_empty()
+            {
+                result.push('\n');
+            }
+
+            for line in &lines[insert_after_idx + 1..] {
+                result.push_str(line);
+                result.push('\n');
+            }
+
+            let inserted_at = insert_after_idx + 2; // 1-based
+
+            if !source.ends_with('\n') && result.ends_with('\n') {
+                result.pop();
+            }
+
+            Ok(InsertResult {
+                content: result,
+                inserted_at_line: inserted_at,
+            })
+        }
+    }
+}
+
+/// Insert content after or before a named symbol.
+fn insert_adjacent(
+    source: &str,
+    content: &str,
+    symbol_name: &str,
+    after: bool,
+    symbols: &[SymbolDef],
+    lines: &[&str],
+) -> anyhow::Result<InsertResult> {
+    let sym = find_symbol(symbols, symbol_name)
+        .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", symbol_name))?;
+
+    // Use the symbol's indentation level for the new content
+    let sym_start_idx = sym.start_line.saturating_sub(1);
+    let indent = if sym_start_idx < lines.len() {
+        let line = lines[sym_start_idx];
+        let trimmed = line.trim_start();
+        &line[..line.len() - trimmed.len()]
+    } else {
+        ""
+    };
+    let adjusted = indent_content(content, indent);
+
+    let mut result = String::new();
+    let inserted_at;
+
+    if after {
+        let end_idx = sym.end_line.min(lines.len());
+        for line in &lines[..end_idx] {
+            result.push_str(line);
+            result.push('\n');
+        }
+        result.push('\n');
+        result.push_str(&adjusted);
+        if !adjusted.ends_with('\n') {
+            result.push('\n');
+        }
+        inserted_at = end_idx + 1; // 1-based
+        for line in &lines[end_idx..] {
+            result.push_str(line);
+            result.push('\n');
+        }
+    } else {
+        // Before
+        let start_idx = sym.start_line.saturating_sub(1);
+        for line in &lines[..start_idx] {
+            result.push_str(line);
+            result.push('\n');
+        }
+        result.push_str(&adjusted);
+        if !adjusted.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push('\n');
+        inserted_at = start_idx + 1; // 1-based
+        for line in &lines[start_idx..] {
+            result.push_str(line);
+            result.push('\n');
+        }
+    }
+
+    if !source.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    Ok(InsertResult {
+        content: result,
+        inserted_at_line: inserted_at,
+    })
+}
+
+/// Find the line with the opening brace/colon of a container.
+fn find_opening_line(lines: &[&str], start_idx: usize, end_idx: usize) -> usize {
+    for (i, line) in lines
+        .iter()
+        .enumerate()
+        .take(end_idx.min(lines.len()))
+        .skip(start_idx)
+    {
+        let trimmed = line.trim();
+        if trimmed.ends_with('{') || trimmed.ends_with(':') || trimmed.ends_with(":{") {
+            return i;
+        }
+    }
+    // Fallback: use the start line itself
+    start_idx
+}
+
+/// Detect the indentation used inside a container block.
+fn detect_indent(lines: &[&str], start_idx: usize, end_idx: usize) -> String {
+    // Look at the first non-empty line inside the block (after the opening)
+    let body_start = find_opening_line(lines, start_idx, end_idx) + 1;
+    for i in body_start..end_idx.saturating_sub(1) {
+        if i < lines.len() && !lines[i].trim().is_empty() {
+            let line = lines[i];
+            let trimmed = line.trim_start();
+            return line[..line.len() - trimmed.len()].to_string();
+        }
+    }
+    // Fallback: base indent of container + 4 spaces
+    if start_idx < lines.len() {
+        let line = lines[start_idx];
+        let trimmed = line.trim_start();
+        let base = &line[..line.len() - trimmed.len()];
+        return format!("{base}    ");
+    }
+    "    ".to_string()
+}
+
+/// Indent content to match the target indentation.
+///
+/// Strips the common leading whitespace from the content, then prepends
+/// the target indentation to each line.
+fn indent_content(content: &str, target_indent: &str) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    if lines.is_empty() {
+        return String::new();
+    }
+
+    // Find the minimum indentation of non-empty lines
+    let min_indent = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    lines
+        .iter()
+        .map(|line| {
+            if line.trim().is_empty() {
+                String::new()
+            } else {
+                let stripped = &line[min_indent..];
+                format!("{target_indent}{stripped}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_inside_mod_end() {
+        let source = "mod tests {\n    fn existing() {}\n}\n";
+        let content = "#[test]\nfn new_test() {\n    assert!(true);\n}";
+        let result = insert_code(
+            source,
+            content,
+            Some("tests"),
+            None,
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.content.contains("fn new_test()"));
+        assert!(result.content.contains("fn existing()"));
+        // The new test should be before the closing brace
+        let close_pos = result.content.rfind('}').unwrap();
+        let new_fn_pos = result.content.find("fn new_test").unwrap();
+        assert!(new_fn_pos < close_pos);
+    }
+
+    #[test]
+    fn insert_inside_mod_start() {
+        let source = "mod tests {\n    fn existing() {}\n}\n";
+        let content = "use super::*;";
+        let result = insert_code(
+            source,
+            content,
+            Some("tests"),
+            None,
+            None,
+            InsertPosition::Start,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.content.contains("use super::*;"));
+        // use should come before existing()
+        let use_pos = result.content.find("use super::*").unwrap();
+        let fn_pos = result.content.find("fn existing").unwrap();
+        assert!(use_pos < fn_pos);
+    }
+
+    #[test]
+    fn insert_after_symbol() {
+        let source = "fn foo() {\n    let x = 1;\n}\n\nfn bar() {}\n";
+        let content = "fn baz() {\n    let y = 2;\n}";
+        let result = insert_code(
+            source,
+            content,
+            None,
+            Some("foo"),
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.content.contains("fn baz()"));
+        let foo_pos = result.content.find("fn foo").unwrap();
+        let baz_pos = result.content.find("fn baz").unwrap();
+        let bar_pos = result.content.find("fn bar").unwrap();
+        assert!(foo_pos < baz_pos);
+        assert!(baz_pos < bar_pos);
+    }
+
+    #[test]
+    fn insert_before_symbol() {
+        let source = "fn foo() {}\n\nfn bar() {}\n";
+        let content = "fn baz() {}";
+        let result = insert_code(
+            source,
+            content,
+            None,
+            None,
+            Some("bar"),
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.content.contains("fn baz()"));
+        let baz_pos = result.content.find("fn baz").unwrap();
+        let bar_pos = result.content.find("fn bar").unwrap();
+        assert!(baz_pos < bar_pos);
+    }
+
+    #[test]
+    fn insert_indentation_adjusted() {
+        let source = "mod tests {\n    fn test_a() {\n        assert!(true);\n    }\n}\n";
+        let content = "fn test_b() {\n    assert!(false);\n}";
+        let result = insert_code(
+            source,
+            content,
+            Some("tests"),
+            None,
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        // Should be indented to match existing content inside the module
+        assert!(result.content.contains("    fn test_b()"));
+        assert!(result.content.contains("        assert!(false)"));
+    }
+
+    #[test]
+    fn insert_symbol_not_found() {
+        let source = "fn foo() {}\n";
+        let result = insert_code(
+            source,
+            "fn bar() {}",
+            Some("nonexistent"),
+            None,
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn insert_requires_exactly_one_mode() {
+        let source = "fn foo() {}\n";
+        // None specified
+        let result = insert_code(
+            source,
+            "fn bar() {}",
+            None,
+            None,
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        );
+        assert!(result.is_err());
+
+        // Two specified
+        let result = insert_code(
+            source,
+            "fn bar() {}",
+            Some("foo"),
+            Some("foo"),
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn insert_python_inside_class() {
+        let source = "class MyClass:\n    def existing(self):\n        pass\n";
+        let content = "def new_method(self):\n    return 42";
+        let result = insert_code(
+            source,
+            content,
+            Some("MyClass"),
+            None,
+            None,
+            InsertPosition::End,
+            Language::Python,
+        )
+        .unwrap();
+        assert!(result.content.contains("def new_method"));
+    }
+
+    #[test]
+    fn insert_typescript_after_function() {
+        let source = "function hello() {\n  console.log('hi');\n}\n\nfunction world() {}\n";
+        let content = "function middle() {\n  return 1;\n}";
+        let result = insert_code(
+            source,
+            content,
+            None,
+            Some("hello"),
+            None,
+            InsertPosition::End,
+            Language::TypeScript,
+        )
+        .unwrap();
+        assert!(result.content.contains("function middle()"));
+        let hello_pos = result.content.find("function hello").unwrap();
+        let middle_pos = result.content.find("function middle").unwrap();
+        let world_pos = result.content.find("function world").unwrap();
+        assert!(hello_pos < middle_pos);
+        assert!(middle_pos < world_pos);
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -7,6 +7,8 @@
 pub mod deps;
 pub mod diff;
 pub mod impact;
+pub mod imports;
+pub mod insert;
 pub mod map;
 pub mod refs;
 pub mod rename;
@@ -14,6 +16,7 @@ pub mod replace;
 pub mod search;
 pub mod symbols;
 pub mod validate;
+pub mod wrap;
 
 use std::path::Path;
 

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -1,0 +1,325 @@
+//! AST-aware code wrapping: wrap existing code in a block (module, impl, etc.).
+
+use super::Language;
+use super::symbols::{extract_symbols, find_symbol};
+
+/// Result of a wrap operation.
+#[derive(Debug)]
+pub struct WrapResult {
+    /// The full file content after wrapping.
+    pub content: String,
+}
+
+/// Wrap code in a structural block.
+///
+/// Exactly one of `symbols` or `lines` must be specified.
+///
+/// - `symbols`: names of symbols to wrap.
+/// - `lines`: line range (e.g. "10:50") to wrap.
+/// - `wrapper`: the wrapping construct (e.g. "mod foo", "impl Bar", "#[cfg(test)]").
+/// - `preamble`: optional content to insert at the top of the wrapped block.
+pub fn wrap_code(
+    source: &str,
+    symbols_arg: Option<&[String]>,
+    lines_arg: Option<&str>,
+    wrapper: &str,
+    preamble: Option<&str>,
+    lang: Language,
+) -> anyhow::Result<WrapResult> {
+    let mode_count = symbols_arg.is_some() as u8 + lines_arg.is_some() as u8;
+    if mode_count != 1 {
+        anyhow::bail!("exactly one of 'symbols' or 'lines' must be specified");
+    }
+
+    let source_lines: Vec<&str> = source.lines().collect();
+
+    // Determine the range of lines to wrap (0-based indices).
+    let (start_idx, end_idx) = if let Some(symbol_names) = symbols_arg {
+        find_symbol_range(source, symbol_names, lang)?
+    } else {
+        parse_line_range_to_indices(lines_arg.unwrap(), source_lines.len())?
+    };
+
+    // Extract the code to wrap
+    let target_lines = &source_lines[start_idx..end_idx];
+
+    // Detect the indentation of the target code
+    let base_indent = if start_idx < source_lines.len() {
+        let line = source_lines[start_idx];
+        let trimmed = line.trim_start();
+        &line[..line.len() - trimmed.len()]
+    } else {
+        ""
+    };
+
+    // Build the wrapped output
+    let mut wrapped = String::new();
+
+    // Opening line: wrapper + opening brace
+    let wrapper_opening = format_wrapper_opening(wrapper);
+    wrapped.push_str(base_indent);
+    wrapped.push_str(&wrapper_opening);
+    wrapped.push('\n');
+
+    // Preamble (if any)
+    if let Some(pre) = preamble {
+        for pline in pre.lines() {
+            if pline.trim().is_empty() {
+                wrapped.push('\n');
+            } else {
+                wrapped.push_str(base_indent);
+                wrapped.push_str("    ");
+                wrapped.push_str(pline.trim());
+                wrapped.push('\n');
+            }
+        }
+        wrapped.push('\n');
+    }
+
+    // Indented body
+    for line in target_lines {
+        if line.trim().is_empty() {
+            wrapped.push('\n');
+        } else {
+            wrapped.push_str("    ");
+            wrapped.push_str(line);
+            wrapped.push('\n');
+        }
+    }
+
+    // Closing brace
+    wrapped.push_str(base_indent);
+    wrapped.push('}');
+    wrapped.push('\n');
+
+    // Reconstruct the file
+    let mut result = String::new();
+    for line in &source_lines[..start_idx] {
+        result.push_str(line);
+        result.push('\n');
+    }
+    result.push_str(&wrapped);
+    for line in &source_lines[end_idx..] {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Preserve trailing newline behavior
+    if !source.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    Ok(WrapResult { content: result })
+}
+
+/// Format the wrapper opening line.
+///
+/// Handles patterns like:
+/// - "mod foo" -> "mod foo {"
+/// - "impl Bar" -> "impl Bar {"
+/// - "#[cfg(test)]" -> "#[cfg(test)] {"  (attribute-like)
+/// - "pub(crate) mod helpers" -> "pub(crate) mod helpers {"
+fn format_wrapper_opening(wrapper: &str) -> String {
+    let trimmed = wrapper.trim();
+    if trimmed.ends_with('{') {
+        trimmed.to_string()
+    } else {
+        format!("{trimmed} {{")
+    }
+}
+
+/// Find the 0-based start and end line indices that span all named symbols.
+fn find_symbol_range(
+    source: &str,
+    symbol_names: &[String],
+    lang: Language,
+) -> anyhow::Result<(usize, usize)> {
+    if symbol_names.is_empty() {
+        anyhow::bail!("symbols list must not be empty");
+    }
+    let symbols = extract_symbols(source, lang);
+    let mut min_start = usize::MAX;
+    let mut max_end = 0usize;
+
+    for name in symbol_names {
+        let sym = find_symbol(&symbols, name)
+            .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", name))?;
+        let start = sym.start_line.saturating_sub(1);
+        let end = sym.end_line;
+        if start < min_start {
+            min_start = start;
+        }
+        if end > max_end {
+            max_end = end;
+        }
+    }
+
+    Ok((min_start, max_end))
+}
+
+/// Parse a line range like "10:50" into 0-based start/end indices.
+fn parse_line_range_to_indices(spec: &str, total_lines: usize) -> anyhow::Result<(usize, usize)> {
+    let parts: Vec<&str> = if spec.contains(':') {
+        spec.splitn(2, ':').collect()
+    } else if spec.contains('-') && !spec.starts_with('-') {
+        spec.splitn(2, '-').collect()
+    } else {
+        anyhow::bail!("invalid line range format: '{spec}' (expected START:END)");
+    };
+
+    if parts.len() != 2 {
+        anyhow::bail!("invalid line range: '{spec}'");
+    }
+
+    let start: usize = parts[0]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid start line: {}", parts[0]))?;
+    let end: usize = parts[1]
+        .parse()
+        .map_err(|_| anyhow::anyhow!("invalid end line: {}", parts[1]))?;
+
+    if start == 0 {
+        anyhow::bail!("line numbers are 1-based, got 0");
+    }
+    if end < start {
+        anyhow::bail!("end line {end} is before start line {start}");
+    }
+
+    let start_idx = start - 1;
+    let end_idx = end.min(total_lines);
+
+    Ok((start_idx, end_idx))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wrap_symbols_in_module() {
+        let source = "fn helper_a() {}\n\nfn helper_b() {}\n";
+        let result = wrap_code(
+            source,
+            Some(&["helper_a".into(), "helper_b".into()]),
+            None,
+            "pub(crate) mod helpers",
+            None,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.content.contains("pub(crate) mod helpers {"));
+        assert!(result.content.contains("    fn helper_a()"));
+        assert!(result.content.contains("    fn helper_b()"));
+        assert!(result.content.contains("}"));
+    }
+
+    #[test]
+    fn wrap_with_preamble() {
+        let source = "fn test_a() {}\n\nfn test_b() {}\n";
+        let result = wrap_code(
+            source,
+            Some(&["test_a".into(), "test_b".into()]),
+            None,
+            "mod tests",
+            Some("use super::*;"),
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.content.contains("mod tests {"));
+        assert!(result.content.contains("    use super::*;"));
+        let use_pos = result.content.find("use super::*").unwrap();
+        let fn_pos = result.content.find("fn test_a").unwrap();
+        assert!(use_pos < fn_pos);
+    }
+
+    #[test]
+    fn wrap_lines_range() {
+        let source = "line1\nline2\nline3\nline4\nline5\n";
+        let result = wrap_code(
+            source,
+            None,
+            Some("2:4"),
+            "#[cfg(test)]",
+            None,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.content.contains("#[cfg(test)] {"));
+        assert!(result.content.contains("    line2"));
+        assert!(result.content.contains("    line3"));
+        assert!(result.content.contains("    line4"));
+        // line1 and line5 should not be wrapped
+        assert!(result.content.starts_with("line1\n"));
+        assert!(result.content.contains("}\nline5"));
+    }
+
+    #[test]
+    fn wrap_preserves_indentation() {
+        let source = "    fn inner_a() {}\n    fn inner_b() {}\n";
+        let result = wrap_code(
+            source,
+            Some(&["inner_a".into(), "inner_b".into()]),
+            None,
+            "mod nested",
+            None,
+            Language::Rust,
+        )
+        .unwrap();
+        // The wrapper should use the same base indentation
+        assert!(result.content.contains("    mod nested {"));
+        assert!(result.content.contains("        fn inner_a()"));
+    }
+
+    #[test]
+    fn wrap_symbol_not_found() {
+        let source = "fn foo() {}\n";
+        let result = wrap_code(
+            source,
+            Some(&["nonexistent".into()]),
+            None,
+            "mod wrapper",
+            None,
+            Language::Rust,
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn wrap_requires_exactly_one_mode() {
+        let source = "fn foo() {}\n";
+        // None specified
+        let result = wrap_code(source, None, None, "mod x", None, Language::Rust);
+        assert!(result.is_err());
+
+        // Both specified
+        let result = wrap_code(
+            source,
+            Some(&["foo".into()]),
+            Some("1:1"),
+            "mod x",
+            None,
+            Language::Rust,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn wrap_cfg_attribute() {
+        let source = "fn feature_a() {\n    // experimental\n}\n";
+        let result = wrap_code(
+            source,
+            Some(&["feature_a".into()]),
+            None,
+            "#[cfg(feature = \"experimental\")]",
+            None,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(
+            result
+                .content
+                .contains("#[cfg(feature = \"experimental\")] {")
+        );
+    }
+}

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -345,6 +345,63 @@ fn describe_operation(op: &Operation) -> String {
         } => {
             format!("AST replace \"{from}\" with \"{to}\" in {symbol} in {path}")
         }
+        #[cfg(feature = "ast")]
+        Operation::AstInsert {
+            path,
+            inside,
+            after,
+            before,
+            ..
+        } => {
+            let target = inside
+                .as_deref()
+                .or(after.as_deref())
+                .or(before.as_deref())
+                .unwrap_or("(file)");
+            format!("AST insert code near \"{target}\" in {path}")
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstWrap {
+            path,
+            symbols,
+            lines,
+            wrapper,
+            ..
+        } => {
+            let target = if let Some(syms) = symbols {
+                syms.join(", ")
+            } else if let Some(l) = lines {
+                format!("lines {l}")
+            } else {
+                "(unknown)".to_string()
+            };
+            format!("AST wrap {target} in \"{wrapper}\" in {path}")
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstImports {
+            path,
+            add,
+            remove,
+            dedupe,
+            ..
+        } => {
+            let mut parts = Vec::new();
+            if let Some(a) = add {
+                parts.push(format!("add {}", a.len()));
+            }
+            if let Some(r) = remove {
+                parts.push(format!("remove {}", r.len()));
+            }
+            if *dedupe {
+                parts.push("dedupe".to_string());
+            }
+            let action = if parts.is_empty() {
+                "list".to_string()
+            } else {
+                parts.join(", ")
+            };
+            format!("AST imports ({action}) in {path}")
+        }
     }
 }
 

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -632,6 +632,79 @@ pub(super) fn handle_ast_replace(
     Ok(CallToolResult::success(vec![Content::text(json)]))
 }
 
+pub(super) fn handle_ast_insert(
+    svc: &PatchloomService,
+    p: AstInsertParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_content_size("content", &p.content)?;
+    let op = crate::plan::Operation::AstInsert {
+        path: p.path,
+        content: p.content,
+        inside: p.inside,
+        after: p.after,
+        before: p.before,
+        position: p.position,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
+pub(super) fn handle_ast_wrap(
+    svc: &PatchloomService,
+    p: AstWrapParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("wrapper", &p.wrapper)?;
+    let op = crate::plan::Operation::AstWrap {
+        path: p.path,
+        symbols: p.symbols,
+        lines: p.lines,
+        wrapper: p.wrapper,
+        preamble: p.preamble,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
+pub(super) fn handle_ast_imports(
+    svc: &PatchloomService,
+    p: AstImportsParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+
+    // List-only mode (no mutation)
+    if p.add.is_none() && p.remove.is_none() && !p.dedupe {
+        let cwd = svc.cwd().to_path_buf();
+        let target = cwd.join(&p.path);
+        let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
+        let source = std::fs::read_to_string(&target)
+            .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
+        let imports = crate::ast::imports::list_imports(&source, lang);
+        let obj = serde_json::json!({
+            "file": p.path,
+            "imports": imports.iter().map(|i| serde_json::json!({
+                "text": i.text,
+                "line": i.line,
+            })).collect::<Vec<_>>(),
+            "count": imports.len(),
+        });
+        let json = serde_json::to_string_pretty(&obj)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        return Ok(CallToolResult::success(vec![Content::text(json)]));
+    }
+
+    let op = crate::plan::Operation::AstImports {
+        path: p.path,
+        add: p.add,
+        remove: p.remove,
+        dedupe: p.dedupe,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -715,6 +715,42 @@ impl PatchloomService {
             .await
     }
 
+    #[cfg(feature = "ast")]
+    #[tool(
+        description = "Insert code at a structurally-aware position: inside a module/impl/struct (at start or end), or after/before a named symbol. Indentation is auto-detected. Example: {\"path\": \"src/lib.rs\", \"content\": \"fn new_fn() {}\", \"after\": \"existing_fn\"}"
+    )]
+    async fn ast_insert(
+        &self,
+        Parameters(p): Parameters<AstInsertParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_insert(svc, p))
+            .await
+    }
+
+    #[cfg(feature = "ast")]
+    #[tool(
+        description = "Wrap existing code in a structural block (module, impl, cfg, etc.). Specify symbols by name or a line range. Example: {\"path\": \"src/lib.rs\", \"symbols\": [\"helper_fn\", \"HelperStruct\"], \"wrapper\": \"mod helpers\"}"
+    )]
+    async fn ast_wrap(
+        &self,
+        Parameters(p): Parameters<AstWrapParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_wrap(svc, p))
+            .await
+    }
+
+    #[cfg(feature = "ast")]
+    #[tool(
+        description = "Manage import/use statements: add (idempotent), remove, deduplicate. With no mutation args, lists existing imports. Example: {\"path\": \"src/main.rs\", \"add\": [\"use std::collections::HashMap;\"]}"
+    )]
+    async fn ast_imports(
+        &self,
+        Parameters(p): Parameters<AstImportsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_imports(svc, p))
+            .await
+    }
+
     #[tool(
         description = "Show uncommitted file changes vs git HEAD. Returns lists of modified, created, and deleted files. No parameters required."
     )]

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -432,6 +432,73 @@ pub(crate) struct AstReplaceParams {
     pub lang: Option<String>,
 }
 
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct AstInsertParams {
+    /// File to insert code into.
+    pub path: String,
+    /// Code to insert.
+    pub content: String,
+    /// Module/impl/struct to insert into (mutually exclusive with after/before).
+    #[serde(default)]
+    pub inside: Option<String>,
+    /// Insert after this symbol (mutually exclusive with inside/before).
+    #[serde(default)]
+    pub after: Option<String>,
+    /// Insert before this symbol (mutually exclusive with inside/after).
+    #[serde(default)]
+    pub before: Option<String>,
+    /// Position within `inside`: "start" or "end" (default).
+    #[serde(default)]
+    pub position: Option<String>,
+    /// Language hint.
+    pub lang: Option<String>,
+}
+
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct AstWrapParams {
+    /// File to modify.
+    pub path: String,
+    /// Symbols to wrap (mutually exclusive with lines).
+    #[serde(default)]
+    pub symbols: Option<Vec<String>>,
+    /// Line range to wrap (e.g. "10:50", mutually exclusive with symbols).
+    #[serde(default)]
+    pub lines: Option<String>,
+    /// The wrapping construct (e.g. "mod foo", "impl Bar", "#[cfg(test)]").
+    pub wrapper: String,
+    /// Content to insert at the top of the wrapped block.
+    #[serde(default)]
+    pub preamble: Option<String>,
+    /// Language hint.
+    pub lang: Option<String>,
+}
+
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct AstImportsParams {
+    /// File to modify.
+    pub path: String,
+    /// Import statements to add (idempotent; skips if already present).
+    #[serde(default)]
+    pub add: Option<Vec<String>>,
+    /// Import statements to remove.
+    #[serde(default)]
+    pub remove: Option<Vec<String>>,
+    /// Deduplicate imports.
+    #[serde(default)]
+    pub dedupe: bool,
+    /// Language hint.
+    pub lang: Option<String>,
+}
+
 /// No-parameter wrapper for tools that need no input (e.g., git_status).
 /// Required because rmcp 1.8+ validates that `inputSchema` has a root
 /// `type: "object"` field, which `serde_json::Value` does not provide.

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -104,8 +104,11 @@ mod basic {
             "missing md_move_section tool"
         );
         assert!(names.contains(&"append_file"), "missing append_file tool");
-        // 32 base tools + 11 AST tools = 43
-        assert_eq!(names.len(), 43, "expected 43 tools, got {}", names.len());
+        assert!(names.contains(&"ast_insert"), "missing ast_insert tool");
+        assert!(names.contains(&"ast_wrap"), "missing ast_wrap tool");
+        assert!(names.contains(&"ast_imports"), "missing ast_imports tool");
+        // 32 base tools + 14 AST tools = 46
+        assert_eq!(names.len(), 46, "expected 46 tools, got {}", names.len());
         client.cancel().await.unwrap();
     }
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -6,7 +6,9 @@ use globset::{Glob, GlobSet, GlobSetBuilder};
 use ignore::WalkBuilder;
 #[cfg(feature = "cli")]
 use ignore::WalkState;
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(any(feature = "cli", feature = "files"))]
+use std::path::PathBuf;
 #[cfg(feature = "cli")]
 use std::sync::Mutex;
 

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -625,6 +625,7 @@ fn find_match(haystack: &[&str], needle: &[&str], expected: isize, fuzz: usize) 
     None
 }
 
+#[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn apply_patch_with_loader<F>(
     diff_text: &str,
     mut load_original: F,

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -135,6 +135,7 @@ mod basic {
     }
 
     #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
     fn apply_patch_with_loader_basic() {
         let diff = "\
 --- a/test.txt

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -1,8 +1,10 @@
 #[allow(unused_imports)]
 use anyhow::bail;
 
+#[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) type LineRange = (usize, Option<usize>);
 
+#[cfg(any(feature = "cli", feature = "files"))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SelectedLines {
     pub content: String,
@@ -11,6 +13,7 @@ pub(crate) struct SelectedLines {
     pub total_lines: usize,
 }
 
+#[cfg(any(feature = "cli", feature = "files"))]
 impl SelectedLines {
     pub fn empty(total_lines: usize) -> Self {
         Self {
@@ -23,6 +26,7 @@ impl SelectedLines {
 }
 
 /// Parse a line range spec like "10", "10:20", "10-20", ":20", "10:" .
+#[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
     // Accept both ':' and '-' as range separators so `--lines 1:10` and
     // `--lines 1-10` both work (the help examples show the dash form).
@@ -67,6 +71,7 @@ pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
 }
 
 /// Select a range of lines (1-based). Normalizes line endings to LF in output.
+#[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn select_lines(content: &str, lines: LineRange) -> SelectedLines {
     let all_lines: Vec<&str> = content.lines().collect();
     let total_lines = all_lines.len();
@@ -105,6 +110,7 @@ pub(crate) fn select_lines(content: &str, lines: LineRange) -> SelectedLines {
 }
 
 #[cfg(test)]
+#[cfg(any(feature = "cli", feature = "files"))]
 mod tests {
     use super::*;
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -333,6 +333,60 @@ pub enum Operation {
         #[serde(default)]
         lang: Option<String>,
     },
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.insert", alias = "ast_insert")]
+    AstInsert {
+        path: String,
+        content: String,
+        /// Module/impl/struct to insert into.
+        #[serde(default)]
+        inside: Option<String>,
+        /// Insert after this symbol.
+        #[serde(default)]
+        after: Option<String>,
+        /// Insert before this symbol.
+        #[serde(default)]
+        before: Option<String>,
+        /// Position within `inside`: "start" or "end" (default).
+        #[serde(default)]
+        position: Option<String>,
+        #[serde(default)]
+        lang: Option<String>,
+    },
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.wrap", alias = "ast_wrap")]
+    AstWrap {
+        path: String,
+        /// Symbols to wrap (mutually exclusive with `lines`).
+        #[serde(default)]
+        symbols: Option<Vec<String>>,
+        /// Line range to wrap (mutually exclusive with `symbols`).
+        #[serde(default)]
+        lines: Option<String>,
+        /// The wrapping construct (e.g. "mod foo", "impl Bar").
+        wrapper: String,
+        /// Content to insert at the top of the wrapped block.
+        #[serde(default)]
+        preamble: Option<String>,
+        #[serde(default)]
+        lang: Option<String>,
+    },
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.imports", alias = "ast_imports")]
+    AstImports {
+        path: String,
+        /// Import statements to add.
+        #[serde(default)]
+        add: Option<Vec<String>>,
+        /// Import statements to remove.
+        #[serde(default)]
+        remove: Option<Vec<String>>,
+        /// Deduplicate imports.
+        #[serde(default)]
+        dedupe: bool,
+        #[serde(default)]
+        lang: Option<String>,
+    },
 }
 
 impl Operation {
@@ -369,6 +423,12 @@ impl Operation {
             Operation::AstRename { .. } => "ast.rename",
             #[cfg(feature = "ast")]
             Operation::AstReplace { .. } => "ast.replace",
+            #[cfg(feature = "ast")]
+            Operation::AstInsert { .. } => "ast.insert",
+            #[cfg(feature = "ast")]
+            Operation::AstWrap { .. } => "ast.wrap",
+            #[cfg(feature = "ast")]
+            Operation::AstImports { .. } => "ast.imports",
         }
     }
 
@@ -399,7 +459,11 @@ impl Operation {
             {
                 matches!(
                     self,
-                    Operation::AstRename { .. } | Operation::AstReplace { .. }
+                    Operation::AstRename { .. }
+                        | Operation::AstReplace { .. }
+                        | Operation::AstInsert { .. }
+                        | Operation::AstWrap { .. }
+                        | Operation::AstImports { .. }
                 )
             }
             #[cfg(not(feature = "ast"))]
@@ -572,7 +636,11 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<&str> {
         | Operation::Search { path, .. }
         | Operation::MdLintAgents { path, .. } => vec![path.as_str()],
         #[cfg(feature = "ast")]
-        Operation::AstRename { path, .. } | Operation::AstReplace { path, .. } => {
+        Operation::AstRename { path, .. }
+        | Operation::AstReplace { path, .. }
+        | Operation::AstInsert { path, .. }
+        | Operation::AstWrap { path, .. }
+        | Operation::AstImports { path, .. } => {
             vec![path.as_str()]
         }
     }
@@ -724,10 +792,13 @@ mod tests {
             {"op": "search", "path": "f.txt", "pattern": "TODO", "invert_match": true, "assert_count": 5},
             {"op": "search", "path": ".", "pattern": "foo", "literal": true, "exclude_patterns": ["target/**"], "custom_ignore_filenames": [".blineignore"], "max_results": 10},
             {"op": "ast.rename", "path": "f.rs", "old_name": "Foo", "new_name": "Bar"},
-            {"op": "ast.replace", "path": "f.rs", "symbol": "main", "from": "a", "to": "b"}
+            {"op": "ast.replace", "path": "f.rs", "symbol": "main", "from": "a", "to": "b"},
+            {"op": "ast.insert", "path": "f.rs", "content": "fn new() {}", "after": "main"},
+            {"op": "ast.wrap", "path": "f.rs", "symbols": ["helper"], "wrapper": "mod internal"},
+            {"op": "ast.imports", "path": "f.rs", "add": ["use std::io;"]}
         ]}"#;
         let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 36);
+        assert_eq!(plan.operations.len(), 39);
     }
 
     #[test]
@@ -757,10 +828,13 @@ mod tests {
             {"op": "read_file", "path": "f.txt"},
             {"op": "md_lint", "path": "f.md"},
             {"op": "ast_rename", "path": "f.rs", "old_name": "A", "new_name": "B"},
-            {"op": "ast_replace", "path": "f.rs", "symbol": "main", "from": "x", "to": "y"}
+            {"op": "ast_replace", "path": "f.rs", "symbol": "main", "from": "x", "to": "y"},
+            {"op": "ast_insert", "path": "f.rs", "content": "fn x() {}", "inside": "Foo"},
+            {"op": "ast_wrap", "path": "f.rs", "lines": "1:10", "wrapper": "mod m"},
+            {"op": "ast_imports", "path": "f.rs", "remove": ["use old;"]}
         ]}"#;
         let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 22);
+        assert_eq!(plan.operations.len(), 25);
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -405,10 +405,38 @@ const AST_OPERATION_REGISTRY: &[OpMeta] = &[
             r###"{"op":"ast.replace","path":"src/config.rs","symbol":"default_timeout","from":"30","to":"60"}"###,
         )],
     },
+    OpMeta {
+        name: "ast.insert",
+        description: "Insert code at a structurally-aware position: inside a container, or after/before a named symbol.",
+        tier: Tier::Medium,
+        examples: &[(
+            "Insert a function after an existing one",
+            r###"{"op":"ast.insert","path":"src/lib.rs","content":"fn new_fn() {}","after":"existing_fn"}"###,
+        )],
+    },
+    OpMeta {
+        name: "ast.wrap",
+        description: "Wrap existing code in a structural block (module, impl, cfg, etc.).",
+        tier: Tier::Medium,
+        examples: &[(
+            "Wrap helpers in a module",
+            r###"{"op":"ast.wrap","path":"src/lib.rs","symbols":["helper_a","helper_b"],"wrapper":"mod helpers"}"###,
+        )],
+    },
+    OpMeta {
+        name: "ast.imports",
+        description: "Manage import/use statements: add (idempotent), remove, deduplicate.",
+        tier: Tier::Medium,
+        examples: &[(
+            "Add an import statement",
+            r###"{"op":"ast.imports","path":"src/main.rs","add":["use std::collections::HashMap;"]}"###,
+        )],
+    },
 ];
 
 /// Return the complete registry of all patchloom operations with schemas.
 pub fn operation_schemas() -> Vec<OperationSchema> {
+    #[allow(unused_mut)]
     let mut all: Vec<&OpMeta> = OPERATION_REGISTRY.iter().collect();
     #[cfg(feature = "ast")]
     all.extend(AST_OPERATION_REGISTRY.iter());

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -254,6 +254,7 @@ mod basic {
 
         // Build representative Operation values for each schema op name.
         // Only the field names matter; values are dummies.
+        #[allow(unused_mut)]
         let mut ops: Vec<(&str, Operation)> = vec![
             (
                 "replace",
@@ -496,6 +497,39 @@ mod basic {
                     from: "a".into(),
                     to: "b".into(),
                     regex: false,
+                    lang: None,
+                },
+            ));
+            ops.push((
+                "ast.insert",
+                Operation::AstInsert {
+                    path: "f.rs".into(),
+                    content: "fn new() {}".into(),
+                    inside: None,
+                    after: Some("main".into()),
+                    before: None,
+                    position: None,
+                    lang: None,
+                },
+            ));
+            ops.push((
+                "ast.wrap",
+                Operation::AstWrap {
+                    path: "f.rs".into(),
+                    symbols: Some(vec!["helper".into()]),
+                    lines: None,
+                    wrapper: "mod internal".into(),
+                    preamble: None,
+                    lang: None,
+                },
+            ));
+            ops.push((
+                "ast.imports",
+                Operation::AstImports {
+                    path: "f.rs".into(),
+                    add: Some(vec!["use std::io;".into()]),
+                    remove: None,
+                    dedupe: false,
                     lang: None,
                 },
             ));

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -713,6 +713,105 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                 None => anyhow::bail!("symbol '{}' not found in {}", symbol, path),
             }
         }
+
+        #[cfg(feature = "ast")]
+        Operation::AstInsert {
+            path,
+            content: insert_content,
+            inside,
+            after,
+            before,
+            position,
+            lang,
+        } => {
+            let abs = tx.cwd.join(path);
+            let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let pos = match position.as_deref() {
+                Some("start") => crate::ast::insert::InsertPosition::Start,
+                _ => crate::ast::insert::InsertPosition::End,
+            };
+            let result = crate::ast::insert::insert_code(
+                file_content,
+                insert_content,
+                inside.as_deref(),
+                after.as_deref(),
+                before.as_deref(),
+                pos,
+                lang_val,
+            )?;
+            update_file_content(tx.pending, tx.deletions, &abs, result.content);
+            return Ok(1);
+        }
+
+        #[cfg(feature = "ast")]
+        Operation::AstWrap {
+            path,
+            symbols: sym_names,
+            lines: line_range,
+            wrapper,
+            preamble,
+            lang,
+        } => {
+            let abs = tx.cwd.join(path);
+            let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let result = crate::ast::wrap::wrap_code(
+                file_content,
+                sym_names.as_deref(),
+                line_range.as_deref(),
+                wrapper,
+                preamble.as_deref(),
+                lang_val,
+            )?;
+            update_file_content(tx.pending, tx.deletions, &abs, result.content);
+            return Ok(1);
+        }
+
+        #[cfg(feature = "ast")]
+        Operation::AstImports {
+            path,
+            add,
+            remove,
+            dedupe,
+            lang,
+        } => {
+            let abs = tx.cwd.join(path);
+            let mut file_content =
+                read_file_content(tx.pending, tx.existed_before, &abs)?.to_string();
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let mut total_changes = 0usize;
+
+            if let Some(add_list) = add {
+                let result = crate::ast::imports::add_imports(&file_content, add_list, lang_val);
+                total_changes += result.added;
+                file_content = result.content;
+            }
+            if let Some(remove_list) = remove {
+                let result =
+                    crate::ast::imports::remove_imports(&file_content, remove_list, lang_val);
+                total_changes += result.removed;
+                file_content = result.content;
+            }
+            if *dedupe {
+                let result = crate::ast::imports::dedupe_imports(&file_content, lang_val);
+                total_changes += result.deduped;
+                file_content = result.content;
+            }
+            if total_changes > 0 {
+                update_file_content(tx.pending, tx.deletions, &abs, file_content);
+            }
+            return Ok(total_changes);
+        }
     }
 
     Ok(0)

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -55,7 +55,11 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
         | Operation::MdLintAgents { .. }
         | Operation::PatchApply { .. } => Ok(()),
         #[cfg(feature = "ast")]
-        Operation::AstRename { .. } | Operation::AstReplace { .. } => Ok(()),
+        Operation::AstRename { .. }
+        | Operation::AstReplace { .. }
+        | Operation::AstInsert { .. }
+        | Operation::AstWrap { .. }
+        | Operation::AstImports { .. } => Ok(()),
         Operation::TidyFix { dedent, indent, .. } => {
             if dedent.is_some() && indent.is_some() {
                 anyhow::bail!("tidy.fix: 'dedent' and 'indent' cannot both be set");


### PR DESCRIPTION
Add three new AST-aware operations for Phase B:

## ast.insert (#1015)
Insert code at structurally-aware positions: inside a container (module, impl, struct) at start or end, or after/before a named symbol. Auto-detects and adjusts indentation.

## ast.wrap (#1017)
Wrap existing code in a structural block (module, impl, cfg, etc.) by specifying symbols or line ranges, with optional preamble content.

## ast.imports (#1020)
Manage import/use statements: add (idempotent), remove, deduplicate. Supports Rust, Python, TypeScript, JavaScript, Go, Java, and Kotlin. Read-only list mode when no mutations are specified.

All three operations are available via transaction plans and MCP tools (46 total, up from 43).

Also fixes dead_code warnings under `--no-default-features` (#1037) by adding appropriate `#[cfg]` gates.

**Tests:** 25 new unit tests across the three modules, plus updates to plan parsing tests, MCP tool list test, schema registry, and operation variant coverage tests. Full `make check` passes.

Closes #1015
Closes #1017
Closes #1020
Closes #1037