### PR TITLE
fix: three bugs in symbol spans, inline code stripping, and line ending handling

### DIFF
--- a/src/ast/diff.rs
+++ b/src/ast/diff.rs
@@ -179,18 +179,18 @@ fn extract_body<'a>(source: &'a str, sym: &SymbolDef) -> &'a str {
     if start >= lines.len() || start >= end {
         return "";
     }
-    let line_sep_len = if source.contains("\r\n") { 2 } else { 1 };
-    let start_byte: usize = source
-        .lines()
-        .take(start)
-        .map(|l| l.len() + line_sep_len)
-        .sum();
-    let end_byte: usize = source
-        .lines()
-        .take(end)
-        .map(|l| l.len() + line_sep_len)
-        .sum();
-    &source[start_byte..end_byte.min(source.len())]
+    let offsets = crate::ast::symbols::compute_line_byte_offsets(source);
+    let start_byte = if start < offsets.len() {
+        offsets[start]
+    } else {
+        source.len()
+    };
+    let end_byte = if end < offsets.len() {
+        offsets[end]
+    } else {
+        source.len()
+    };
+    &source[start_byte..end_byte]
 }
 
 /// Render changes as human-readable text.

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -964,7 +964,6 @@ fn is_annotation_line(trimmed: &str, lang: Language) -> bool {
         Language::Rust => {
             trimmed.starts_with("#[")
                 || trimmed.starts_with("///")
-                || trimmed.starts_with("//!")
                 || trimmed.starts_with("/**")
                 || trimmed.starts_with("* ")
                 || trimmed == "*/"
@@ -995,27 +994,50 @@ fn is_annotation_line(trimmed: &str, lang: Language) -> bool {
 
 /// Extract the text of a symbol from source, using the full span (including
 /// attributes and doc comments).
+/// Compute the byte offset of the start of each line in `source`.
+/// Returns a vector where `offsets[i]` is the byte position of the start of
+/// line `i` (0-indexed). `offsets[lines.len()]` is `source.len()`, so that
+/// `source[offsets[i]..offsets[i+1]]` gives line `i` including its line ending.
+pub(crate) fn compute_line_byte_offsets(source: &str) -> Vec<usize> {
+    let mut offsets = vec![0usize];
+    let bytes = source.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\n' {
+            offsets.push(i + 1);
+            i += 1;
+        } else if bytes[i] == b'\r' && i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
+            offsets.push(i + 2);
+            i += 2;
+        } else if bytes[i] == b'\r' {
+            offsets.push(i + 1);
+            i += 1;
+        } else {
+            i += 1;
+        }
+    }
+    offsets
+}
+
 pub fn extract_symbol_text<'a>(source: &'a str, sym: &SymbolDef, lang: Language) -> &'a str {
     let (full_start, full_end) = full_symbol_span(source, sym, lang);
     let lines: Vec<&str> = source.lines().collect();
     let start_0 = full_start.saturating_sub(1);
     let end_0 = full_end.min(lines.len());
 
-    // Find byte offsets. str::lines() strips both \n and \r\n, so line.len()
-    // excludes the line ending. We must account for the actual ending size.
-    let line_ending_len = if source.contains("\r\n") { 2 } else { 1 };
-    let mut byte_start = 0;
-    for line in &lines[..start_0] {
-        byte_start += line.len() + line_ending_len;
-    }
-
-    let mut byte_end = byte_start;
-    for line in &lines[start_0..end_0] {
-        byte_end += line.len() + line_ending_len;
-    }
-
-    // Don't go past source length
-    byte_end = byte_end.min(source.len());
+    // Compute byte offsets by scanning the actual source bytes rather than
+    // assuming uniform line endings (files may mix \r\n and \n).
+    let line_offsets = compute_line_byte_offsets(source);
+    let byte_start = if start_0 < line_offsets.len() {
+        line_offsets[start_0]
+    } else {
+        source.len()
+    };
+    let byte_end = if end_0 < line_offsets.len() {
+        line_offsets[end_0]
+    } else {
+        source.len()
+    };
 
     &source[byte_start..byte_end]
 }
@@ -1522,6 +1544,20 @@ struct Point {
         assert_eq!(start, 1);
     }
 
+    // Regression: //! inner doc comments belong to the module, not the
+    // following symbol. full_symbol_span must not absorb them.
+    #[test]
+    fn full_span_excludes_inner_doc_comments() {
+        let source = "//! Module-level doc.\nstruct Config {}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let sym = symbols.iter().find(|s| s.name == "Config").unwrap();
+        let (start, _) = full_symbol_span(source, sym, Language::Rust);
+        assert_eq!(
+            start, 2,
+            "inner doc comment //! should not be included in Config's span"
+        );
+    }
+
     #[test]
     fn full_span_stops_at_unrelated_code() {
         let source = "fn bar() {}\n\n#[test]\nfn foo() {}\n";
@@ -1540,6 +1576,25 @@ struct Point {
         assert!(text.contains("#[test]"));
         assert!(text.contains("fn foo()"));
         assert!(!text.contains("fn bar"));
+    }
+
+    // Regression: extract_symbol_text used a global line-ending heuristic
+    // that produced wrong byte offsets on files with mixed \r\n and \n endings.
+    #[test]
+    fn extract_symbol_text_mixed_line_endings() {
+        // First line uses \r\n, rest use \n.
+        let source = "fn first() {}\r\nfn second() {\n    42\n}\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let second = symbols.iter().find(|s| s.name == "second").unwrap();
+        let text = extract_symbol_text(source, second, Language::Rust);
+        assert!(
+            text.contains("fn second()"),
+            "should contain fn second(): {text:?}"
+        );
+        assert!(
+            !text.contains("fn first()"),
+            "should not contain fn first(): {text:?}"
+        );
     }
 
     // ── find_function_span tests ──────────────────────────────────

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -566,25 +566,53 @@ pub fn table_append_for_tx(content: &str, heading: &str, row: &str) -> Option<St
 }
 
 /// Strip inline code spans (between backticks) from a line so that
