### PR TITLE
fix: remove dead code and misleading #[allow(dead_code)] in tx engine

### DIFF
--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -9,9 +9,8 @@
 //! ensuring a single execution engine for all surfaces.
 
 use crate::cli::global::GlobalFlags;
-use crate::exit;
 use crate::plan::{Operation, Plan, SCHEMA_VERSION};
-use crate::tx::output::{TxExecResult, build_full_tx_output};
+use crate::tx::output::TxExecResult;
 
 use std::path::Path;
 
@@ -30,12 +29,14 @@ pub struct ExecuteOptions<'a> {
 ///
 /// Contains everything a CLI command needs to decide on output:
 /// which files changed, what diffs were produced, and the exit code.
-#[allow(dead_code)] // Public API: fields used by library embedders and MCP
+///
+/// Used by CLI commands directly and by the library API via
+/// `crate::api::execute_as_edit_result()` (under the `files` feature).
+/// The module-level `allow(dead_code)` in `tx/mod.rs` handles the case
+/// where neither `cli` nor `files` is enabled.
 pub struct ExecutionResult {
     /// The collected execution result from the engine.
     pub(crate) exec_result: TxExecResult,
-    /// Pre-computed exit code.
-    pub exit_code: u8,
     /// Whether any effective changes were produced.
     pub has_changes: bool,
     /// Working directory used.
@@ -89,12 +90,6 @@ impl ExecutionResult {
         )
         .map_err(|e| anyhow::anyhow!("{}", e.message))
     }
-
-    /// Build a `TxOutput` report from this result.
-    #[allow(dead_code)] // Public API for library embedders
-    pub fn into_tx_output(mut self) -> crate::tx::TxOutput {
-        build_full_tx_output("success", &mut self.exec_result, &self.cwd)
-    }
 }
 
 /// Execute a single `Operation` through the unified engine.
@@ -118,7 +113,8 @@ pub fn execute_single(
 ///
 /// Similar to `execute_single` but for multi-operation batches that need
 /// atomicity (all succeed or none are committed).
-#[allow(dead_code)] // Public API for library embedders
+///
+/// Used by CLI commands (`tidy`, `ast rename`) for multi-file batches.
 pub fn execute_operations(
     operations: Vec<Operation>,
     options: ExecuteOptions<'_>,
@@ -179,7 +175,6 @@ pub fn execute_precomputed(
 
     ExecutionResult {
         exec_result,
-        exit_code: exit::SUCCESS,
         has_changes: !no_effective_changes,
         cwd,
     }
@@ -226,15 +221,9 @@ fn execute_plan_inner(
     let result = super::execute_and_collect(&plan, &cwd, options.global, true, true)?;
 
     let has_changes = !result.no_effective_changes;
-    let exit_code = if result.replace_no_matches {
-        exit::NO_MATCHES
-    } else {
-        exit::SUCCESS
-    };
 
     Ok(ExecutionResult {
         exec_result: result,
-        exit_code,
         has_changes,
         cwd,
     })
@@ -243,7 +232,6 @@ fn execute_plan_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::exit;
     use std::fs;
     use tempfile::TempDir;
 
@@ -268,7 +256,6 @@ mod tests {
 
         let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
         assert!(result.has_changes);
-        assert_eq!(result.exit_code, exit::SUCCESS);
 
         // File should not exist yet (not committed)
         assert!(!dir.path().join("new_file.txt").exists());
@@ -292,7 +279,6 @@ mod tests {
 
         let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
         assert!(result.has_changes);
-        assert_eq!(result.exit_code, exit::SUCCESS);
 
         // Still exists until commit
         assert!(file.exists());
@@ -358,7 +344,6 @@ mod tests {
 
         let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
         assert!(!result.has_changes);
-        assert_eq!(result.exit_code, exit::SUCCESS);
     }
 
     #[test]
@@ -425,24 +410,6 @@ mod tests {
     }
 
     #[test]
-    fn execute_single_into_tx_output() {
-        let dir = TempDir::new().unwrap();
-        let global = GlobalFlags::test_default();
-
-        let op = Operation::FileCreate {
-            path: "report.txt".to_string(),
-            content: "data\n".to_string(),
-            force: None,
-        };
-
-        let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
-        let output = result.into_tx_output();
-        assert!(output.ok);
-        assert_eq!(output.status, "success");
-        assert_eq!(output.files_created, 1);
-    }
-
-    #[test]
     fn execute_precomputed_commits_changes() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("test.txt");
@@ -457,7 +424,6 @@ mod tests {
 
         let result = execute_precomputed(changes, test_options(dir.path(), &global));
         assert!(result.has_changes);
-        assert_eq!(result.exit_code, exit::SUCCESS);
 
         // Not committed yet.
         assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -1,3 +1,14 @@
+// Most items in `tx` are consumed by CLI commands or the `files`-feature
+// library API (`crate::api`).  When neither feature is active the types
+// are still compiled (Plan lives here unconditionally) but have no
+// callers, so we suppress the warnings at the module level.
+//
+// NOTE: this blanket means `make test-library-hygiene` (which runs
+// clippy under `--no-default-features --features "ast,files"`) will
+// NOT flag genuinely dead items in this module.  Add per-item
+// `#[cfg(…)]` gates or targeted `#[allow(dead_code)]` with a
+// justification comment for items that are only used under a specific
+// feature set.
 #![cfg_attr(not(feature = "cli"), allow(dead_code, unused_imports))]
 
 pub mod engine;


### PR DESCRIPTION
## Summary

Removes dead code and misleading `#[allow(dead_code)]` annotations in `src/tx/engine.rs` that were masked by a blanket module-level `allow(dead_code)` in `tx/mod.rs`.

## Changes

### Dead code removed

- **`into_tx_output()` method**: zero production callers. Only one test called it. The library API uses `api::execution_result_to_edit_result()` instead. Method and its test removed.
- **`exit_code` field on `ExecutionResult`**: never read by any production code. All callers (`cmd/tidy.rs`, `cmd/replace.rs`, `cmd/ast.rs`, `api/mod.rs`) compute exit codes independently. Field and test assertions removed.

### Misleading annotations fixed

- **`ExecutionResult` struct**: removed `#[allow(dead_code)]` with comment "Public API: fields used by library embedders and MCP". The struct IS used (via `api/mod.rs` under the `files` feature), so the annotation was unnecessary. The `tx` module is `pub(crate)`, not externally visible.
- **`execute_operations()` function**: removed `#[allow(dead_code)]` with comment "Public API for library embedders". The function is used by CLI commands (`tidy`, `ast rename`), not by library embedders.

### Documentation added

- Added explanatory comment to the blanket `#![cfg_attr(not(feature = "cli"), allow(dead_code, unused_imports))]` in `tx/mod.rs` noting that it masks dead code warnings under `make test-library-hygiene` and that per-item gates should be used for feature-specific items.

## Root cause

The comments claimed "Public API for library embedders" but the `tx` module is `pub(crate)` (not reachable by external consumers). The module-level blanket `allow(dead_code)` suppressed all warnings when `cli` was disabled, so `make test-library-hygiene` (which runs under `--no-default-features --features "ast,files"`) could not catch genuinely dead items.

Closes #1059