### PR TITLE
fix: three bugs in markdown ops and schema type rendering

### DIFF
--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -496,9 +496,12 @@ fn is_separator_row(line: &str) -> bool {
     if t.len() < 3 || !t.starts_with('|') || !t.ends_with('|') {
         return false;
     }
-    t[1..t.len() - 1]
-        .chars()
-        .all(|c| matches!(c, '-' | ':' | '|' | ' '))
+    let inner = &t[1..t.len() - 1];
+    if !inner.chars().all(|c| matches!(c, '-' | ':' | '|' | ' ')) {
+        return false;
+    }
+    // Each cell must contain at least one dash per CommonMark spec.
+    inner.split('|').all(|cell| cell.contains('-'))
 }
 
 pub fn table_append_in(
@@ -609,8 +612,11 @@ pub(crate) fn strip_inline_code(line: &str) -> Cow<'_, str> {
                 return Cow::Owned(result);
             }
         } else {
-            result.push(bytes[i] as char);
-            i += 1;
+            // Advance by one UTF-8 character, not one byte.
+            // `bytes[i] as char` corrupts multi-byte UTF-8 (e.g. é → Ã©).
+            let ch = line[i..].chars().next().unwrap();
+            result.push(ch);
+            i += ch.len_utf8();
         }
     }
     Cow::Owned(result)

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -652,6 +652,15 @@ mod edge_cases {
     }
 
     #[test]
+    fn strip_inline_code_preserves_non_ascii_utf8() {
+        // Multi-byte UTF-8 characters (é, ñ, 日) outside code spans must
+        // not be corrupted by byte-to-char casting.
+        assert_eq!(strip_inline_code("café `code` résumé"), "café  résumé");
+        assert_eq!(strip_inline_code("日本語テスト"), "日本語テスト");
+        assert_eq!(strip_inline_code("`hidden` naïve"), " naïve");
+    }
+
+    #[test]
     fn git_add_dot_empty_string() {
         assert!(!has_dangerous_git_add_dot(""));
     }
