### PR TITLE
fix: three bugs in replace, reorder, and rewrite_function_signature

### DIFF
--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -132,6 +132,7 @@ fn replace_write(
             &insert_before,
             &insert_after,
             compiled_re.is_some(),
+            is_regex,
         );
 
         let parsed_range = range.as_deref().map(|r| {
@@ -228,6 +229,7 @@ pub fn replace_in_content(
         &opts.insert_before,
         &opts.insert_after,
         compiled_re.is_some(),
+        is_regex,
     );
 
     let parsed_range = opts.range;

--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -90,18 +90,33 @@ pub fn reorder_symbols(
     }
 
     // Rebuild the scope section with symbols in the new order.
-    // Collect the text of each symbol in original order, keyed by name.
+    // Collect the text of each symbol (spans are already in new order after sort).
     let mut sym_texts: Vec<(&str, String)> = Vec::new();
     for span in &spans {
         let text: String = lines[span.start_0..span.end_0].join("\n");
         sym_texts.push((&span.name, text));
     }
 
-    // Now rebuild: prefix (before scope) + reordered symbols + suffix (after scope)
+    // Find the positional boundaries of all symbols (by line index).
+    let first_sym_start = spans
+        .iter()
+        .map(|s| s.start_0)
+        .min()
+        .unwrap_or(scope_start_0);
+    let last_sym_end = spans.iter().map(|s| s.end_0).max().unwrap_or(scope_end_0);
+
+    // Now rebuild: before-scope + scope-prefix + reordered symbols + scope-suffix + after-scope
     let mut result = String::new();
 
-    // Lines before the scope
+    // Lines before the scope (container preamble when using `inside`)
     for line in &lines[..scope_start_0] {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Scope prefix: non-symbol lines inside the scope before the first symbol
+    // (use statements, module-level comments, extern crate, etc.)
+    for line in &lines[scope_start_0..first_sym_start] {
         result.push_str(line);
         result.push('\n');
     }
@@ -115,7 +130,13 @@ pub fn reorder_symbols(
         result.push('\n');
     }
 
-    // Lines after the scope
+    // Scope suffix: non-symbol lines inside the scope after the last symbol
+    for line in &lines[last_sym_end..scope_end_0] {
+        result.push_str(line);
+        result.push('\n');
+    }
+
+    // Lines after the scope (closing brace, trailing content)
     for line in &lines[scope_end_0..] {
         result.push_str(line);
         result.push('\n');
@@ -392,5 +413,34 @@ mod tests {
     fn parse_strategy_invalid() {
         let v = serde_json::json!(42);
         assert!(parse_strategy(&v).is_err());
+    }
+
+    // Regression: reorder must preserve non-symbol content (use statements,
+    // module-level comments) that appears before the first symbol.
+    #[test]
+    fn reorder_preserves_use_statements() {
+        let source =
+            "use std::collections::HashMap;\n\n// Module doc\nfn zebra() {}\n\nfn alpha() {}\n";
+        let result =
+            reorder_symbols(source, None, &ReorderStrategy::Alphabetical, Language::Rust).unwrap();
+        assert!(
+            result.content.contains("use std::collections::HashMap;"),
+            "use statement should be preserved: {}",
+            result.content
+        );
+        assert!(
+            result.content.contains("// Module doc"),
+            "module comment should be preserved: {}",
+            result.content
+        );
+        let alpha_pos = result.content.find("fn alpha").unwrap();
+        let zebra_pos = result.content.find("fn zebra").unwrap();
+        assert!(alpha_pos < zebra_pos, "alpha should come before zebra");
+        // use statement should come before any function
+        let use_pos = result.content.find("use std").unwrap();
+        assert!(
+            use_pos < alpha_pos,
+            "use statement should remain before symbols"
+        );
     }
 }

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -402,30 +402,45 @@ pub fn rewrite_function_signature(
     let fn_node = find_fn_for_rewrite(root, source, old_name)?;
 
     // Build replacement sig from edit or keep original parts.
-    let vis = edit
-        .visibility
-        .as_deref()
-        .unwrap_or_else(|| child_text_by_kind(fn_node, "visibility", source).unwrap_or(""));
+    let vis = edit.visibility.as_deref().unwrap_or_else(|| {
+        child_text_by_kind(fn_node, "visibility_modifier", source).unwrap_or("")
+    });
     let params = edit
         .parameters
         .as_deref()
         .unwrap_or_else(|| child_text_by_kind(fn_node, "parameters", source).unwrap_or("()"));
+    // tree-sitter-rust has no "return_type" wrapper node. The return type is
+    // represented as a "->" child followed by a type child (e.g. "generic_type").
+    // Extract it from source: everything between the parameters close and the
+    // body (or node end), trimmed.
     let ret = edit
         .return_type
         .as_deref()
-        .unwrap_or_else(|| child_text_by_kind(fn_node, "return_type", source).unwrap_or(""));
+        .unwrap_or_else(|| extract_return_type(fn_node, source).unwrap_or(""));
+
+    // Preserve function qualifiers (async, unsafe, const, extern) from the
+    // original source. These appear between the visibility/start and "fn".
+    let qualifiers = extract_fn_qualifiers(fn_node, source);
 
     let vis_part = if vis.is_empty() {
         String::new()
     } else {
         format!("{} ", vis)
     };
+    let qual_part = if qualifiers.is_empty() {
+        String::new()
+    } else {
+        format!("{} ", qualifiers)
+    };
     let ret_part = if ret.is_empty() {
         String::new()
     } else {
         format!(" {}", ret)
     };
-    let new_sig = format!("{}fn {}{}{}", vis_part, old_name, params, ret_part);
+    let new_sig = format!(
+        "{}{}fn {}{}{}",
+        vis_part, qual_part, old_name, params, ret_part
+    );
 
     // Use the same byte-range logic as replace to swap only the sig.
     let sig_end = find_body_start(fn_node).unwrap_or(fn_node.end_byte());
@@ -434,6 +449,51 @@ pub fn rewrite_function_signature(
     let before = &source[..start];
     let after = &source[sig_end..];
     Some(format!("{}{}{}", before, new_sig, after))
+}
+
+/// Extract the return type from a function_item node. tree-sitter-rust has no
+/// "return_type" wrapper; the return type is a `->` child followed by a type
+/// child (e.g. `generic_type`). Returns `"-> Type"` including the arrow.
+fn extract_return_type<'a>(fn_node: tree_sitter_lib::Node, source: &'a str) -> Option<&'a str> {
+    let mut cursor = fn_node.walk();
+    let mut arrow_start = None;
+    for child in fn_node.children(&mut cursor) {
+        if child.kind() == "->" {
+            arrow_start = Some(child.start_byte());
+            continue;
+        }
+        if let Some(a) = arrow_start {
+            // The child right after "->" is the type node.
+            return Some(source[a..child.end_byte()].trim_end());
+        }
+    }
+    None
+}
+
+/// Extract function qualifiers (async, unsafe, const, extern "C") from a
+/// function_item node by scanning the source text between the visibility
+/// (or node start) and the "fn" keyword. This is more robust than matching
+/// tree-sitter node kinds, which vary across grammar versions.
+fn extract_fn_qualifiers(fn_node: tree_sitter_lib::Node, source: &str) -> String {
+    let node_text = &source[fn_node.start_byte()..fn_node.end_byte()];
+    // Find "fn " (with trailing space) in the node text.
+    // Everything between the visibility and "fn " consists of qualifiers.
+    let fn_pos = match node_text.find("fn ") {
+        Some(pos) => pos,
+        None => return String::new(),
+    };
+    let prefix = &node_text[..fn_pos];
+    // Strip the visibility part (e.g., "pub ", "pub(crate) ") if present.
+    let vis = child_text_by_kind(fn_node, "visibility_modifier", source)
+        .or_else(|| child_text_by_kind(fn_node, "visibility", source));
+    let quals = if let Some(v) = vis {
+        // Remove the visibility and any trailing whitespace
+        let after_vis = prefix.strip_prefix(v).unwrap_or(prefix);
+        after_vis.trim()
+    } else {
+        prefix.trim()
+    };
+    quals.to_string()
 }
 
 // Small helper duplicated from internal for rewrite (to avoid exposing private).
@@ -1367,6 +1427,40 @@ struct Point {
         assert!(out.contains("pub(crate) fn old(x: u32, y: &str) -> String"));
         assert!(out.contains("fn other"));
         assert!(!out.contains("fn old(a: i32)"));
+    }
+
+    // Regression: rewrite_function_signature must preserve qualifiers
+    // (async, unsafe, const, extern) from the original function.
+    #[test]
+    fn rewrite_function_signature_preserves_async() {
+        let src = "pub async fn process(data: &[u8]) -> Result<()> { Ok(()) }";
+        let edit = FunctionSigEdit {
+            visibility: None,
+            parameters: Some("(input: &str)".to_string()),
+            return_type: None,
+        };
+        let res = rewrite_function_signature(src, "process", &edit);
+        let out = res.expect("rewrite should succeed");
+        assert!(
+            out.contains("pub async fn process(input: &str) -> Result<()>"),
+            "async qualifier should be preserved: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_function_signature_preserves_unsafe() {
+        let src = "pub unsafe fn dangerous(ptr: *const u8) {}";
+        let edit = FunctionSigEdit {
+            visibility: None,
+            parameters: Some("(ptr: *mut u8)".to_string()),
+            return_type: None,
+        };
+        let res = rewrite_function_signature(src, "dangerous", &edit);
+        let out = res.expect("rewrite should succeed");
+        assert!(
+            out.contains("pub unsafe fn dangerous(ptr: *mut u8)"),
+            "unsafe qualifier should be preserved: {out}"
+        );
     }
 
     // ── full_symbol_span tests ────────────────────────────────────

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -117,6 +117,7 @@ fn build_replacement(args: &ReplaceArgs) -> String {
         &args.insert_before,
         &args.insert_after,
         args.regex || args.case_insensitive || args.word_boundary,
+        args.regex,
     )
 }
 

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -218,14 +218,14 @@ mod basic {
 
     #[test]
     fn regex_insert_before_uses_match_anchor_in_replacement_text() {
-        let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true);
+        let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true, true);
 
         assert_eq!(text, "X${0}");
     }
 
     #[test]
     fn regex_insert_after_uses_match_anchor_in_replacement_text() {
-        let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true);
+        let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true, true);
 
         assert_eq!(text, "${0}X");
     }

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -149,18 +149,39 @@ pub fn replacement_text(
     insert_before: &Option<String>,
     insert_after: &Option<String>,
     use_match_anchor: bool,
+    regex_mode: bool,
 ) -> String {
     let anchor = if use_match_anchor { "${0}" } else { from };
 
+    // When a regex is compiled internally (case_insensitive / word_boundary)
+    // but the user did NOT request regex mode, dollar signs in user-provided
+    // replacement text must be escaped so caps.expand() treats them literally.
+    let needs_escape = use_match_anchor && !regex_mode;
+
     if let Some(text) = insert_before {
-        return format!("{text}{anchor}");
+        let safe = if needs_escape {
+            text.replace('$', "$$")
+        } else {
+            text.clone()
+        };
+        return format!("{safe}{anchor}");
     }
 
     if let Some(text) = insert_after {
-        return format!("{anchor}{text}");
+        let safe = if needs_escape {
+            text.replace('$', "$$")
+        } else {
+            text.clone()
+        };
+        return format!("{anchor}{safe}");
     }
 
-    to.clone().unwrap_or_default()
+    let raw = to.clone().unwrap_or_default();
+    if needs_escape {
+        raw.replace('$', "$$")
+    } else {
+        raw
+    }
 }
 
 fn expand_regex_replacement(caps: &regex::Captures<'_>, replacement: &str) -> String {

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -81,34 +81,77 @@ mod replace_tests {
 
         #[test]
         fn replacement_text_with_to() {
-            let result = replacement_text("from", &Some("to".into()), &None, &None, false);
+            let result = replacement_text("from", &Some("to".into()), &None, &None, false, false);
             assert_eq!(result, "to");
         }
 
         #[test]
         fn replacement_text_insert_before_literal() {
-            let result =
-                replacement_text("original", &None, &Some("PREFIX\n".into()), &None, false);
+            let result = replacement_text(
+                "original",
+                &None,
+                &Some("PREFIX\n".into()),
+                &None,
+                false,
+                false,
+            );
             assert_eq!(result, "PREFIX\noriginal");
         }
 
         #[test]
         fn replacement_text_insert_after_literal() {
-            let result =
-                replacement_text("original", &None, &None, &Some("\nSUFFIX".into()), false);
+            let result = replacement_text(
+                "original",
+                &None,
+                &None,
+                &Some("\nSUFFIX".into()),
+                false,
+                false,
+            );
             assert_eq!(result, "original\nSUFFIX");
         }
 
         #[test]
         fn replacement_text_insert_before_regex_anchor() {
-            let result = replacement_text("ignored", &None, &Some("PREFIX\n".into()), &None, true);
+            let result = replacement_text(
+                "ignored",
+                &None,
+                &Some("PREFIX\n".into()),
+                &None,
+                true,
+                true,
+            );
             assert_eq!(result, "PREFIX\n${0}");
         }
 
         #[test]
         fn replacement_text_insert_after_regex_anchor() {
-            let result = replacement_text("ignored", &None, &None, &Some("\nSUFFIX".into()), true);
+            let result = replacement_text(
+                "ignored",
+                &None,
+                &None,
+                &Some("\nSUFFIX".into()),
+                true,
+                true,
+            );
             assert_eq!(result, "${0}\nSUFFIX");
+        }
+
+        // Regression: dollar signs in replacement text must be preserved
+        // when case_insensitive/word_boundary compiles an internal regex.
+        #[test]
+        fn replacement_text_escapes_dollars_for_internal_regex() {
+            // use_match_anchor=true (internal regex), regex_mode=false (not user-requested)
+            let result = replacement_text("cost", &Some("$100".into()), &None, &None, true, false);
+            assert_eq!(result, "$$100");
+        }
+
+        #[test]
+        fn replacement_text_preserves_dollars_for_user_regex() {
+            // use_match_anchor=true, regex_mode=true (user explicitly requested regex)
+            let result =
+                replacement_text("(c)ost", &Some("$1ost".into()), &None, &None, true, true);
+            assert_eq!(result, "$1ost");
         }
 
         #[test]

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -39,7 +39,8 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         }
     );
     let use_regex = regex_mode || *case_insensitive || word_boundary;
