### PR TITLE
feat(ast): Phase C operations and for_each glob batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2200%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2300%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-2200+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+2300+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -872,6 +872,14 @@ Use these when newline and whitespace correctness is the main concern.
 - **Failure behavior:** When a check fails, the transaction rolls back and exits with `VALIDATION_FAILED` (6).
 - **Prefer instead:** Omit when the plan only touches configuration files or non-code content.
 
+<!-- ref:tx-field:for_each -->
+### `for_each`
+
+- **What it does:** Glob-driven batch expansion. When present, the plan's `operations` are treated as templates and expanded once per matching file. Template variables (`{path}`, `{dir}`, `{stem}`, `{ext}`, `{name}`) are substituted in all operation fields.
+- **Use when:** The same structural transform (extract tests, add headers, reorder symbols) must be applied to many files matching a glob pattern.
+- **Field value:** Object with `glob` (required), `exclude` (optional array of glob patterns), and `filter` (optional, e.g. `has_symbol(tests)`).
+- **Failure behavior:** If the glob matches zero files, the plan produces zero operations (success with no changes). If any expanded operation fails, the entire batch rolls back atomically.
+
 ### Transaction operations
 
 The operations below are the building blocks inside `operations`.
@@ -1055,6 +1063,76 @@ The operations below are the building blocks inside `operations`.
 - **What it does:** Applies a unified diff inside a transaction. Supports `on_stale: "merge"` for three-way merge when the on-disk file diverged from the patch base, and `allow_conflicts: true` to write conflict markers instead of failing during staging.
 - **Use when:** Patch replay needs to compose with earlier in-plan edits and share the same rollback or validation behavior.
 - **Related:** top level `patch apply`, `patch merge`
+
+<!-- ref:tx-op:ast.rename -->
+### `ast.rename`
+
+- **What it does:** Renames all occurrences of an identifier within a file using tree-sitter AST awareness, skipping strings, comments, and documentation. References inside the renamed symbol and callers are updated atomically.
+- **Use when:** You need a precise identifier rename that respects language semantics (e.g., renaming `old_fn` to `new_fn` without touching the string `"old_fn"` in a log message).
+- **Related:** `replace` (text-level), `ast replace`
+
+<!-- ref:tx-op:ast.replace -->
+### `ast.replace`
+
+- **What it does:** Performs a scoped text replacement within a single symbol's body. Only the text inside the named symbol is searched and modified; the rest of the file is untouched.
+- **Use when:** You need to change a value, string, or expression inside a specific function or struct without affecting identically-named text in other symbols.
+- **Related:** `replace` (file-level), `ast.rename` (identifier rename)
+
+<!-- ref:tx-op:ast.insert -->
+### `ast.insert`
+
+- **What it does:** Inserts new source code at a position relative to an existing symbol (before, after, inside-start, inside-end). Handles indentation matching and blank-line separation.
+- **Use when:** You need to add a new function, field, or statement adjacent to or inside an existing symbol without manually computing line numbers.
+- **Related:** `ast.wrap`, `ast.group`
+
+<!-- ref:tx-op:ast.wrap -->
+### `ast.wrap`
+
+- **What it does:** Wraps an existing symbol with a prefix and suffix, re-indenting the original body. Commonly used for wrapping a function in an `impl` block, a `mod` block, or an `if` guard.
+- **Use when:** You need to add structural nesting around an existing symbol (e.g., wrapping free functions in an `impl`, adding `#[cfg(test)]` module wrappers).
+- **Related:** `ast.insert`, `ast.group`
+
+<!-- ref:tx-op:ast.imports -->
+### `ast.imports`
+
+- **What it does:** Adds or removes import statements from a file. Supports `add` and `remove` actions with deduplication. Language-aware: handles `use` (Rust), `import` (Python/JS/TS/Go/Java), `#include` (C/C++).
+- **Use when:** You need to manage imports programmatically after moving symbols, adding new dependencies, or cleaning up unused imports.
+- **Related:** `ast.move`, `ast.extract_to_file`
+
+<!-- ref:tx-op:ast.reorder -->
+### `ast.reorder`
+
+- **What it does:** Reorders top-level symbols (or symbols inside a scope) according to a strategy: `alphabetical`, `reverse`, `kind-first` (types before functions), or a custom ordered list of names. Preserves attached doc comments and attributes.
+- **Use when:** You want to enforce a consistent declaration order (e.g., alphabetical functions, types-first convention) or manually arrange symbols to match a specification.
+- **Related:** `ast.group`, `ast.move`
+
+<!-- ref:tx-op:ast.group -->
+### `ast.group`
+
+- **What it does:** Moves one or more symbols into a new or existing module block within the same file. Supports a preamble (e.g., `use super::*;`) and configurable placement (first-symbol position, end of file, or after a specific symbol).
+- **Use when:** You want to organize related symbols into a `mod tests { ... }` block or group utility functions into a sub-module without extracting to a separate file.
+- **Related:** `ast.extract_to_file`, `ast.move`, `ast.reorder`
+
+<!-- ref:tx-op:ast.move -->
+### `ast.move`
+
+- **What it does:** Moves symbols from one file to another, removing them from the source and inserting at a specified position in the target. Supports creating the target file with an optional prepend. Preserves attached doc comments and attributes.
+- **Use when:** You need to relocate functions, structs, or constants between files during a refactoring (e.g., moving helpers from `lib.rs` to `utils.rs`).
+- **Related:** `ast.extract_to_file`, `ast.group`, `ast.imports`
+
+<!-- ref:tx-op:ast.extract_to_file -->
+### `ast.extract_to_file`
+
+- **What it does:** Extracts a single symbol from a source file into a new target file. For module blocks, it can unwrap the module wrapper and un-indent the body. Leaves an optional replacement text (e.g., `mod tests;`) in the source. Supports a prepend for the target (e.g., `use super::*;`).
+- **Use when:** You want to extract a test module, a large struct, or a helper block into its own file while leaving a `mod` declaration behind.
+- **Related:** `ast.split`, `ast.move`, `ast.imports`
+
+<!-- ref:tx-op:ast.split -->
+### `ast.split`
+
+- **What it does:** Splits a file into multiple target files by distributing symbols. Each target specifies which symbols it receives and an optional prepend. Symbols not assigned to any target stay in the source (controlled by `keep_in_source`). Supports `source_suffix` and `source_prefix` for adding `mod` declarations. Enforces exhaustive accounting by default.
+- **Use when:** A file has grown too large and you want to distribute its symbols across several new files in one atomic operation, with `mod` re-exports generated automatically.
+- **Related:** `ast.extract_to_file`, `ast.move`, `ast.group`
 
 ## Library API
 

