### PR TITLE
fix: 4 bugs found by code audit round 9 with regression tests

### DIFF
--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -553,6 +553,11 @@ impl PatchloomService {
             // (it defaults to true). This provides a simple, predictable experience for agents.
             plan.strict = Some(p.strict);
 
+            // Strip plan.cwd to prevent containment bypass: a plan with
+            // cwd="/etc" would resolve relative paths against /etc instead
+            // of the workspace, escaping the PathGuard.
+            plan.cwd = None;
+
             execute_plan_validated(plan, svc.cwd(), Some(&svc.path_guard))
         })
         .await

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -407,9 +407,24 @@ pub fn execute_plan_direct(
     };
 
     // PathGuard enforcement for library callers of execute_plan (addresses #755).
-    // Upfront check on declared paths using shared helper; dynamic (globs
-    // patterns, patch embedded paths) are best-effort or handled by loaders.
     if let Some(g) = guard {
+        // Defense-in-depth: reject plans whose cwd would escape the guard's
+        // workspace root. The MCP handler strips plan.cwd, but library
+        // callers might not.
+        if plan.cwd.is_some() {
+            let canon_cwd = effective_cwd
+                .canonicalize()
+                .unwrap_or_else(|_| effective_cwd.clone());
+            if !canon_cwd.starts_with(g.canon_root()) {
+                anyhow::bail!(
+                    "plan cwd '{}' escapes workspace root '{}'",
+                    effective_cwd.display(),
+                    g.root().display()
+                );
+            }
+        }
+        // Upfront check on declared paths using shared helper; dynamic (globs
+        // patterns, patch embedded paths) are best-effort or handled by loaders.
         for op in &plan.operations {
             for p in op.declared_paths() {
                 g.check_path(p)
@@ -581,6 +596,43 @@ mod tests {
         assert_eq!(
             resolve_plan_cwd(base, Some("/other/dir")),
             PathBuf::from("/other/dir")
+        );
+    }
+
+    #[test]
+    fn execute_plan_direct_rejects_escaped_cwd_with_guard() {
+        // Regression: a plan with cwd pointing outside the workspace
+        // must be rejected when a PathGuard is present.
+        use crate::containment::{AbsolutePathPolicy, PathGuard};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("test.txt"), "content").unwrap();
+        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+
+        let plan = crate::plan::Plan {
+            version: "1".into(),
+            cwd: Some("/tmp".into()),
+            operations: vec![crate::plan::Operation::Read {
+                path: "test.txt".into(),
+                lines: None,
+            }],
+            write_policy: None,
+            strict: None,
+            format: None,
+            validate: None,
+            verify: None,
+            for_each: None,
+        };
+
+        let result = execute_plan_direct(plan, dir.path(), Some(&guard));
+        assert!(
+            result.is_err(),
+            "should reject plan.cwd that escapes workspace"
+        );
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("escapes workspace root"),
+            "error should mention escape: {msg}"
         );
     }
 

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -47,6 +47,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         *multiline,
         word_boundary,
     )?;
+    if range.is_some() && !*whole_line {
+        anyhow::bail!("range requires whole_line mode");
+    }
     let parsed_range = range
         .as_deref()
         .map(crate::ops::read::parse_line_range)
@@ -583,6 +586,58 @@ mod tests {
         assert!(
             result.contains("/// Process input."),
             "insert_before text must be present, got: {result}"
+        );
+    }
+
+    #[test]
+    fn replace_range_without_whole_line_is_rejected() {
+        // Regression: range was silently ignored when whole_line was false.
+        // Now the tx engine validates this, matching the CLI behavior.
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, "line1\nline2\nline3\n").unwrap();
+
+        let op = Operation::Replace {
+            path: Some("test.txt".into()),
+            glob: None,
+            mode: None,
+            from: "line".into(),
+            to: Some("LINE".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            whole_line: false,
+            word_boundary: false,
+            range: Some("1:2".into()),
+            before_context: None,
+            after_context: None,
+            if_exists: false,
+        };
+
+        let mut pending = HashMap::new();
+        let mut deletions = HashSet::new();
+        let mut existed = HashSet::new();
+        let mut doc_cache = HashMap::new();
+        let mut reads = Vec::new();
+        let mut searches = Vec::new();
+        let mut lints = Vec::new();
+        let mut tx = make_tx_state(
+            &mut pending,
+            &mut deletions,
+            &mut existed,
+            &mut doc_cache,
+            &mut reads,
+            &mut searches,
+            &mut lints,
+            dir.path(),
+        );
+
+        let err = execute_replace_op(&op, &mut tx).unwrap_err();
+        assert!(
+            err.to_string().contains("range requires whole_line"),
+            "should reject range without whole_line: {err}"
         );
     }
 }

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -37,8 +37,10 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
         anyhow::bail!("search: literal and regex cannot be combined");
     }
 