@@ -851,6 +860,20 @@ mod error_handling {
         let content = "# API\nJust text\n";
         let (start, end) = find_section(content, "API").unwrap();
         assert!(table_append_in(content, start, end, "| b | 2 |").is_none());
+    }
+
+    #[test]
+    fn is_separator_row_rejects_dashless_cells() {
+        // A row like "| |" or "| : |" has no dashes and is not a valid
+        // CommonMark table separator. Each cell must contain at least one dash.
+        use super::is_separator_row;
+        assert!(!is_separator_row("|  |"), "spaces only");
+        assert!(!is_separator_row("| : |"), "colon only");
+        assert!(!is_separator_row("| : : |"), "colons and spaces");
+        // Valid separators should still pass.
+        assert!(is_separator_row("| --- |"));
+        assert!(is_separator_row("| :--: | --- |"));
+        assert!(is_separator_row("|---|"));
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -538,6 +538,24 @@ pub fn operations_for_tier(tier: Tier) -> Vec<OperationSchema> {
         .collect()
 }
 
+/// Extract a human-readable type string from a JSON Schema `type` field.
+///
+/// Handles both `"type": "string"` (scalar) and `"type": ["string", "null"]`
+/// (nullable, produced by schemars for `Option<T>` fields).
+fn extract_type_str(schema: &serde_json::Value) -> String {
+    match schema.get("type") {
+        Some(t) if t.is_string() => t.as_str().unwrap().to_string(),
+        Some(t) if t.is_array() => t
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join(" | "),
+        _ => "any".to_string(),
+    }
+}
+
 /// Generate a system prompt fragment describing available operations at this tier.
 ///
 /// The output is markdown text suitable for inclusion in an LLM system prompt.
@@ -567,7 +585,7 @@ pub fn system_prompt_for_tier(tier: Tier) -> String {
                 .unwrap_or_default();
 
             for (key, schema) in obj {
-                let type_str = schema.get("type").and_then(|t| t.as_str()).unwrap_or("any");
+                let type_str = extract_type_str(schema);
                 let desc = schema
                     .get("description")
                     .and_then(|d| d.as_str())
@@ -605,7 +623,7 @@ pub fn system_prompt_for_tier(tier: Tier) -> String {
     {
         out.push_str("**Fields:**\n\n");
         for (key, schema) in obj {
-            let type_str = schema.get("type").and_then(|t| t.as_str()).unwrap_or("any");
+            let type_str = extract_type_str(schema);
             let desc = schema
                 .get("description")
                 .and_then(|d| d.as_str())

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -596,6 +596,50 @@ mod error_handling {
     }
 }
 
+mod type_extraction {
+    use super::*;
+
+    #[test]
+    fn extract_type_str_scalar() {
+        let schema = serde_json::json!({"type": "string"});
+        assert_eq!(extract_type_str(&schema), "string");
+    }
+
+    #[test]
+    fn extract_type_str_nullable_array() {
+        // schemars generates {"type": ["string", "null"]} for Option<String>.
+        let schema = serde_json::json!({"type": ["string", "null"]});
+        let result = extract_type_str(&schema);
+        assert!(
+            result.contains("string") && result.contains("null"),
+            "expected 'string | null' or similar, got '{result}'"
+        );
+    }
+
+    #[test]
+    fn extract_type_str_missing() {
+        let schema = serde_json::json!({"description": "no type"});
+        assert_eq!(extract_type_str(&schema), "any");
+    }
+
+    #[test]
+    fn system_prompt_does_not_show_any_for_optional_params() {
+        // The system prompt should show real types (string, boolean, etc.)
+        // for optional parameters, not "any".
+        let prompt = system_prompt_for_tier(Tier::Strong);
+        // Count occurrences of ": any" — there should be very few.
+        let any_count = prompt.matches(": any").count();
+        // Some fields genuinely have no type (e.g., `value` in doc.set
+        // accepts any JSON), but the majority should have real types.
+        // If nullable fields show "any", this count will be very high.
+        assert!(
+            any_count < 15,
+            "too many 'any' types in system prompt ({any_count}); \
+             nullable fields may not be rendering correctly"
+        );
+    }
+}
+
 // Static assertion: types must be Send + Sync.
 const _: () = {
     fn _assert<T: Send + Sync>() {}


### PR DESCRIPTION
## Code Audit Round 18

Three bugs found by reading the source code, each with regression tests.

### Bug 1: `strip_inline_code` corrupts non-ASCII UTF-8

The function processed content byte-by-byte and cast each byte to `char` via `bytes[i] as char`. For multi-byte UTF-8 characters (e.g., `e` with accent = 0xC3 0xA9), each byte was pushed as a separate code point, producing garbled output.

**Fix:** Advance by one UTF-8 character using `line[i..].chars().next()` and `ch.len_utf8()`.

### Bug 2: `is_separator_row` accepts dashless rows

The function accepted rows like `|  |` (pipes with only spaces/colons) as valid CommonMark table separators. Per the spec, each cell in a delimiter row must contain at least one dash (`-`).

**Fix:** After checking that inner characters are valid separator characters, also verify that each cell (split by `|`) contains at least one dash.

### Bug 3: Schema system prompt renders "any" for nullable fields

`system_prompt_for_tier` used `.as_str()` to extract the JSON Schema `type` field, which returns `None` for the `["string", "null"]` arrays that schemars generates for `Option<T>` fields. This caused all optional parameters to show as `type: any` in the LLM system prompt.

**Fix:** Added `extract_type_str()` helper that handles both scalar types (`"string"`) and array types (`["string", "null"]` renders as `string | null`).

---

All fixes include regression tests. `make check-fast` passes (1679 unit, 789 integration, 10 PTY tests).