### PR TITLE
fix: 5 bugs found by code audit round 2 with regression tests

### DIFF
--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -369,8 +369,13 @@ fn serialize_block_entries(entries: &[serde_json::Value], indent: &str) -> anyho
             serde_json::Value::String(s) => {
                 out.push_str(indent);
                 out.push_str("- ");
-                // Quote strings that need it.
-                if needs_yaml_quoting(s) {
+                // Quote strings that need it. Use double-quoting for strings
+                // containing newlines because YAML single-quoted scalars fold
+                // line breaks into spaces, corrupting the data.
+                if s.contains('\n') {
+                    let escaped = serde_json::to_string(s).expect("JSON string");
+                    out.push_str(&escaped);
+                } else if needs_yaml_quoting(s) {
                     out.push_str(&format!("'{}'", s.replace('\'', "''")));
                 } else {
                     out.push_str(s);
@@ -423,6 +428,11 @@ pub fn needs_yaml_quoting(s: &str) -> bool {
     }
     // Trailing colon makes the value look like a mapping key (e.g., "host:").
     if s.ends_with(':') {
+        return true;
+    }
+    // "- " at the start looks like a block sequence entry when emitted
+    // inside a block sequence context (e.g., `- - item` is a nested sequence).
+    if s.starts_with("- ") || s == "-" {
         return true;
     }
     // YAML tag indicator (e.g., "!important", "!!str").
@@ -637,6 +647,32 @@ mod tests {
         assert!(!needs_yaml_quoting("hello"));
         assert!(!needs_yaml_quoting("foo-bar_baz"));
         assert!(!needs_yaml_quoting("http://example.com:8080/path"));
+    }
+
+    #[test]
+    fn needs_quoting_dash_space_prefix() {
+        // "- item" at the start of a block sequence entry produces `- - item`
+        // which YAML parses as a nested sequence, not a string.
+        assert!(needs_yaml_quoting("- item"));
+        assert!(needs_yaml_quoting("- "));
+        assert!(needs_yaml_quoting("-")); // bare dash is also ambiguous
+        // Plain dash in the middle or end is fine.
+        assert!(!needs_yaml_quoting("foo-bar"));
+        assert!(!needs_yaml_quoting("a-"));
+    }
+
+    #[test]
+    fn serialize_string_with_newline_uses_double_quote() {
+        use serde_json::json;
+        let entries = vec![json!("hello\nworld")];
+        let result = serialize_block_entries(&entries, "").unwrap();
+        // Must use double-quoting to preserve the newline.
+        assert!(
+            result.contains('"'),
+            "expected double-quoted string for newline, got: {result}"
+        );
+        let parsed: Vec<serde_json::Value> = serde_yaml_ng::from_str(&result).unwrap();
+        assert_eq!(parsed, vec![json!("hello\nworld")]);
     }
 
     // -----------------------------------------------------------------------

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -78,6 +78,32 @@ fn setext_underline_level(line: &str) -> Option<usize> {
     }
 }
 
+/// Strip an optional ATX closing sequence from heading text.
+///
+/// Per CommonMark, a trailing sequence of `#` characters preceded by a space
+/// (or tabs) is removed, along with any trailing whitespace before that space.
+/// Example: `" Heading ## "` → `"Heading"`.
+fn strip_atx_closing(text: &str) -> String {
+    let trimmed = text.trim_end();
+    // Count trailing '#' characters.
+    let hash_count = trimmed.bytes().rev().take_while(|&b| b == b'#').count();
+    if hash_count == 0 {
+        return trimmed.to_string();
+    }
+    // The hashes must be preceded by a space/tab, or the text is entirely hashes.
+    let before = &trimmed[..trimmed.len() - hash_count];
+    if before.is_empty() {
+        // Text is all '#' — the entire content is the closing sequence.
+        return String::new();
+    }
+    if before.ends_with([' ', '\t']) {
+        before.trim_end().to_string()
+    } else {
+        // No space before hashes — they are part of the heading text.
+        trimmed.to_string()
+    }
+}
+
 pub fn parse_headings(content: &str) -> Vec<HeadingInfo> {
     let mut headings = Vec::new();
     let total_lines = content.lines().count();
@@ -97,7 +123,7 @@ pub fn parse_headings(content: &str) -> Vec<HeadingInfo> {
             }
             headings.push(HeadingInfo {
                 level: hashes,
-                text: line[hashes + 1..].to_string(),
+                text: strip_atx_closing(&line[hashes + 1..]),
                 line_start: idx,
                 body_line: idx + 1,
                 line_end: 0,

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -517,6 +517,32 @@ mod edge_cases {
     }
 
     #[test]
+    fn parse_headings_strips_atx_closing_hashes() {
+        let content = "## Heading ##\n### Another ###\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 2);
+        assert_eq!(headings[0].text, "Heading");
+        assert_eq!(headings[1].text, "Another");
+    }
+
+    #[test]
+    fn parse_headings_closing_hashes_without_space_are_content() {
+        // Per CommonMark, closing hashes must be preceded by a space.
+        let content = "# foo#\n## bar##baz\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 2);
+        assert_eq!(headings[0].text, "foo#");
+        assert_eq!(headings[1].text, "bar##baz");
+    }
+
+    #[test]
+    fn find_section_matches_heading_with_closing_hashes() {
+        let content = "## API ##\nsome text\n## Next\nother\n";
+        let (start, end) = find_section(content, "API").unwrap();
+        assert_eq!(&content[start..end], "some text\n");
+    }
+
+    #[test]
     fn find_section_with_hashes_in_query() {
         let content = "## API\nsome text\n";
         let (start, end) = find_section(content, "## API").unwrap();

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -25,7 +25,7 @@ impl SelectedLines {
     }
 }
 
-/// Parse a line range spec like "10", "10:20", "10-20", ":20", "10:" .
+/// Parse a line range spec like "10", "10:20", "10-20".
 #[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
     // Accept both ':' and '-' as range separators so `--lines 1:10` and

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -866,6 +866,20 @@ pub fn parse_plan_auto(
 /// substitute template variables into each operation, and flatten the result into
 /// `plan.operations`. After this call, `plan.for_each` is `None`.
 ///
+/// Escape a string for safe embedding inside a JSON string literal.
+///
+/// The template substitution operates on the serialized JSON, replacing
+/// `{path}` etc. inside already-quoted `"..."` values. If the substituted
+/// text contains JSON-special characters (backslash, quote, newline, etc.),
+/// the resulting JSON would be malformed. This function applies the same
+/// escaping that `serde_json::to_string` would use for string content.
+#[cfg(feature = "cli")]
+fn json_escape(s: &str) -> String {
+    // Use serde_json to produce `"escaped"`, then strip the surrounding quotes.
+    let quoted = serde_json::to_string(s).unwrap_or_else(|_| format!("\"{s}\""));
+    quoted[1..quoted.len() - 1].to_string()
+}
+
 /// Template variables: `{path}`, `{dir}`, `{stem}`, `{ext}`, `{name}`.
 #[cfg(feature = "cli")]
 pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result<()> {
@@ -958,12 +972,14 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
             .map(|e| e.to_string_lossy().into_owned())
             .unwrap_or_default();
 
+        // JSON-escape all substitution values so file paths containing
+        // quotes, backslashes, or control characters don't produce invalid JSON.
         let substituted = template_ops_json
-            .replace("{path}", &rel_str)
-            .replace("{dir}", &dir)
-            .replace("{stem}", &stem)
-            .replace("{ext}", &ext)
-            .replace("{name}", &name);
+            .replace("{path}", &json_escape(&rel_str))
+            .replace("{dir}", &json_escape(&dir))
+            .replace("{stem}", &json_escape(&stem))
+            .replace("{ext}", &json_escape(&ext))
+            .replace("{name}", &json_escape(&name));
 
         let file_ops: Vec<Operation> = serde_json::from_str(&substituted)
             .map_err(|e| anyhow::anyhow!("for_each: template expansion failed: {e}"))?;
@@ -977,6 +993,21 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn json_escape_handles_special_chars() {
+        // Backslash
+        assert_eq!(json_escape(r#"a\b"#), r#"a\\b"#);
+        // Quotes
+        assert_eq!(json_escape(r#"a"b"#), r#"a\"b"#);
+        // Newlines
+        assert_eq!(json_escape("a\nb"), r#"a\nb"#);
+        // Combined
+        assert_eq!(json_escape("he said \"hi\"\n"), r#"he said \"hi\"\n"#);
+        // Plain string (no escaping needed)
+        assert_eq!(json_escape("hello"), "hello");
+    }
 
     #[test]
     fn parse_minimal_plan() {

--- a/src/write.rs
+++ b/src/write.rs
@@ -283,6 +283,15 @@ pub fn collapse_blanks(content: &str) -> std::borrow::Cow<'_, str> {
         scan = &scan[end..];
     }
 
+    // Check trailing content after the last newline: if the remainder is
+    // blank and the previous line was also blank, we still need to collapse.
+    if !needs_collapse && prev_blank && !scan.is_empty() {
+        let trailing = std::str::from_utf8(scan).unwrap_or("");
+        if trailing.trim().is_empty() {
+            needs_collapse = true;
+        }
+    }
+
     if !needs_collapse {
         return Cow::Borrowed(content);
     }

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -609,6 +609,16 @@ mod edge_cases {
         let result = collapse_blanks(input);
         assert_eq!(result, input);
     }
+
+    #[test]
+    fn collapse_blanks_trailing_blank_no_newline() {
+        // Two consecutive blank lines where the last has no trailing newline.
+        // The fast-scan must detect this to trigger collapsing.
+        // The first blank line is preserved (with its newline); the second is dropped.
+        let input = "a\n \n ";
+        let result = collapse_blanks(input);
+        assert_eq!(result, "a\n \n");
+    }
 }
 
 mod dedent_indent {


### PR DESCRIPTION
## Summary

Five bugs discovered through code review (round 2), each with targeted regression tests.

### Fixes

| # | Bug | File | Impact |
|---|-----|------|--------|
| 1 | ATX heading closing `#` sequence not stripped | `src/ops/md.rs` | `## Heading ##` stored text as `Heading ##` instead of `Heading`, breaking section matching |
| 2 | `needs_yaml_quoting` missing `"- "` prefix | `src/ops/doc/yaml_splice.rs` | String `"- item"` emitted as `- - item` (nested sequence) instead of quoted scalar |
| 3 | Single-quoted YAML for strings with newlines | `src/ops/doc/yaml_splice.rs` | YAML single-quote folds newlines into spaces, corrupting multi-line strings |
| 4 | `collapse_blanks` fast-scan misses trailing blank | `src/write.rs` | Trailing blank line without newline not detected by fast-scan, skipping collapse |
| 5 | `for_each` template substitution skips JSON escaping | `src/plan.rs` | File paths with quotes/backslashes produce invalid JSON during template expansion |

### Testing

Each fix includes a targeted regression test. All existing tests pass (`make check-fast`: 1622 unit + 786 integration + 10 PTY).