### PR TITLE
fix: ATX heading CommonMark compliance and reorder slice panic

### DIFF
--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -102,8 +102,14 @@ pub fn reorder_symbols(
         .iter()
         .map(|s| s.start_0)
         .min()
-        .unwrap_or(scope_start_0);
-    let last_sym_end = spans.iter().map(|s| s.end_0).max().unwrap_or(scope_end_0);
+        .unwrap_or(scope_start_0)
+        .max(scope_start_0);
+    let last_sym_end = spans
+        .iter()
+        .map(|s| s.end_0)
+        .max()
+        .unwrap_or(scope_end_0)
+        .min(scope_end_0);
 
     // Now rebuild: before-scope + scope-prefix + reordered symbols + scope-suffix + after-scope
     let mut result = String::new();
@@ -442,5 +448,22 @@ mod tests {
             use_pos < alpha_pos,
             "use statement should remain before symbols"
         );
+    }
+
+    #[test]
+    fn reorder_inside_single_line_container_no_panic() {
+        // When children start on the same line as the container's opening brace,
+        // first_sym_start could be < scope_start_0 causing a slice panic.
+        let source = "mod m {\nfn b() {}\nfn a() {}\n}\n";
+        let result = reorder_symbols(
+            source,
+            Some("m"),
+            &ReorderStrategy::Alphabetical,
+            Language::Rust,
+        )
+        .unwrap();
+        let a_pos = result.content.find("fn a").unwrap();
+        let b_pos = result.content.find("fn b").unwrap();
+        assert!(a_pos < b_pos, "a should come before b: {}", result.content);
     }
 }

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -115,18 +115,30 @@ pub fn parse_headings(content: &str) -> Vec<HeadingInfo> {
     let nf_lines: Vec<(usize, &str)> = non_fenced_lines(content).collect();
 
     for (pos, &(idx, line)) in nf_lines.iter().enumerate() {
-        // ATX heading: starts with #
-        if line.starts_with('#') {
-            let hashes = line.bytes().take_while(|&b| b == b'#').count();
-            if hashes > 6 || hashes >= line.len() {
+        // ATX heading: optional 0-3 spaces then 1-6 '#' then space/tab/EOL
+        let stripped = line.trim_start_matches(' ');
+        let indent = line.len() - stripped.len();
+        if indent <= 3 && stripped.starts_with('#') {
+            let hashes = stripped.bytes().take_while(|&b| b == b'#').count();
+            if hashes > 6 {
                 continue;
             }
-            if line.as_bytes()[hashes] != b' ' {
+            // After the hashes: must be end-of-line, space, or tab
+            if hashes < stripped.len()
+                && stripped.as_bytes()[hashes] != b' '
+                && stripped.as_bytes()[hashes] != b'\t'
+            {
                 continue;
             }
+            let text = if hashes >= stripped.len() {
+                // Empty heading (line is only '#' characters)
+                String::new()
+            } else {
+                strip_atx_closing(stripped[hashes + 1..].trim_start())
+            };
             headings.push(HeadingInfo {
                 level: hashes,
-                text: strip_atx_closing(&line[hashes + 1..]),
+                text,
                 line_start: idx,
                 body_line: idx + 1,
                 line_end: 0,

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1174,4 +1174,42 @@ body text
         assert_eq!(headings.len(), 1);
         assert_eq!(headings[0].text, "Real heading");
     }
+
+    #[test]
+    fn parse_headings_empty_atx_heading() {
+        // CommonMark 4.2: "###" with no trailing text/space is a valid empty heading
+        let content = "###\nsome body\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1, "bare ### should be a level-3 heading");
+        assert_eq!(headings[0].level, 3);
+        assert_eq!(headings[0].text, "");
+    }
+
+    #[test]
+    fn parse_headings_tab_after_hashes() {
+        // CommonMark 4.2: opening # can be followed by spaces OR tabs
+        let content = "#\tTitle\nbody\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1, "tab after # should be accepted");
+        assert_eq!(headings[0].level, 1);
+        assert_eq!(headings[0].text, "Title");
+    }
+
+    #[test]
+    fn parse_headings_indented_up_to_3_spaces() {
+        // CommonMark 4.2: up to 3 spaces of leading indentation allowed
+        let content = "  ## Indented\nbody\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1, "2-space indent should be accepted");
+        assert_eq!(headings[0].level, 2);
+        assert_eq!(headings[0].text, "Indented");
+    }
+
+    #[test]
+    fn parse_headings_4_space_indent_rejected() {
+        // CommonMark 4.2: 4+ spaces is an indented code block, not a heading
+        let content = "    ## Not a heading\nbody\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 0, "4-space indent should NOT be a heading");
+    }
 }


### PR DESCRIPTION
## Code Audit Round 20 - 2 Bug Fixes

### Bug 1: ATX heading parsing violates CommonMark 4.2 spec (3 sub-issues)

Three CommonMark spec violations in `parse_headings`:

**(a) Empty headings rejected:** A line of only `#` characters (e.g., `###`) is a valid empty heading per CommonMark 4.2: "The opening sequence of # characters must be followed by spaces or tabs, or by the end of line." The code rejected these because `hashes >= line.len()` was treated as invalid.

**(b) Tab after `#` rejected:** The spec says the opening `#` can be followed by "spaces or tabs", but only `b' '` (space) was accepted. A heading like `#\tTitle` was skipped.

**(c) Indented ATX headings rejected:** The spec allows "up to three spaces of indentation" before the opening `#`. The code used `line.starts_with('#')` which required column 0. A heading like `  ## Heading` was not detected.

**Fix:** Strip up to 3 leading spaces before checking for `#`, accept tab as well as space after hashes, and handle the empty heading case (`hashes == stripped.len()`) separately.

### Bug 2: reorder.rs slice panic with `inside` container

When reordering symbols inside a container using the `inside` parameter, if a child symbol's `full_symbol_span` extended before `scope_start_0` (e.g., a child starting on the same line as the container's opening brace), the slice `lines[scope_start_0..first_sym_start]` had `start > end`, causing a runtime panic.

Similarly, if a child's span extended past `scope_end_0`, the suffix slice `lines[last_sym_end..scope_end_0]` would also panic.

**Fix:** Clamp `first_sym_start` to `max(scope_start_0)` and `last_sym_end` to `min(scope_end_0)`.

### Tests added
- `parse_headings_empty_atx_heading`: bare `###` produces level-3 heading
- `parse_headings_tab_after_hashes`: `#\tTitle` produces level-1 heading
- `parse_headings_indented_up_to_3_spaces`: 2-space indent accepted
- `parse_headings_4_space_indent_rejected`: 4-space indent NOT a heading
- `reorder_inside_single_line_container_no_panic`: no panic when children near container boundary