### PR TITLE
fix: C++ qualified name lookup and empty append spurious newline

### DIFF
--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -259,7 +259,7 @@ fn function_node_has_name(node: tree_sitter_lib::Node, source: &str, name: &str)
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind().contains("declarator") {
-            if child_text_by_kinds(child, name_kinds, source) == Some(name) {
+            if check_declarator_for_name(child, name_kinds, source, name) {
                 return true;
             }
             // One more level: function_declarator -> declarator -> identifier
@@ -270,11 +270,62 @@ fn function_node_has_name(node: tree_sitter_lib::Node, source: &str, name: &str)
                         if grandchild.utf8_text(source.as_bytes()).ok() == Some(name) {
                             return true;
                         }
-                    } else if child_text_by_kinds(grandchild, name_kinds, source) == Some(name) {
+                    } else if check_declarator_for_name(grandchild, name_kinds, source, name) {
                         return true;
                     }
                 }
             }
+        }
+    }
+    false
+}
+
+/// Check a declarator node for a matching name, including inside
+/// `qualified_identifier` / `scoped_identifier` nodes (C++ `MyClass::method`).
+fn check_declarator_for_name(
+    node: tree_sitter_lib::Node,
+    name_kinds: &[&str],
+    source: &str,
+    name: &str,
+) -> bool {
+    // Direct identifier child
+    if child_text_by_kinds(node, name_kinds, source) == Some(name) {
+        return true;
+    }
+    // Check inside qualified_identifier / scoped_identifier for nested name.
+    // Recurse because nested namespaces produce chains:
+    //   qualified_identifier -> name: qualified_identifier -> name: identifier
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if (child.kind() == "qualified_identifier" || child.kind() == "scoped_identifier")
+            && qualified_identifier_has_name(child, name_kinds, source, name)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Recursively check a `qualified_identifier` / `scoped_identifier` for the
+/// innermost identifier matching `name`. Handles arbitrary nesting depth
+/// (e.g. `ns::MyClass::method`).
+fn qualified_identifier_has_name(
+    node: tree_sitter_lib::Node,
+    name_kinds: &[&str],
+    source: &str,
+    name: &str,
+) -> bool {
+    // Check direct identifier children
+    if child_text_by_kinds(node, name_kinds, source) == Some(name) {
+        return true;
+    }
+    // Recurse into nested qualified_identifier / scoped_identifier children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if (child.kind() == "qualified_identifier" || child.kind() == "scoped_identifier")
+            && qualified_identifier_has_name(child, name_kinds, source, name)
+        {
+            return true;
         }
     }
     false
@@ -1449,6 +1500,22 @@ struct Point {
                 .contains("void process(int x, double y)")
         );
         assert!(!span.signature_text.contains("// body"));
+    }
+
+    #[test]
+    fn find_function_span_cpp_qualified_name() {
+        let source = "void MyClass::process(int x) {\n    // body\n}\n";
+        let span = find_function_span(source, "process", Language::Cpp).unwrap();
+        assert_eq!(span.name, "process");
+        assert!(span.signature_text.contains("void MyClass::process(int x)"));
+    }
+
+    #[test]
+    fn find_function_span_cpp_nested_namespace_qualified() {
+        let source = "int ns::MyClass::deep() {\n    return 0;\n}\n";
+        let span = find_function_span(source, "deep", Language::Cpp).unwrap();
+        assert_eq!(span.name, "deep");
+        assert!(span.signature_text.contains("ns::MyClass::deep()"));
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -2,6 +2,9 @@
 /// Used by api::file_* , plan execution (tx), and cmd/append for consistency.
 /// Centralizes the "ensure nl between existing and new" logic.
 pub fn append_content(existing: &str, append: &str) -> String {
+    if append.is_empty() {
+        return existing.to_string();
+    }
     let mut combined = existing.to_string();
     if !combined.is_empty() && !combined.ends_with('\n') {
         combined.push('\n');
@@ -56,6 +59,16 @@ mod tests {
     #[test]
     fn prepend_empty_prepend() {
         assert_eq!(prepend_content("existing", ""), "existing");
+    }
+
+    #[test]
+    fn append_empty_append() {
+        assert_eq!(append_content("existing", ""), "existing");
+    }
+
+    #[test]
+    fn append_empty_both() {
+        assert_eq!(append_content("", ""), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Two bug fixes:

1. **#1052**: `find_function_span` failed on C++ qualified names (`MyClass::process`, `ns::MyClass::deep`). The tree-sitter C++ grammar wraps qualified names in `qualified_identifier` nodes, which can be nested for multi-level scopes. Added `check_declarator_for_name` and `qualified_identifier_has_name` helpers that recursively traverse these nodes to find the innermost identifier.

2. **#1053**: `append_content("existing", "")` incorrectly returned `"existing\n"` instead of `"existing"`. Added an early return guard when the append string is empty, matching the pattern already used in `prepend_content`.

## Tests added

- `find_function_span_cpp_qualified_name`: `void MyClass::process(int x) {...}`
- `find_function_span_cpp_nested_namespace_qualified`: `int ns::MyClass::deep() {...}`
- `append_empty_append`: `append_content("existing", "")` returns `"existing"`
- `append_empty_both`: `append_content("", "")` returns `""`

Existing tests (unqualified C++ function, non-empty appends) continue to pass.

Closes #1052
Closes #1053