### PR TITLE
fix: dead code and weak test assertions

### DIFF
--- a/src/ast/extract.rs
+++ b/src/ast/extract.rs
@@ -150,7 +150,11 @@ mod tests {
         assert!(!result.source_content.contains("fn foo"));
         assert!(result.source_content.contains("fn bar"));
         assert!(result.target_content.contains("fn foo()"));
-        assert!(result.target_content.contains("42"));
+        assert!(
+            result.target_content.contains("    42"),
+            "target should contain the function body: {}",
+            result.target_content
+        );
     }
 
     #[test]

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -233,7 +233,11 @@ mod tests {
         .unwrap();
         assert!(!result.source_content.contains("fn foo"));
         assert!(result.target_content.contains("fn foo()"));
-        assert!(result.target_content.contains("42"));
+        assert!(
+            result.target_content.contains("    42"),
+            "target should contain the function body: {}",
+            result.target_content
+        );
     }
 
     #[test]

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -212,8 +212,7 @@ mod tests {
             symbols: vec!["alpha".into()],
             prepend: None,
         }];
-        let result = split_file(source, &targets, &[], None, None, false, Language::Rust);
-        assert!(result.is_ok());
+        split_file(source, &targets, &[], None, None, false, Language::Rust).unwrap();
     }
 
     #[test]

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -210,7 +210,11 @@ mod tests {
         assert!(result.content.contains("pub(crate) mod helpers {"));
         assert!(result.content.contains("    fn helper_a()"));
         assert!(result.content.contains("    fn helper_b()"));
-        assert!(result.content.contains("}"));
+        assert!(
+            result.content.ends_with("}\n") || result.content.ends_with('}'),
+            "module wrapper should close with }}: {}",
+            result.content
+        );
     }
 
     #[test]