-/// we don't false-positive on code examples.
+/// we don't false-positive on code examples. Handles multi-backtick
+/// spans (e.g. `` `code` ``, ``` ``code`` ```).
 pub(crate) fn strip_inline_code(line: &str) -> Cow<'_, str> {
     if !line.contains('`') {
         return Cow::Borrowed(line);
     }
     let mut result = String::with_capacity(line.len());
-    let mut rest = line;
-    while let Some(open) = rest.find('`') {
-        result.push_str(&rest[..open]);
-        let after_open = &rest[open + 1..];
-        if let Some(close) = after_open.find('`') {
-            rest = &after_open[close + 1..];
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'`' {
+            // Count the opening backtick run length.
+            let run_start = i;
+            while i < bytes.len() && bytes[i] == b'`' {
+                i += 1;
+            }
+            let run_len = i - run_start;
+            // Find the matching closing run of the same length.
+            let mut found = false;
+            let mut j = i;
+            while j < bytes.len() {
+                if bytes[j] == b'`' {
+                    let close_start = j;
+                    while j < bytes.len() && bytes[j] == b'`' {
+                        j += 1;
+                    }
+                    if j - close_start == run_len {
+                        // Matched closing run — skip the entire span.
+                        i = j;
+                        found = true;
+                        break;
+                    }
+                    // Different run length — not a match, continue searching.
+                } else {
+                    j += 1;
+                }
+            }
+            if !found {
+                // Unmatched backtick run — keep the rest as-is.
+                result.push_str(&line[run_start..]);
+                return Cow::Owned(result);
+            }
         } else {
-            // Unmatched backtick — keep the rest as-is.
-            rest = after_open;
-            break;
+            result.push(bytes[i] as char);
+            i += 1;
         }
     }
-    result.push_str(rest);
     Cow::Owned(result)
 }
 

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -618,7 +618,8 @@ mod edge_cases {
 
     #[test]
     fn strip_inline_code_unmatched_backtick() {
-        assert_eq!(strip_inline_code("before `after"), "before after");
+        // Unmatched backtick is kept as literal text (correct per CommonMark).
+        assert_eq!(strip_inline_code("before `after"), "before `after");
     }
 
     #[test]
@@ -630,12 +631,24 @@ mod edge_cases {
 
     #[test]
     fn strip_inline_code_adjacent_backticks() {
-        assert_eq!(strip_inline_code("``"), "");
+        // Two backticks with no matching closing run is unmatched.
+        assert_eq!(strip_inline_code("``"), "``");
     }
 
     #[test]
     fn strip_inline_code_only_backtick_content() {
         assert_eq!(strip_inline_code("`code`"), "");
+    }
+
+    // Regression: double-backtick code spans should strip their content.
+    #[test]
+    fn strip_inline_code_double_backtick_span() {
+        assert_eq!(strip_inline_code("Use ``git add .`` safely"), "Use  safely");
+    }
+
+    #[test]
+    fn strip_inline_code_triple_backtick_span() {
+        assert_eq!(strip_inline_code("Run ```git add .``` here"), "Run  here");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Round 15 of the code audit. Three bugs fixed with 4 regression tests.

### Bug 1: //! inner doc comments absorbed into symbol spans

`is_annotation_line` treated `//!` (inner doc comments) as symbol annotations. Inner doc comments document the *containing module*, not the following item. This caused `full_symbol_span`, `extract_symbol_text`, and all dependent operations (extract, move, split, group) to incorrectly absorb module-level `//!` docs into the first symbol's text.

**Fix:** Remove `//!` from the Rust annotation patterns. Only `///` (outer doc comments) and `#[...]` (attributes) are included.

### Bug 2: strip_inline_code fails on multi-backtick code spans

`strip_inline_code` only handled single-backtick code spans (\`code\`), failing on double (\`\`code\`\`) and triple backtick spans. CommonMark allows multi-backtick inline code. The function treated double backticks as two single-backtick pairs, stripping wrong content and leaving inner text exposed, causing false positive lint warnings from `has_dangerous_git_add_dot`.

**Fix:** Detect opening backtick run length and find matching closing run of the same length.

### Bug 3: Mixed line endings produce wrong byte offsets in extract_symbol_text and ast diff

Both `extract_symbol_text` and `extract_body` (ast diff) used a global line-ending heuristic: `if source.contains("\r\n") { 2 } else { 1 }`. On files with mixed line endings (some \r\n, some \n), all lines were counted with the same ending size, causing byte offsets to drift. This could produce wrong text slices or panic on non-char-boundary indices.

**Fix:** Added `compute_line_byte_offsets()` helper that scans actual source bytes to build accurate per-line byte offset table. Used by both functions.