### PR TITLE
fix: C++ qualified name handling in AST operations and refactor traversal

### DIFF
--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -212,8 +212,7 @@ mod tests {
             symbols: vec!["alpha".into()],
             prepend: None,
         }];
-        let result = split_file(source, &targets, &[], None, None, false, Language::Rust);
-        assert!(result.is_ok());
+        split_file(source, &targets, &[], None, None, false, Language::Rust).unwrap();
     }
 
     #[test]

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -827,10 +827,38 @@ fn extract_generic(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolK
     // C-family: name nested inside a declarator node
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if (child.kind().contains("declarator") || child.kind() == "name")
-            && let Some(name) = child_text_by_kinds(child, GENERIC_NAME_KINDS, source)
-        {
-            return Some((symbol_kind, name.to_string()));
+        if child.kind().contains("declarator") || child.kind() == "name" {
+            if let Some(name) = child_text_by_kinds(child, GENERIC_NAME_KINDS, source) {
+                return Some((symbol_kind, name.to_string()));
+            }
+            // C++ qualified names: declarator -> qualified_identifier -> name: identifier
+            if let Some(name) = find_name_in_qualified_children(child, GENERIC_NAME_KINDS, source) {
+                return Some((symbol_kind, name.to_string()));
+            }
+        }
+    }
+    None
+}
+
+/// Search child nodes for `qualified_identifier` / `scoped_identifier` and
+/// return the innermost identifier name. Used by `extract_generic` to handle
+/// C++ qualified method definitions (e.g. `void MyClass::method()`).
+fn find_name_in_qualified_children<'a>(
+    node: tree_sitter_lib::Node<'a>,
+    name_kinds: &[&str],
+    source: &'a str,
+) -> Option<&'a str> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "qualified_identifier" || child.kind() == "scoped_identifier" {
+            // Check direct identifier children first
+            if let Some(name) = child_text_by_kinds(child, name_kinds, source) {
+                return Some(name);
+            }
+            // Recurse for deeper nesting (ns::MyClass::method)
+            if let Some(name) = find_name_in_qualified_children(child, name_kinds, source) {
+                return Some(name);
+            }
         }
     }
     None
@@ -1302,6 +1330,17 @@ struct Point {
     }
 
     #[test]