--- a/src/ast/extract.rs
+++ b/src/ast/extract.rs
@@ -1,0 +1,223 @@
+//! AST-aware symbol extraction: extract a symbol to a separate file.
+
+use super::Language;
+use super::symbols::{
+    SymbolKind, extract_symbol_text, extract_symbols, find_symbol, full_symbol_span,
+};
+
+/// Result of an extract-to-file operation.
+#[derive(Debug)]
+pub struct ExtractResult {
+    /// The source file content after extraction.
+    pub source_content: String,
+    /// The target file content (extracted code).
+    pub target_content: String,
+    /// Number of lines extracted.
+    pub extracted_lines: usize,
+}
+
+/// Extract a named symbol from source and produce content for a new file.
+///
+/// When `unwrap` is true and the symbol is a module, the module's body
+/// content is extracted (un-indented by one level) without the `mod name { }` wrapper.
+pub fn extract_to_file(
+    source: &str,
+    symbol: &str,
+    replacement: Option<&str>,
+    unwrap: bool,
+    prepend: Option<&str>,
+    lang: Language,
+) -> anyhow::Result<ExtractResult> {
+    let symbols = extract_symbols(source, lang);
+    let sym = find_symbol(&symbols, symbol)
+        .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", symbol))?;
+
+    let (full_start, full_end) = full_symbol_span(source, sym, lang);
+    let lines: Vec<&str> = source.lines().collect();
+    let start_0 = full_start.saturating_sub(1);
+    let end_0 = full_end.min(lines.len());
+
+    // Extract the symbol's content for the target file
+    let target_body = if unwrap && sym.kind == SymbolKind::Module {
+        unwrap_module_body(&lines, sym.start_line.saturating_sub(1), end_0)
+    } else {
+        let text = extract_symbol_text(source, sym, lang);
+        text.to_string()
+    };
+
+    let extracted_lines = target_body.lines().count();
+
+    // Build target content
+    let mut target_content = String::new();
+    if let Some(pre) = prepend {
+        target_content.push_str(pre);
+        if !pre.ends_with('\n') {
+            target_content.push('\n');
+        }
+        target_content.push('\n');
+    }
+    target_content.push_str(&target_body);
+    if !target_content.ends_with('\n') {
+        target_content.push('\n');
+    }
+
+    // Build source content with the symbol removed or replaced
+    let mut source_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+    let mut remove_end = end_0;
+    // Also remove trailing blank line
+    if remove_end < source_lines.len() && source_lines[remove_end].trim().is_empty() {
+        remove_end += 1;
+    }
+    source_lines.drain(start_0..remove_end.min(source_lines.len()));
+
+    if let Some(repl) = replacement {
+        // Insert replacement text at the position
+        let repl_lines: Vec<String> = repl.lines().map(String::from).collect();
+        for (i, line) in repl_lines.iter().enumerate() {
+            source_lines.insert(start_0 + i, line.clone());
+        }
+    }
+
+    let mut source_content = source_lines.join("\n");
+    if source.ends_with('\n') && !source_content.ends_with('\n') {
+        source_content.push('\n');
+    }
+
+    Ok(ExtractResult {
+        source_content,
+        target_content,
+        extracted_lines,
+    })
+}
+
+/// Extract the body of a module, removing the wrapper and un-indenting.
+fn unwrap_module_body(lines: &[&str], sym_start_0: usize, sym_end_0: usize) -> String {
+    // Find the opening brace line
+    let mut body_start = sym_start_0;
+    for (i, line) in lines.iter().enumerate().take(sym_end_0).skip(sym_start_0) {
+        let trimmed = line.trim();
+        if trimmed.ends_with('{') {
+            body_start = i + 1;
+            break;
+        }
+    }
+
+    // The closing brace is on the last line
+    let body_end = if sym_end_0 > 0 {
+        sym_end_0 - 1
+    } else {
+        sym_end_0
+    };
+
+    if body_start >= body_end {
+        return String::new();
+    }
+
+    let body_lines = &lines[body_start..body_end];
+
+    // Find common indentation
+    let min_indent = body_lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    // Un-indent
+    body_lines
+        .iter()
+        .map(|line| {
+            if line.trim().is_empty() {
+                String::new()
+            } else if line.len() >= min_indent {
+                line[min_indent..].to_string()
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_basic_function() {
+        let source = "fn foo() {\n    42\n}\n\nfn bar() {}\n";
+        let result = extract_to_file(source, "foo", None, false, None, Language::Rust).unwrap();
+        assert!(!result.source_content.contains("fn foo"));
+        assert!(result.source_content.contains("fn bar"));
+        assert!(result.target_content.contains("fn foo()"));
+        assert!(result.target_content.contains("42"));
+    }
+
+    #[test]
+    fn extract_with_replacement() {
+        let source = "mod tests {\n    fn test_a() {}\n}\n\nfn other() {}\n";
+        let replacement = "#[path = \"tests.rs\"]\nmod tests;";
+        let result = extract_to_file(
+            source,
+            "tests",
+            Some(replacement),
+            true,
+            None,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.source_content.contains("#[path = \"tests.rs\"]"));
+        assert!(result.source_content.contains("mod tests;"));
+        assert!(!result.source_content.contains("fn test_a"));
+    }
+
+    #[test]
+    fn extract_unwrap_module() {
+        let source = "mod tests {\n    fn test_a() {\n        assert!(true);\n    }\n}\n";
+        let result = extract_to_file(source, "tests", None, true, None, Language::Rust).unwrap();
+        // Content should be un-indented
+        assert!(result.target_content.contains("fn test_a()"));
+        assert!(result.target_content.contains("    assert!(true);"));
+        // Should NOT contain the mod wrapper
+        assert!(!result.target_content.contains("mod tests"));
+    }
+
+    #[test]
+    fn extract_with_prepend() {
+        let source = "fn foo() {}\n\nfn bar() {}\n";
+        let result = extract_to_file(
+            source,
+            "foo",
+            None,
+            false,
+            Some("use super::*;"),
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.target_content.starts_with("use super::*;"));
+        assert!(result.target_content.contains("fn foo()"));
+    }
+
+    #[test]
+    fn extract_no_unwrap() {
+        let source = "mod tests {\n    fn test_a() {}\n}\n";
+        let result = extract_to_file(source, "tests", None, false, None, Language::Rust).unwrap();
+        // Full module text should be preserved
+        assert!(result.target_content.contains("mod tests {"));
+    }
+
+    #[test]
+    fn extract_symbol_not_found() {
+        let source = "fn foo() {}\n";
+        let result = extract_to_file(source, "nonexistent", None, false, None, Language::Rust);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn extract_preserves_attributes() {
+        let source = "/// Doc comment.\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n";
+        let result = extract_to_file(source, "tests", None, false, None, Language::Rust).unwrap();
+        assert!(result.target_content.contains("/// Doc comment."));
+        assert!(result.target_content.contains("#[cfg(test)]"));
+    }
+}

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -1,0 +1,354 @@
+//! AST-aware symbol grouping: move symbols into named modules within a file.
+
+use super::Language;
+use super::symbols::{extract_symbol_text, extract_symbols, find_symbol, full_symbol_span};
+
+/// Where to place a newly created module.
+#[derive(Debug, Clone)]
+pub enum GroupPosition {
+    /// At the position of the first moved symbol (default).
+    FirstSymbol,
+    /// At the end of the file.
+    End,
+    /// After a named symbol.
+    After(String),
+}
+
+/// Specification for a group operation.
+#[derive(Debug)]
+pub struct GroupSpec {
+    pub module: String,
+    pub symbols: Vec<String>,
+    pub preamble: Option<String>,
+    pub position: GroupPosition,
+}
+
+/// Result of a group operation.
+#[derive(Debug)]
+pub struct GroupResult {
+    pub content: String,
+    pub symbols_moved: usize,
+    pub module_created: bool,
+}
+
+/// Group named symbols into a module within the same file.
+pub fn group_symbols(
+    source: &str,
+    spec: &GroupSpec,
+    lang: Language,
+) -> anyhow::Result<GroupResult> {
+    let symbols = extract_symbols(source, lang);
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Check if target module already exists
+    let existing_mod = find_symbol(&symbols, &spec.module);
+    let module_exists = existing_mod.is_some();
+
+    // Find each symbol to move and collect their text + spans
+    let mut to_move: Vec<(usize, usize, String)> = Vec::new(); // (start_0, end_0, text)
+    let mut missing: Vec<&str> = Vec::new();
+
+    for name in &spec.symbols {
+        if let Some(sym) = find_symbol(&symbols, name) {
+            // Check if already inside the target module
+            if let Some(parent_mod) = &existing_mod
+                && sym.start_line >= parent_mod.start_line
+                && sym.end_line <= parent_mod.end_line
+            {
+                continue; // already inside target module
+            }
+            let (full_start, full_end) = full_symbol_span(source, sym, lang);
+            let text = extract_symbol_text(source, sym, lang).to_string();
+            to_move.push((
+                full_start.saturating_sub(1),
+                full_end.min(lines.len()),
+                text,
+            ));
+        } else {
+            missing.push(name);
+        }
+    }
+
+    if !missing.is_empty() {
+        anyhow::bail!("symbol(s) not found: {}", missing.join(", "));
+    }
+
+    if to_move.is_empty() {
+        return Ok(GroupResult {
+            content: source.to_string(),
+            symbols_moved: 0,
+            module_created: false,
+        });
+    }
+
+    let symbols_moved = to_move.len();
+
+    // Sort spans by start position (descending) for safe removal
+    to_move.sort_by_key(|b| std::cmp::Reverse(b.0));
+
+    // Build the module content: indent each symbol by 4 spaces
+    let mut module_body = String::new();
+    if let Some(preamble) = &spec.preamble {
+        module_body.push_str(&indent_text(preamble, "    "));
+        module_body.push_str("\n\n");
+    }
+
+    // Collect texts in original order (we sorted descending for removal)
+    let mut texts_in_order: Vec<(usize, &str)> = to_move
+        .iter()
+        .map(|(start, _, text)| (*start, text.as_str()))
+        .collect();
+    texts_in_order.sort_by_key(|(start, _)| *start);
+
+    for (i, (_, text)) in texts_in_order.iter().enumerate() {
+        if i > 0 {
+            module_body.push('\n');
+        }
+        let trimmed = text.trim_end_matches('\n');
+        module_body.push_str(&indent_text(trimmed, "    "));
+        module_body.push('\n');
+    }
+
+    // Remove symbols from source (in reverse order to preserve offsets)
+    let mut modified_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+    for (start_0, end_0, _) in &to_move {
+        // Remove the lines, also removing a trailing blank line if present
+        let mut remove_end = *end_0;
+        if remove_end < modified_lines.len() && modified_lines[remove_end].trim().is_empty() {
+            remove_end += 1;
+        }
+        modified_lines.drain(*start_0..remove_end);
+    }
+
+    if module_exists {
+        // Find the existing module's closing brace in modified_lines
+        // Re-parse to find the module in modified source
+        let modified_source = modified_lines.join("\n");
+        let mod_symbols = extract_symbols(&modified_source, lang);
+        if let Some(mod_sym) = find_symbol(&mod_symbols, &spec.module) {
+            let close_line_0 = mod_sym.end_line.saturating_sub(1);
+            // Insert before closing brace
+            let mut result_lines: Vec<String> = Vec::new();
+            let re_lines: Vec<&str> = modified_source.lines().collect();
+            for (i, line) in re_lines.iter().enumerate() {
+                if i == close_line_0 {
+                    // Add a blank line before new content if previous line isn't blank
+                    if i > 0 && !re_lines[i - 1].trim().is_empty() {
+                        result_lines.push(String::new());
+                    }
+                    for body_line in module_body.lines() {
+                        result_lines.push(body_line.to_string());
+                    }
+                }
+                result_lines.push(line.to_string());
+            }
+            let mut result = result_lines.join("\n");
+            if source.ends_with('\n') && !result.ends_with('\n') {
+                result.push('\n');
+            }
+            return Ok(GroupResult {
+                content: result,
+                symbols_moved,
+                module_created: false,
+            });
+        }
+    }
+
+    // Build the module block for a new module
+    let module_block = format!("mod {} {{\n{}}}\n", spec.module, module_body);
+
+    // Insert new module at the specified position
+    let insert_idx = match &spec.position {
+        GroupPosition::FirstSymbol => {
+            // Position of the first moved symbol (in the original line indices)
+            let first_start = texts_in_order.first().map(|(s, _)| *s).unwrap_or(0);
+            // Map to modified_lines index: count how many lines were removed before this point
+            let mut offset = 0usize;
+            let mut spans_before: Vec<(usize, usize)> = to_move
+                .iter()
+                .map(|(s, e, _)| {
+                    let mut end = *e;
+                    if end < lines.len() && lines[end].trim().is_empty() {
+                        end += 1;
+                    }
+                    (*s, end)
+                })
+                .collect();
+            spans_before.sort_by_key(|(s, _)| *s);
+            for (s, e) in &spans_before {
+                if *s < first_start {
+                    offset += e - s;
+                }
+            }
+            first_start.saturating_sub(offset)
+        }
+        GroupPosition::End => modified_lines.len(),
+        GroupPosition::After(sym_name) => {
+            let modified_source = modified_lines.join("\n");
+            let mod_symbols = extract_symbols(&modified_source, lang);
+            if let Some(sym) = find_symbol(&mod_symbols, sym_name) {
+                sym.end_line.min(modified_lines.len())
+            } else {
+                modified_lines.len()
+            }
+        }
+    };
+
+    let insert_idx = insert_idx.min(modified_lines.len());
+
+    // Insert module block
+    let block_lines: Vec<String> = module_block.lines().map(String::from).collect();
+    // Add blank line before if needed
+    if insert_idx > 0
+        && insert_idx <= modified_lines.len()
+        && !modified_lines[insert_idx - 1].trim().is_empty()
+    {
+        modified_lines.insert(insert_idx, String::new());
+        let idx = insert_idx + 1;
+        for (i, bl) in block_lines.iter().enumerate() {
+            modified_lines.insert(idx + i, bl.clone());
+        }
+    } else {
+        for (i, bl) in block_lines.iter().enumerate() {
+            modified_lines.insert(insert_idx + i, bl.clone());
+        }
+    }
+
+    let mut result = modified_lines.join("\n");
+    if source.ends_with('\n') && !result.ends_with('\n') {
+        result.push('\n');
+    }
+    if !source.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    Ok(GroupResult {
+        content: result,
+        symbols_moved,
+        module_created: true,
+    })
+}
+
+fn indent_text(text: &str, indent: &str) -> String {
+    text.lines()
+        .map(|line| {
+            if line.trim().is_empty() {
+                String::new()
+            } else {
+                format!("{indent}{line}")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn group_basic() {
+        let source = "fn foo() {}\n\nfn bar() {}\n\nfn baz() {}\n";
+        let spec = GroupSpec {
+            module: "helpers".into(),
+            symbols: vec!["foo".into(), "bar".into()],
+            preamble: None,
+            position: GroupPosition::FirstSymbol,
+        };
+        let result = group_symbols(source, &spec, Language::Rust).unwrap();
+        assert!(result.content.contains("mod helpers {"));
+        assert!(result.content.contains("    fn foo()"));
+        assert!(result.content.contains("    fn bar()"));
+        assert!(result.content.contains("fn baz()")); // not grouped
+        assert_eq!(result.symbols_moved, 2);
+        assert!(result.module_created);
+    }
+
+    #[test]
+    fn group_with_preamble() {
+        let source = "fn test_a() {}\n\nfn test_b() {}\n";
+        let spec = GroupSpec {
+            module: "tests".into(),
+            symbols: vec!["test_a".into(), "test_b".into()],
+            preamble: Some("use super::*;".into()),
+            position: GroupPosition::FirstSymbol,
+        };
+        let result = group_symbols(source, &spec, Language::Rust).unwrap();
+        assert!(result.content.contains("use super::*;"));
+        assert!(result.content.contains("mod tests {"));
+    }
+
+    #[test]
+    fn group_symbol_not_found() {
+        let source = "fn foo() {}\n";
+        let spec = GroupSpec {
+            module: "m".into(),
+            symbols: vec!["nonexistent".into()],
+            preamble: None,
+            position: GroupPosition::FirstSymbol,
+        };
+        let result = group_symbols(source, &spec, Language::Rust);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[test]
+    fn group_preserves_attributes() {
+        let source = "#[test]\nfn test_a() {}\n\nfn helper() {}\n";
+        let spec = GroupSpec {
+            module: "tests".into(),
+            symbols: vec!["test_a".into()],
+            preamble: None,
+            position: GroupPosition::FirstSymbol,
+        };
+        let result = group_symbols(source, &spec, Language::Rust).unwrap();
+        assert!(result.content.contains("#[test]"));
+        assert!(result.content.contains("fn test_a()"));
+    }
+
+    #[test]
+    fn group_position_end() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n";
+        let spec = GroupSpec {
+            module: "m".into(),
+            symbols: vec!["alpha".into()],
+            preamble: None,
+            position: GroupPosition::End,
+        };
+        let result = group_symbols(source, &spec, Language::Rust).unwrap();
+        // Module should be after beta
+        let beta_pos = result.content.find("fn beta").unwrap();
+        let mod_pos = result.content.find("mod m {").unwrap();
+        assert!(mod_pos > beta_pos);
+    }
+
+    #[test]
+    fn group_append_to_existing_module() {
+        let source = "mod helpers {\n    fn existing() {}\n}\n\nfn new_helper() {}\n";
+        let spec = GroupSpec {
+            module: "helpers".into(),
+            symbols: vec!["new_helper".into()],
+            preamble: None,
+            position: GroupPosition::FirstSymbol,
+        };
+        let result = group_symbols(source, &spec, Language::Rust).unwrap();
+        assert!(result.content.contains("fn existing()"));
+        assert!(result.content.contains("fn new_helper()"));
+        assert!(!result.module_created);
+        // Should only have one "mod helpers"
+        assert_eq!(result.content.matches("mod helpers").count(), 1);
+    }
+
+    #[test]
+    fn group_no_op_already_inside() {
+        let source = "mod m {\n    fn foo() {}\n}\n";
+        let spec = GroupSpec {
+            module: "m".into(),
+            symbols: vec!["foo".into()],
+            preamble: None,
+            position: GroupPosition::FirstSymbol,
+        };
+        let result = group_symbols(source, &spec, Language::Rust).unwrap();
+        assert_eq!(result.symbols_moved, 0);
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -6,14 +6,19 @@
 
 pub mod deps;
 pub mod diff;
+pub mod extract;
+pub mod group;
 pub mod impact;
 pub mod imports;
 pub mod insert;
 pub mod map;
+pub mod move_symbols;
 pub mod refs;
 pub mod rename;
+pub mod reorder;
 pub mod replace;
 pub mod search;
+pub mod split;
 pub mod symbols;
 pub mod validate;
 pub mod wrap;

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -1,0 +1,315 @@
+//! AST-aware symbol movement between files.
+
+use super::Language;
+use super::symbols::{extract_symbol_text, extract_symbols, find_symbol, full_symbol_span};
+
+/// Position to insert symbols in the target file.
+#[derive(Debug, Clone)]
+pub enum MovePosition {
+    End,
+    Start,
+    After(String),
+    Before(String),
+}
+
+/// Result of a move operation.
+#[derive(Debug)]
+pub struct MoveResult {
+    pub source_content: String,
+    pub target_content: String,
+    pub symbols_moved: usize,
+}
+
+/// Parse a position string into a MovePosition.
+pub fn parse_position(s: Option<&str>) -> MovePosition {
+    match s {
+        Some("start") => MovePosition::Start,
+        Some(s) if s.starts_with("after:") => MovePosition::After(s[6..].to_string()),
+        Some(s) if s.starts_with("before:") => MovePosition::Before(s[7..].to_string()),
+        _ => MovePosition::End,
+    }
+}
+
+/// Move named symbols from source to target file.
+pub fn move_symbols(
+    source: &str,
+    target: &str,
+    symbols: &[String],
+    position: MovePosition,
+    lang: Language,
+) -> anyhow::Result<MoveResult> {
+    let src_symbols = extract_symbols(source, lang);
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Collect symbols to move
+    let mut to_move: Vec<(usize, usize, String)> = Vec::new(); // (start_0, end_0, text)
+    let mut missing: Vec<&str> = Vec::new();
+
+    for name in symbols {
+        if let Some(sym) = find_symbol(&src_symbols, name) {
+            let (full_start, full_end) = full_symbol_span(source, sym, lang);
+            let text = extract_symbol_text(source, sym, lang).to_string();
+            to_move.push((
+                full_start.saturating_sub(1),
+                full_end.min(lines.len()),
+                text,
+            ));
+        } else {
+            missing.push(name);
+        }
+    }
+
+    if !missing.is_empty() {
+        anyhow::bail!("symbol(s) not found in source: {}", missing.join(", "));
+    }
+
+    if to_move.is_empty() {
+        return Ok(MoveResult {
+            source_content: source.to_string(),
+            target_content: target.to_string(),
+            symbols_moved: 0,
+        });
+    }
+
+    let symbols_moved = to_move.len();
+
+    // Sort by start position (ascending) for ordered insertion into target
+    to_move.sort_by_key(|(start, _, _)| *start);
+    let ordered_texts: Vec<String> = to_move.iter().map(|(_, _, t)| t.clone()).collect();
+
+    // Remove from source in reverse order
+    let mut src_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+    let mut sorted_desc = to_move.clone();
+    sorted_desc.sort_by_key(|b| std::cmp::Reverse(b.0));
+    for (start_0, end_0, _) in &sorted_desc {
+        let mut remove_end = *end_0;
+        // Also remove trailing blank line if present
+        if remove_end < src_lines.len() && src_lines[remove_end].trim().is_empty() {
+            remove_end += 1;
+        }
+        let drain_end = remove_end.min(src_lines.len());
+        src_lines.drain(*start_0..drain_end);
+    }
+
+    let mut source_result = src_lines.join("\n");
+    if source.ends_with('\n') && !source_result.ends_with('\n') {
+        source_result.push('\n');
+    }
+
+    // Build text to insert into target
+    let mut insert_text = String::new();
+    for (i, text) in ordered_texts.iter().enumerate() {
+        if i > 0 {
+            insert_text.push('\n');
+        }
+        insert_text.push_str(text.trim_end_matches('\n'));
+        insert_text.push('\n');
+    }
+
+    // Insert into target
+    let target_result = insert_into_target(target, &insert_text, &position, lang)?;
+
+    Ok(MoveResult {
+        source_content: source_result,
+        target_content: target_result,
+        symbols_moved,
+    })
+}
+
+fn insert_into_target(
+    target: &str,
+    insert_text: &str,
+    position: &MovePosition,
+    lang: Language,
+) -> anyhow::Result<String> {
+    if target.is_empty() {
+        return Ok(insert_text.to_string());
+    }
+
+    let lines: Vec<&str> = target.lines().collect();
+
+    match position {
+        MovePosition::End => {
+            let mut result = target.to_string();
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            result.push('\n');
+            result.push_str(insert_text);
+            Ok(result)
+        }
+        MovePosition::Start => {
+            let mut result = insert_text.to_string();
+            result.push('\n');
+            result.push_str(target);
+            Ok(result)
+        }
+        MovePosition::After(sym_name) => {
+            let symbols = extract_symbols(target, lang);
+            let sym = find_symbol(&symbols, sym_name)
+                .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in target", sym_name))?;
+            let end_0 = sym.end_line.min(lines.len());
+            let mut result = String::new();
+            for line in &lines[..end_0] {
+                result.push_str(line);
+                result.push('\n');
+            }
+            result.push('\n');
+            result.push_str(insert_text);
+            for line in &lines[end_0..] {
+                result.push_str(line);
+                result.push('\n');
+            }
+            if !target.ends_with('\n') && result.ends_with('\n') {
+                result.pop();
+            }
+            Ok(result)
+        }
+        MovePosition::Before(sym_name) => {
+            let symbols = extract_symbols(target, lang);
+            let sym = find_symbol(&symbols, sym_name)
+                .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in target", sym_name))?;
+            let (full_start, _) = full_symbol_span(target, sym, lang);
+            let start_0 = full_start.saturating_sub(1);
+            let mut result = String::new();
+            for line in &lines[..start_0] {
+                result.push_str(line);
+                result.push('\n');
+            }
+            result.push_str(insert_text);
+            result.push('\n');
+            for line in &lines[start_0..] {
+                result.push_str(line);
+                result.push('\n');
+            }
+            if !target.ends_with('\n') && result.ends_with('\n') {
+                result.pop();
+            }
+            Ok(result)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn move_basic() {
+        let source = "fn foo() {}\n\nfn bar() {}\n";
+        let target = "fn existing() {}\n";
+        let result = move_symbols(
+            source,
+            target,
+            &["foo".into()],
+            MovePosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(!result.source_content.contains("fn foo"));
+        assert!(result.source_content.contains("fn bar"));
+        assert!(result.target_content.contains("fn foo"));
+        assert!(result.target_content.contains("fn existing"));
+        assert_eq!(result.symbols_moved, 1);
+    }
+
+    #[test]
+    fn move_to_empty_file() {
+        let source = "fn foo() {\n    42\n}\n\nfn bar() {}\n";
+        let result = move_symbols(
+            source,
+            "",
+            &["foo".into()],
+            MovePosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(!result.source_content.contains("fn foo"));
+        assert!(result.target_content.contains("fn foo()"));
+        assert!(result.target_content.contains("42"));
+    }
+
+    #[test]
+    fn move_multiple_symbols() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n\nfn gamma() {}\n";
+        let result = move_symbols(
+            source,
+            "",
+            &["alpha".into(), "gamma".into()],
+            MovePosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(!result.source_content.contains("fn alpha"));
+        assert!(result.source_content.contains("fn beta"));
+        assert!(!result.source_content.contains("fn gamma"));
+        assert!(result.target_content.contains("fn alpha"));
+        assert!(result.target_content.contains("fn gamma"));
+        assert_eq!(result.symbols_moved, 2);
+    }
+
+    #[test]
+    fn move_symbol_not_found() {
+        let source = "fn foo() {}\n";
+        let result = move_symbols(
+            source,
+            "",
+            &["nonexistent".into()],
+            MovePosition::End,
+            Language::Rust,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn move_preserves_attributes() {
+        let source = "#[test]\n#[cfg(unix)]\nfn foo() {}\n\nfn bar() {}\n";
+        let result = move_symbols(
+            source,
+            "",
+            &["foo".into()],
+            MovePosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.target_content.contains("#[test]"));
+        assert!(result.target_content.contains("#[cfg(unix)]"));
+        assert!(result.target_content.contains("fn foo()"));
+    }
+
+    #[test]
+    fn move_position_start() {
+        let source = "fn new_fn() {}\n";
+        let target = "fn existing() {}\n";
+        let result = move_symbols(
+            source,
+            target,
+            &["new_fn".into()],
+            MovePosition::Start,
+            Language::Rust,
+        )
+        .unwrap();
+        let new_pos = result.target_content.find("fn new_fn").unwrap();
+        let existing_pos = result.target_content.find("fn existing").unwrap();
+        assert!(new_pos < existing_pos);
+    }
+
+    #[test]
+    fn move_position_after() {
+        let source = "fn moved() {}\n";
+        let target = "fn first() {}\n\nfn last() {}\n";
+        let result = move_symbols(
+            source,
+            target,
+            &["moved".into()],
+            MovePosition::After("first".into()),
+            Language::Rust,
+        )
+        .unwrap();
+        let first_pos = result.target_content.find("fn first").unwrap();
+        let moved_pos = result.target_content.find("fn moved").unwrap();
+        let last_pos = result.target_content.find("fn last").unwrap();
+        assert!(first_pos < moved_pos);
+        assert!(moved_pos < last_pos);
+    }
+}

--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -1,0 +1,375 @@
+//! AST-aware symbol reordering within a file or scope.
+
+use super::Language;
+use super::symbols::{SymbolDef, SymbolKind, extract_symbols, find_symbol, full_symbol_span};
+
+/// Strategy for reordering symbols.
+#[derive(Debug, Clone)]
+pub enum ReorderStrategy {
+    /// Sort symbols alphabetically by name.
+    Alphabetical,
+    /// Sort symbols in reverse alphabetical order.
+    Reverse,
+    /// Types (structs, enums, traits, interfaces) first, then functions.
+    KindFirst,
+    /// Explicit ordering: symbols appear in the given order.
+    Custom(Vec<String>),
+}
+
+/// Result of a reorder operation.
+#[derive(Debug)]
+pub struct ReorderResult {
+    /// The full file content after reordering.
+    pub content: String,
+    /// Number of symbols that changed position.
+    pub symbols_reordered: usize,
+}
+
+/// Reorder symbols within a file or a specific scope (module, impl block).
+///
+/// When `inside` is `Some`, only symbols inside that container are reordered;
+/// the container itself and everything outside it remain in place.
+pub fn reorder_symbols(
+    source: &str,
+    inside: Option<&str>,
+    strategy: &ReorderStrategy,
+    lang: Language,
+) -> anyhow::Result<ReorderResult> {
+    let all_symbols = extract_symbols(source, lang);
+    let lines: Vec<&str> = source.lines().collect();
+
+    let (scope_symbols, scope_start_0, scope_end_0) = if let Some(container) = inside {
+        let parent = find_symbol(&all_symbols, container)
+            .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", container))?;
+        // Find the opening brace line of the container
+        let open_line_0 = find_opening_line(&lines, parent.start_line.saturating_sub(1));
+        let close_line_0 = parent.end_line.min(lines.len()).saturating_sub(1);
+        (&parent.children, open_line_0 + 1, close_line_0)
+    } else {
+        (&all_symbols as &Vec<SymbolDef>, 0usize, lines.len())
+    };
+
+    if scope_symbols.is_empty() {
+        return Ok(ReorderResult {
+            content: source.to_string(),
+            symbols_reordered: 0,
+        });
+    }
+
+    // Build spans for each symbol, including attrs/docs
+    let mut spans: Vec<SymbolSpan> = scope_symbols
+        .iter()
+        .map(|sym| {
+            let (full_start, full_end) = full_symbol_span(source, sym, lang);
+            SymbolSpan {
+                name: sym.name.clone(),
+                kind: sym.kind,
+                start_0: full_start.saturating_sub(1),
+                end_0: full_end.min(lines.len()),
+            }
+        })
+        .collect();
+
+    // Sort according to strategy
+    let original_order: Vec<String> = spans.iter().map(|s| s.name.clone()).collect();
+    sort_spans(&mut spans, strategy)?;
+    let new_order: Vec<String> = spans.iter().map(|s| s.name.clone()).collect();
+
+    // Count how many changed position
+    let symbols_reordered = original_order
+        .iter()
+        .zip(new_order.iter())
+        .filter(|(a, b)| a != b)
+        .count();
+
+    if symbols_reordered == 0 {
+        return Ok(ReorderResult {
+            content: source.to_string(),
+            symbols_reordered: 0,
+        });
+    }
+
+    // Rebuild the scope section with symbols in the new order.
+    // Collect the text of each symbol in original order, keyed by name.
+    let mut sym_texts: Vec<(&str, String)> = Vec::new();
+    for span in &spans {
+        let text: String = lines[span.start_0..span.end_0].join("\n");
+        sym_texts.push((&span.name, text));
+    }
+
+    // Now rebuild: prefix (before scope) + reordered symbols + suffix (after scope)
+    let mut result = String::new();
+
+    // Lines before the scope
+    for line in &lines[..scope_start_0] {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Emit symbols in new order with blank line separators
+    for (i, (_name, text)) in sym_texts.iter().enumerate() {
+        if i > 0 {
+            result.push('\n');
+        }
+        result.push_str(text);
+        result.push('\n');
+    }
+
+    // Lines after the scope
+    for line in &lines[scope_end_0..] {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Preserve trailing newline behavior
+    if !source.ends_with('\n') && result.ends_with('\n') {
+        result.pop();
+    }
+
+    Ok(ReorderResult {
+        content: result,
+        symbols_reordered,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct SymbolSpan {
+    name: String,
+    kind: SymbolKind,
+    start_0: usize, // 0-based line index
+    end_0: usize,   // 0-based exclusive end
+}
+
+fn sort_spans(spans: &mut [SymbolSpan], strategy: &ReorderStrategy) -> anyhow::Result<()> {
+    match strategy {
+        ReorderStrategy::Alphabetical => {
+            spans.sort_by_key(|a| a.name.to_lowercase());
+        }
+        ReorderStrategy::Reverse => {
+            spans.sort_by_key(|b| std::cmp::Reverse(b.name.to_lowercase()));
+        }
+        ReorderStrategy::KindFirst => {
+            spans.sort_by(|a, b| {
+                let ka = kind_priority(a.kind);
+                let kb = kind_priority(b.kind);
+                ka.cmp(&kb)
+                    .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+            });
+        }
+        ReorderStrategy::Custom(order) => {
+            spans.sort_by(|a, b| {
+                let ia = order
+                    .iter()
+                    .position(|n| *n == a.name)
+                    .unwrap_or(usize::MAX);
+                let ib = order
+                    .iter()
+                    .position(|n| *n == b.name)
+                    .unwrap_or(usize::MAX);
+                ia.cmp(&ib)
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Priority for kind-first ordering: types before functions.
+fn kind_priority(kind: SymbolKind) -> u8 {
+    match kind {
+        SymbolKind::Struct => 0,
+        SymbolKind::Enum => 1,
+        SymbolKind::Trait | SymbolKind::Interface => 2,
+        SymbolKind::Type => 3,
+        SymbolKind::Const => 4,
+        SymbolKind::Class => 5,
+        SymbolKind::Impl => 6,
+        SymbolKind::Module => 7,
+        SymbolKind::Function => 8,
+        SymbolKind::Method => 9,
+    }
+}
+
+/// Find the line with the opening brace of a container (0-based index).
+fn find_opening_line(lines: &[&str], start_0: usize) -> usize {
+    for (i, line) in lines.iter().enumerate().skip(start_0) {
+        let trimmed = line.trim();
+        if trimmed.ends_with('{') || trimmed.ends_with(':') || trimmed.ends_with(":{") {
+            return i;
+        }
+    }
+    start_0
+}
+
+/// Parse a reorder strategy from a `serde_json::Value`.
+///
+/// - String `"alphabetical"`, `"reverse"`, `"kind-first"` -> named strategy
+/// - Array of strings -> `Custom` order
+pub fn parse_strategy(value: &serde_json::Value) -> anyhow::Result<ReorderStrategy> {
+    match value {
+        serde_json::Value::String(s) => match s.as_str() {
+            "alphabetical" => Ok(ReorderStrategy::Alphabetical),
+            "reverse" => Ok(ReorderStrategy::Reverse),
+            "kind-first" | "kind_first" => Ok(ReorderStrategy::KindFirst),
+            other => anyhow::bail!("unknown reorder strategy: '{other}'"),
+        },
+        serde_json::Value::Array(arr) => {
+            let names: Result<Vec<String>, _> = arr
+                .iter()
+                .map(|v| {
+                    v.as_str()
+                        .map(String::from)
+                        .ok_or_else(|| anyhow::anyhow!("custom order items must be strings"))
+                })
+                .collect();
+            Ok(ReorderStrategy::Custom(names?))
+        }
+        _ => anyhow::bail!("'order' must be a string or array of strings"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reorder_alphabetical() {
+        let source = "fn charlie() {}\n\nfn alpha() {}\n\nfn bravo() {}\n";
+        let result =
+            reorder_symbols(source, None, &ReorderStrategy::Alphabetical, Language::Rust).unwrap();
+        let alpha_pos = result.content.find("fn alpha").unwrap();
+        let bravo_pos = result.content.find("fn bravo").unwrap();
+        let charlie_pos = result.content.find("fn charlie").unwrap();
+        assert!(alpha_pos < bravo_pos);
+        assert!(bravo_pos < charlie_pos);
+        assert_eq!(result.symbols_reordered, 3);
+    }
+
+    #[test]
+    fn reorder_reverse() {
+        let source = "fn alpha() {}\n\nfn bravo() {}\n\nfn charlie() {}\n";
+        let result =
+            reorder_symbols(source, None, &ReorderStrategy::Reverse, Language::Rust).unwrap();
+        let alpha_pos = result.content.find("fn alpha").unwrap();
+        let bravo_pos = result.content.find("fn bravo").unwrap();
+        let charlie_pos = result.content.find("fn charlie").unwrap();
+        assert!(charlie_pos < bravo_pos);
+        assert!(bravo_pos < alpha_pos);
+    }
+
+    #[test]
+    fn reorder_kind_first() {
+        let source =
+            "fn do_stuff() {}\n\nstruct Config {\n    x: i32,\n}\n\nenum Mode {\n    A,\n}\n";
+        let result =
+            reorder_symbols(source, None, &ReorderStrategy::KindFirst, Language::Rust).unwrap();
+        let struct_pos = result.content.find("struct Config").unwrap();
+        let enum_pos = result.content.find("enum Mode").unwrap();
+        let fn_pos = result.content.find("fn do_stuff").unwrap();
+        assert!(struct_pos < enum_pos);
+        assert!(enum_pos < fn_pos);
+    }
+
+    #[test]
+    fn reorder_custom() {
+        let source = "fn charlie() {}\n\nfn alpha() {}\n\nfn bravo() {}\n";
+        let order = vec!["bravo".into(), "charlie".into(), "alpha".into()];
+        let result = reorder_symbols(
+            source,
+            None,
+            &ReorderStrategy::Custom(order),
+            Language::Rust,
+        )
+        .unwrap();
+        let alpha_pos = result.content.find("fn alpha").unwrap();
+        let bravo_pos = result.content.find("fn bravo").unwrap();
+        let charlie_pos = result.content.find("fn charlie").unwrap();
+        assert!(bravo_pos < charlie_pos);
+        assert!(charlie_pos < alpha_pos);
+    }
+
+    #[test]
+    fn reorder_inside_module() {
+        let source = "fn outside() {}\n\nmod tests {\n    fn zebra() {}\n    fn apple() {}\n}\n";
+        let result = reorder_symbols(
+            source,
+            Some("tests"),
+            &ReorderStrategy::Alphabetical,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.content.contains("fn outside()")); // unchanged
+        let apple_pos = result.content.find("fn apple").unwrap();
+        let zebra_pos = result.content.find("fn zebra").unwrap();
+        assert!(apple_pos < zebra_pos);
+    }
+
+    #[test]
+    fn reorder_no_op_when_already_sorted() {
+        let source = "fn alpha() {}\n\nfn bravo() {}\n\nfn charlie() {}\n";
+        let result =
+            reorder_symbols(source, None, &ReorderStrategy::Alphabetical, Language::Rust).unwrap();
+        assert_eq!(result.symbols_reordered, 0);
+        assert_eq!(result.content, source);
+    }
+
+    #[test]
+    fn reorder_preserves_attributes() {
+        let source = "#[test]\nfn zebra() {}\n\n/// Doc for alpha.\n#[cfg(test)]\nfn alpha() {}\n";
+        let result =
+            reorder_symbols(source, None, &ReorderStrategy::Alphabetical, Language::Rust).unwrap();
+        // alpha (with its doc + cfg) should come first
+        let alpha_pos = result.content.find("fn alpha").unwrap();
+        let zebra_pos = result.content.find("fn zebra").unwrap();
+        assert!(alpha_pos < zebra_pos);
+        // attributes should still be present
+        assert!(result.content.contains("/// Doc for alpha."));
+        assert!(result.content.contains("#[cfg(test)]"));
+        assert!(result.content.contains("#[test]"));
+    }
+
+    #[test]
+    fn reorder_symbol_not_found_inside() {
+        let source = "fn foo() {}\n";
+        let result = reorder_symbols(
+            source,
+            Some("nonexistent"),
+            &ReorderStrategy::Alphabetical,
+            Language::Rust,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_strategy_string() {
+        let v = serde_json::json!("alphabetical");
+        assert!(matches!(
+            parse_strategy(&v).unwrap(),
+            ReorderStrategy::Alphabetical
+        ));
+        let v = serde_json::json!("reverse");
+        assert!(matches!(
+            parse_strategy(&v).unwrap(),
+            ReorderStrategy::Reverse
+        ));
+        let v = serde_json::json!("kind-first");
+        assert!(matches!(
+            parse_strategy(&v).unwrap(),
+            ReorderStrategy::KindFirst
+        ));
+    }
+
+    #[test]
+    fn parse_strategy_array() {
+        let v = serde_json::json!(["b", "a", "c"]);
+        let strategy = parse_strategy(&v).unwrap();
+        assert!(
+            matches!(strategy, ReorderStrategy::Custom(ref names) if names == &["b", "a", "c"])
+        );
+    }
+
+    #[test]
+    fn parse_strategy_invalid() {
+        let v = serde_json::json!(42);
+        assert!(parse_strategy(&v).is_err());
+    }
+}

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -1,0 +1,279 @@
+//! AST-aware file splitting: distribute symbols across multiple target files.
+
+use super::Language;
+use super::symbols::{extract_symbol_text, extract_symbols, full_symbol_span};
+
+/// Target specification for a split operation.
+#[derive(Debug)]
+pub struct SplitTarget {
+    pub path: String,
+    pub symbols: Vec<String>,
+    pub prepend: Option<String>,
+}
+
+/// Result of a split operation.
+#[derive(Debug)]
+pub struct SplitResult {
+    /// The source file content after splitting.
+    pub source_content: String,
+    /// Target file contents: (path, content) pairs.
+    pub targets: Vec<(String, String)>,
+    /// Total number of symbols distributed to targets.
+    pub symbols_distributed: usize,
+}
+
+/// Split a file by distributing symbols across multiple target files.
+///
+/// When `require_exhaustive` is true, every top-level symbol must be accounted
+/// for in either `targets` or `keep_in_source`.
+pub fn split_file(
+    source: &str,
+    targets: &[SplitTarget],
+    keep_in_source: &[String],
+    source_suffix: Option<&str>,
+    source_prefix: Option<&str>,
+    require_exhaustive: bool,
+    lang: Language,
+) -> anyhow::Result<SplitResult> {
+    let all_symbols = extract_symbols(source, lang);
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Build a map of symbol name -> target index
+    let mut sym_to_target: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::new();
+    for (idx, target) in targets.iter().enumerate() {
+        for name in &target.symbols {
+            sym_to_target.insert(name.as_str(), idx);
+        }
+    }
+
+    // Validate exhaustiveness
+    if require_exhaustive {
+        let mut unaccounted: Vec<&str> = Vec::new();
+        for sym in &all_symbols {
+            if !sym_to_target.contains_key(sym.name.as_str())
+                && !keep_in_source.iter().any(|k| k == &sym.name)
+            {
+                unaccounted.push(&sym.name);
+            }
+        }
+        if !unaccounted.is_empty() {
+            anyhow::bail!(
+                "unaccounted symbols (use keep_in_source or add to a target): {}",
+                unaccounted.join(", ")
+            );
+        }
+    }
+
+    // Collect spans for symbols being distributed
+    let mut spans_to_remove: Vec<(usize, usize)> = Vec::new(); // (start_0, end_0)
+    let mut target_contents: Vec<String> = vec![String::new(); targets.len()];
+
+    // Build target contents
+    for sym in &all_symbols {
+        if let Some(&target_idx) = sym_to_target.get(sym.name.as_str()) {
+            let text = extract_symbol_text(source, sym, lang);
+            if !target_contents[target_idx].is_empty() {
+                target_contents[target_idx].push('\n');
+            }
+            target_contents[target_idx].push_str(text.trim_end_matches('\n'));
+            target_contents[target_idx].push('\n');
+
+            let (full_start, full_end) = full_symbol_span(source, sym, lang);
+            spans_to_remove.push((full_start.saturating_sub(1), full_end.min(lines.len())));
+        }
+    }
+
+    let symbols_distributed = spans_to_remove.len();
+
+    // Remove distributed symbols from source (in reverse order)
+    let mut src_lines: Vec<String> = lines.iter().map(|l| l.to_string()).collect();
+    spans_to_remove.sort_by_key(|b| std::cmp::Reverse(b.0));
+    for (start_0, end_0) in &spans_to_remove {
+        let mut remove_end = *end_0;
+        if remove_end < src_lines.len() && src_lines[remove_end].trim().is_empty() {
+            remove_end += 1;
+        }
+        src_lines.drain(*start_0..remove_end.min(src_lines.len()));
+    }
+
+    // Apply source_prefix and source_suffix
+    if let Some(prefix) = source_prefix {
+        let prefix_lines: Vec<String> = prefix.lines().map(String::from).collect();
+        for (i, line) in prefix_lines.iter().enumerate() {
+            src_lines.insert(i, line.clone());
+        }
+    }
+    if let Some(suffix) = source_suffix {
+        if !src_lines.is_empty() && !src_lines.last().unwrap().trim().is_empty() {
+            src_lines.push(String::new());
+        }
+        for line in suffix.lines() {
+            src_lines.push(line.to_string());
+        }
+    }
+
+    let mut source_content = src_lines.join("\n");
+    if source.ends_with('\n') && !source_content.ends_with('\n') {
+        source_content.push('\n');
+    }
+
+    // Build final target contents with prepend
+    let result_targets: Vec<(String, String)> = targets
+        .iter()
+        .zip(target_contents.iter())
+        .map(|(spec, content)| {
+            let mut final_content = String::new();
+            if let Some(pre) = &spec.prepend {
+                final_content.push_str(pre);
+                if !pre.ends_with('\n') {
+                    final_content.push('\n');
+                }
+                final_content.push('\n');
+            }
+            final_content.push_str(content);
+            if !final_content.ends_with('\n') {
+                final_content.push('\n');
+            }
+            (spec.path.clone(), final_content)
+        })
+        .collect();
+
+    Ok(SplitResult {
+        source_content,
+        targets: result_targets,
+        symbols_distributed,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_basic() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n\nfn gamma() {}\n";
+        let targets = vec![
+            SplitTarget {
+                path: "a.rs".into(),
+                symbols: vec!["alpha".into()],
+                prepend: None,
+            },
+            SplitTarget {
+                path: "b.rs".into(),
+                symbols: vec!["beta".into()],
+                prepend: None,
+            },
+        ];
+        let result = split_file(
+            source,
+            &targets,
+            &["gamma".into()],
+            None,
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.source_content.contains("fn gamma"));
+        assert!(!result.source_content.contains("fn alpha"));
+        assert!(!result.source_content.contains("fn beta"));
+        assert_eq!(result.targets.len(), 2);
+        assert!(result.targets[0].1.contains("fn alpha"));
+        assert!(result.targets[1].1.contains("fn beta"));
+        assert_eq!(result.symbols_distributed, 2);
+    }
+
+    #[test]
+    fn split_exhaustive_check_fails() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let result = split_file(source, &targets, &[], None, None, true, Language::Rust);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("beta"));
+    }
+
+    #[test]
+    fn split_non_exhaustive_ok() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let result = split_file(source, &targets, &[], None, None, false, Language::Rust);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn split_with_prepend_and_suffix() {
+        let source = "fn alpha() {}\n\nfn beta() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: Some("use super::*;".into()),
+        }];
+        let result = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            Some("mod a;"),
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.targets[0].1.contains("use super::*;"));
+        assert!(result.targets[0].1.contains("fn alpha"));
+        assert!(result.source_content.contains("mod a;"));
+    }
+
+    #[test]
+    fn split_keep_in_source() {
+        let source = "struct Config {\n    x: i32,\n}\n\nfn helper() {}\n\nfn process() {}\n";
+        let targets = vec![SplitTarget {
+            path: "helpers.rs".into(),
+            symbols: vec!["helper".into()],
+            prepend: None,
+        }];
+        let result = split_file(
+            source,
+            &targets,
+            &["Config".into(), "process".into()],
+            None,
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.source_content.contains("struct Config"));
+        assert!(result.source_content.contains("fn process"));
+        assert!(!result.source_content.contains("fn helper"));
+    }
+
+    #[test]
+    fn split_preserves_attributes() {
+        let source = "/// Alpha doc.\n#[test]\nfn alpha() {}\n\nfn beta() {}\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let result = split_file(
+            source,
+            &targets,
+            &["beta".into()],
+            None,
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        assert!(result.targets[0].1.contains("/// Alpha doc."));
+        assert!(result.targets[0].1.contains("#[test]"));
+    }
+}

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -628,6 +628,110 @@ fn extract_generic(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolK
     None
 }
 
+/// Compute the full source range of a symbol including preceding attributes
+/// and doc comments that are conventionally part of the symbol definition.
+///
+/// Returns `(full_start_line, end_line)` where both are 1-based and
+/// `full_start_line` may be earlier than `sym.start_line`.
+///
+/// Language-aware: handles `#[...]` for Rust, `@decorator` for Python/TS/Java,
+/// `///` and `//!` doc comments for Rust, `/** ... */` JSDoc for JS/TS/Java,
+/// and `//` doc comments preceding Go functions.
+pub fn full_symbol_span(source: &str, sym: &SymbolDef, lang: Language) -> (usize, usize) {
+    let lines: Vec<&str> = source.lines().collect();
+    let sym_start_0 = sym.start_line.saturating_sub(1); // convert to 0-based
+    if sym_start_0 == 0 {
+        return (sym.start_line, sym.end_line);
+    }
+
+    let mut first_line_0 = sym_start_0;
+
+    // Walk backwards from the line before the symbol
+    let mut i = sym_start_0;
+    while i > 0 {
+        i -= 1;
+        let trimmed = lines[i].trim();
+
+        if trimmed.is_empty() {
+            // Empty line: include only if the line above is also an attribute/doc
+            // (i.e., don't include leading blank lines that aren't between attrs)
+            if i > 0 && is_annotation_line(lines[i - 1].trim(), lang) {
+                first_line_0 = i;
+                continue;
+            }
+            break;
+        }
+
+        if is_annotation_line(trimmed, lang) {
+            first_line_0 = i;
+        } else {
+            break;
+        }
+    }
+
+    (first_line_0 + 1, sym.end_line) // back to 1-based
+}
+
+/// Check if a line is an annotation/attribute/decorator/doc-comment for a symbol.
+fn is_annotation_line(trimmed: &str, lang: Language) -> bool {
+    match lang {
+        Language::Rust => {
+            trimmed.starts_with("#[")
+                || trimmed.starts_with("///")
+                || trimmed.starts_with("//!")
+                || trimmed.starts_with("/**")
+                || trimmed.starts_with("* ")
+                || trimmed == "*/"
+                || trimmed == "*"
+        }
+        Language::Python => trimmed.starts_with('@'),
+        Language::TypeScript | Language::JavaScript => {
+            trimmed.starts_with('@')
+                || trimmed.starts_with("/**")
+                || trimmed.starts_with("* ")
+                || trimmed == "*/"
+                || trimmed == "*"
+        }
+        Language::Java | Language::Kotlin => {
+            trimmed.starts_with('@')
+                || trimmed.starts_with("/**")
+                || trimmed.starts_with("* ")
+                || trimmed == "*/"
+                || trimmed == "*"
+        }
+        Language::Go => {
+            // Go doc comments are // lines immediately preceding a declaration
+            trimmed.starts_with("//")
+        }
+        _ => false,
+    }
+}
+
+/// Extract the text of a symbol from source, using the full span (including
+/// attributes and doc comments).
+pub fn extract_symbol_text<'a>(source: &'a str, sym: &SymbolDef, lang: Language) -> &'a str {
+    let (full_start, full_end) = full_symbol_span(source, sym, lang);
+    let lines: Vec<&str> = source.lines().collect();
+    let start_0 = full_start.saturating_sub(1);
+    let end_0 = full_end.min(lines.len());
+
+    // Find byte offsets
+    let mut byte_start = 0;
+    for line in &lines[..start_0] {
+        byte_start += line.len() + 1; // +1 for '\n'
+    }
+
+    let mut byte_end = byte_start;
+    for line in &lines[start_0..end_0] {
+        byte_end += line.len() + 1;
+    }
+
+    // Don't go past source length
+    byte_end = byte_end.min(source.len());
+
+    &source[byte_start..byte_end]
+}
+
 /// Parse a comma-separated kind filter string into a list of `SymbolKind`s.
 pub fn parse_kind_filter(kind_arg: &Option<String>) -> Vec<SymbolKind> {
     match kind_arg {
@@ -1002,5 +1106,84 @@ struct Point {
         assert!(out.contains("pub(crate) fn old(x: u32, y: &str) -> String"));
         assert!(out.contains("fn other"));
         assert!(!out.contains("fn old(a: i32)"));
+    }
+
+    // ── full_symbol_span tests ────────────────────────────────────
+
+    #[test]
+    fn full_span_no_attributes() {
+        let source = "fn foo() {\n    42\n}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let sym = &symbols[0];
+        let (start, end) = full_symbol_span(source, sym, Language::Rust);
+        assert_eq!(start, sym.start_line);
+        assert_eq!(end, sym.end_line);
+    }
+
+    #[test]
+    fn full_span_single_attribute() {
+        let source = "#[test]\nfn foo() {\n    42\n}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let sym = &symbols[0];
+        assert_eq!(sym.start_line, 2); // tree-sitter sees fn on line 2
+        let (start, end) = full_symbol_span(source, sym, Language::Rust);
+        assert_eq!(start, 1); // includes #[test]
+        assert_eq!(end, sym.end_line);
+    }
+
+    #[test]
+    fn full_span_stacked_attributes() {
+        let source = "#[test]\n#[cfg(unix)]\nfn foo() {}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let sym = &symbols[0];
+        let (start, _) = full_symbol_span(source, sym, Language::Rust);
+        assert_eq!(start, 1); // includes both attributes
+    }
+
+    #[test]
+    fn full_span_doc_comment() {
+        let source = "/// This is a doc comment.\n/// Second line.\nfn foo() {}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let sym = &symbols[0];
+        let (start, _) = full_symbol_span(source, sym, Language::Rust);
+        assert_eq!(start, 1);
+    }
+
+    #[test]
+    fn full_span_mixed_attrs_and_docs() {
+        let source = "/// A doc comment.\n#[test]\n#[cfg(unix)]\nfn foo() {}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let sym = &symbols[0];
+        let (start, _) = full_symbol_span(source, sym, Language::Rust);
+        assert_eq!(start, 1);
+    }
+
+    #[test]
+    fn full_span_python_decorator() {
+        let source = "@staticmethod\ndef foo():\n    pass\n";
+        let symbols = extract_symbols(source, Language::Python);
+        let sym = &symbols[0];
+        let (start, _) = full_symbol_span(source, sym, Language::Python);
+        assert_eq!(start, 1);
+    }
+
+    #[test]
+    fn full_span_stops_at_unrelated_code() {
+        let source = "fn bar() {}\n\n#[test]\nfn foo() {}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let foo = symbols.iter().find(|s| s.name == "foo").unwrap();
+        let (start, _) = full_symbol_span(source, foo, Language::Rust);
+        assert_eq!(start, 3); // #[test] on line 3, not line 1
+    }
+
+    #[test]
+    fn extract_symbol_text_basic() {
+        let source = "#[test]\nfn foo() {\n    42\n}\n\nfn bar() {}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let foo = symbols.iter().find(|s| s.name == "foo").unwrap();
+        let text = extract_symbol_text(source, foo, Language::Rust);
+        assert!(text.contains("#[test]"));
+        assert!(text.contains("fn foo()"));
+        assert!(!text.contains("fn bar"));
     }
 }

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -416,6 +416,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             format: None,
             validate: None,
             verify: None,
+            for_each: None,
         };
         serde_json::to_string(&plan)?
     };

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -40,8 +40,14 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         (content, Some(p.to_string()))
     };
 
-    let plan = crate::plan::parse_plan_auto(&input, path.as_deref(), args.format.as_deref())?;
+    let mut plan = crate::plan::parse_plan_auto(&input, path.as_deref(), args.format.as_deref())?;
     let cwd = global.resolve_cwd()?;
+
+    // Expand for_each before summarizing so the explain output shows all
+    // expanded operations (not the template).
+    if plan.for_each.is_some() {
+        crate::plan::expand_for_each(&mut plan, &cwd)?;
+    }
     let config_strict = crate::config::find_and_load(&cwd)
         .map(|(config, _)| config.tx.strict)
         .unwrap_or(None);
@@ -402,6 +408,60 @@ fn describe_operation(op: &Operation) -> String {
             };
             format!("AST imports ({action}) in {path}")
         }
+        #[cfg(feature = "ast")]
+        Operation::AstReorder {
+            path,
+            inside,
+            order,
+            ..
+        } => {
+            let scope = inside.as_deref().unwrap_or("top-level");
+            let strategy = match order {
+                serde_json::Value::String(s) => s.clone(),
+                serde_json::Value::Array(arr) => format!("custom ({})", arr.len()),
+                _ => "unknown".to_string(),
+            };
+            format!("AST reorder {scope} symbols by {strategy} in {path}")
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstGroup {
+            path,
+            module,
+            symbols,
+            ..
+        } => {
+            format!(
+                "AST group {} symbol(s) into mod {module} in {path}",
+                symbols.len()
+            )
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstMove {
+            path,
+            target,
+            symbols,
+            ..
+        } => {
+            format!(
+                "AST move {} symbol(s) from {path} to {target}",
+                symbols.len()
+            )
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstExtractToFile {
+            source,
+            symbol,
+            target,
+            ..
+        } => {
+            format!("AST extract \"{symbol}\" from {source} to {target}")
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstSplit {
+            source, targets, ..
+        } => {
+            format!("AST split {source} into {} target file(s)", targets.len())
+        }
     }
 }
 
@@ -549,6 +609,7 @@ mod tests {
             format: None,
             validate: None,
             verify: None,
+            for_each: None,
         };
         // Just ensure it doesn't panic.
         print_human_summary(&plan, true);
@@ -574,6 +635,7 @@ mod tests {
                 timeout: None,
             }]),
             verify: None,
+            for_each: None,
         };
         let json = build_json_summary(&plan, false);
         assert_eq!(json["operation_count"], 1);

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -705,6 +705,101 @@ pub(super) fn handle_ast_imports(
     svc.run_one_op(op, None)
 }
 
+pub(super) fn handle_ast_reorder(
+    svc: &PatchloomService,
+    p: AstReorderParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    let op = crate::plan::Operation::AstReorder {
+        path: p.path,
+        inside: p.inside,
+        order: p.order,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
+pub(super) fn handle_ast_group(
+    svc: &PatchloomService,
+    p: AstGroupParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    let op = crate::plan::Operation::AstGroup {
+        path: p.path,
+        module: p.module,
+        symbols: p.symbols,
+        preamble: p.preamble,
+        position: p.position,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
+pub(super) fn handle_ast_move(
+    svc: &PatchloomService,
+    p: AstMoveParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    svc.check_path(&p.target)?;
+    let op = crate::plan::Operation::AstMove {
+        path: p.path,
+        target: p.target,
+        symbols: p.symbols,
+        position: p.position,
+        target_prepend: p.target_prepend,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
+pub(super) fn handle_ast_extract_to_file(
+    svc: &PatchloomService,
+    p: AstExtractToFileParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.source)?;
+    svc.check_path(&p.target)?;
+    let op = crate::plan::Operation::AstExtractToFile {
+        source: p.source,
+        symbol: p.symbol,
+        target: p.target,
+        replacement: p.replacement,
+        unwrap: p.unwrap,
+        prepend: p.prepend,
+        force: p.force,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
+pub(super) fn handle_ast_split(
+    svc: &PatchloomService,
+    p: AstSplitParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.source)?;
+    for t in &p.targets {
+        svc.check_path(&t.path)?;
+    }
+    let targets: Vec<crate::plan::SplitTargetSpec> = p
+        .targets
+        .into_iter()
+        .map(|t| crate::plan::SplitTargetSpec {
+            path: t.path,
+            symbols: t.symbols,
+            prepend: t.prepend,
+        })
+        .collect();
+    let op = crate::plan::Operation::AstSplit {
+        source: p.source,
+        targets,
+        keep_in_source: p.keep_in_source,
+        source_suffix: p.source_suffix,
+        source_prefix: p.source_prefix,
+        require_exhaustive: p.require_exhaustive,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -531,6 +531,13 @@ impl PatchloomService {
                 ));
             };
 
+            // Expand for_each (glob-driven batch) before path validation.
+            if plan.for_each.is_some() {
+                crate::plan::expand_for_each(&mut plan, svc.cwd()).map_err(|e| {
+                    McpError::invalid_params(format!("for_each expansion failed: {e}"), None)
+                })?;
+            }
+
             // Validate every path declared by operations against the PathGuard
             // (including special handling for paths embedded in PatchApply diffs).
             for op in &plan.operations {
@@ -748,6 +755,66 @@ impl PatchloomService {
         Parameters(p): Parameters<AstImportsParams>,
     ) -> Result<CallToolResult, McpError> {
         self.blocking(move |svc| ast_tools::handle_ast_imports(svc, p))
+            .await
+    }
+
+    #[cfg(feature = "ast")]
+    #[tool(
+        description = "Reorder symbols within a file or scope by name, kind, or custom order. Example: {\"path\": \"src/lib.rs\", \"order\": \"alphabetical\"} or {\"path\": \"src/lib.rs\", \"order\": [\"Struct\", \"impl Struct\", \"helper\"], \"inside\": \"mod tests\"}"
+    )]
+    async fn ast_reorder(
+        &self,
+        Parameters(p): Parameters<AstReorderParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_reorder(svc, p))
+            .await
+    }
+
+    #[cfg(feature = "ast")]
+    #[tool(
+        description = "Group symbols into a named module within a file. Creates the module if it doesn't exist, or appends to it. Example: {\"path\": \"src/tests.rs\", \"module\": \"line_endings\", \"symbols\": [\"test_crlf\", \"test_lf\"], \"preamble\": \"use super::*;\"}"
+    )]
+    async fn ast_group(
+        &self,
+        Parameters(p): Parameters<AstGroupParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_group(svc, p))
+            .await
+    }
+
+    #[cfg(feature = "ast")]
+    #[tool(
+        description = "Move symbols between files. Removes from source, inserts into target (creating it if needed). Example: {\"path\": \"src/big.rs\", \"target\": \"src/helpers.rs\", \"symbols\": [\"helper_fn\"], \"target_prepend\": \"use super::*;\"}"
+    )]
+    async fn ast_move(
+        &self,
+        Parameters(p): Parameters<AstMoveParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_move(svc, p))
+            .await
+    }
+
+    #[cfg(feature = "ast")]
+    #[tool(
+        description = "Extract a symbol (module, function, struct) to a separate file. For modules with unwrap=true, content is un-indented. Example: {\"source\": \"src/lib.rs\", \"symbol\": \"tests\", \"target\": \"src/lib_tests.rs\", \"replacement\": \"mod tests;\", \"prepend\": \"use super::*;\"}"
+    )]
+    async fn ast_extract_to_file(
+        &self,
+        Parameters(p): Parameters<AstExtractToFileParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_extract_to_file(svc, p))
+            .await
+    }
+
+    #[cfg(feature = "ast")]
+    #[tool(
+        description = "Split a file into multiple target files by distributing symbols. Atomic: all targets succeed or all roll back. Example: {\"source\": \"src/big.rs\", \"targets\": [{\"path\": \"src/types.rs\", \"symbols\": [\"Config\", \"Mode\"], \"prepend\": \"use super::*;\"}], \"keep_in_source\": [\"main\"], \"source_suffix\": \"mod types;\"}"
+    )]
+    async fn ast_split(
+        &self,
+        Parameters(p): Parameters<AstSplitParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_split(svc, p))
             .await
     }
 

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -327,6 +327,7 @@ fn make_plan_strict(operations: Vec<Operation>, strict: Option<bool>) -> Plan {
         format: None,
         validate: None,
         verify: None,
+        for_each: None,
     }
 }
 

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -499,6 +499,129 @@ pub(crate) struct AstImportsParams {
     pub lang: Option<String>,
 }
 
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct AstReorderParams {
+    /// File to reorder symbols in.
+    pub path: String,
+    /// Scope to reorder within (module/impl). Default: top-level.
+    #[serde(default)]
+    pub inside: Option<String>,
+    /// Ordering: "alphabetical", "reverse", "kind-first", or array of names.
+    pub order: serde_json::Value,
+    /// Language hint.
+    pub lang: Option<String>,
+}
+
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct AstGroupParams {
+    /// File to modify.
+    pub path: String,
+    /// Module name to create or append to.
+    pub module: String,
+    /// Symbols to move into the module.
+    pub symbols: Vec<String>,
+    /// Code to insert at the top of the module (e.g., `use super::*;`).
+    #[serde(default)]
+    pub preamble: Option<String>,
+    /// Where to place new module: "first-symbol" (default), "end", or "after:<symbol>".
+    #[serde(default)]
+    pub position: Option<String>,
+    /// Language hint.
+    pub lang: Option<String>,
+}
+
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct AstMoveParams {
+    /// Source file.
+    pub path: String,
+    /// Target file.
+    pub target: String,
+    /// Symbols to move.
+    pub symbols: Vec<String>,
+    /// Position in target: "end" (default), "start", "after:<symbol>", "before:<symbol>".
+    #[serde(default)]
+    pub position: Option<String>,
+    /// Content to prepend to target file if creating it.
+    #[serde(default)]
+    pub target_prepend: Option<String>,
+    /// Language hint.
+    pub lang: Option<String>,
+}
+
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct AstExtractToFileParams {
+    /// Source file containing the symbol.
+    pub source: String,
+    /// Name of the symbol to extract.
+    pub symbol: String,
+    /// Destination file path.
+    pub target: String,
+    /// Text to leave in place of the extracted block.
+    #[serde(default)]
+    pub replacement: Option<String>,
+    /// If true (default), remove wrapper and un-indent for modules.
+    #[serde(default)]
+    pub unwrap: Option<bool>,
+    /// Content to prepend to the target file.
+    #[serde(default)]
+    pub prepend: Option<String>,
+    /// Overwrite target if it exists.
+    #[serde(default)]
+    pub force: bool,
+    /// Language hint.
+    pub lang: Option<String>,
+}
+
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[non_exhaustive]
+pub(crate) struct AstSplitParams {
+    /// The file to split.
+    pub source: String,
+    /// Target file specs.
+    pub targets: Vec<AstSplitTargetParam>,
+    /// Symbols to keep in the source file.
+    #[serde(default)]
+    pub keep_in_source: Vec<String>,
+    /// Text to append to source after split (e.g., `mod` declarations).
+    #[serde(default)]
+    pub source_suffix: Option<String>,
+    /// Text to prepend to source after split.
+    #[serde(default)]
+    pub source_prefix: Option<String>,
+    /// Error if any symbol is unaccounted for (default: true).
+    #[serde(default)]
+    pub require_exhaustive: Option<bool>,
+    /// Language hint.
+    pub lang: Option<String>,
+}
+
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct AstSplitTargetParam {
+    /// Target file path.
+    pub path: String,
+    /// Symbols to move into this file.
+    pub symbols: Vec<String>,
+    /// Content to prepend to this target file.
+    #[serde(default)]
+    pub prepend: Option<String>,
+}
+
 /// No-parameter wrapper for tools that need no input (e.g., git_status).
 /// Required because rmcp 1.8+ validates that `inputSchema` has a root
 /// `type: "object"` field, which `serde_json::Value` does not provide.

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -107,8 +107,16 @@ mod basic {
         assert!(names.contains(&"ast_insert"), "missing ast_insert tool");
         assert!(names.contains(&"ast_wrap"), "missing ast_wrap tool");
         assert!(names.contains(&"ast_imports"), "missing ast_imports tool");
+        assert!(names.contains(&"ast_reorder"), "missing ast_reorder tool");
+        assert!(names.contains(&"ast_group"), "missing ast_group tool");
+        assert!(names.contains(&"ast_move"), "missing ast_move tool");
+        assert!(
+            names.contains(&"ast_extract_to_file"),
+            "missing ast_extract_to_file tool"
+        );
+        assert!(names.contains(&"ast_split"), "missing ast_split tool");
         // 32 base tools + 14 AST tools = 46
-        assert_eq!(names.len(), 46, "expected 46 tools, got {}", names.len());
+        assert_eq!(names.len(), 51, "expected 51 tools, got {}", names.len());
         client.cancel().await.unwrap();
     }
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -244,8 +244,22 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     };
 
-    // 3. Validate plan and resolve working directory.
+    // 2b. Expand for_each (glob-driven batch) before validation.
     let base_cwd = global.resolve_cwd()?;
+    let mut plan = plan;
+    if plan.for_each.is_some()
+        && let Err(e) = crate::plan::expand_for_each(&mut plan, &base_cwd)
+    {
+        let msg = e.to_string();
+        if structured {
+            emit_error_json("parse_error", &msg, None, compact);
+        } else {
+            eprintln!("tx: {msg}");
+        }
+        return Ok(exit::PARSE_ERROR);
+    }
+
+    // 3. Validate plan and resolve working directory.
     let (cwd, strict, _resolved_global) =
         match crate::tx::validate_and_prepare_plan(&plan, &base_cwd, args.no_strict) {
             Ok(v) => v,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -41,6 +41,24 @@ pub struct Plan {
     /// Pre/post-operation symbol verification checks.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verify: Option<Vec<VerifyCheck>>,
+    /// Glob-driven batch: expand operations once per matching file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub for_each: Option<ForEach>,
+}
+
+/// Glob-driven batch expansion: apply the same set of operations to every
+/// file matching a glob pattern, with template variable substitution.
+#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+pub struct ForEach {
+    /// Glob pattern to expand (e.g. `src/**/*.rs`).
+    pub glob: String,
+    /// Glob patterns to exclude from the matched set.
+    #[serde(default)]
+    pub exclude: Vec<String>,
+    /// Optional filter expression (e.g. `has_symbol(tests)`).
+    #[serde(default)]
+    pub filter: Option<String>,
 }
 
 /// A single verification check parsed from `--verify` or plan `verify` field.
@@ -387,6 +405,112 @@ pub enum Operation {
         #[serde(default)]
         lang: Option<String>,
     },
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.reorder", alias = "ast_reorder")]
+    AstReorder {
+        path: String,
+        /// Scope to reorder within (module/impl). Default: top-level.
+        #[serde(default)]
+        inside: Option<String>,
+        /// Ordering: "alphabetical", "reverse", "kind-first", or array of names.
+        order: serde_json::Value,
+        #[serde(default)]
+        lang: Option<String>,
+    },
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.group", alias = "ast_group")]
+    AstGroup {
+        path: String,
+        /// Module name to create or append to.
+        module: String,
+        /// Symbols to move into the module.
+        symbols: Vec<String>,
+        /// Code to insert at the top of the module (e.g., `use super::*;`).
+        #[serde(default)]
+        preamble: Option<String>,
+        /// Where to place new module: "first-symbol" (default), "end", or "after:<symbol>".
+        #[serde(default)]
+        position: Option<String>,
+        #[serde(default)]
+        lang: Option<String>,
+    },
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.move", alias = "ast_move")]
+    AstMove {
+        /// Source file.
+        path: String,
+        /// Target file.
+        target: String,
+        /// Symbols to move.
+        symbols: Vec<String>,
+        /// Position in target: "end" (default), "start", "after:<symbol>", "before:<symbol>".
+        #[serde(default)]
+        position: Option<String>,
+        /// Content to prepend to target file if it's being created.
+        #[serde(default)]
+        target_prepend: Option<String>,
+        #[serde(default)]
+        lang: Option<String>,
+    },
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.extract_to_file", alias = "ast_extract_to_file")]
+    AstExtractToFile {
+        /// Source file containing the symbol.
+        source: String,
+        /// Name of the symbol to extract.
+        symbol: String,
+        /// Destination file path.
+        target: String,
+        /// Text to leave in place of the extracted block.
+        #[serde(default)]
+        replacement: Option<String>,
+        /// If true (default for modules), remove the wrapper and un-indent.
+        #[serde(default)]
+        unwrap: Option<bool>,
+        /// Content to prepend to the target file.
+        #[serde(default)]
+        prepend: Option<String>,
+        /// Overwrite target if it exists.
+        #[serde(default)]
+        force: bool,
+        #[serde(default)]
+        lang: Option<String>,
+    },
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.split", alias = "ast_split")]
+    AstSplit {
+        /// The file to split.
+        source: String,
+        /// Target file specs.
+        targets: Vec<SplitTargetSpec>,
+        /// Symbols to keep in the source file.
+        #[serde(default)]
+        keep_in_source: Vec<String>,
+        /// Text to append to source after split (e.g., `mod` declarations).
+        #[serde(default)]
+        source_suffix: Option<String>,
+        /// Text to prepend to source after split.
+        #[serde(default)]
+        source_prefix: Option<String>,
+        /// Error if any symbol is unaccounted for (default: true).
+        #[serde(default)]
+        require_exhaustive: Option<bool>,
+        #[serde(default)]
+        lang: Option<String>,
+    },
+}
+
+/// Target file specification for `ast.split`.
+#[cfg(feature = "ast")]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, schemars::JsonSchema)]
+pub struct SplitTargetSpec {
+    /// Target file path.
+    pub path: String,
+    /// Symbols to move into this file.
+    pub symbols: Vec<String>,
+    /// Content to prepend to this target file.
+    #[serde(default)]
+    pub prepend: Option<String>,
 }
 
 impl Operation {
@@ -429,6 +553,16 @@ impl Operation {
             Operation::AstWrap { .. } => "ast.wrap",
             #[cfg(feature = "ast")]
             Operation::AstImports { .. } => "ast.imports",
+            #[cfg(feature = "ast")]
+            Operation::AstReorder { .. } => "ast.reorder",
+            #[cfg(feature = "ast")]
+            Operation::AstGroup { .. } => "ast.group",
+            #[cfg(feature = "ast")]
+            Operation::AstMove { .. } => "ast.move",
+            #[cfg(feature = "ast")]
+            Operation::AstExtractToFile { .. } => "ast.extract_to_file",
+            #[cfg(feature = "ast")]
+            Operation::AstSplit { .. } => "ast.split",
         }
     }
 
@@ -464,6 +598,11 @@ impl Operation {
                         | Operation::AstInsert { .. }
                         | Operation::AstWrap { .. }
                         | Operation::AstImports { .. }
+                        | Operation::AstReorder { .. }
+                        | Operation::AstGroup { .. }
+                        | Operation::AstMove { .. }
+                        | Operation::AstExtractToFile { .. }
+                        | Operation::AstSplit { .. }
                 )
             }
             #[cfg(not(feature = "ast"))]
@@ -640,8 +779,26 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<&str> {
         | Operation::AstReplace { path, .. }
         | Operation::AstInsert { path, .. }
         | Operation::AstWrap { path, .. }
-        | Operation::AstImports { path, .. } => {
+        | Operation::AstImports { path, .. }
+        | Operation::AstReorder { path, .. }
+        | Operation::AstGroup { path, .. } => {
             vec![path.as_str()]
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstMove { path, target, .. } => vec![path.as_str(), target.as_str()],
+        #[cfg(feature = "ast")]
+        Operation::AstExtractToFile { source, target, .. } => {
+            vec![source.as_str(), target.as_str()]
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstSplit {
+            source, targets, ..
+        } => {
+            let mut p = vec![source.as_str()];
+            for t in targets {
+                p.push(t.path.as_str());
+            }
+            p
         }
     }
 }
@@ -694,6 +851,122 @@ pub fn parse_plan_auto(
         Some("toml") => parse_plan_toml(input),
         _ => parse_plan(input),
     }
+}
+
+// ---------------------------------------------------------------------------
+// for_each expansion
+// ---------------------------------------------------------------------------
+
+/// Expand a plan's `for_each` block: match files via glob, apply exclude/filter,
+/// substitute template variables into each operation, and flatten the result into
+/// `plan.operations`. After this call, `plan.for_each` is `None`.
+///
+/// Template variables: `{path}`, `{dir}`, `{stem}`, `{ext}`, `{name}`.
+#[cfg(feature = "cli")]
+pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result<()> {
+    let fe = match plan.for_each.take() {
+        Some(fe) => fe,
+        None => return Ok(()),
+    };
+
+    // 1. Collect matching files.
+    let glob_set = crate::files::build_glob_matcher(std::slice::from_ref(&fe.glob))?
+        .ok_or_else(|| anyhow::anyhow!("for_each: invalid glob pattern"))?;
+
+    let all_files = crate::files::collect_file_paths(cwd, false)?;
+    let mut matched: Vec<std::path::PathBuf> = all_files
+        .into_iter()
+        .filter(|p| {
+            let rel = p.strip_prefix(cwd).unwrap_or(p);
+            glob_set.is_match(rel)
+        })
+        .collect();
+    matched.sort();
+
+    // 2. Apply exclude patterns.
+    if !fe.exclude.is_empty() {
+        let excl = crate::files::build_glob_matcher(&fe.exclude)?;
+        if let Some(excl_set) = excl {
+            matched.retain(|p| {
+                let rel = p.strip_prefix(cwd).unwrap_or(p);
+                !excl_set.is_match(rel)
+            });
+        }
+    }
+
+    // 3. Apply filter (currently supports `has_symbol(NAME)`).
+    if let Some(ref filter) = fe.filter {
+        let filter = filter.trim();
+        if let Some(sym_name) = filter
+            .strip_prefix("has_symbol(")
+            .and_then(|s| s.strip_suffix(')'))
+        {
+            let sym_name = sym_name.trim();
+            #[cfg(feature = "ast")]
+            {
+                matched.retain(|p| {
+                    let syms = crate::ast::symbols::extract_symbols_from_file(p, None);
+                    syms.iter().any(|s| s.name == sym_name)
+                });
+            }
+            #[cfg(not(feature = "ast"))]
+            {
+                let _ = sym_name;
+                anyhow::bail!("for_each filter `has_symbol(...)` requires the `ast` feature");
+            }
+        } else {
+            anyhow::bail!("for_each: unsupported filter expression: {filter}");
+        }
+    }
+
+    if matched.is_empty() {
+        // No files matched; clear operations (nothing to do).
+        plan.operations.clear();
+        return Ok(());
+    }
+
+    // 4. Serialize template operations once, then substitute per file.
+    let template_ops_json = serde_json::to_string(&plan.operations)?;
+
+    let mut expanded = Vec::with_capacity(matched.len() * plan.operations.len());
+    for file_path in &matched {
+        let rel = file_path
+            .strip_prefix(cwd)
+            .unwrap_or(file_path)
+            .to_string_lossy();
+        let rel_str = rel.replace('\\', "/");
+
+        let dir = std::path::Path::new(&rel_str)
+            .parent()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let name = std::path::Path::new(&rel_str)
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let stem = std::path::Path::new(&rel_str)
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let ext = std::path::Path::new(&rel_str)
+            .extension()
+            .map(|e| e.to_string_lossy().into_owned())
+            .unwrap_or_default();
+
+        let substituted = template_ops_json
+            .replace("{path}", &rel_str)
+            .replace("{dir}", &dir)
+            .replace("{stem}", &stem)
+            .replace("{ext}", &ext)
+            .replace("{name}", &name);
+
+        let file_ops: Vec<Operation> = serde_json::from_str(&substituted)
+            .map_err(|e| anyhow::anyhow!("for_each: template expansion failed: {e}"))?;
+        expanded.extend(file_ops);
+    }
+
+    plan.operations = expanded;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -795,10 +1068,16 @@ mod tests {
             {"op": "ast.replace", "path": "f.rs", "symbol": "main", "from": "a", "to": "b"},
             {"op": "ast.insert", "path": "f.rs", "content": "fn new() {}", "after": "main"},
             {"op": "ast.wrap", "path": "f.rs", "symbols": ["helper"], "wrapper": "mod internal"},
-            {"op": "ast.imports", "path": "f.rs", "add": ["use std::io;"]}
+            {"op": "ast.imports", "path": "f.rs", "add": ["use std::io;"]},
+            {"op": "ast.reorder", "path": "f.rs", "order": "alphabetical"},
+            {"op": "ast.reorder", "path": "f.rs", "order": ["b", "a"], "inside": "mod tests"},
+            {"op": "ast.group", "path": "f.rs", "module": "tests", "symbols": ["test_a"]},
+            {"op": "ast.move", "path": "src.rs", "target": "dst.rs", "symbols": ["foo"]},
+            {"op": "ast.extract_to_file", "source": "lib.rs", "symbol": "tests", "target": "lib_tests.rs"},
+            {"op": "ast.split", "source": "big.rs", "targets": [{"path": "a.rs", "symbols": ["A"]}]}
         ]}"#;
         let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 39);
+        assert_eq!(plan.operations.len(), 45);
     }
 
     #[test]
@@ -831,10 +1110,40 @@ mod tests {
             {"op": "ast_replace", "path": "f.rs", "symbol": "main", "from": "x", "to": "y"},
             {"op": "ast_insert", "path": "f.rs", "content": "fn x() {}", "inside": "Foo"},
             {"op": "ast_wrap", "path": "f.rs", "lines": "1:10", "wrapper": "mod m"},
-            {"op": "ast_imports", "path": "f.rs", "remove": ["use old;"]}
+            {"op": "ast_imports", "path": "f.rs", "remove": ["use old;"]},
+            {"op": "ast_reorder", "path": "f.rs", "order": "reverse"},
+            {"op": "ast_group", "path": "f.rs", "module": "m", "symbols": ["x"]},
+            {"op": "ast_move", "path": "a.rs", "target": "b.rs", "symbols": ["f"]},
+            {"op": "ast_extract_to_file", "source": "a.rs", "symbol": "tests", "target": "a_tests.rs"},
+            {"op": "ast_split", "source": "big.rs", "targets": [{"path": "s.rs", "symbols": ["S"]}]}
         ]}"#;
         let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 25);
+        assert_eq!(plan.operations.len(), 30);
+    }
+
+    #[test]
+    fn parse_plan_with_for_each() {
+        let json = r#"{
+            "version": "1",
+            "for_each": {
+                "glob": "src/**/*.rs",
+                "exclude": ["src/main.rs"],
+                "filter": "has_symbol(tests)"
+            },
+            "operations": [{"op": "replace", "path": "{path}", "from": "a", "to": "b"}]
+        }"#;
+        let plan = parse_plan(json).unwrap();
+        let fe = plan.for_each.unwrap();
+        assert_eq!(fe.glob, "src/**/*.rs");
+        assert_eq!(fe.exclude, vec!["src/main.rs"]);
+        assert_eq!(fe.filter.as_deref(), Some("has_symbol(tests)"));
+    }
+
+    #[test]
+    fn parse_plan_without_for_each_is_none() {
+        let json = r#"{"version": "1", "operations": [{"op": "replace", "from": "a", "to": "b"}]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert!(plan.for_each.is_none());
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -432,6 +432,51 @@ const AST_OPERATION_REGISTRY: &[OpMeta] = &[
             r###"{"op":"ast.imports","path":"src/main.rs","add":["use std::collections::HashMap;"]}"###,
         )],
     },
+    OpMeta {
+        name: "ast.reorder",
+        description: "Reorder symbols within a file or scope by name, kind, or custom order.",
+        tier: Tier::Medium,
+        examples: &[(
+            "Alphabetize functions",
+            r###"{"op":"ast.reorder","path":"src/lib.rs","order":"alphabetical"}"###,
+        )],
+    },
+    OpMeta {
+        name: "ast.group",
+        description: "Group symbols into a named module within a file.",
+        tier: Tier::Medium,
+        examples: &[(
+            "Group test functions into a module",
+            r###"{"op":"ast.group","path":"src/tests.rs","module":"line_endings","symbols":["test_crlf","test_lf"],"preamble":"use super::*;"}"###,
+        )],
+    },
+    OpMeta {
+        name: "ast.move",
+        description: "Move symbols between files with optional target creation.",
+        tier: Tier::Medium,
+        examples: &[(
+            "Move helpers to a utility file",
+            r###"{"op":"ast.move","path":"src/lib.rs","target":"src/helpers.rs","symbols":["helper_fn"]}"###,
+        )],
+    },
+    OpMeta {
+        name: "ast.extract_to_file",
+        description: "Extract a symbol to a separate file with optional module unwrapping.",
+        tier: Tier::Medium,
+        examples: &[(
+            "Extract test module to companion file",
+            r###"{"op":"ast.extract_to_file","source":"src/lib.rs","symbol":"tests","target":"src/lib_tests.rs","replacement":"mod tests;","prepend":"use super::*;"}"###,
+        )],
+    },
+    OpMeta {
+        name: "ast.split",
+        description: "Split a file into multiple target files by distributing symbols.",
+        tier: Tier::Strong,
+        examples: &[(
+            "Split a large module into sub-modules",
+            r###"{"op":"ast.split","source":"src/big.rs","targets":[{"path":"src/types.rs","symbols":["Config"],"prepend":"use super::*;"}],"keep_in_source":["main"],"source_suffix":"mod types;"}"###,
+        )],
+    },
 ];
 
 /// Return the complete registry of all patchloom operations with schemas.

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -219,6 +219,7 @@ fn execute_plan_inner(
         cwd: None,
         strict: None,
         write_policy: None,
+        for_each: None,
     };
 
     let cwd = options.cwd.to_path_buf();

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -812,6 +812,190 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             }
             return Ok(total_changes);
         }
