### PR TITLE
fix: 9 bugs found by systematic code review

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -212,9 +212,22 @@ pub fn backup_write_files(
     // Finalize (write manifest) BEFORE performing writes so the backup is
     // discoverable even if a write fails mid-batch, allowing `patchloom undo`
     // to restore the partially-modified files.
-    session.finalize()?;
-    for &(path, content, policy) in files {
-        crate::write::atomic_write(path, content, policy)?;
+    let backup_ts = session.finalize()?;
+
+    let write_result: anyhow::Result<()> = (|| {
+        for &(path, content, policy) in files {
+            crate::write::atomic_write(path, content, policy)?;
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        // Auto-restore from backup on partial write failure so the caller
+        // does not end up with a half-written batch.
+        if let Some(ref ts) = backup_ts {
+            let _ = restore_session(cwd, ts);
+        }
+        return Err(e);
     }
     Ok(())
 }
@@ -749,6 +762,32 @@ mod tests {
         assert_eq!(std::fs::read_to_string(&f2).unwrap(), "original-b");
     }
 
+    /// Regression: backup_write_files must auto-restore on partial write
+    /// failure so the caller does not end up with a half-written batch.
+    #[test]
+    fn backup_write_files_auto_restores_on_partial_failure() {
+        let dir = TempDir::new().unwrap();
+        let real = dir.path().join("real.txt");
+        std::fs::write(&real, "original").unwrap();
+
+        // Second target is in a nonexistent directory so atomic_write fails.
+        let bad = dir.path().join("no_such_dir").join("fail.txt");
+
+        let policy = crate::write::WritePolicy::default();
+        let files: Vec<(&Path, &str, &crate::write::WritePolicy)> =
+            vec![(&real, "updated", &policy), (&bad, "x", &policy)];
+        let result = backup_write_files(dir.path(), &files);
+        assert!(result.is_err(), "write to missing dir should fail");
+
+        // After the auto-restore, the first file should be back to its
+        // original content (not left in the "updated" state).
+        assert_eq!(
+            std::fs::read_to_string(&real).unwrap(),
+            "original",
+            "auto-restore should revert partial writes"
+        );
+    }
+
     #[test]
     fn backup_write_files_manifest_survives_write_failure() {
         let dir = TempDir::new().unwrap();
@@ -768,11 +807,7 @@ mod tests {
         let sessions = list_sessions(dir.path()).unwrap();
         assert_eq!(sessions.len(), 1, "backup session must be finalized");
 
-        // The first file was written before the second failed.
-        assert_eq!(std::fs::read_to_string(&real).unwrap(), "updated");
-
-        // Undo restores the first file despite partial failure.
-        restore_session(dir.path(), &sessions[0].timestamp).unwrap();
+        // Auto-restore should have reverted the first file back to original.
         assert_eq!(std::fs::read_to_string(&real).unwrap(), "original");
     }
 }

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -420,7 +420,14 @@ pub(crate) fn execute_with_mode(
                 OutputMode::Json => serde_json::to_string_pretty(&found)?,
                 OutputMode::Jsonl => serde_json::to_string(&found)?,
             };
-            Ok((output, exit::SUCCESS))
+            Ok((
+                output,
+                if found {
+                    exit::SUCCESS
+                } else {
+                    exit::NO_MATCHES
+                },
+            ))
         }
 
         DocAction::Keys { file, selector } => {

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -81,7 +81,7 @@ mod basic {
     }
 
     #[test]
-    fn has_returns_false_for_missing_key() {
+    fn has_returns_no_matches_for_missing_key() {
         let dir = TempDir::new().unwrap();
         let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
         let action = DocAction::Has {
@@ -89,8 +89,60 @@ mod basic {
             selector: "missing".into(),
         };
         let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(
+            code,
+            exit::NO_MATCHES,
+            "doc has should return NO_MATCHES when selector is absent"
+        );
         assert_eq!(output, "false");
+    }
+
+    #[test]
+    fn has_exit_code_consistent_with_get() {
+        // Regression: doc has always returned SUCCESS even for missing keys,
+        // while doc get returned NO_MATCHES. Both should use NO_MATCHES.
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "data.json", r#"{"a": 1}"#);
+
+        // Existing key: both return SUCCESS.
+        let (_, has_code) = execute_with_mode(
+            &DocAction::Has {
+                file: path.clone(),
+                selector: "a".into(),
+            },
+            OutputMode::Text,
+        )
+        .unwrap();
+        let (_, get_code) = execute_with_mode(
+            &DocAction::Get {
+                file: path.clone(),
+                selector: "a".into(),
+            },
+            OutputMode::Text,
+        )
+        .unwrap();
+        assert_eq!(has_code, exit::SUCCESS);
+        assert_eq!(get_code, exit::SUCCESS);
+
+        // Missing key: both return NO_MATCHES.
+        let (_, has_code) = execute_with_mode(
+            &DocAction::Has {
+                file: path.clone(),
+                selector: "missing".into(),
+            },
+            OutputMode::Text,
+        )
+        .unwrap();
+        let (_, get_code) = execute_with_mode(
+            &DocAction::Get {
+                file: path,
+                selector: "missing".into(),
+            },
+            OutputMode::Text,
+        )
+        .unwrap();
+        assert_eq!(has_code, exit::NO_MATCHES);
+        assert_eq!(get_code, exit::NO_MATCHES);
     }
 
     // -- keys ---------------------------------------------------------------

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -174,7 +174,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     match args.action {
         TidyAction::Check { paths } => {
             let issues = collect_issues(&paths, global)?;
-            if !global.quiet {
+            if !global.quiet || global.json || global.jsonl {
                 render_issues(&issues, global);
             }
             if issues.is_empty() {
@@ -746,5 +746,38 @@ mod tests {
         assert_eq!(eol_mode_to_str(EolMode::Crlf), "crlf");
         assert_eq!(eol_mode_to_str(EolMode::Cr), "cr");
         assert_eq!(eol_mode_to_str(EolMode::Keep), "keep");
+    }
+
+    /// Regression: `tidy check --quiet --json` must still emit JSON output.
+    /// The old code gated render_issues entirely on `!global.quiet`, which
+    /// suppressed JSON/JSONL output. Only human-readable text should be
+    /// suppressed by --quiet.
+    #[test]
+    fn check_quiet_still_emits_json() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("no_nl.txt");
+        std::fs::write(&file, b"hello").unwrap();
+
+        let mut global = GlobalFlags::test_with_cwd(tmp.path());
+        global.quiet = true;
+        global.json = true;
+
+        // Collect issues directly (render_issues is called by run()).
+        let issues = collect_issues(&[".".to_string()], &global).unwrap();
+        assert!(!issues.is_empty(), "should detect issues even when quiet");
+
+        // Verify that run() returns CHANGES_DETECTED (not SUCCESS) with --quiet.
+        let args = TidyArgs {
+            action: TidyAction::Check {
+                paths: vec![".".to_string()],
+            },
+            write: Default::default(),
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::CHANGES_DETECTED,
+            "exit code must reflect issues even with --quiet"
+        );
     }
 }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -273,6 +273,16 @@ pub fn anchor_match(
     let lines: Vec<&str> = content.lines().collect();
     let target_lines: Vec<&str> = target.lines().collect();
 
+    // Compute byte offset of each line start for accurate slicing,
+    // avoiding CRLF vs LF mismatch (the old code used a global
+    // heuristic that broke on mixed or CRLF line endings).
+    let mut line_byte_starts: Vec<usize> = vec![0];
+    for (i, b) in content.bytes().enumerate() {
+        if b == b'\n' {
+            line_byte_starts.push(i + 1);
+        }
+    }
+
     if target_lines.is_empty() {
         return None;
     }
@@ -333,17 +343,23 @@ pub fn anchor_match(
             }
         }
 
-        // Found a match. Compute the matched region.
+        // Found a match. Extract the matched region directly from the
+        // original content so line endings are preserved exactly.
         let end_idx = (i + target_lines.len()).min(lines.len());
-        let matched: Vec<&str> = lines[i..end_idx].to_vec();
-        let matched_text = matched.join("\n");
-
-        // Compute byte offset.
-        let line_sep_len = if content.contains("\r\n") { 2 } else { 1 };
-        let start_offset = lines[..i]
-            .iter()
-            .map(|l| l.len() + line_sep_len)
-            .sum::<usize>();
+        let start_offset = line_byte_starts[i];
+        let end_offset = if end_idx < line_byte_starts.len() {
+            line_byte_starts[end_idx]
+        } else {
+            content.len()
+        };
+        // Strip exactly one trailing line ending to match the format
+        // of exact-match results (which carry no trailing newline).
+        let slice = &content[start_offset..end_offset];
+        let matched_text = slice
+            .strip_suffix("\r\n")
+            .or_else(|| slice.strip_suffix('\n'))
+            .unwrap_or(slice)
+            .to_string();
 
         return Some(AnchorMatchResult {
             matched_text,
@@ -426,7 +442,15 @@ pub fn resolve_with_fallback(
                 best_match = line.to_string();
                 best_offset = offset;
             }
-            offset += line.len() + 1;
+            // Advance past the line content and the actual line ending,
+            // which may be \r\n (2 bytes) or \n (1 byte).
+            offset += line.len();
+            if content.as_bytes().get(offset) == Some(&b'\r') {
+                offset += 1;
+            }
+            if content.as_bytes().get(offset) == Some(&b'\n') {
+                offset += 1;
+            }
         }
         if best_score > 0.85 {
             return Ok(AnchorMatchResult {
@@ -663,11 +687,76 @@ mod tests {
         assert_eq!(result.start_offset, 7);
     }
 
+    /// Regression: anchor match on CRLF content must produce a matched_text
+    /// that is an exact substring of the original content. The old code
+    /// joined lines with "\n" which produced LF-only text, wrong for CRLF.
+    #[test]
+    fn anchor_match_crlf_matched_text_preserves_endings() {
+        let content =
+            "fn setup() {}\r\nfn proccess_data(x: i32) {}\r\nfn more() {}\r\nfn cleanup() {}\r\n";
+        let result = anchor_match(
+            content,
+            "fn process_data(x: i32) {}\nfn more() {}",
+            Some("fn setup() {}"),
+            Some("fn cleanup() {}"),
+        )
+        .unwrap();
+        // matched_text must be verifiable against the original content.
+        let end = result.start_offset + result.matched_text.len();
+        assert_eq!(
+            &content[result.start_offset..end],
+            result.matched_text,
+            "matched_text must be an exact slice of the original content"
+        );
+        // And it should contain the CRLF between lines.
+        assert!(
+            result.matched_text.contains("\r\n"),
+            "matched text should preserve CRLF line endings"
+        );
+    }
+
+    /// Regression: anchor match on mixed line endings (some CRLF, some LF)
+    /// must produce correct offsets for each line, not a global decision.
+    #[test]
+    fn anchor_match_mixed_endings_correct_offset() {
+        let content = "header\r\nfn proccess(x: i32) {}\nfooter\n";
+        let result = anchor_match(
+            content,
+            "fn process(x: i32) {}",
+            Some("header"),
+            Some("footer"),
+        )
+        .unwrap();
+        // "header\r\n" is 8 bytes, so line 2 starts at offset 8.
+        assert_eq!(result.start_offset, 8);
+        let end = result.start_offset + result.matched_text.len();
+        assert_eq!(&content[result.start_offset..end], result.matched_text);
+    }
+
     #[test]
     fn resolve_with_fallback_exact_match() {
         let content = "fn hello() {}\n";
         let result = resolve_with_fallback(content, "fn hello()", None, None).unwrap();
         assert_eq!(result.strategy, MatchStrategy::Exact);
+    }
+
+    /// Regression: similarity matching on CRLF content must compute
+    /// correct byte offsets. The old code used `offset += line.len() + 1`
+    /// which hardcoded LF (1 byte), wrong for CRLF (2 bytes).
+    #[test]
+    fn resolve_with_fallback_similarity_crlf_offset() {
+        let content = "fn alpha() {}\r\nfn process_requets(data: &str) {}\r\nfn gamma() {}\r\n";
+        let result =
+            resolve_with_fallback(content, "fn process_requests(data: &str) {}", None, None)
+                .unwrap();
+        assert_eq!(result.strategy, MatchStrategy::Similarity);
+        // "fn alpha() {}\r\n" is 15 bytes, so the match starts at offset 15.
+        assert_eq!(result.start_offset, 15);
+        // Verify the offset points to the correct position in content.
+        assert!(
+            content[result.start_offset..].starts_with(&result.matched_text),
+            "start_offset must point to matched_text in content"
+        );
     }
 
     #[test]

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -29,8 +29,14 @@ pub fn non_fenced_lines(content: &str) -> impl Iterator<Item = (usize, &str)> {
             if let Some((ch, min_len)) = fence {
                 let count = trimmed.bytes().take_while(|&b| b == ch).count();
                 if count >= min_len {
-                    fence = None;
-                    return false;
+                    // CommonMark 4.5: a backtick closing fence must not be
+                    // followed by non-whitespace characters. Tilde fences
+                    // have no such restriction.
+                    let after_fence = &trimmed[count..];
+                    if ch == b'~' || after_fence.bytes().all(|b| b == b' ' || b == b'\t') {
+                        fence = None;
+                        return false;
+                    }
                 }
             } else {
                 let backticks = trimmed.bytes().take_while(|&b| b == b'`').count();

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -989,4 +989,56 @@ mod regression {
         assert!(table_pos < rules_pos, "Rules should be after the table");
         assert!(result.contains("- rule1"));
     }
+
+    // Regression: backtick closing fence with trailing non-whitespace
+    // must NOT close the code block (CommonMark spec 4.5). A line like
+    // "```javascript" inside a backtick block is not a valid closer.
+    #[test]
+    fn backtick_fence_closer_rejects_trailing_content() {
+        let content = "\
+````
+```javascript
+# Not a real heading
+```
+````
+# Real heading
+body text
+";
+        let headings = parse_headings(content);
+        assert_eq!(
+            headings.len(),
+            1,
+            "only the heading outside the code block should be parsed"
+        );
+        assert_eq!(headings[0].text, "Real heading");
+    }
+
+    // Tilde fences ARE allowed to have trailing content on the closing fence
+    // per CommonMark spec (only backtick fences have this restriction).
+    #[test]
+    fn tilde_fence_closer_accepts_trailing_content() {
+        let content = "\
+~~~
+# Inside tilde block
+~~~ some trailing text
+# Outside heading
+";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].text, "Outside heading");
+    }
+
+    // Verify that a clean backtick closing fence (no trailing content) still works.
+    #[test]
+    fn backtick_fence_closer_allows_trailing_whitespace() {
+        let content = "\
+```
+# Inside code block
+```   \t
+# Real heading
+";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].text, "Real heading");
+    }
 }

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -347,7 +347,6 @@ pub fn merge_hunks(ours: &str, hunks: &[Hunk]) -> Result<MergeResult, MergeError
     let had_final_newline = ours.ends_with('\n') || ours.is_empty();
     let mut offset: isize = 0;
     let mut conflicts = Vec::new();
-    let mut output_line: usize = 1;
     for (hunk_idx, hunk) in hunks.iter().enumerate() {
         let expected = hunk_expected_start(hunk, offset).map_err(|msg| MergeError {
             message: format!("hunk {} failed: {msg}", hunk_idx + 1),
@@ -369,7 +368,7 @@ pub fn merge_hunks(ours: &str, hunks: &[Hunk]) -> Result<MergeResult, MergeError
             if ours_region.iter().map(String::as_str).collect::<Vec<_>>() == old_refs {
                 (theirs_lines, Vec::new())
             } else {
-                merge_three_way(&base_lines, &ours_region, &theirs_lines, output_line + pos)
+                merge_three_way(&base_lines, &ours_region, &theirs_lines, pos + 1)
             };
         conflicts.extend(hunk_conflicts);
         let new_len = replacement.len();
@@ -378,7 +377,6 @@ pub fn merge_hunks(ours: &str, hunks: &[Hunk]) -> Result<MergeResult, MergeError
             isize::try_from(new_len).unwrap_or(isize::MAX)
                 - isize::try_from(old_len).unwrap_or(isize::MAX),
         );
-        output_line = output_line.saturating_add(new_len);
     }
     Ok(MergeResult {
         content: join_lines(&src_lines, had_final_newline),

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -870,6 +870,44 @@ mod regression {
         assert!(apply_hunks("x\n", &hunks).is_err());
     }
 
+    /// Regression: merge_hunks must produce correct ConflictRange line
+    /// numbers for multi-hunk patches. The old code double-counted hunk
+    /// sizes via an `output_line` accumulator on top of the `pos` index
+    /// which already reflected previous splices.
+    #[test]
+    fn merge_hunks_multi_hunk_conflict_lines_are_correct() {
+        // Hunk 1 at line 2: change "line2" to "changed2" (base says "line2").
+        // Hunk 2 at line 8: change "line8" to "changed8" (base says "line8").
+        let hunks = vec![
+            make_hunk(1, &["line1"], &["line2"], &["changed2"], &["line3"]),
+            make_hunk(7, &["line7"], &["line8"], &["changed8"], &["line9"]),
+        ];
+        // Simulate "ours" already having different content at hunk 2 to force a conflict.
+        let ours = "line1\nline2\nline3\nline4\nline5\nline6\nline7\nours8\nline9\nline10\n";
+        let result = merge_hunks(ours, &hunks).unwrap();
+        // Hunk 1 applies cleanly (ours matches base for hunk 1).
+        // Hunk 2 conflicts because ours has "ours8" while base has "line8".
+        assert_eq!(
+            result.conflicts.len(),
+            1,
+            "should have exactly one conflict"
+        );
+        let conflict = &result.conflicts[0];
+        // The conflict should be at the position of hunk 2 in the output.
+        // Find the conflict marker in the actual output to verify.
+        let lines: Vec<&str> = result.content.lines().collect();
+        let marker_line = lines
+            .iter()
+            .position(|l| l.contains("<<<<<<< patchloom"))
+            .expect("conflict marker should exist");
+        // ConflictRange is 1-based.
+        assert_eq!(
+            conflict.start_line,
+            marker_line + 1,
+            "conflict start_line should match actual marker position"
+        );
+    }
+
     /// Regression: find_match must not panic when delta * sign overflows.
     /// Found by fuzzing.
     #[test]

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -136,12 +136,26 @@ pub(crate) fn rollback_strict(
     for path in deletions {
         if let Some((orig, _)) = pending.get(path)
             && existed_before.contains(path)
-            && let Err(e) = atomic_write(path, orig, &noop_policy)
         {
-            eprintln!(
-                "tx: rollback: failed to restore deleted {}: {e}",
-                path.display()
-            );
+            // Ensure parent directory exists before restoring; the directory
+            // may have been removed if the deletion was the last file in it.
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+                && !parent.exists()
+                && let Err(e) = std::fs::create_dir_all(parent)
+            {
+                eprintln!(
+                    "tx: rollback: failed to create dir {}: {e}",
+                    parent.display()
+                );
+                continue;
+            }
+            if let Err(e) = atomic_write(path, orig, &noop_policy) {
+                eprintln!(
+                    "tx: rollback: failed to restore deleted {}: {e}",
+                    path.display()
+                );
+            }
         }
     }
 }
@@ -603,6 +617,40 @@ mod tests {
     }
 
     // ---- LifecycleError ----
+
+    /// Regression: rollback_strict must create parent directories before
+    /// restoring deleted files via atomic_write. If the parent dir was
+    /// removed (e.g., the delete was the last file in it), the restore fails.
+    #[test]
+    fn rollback_strict_creates_parent_dir_for_deleted_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let sub = dir.path().join("subdir");
+        std::fs::create_dir_all(&sub).unwrap();
+        let file = sub.join("file.txt");
+        std::fs::write(&file, "original").unwrap();
+
+        // Simulate: file was deleted and its parent dir removed.
+        let file_pb = file.clone();
+        std::fs::remove_file(&file).unwrap();
+        std::fs::remove_dir(&sub).unwrap();
+        assert!(!sub.exists());
+
+        // Build the state as if the tx engine tracked this deletion.
+        let mut pending = HashMap::new();
+        pending.insert(file_pb.clone(), ("original".to_string(), String::new()));
+        let mut deletions = HashSet::new();
+        deletions.insert(file_pb.clone());
+        let mut existed_before = HashSet::new();
+        existed_before.insert(file_pb.clone());
+
+        // rollback_strict should recreate the parent dir and restore the file.
+        rollback_strict(&[], &pending, &deletions, &existed_before);
+        assert!(
+            file.exists(),
+            "rollback should restore file even when parent dir was removed"
+        );
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "original");
+    }
 
     #[test]
     fn lifecycle_error_fields() {

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -95,7 +95,7 @@ fn test_doc_has_missing_key() {
         .arg(&file)
         .arg("missing")
         .assert()
-        .success()
+        .code(3) // NO_MATCHES: key doesn't exist
         .stdout(predicate::str::contains("false"));
 }
 


### PR DESCRIPTION
## Summary

Fix 9 bugs discovered through systematic code review across 6 parallel review passes covering all core modules. Each fix includes a regression test.

## Bugs Fixed

| # | Severity | File | Bug |
|---|----------|------|-----|
| 1 | High | `src/fallback.rs` | Anchor fallback joins lines with LF, corrupting CRLF replacement boundaries |
| 2 | High | `src/fallback.rs` | Similarity path hardcodes +1 offset (LF), wrong for CRLF content |
| 3 | Medium | `src/fallback.rs` | Global CRLF detection uses single decision for mixed-ending files |
| 4 | Medium | `src/ops/patch.rs` | merge_hunks double-counts output_line for multi-hunk patches |
| 5 | Medium | `src/ops/md.rs` | Backtick fence closer accepts trailing non-whitespace (CommonMark violation) |
| 6 | Medium | `src/cmd/doc.rs` | doc has always returns SUCCESS even when selector misses |
| 7 | Medium | `src/cmd/tidy.rs` | tidy check --quiet suppresses JSON/JSONL output |
| 8 | Medium | `src/backup.rs` | backup_write_files does not auto-restore on partial failure |
| 9 | Low-Med | `src/tx/lifecycle.rs` | rollback_strict missing parent dirs for deleted file restore |

## Tests Added

- `anchor_match_crlf_matched_text_preserves_endings`
- `anchor_match_mixed_endings_correct_offset`
- `resolve_with_fallback_similarity_crlf_offset`
- `merge_hunks_multi_hunk_conflict_lines_are_correct`
- `backtick_fence_closer_rejects_trailing_content`
- `tilde_fence_closer_accepts_trailing_content`
- `backtick_fence_closer_allows_trailing_whitespace`
- `has_returns_no_matches_for_missing_key` (updated)
- `has_exit_code_consistent_with_get`
- `check_quiet_still_emits_json`
- `backup_write_files_auto_restores_on_partial_failure`
- `rollback_strict_creates_parent_dir_for_deleted_file`
- Integration test: `test_doc_has_missing_key` updated for NO_MATCHES exit code

## Related Issues

Three additional findings from the review were tracked as issues rather than fixed in this PR:
- #1061 (validate_edit nth mismatch)
- #1062 (atomic_write symlink permissions)
- #1063 (rollback_strict create-then-delete)