### PR TITLE
fix: 5 bugs found by code audit with regression tests

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -395,10 +395,10 @@ pub fn format_search_results(results: &[SearchResult], as_json: bool) -> String 
         }
     } else {
         for r in results {
-            let _ = writeln!(out, "{}:{}: {}", r.path.display(), r.line_number, r.line);
             for ctx in &r.context_before {
                 let _ = writeln!(out, "  {}", ctx);
             }
+            let _ = writeln!(out, "{}:{}: {}", r.path.display(), r.line_number, r.line);
             for ctx in &r.context_after {
                 let _ = writeln!(out, "  {}", ctx);
             }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1840,6 +1840,32 @@ fn search_format_results_human_and_json() {
     assert!(js.contains("\"column\"") || js.contains("column"));
 }
 
+/// Regression: format_search_results must print context_before lines
+/// BEFORE the match line, not after.
+#[test]
+fn search_format_results_context_before_appears_before_match() {
+    let results = vec![SearchResult {
+        path: std::path::PathBuf::from("file.rs"),
+        line_number: 5,
+        line: "fn handle_error()".to_string(),
+        column: 0,
+        context_before: vec!["fn validate_input() {".to_string()],
+        context_after: vec!["    Ok(())".to_string()],
+    }];
+    let txt = format_search_results(&results, false);
+    let before_pos = txt.find("validate_input").expect("context_before missing");
+    let match_pos = txt.find("handle_error").expect("match line missing");
+    let after_pos = txt.find("Ok(())").expect("context_after missing");
+    assert!(
+        before_pos < match_pos,
+        "context_before must appear before match line"
+    );
+    assert!(
+        match_pos < after_pos,
+        "context_after must appear after match line"
+    );
+}
+
 #[test]
 #[cfg(any(feature = "cli", feature = "files"))]
 fn search_multiline_literal_auto_escapes_metacharacters() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -173,7 +173,7 @@ pub fn apply_config(global: &mut crate::cli::global::GlobalFlags, config: &Proje
 
 fn invalid_normalize_eol_warning(invalid: &str) -> String {
     format!(
-        "warning: invalid write_policy.normalize_eol value {invalid:?}; expected \"lf\" or \"crlf\""
+        "warning: invalid write_policy.normalize_eol value {invalid:?}; expected \"lf\", \"crlf\", or \"cr\""
     )
 }
 
@@ -438,6 +438,7 @@ color = "always"
         assert!(warning.contains("CRLF"));
         assert!(warning.contains("\"lf\""));
         assert!(warning.contains("\"crlf\""));
+        assert!(warning.contains("\"cr\""));
     }
 
     #[test]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -171,6 +171,13 @@ pub fn validate_edit_nth(
     }
 
     let new_content = match nth {
+        Some(0) => {
+            return ValidationResult {
+                valid: false,
+                errors: vec!["nth must be >= 1 (1-based indexing)".into()],
+                warnings: vec![],
+            };
+        }
         Some(n) => {
             // Replace only the Nth (1-based) occurrence.
             let mut count = 0usize;
@@ -1015,6 +1022,15 @@ mod tests {
         let content = "aXbXc";
         let result = validate_edit_nth(content, "X", "Y", None, Some(5));
         assert!(result.valid);
+    }
+
+    #[test]
+    fn validate_edit_nth_zero_rejected() {
+        // nth=0 is invalid (1-based indexing); must not truncate content.
+        let content = r#"{"a": "val"}"#;
+        let result = validate_edit_nth(content, "val", "X", Some("f.json"), Some(0));
+        assert!(!result.valid);
+        assert!(result.errors[0].contains("nth must be >= 1"));
     }
 
     #[test]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -588,6 +588,9 @@ impl Operation {
                 | Operation::PatchApply { .. }
                 | Operation::FileAppend { .. }
                 | Operation::FilePrepend { .. }
+                | Operation::FileCreate { .. }
+                | Operation::FileDelete { .. }
+                | Operation::FileRename { .. }
                 | Operation::Read { .. }
                 | Operation::Search { .. }
                 | Operation::MdLintAgents { .. }
@@ -1333,5 +1336,38 @@ mod tests {
         let plan = parse_plan(set_json).unwrap();
         let (_, mutation) = op_to_doc_mutation(&plan.operations[0]).unwrap();
         assert!(matches!(mutation, DocMutation::Set { .. }));
+    }
+
+    /// Regression: FileCreate, FileDelete, and FileRename must trigger a doc
+    /// cache flush, otherwise a preceding doc.set can be silently undone.
+    #[test]
+    fn needs_doc_flush_includes_file_create_delete_rename() {
+        let create = Operation::FileCreate {
+            path: "f.json".into(),
+            content: "{}".into(),
+            force: Some(false),
+        };
+        assert!(
+            create.needs_doc_flush(),
+            "FileCreate must trigger doc flush"
+        );
+
+        let delete = Operation::FileDelete {
+            path: "f.json".into(),
+        };
+        assert!(
+            delete.needs_doc_flush(),
+            "FileDelete must trigger doc flush"
+        );
+
+        let rename = Operation::FileRename {
+            from: "a.json".into(),
+            to: "b.json".into(),
+            force: false,
+        };
+        assert!(
+            rename.needs_doc_flush(),
+            "FileRename must trigger doc flush"
+        );
     }
 }

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -314,10 +314,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             if file_path.exists() && !file_path.is_file() {
                 anyhow::bail!("target is not a file: {path}");
             }
-            if !tx.deletions.contains(&file_path)
-                && !file_path.exists()
-                && !tx.pending.contains_key(&file_path)
-            {
+            if tx.deletions.contains(&file_path) {
+                anyhow::bail!("file was deleted earlier in this transaction: {path}");
+            }
+            if !file_path.exists() && !tx.pending.contains_key(&file_path) {
                 anyhow::bail!("file does not exist: {path}");
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
@@ -330,10 +330,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             if file_path.exists() && !file_path.is_file() {
                 anyhow::bail!("target is not a file: {path}");
             }
-            if !tx.deletions.contains(&file_path)
-                && !file_path.exists()
-                && !tx.pending.contains_key(&file_path)
-            {
+            if tx.deletions.contains(&file_path) {
+                anyhow::bail!("file was deleted earlier in this transaction: {path}");
+            }
+            if !file_path.exists() && !tx.pending.contains_key(&file_path) {
                 anyhow::bail!("file does not exist: {path}");
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
@@ -1360,5 +1360,98 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
         assert!(op_needs_doc_flush(&op));
+    }
+
+    /// Regression: appending to a file deleted earlier in the same tx must
+    /// fail, not silently resurrect the file.
+    #[test]
+    fn file_append_to_deleted_file_errors() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("victim.txt");
+        std::fs::write(&file, "original").unwrap();
+
+        let mut pending = HashMap::new();
+        let mut existed_before = HashSet::new();
+        let mut deletions = HashSet::new();
+        let mut doc_cache = HashMap::new();
+        let mut tx_reads = Vec::new();
+        let mut tx_searches = Vec::new();
+        let mut tx_lints = Vec::new();
+
+        // Simulate: file was loaded and then deleted in this tx.
+        let _ = read_file_content(&mut pending, &mut existed_before, &file).unwrap();
+        deletions.insert(file.clone());
+
+        let mut tx = TxState {
+            cwd: dir.path(),
+            pending: &mut pending,
+            existed_before: &mut existed_before,
+            deletions: &mut deletions,
+            doc_cache: &mut doc_cache,
+            tx_reads: &mut tx_reads,
+            tx_searches: &mut tx_searches,
+            tx_lints: &mut tx_lints,
+            replace_hint: None,
+            quiet: false,
+            structured: false,
+        };
+
+        let op = Operation::FileAppend {
+            path: "victim.txt".into(),
+            content: "new stuff".into(),
+        };
+        let result = execute_file_op(&op, &mut tx);
+        assert!(
+            result.is_err(),
+            "append to deleted file should error, not resurrect"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("deleted earlier"),
+            "error message should mention deletion: {msg}"
+        );
+    }
+
+    /// Same regression for prepend.
+    #[test]
+    fn file_prepend_to_deleted_file_errors() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("victim.txt");
+        std::fs::write(&file, "original").unwrap();
+
+        let mut pending = HashMap::new();
+        let mut existed_before = HashSet::new();
+        let mut deletions = HashSet::new();
+        let mut doc_cache = HashMap::new();
+        let mut tx_reads = Vec::new();
+        let mut tx_searches = Vec::new();
+        let mut tx_lints = Vec::new();
+
+        let _ = read_file_content(&mut pending, &mut existed_before, &file).unwrap();
+        deletions.insert(file.clone());
+
+        let mut tx = TxState {
+            cwd: dir.path(),
+            pending: &mut pending,
+            existed_before: &mut existed_before,
+            deletions: &mut deletions,
+            doc_cache: &mut doc_cache,
+            tx_reads: &mut tx_reads,
+            tx_searches: &mut tx_searches,
+            tx_lints: &mut tx_lints,
+            replace_hint: None,
+            quiet: false,
+            structured: false,
+        };
+
+        let op = Operation::FilePrepend {
+            path: "victim.txt".into(),
+            content: "prefix".into(),
+        };
+        let result = execute_file_op(&op, &mut tx);
+        assert!(
+            result.is_err(),
+            "prepend to deleted file should error, not resurrect"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Five bugs discovered through systematic code review, each with a targeted regression test.

### Fixes

| # | Bug | File | Impact |
|---|-----|------|--------|
| 1 | `context_before` lines printed after match line | `src/api/search.rs` | Search context output was inverted |
| 2 | `needs_doc_flush` missing file operation variants | `src/plan.rs` | Doc cache could silently undo file creates/deletes/renames |
| 3 | `normalize_eol` warning omitted valid `cr` value | `src/config.rs` | Warning message was misleading |
| 4 | `validate_edit_nth(0)` produced truncated content | `src/fallback.rs` | Zero index silently corrupted output |
| 5 | `FileAppend/FilePrepend` to deleted file silently resurrected it | `src/tx/execute.rs` | Transaction could resurrect deleted files |

### Testing

Each fix includes a targeted regression test. All existing tests pass.

Closes #1066
Closes #1067
Closes #1068
Closes #1069
Closes #1070