--- a/src/ops/doc/toml_preserve.rs
+++ b/src/ops/doc/toml_preserve.rs
@@ -193,7 +193,10 @@ mod tests {
         let new = json(r#"{"a": 1, "c": 3}"#);
         apply_value_diff(doc.as_item_mut(), &old, &new);
         let result = doc.to_string();
-        assert!(result.contains("c"), "new key should appear: {result}");
+        assert!(
+            result.contains("c = 3"),
+            "new key 'c = 3' should appear: {result}"
+        );
     }
 
     #[test]
@@ -214,7 +217,11 @@ mod tests {
         let result = doc.to_string();
         assert!(
             result.contains("99"),
-            "array element should be updated: {result}"
+            "array element 99 should appear: {result}"
+        );
+        assert!(
+            !result.contains(", 2, 3]"),
+            "old array layout should not persist: {result}"
         );
     }
 
@@ -226,8 +233,8 @@ mod tests {
         apply_value_diff(doc.as_item_mut(), &old, &new);
         let result = doc.to_string();
         assert!(
-            result.contains("3"),
-            "longer array should be applied: {result}"
+            result.contains("1, 2, 3"),
+            "extended array [1, 2, 3] should appear: {result}"
         );
     }
 

--- a/src/ops/search.rs
+++ b/src/ops/search.rs
@@ -326,23 +326,41 @@ mod tests {
     fn build_matcher_literal_case_sensitive() {
         let m = build_matcher("hello", true, false, false).unwrap();
         assert!(matches!(m, Matcher::Literal(_)));
-        assert!(m.find("say hello world").is_some());
-        assert!(m.find("say Hello world").is_none());
+        assert!(
+            m.find("say hello world").is_some(),
+            "literal 'hello' should match in 'say hello world'"
+        );
+        assert!(
+            m.find("say Hello world").is_none(),
+            "literal 'hello' should NOT match 'Hello' (case-sensitive)"
+        );
     }
 
     #[test]
     fn build_matcher_literal_case_insensitive_uses_regex() {
         let m = build_matcher("hello", true, true, false).unwrap();
         assert!(matches!(m, Matcher::Regex(_)));
-        assert!(m.find("say Hello world").is_some());
+        assert!(
+            m.find("say Hello world").is_some(),
+            "case-insensitive literal should match 'Hello'"
+        );
     }
 
     #[test]
     fn build_matcher_regex_pattern() {
         let m = build_matcher(r"hel+o", false, false, false).unwrap();
-        assert!(m.find("hello").is_some());
-        assert!(m.find("helllo").is_some());
-        assert!(m.find("heo").is_none());
+        assert!(
+            m.find("hello").is_some(),
+            "regex 'hel+o' should match 'hello'"
+        );
+        assert!(
+            m.find("helllo").is_some(),
+            "regex 'hel+o' should match 'helllo' (l+ matches multiple)"
+        );
+        assert!(
+            m.find("heo").is_none(),
+            "regex 'hel+o' should NOT match 'heo' (l+ requires at least one l)"
+        );
     }
 
     #[test]

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -25,8 +25,8 @@ pub(crate) struct SymbolSnapshot {
 #[derive(Debug, Clone)]
 pub(crate) struct SnappedSymbol {
     pub(crate) name: String,
-    /// Retained for diagnostic messages in compare_snapshots.
-    #[allow(dead_code)]
+    /// Used in `compare_snapshots` diagnostic messages to show which
+    /// specific symbols were added or removed (e.g. "fn 'foo' removed").
     pub(crate) kind: symbols::SymbolKind,
 }
 
@@ -259,12 +259,44 @@ pub(crate) fn compare_snapshots(
                     before.files.keys().chain(after.files.keys()).collect();
 
                 for path in all_files {
-                    let b = before.files.get(path).map_or(0, |v| v.len());
-                    let a = after.files.get(path).map_or(0, |v| v.len());
+                    let before_syms = before.files.get(path);
+                    let after_syms = after.files.get(path);
+                    let b = before_syms.map_or(0, |v| v.len());
+                    let a = after_syms.map_or(0, |v| v.len());
                     if b != a {
                         let display = path.strip_prefix(cwd).unwrap_or(path).display();
                         let diff = a as isize - b as isize;
-                        details.push(format!("  {display}: {b} -> {a} ({diff:+})"));
+                        let mut line = format!("  {display}: {b} -> {a} ({diff:+})");
+
+                        // Show which specific symbols were added or removed
+                        let before_names: HashSet<&str> = before_syms
+                            .map(|v| v.iter().map(|s| s.name.as_str()).collect())
+                            .unwrap_or_default();
+                        let after_names: HashSet<&str> = after_syms
+                            .map(|v| v.iter().map(|s| s.name.as_str()).collect())
+                            .unwrap_or_default();
+
+                        let removed: Vec<_> = before_syms
+                            .into_iter()
+                            .flat_map(|v| v.iter())
+                            .filter(|s| !after_names.contains(s.name.as_str()))
+                            .map(|s| format!("{} '{}'", s.kind, s.name))
+                            .collect();
+                        let added: Vec<_> = after_syms
+                            .into_iter()
+                            .flat_map(|v| v.iter())
+                            .filter(|s| !before_names.contains(s.name.as_str()))
+                            .map(|s| format!("{} '{}'", s.kind, s.name))
+                            .collect();
+
+                        if !removed.is_empty() {
+                            line.push_str(&format!(" removed: {}", removed.join(", ")));
+                        }
+                        if !added.is_empty() {
+                            line.push_str(&format!(" added: {}", added.join(", ")));
+                        }
+
+                        details.push(line);
                     }
                 }
 
@@ -485,7 +517,63 @@ fn my_test() {
         };
         let result = compare_snapshots(&before, &after, &check, Path::new("/tmp"));
         assert!(!result.passed);
-        assert!(result.message.contains("-2"));
+        assert!(
+            result.message.contains("-2"),
+            "should show count diff: {}",
+            result.message
+        );
+        assert!(
+            result.message.contains("function (attr=test)"),
+            "should include kind label with attr: {}",
+            result.message
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn compare_snapshots_mismatch_shows_symbol_names_and_kinds() {
+        let check = VerifyCheck::SymbolCount {
+            kind: "function".to_string(),
+            attr: None,
+        };
+        let before = SymbolSnapshot {
+            files: HashMap::from([(
+                PathBuf::from("/tmp/lib.rs"),
+                vec![
+                    SnappedSymbol {
+                        name: "alpha".into(),
+                        kind: symbols::SymbolKind::Function,
+                    },
+                    SnappedSymbol {
+                        name: "beta".into(),
+                        kind: symbols::SymbolKind::Function,
+                    },
+                ],
+            )]),
+            total: 2,
+        };
+        let after = SymbolSnapshot {
+            files: HashMap::from([(
+                PathBuf::from("/tmp/lib.rs"),
+                vec![SnappedSymbol {
+                    name: "alpha".into(),
+                    kind: symbols::SymbolKind::Function,
+                }],
+            )]),
+            total: 1,
+        };
+        let result = compare_snapshots(&before, &after, &check, Path::new("/tmp"));
+        assert!(!result.passed);
+        assert!(
+            result.message.contains("fn 'beta'"),
+            "should name the removed symbol with its kind: {}",
+            result.message
+        );
+        assert!(
+            result.message.contains("removed:"),
+            "should label the removed symbols: {}",
+            result.message
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix two issues found during MPI post-cycle gate audit: dead code with inaccurate justification (#1056) and weak test assertions that could mask regressions (#1057).

## Changes

### #1056: SnappedSymbol::kind dead code

`SnappedSymbol::kind` was populated in 4 places but never read. The comment claimed it was "retained for diagnostic messages in `compare_snapshots`" but `compare_snapshots()` only counted symbols per file, never showed their names or kinds.

**Fix**: Enhanced `compare_snapshots()` to show which specific symbols were added or removed with their kind (e.g. `fn 'beta' removed`), making the field genuinely useful. Removed the `#[allow(dead_code)]` annotation.

Closes #1056

### #1057: Weak test assertions

Strengthened fragile assertions across 6 files:
- TOML tests: `contains("c")` (matches any string with letter c) -> `contains("c = 3")`
- TOML tests: `contains("3")` -> `contains("1, 2, 3")` 
- Search matcher tests: bare `is_some()`/`is_none()` -> added descriptive failure messages
- AST tests: `contains("42")` -> `contains("    42")` (verifies indentation too)
- AST wrap test: `contains("}")` -> `ends_with` check for proper module closure
- AST split test: bare `assert!(result.is_ok())` -> `.unwrap()` for error visibility

Closes #1057

## Testing

All tests pass. `make check-fast` clean.