### PR TITLE
fix: impl trait naming, deletion patch path, Go grouped types

### DIFF
--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -617,7 +617,12 @@ fn extract_rust(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind
             Some((SymbolKind::Trait, name.to_string()))
         }
         "impl_item" => {
-            let name = child_text_by_kind(node, "type_identifier", source)?;
+            // Use the `type` field to get the impl target, not the first
+            // `type_identifier` child.  For `impl Display for Foo`, the
+            // first `type_identifier` is the trait (`Display`), but the
+            // `type` field always points to the target type (`Foo`).
+            let type_node = node.child_by_field_name("type")?;
+            let name = type_node.utf8_text(source.as_bytes()).ok()?;
             Some((SymbolKind::Impl, name.to_string()))
         }
         "const_item" => {
@@ -724,28 +729,29 @@ fn extract_go(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, 
             let name = child_text_by_kinds(node, &["field_identifier", "identifier"], source)?;
             Some((SymbolKind::Method, name.to_string()))
         }
-        "type_declaration" => {
-            let mut cursor = node.walk();
-            for child in node.children(&mut cursor) {
-                if child.kind() == "type_spec" {
-                    let name =
-                        child_text_by_kinds(child, &["type_identifier", "identifier"], source)?;
-                    let mut inner = child.walk();
-                    for grandchild in child.children(&mut inner) {
-                        match grandchild.kind() {
-                            "struct_type" => {
-                                return Some((SymbolKind::Struct, name.to_string()));
-                            }
-                            "interface_type" => {
-                                return Some((SymbolKind::Interface, name.to_string()));
-                            }
-                            _ => {}
-                        }
+        // Match `type_spec` and `type_alias` instead of `type_declaration` so
+        // grouped `type ( A struct{...}; B = int )` blocks emit one symbol
+        // per spec.  `visit_node` naturally recurses into the parent
+        // `type_declaration`.
+        "type_spec" => {
+            let name = child_text_by_kinds(node, &["type_identifier", "identifier"], source)?;
+            let mut inner = node.walk();
+            for grandchild in node.children(&mut inner) {
+                match grandchild.kind() {
+                    "struct_type" => {
+                        return Some((SymbolKind::Struct, name.to_string()));
                     }
-                    return Some((SymbolKind::Type, name.to_string()));
+                    "interface_type" => {
+                        return Some((SymbolKind::Interface, name.to_string()));
+                    }
+                    _ => {}
                 }
             }
-            None
+            Some((SymbolKind::Type, name.to_string()))
+        }
+        "type_alias" => {
+            let name = child_text_by_kinds(node, &["type_identifier", "identifier"], source)?;
+            Some((SymbolKind::Type, name.to_string()))
         }
         _ => None,
     }
@@ -1100,6 +1106,39 @@ impl Foo {
     }
 
     #[test]
+    fn rust_impl_trait_extracts_type_not_trait() {
+        // Regression: `impl Display for Foo` returned "Display" (the trait)
+        // because child_text_by_kind found the first type_identifier.
+        // The fix uses child_by_field_name("type") to get the target type.
+        let source = r#"
+use std::fmt;
+
+struct Foo;
+
+impl fmt::Display for Foo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Foo")
+    }
+}
+"#;
+        let symbols = extract_symbols(source, Language::Rust);
+        let impl_sym = symbols.iter().find(|s| s.kind == SymbolKind::Impl).unwrap();
+        assert_eq!(
+            impl_sym.name, "Foo",
+            "impl target should be Foo, not the trait"
+        );
+    }
+
+    #[test]
+    fn rust_impl_without_trait() {
+        // Inherent impl (no trait) should still extract the type name.
+        let source = "struct Bar;\nimpl Bar { fn go(&self) {} }\n";
+        let symbols = extract_symbols(source, Language::Rust);
+        let impl_sym = symbols.iter().find(|s| s.kind == SymbolKind::Impl).unwrap();
+        assert_eq!(impl_sym.name, "Bar");
+    }
+
+    #[test]
     fn extract_python_symbols() {
         let source = r#"
 class MyClass:
@@ -1153,6 +1192,23 @@ type Config struct {
         let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
         assert!(names.contains(&"main"));
         assert!(names.contains(&"Config"));
+    }
+
+    #[test]
+    fn go_grouped_type_declaration() {
+        // Regression: grouped `type (...)` blocks only returned the first type_spec.
+        // The fix matches `type_spec` instead of `type_declaration` so visit_node
+        // recurses into each spec independently.
+        let source = "package main\n\ntype (\n\tPoint struct{ X, Y int }\n\tReader interface{ Read([]byte) (int, error) }\n\tAlias = int\n)\n";
+        let symbols = extract_symbols(source, Language::Go);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"Point"), "missing Point, got {:?}", names);
+        assert!(names.contains(&"Reader"), "missing Reader, got {:?}", names);
+        assert!(names.contains(&"Alias"), "missing Alias, got {:?}", names);
+        let point = symbols.iter().find(|s| s.name == "Point").unwrap();
+        assert_eq!(point.kind, SymbolKind::Struct);
+        let reader = symbols.iter().find(|s| s.name == "Reader").unwrap();
+        assert_eq!(reader.kind, SymbolKind::Interface);
     }
 
     #[test]

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -37,7 +37,13 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
             return Err(format!("expected +++ line after --- at line {}", i + 1));
         }
 
