### PR TITLE
fix: 5 bugs found by code audit round 4 with regression tests

### DIFF
--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -447,6 +447,9 @@ fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::Result<u8> 
     });
 
     for vr in &results {
+        if !vr.result.valid {
+            all_valid = false;
+        }
         if global.json || global.jsonl {
             let obj = serde_json::json!({
                 "file": vr.display,
@@ -456,7 +459,6 @@ fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::Result<u8> 
             });
             global.emit_json(&obj)?;
         } else if !vr.result.valid {
-            all_valid = false;
             eprintln!("{}: INVALID ({})", vr.display, vr.result.language);
             for err in &vr.result.errors {
                 eprintln!("  line {}:{}: {}", err.line, err.column, err.text.trim());

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -181,6 +181,9 @@ pub fn move_at_path(
     };
 
     // Insert at destination path.
+    if to_segments.is_empty() {
+        anyhow::bail!("empty to selector");
+    }
     let (parent_path, last) = split_last(to_segments);
     let parent = navigate_mut(root, parent_path, true)?;
     match last {
@@ -401,6 +404,20 @@ mod tests {
         move_at_path(&mut root, &segs("src"), &segs("dst.moved")).unwrap();
         assert!(root.get("src").is_none());
         assert_eq!(root["dst"]["moved"], json!(42));
+    }
+
+    #[test]
+    fn move_at_path_empty_to_selector_fails() {
+        let mut root = json!({"src": 42});
+        let result = move_at_path(&mut root, &segs("src"), &[]);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("empty to selector"),
+            "should report empty to selector"
+        );
     }
 
     #[test]

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -407,6 +407,10 @@ pub fn needs_yaml_quoting(s: &str) -> bool {
     if s.is_empty() {
         return true;
     }
+    // Strings with leading/trailing whitespace lose it in plain scalar context.
+    if s != s.trim() {
+        return true;
+    }
     // Values that look like booleans, null, or YAML special floats.
     if s.eq_ignore_ascii_case("true")
         || s.eq_ignore_ascii_case("false")
@@ -446,6 +450,34 @@ pub fn needs_yaml_quoting(s: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // needs_yaml_quoting
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn needs_yaml_quoting_leading_whitespace() {
+        assert!(needs_yaml_quoting(" hello"), "leading space needs quoting");
+    }
+
+    #[test]
+    fn needs_yaml_quoting_trailing_whitespace() {
+        assert!(needs_yaml_quoting("hello "), "trailing space needs quoting");
+    }
+
+    #[test]
+    fn needs_yaml_quoting_only_whitespace() {
+        assert!(needs_yaml_quoting(" "), "single space needs quoting");
+        assert!(needs_yaml_quoting("  "), "double space needs quoting");
+    }
+
+    #[test]
+    fn needs_yaml_quoting_plain_string_ok() {
+        assert!(
+            !needs_yaml_quoting("hello"),
+            "plain string does not need quoting"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // find_yaml_key_line

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -244,7 +244,9 @@ pub fn exit_code_from_tx_output(report: &TxOutput) -> u8 {
             Some("parse_error") => exit::PARSE_ERROR,
             Some("rollback") => exit::ROLLBACK,
             Some("rollback_failed") => exit::FAILURE, // preserve historical CLI exit for this case
-            Some("validation_failed") | Some("format_failed") => exit::VALIDATION_FAILED,
+            Some("validation_failed") | Some("format_failed") | Some("verification_failed") => {
+                exit::VALIDATION_FAILED
+            }
             Some("operation_failed") => exit::OPERATION_FAILED,
             _ => exit::FAILURE,
         }
@@ -397,6 +399,10 @@ mod tests {
         );
         assert_eq!(
             exit_code_from_tx_output(&err_output("format_failed")),
+            exit::VALIDATION_FAILED
+        );
+        assert_eq!(
+            exit_code_from_tx_output(&err_output("verification_failed")),
             exit::VALIDATION_FAILED
         );
         assert_eq!(

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -182,27 +182,30 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
         }
     }
 
-    // Cap after collection. Append order matches walk order.
-    if *max_results > 0 {
-        all_matches.truncate(*max_results);
-    }
+    // Validate assert_count against the true total before truncation.
+    let total_match_count = all_matches.len();
 
     if let Some(expected) = assert_count
-        && all_matches.len() != *expected
+        && total_match_count != *expected
     {
         anyhow::bail!(
             "search assert_count: expected {} matches for '{}' in {}, found {}",
             expected,
             pattern,
             path,
-            all_matches.len()
+            total_match_count
         );
+    }
+
+    // Cap after assertion check. Append order matches walk order.
+    if *max_results > 0 {
+        all_matches.truncate(*max_results);
     }
 
     tx.tx_searches.push(TxSearchResult {
         path: path.clone(),
         pattern: pattern.clone(),
-        match_count: all_matches.len(),
+        match_count: total_match_count,
         matches: all_matches,
     });
     Ok(())
@@ -656,7 +659,60 @@ mod tests {
         );
 
         execute_search_op(&op, &mut tx).unwrap();
-        assert_eq!(searches[0].match_count, 2);
+        // match_count reports the true total (5 matches), not the truncated count
+        assert_eq!(searches[0].match_count, 5);
+        // matches vec is truncated to max_results
         assert_eq!(searches[0].matches.len(), 2);
+    }
+
+    #[test]
+    fn search_assert_count_checks_before_max_results_truncation() {
+        // File has 3 matches. assert_count=3 should pass even with max_results=1.
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, "foo\nfoo\nfoo\n").unwrap();
+
+        let op = Operation::Search {
+            path: "test.txt".into(),
+            pattern: "foo".into(),
+            regex: false,
+            case_insensitive: false,
+            multiline: false,
+            invert_match: false,
+            context: None,
+            before_context: None,
+            after_context: None,
+            assert_count: Some(3),
+            literal: false,
+            globs: Vec::new(),
+            max_results: 1,
+            exclude_patterns: Vec::new(),
+            custom_ignore_filenames: Vec::new(),
+        };
+
+        let mut pending = HashMap::new();
+        let mut deletions = HashSet::new();
+        let mut existed = HashSet::new();
+        let mut doc_cache = HashMap::new();
+        let mut reads = Vec::new();
+        let mut searches = Vec::new();
+        let mut lints = Vec::new();
+
+        let mut tx = make_tx_state(
+            &mut pending,
+            &mut deletions,
+            &mut existed,
+            &mut doc_cache,
+            &mut reads,
+            &mut searches,
+            &mut lints,
+            dir.path(),
+        );
+
+        execute_search_op(&op, &mut tx).unwrap();
+        // match_count reports the true total, not the truncated count
+        assert_eq!(searches[0].match_count, 3);
+        // matches is truncated to max_results
+        assert_eq!(searches[0].matches.len(), 1);
     }
 }

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -246,6 +246,24 @@ fn test_ast_validate_jsonl_output() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_validate_json_exit_code_on_invalid_file() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("bad.rs");
+    fs::write(&f, "fn broken( {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["ast", "validate", "bad.rs", "--json"])
+        .assert()
+        .code(1) // exit::FAILURE, not SUCCESS
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let v: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
+    assert_eq!(v["valid"], serde_json::json!(false));
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_search_jsonl_output() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("lib.rs");


### PR DESCRIPTION
## Summary

Five bugs found by reading the source code, each with a regression test.

### 1. `ast validate` always returns SUCCESS in JSON mode (`src/cmd/ast.rs`)

The `all_valid` flag was only updated in the non-JSON output branch. When `--json` or `--jsonl` was passed, the function always returned exit code 0 regardless of validation results. Now updates `all_valid` before the output-format branch.

### 2. `move_at_path` panics on empty `to` selector (`src/ops/doc/navigate.rs`)

`move_at_path` validated that `from_segments` was non-empty but did not check `to_segments`. An empty `to` selector caused a `usize` underflow in `split_last()` (which computes `segments.len() - 1`). Added the same guard that exists for `from_segments`.

### 3. `assert_count` checked after `max_results` truncation (`src/tx/search_op.rs`)

`max_results` truncated the match list before `assert_count` validated the total count. A search with 10 matches, `max_results: 3`, and `assert_count: 10` would incorrectly fail with "expected 10 matches, found 3". Now validates before truncation. Also fixes `match_count` to report the true total.

### 4. `exit_code_from_tx_output` missing `verification_failed` (`src/tx/output.rs`)

The `verification_failed` error kind (emitted by the verify lifecycle) fell through to the default `FAILURE` (exit code 1) instead of mapping to `VALIDATION_FAILED` (exit code 6) like the CLI path. This caused inconsistent exit codes between CLI and library/MCP callers.

### 5. `needs_yaml_quoting` misses whitespace strings (`src/ops/doc/yaml_splice.rs`)

Strings with leading/trailing whitespace (e.g. `" hello "`) were not flagged for quoting. When emitted as plain YAML scalars, the whitespace would be silently stripped by YAML parsers. Added a `s != s.trim()` check.