### PR TITLE
fix: validate_edit nth, atomic_write symlink perms, rollback create-then-delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2300%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2400%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-2300+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+2400+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -275,8 +275,13 @@ impl PatchloomService {
                 let abs = svc.cwd().join(&p.path);
                 if let Ok(content) = std::fs::read_to_string(&abs) {
                     let to_str = p.to.as_deref().unwrap_or("");
-                    let result =
-                        crate::fallback::validate_edit(&content, &p.from, to_str, Some(&p.path));
+                    let result = crate::fallback::validate_edit_nth(
+                        &content,
+                        &p.from,
+                        to_str,
+                        Some(&p.path),
+                        p.nth,
+                    );
                     let mut warnings = result.warnings;
                     if !result.valid {
                         warnings.extend(result.errors);

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -46,6 +46,16 @@
 //! let result = validate_edit(json, "value", "new_value", Some("config.json"));
 //! assert!(result.valid);
 //! ```
+//!
+//! Validate with `--nth` semantics (only replace the Nth occurrence):
+//!
+//! ```rust
+//! use patchloom::fallback::validate_edit_nth;
+//!
+//! let json = r#"{"a": "val", "b": "val"}"#;
+//! let result = validate_edit_nth(json, "val", "new", Some("data.json"), Some(1));
+//! assert!(result.valid);
+//! ```
 
 use serde::{Deserialize, Serialize};
 
@@ -120,11 +130,26 @@ pub struct ValidationResult {
 ///
 /// Performs the replacement in memory and checks basic structural validity
 /// of the resulting content (JSON, YAML, TOML validation for structured files).
+///
+/// When `nth` is `Some(n)`, only the Nth (1-based) occurrence is replaced,
+/// matching the behavior of the replace command's `--nth` flag. When `None`,
+/// all occurrences are replaced.
 pub fn validate_edit(
     content: &str,
     from: &str,
     to: &str,
     file_path: Option<&str>,
+) -> ValidationResult {
+    validate_edit_nth(content, from, to, file_path, None)
+}
+
+/// Like [`validate_edit`] but with an explicit `nth` occurrence parameter.
+pub fn validate_edit_nth(
+    content: &str,
+    from: &str,
+    to: &str,
+    file_path: Option<&str>,
+    nth: Option<usize>,
 ) -> ValidationResult {
     if from.is_empty() {
         return ValidationResult {
@@ -145,7 +170,32 @@ pub fn validate_edit(
         };
     }
 
-    let new_content = content.replace(from, to);
+    let new_content = match nth {
+        Some(n) => {
+            // Replace only the Nth (1-based) occurrence.
+            let mut count = 0usize;
+            let mut result = String::with_capacity(content.len());
+            let mut remaining = content;
+            while let Some(pos) = remaining.find(from) {
+                count += 1;
+                if count == n {
+                    result.push_str(&remaining[..pos]);
+                    result.push_str(to);
+                    result.push_str(&remaining[pos + from.len()..]);
+                    break;
+                }
+                result.push_str(&remaining[..pos + from.len()]);
+                remaining = &remaining[pos + from.len()..];
+            }
+            if count < n {
+                // Nth occurrence not found; use content as-is.
+                content.to_string()
+            } else {
+                result
+            }
+        }
+        None => content.replace(from, to),
+    };
     let mut errors = Vec::new();
     let mut warnings = Vec::new();
 
@@ -939,6 +989,40 @@ mod tests {
             "expected YAML error, got: {}",
             result.errors[0]
         );
+    }
+
+    // -- validate_edit_nth (#1061) -------------------------------------------
+
+    #[test]
+    fn validate_edit_nth_replaces_only_nth_occurrence() {
+        // Two occurrences of "val"; replacing only the 1st is valid JSON.
+        let json = r#"{"a": "val", "b": "val"}"#;
+        let result = validate_edit_nth(json, "val", "new", Some("data.json"), Some(1));
+        assert!(result.valid, "nth=1 should produce valid JSON");
+    }
+
+    #[test]
+    fn validate_edit_nth_none_replaces_all() {
+        // nth=None replaces all occurrences (same as validate_edit).
+        let content = "aXbXc";
+        let result = validate_edit_nth(content, "X", "Y", None, None);
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn validate_edit_nth_out_of_range() {
+        // nth=5 but only 2 occurrences: content is unchanged, still valid.
+        let content = "aXbXc";
+        let result = validate_edit_nth(content, "X", "Y", None, Some(5));
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn validate_edit_nth_detects_invalid_json_for_single_occurrence() {
+        // Replacing only the 1st "value" with a broken fragment is invalid.
+        let json = r#"{"a": "value", "b": "value"}"#;
+        let result = validate_edit_nth(json, "\"value\"", "broken}", Some("config.json"), Some(1));
+        assert!(!result.valid, "nth=1 should detect broken JSON");
     }
 
     // -- anchor_match and resolve_with_fallback edge cases (#978) -----------

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -125,13 +125,17 @@ pub(crate) fn rollback_strict(
 ) {
     let noop_policy = WritePolicy::default();
     for (path, original, _) in changes {
-        if !existed_before.contains(path) && !deletions.contains(path) {
-            if let Err(e) = std::fs::remove_file(path) {
-                eprintln!("tx: rollback: failed to remove {}: {e}", path.display());
+        if !existed_before.contains(path) {
+            // File was created during this tx. Whether it was also deleted
+            // does not matter: it should not exist after rollback.
+            let _ = std::fs::remove_file(path);
+        } else if !deletions.contains(path) {
+            // File existed before and was modified (not deleted): restore.
+            if let Err(e) = atomic_write(path, original, &noop_policy) {
+                eprintln!("tx: rollback: failed to restore {}: {e}", path.display());
             }
-        } else if let Err(e) = atomic_write(path, original, &noop_policy) {
-            eprintln!("tx: rollback: failed to restore {}: {e}", path.display());
         }
+        // If existed_before AND in deletions: handled by the deletions loop below.
     }
     for path in deletions {
         if let Some((orig, _)) = pending.get(path)
@@ -649,6 +653,69 @@ mod tests {
             file.exists(),
             "rollback should restore file even when parent dir was removed"
         );
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "original");
+    }
+
+    /// Regression (#1063): a file created and then deleted in the same tx
+    /// must not exist after rollback (it did not exist before the tx).
+    #[test]
+    fn rollback_strict_create_then_delete_leaves_no_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("ephemeral.txt");
+
+        // Simulate: the tx engine created this file and then deleted it.
+        // The changes list contains an entry with empty original (did not
+        // exist before) and the deletions set also contains it.
+        let file_pb = file.clone();
+        let changes = vec![(file_pb.clone(), String::new(), "hello".to_string())];
+        let pending = HashMap::new();
+        let mut deletions = HashSet::new();
+        deletions.insert(file_pb.clone());
+        let existed_before = HashSet::new(); // did NOT exist before tx
+
+        // Create the file on disk to simulate mid-tx state.
+        std::fs::write(&file, "hello").unwrap();
+
+        rollback_strict(&changes, &pending, &deletions, &existed_before);
+
+        assert!(
+            !file.exists(),
+            "create-then-delete file must not exist after rollback"
+        );
+    }
+
+    /// Ensure rollback_strict still restores modified-then-deleted files
+    /// (files that existed before the tx, were modified, then deleted).
+    #[test]
+    fn rollback_strict_modify_then_delete_restores_original() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("existing.txt");
+        std::fs::write(&file, "original").unwrap();
+
+        let file_pb = file.clone();
+        // File was modified (shows up in changes) and also deleted.
+        let changes = vec![(
+            file_pb.clone(),
+            "original".to_string(),
+            "modified".to_string(),
+        )];
+        let mut pending = HashMap::new();
+        pending.insert(
+            file_pb.clone(),
+            ("original".to_string(), "modified".to_string()),
+        );
+        let mut deletions = HashSet::new();
+        deletions.insert(file_pb.clone());
+        let mut existed_before = HashSet::new();
+        existed_before.insert(file_pb.clone());
+
+        // Simulate mid-tx state: file was deleted.
+        std::fs::remove_file(&file).unwrap();
+
+        rollback_strict(&changes, &pending, &deletions, &existed_before);
+
+        // The deletions loop should restore the original.
+        assert!(file.exists(), "deleted file should be restored");
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "original");
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -647,7 +647,14 @@ pub fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow:
     let final_content = apply_policy(content, policy);
 
     // Capture the original file's permissions before overwriting.
-    let original_perms = std::fs::metadata(path).ok().map(|m| m.permissions());
+    // Use symlink_metadata so that when `path` is a symlink we get the
+    // symlink entry's metadata, not the target's. persist() replaces the
+    // path entry (the symlink) with a regular file, so carrying over the
+    // target's permissions would be wrong.
+    let original_perms = std::fs::symlink_metadata(path)
+        .ok()
+        .filter(|m| !m.file_type().is_symlink())
+        .map(|m| m.permissions());
 
     let parent = path
         .parent()

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -933,4 +933,37 @@ mod format_preservation {
             "permissions should be preserved after atomic_write"
         );
     }
+
+    /// Regression (#1062): when `path` is a symlink, atomic_write should not
+    /// carry over the symlink target's permissions to the new regular file.
+    #[test]
+    #[cfg(unix)]
+    fn atomic_write_symlink_does_not_carry_target_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.txt");
+        fs::write(&target, "content").unwrap();
+        // Use 0o444 (read-only) which is distinctive from default tempfile
+        // permissions (typically 0o600).
+        fs::set_permissions(&target, std::fs::Permissions::from_mode(0o444)).unwrap();
+
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let policy = WritePolicy::default();
+        atomic_write(&link, "new content", &policy).unwrap();
+
+        // The link should now be a regular file, not a symlink.
+        assert!(!link.symlink_metadata().unwrap().file_type().is_symlink());
+        // The original target should be untouched.
+        assert_eq!(fs::read_to_string(&target).unwrap(), "content");
+        // The new file should NOT have the target's 0o444 permissions forced
+        // on it; it should have the default tempfile permissions instead.
+        let mode = fs::metadata(&link).unwrap().permissions().mode() & 0o777;
+        assert_ne!(
+            mode, 0o444,
+            "symlink target permissions should not be carried over"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Three bug fixes for issues found during code review:

### 1. `validate_edit()` replaces all occurrences but actual edit may only replace one (`--nth`)

`validate_edit()` called `content.replace(from, to)` which replaces every occurrence. The actual edit engine respects `--nth`, so validation could produce false negatives (spurious warnings) or false positives (missed warnings).

**Fix:** Added `validate_edit_nth()` with an optional `nth` parameter. The MCP `replace_text` handler now passes `p.nth` through to validation.

### 2. `atomic_write()` captures symlink target permissions instead of symlink-path permissions

`std::fs::metadata()` follows symlinks, but `NamedTempFile::persist()` replaces the symlink entry itself. This caused the new regular file to inherit the symlink target's permissions.

**Fix:** Use `symlink_metadata()` and skip permission transfer entirely when the path is a symlink, since the file type changes fundamentally.

### 3. `rollback_strict` writes empty file for create-then-delete in same transaction

When a file was created and then deleted in the same transaction, rollback would write an empty file (the empty original content) instead of removing it.

**Fix:** Simplified the condition: files not in `existed_before` are always removed on rollback, regardless of whether they appear in `deletions`.

## Tests

- 4 new unit tests for `validate_edit_nth` (nth replaces only Nth occurrence, nth=None replaces all, nth out of range, nth detects invalid JSON)
- 1 new unit test for symlink permission handling
- 2 new unit tests for rollback (create-then-delete leaves no file, modify-then-delete restores original)
- All 1608 unit tests pass, all 786 integration tests pass, all 10 PTY tests pass

Closes #1061
Closes #1062
Closes #1063