### PR TITLE
fix: wrap.rs full_symbol_span, extract.rs brace detection, imports.rs scope awareness

### DIFF
--- a/src/ast/extract.rs
+++ b/src/ast/extract.rs
@@ -96,7 +96,7 @@ fn unwrap_module_body(lines: &[&str], sym_start_0: usize, sym_end_0: usize) -> S
     let mut body_start = sym_start_0;
     for (i, line) in lines.iter().enumerate().take(sym_end_0).skip(sym_start_0) {
         let trimmed = line.trim();
-        if trimmed.ends_with('{') {
+        if trimmed.contains('{') {
             body_start = i + 1;
             break;
         }
@@ -223,5 +223,21 @@ mod tests {
         let result = extract_to_file(source, "tests", None, false, None, Language::Rust).unwrap();
         assert!(result.target_content.contains("/// Doc comment."));
         assert!(result.target_content.contains("#[cfg(test)]"));
+    }
+
+    #[test]
+    fn unwrap_module_with_trailing_comment_on_brace_line() {
+        // Opening brace line has a trailing comment: `mod tests { // test module`
+        // The brace detection must still find it
+        let source =
+            "mod tests { // test module\n    fn test_a() {\n        assert!(true);\n    }\n}\n";
+        let result = extract_to_file(source, "tests", None, true, None, Language::Rust).unwrap();
+        // The mod declaration line should NOT leak into the unwrapped body
+        assert!(
+            !result.target_content.contains("mod tests"),
+            "mod declaration should not appear in unwrapped body: {}",
+            result.target_content
+        );
+        assert!(result.target_content.contains("fn test_a()"));
     }
 }

--- a/src/ast/imports.rs
+++ b/src/ast/imports.rs
@@ -30,10 +30,9 @@ pub fn list_imports(source: &str, lang: Language) -> Vec<ImportStatement> {
     let mut imports = Vec::new();
 
     for (i, line) in lines.iter().enumerate() {
-        let trimmed = line.trim();
-        if is_import_line(trimmed, lang) {
+        if is_top_level_import(line, lang) {
             imports.push(ImportStatement {
-                text: trimmed.to_string(),
+                text: line.trim().to_string(),
                 line: i + 1,
             });
         }
@@ -126,7 +125,7 @@ pub fn remove_imports(source: &str, imports_to_remove: &[String], lang: Language
 
     for line in &lines {
         let trimmed = line.trim();
-        if is_import_line(trimmed, lang) && remove_set.contains(&normalize_import(trimmed)) {
+        if is_top_level_import(line, lang) && remove_set.contains(&normalize_import(trimmed)) {
             removed += 1;
             continue;
         }
@@ -156,7 +155,7 @@ pub fn dedupe_imports(source: &str, lang: Language) -> ImportsResult {
 
     for line in &lines {
         let trimmed = line.trim();
-        if is_import_line(trimmed, lang) {
+        if is_top_level_import(line, lang) {
             let normalized = normalize_import(trimmed);
             if seen.contains(&normalized) {
                 deduped += 1;
@@ -179,6 +178,18 @@ pub fn dedupe_imports(source: &str, lang: Language) -> ImportsResult {
         removed: 0,
         deduped,
     }
+}
+
+/// Check if a line is a top-level import (no leading whitespace).
+///
+/// Scoped imports inside function bodies, impl blocks, or modules are
+/// indented and should not be treated as top-level imports.
+fn is_top_level_import(line: &str, lang: Language) -> bool {
+    let first = line.as_bytes().first().copied().unwrap_or(b' ');
+    if first == b' ' || first == b'\t' {
+        return false;
+    }
+    is_import_line(line.trim(), lang)
 }
 
 /// Check if a line is an import/use statement for the given language.
@@ -228,8 +239,7 @@ fn find_import_insert_point(lines: &[&str], lang: Language) -> usize {
     let mut last_import_line = None;
 
     for (i, line) in lines.iter().enumerate() {
-        let trimmed = line.trim();
-        if is_import_line(trimmed, lang) {
+        if is_top_level_import(line, lang) {
             last_import_line = Some(i);
         }
     }
@@ -343,5 +353,66 @@ mod tests {
         let source = "import os\nfrom pathlib import Path\n\ndef main():\n    pass\n";
         let imports = list_imports(source, Language::Python);
         assert_eq!(imports.len(), 2);
+    }
+
+    #[test]
+    fn scoped_use_not_treated_as_top_level() {
+        // Scoped `use` inside a function body should be ignored by all import functions
+        let source =
+            "use std::io;\n\nfn main() {\n    use std::fmt;\n    println!(\"hello\");\n}\n";
+        let imports = list_imports(source, Language::Rust);
+        assert_eq!(imports.len(), 1, "scoped use should not be listed");
+        assert_eq!(imports[0].text, "use std::io;");
+    }
+
+    #[test]
+    fn add_import_not_inside_function() {
+        // New imports must be inserted at the top level, not inside a function body
+        let source =
+            "use std::io;\n\nfn main() {\n    use std::fmt;\n    println!(\"hello\");\n}\n";
+        let result = add_imports(source, &["use std::fs".into()], Language::Rust);
+        assert_eq!(result.added, 1);
+        // The new import should appear after the existing top-level import (line 1),
+        // not after the scoped import inside main()
+        let lines: Vec<&str> = result.content.lines().collect();
+        let fs_line = lines
+            .iter()
+            .position(|l| l.trim() == "use std::fs;")
+            .expect("use std::fs; should be present");
+        let fn_line = lines
+            .iter()
+            .position(|l| l.trim().starts_with("fn main"))
+            .expect("fn main should be present");
+        assert!(
+            fs_line < fn_line,
+            "new import at line {} should be before fn main at line {}",
+            fs_line,
+            fn_line
+        );
+    }
+
+    #[test]
+    fn remove_import_ignores_scoped_use() {
+        // remove_imports should not remove scoped `use` inside function bodies
+        let source =
+            "use std::fmt;\n\nfn main() {\n    use std::fmt;\n    println!(\"hello\");\n}\n";
+        let result = remove_imports(source, &["use std::fmt".into()], Language::Rust);
+        assert_eq!(result.removed, 1);
+        // The scoped `use std::fmt;` inside main() should remain
+        assert!(
+            result.content.contains("    use std::fmt;"),
+            "scoped use should be preserved: {}",
+            result.content
+        );
+    }
+
+    #[test]
+    fn dedupe_ignores_scoped_use() {
+        // A scoped `use` that duplicates a top-level `use` should NOT be removed
+        let source =
+            "use std::fmt;\n\nfn main() {\n    use std::fmt;\n    println!(\"hello\");\n}\n";
+        let result = dedupe_imports(source, Language::Rust);
+        assert_eq!(result.deduped, 0, "scoped use is not a duplicate");
+        assert_eq!(result.content, source);
     }
 }

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -1,7 +1,7 @@
 //! AST-aware code wrapping: wrap existing code in a block (module, impl, etc.).
 
 use super::Language;
-use super::symbols::{extract_symbols, find_symbol};
+use super::symbols::{extract_symbols, find_symbol, full_symbol_span};
 
 /// Result of a wrap operation.
 #[derive(Debug)]
@@ -144,8 +144,9 @@ fn find_symbol_range(
     for name in symbol_names {
         let sym = find_symbol(&symbols, name)
             .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", name))?;
-        let start = sym.start_line.saturating_sub(1);
-        let end = sym.end_line;
+        let (full_start, full_end) = full_symbol_span(source, sym, lang);
+        let start = full_start.saturating_sub(1);
+        let end = full_end;
         if start < min_start {
             min_start = start;
         }
@@ -306,6 +307,35 @@ mod tests {
             Language::Rust,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn wrap_includes_doc_comments_and_attributes() {
+        // Doc comments and attributes above a symbol must be included in the wrap
+        let source = "/// Helper docs\n#[inline]\nfn helper() {\n    42\n}\n";
+        let result = wrap_code(
+            source,
+            Some(&["helper".into()]),
+            None,
+            "mod utils",
+            None,
+            Language::Rust,
+        )
+        .unwrap();
+        // The doc comment and attribute must be inside the module wrapper
+        let wrapper_pos = result.content.find("mod utils {").unwrap();
+        let doc_pos = result.content.find("/// Helper docs").unwrap();
+        let attr_pos = result.content.find("#[inline]").unwrap();
+        assert!(
+            doc_pos > wrapper_pos,
+            "doc comment should be inside wrapper: {}",
+            result.content
+        );
+        assert!(
+            attr_pos > wrapper_pos,
+            "attribute should be inside wrapper: {}",
+            result.content
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Code Audit Round 19 - 3 Bug Fixes

### Bug 1: wrap.rs `find_symbol_range` omits doc comments and attributes
`find_symbol_range` used `sym.start_line` directly instead of calling `full_symbol_span()`. When wrapping a symbol that has doc comments (`///`) or attributes (`#[inline]`, `#[cfg(...)]`) above it, those lines were left outside the wrapper block while the symbol itself was wrapped inside. All other AST modules (group, extract, insert, reorder, move, split) already use `full_symbol_span` for this purpose.

### Bug 2: extract.rs `unwrap_module_body` fails with trailing comments on brace line
The opening brace detection in `unwrap_module_body` used `ends_with('{')`, which fails when the brace line has a trailing comment (e.g., `mod tests { // unit tests`). The brace is not the last character, so the function falls through without finding it, causing the mod declaration line to leak into the unwrapped body. Changed to `contains('{')`.

### Bug 3: imports.rs scans entire file without scope awareness
All four import functions (`list_imports`, `add_imports`, `remove_imports`, `dedupe_imports`) plus `find_import_insert_point` scanned every line of the file. A scoped `use std::fmt;` inside a function body was treated as a top-level import. This caused:
- `add_imports` to insert new imports after the scoped use (inside the function body)
- `remove_imports` to remove scoped imports that should be preserved
- `dedupe_imports` to remove scoped uses that duplicate a top-level import (which may be intentional)
- `list_imports` to report scoped imports as top-level

Added `is_top_level_import()` that checks for zero indentation before matching import syntax, and updated all call sites.

### Tests added
- `wrap_includes_doc_comments_and_attributes`: verifies doc comments and attributes are inside the wrapper
- `unwrap_module_with_trailing_comment_on_brace_line`: verifies brace detection with trailing comments
- `scoped_use_not_treated_as_top_level`: verifies list_imports ignores scoped use
- `add_import_not_inside_function`: verifies new imports go before fn main, not inside it
- `remove_import_ignores_scoped_use`: verifies scoped use is preserved during removal
- `dedupe_ignores_scoped_use`: verifies scoped duplicates are not removed