-        let path = parse_file_path(lines[i + 1]);
+        // For deletions the `+++` line is `/dev/null`; take path from `---`.
+        let plus_path = parse_file_path(lines[i + 1]);
+        let path = if plus_path == "/dev/null" {
+            parse_file_path(lines[i])
+        } else {
+            plus_path
+        };
         i += 2;
 
         let mut hunks: Vec<Hunk> = Vec::new();

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -942,4 +942,24 @@ mod regression {
         let result = parse_file_path("--- a/src/main.rs\t2024-06-01 12:00:00.000 +0000");
         assert_eq!(result, "src/main.rs");
     }
+
+    #[test]
+    fn parse_patches_deletion_uses_minus_path() {
+        // Regression: deletion patches have `+++ /dev/null` so the path must
+        // come from the `---` line.  Previously the parser always read from
+        // `+++`, producing "/dev/null" as the file path.
+        let diff = "\
+--- a/old_file.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-line one
+-line two
+";
+        let patches = parse_patch(diff).expect("should parse deletion patch");
+        assert_eq!(patches.len(), 1);
+        assert_eq!(
+            patches[0].path, "old_file.txt",
+            "path should come from --- line for deletions"
+        );
+    }
 }


### PR DESCRIPTION
## Code Audit Round 21

Three bugs found by reading the source code, with regression tests.

### Bug 1: `impl_item` extracts trait name instead of type name
For `impl Display for Foo`, `child_text_by_kind(node, "type_identifier")` returned `Display` (the trait) because it finds the first `type_identifier` child. The impl target type `Foo` is the second one. Fix: use `child_by_field_name("type")` which the tree-sitter Rust grammar provides specifically for the impl target.

### Bug 2: Deletion patches produce wrong file path
`parse_patch` always read the path from the `+++` line. For file deletions, `+++` is `/dev/null`, so the resulting path was "/dev/null" instead of the actual file. Fix: when `+++` is `/dev/null`, fall back to the `---` line.

### Bug 3: Go grouped type declarations only return first type
`type ( A struct{...}; B int; C = string )` only extracted `A` because `extract_go` matched `type_declaration` and returned on the first `type_spec` child. Fix: match `type_spec` and `type_alias` directly instead of the parent `type_declaration`, so `visit_node` naturally recurses into each child.

### Files changed
- `src/ast/symbols.rs`: impl_item fix + Go type_spec/type_alias fix
- `src/ops/patch.rs`: deletion path fix
- `src/ops/patch_tests.rs`: regression test for deletion patch

All tests pass (`make check-fast`).