### PR TITLE
fix: Java static import path, Python from-import path, YAML key scope escape

### DIFF
--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -104,7 +104,18 @@ fn collect_rust_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut
 fn collect_python_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
     if node.kind() == "import_statement" || node.kind() == "import_from_statement" {
         if let Ok(text) = node.utf8_text(source.as_bytes()) {
-            let path = extract_path_from_text(text, &["from ", "import "], &[]);
+            // `from X import Y` must extract only the module path `X`, not
+            // `X import Y`.  Strip the `from ` prefix, then truncate at
+            // ` import `.  Plain `import X` just strips `import `.
+            let path = if node.kind() == "import_from_statement" {
+                let raw = extract_path_from_text(text, &["from "], &[]);
+                match raw.find(" import ") {
+                    Some(pos) => raw[..pos].to_string(),
+                    None => raw,
+                }
+            } else {
+                extract_path_from_text(text, &["import "], &[])
+            };
             imports.push(Import {
                 path,
                 line: node.start_position().row + 1,
@@ -238,7 +249,7 @@ fn collect_go_import_specs(node: tree_sitter_lib::Node, source: &str, imports: &
 fn collect_java_imports(node: tree_sitter_lib::Node, source: &str, imports: &mut Vec<Import>) {
     if node.kind() == "import_declaration" {
         if let Ok(text) = node.utf8_text(source.as_bytes()) {
-            let path = extract_path_from_text(text, &["import ", "import static "], &[';']);
+            let path = extract_path_from_text(text, &["import static ", "import "], &[';']);
             imports.push(Import {
                 path,
                 line: node.start_position().row + 1,
@@ -639,5 +650,37 @@ namespace app {
             Some("react".to_string())
         );
         assert_eq!(extract_quoted_string("no quotes"), None);
+    }
+
+    #[test]
+    fn java_static_import_path_strips_static_keyword() {
+        // Regression: prefix order ["import ", "import static "] matched
+        // "import " first, leaving "static org.junit..." in the path.
+        let source = "import static org.junit.Assert.*;\n";
+        let imports = extract_imports(source, Language::Java);
+        assert_eq!(imports.len(), 1);
+        assert_eq!(
+            imports[0].path, "org.junit.Assert.*",
+            "static import path should not contain 'static '"
+        );
+    }
+
+    #[test]
+    fn python_from_import_extracts_module_only() {
+        // Regression: `from pathlib import Path` returned path
+        // "pathlib import Path" instead of "pathlib".
+        let source = "from pathlib import Path\nimport os\n";
+        let imports = extract_imports(source, Language::Python);
+        let paths: Vec<&str> = imports.iter().map(|i| i.path.as_str()).collect();
+        assert!(
+            paths.contains(&"pathlib"),
+            "from-import should extract 'pathlib', got {:?}",
+            paths
+        );
+        assert!(
+            paths.contains(&"os"),
+            "plain import should extract 'os', got {:?}",
+            paths
+        );
     }
 }

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -264,7 +264,13 @@ fn find_yaml_key_line(lines: &[&str], key_path: &[String]) -> Option<usize> {
             let trimmed = line.trim_start();
             let indent = line.len() - trimmed.len();
             if indent < min_indent {
-                continue;
+                // Blank lines and comments do not indicate scope exit.
+                if trimmed.is_empty() || trimmed.starts_with('#') {
+                    continue;
+                }
+                // A non-blank, non-comment line at lower indent means we
+                // left the parent key's scope.  Stop searching.
+                break;
             }
             if trimmed == key_colon || trimmed.starts_with(&key_colon_sp) {
                 search_start = i + 1;
@@ -930,5 +936,25 @@ mod tests {
         let lines: Vec<&str> = yaml.lines().collect();
         let result = find_yaml_key_line(&lines, &["name".into()]);
         assert_eq!(result, Some(0));
+    }
+
+    #[test]
+    fn find_yaml_key_line_does_not_escape_into_sibling() {
+        // Regression: searching for ["a", "target"] found "target:" under
+        // "b:" because lines with indent < min_indent were skipped instead
+        // of stopping the search.
+        let yaml = "a:\n  x: 1\nb:\n  target:\n    value: found_me\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        let result = find_yaml_key_line(&lines, &["a".into(), "target".into()]);
+        assert_eq!(result, None, "should not find 'target' under sibling 'b'");
+    }
+
+    #[test]
+    fn find_yaml_key_line_finds_child_within_scope() {
+        // Positive test: the key IS within the parent's scope.
+        let yaml = "a:\n  target:\n    value: here\nb:\n  other: 1\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        let result = find_yaml_key_line(&lines, &["a".into(), "target".into()]);
+        assert_eq!(result, Some(1), "should find 'target' under 'a'");
     }
 }


### PR DESCRIPTION
## Code Audit Round 22

Three bugs found by reading the source code, with regression tests.

### Bug 1: Java static import prefix ordering (`deps.rs`)
`extract_path_from_text` used prefix order `["import ", "import static "]` which matched `"import "` first on static imports like `import static org.junit.Assert.*`, leaving `"static org.junit.Assert.*"` as the extracted path. Fix: reverse to `["import static ", "import "]` so the longer, more specific prefix is tried first.

### Bug 2: Python from-import path includes import clause (`deps.rs`)
`from pathlib import Path` was extracting path `"pathlib import Path"` instead of `"pathlib"`. The `from ` prefix was stripped but the ` import Y` suffix remained. Fix: for `import_from_statement` nodes specifically, truncate the extracted text at ` import ` to get just the module path.

### Bug 3: YAML `find_yaml_key_line` escapes into sibling mappings (`yaml_splice.rs`)
Searching for key path `["a", "target"]` on a YAML document with `a:` and `b:` at the same level would find `target:` under `b:` because lines at lower indent were skipped (`continue`) instead of stopping the search (`break`). This could cause `splice_yaml_array` to modify the wrong array in a document. Fix: `break` on non-blank, non-comment lines at lower indent to respect YAML scope boundaries.

### Files changed
- `src/ast/deps.rs`: Java prefix fix + Python from-import fix + tests
- `src/ops/doc/yaml_splice.rs`: YAML scope fix + tests

All tests pass (`make check-fast`).