### PR TITLE
fix: four bugs in refs, selector parser, fallback, and backup

### DIFF
--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -250,14 +250,18 @@ fn is_definition_site(node: tree_sitter_lib::Node) -> bool {
     if let Some(parent) = node.parent()
         && DEFINITION_PARENT_KINDS.contains(&parent.kind())
     {
-        // Check if this node is the "name" field of the parent
-        // by checking the field name
+        // Use tree-sitter's field API: the "name" field points to the
+        // symbol being defined. Other identifier children (parameters,
+        // return types, etc.) are NOT definitions.
+        if let Some(name_node) = parent.child_by_field_name("name") {
+            return name_node.id() == node.id();
+        }
+        // Fallback for grammars without a "name" field: treat the first
+        // identifier child as the definition name.
         let mut cursor = parent.walk();
         for child in parent.children(&mut cursor) {
-            if child.id() == node.id() {
-                // This identifier is a direct child of a definition node.
-                // It's a definition if it's the name child (first identifier).
-                return true;
+            if IDENTIFIER_KINDS.contains(&child.kind()) {
+                return child.id() == node.id();
             }
         }
     }
@@ -486,5 +490,43 @@ int main() {
     fn ref_kind_serializes() {
         let json = serde_json::to_string(&RefKind::Definition).unwrap();
         assert_eq!(json, "\"definition\"");
+    }
+
+    #[test]
+    fn is_definition_site_only_matches_name_child() {
+        // Parameters inside a function definition should NOT be classified
+        // as definitions of the parameter name.
+        let source = r#"
+fn process(input: &str, count: usize) -> bool {
+    count > 0
+}
+
+fn main() {
+    process("hello", 5);
+}
+"#;
+        let refs = find_refs_in_source(source, "process", Language::Rust, "test.rs");
+        let defs: Vec<_> = refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Definition)
+            .collect();
+        // "process" should have exactly one definition (the fn declaration)
+        assert_eq!(
+            defs.len(),
+            1,
+            "expected exactly 1 definition of 'process', got {defs:?}"
+        );
+
+        // "input" should NOT be classified as a definition (it's a parameter)
+        let input_refs = find_refs_in_source(source, "input", Language::Rust, "test.rs");
+        let input_defs: Vec<_> = input_refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Definition)
+            .collect();
+        // Parameters are not definitions of top-level symbols
+        assert!(
+            input_defs.is_empty(),
+            "parameter 'input' should not be classified as a definition: {input_defs:?}"
+        );
     }
 }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -400,8 +400,11 @@ pub fn prune_old_backups(project_root: &Path) -> anyhow::Result<usize> {
         if let Some(nanos_str) = dir_name.split('_').next()
             && let Ok(nanos) = nanos_str.parse::<u128>()
         {
-            let created = std::time::Duration::from_nanos(nanos as u64);
-            if now.saturating_sub(created) > max_age {
+            // Compare using u128 nanos directly to avoid u128→u64 truncation.
+            let now_nanos = now.as_nanos();
+            let age_nanos = now_nanos.saturating_sub(nanos);
+            let max_age_nanos = max_age.as_nanos();
+            if age_nanos > max_age_nanos {
                 let _ = std::fs::remove_dir_all(entry.path());
                 pruned += 1;
             }
@@ -573,6 +576,33 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let pruned = prune_old_backups(dir.path()).unwrap();
         assert_eq!(pruned, 0);
+    }
+
+    #[test]
+    fn prune_old_backups_handles_large_nanos_without_truncation() {
+        let dir = TempDir::new().unwrap();
+
+        // Create a fake session with a timestamp that exceeds u64::MAX nanos.
+        // u64::MAX nanos = ~584 years from epoch (around year 2554).
+        // Use a value > u64::MAX to verify no truncation occurs.
+        let huge_nanos: u128 = u64::MAX as u128 + 1_000_000_000;
+        let ts_str = format!("{huge_nanos}_0");
+        let future_dir = dir.path().join(BACKUP_DIR).join(&ts_str);
+        std::fs::create_dir_all(&future_dir).unwrap();
+        std::fs::write(future_dir.join("manifest.json"), "[]").unwrap();
+
+        // This session is far in the future, so pruning should NOT remove it.
+        // Before the fix, `as u64` truncation would make the timestamp wrap
+        // around to near-epoch, causing it to appear very old and get pruned.
+        let pruned = prune_old_backups(dir.path()).unwrap();
+        assert_eq!(
+            pruned, 0,
+            "future session with u128 timestamp should not be pruned"
+        );
+        assert!(
+            future_dir.exists(),
+            "directory should still exist after prune"
+        );
     }
 
     #[test]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -384,24 +384,30 @@ pub fn anchor_match(
         }
 
         // If we have before_context, verify the preceding line matches.
+        // For multi-line context, compare only the last line (the one
+        // immediately before the target region).
         if let Some(before) = before_context {
             if i == 0 {
                 continue;
             }
             let prev = lines[i - 1].trim();
-            if strsim::jaro_winkler(prev, before.trim()) < 0.8 {
+            let before_line = before.lines().last().unwrap_or(before).trim();
+            if strsim::jaro_winkler(prev, before_line) < 0.8 {
                 continue;
             }
         }
 
         // If we have after_context, check the line after the candidate region.
+        // For multi-line context, compare only the first line (the one
+        // immediately after the target region).
         if let Some(after) = after_context {
             let end_idx = i + target_lines.len();
             if end_idx >= lines.len() {
                 continue;
             }
             let next = lines[end_idx].trim();
-            if strsim::jaro_winkler(next, after.trim()) < 0.8 {
+            let after_line = after.lines().next().unwrap_or(after).trim();
+            if strsim::jaro_winkler(next, after_line) < 0.8 {
                 continue;
             }
         }
@@ -1098,6 +1104,41 @@ mod tests {
         let result = resolve_with_fallback("", "fn hello()", None, None);
         let err = result.unwrap_err();
         assert_eq!(err.kind, EditErrorKind::NoMatch);
+    }
+
+    #[test]
+    fn anchor_match_multiline_before_context() {
+        // Multi-line before_context should use the last line for matching,
+        // not the entire multi-line string.
+        let content = "fn setup() {}\nfn target() {}\nfn cleanup() {}\n";
+        let result = anchor_match(
+            content,
+            "fn target() {}",
+            Some("fn other() {}\nfn setup() {}"),
+            None,
+        );
+        assert!(
+            result.is_some(),
+            "anchor_match should match using the last line of multi-line before_context"
+        );
+        assert_eq!(result.unwrap().matched_text, "fn target() {}");
+    }
+
+    #[test]
+    fn anchor_match_multiline_after_context() {
+        // Multi-line after_context should use the first line for matching.
+        let content = "fn setup() {}\nfn target() {}\nfn cleanup() {}\n";
+        let result = anchor_match(
+            content,
+            "fn target() {}",
+            None,
+            Some("fn cleanup() {}\nfn extra() {}"),
+        );
+        assert!(
+            result.is_some(),
+            "anchor_match should match using the first line of multi-line after_context"
+        );
+        assert_eq!(result.unwrap().matched_text, "fn target() {}");
     }
 
     // Static assertions: types must be Send + Sync.

--- a/src/selector/parser.rs
+++ b/src/selector/parser.rs
@@ -39,10 +39,18 @@ pub fn parse(input: &str) -> Result<Selector, String> {
         if bytes[i] == b'[' {
             i += 1; // skip '['
             let start = i;
-            while i < len && bytes[i] != b']' {
-                i += 1;
+            let mut depth = 1u32;
+            while i < len && depth > 0 {
+                if bytes[i] == b'[' {
+                    depth += 1;
+                } else if bytes[i] == b']' {
+                    depth -= 1;
+                }
+                if depth > 0 {
+                    i += 1;
+                }
             }
-            if i >= len {
+            if depth > 0 {
                 return Err("unclosed bracket in selector".to_string());
             }
             let content = &input[start..i];
@@ -217,6 +225,39 @@ mod tests {
                 Segment::Predicate {
                     key: "url".into(),
                     value: "a=b".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_predicate_value_with_brackets() {
+        // A predicate value containing brackets (e.g. regex character class)
+        // should be parsed correctly without truncating at the inner `]`.
+        let sel = parse("items[pattern=[0-9]]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("items".into()),
+                Segment::Predicate {
+                    key: "pattern".into(),
+                    value: "[0-9]".into(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_nested_brackets_in_value() {
+        // Deeply nested brackets should be handled.
+        let sel = parse("data[regex=[a[b]c]]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("data".into()),
+                Segment::Predicate {
+                    key: "regex".into(),
+                    value: "[a[b]c]".into(),
                 },
             ]
         );


### PR DESCRIPTION
## Code Audit Round 17

Four bugs found by reading the source code, each with regression tests.

### Bug 1: `ast/refs.rs` - `is_definition_site` misclassifies non-name children

`is_definition_site()` returned `true` for any identifier child of a definition node, not just the name child. This meant parameters (`fn foo(input: &str)`, where `input` is an identifier child of `function_item`) were classified as `RefKind::Definition` instead of `RefKind::Reference`.

**Fix:** Use tree-sitter's `child_by_field_name("name")` to check only the actual name field, with a fallback to the first identifier child for grammars without a "name" field.

### Bug 2: `selector/parser.rs` - Brackets inside predicate values silently truncated

The bracket parser scanned for the first `]` to close the segment. A predicate value containing brackets (e.g., `items[pattern=[0-9]]`) was silently truncated at the inner `]`, producing `pattern=[0-9` instead of `pattern=[0-9]`.

**Fix:** Track bracket nesting depth so inner brackets are preserved.

### Bug 3: `fallback.rs` - Multi-line context silently fails anchor match

`anchor_match` compared multi-line `before_context`/`after_context` strings (containing newlines) against a single source line via Jaro-Winkler similarity. The newlines in the context string always produced a low similarity score, causing the anchor to silently fail.

**Fix:** Extract only the relevant adjacent line: last line of `before_context`, first line of `after_context`.

### Bug 4: `backup.rs` - `u128` to `u64` truncation in prune timestamps

`prune_old_backups` cast `u128` nanosecond timestamps to `u64` via `as u64`. After ~year 2554 when nanos exceed `u64::MAX`, the truncation would make future sessions appear near-epoch, causing them to be immediately pruned.

**Fix:** Use `u128` arithmetic throughout the comparison.

---

All fixes include regression tests. `make check-fast` passes (1673 unit, 789 integration, 10 PTY tests).