### PR TITLE
fix: 4 bugs found by code audit round 11 with regression tests

### DIFF
--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -252,7 +252,7 @@ pub(super) fn inject_strict_into_schema(mut schema: serde_json::Value) -> serde_
             "strict".to_string(),
             serde_json::json!({
                 "type": "boolean",
-                "description": "Enable strict mode (default true). When true, ambiguous matches cause an error instead of a best-effort resolution.",
+                "description": "Enable strict mode (default true). When true, roll back all file writes if format or validate lifecycle steps fail.",
                 "default": true
             }),
         );

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -195,11 +195,17 @@ pub fn validate_edit_nth(
                 remaining = &remaining[pos + from.len()..];
             }
             if count < n {
-                // Nth occurrence not found; use content as-is.
-                content.to_string()
-            } else {
-                result
+                return ValidationResult {
+                    valid: false,
+                    errors: vec![format!(
+                        "occurrence {n} not found (only {count} occurrence{} exist{})",
+                        if count == 1 { "" } else { "s" },
+                        if count == 1 { "s" } else { "" },
+                    )],
+                    warnings: vec![],
+                };
             }
+            result
         }
         None => content.replace(from, to),
     };
@@ -1018,10 +1024,18 @@ mod tests {
 
     #[test]
     fn validate_edit_nth_out_of_range() {
-        // nth=5 but only 2 occurrences: content is unchanged, still valid.
+        // nth=5 but only 2 occurrences: should return invalid with descriptive error.
         let content = "aXbXc";
         let result = validate_edit_nth(content, "X", "Y", None, Some(5));
-        assert!(result.valid);
+        assert!(
+            !result.valid,
+            "nth beyond occurrence count should be invalid"
+        );
+        assert!(
+            result.errors[0].contains("occurrence 5 not found"),
+            "error should mention the missing occurrence: {:?}",
+            result.errors
+        );
     }
 
     #[test]

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -266,7 +266,7 @@ fn find_yaml_key_line(lines: &[&str], key_path: &[String]) -> Option<usize> {
             if indent < min_indent {
                 continue;
             }
-            if trimmed.starts_with(&key_colon) || trimmed.starts_with(&key_colon_sp) {
+            if trimmed == key_colon || trimmed.starts_with(&key_colon_sp) {
                 search_start = i + 1;
                 min_indent = indent + 1;
                 if depth == key_path.len() - 1 {
@@ -908,5 +908,27 @@ mod tests {
                 "round-trip mismatch: {spliced}"
             );
         }
+    }
+
+    #[test]
+    fn find_yaml_key_line_rejects_prefix_match() {
+        // Regression: "name:" must not match "namespace:".
+        let yaml = "namespace: kube-system\nname: my-app\nitems:\n  - one\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        let result = find_yaml_key_line(&lines, &["name".into()]);
+        assert_eq!(
+            result,
+            Some(1),
+            "should match 'name:' on line 1, not 'namespace:' on line 0"
+        );
+    }
+
+    #[test]
+    fn find_yaml_key_line_matches_key_only_on_line() {
+        // "name:" at end of line (value on next line) should match.
+        let yaml = "name:\n  first: Alice\n  last: Smith\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        let result = find_yaml_key_line(&lines, &["name".into()]);
+        assert_eq!(result, Some(0));
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -432,18 +432,30 @@ pub fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usize>)> {
         let start: usize = left
             .parse()
             .map_err(|_| anyhow::anyhow!("invalid line range start: '{left}'"))?;
+        if start == 0 {
+            anyhow::bail!("line numbers are 1-based, got start=0");
+        }
         if right.is_empty() {
             Ok((start, None))
         } else {
             let end: usize = right
                 .parse()
                 .map_err(|_| anyhow::anyhow!("invalid line range end: '{right}'"))?;
+            if end == 0 {
+                anyhow::bail!("line numbers are 1-based, got end=0");
+            }
+            if end < start {
+                anyhow::bail!("inverted line range: start ({start}) > end ({end})");
+            }
             Ok((start, Some(end)))
         }
     } else {
         let line: usize = spec
             .parse()
             .map_err(|_| anyhow::anyhow!("invalid line number: '{spec}'"))?;
+        if line == 0 {
+            anyhow::bail!("line numbers are 1-based, got 0");
+        }
         Ok((line, Some(line)))
     }
 }

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -743,6 +743,24 @@ mod dedent_indent {
     }
 
     #[test]
+    fn parse_line_range_rejects_zero() {
+        // Line numbers are 1-based; 0 is invalid.
+        assert!(parse_line_range("0").is_err());
+        assert!(parse_line_range("0:5").is_err());
+        assert!(parse_line_range("1:0").is_err());
+    }
+
+    #[test]
+    fn parse_line_range_rejects_inverted() {
+        // start > end is an error, not a silent no-op.
+        let err = parse_line_range("50:10").unwrap_err();
+        assert!(
+            err.to_string().contains("inverted"),
+            "should mention inverted range: {err}"
+        );
+    }
+
+    #[test]
     fn dedent_auto_line_range() {
         // Only dedent lines 2-3; leave lines 1 and 4 alone.
         let input = "    a\n        b\n        c\n    d\n";


### PR DESCRIPTION
## Summary

Four bugs found by reading the source code (audit round 11), each with regression tests.

### Bug 1: YAML splice key-prefix matching

`find_yaml_key_line` used `starts_with("name:")` to match YAML keys, which incorrectly matched `namespace:`, `names:`, etc. Changed to exact equality (`trimmed == key_colon`) for standalone keys and `starts_with(key_colon_sp)` for keys with inline values. This prevents the splice from targeting the wrong YAML key.

### Bug 2: validate_edit_nth false positive for missing occurrence

`validate_edit_nth` returned `valid: true` when the Nth occurrence did not exist in the content. The caller received a false validation signal while the subsequent replacement would silently do nothing. Now returns `valid: false` with an error message like "occurrence 5 not found (only 2 occurrences exist)".

### Bug 3: parse_line_range accepted invalid ranges

The `parse_line_range` function in `write.rs` (used by tidy dedent/indent) accepted `start=0` and inverted ranges (`50:10`), both of which silently produced no-ops. Added validation that rejects 0 (line numbers are 1-based) and inverted ranges with clear error messages.

### Bug 4: MCP strict schema description corrected

The auto-generated MCP schema for the `strict` parameter claimed it controls "ambiguous match resolution" when it actually controls rollback behavior on format/validate lifecycle failures. Updated to match the documented behavior.