+
+        #[cfg(feature = "ast")]
+        Operation::AstReorder {
+            path,
+            inside,
+            order,
+            lang,
+        } => {
+            let abs = tx.cwd.join(path);
+            let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let strategy = crate::ast::reorder::parse_strategy(order)?;
+            let result = crate::ast::reorder::reorder_symbols(
+                file_content,
+                inside.as_deref(),
+                &strategy,
+                lang_val,
+            )?;
+            if result.symbols_reordered > 0 {
+                update_file_content(tx.pending, tx.deletions, &abs, result.content);
+            }
+            return Ok(result.symbols_reordered);
+        }
+
+        #[cfg(feature = "ast")]
+        Operation::AstGroup {
+            path,
+            module,
+            symbols: sym_names,
+            preamble,
+            position,
+            lang,
+        } => {
+            let abs = tx.cwd.join(path);
+            let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let pos = match position.as_deref() {
+                Some("end") => crate::ast::group::GroupPosition::End,
+                Some(s) if s.starts_with("after:") => {
+                    crate::ast::group::GroupPosition::After(s[6..].to_string())
+                }
+                _ => crate::ast::group::GroupPosition::FirstSymbol,
+            };
+            let spec = crate::ast::group::GroupSpec {
+                module: module.clone(),
+                symbols: sym_names.clone(),
+                preamble: preamble.clone(),
+                position: pos,
+            };
+            let result = crate::ast::group::group_symbols(file_content, &spec, lang_val)?;
+            if result.symbols_moved > 0 {
+                update_file_content(tx.pending, tx.deletions, &abs, result.content);
+            }
+            return Ok(result.symbols_moved);
+        }
+
+        #[cfg(feature = "ast")]
+        Operation::AstMove {
+            path,
+            target,
+            symbols: sym_names,
+            position,
+            target_prepend,
+            lang,
+        } => {
+            let abs_source = tx.cwd.join(path);
+            let abs_target = tx.cwd.join(target);
+            let source_content =
+                read_file_content(tx.pending, tx.existed_before, &abs_source)?.to_string();
+            let target_content = if abs_target.exists() || tx.pending.contains_key(&abs_target) {
+                read_file_content(tx.pending, tx.existed_before, &abs_target)?.to_string()
+            } else {
+                target_prepend
+                    .as_ref()
+                    .map(|p| format!("{p}\n\n"))
+                    .unwrap_or_default()
+            };
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
+            let pos = crate::ast::move_symbols::parse_position(position.as_deref());
+            let result = crate::ast::move_symbols::move_symbols(
+                &source_content,
+                &target_content,
+                sym_names,
+                pos,
+                lang_val,
+            )?;
+            update_file_content(tx.pending, tx.deletions, &abs_source, result.source_content);
+            update_file_content(tx.pending, tx.deletions, &abs_target, result.target_content);
+            return Ok(result.symbols_moved);
+        }
+
+        #[cfg(feature = "ast")]
+        Operation::AstExtractToFile {
+            source,
+            symbol,
+            target,
+            replacement,
+            unwrap,
+            prepend,
+            force,
+            lang,
+        } => {
+            let abs_source = tx.cwd.join(source);
+            let abs_target = tx.cwd.join(target);
+            if !force && (abs_target.exists() || tx.pending.contains_key(&abs_target)) {
+                anyhow::bail!(
+                    "target file '{}' already exists (use force: true to overwrite)",
+                    target
+                );
+            }
+            let source_content = read_file_content(tx.pending, tx.existed_before, &abs_source)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
+            let do_unwrap = unwrap.unwrap_or(true);
+            let result = crate::ast::extract::extract_to_file(
+                source_content,
+                symbol,
+                replacement.as_deref(),
+                do_unwrap,
+                prepend.as_deref(),
+                lang_val,
+            )?;
+            update_file_content(tx.pending, tx.deletions, &abs_source, result.source_content);
+            update_file_content(tx.pending, tx.deletions, &abs_target, result.target_content);
+            return Ok(1);
+        }
+
+        #[cfg(feature = "ast")]
+        Operation::AstSplit {
+            source,
+            targets,
+            keep_in_source,
+            source_suffix,
+            source_prefix,
+            require_exhaustive,
+            lang,
+        } => {
+            let abs_source = tx.cwd.join(source);
+            let source_content = read_file_content(tx.pending, tx.existed_before, &abs_source)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_extension)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
+            let split_targets: Vec<crate::ast::split::SplitTarget> = targets
+                .iter()
+                .map(|t| crate::ast::split::SplitTarget {
+                    path: t.path.clone(),
+                    symbols: t.symbols.clone(),
+                    prepend: t.prepend.clone(),
+                })
+                .collect();
+            let exhaustive = require_exhaustive.unwrap_or(true);
+            let result = crate::ast::split::split_file(
+                source_content,
+                &split_targets,
+                keep_in_source,
+                source_suffix.as_deref(),
+                source_prefix.as_deref(),
+                exhaustive,
+                lang_val,
+            )?;
+            update_file_content(tx.pending, tx.deletions, &abs_source, result.source_content);
+            for (target_path, target_content) in &result.targets {
+                let abs_target = tx.cwd.join(target_path);
+                update_file_content(
+                    tx.pending,
+                    tx.deletions,
+                    &abs_target,
+                    target_content.clone(),
+                );
+            }
+            return Ok(result.symbols_distributed);
+        }
     }
 
     Ok(0)

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -368,6 +368,14 @@ pub fn execute_plan_direct(
     cwd: &Path,
     guard: Option<&crate::containment::PathGuard>,
 ) -> anyhow::Result<TxOutput> {
+    // Expand for_each (glob-driven batch) before anything else.
+    #[cfg(feature = "cli")]
+    let mut plan = plan;
+    #[cfg(feature = "cli")]
+    if plan.for_each.is_some() {
+        crate::plan::expand_for_each(&mut plan, cwd)?;
+    }
+
     crate::verbose!(
         "tx: direct plan execution ({} ops, cwd={}, guard={})",
         plan.operations.len(),
@@ -619,6 +627,7 @@ mod tests {
             cwd: None,
             strict: None,
             write_policy: None,
+            for_each: None,
         };
         let cwd = Path::new("/tmp");
         assert!(run_lifecycle(&plan, cwd, cwd).is_none());

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -59,7 +59,12 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
         | Operation::AstReplace { .. }
         | Operation::AstInsert { .. }
         | Operation::AstWrap { .. }
-        | Operation::AstImports { .. } => Ok(()),
+        | Operation::AstImports { .. }
+        | Operation::AstReorder { .. }
+        | Operation::AstGroup { .. }
+        | Operation::AstMove { .. }
+        | Operation::AstExtractToFile { .. }
+        | Operation::AstSplit { .. } => Ok(()),
         Operation::TidyFix { dedent, indent, .. } => {
             if dedent.is_some() && indent.is_some() {
                 anyhow::bail!("tidy.fix: 'dedent' and 'indent' cannot both be set");

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2702,3 +2702,245 @@ async fn test_mcp_no_matches_returns_descriptive_message() {
     );
     client.cancel().await.unwrap();
 }
+
+// ── MCP ast_reorder round-trip ─────────────────────────────────
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_reorder_alphabetical() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn zebra() {}\nfn alpha() {}\nfn mid() {}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_reorder",
+        serde_json::json!({"path": "lib.rs", "order": "alphabetical"}),
+    )
+    .await;
+    assert!(!is_error, "ast_reorder should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_reorder ok: {val}");
+
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    let alpha = content.find("fn alpha").unwrap();
+    let mid = content.find("fn mid").unwrap();
+    let zebra = content.find("fn zebra").unwrap();
+    assert!(
+        alpha < mid && mid < zebra,
+        "should be alphabetical: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+// ── MCP ast_group round-trip ───────────────────────────────────
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_group_creates_module() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn public_api() {}\nfn test_a() {}\nfn test_b() {}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_group",
+        serde_json::json!({
+            "path": "lib.rs",
+            "module": "tests",
+            "symbols": ["test_a", "test_b"],
+            "preamble": "use super::*;"
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_group should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_group ok: {val}");
+
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    assert!(content.contains("mod tests"), "module created: {content}");
+    assert!(
+        content.contains("use super::*;"),
+        "preamble present: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+// ── MCP ast_move round-trip ────────────────────────────────────
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_move_between_files() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("src.rs"),
+        "fn keep() {}\nfn moveme() { 42 }\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("dst.rs"), "fn existing() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_move",
+        serde_json::json!({
+            "path": "src.rs",
+            "target": "dst.rs",
+            "symbols": ["moveme"]
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_move should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_move ok: {val}");
+
+    let src = fs::read_to_string(dir.path().join("src.rs")).unwrap();
+    let dst = fs::read_to_string(dir.path().join("dst.rs")).unwrap();
+    assert!(!src.contains("moveme"), "removed from source: {src}");
+    assert!(dst.contains("fn moveme"), "added to target: {dst}");
+    assert!(dst.contains("fn existing"), "existing kept: {dst}");
+    client.cancel().await.unwrap();
+}
+
+// ── MCP ast_extract_to_file round-trip ─────────────────────────
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_extract_to_file() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn main() {}\n\nmod tests {\n    fn test_one() {}\n}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_extract_to_file",
+        serde_json::json!({
+            "source": "lib.rs",
+            "symbol": "tests",
+            "target": "tests.rs",
+            "replacement": "mod tests;",
+            "prepend": "use super::*;\n"
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_extract_to_file should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_extract_to_file ok: {val}");
+
+    let src = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    let tgt = fs::read_to_string(dir.path().join("tests.rs")).unwrap();
+    assert!(src.contains("mod tests;"), "replacement in source: {src}");
+    assert!(
+        tgt.contains("fn test_one"),
+        "extracted content in target: {tgt}"
+    );
+    assert!(tgt.contains("use super::*;"), "prepend in target: {tgt}");
+    client.cancel().await.unwrap();
+}
+
+// ── MCP ast_split round-trip ───────────────────────────────────
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_split_distributes_symbols() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("big.rs"),
+        "struct Config {}\nfn helper() {}\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_split",
+        serde_json::json!({
+            "source": "big.rs",
+            "targets": [
+                {"path": "types.rs", "symbols": ["Config"]},
+                {"path": "utils.rs", "symbols": ["helper"]}
+            ],
+            "keep_in_source": ["main"],
+            "source_suffix": "mod types;\nmod utils;\n"
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_split should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_split ok: {val}");
+
+    let src = fs::read_to_string(dir.path().join("big.rs")).unwrap();
+    let types = fs::read_to_string(dir.path().join("types.rs")).unwrap();
+    let utils = fs::read_to_string(dir.path().join("utils.rs")).unwrap();
+    assert!(src.contains("fn main"), "main stays: {src}");
+    assert!(src.contains("mod types;"), "suffix appended: {src}");
+    assert!(types.contains("struct Config"), "Config in types: {types}");
+    assert!(utils.contains("fn helper"), "helper in utils: {utils}");
+    client.cancel().await.unwrap();
+}
+
+// ── MCP execute_plan with for_each ─────────────────────────────
+
+#[tokio::test]
+async fn test_mcp_execute_plan_for_each() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("a.txt"), "old\n").unwrap();
+    fs::write(src.join("b.txt"), "old\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "execute_plan",
+        serde_json::json!({
+            "plan": {
+                "version": "1",
+                "for_each": {"glob": "src/*.txt"},
+                "operations": [{
+                    "op": "replace",
+                    "path": "{path}",
+                    "from": "old",
+                    "to": "new"
+                }]
+            }
+        }),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "execute_plan with for_each should succeed: {val}"
+    );
+    assert_eq!(val["ok"], true, "for_each plan ok: {val}");
+
+    let a = fs::read_to_string(src.join("a.txt")).unwrap();
+    let b = fs::read_to_string(src.join("b.txt")).unwrap();
+    assert_eq!(a.trim(), "new", "a.txt should be updated: {a}");
+    assert_eq!(b.trim(), "new", "b.txt should be updated: {b}");
+    client.cancel().await.unwrap();
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -5936,3 +5936,543 @@ fn test_tx_replace_whole_line_and_multiline_rejected() {
     // File must not be modified
     assert_eq!(fs::read_to_string(&file).unwrap(), "line1\nline2\nline3\n");
 }
+
+// ── ast.reorder (tx plan) ──────────────────────────────────────
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_reorder_alphabetical_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(&file, "fn zebra() {}\nfn alpha() {}\nfn mid() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "ast.reorder",
+            "path": portable_path_str(&file),
+            "order": "alphabetical"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    let alpha_pos = content.find("fn alpha").expect("alpha should exist");
+    let mid_pos = content.find("fn mid").expect("mid should exist");
+    let zebra_pos = content.find("fn zebra").expect("zebra should exist");
+    assert!(
+        alpha_pos < mid_pos && mid_pos < zebra_pos,
+        "symbols should be in alphabetical order: {content}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_reorder_custom_order_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(&file, "fn a() {}\nfn b() {}\nfn c() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "ast.reorder",
+            "path": portable_path_str(&file),
+            "order": ["c", "a", "b"]
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    let c_pos = content.find("fn c").unwrap();
+    let a_pos = content.find("fn a").unwrap();
+    let b_pos = content.find("fn b").unwrap();
+    assert!(
+        c_pos < a_pos && a_pos < b_pos,
+        "custom order c,a,b should apply: {content}"
+    );
+}
+
+// ── ast.group (tx plan) ────────────────────────────────────────
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_group_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(
+        &file,
+        "fn public_api() {}\n\nfn test_one() {}\n\nfn test_two() {}\n",
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "ast.group",
+            "path": portable_path_str(&file),
+            "module": "tests",
+            "symbols": ["test_one", "test_two"],
+            "preamble": "use super::*;"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("mod tests"),
+        "should create mod tests: {content}"
+    );
+    assert!(
+        content.contains("use super::*;"),
+        "should include preamble: {content}"
+    );
+    assert!(
+        content.contains("fn public_api"),
+        "non-grouped symbol should remain: {content}"
+    );
+}
+
+// ── ast.move (tx plan) ─────────────────────────────────────────
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("source.rs");
+    let target = dir.path().join("target.rs");
+    fs::write(&source, "fn keep() {}\nfn moveme() { let x = 1; }\n").unwrap();
+    fs::write(&target, "fn existing() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "ast.move",
+            "path": portable_path_str(&source),
+            "target": portable_path_str(&target),
+            "symbols": ["moveme"]
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let src_content = fs::read_to_string(&source).unwrap();
+    let tgt_content = fs::read_to_string(&target).unwrap();
+    assert!(
+        !src_content.contains("moveme"),
+        "moveme should be removed from source: {src_content}"
+    );
+    assert!(
+        src_content.contains("fn keep"),
+        "keep should remain in source: {src_content}"
+    );
+    assert!(
+        tgt_content.contains("fn moveme"),
+        "moveme should appear in target: {tgt_content}"
+    );
+    assert!(
+        tgt_content.contains("fn existing"),
+        "existing should remain in target: {tgt_content}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_creates_target() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("source.rs");
+    let target = dir.path().join("new_target.rs");
+    fs::write(&source, "fn stay() {}\nfn go() { 42 }\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "ast.move",
+            "path": portable_path_str(&source),
+            "target": portable_path_str(&target),
+            "symbols": ["go"],
+            "target_prepend": "use crate::prelude::*;\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert!(target.exists(), "target file should be created");
+    let tgt = fs::read_to_string(&target).unwrap();
+    assert!(
+        tgt.contains("use crate::prelude::*;"),
+        "prepend should be present: {tgt}"
+    );
+    assert!(tgt.contains("fn go"), "symbol should be present: {tgt}");
+}
+
+// ── ast.extract_to_file (tx plan) ──────────────────────────────
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_extract_to_file_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("lib.rs");
+    let target = dir.path().join("tests.rs");
+    fs::write(
+        &source,
+        "fn main() {}\n\nmod tests {\n    fn test_a() {}\n}\n",
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "ast.extract_to_file",
+            "source": portable_path_str(&source),
+            "symbol": "tests",
+            "target": portable_path_str(&target),
+            "replacement": "mod tests;",
+            "prepend": "use super::*;\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let src = fs::read_to_string(&source).unwrap();
+    let tgt = fs::read_to_string(&target).unwrap();
+    assert!(
+        src.contains("mod tests;"),
+        "replacement should be in source: {src}"
+    );
+    assert!(
+        !src.contains("fn test_a"),
+        "extracted symbol body should be removed from source: {src}"
+    );
+    assert!(
+        tgt.contains("fn test_a"),
+        "extracted content should be in target: {tgt}"
+    );
+    assert!(
+        tgt.contains("use super::*;"),
+        "prepend should be in target: {tgt}"
+    );
+}
+
+// ── ast.split (tx plan) ────────────────────────────────────────
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_split_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("big.rs");
+    let types_file = dir.path().join("types.rs");
+    let utils_file = dir.path().join("utils.rs");
+    fs::write(&source, "struct Config {}\nfn helper() {}\nfn main() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "ast.split",
+            "source": portable_path_str(&source),
+            "targets": [
+                {
+                    "path": portable_path_str(&types_file),
+                    "symbols": ["Config"],
+                    "prepend": "use super::*;\n"
+                },
+                {
+                    "path": portable_path_str(&utils_file),
+                    "symbols": ["helper"]
+                }
+            ],
+            "keep_in_source": ["main"],
+            "source_suffix": "mod types;\nmod utils;\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let src = fs::read_to_string(&source).unwrap();
+    let types = fs::read_to_string(&types_file).unwrap();
+    let utils = fs::read_to_string(&utils_file).unwrap();
+
+    assert!(src.contains("fn main"), "main should stay in source: {src}");
+    assert!(
+        src.contains("mod types;"),
+        "source_suffix should be appended: {src}"
+    );
+    assert!(
+        !src.contains("struct Config"),
+        "Config should be moved out: {src}"
+    );
+    assert!(
+        types.contains("struct Config"),
+        "Config should be in types.rs: {types}"
+    );
+    assert!(
+        types.contains("use super::*;"),
+        "prepend should be in types.rs: {types}"
+    );
+    assert!(
+        utils.contains("fn helper"),
+        "helper should be in utils.rs: {utils}"
+    );
+}
+
+// ── for_each glob batch (tx plan) ──────────────────────────────
+
+#[test]
+fn test_tx_for_each_glob_expansion_with_templates() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("a.txt"), "old_value\n").unwrap();
+    fs::write(src.join("b.txt"), "old_value\n").unwrap();
+    fs::write(src.join("skip.md"), "old_value\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "for_each": {
+            "glob": "src/*.txt"
+        },
+        "operations": [{
+            "op": "replace",
+            "path": "{path}",
+            "from": "old_value",
+            "to": "new_value in {stem}"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let a = fs::read_to_string(src.join("a.txt")).unwrap();
+    let b = fs::read_to_string(src.join("b.txt")).unwrap();
+    let md = fs::read_to_string(src.join("skip.md")).unwrap();
+
+    assert!(
+        a.contains("new_value in a"),
+        "template {{stem}} should expand to 'a': {a}"
+    );
+    assert!(
+        b.contains("new_value in b"),
+        "template {{stem}} should expand to 'b': {b}"
+    );
+    assert_eq!(
+        md.trim(),
+        "old_value",
+        "skip.md should not be modified (non-matching glob): {md}"
+    );
+}
+
+#[test]
+fn test_tx_for_each_exclude_filters_files() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("keep.txt"), "original\n").unwrap();
+    fs::write(src.join("skip.txt"), "original\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "for_each": {
+            "glob": "src/*.txt",
+            "exclude": ["src/skip.txt"]
+        },
+        "operations": [{
+            "op": "replace",
+            "path": "{path}",
+            "from": "original",
+            "to": "changed"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let keep = fs::read_to_string(src.join("keep.txt")).unwrap();
+    let skip = fs::read_to_string(src.join("skip.txt")).unwrap();
+
+    assert!(
+        keep.contains("changed"),
+        "keep.txt should be modified: {keep}"
+    );
+    assert_eq!(
+        skip.trim(),
+        "original",
+        "skip.txt should be excluded: {skip}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_for_each_filter_has_symbol() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("with_tests.rs"),
+        "fn main() {}\nmod tests { fn test_a() {} }\n",
+    )
+    .unwrap();
+    fs::write(src.join("no_tests.rs"), "fn helper() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "for_each": {
+            "glob": "src/*.rs",
+            "filter": "has_symbol(tests)"
+        },
+        "operations": [{
+            "op": "replace",
+            "path": "{path}",
+            "from": "fn main",
+            "to": "fn entry"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let with = fs::read_to_string(src.join("with_tests.rs")).unwrap();
+    let without = fs::read_to_string(src.join("no_tests.rs")).unwrap();
+
+    assert!(
+        with.contains("fn entry"),
+        "file with tests should be modified: {with}"
+    );
+    assert!(
+        without.contains("fn helper"),
+        "file without tests should not be modified: {without}"
+    );
+}
+
+#[test]
+fn test_tx_for_each_check_mode() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("a.txt"), "hello\n").unwrap();
+    fs::write(src.join("b.txt"), "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "for_each": {
+            "glob": "src/*.txt"
+        },
+        "operations": [{
+            "op": "replace",
+            "path": "{path}",
+            "from": "hello",
+            "to": "world"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    // --check should report changes without modifying files
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--check")
+        .assert()
+        .code(2); // CHANGES_DETECTED
+
+    // Files should be unchanged
+    assert_eq!(fs::read_to_string(src.join("a.txt")).unwrap(), "hello\n");
+    assert_eq!(fs::read_to_string(src.join("b.txt")).unwrap(), "hello\n");
+}
+
+#[test]
+fn test_tx_for_each_no_matches_produces_empty_plan() {
+    let dir = TempDir::new().unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "for_each": {
+            "glob": "nonexistent/**/*.xyz"
+        },
+        "operations": [{
+            "op": "replace",
+            "path": "{path}",
+            "from": "a",
+            "to": "b"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    // No matching files means no operations, success with no changes
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+}


### PR DESCRIPTION
## Summary

Implements the remaining AST operations (Phase C) and glob-driven batch execution:

| Issue | Feature | Description |
|-------|---------|-------------|
| #1011 | `ast.group` | Group symbols into a new container (module/class/namespace) |
| #1012 | `ast.extract_to_file` | Extract symbols to a new file with optional module unwrapping |
| #1013 | `ast.split` | Split a file by distributing symbols across target files |
| #1014 | `ast.move` | Move symbols between files with position control |
| #1016 | `ast.reorder` | Reorder symbols (alphabetical, reverse, kind-first, custom) |
| #1022 | `for_each` | Glob-driven batch execution with filtering and path templates |

## Changes

### Core modules (`src/ast/`)
- `group.rs`: `group_symbols()` with `GroupSpec`, `GroupPosition` enum, existing-container append
- `extract.rs`: `extract_to_file()` with module unwrapping, replacement text, prepend content
- `split.rs`: `split_file()` with `SplitTarget` glob matching
- `move_symbols.rs`: `move_symbols()` with `MovePosition` (start/end/before/after)
- `reorder.rs`: `reorder_symbols()` with `ReorderStrategy` (alphabetical/reverse/kind-first/custom)

### Plan and execution
- 5 new `Operation` variants in `plan.rs`: `AstReorder`, `AstGroup`, `AstMove`, `AstExtractToFile`, `AstSplit`
- `ForEach` struct with glob, exclude, and `has_symbol` filter support
- Path template variables: `{path}`, `{dir}`, `{stem}`, `{ext}`, `{name}`
- tx engine handlers (execute + validate) for all 5 operations
- explain arms for human-readable summaries
- for_each expansion in tx, explain, lifecycle, and MCP handlers

### MCP tools
- 5 new tool handlers in `ast_tools.rs`
- Parameter structs in `params.rs`
- Tool count updated to 51

### Tests
- ~40 unit tests across 5 core modules
- 12 integration tests for tx plan round-trip (including 5 for_each tests)
- 6 MCP tool integration tests
- Total test count: 2314 (1527 unit + 777 integration + 10 PTY)

### Documentation
- 10 reference doc markers for all AST operations
- `for_each` field marker with usage documentation
- README badge updated to 2300+

## Verification

`make check` passes: fmt-check, clippy, all tests, release notes, audit, readme, patchloom-md.

Closes #1011
Closes #1012
Closes #1013
Closes #1014
Closes #1016
Closes #1022