-    let replacement = replacement_text(from, to, insert_before, insert_after, use_regex);
+    let replacement =
+        replacement_text(from, to, insert_before, insert_after, use_regex, regex_mode);
     let compiled_re = compile_replace_regex(
         from,
         regex_mode,


### PR DESCRIPTION
## Summary

Round 14 of the code audit. Three bugs fixed with 5 regression tests.

### Bug 1: Dollar signs corrupted in replacement text (case_insensitive/word_boundary)

`replacement_text()` passes the replacement string through regex replace when `case_insensitive` or `word_boundary` flags trigger an internal regex. Dollar signs (`$`) in the replacement are interpreted as capture group references, corrupting the output.

**Fix:** Add `regex_mode: bool` parameter. When `false` (internal regex, not user-supplied), dollar signs are escaped to `$$`.

### Bug 2: reorder_symbols drops non-symbol content

`reorder_symbols` rebuild logic only emitted symbol bodies, silently dropping `use` statements, module-level comments, and other non-symbol content that precedes/follows the first/last symbol.

**Fix:** Preserve scope prefix (content before first symbol) and scope suffix (content after last symbol) in the reordered output.

### Bug 3: rewrite_function_signature loses visibility and return type

When `FunctionSigEdit` leaves `visibility` and `return_type` as `None` (fallback to reading from AST), the function used wrong tree-sitter node kind names:
- `"visibility"` instead of `"visibility_modifier"`
- `"return_type"` which does not exist in tree-sitter-rust (the return type is a `->` child + type child)

**Fix:** Use `"visibility_modifier"` and add `extract_return_type()` helper that finds the `->` node and grabs the type text after it.