+    fn extract_cpp_qualified_method() {
+        let source = "void MyClass::process(int x) {\n    // body\n}\n";
+        let symbols = extract_symbols(source, Language::Cpp);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(
+            names.contains(&"process"),
+            "should find qualified method process, got: {names:?}"
+        );
+    }
+
+    #[test]
     fn rewrite_function_signature_structured() {
         let src = "fn old(a: i32) -> i32 { a }\nfn other() {}";
         let edit = FunctionSigEdit {
@@ -1520,8 +1559,7 @@ struct Point {
 
     #[test]
     fn find_function_span_cpp_triple_nested_namespace() {
-        let source =
-            "int outer::inner::MyClass::compute(int x) {\n    return x;\n}\n";
+        let source = "int outer::inner::MyClass::compute(int x) {\n    return x;\n}\n";
         let span = find_function_span(source, "compute", Language::Cpp).unwrap();
         assert_eq!(span.name, "compute");
         assert!(
@@ -1532,8 +1570,7 @@ struct Point {
 
     #[test]
     fn find_function_span_cpp_qualified_no_false_positive() {
-        let source =
-            "void MyClass::alpha(int x) {\n}\nvoid MyClass::beta() {\n}\n";
+        let source = "void MyClass::alpha(int x) {\n}\nvoid MyClass::beta() {\n}\n";
         let span = find_function_span(source, "beta", Language::Cpp).unwrap();
         assert_eq!(span.name, "beta");
         assert!(span.signature_text.contains("beta"));

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -315,20 +315,7 @@ fn qualified_identifier_has_name(
     source: &str,
     name: &str,
 ) -> bool {
-    // Check direct identifier children
-    if child_text_by_kinds(node, name_kinds, source) == Some(name) {
-        return true;
-    }
-    // Recurse into nested qualified_identifier / scoped_identifier children
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        if (child.kind() == "qualified_identifier" || child.kind() == "scoped_identifier")
-            && qualified_identifier_has_name(child, name_kinds, source, name)
-        {
-            return true;
-        }
-    }
-    false
+    innermost_qualified_name(node, name_kinds, source) == Some(name)
 }
 
 /// Find the byte offset where the body starts within a function node.
@@ -840,6 +827,30 @@ fn extract_generic(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolK
     None
 }
 
+/// Extract the innermost identifier name from a `qualified_identifier` /
+/// `scoped_identifier` node. Handles arbitrary nesting depth
+/// (e.g. `ns::MyClass::method` returns `"method"`).
+fn innermost_qualified_name<'a>(
+    node: tree_sitter_lib::Node<'a>,
+    name_kinds: &[&str],
+    source: &'a str,
+) -> Option<&'a str> {
+    // Check direct identifier children first
+    if let Some(name) = child_text_by_kinds(node, name_kinds, source) {
+        return Some(name);
+    }
+    // Recurse into nested qualified_identifier / scoped_identifier children
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if (child.kind() == "qualified_identifier" || child.kind() == "scoped_identifier")
+            && let Some(name) = innermost_qualified_name(child, name_kinds, source)
+        {
+            return Some(name);
+        }
+    }
+    None
+}
+
 /// Search child nodes for `qualified_identifier` / `scoped_identifier` and
 /// return the innermost identifier name. Used by `extract_generic` to handle
 /// C++ qualified method definitions (e.g. `void MyClass::method()`).
@@ -850,15 +861,10 @@ fn find_name_in_qualified_children<'a>(
 ) -> Option<&'a str> {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        if child.kind() == "qualified_identifier" || child.kind() == "scoped_identifier" {
-            // Check direct identifier children first
-            if let Some(name) = child_text_by_kinds(child, name_kinds, source) {
-                return Some(name);
-            }
-            // Recurse for deeper nesting (ns::MyClass::method)
-            if let Some(name) = find_name_in_qualified_children(child, name_kinds, source) {
-                return Some(name);
-            }
+        if (child.kind() == "qualified_identifier" || child.kind() == "scoped_identifier")
+            && let Some(name) = innermost_qualified_name(child, name_kinds, source)
+        {
+            return Some(name);
         }
     }
     None

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -1519,6 +1519,28 @@ struct Point {
     }
 
     #[test]
+    fn find_function_span_cpp_triple_nested_namespace() {
+        let source =
+            "int outer::inner::MyClass::compute(int x) {\n    return x;\n}\n";
+        let span = find_function_span(source, "compute", Language::Cpp).unwrap();
+        assert_eq!(span.name, "compute");
+        assert!(
+            span.signature_text
+                .contains("outer::inner::MyClass::compute(int x)")
+        );
+    }
+
+    #[test]
+    fn find_function_span_cpp_qualified_no_false_positive() {
+        let source =
+            "void MyClass::alpha(int x) {\n}\nvoid MyClass::beta() {\n}\n";
+        let span = find_function_span(source, "beta", Language::Cpp).unwrap();
+        assert_eq!(span.name, "beta");
+        assert!(span.signature_text.contains("beta"));
+        assert!(!span.signature_text.contains("alpha"));
+    }
+
+    #[test]
     fn find_function_span_c() {
         let source = "int main(int argc, char *argv[]) {\n    return 0;\n}\n";
         let span = find_function_span(source, "main", Language::C).unwrap();

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -72,6 +72,11 @@ mod tests {
     }
 
     #[test]
+    fn prepend_empty_both() {
+        assert_eq!(prepend_content("", ""), "");
+    }
+
+    #[test]
     fn prepend_symmetry_with_append() {
         // Both ensure a newline separator when content lacks trailing newline
         let a = append_content("base", "added");


### PR DESCRIPTION
## Summary

Fix C++ qualified name handling in both `find_function_span` (already fixed in #1054) and `extract_symbols` (same root cause, different code path). Add comprehensive edge case tests and unify the duplicated qualified-identifier traversal logic.

## Changes

- **Edge case tests**: Triple-nested C++ namespace, qualified name false positive, `extract_symbols` for qualified methods, empty content prepend
- **Fix extract_symbols**: C++ qualified methods (e.g. `void MyClass::process(int x)`) were not extracted because `extract_generic` did not look inside `qualified_identifier` nodes nested within declarator nodes
- **Architecture refactor**: Extract `innermost_qualified_name()` as the shared recursive helper for qualified-identifier traversal, eliminating duplicated logic between `qualified_identifier_has_name()` and `find_name_in_qualified_children()`

## Testing

All existing and new tests pass. `make check-fast` clean (786 unit + 273 integration + 10 PTY tests).