### PR TITLE
fix: 5 bugs found by code audit round 8 with regression tests

### DIFF
--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -241,8 +241,10 @@ fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in {}", args.symbol, args.path))?;
 
     let lines: Vec<&str> = source.lines().collect();
-    let start = sym.start_line.saturating_sub(1 + args.context);
-    let end = (sym.end_line + args.context).min(lines.len());
+    let start = sym
+        .start_line
+        .saturating_sub(args.context.saturating_add(1));
+    let end = sym.end_line.saturating_add(args.context).min(lines.len());
 
     if global.json || global.jsonl {
         let content: String = lines[start..end].iter().map(|l| format!("{l}\n")).collect();
@@ -1212,6 +1214,22 @@ mod tests {
             msg.contains("path not found") && msg.contains("no_such_file.rs"),
             "error should mention path not found and the argument: {msg}"
         );
+    }
+
+    #[test]
+    fn context_line_calculation_no_overflow() {
+        // Regression: 1 + args.context and sym.end_line + args.context
+        // used to overflow with large context values. Verify saturating
+        // arithmetic prevents panic.
+        let start_line: usize = 5;
+        let end_line: usize = 10;
+        let context: usize = usize::MAX;
+        let total_lines: usize = 100;
+
+        let start = start_line.saturating_sub(context.saturating_add(1));
+        let end = end_line.saturating_add(context).min(total_lines);
+        assert_eq!(start, 0);
+        assert_eq!(end, total_lines);
     }
 
     // Note: apply_or_preview tests removed when AST write commands were

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -350,7 +350,12 @@ pub fn tokenize(line: &str) -> anyhow::Result<Vec<String>> {
             loop {
                 match chars.next() {
                     Some('\\') => match chars.next() {
-                        Some(escaped) => current.push(escaped),
+                        Some('"') => current.push('"'),
+                        Some('\\') => current.push('\\'),
+                        Some(other) => {
+                            current.push('\\');
+                            current.push(other);
+                        }
                         None => anyhow::bail!("unexpected end of line after backslash"),
                     },
                     Some('"') => break,

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -355,6 +355,14 @@ mod error_handling {
     use super::*;
 
     #[test]
+    fn tokenize_preserves_backslash_before_non_special_chars() {
+        // Regression: `\n`, `\t`, etc. inside quotes should keep the
+        // backslash because only `\"` and `\\` are recognized escapes.
+        let tokens = tokenize(r#"replace f.txt "C:\new\test" "D:\data""#).unwrap();
+        assert_eq!(tokens, vec!["replace", "f.txt", r"C:\new\test", r"D:\data"]);
+    }
+
+    #[test]
     fn tokenize_trailing_backslash_error() {
         let err = tokenize(r#"doc.set f.json key "trail\"#).unwrap_err();
         assert!(

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -10,6 +10,11 @@ pub fn navigate_mut<'a>(
         current = match seg {
             selector::Segment::Key(k) => {
                 if create {
+                    // Convert null root (e.g. empty YAML) to an empty object
+                    // so intermediate keys can be created.
+                    if current.is_null() {
+                        *current = serde_json::Value::Object(serde_json::Map::new());
+                    }
                     let needs_create = match current.as_object() {
                         Some(obj) => !obj.contains_key(k.as_str()),
                         None => false,
@@ -53,6 +58,12 @@ pub fn set_at_path(
     }
     let (parent_path, last) = split_last(segments);
     let parent = navigate_mut(root, parent_path, true)?;
+
+    // Convert null parent (e.g. empty YAML parsed to null) to an empty
+    // object so `doc set` works on empty documents.
+    if parent.is_null() && matches!(last, selector::Segment::Key(_)) {
+        *parent = serde_json::Value::Object(serde_json::Map::new());
+    }
 
     match last {
         selector::Segment::Key(k) => {
@@ -418,6 +429,25 @@ mod tests {
                 .contains("empty to selector"),
             "should report empty to selector"
         );
+    }
+
+    #[test]
+    fn set_at_path_on_null_root() {
+        // Regression: doc set on an empty YAML file (parsed as null)
+        // should convert null to an empty object, not error.
+        let mut root = serde_json::Value::Null;
+        set_at_path(&mut root, &segs("name"), json!("my-app")).unwrap();
+        assert_eq!(root, json!({"name": "my-app"}));
+    }
+
+    #[test]
+    fn navigate_mut_create_from_null() {
+        // Regression: navigate_mut with create=true should handle
+        // null nodes by converting them to objects.
+        let mut root = serde_json::Value::Null;
+        let val = navigate_mut(&mut root, &segs("a.b"), true).unwrap();
+        assert!(val.is_object());
+        assert!(root.is_object());
     }
 
     #[test]

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -412,15 +412,38 @@ pub fn upsert_bullet_in(content: &str, heading: &str, bullet: &str) -> Option<St
         }
     }
 
+    // Find the end of actual content within the body, before any trailing
+    // blank lines. This ensures the new bullet is grouped with existing
+    // bullets rather than placed after a blank line separator.
+    let trimmed_body = body.trim_end_matches(['\n', '\r', ' ']);
+    let content_end = body_start + trimmed_body.len();
+    // Find the next line boundary after content_end (include the trailing \n of
+    // the last non-blank line so the bullet goes on a new line, not appended).
+    let insert_at = if content_end < body_end {
+        // There is at least one trailing newline; include the first one.
+        content_end
+            + if content.as_bytes().get(content_end) == Some(&b'\r')
+                && content.as_bytes().get(content_end + 1) == Some(&b'\n')
+            {
+                2
+            } else if content.as_bytes().get(content_end) == Some(&b'\n') {
+                1
+            } else {
+                0
+            }
+    } else {
+        body_end
+    };
+
     let mut out = String::with_capacity(content.len() + normalized.len() + 4);
-    out.push_str(&content[..body_end]);
+    out.push_str(&content[..insert_at]);
     if !out.is_empty() && !out.ends_with('\n') {
         out.push('\n');
     }
     out.push_str(&normalized);
     out.push('\n');
     // Preserve the blank line separator before the next heading.
-    let remainder = &content[body_end..];
+    let remainder = &content[insert_at..];
     if remainder.starts_with('#') && !out.ends_with("\n\n") {
         out.push('\n');
     }
@@ -523,6 +546,12 @@ pub fn table_append_in(
 
     let mut out = String::with_capacity(content.len() + row.len() + 2);
     out.push_str(&content[..insert_pos]);
+    // Ensure there is a newline separator before the new row; without
+    // this, files that lack a trailing newline get the new row fused
+    // onto the last existing data row.
+    if insert_pos > 0 && content.as_bytes().get(insert_pos - 1) != Some(&b'\n') {
+        out.push('\n');
+    }
     out.push_str(row);
     if !row.ends_with('\n') {
         out.push('\n');

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -818,6 +818,22 @@ mod error_handling {
     }
 
     #[test]
+    fn table_append_no_trailing_newline() {
+        // Regression: when the file ends without a trailing newline,
+        // the new row must not be fused onto the last existing row.
+        let content = "# API\n| H |\n|---|\n| v |";
+        let result = table_append_in(content, 6, content.len(), "| new |").unwrap();
+        assert!(
+            result.contains("| v |\n| new |"),
+            "rows should be on separate lines: {result}"
+        );
+        assert!(
+            !result.contains("| v || new |"),
+            "rows must not be fused: {result}"
+        );
+    }
+
+    #[test]
     fn table_append_no_table() {
         let content = "# API\nJust text\n";
         let (start, end) = find_section(content, "API").unwrap();
@@ -981,6 +997,24 @@ mod regression {
         let result = upsert_bullet_in(content, "Section A", "- Bullet three").unwrap();
         assert!(
             result.contains("- Bullet three\n\n## Section B"),
+            "blank line before next heading must be preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn upsert_bullet_inserts_before_trailing_blank_lines() {
+        // Regression: the new bullet should be grouped with existing
+        // bullets, not placed after trailing blank lines.
+        let content = "# A\n- item1\n- item2\n\n# B\n";
+        let result = upsert_bullet_in(content, "A", "- item3").unwrap();
+        // The new bullet must appear immediately after item2, before the blank line.
+        assert!(
+            result.contains("- item2\n- item3\n"),
+            "new bullet should be adjacent to existing bullets: {result}"
+        );
+        // The blank line separator before # B must be preserved.
+        assert!(
+            result.contains("item3\n\n# B"),
             "blank line before next heading must be preserved: {result}"
         );
     }


### PR DESCRIPTION
## Summary

5 bugs found by static code audit (round 8), each with a regression test.

### Fixes

1. **Batch tokenizer drops backslashes** (`src/cmd/batch.rs`): Inside quoted strings, `\n`, `\t`, etc. silently dropped the backslash, turning `C:\new\test` into `Cnewtest`. Now only `\\\\` and `\\"` consume the backslash; all other sequences preserve it.

2. **`doc set` fails on empty YAML** (`src/ops/doc/navigate.rs`): An empty YAML file parses to `null`, and `set_at_path` errored with "parent is not an object". Now `null` roots are converted to empty objects when creating keys.

3. **`table_append_in` row fusion** (`src/ops/md.rs`): When a file lacked a trailing newline, the new table row was concatenated directly onto the last existing row (`| v || new |`). Now a newline separator is inserted before the new row.

4. **`ast read --context` integer overflow** (`src/cmd/ast.rs`): `1 + args.context` and `sym.end_line + args.context` could overflow with large context values. Fixed with `saturating_add`.

5. **`upsert_bullet_in` trailing blank lines** (`src/ops/md.rs`): New bullets were placed after trailing blank lines in the section body, breaking CommonMark list grouping. Now inserted before trailing blank lines to stay adjacent to existing bullets.

### Tests

6 regression tests added (1642 unit + 788 integration + 10 PTY tests pass).