-    // literal means treat pattern as literal text (escape it); !regex also escapes for backward compat in plans.
-    let pat = if *literal || !*regex {
+    // Treat pattern as literal text only when explicitly requested.
+    // Default (both literal=false, regex=false) is regex to match CLI
+    // and MCP behavior.
+    let pat = if *literal {
         regex::escape(pattern)
     } else {
         pattern.clone()
@@ -122,8 +124,9 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             // Multiline mode: search the full content so patterns can span lines.
             for m in re.find_iter(content) {
                 let line_idx = content[..m.start()].matches('\n').count();
+                let match_end_line = line_idx + m.as_str().matches('\n').count();
                 let start = line_idx.saturating_sub(ctx_before);
-                let end = (line_idx + 1 + ctx_after).min(lines.len());
+                let end = (match_end_line + 1 + ctx_after).min(lines.len());
                 let matched_text = m.as_str().to_string();
                 let text = if is_multi_file {
                     let display_path = file_path
@@ -143,8 +146,8 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
-                    context_after: if line_idx + 1 < lines.len() {
-                        lines[line_idx + 1..end]
+                    context_after: if match_end_line + 1 < lines.len() {
+                        lines[match_end_line + 1..end]
                             .iter()
                             .map(|s| s.to_string())
                             .collect()
@@ -767,5 +770,91 @@ mod tests {
         // Should not panic even when match is near end of file
         execute_search_op(&op, &mut tx).unwrap();
         assert_eq!(searches[0].match_count, 1);
+    }
+
+    #[test]
+    fn search_default_mode_is_regex_not_literal() {
+        // Regression: when both literal=false and regex=false (defaults),
+        // the pattern should be treated as regex, matching CLI/MCP behavior.
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, "fooXbar\nfoo.bar\n").unwrap();
+
+        // Pattern "foo.bar" should match both lines (dot is regex wildcard)
+        let op = search_op("test.txt", "foo.bar");
+        let mut pending = HashMap::new();
+        let mut deletions = HashSet::new();
+        let mut existed = HashSet::new();
+        let mut doc_cache = HashMap::new();
+        let mut reads = Vec::new();
+        let mut searches = Vec::new();
+        let mut lints = Vec::new();
+        let mut tx = make_tx_state(
+            &mut pending,
+            &mut deletions,
+            &mut existed,
+            &mut doc_cache,
+            &mut reads,
+            &mut searches,
+            &mut lints,
+            dir.path(),
+        );
+        execute_search_op(&op, &mut tx).unwrap();
+        assert_eq!(
+            searches[0].match_count, 2,
+            "regex dot should match any char, yielding 2 matches"
+        );
+    }
+
+    #[test]
+    fn search_multiline_context_after_excludes_match_lines() {
+        // Regression: context_after should start after the last line of
+        // a multiline match, not after the first line.
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        std::fs::write(&file, "aaa\nbbb\nccc\nddd\neee\nfff\n").unwrap();
+
+        let op = Operation::Search {
+            path: "test.txt".into(),
+            pattern: "bbb\nccc\nddd".into(),
+            regex: true,
+            case_insensitive: false,
+            multiline: true,
+            invert_match: false,
+            context: None,
+            before_context: None,
+            after_context: Some(1),
+            assert_count: None,
+            literal: false,
+            globs: Vec::new(),
+            max_results: 0,
+            exclude_patterns: Vec::new(),
+            custom_ignore_filenames: Vec::new(),
+        };
+        let mut pending = HashMap::new();
+        let mut deletions = HashSet::new();
+        let mut existed = HashSet::new();
+        let mut doc_cache = HashMap::new();
+        let mut reads = Vec::new();
+        let mut searches = Vec::new();
+        let mut lints = Vec::new();
+        let mut tx = make_tx_state(
+            &mut pending,
+            &mut deletions,
+            &mut existed,
+            &mut doc_cache,
+            &mut reads,
+            &mut searches,
+            &mut lints,
+            dir.path(),
+        );
+        execute_search_op(&op, &mut tx).unwrap();
+        assert_eq!(searches[0].match_count, 1);
+        let ctx_after = &searches[0].matches[0].context_after;
+        assert_eq!(
+            ctx_after,
+            &["eee"],
+            "context_after should be the line after the match, not a match line"
+        );
     }
 }


### PR DESCRIPTION
## Summary

4 bugs found by static code audit (round 9), including a critical containment bypass, each with a regression test.

### Fixes

1. **SECURITY: MCP `execute_plan` containment bypass** (`src/cmd/mcp/handlers.rs`, `src/tx/lifecycle.rs`): A plan with `cwd: "/etc"` could escape the workspace PathGuard, allowing arbitrary file read/write outside the workspace. Fixed by stripping `plan.cwd` in the MCP handler (primary fix) and adding defense-in-depth validation in `execute_plan_direct` that rejects escaped effective_cwd when a guard is present.

2. **tx search default mode inconsistency** (`src/tx/search_op.rs`): When both `literal` and `regex` defaulted to `false`, the tx engine escaped the pattern (literal mode), while CLI and MCP treated it as regex. Fixed to only escape when `literal=true`.

3. **Multiline search `context_after` includes match lines** (`src/tx/search_op.rs`): For multiline matches spanning N lines, `context_after` started from the first match line instead of after the last match line. Fixed by computing the match end line.

4. **tx replace `range` silently ignored** (`src/tx/replace_op.rs`): `range` parameter was accepted but had no effect when `whole_line` was `false`. Added validation matching the CLI behavior (`range requires whole_line`).

### Tests

4 regression tests added (1646 unit + 788 integration + 10 PTY tests pass).