### PR TITLE
fix: patch merge exit code, dedent tabs, confirm double-prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2400%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2500%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-2400+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+2500+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -281,7 +281,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         });
     }
 
-    if merge_mode && (global.check || (!global.apply && !global.should_apply())) {
+    if merge_mode && (global.check || (!global.apply && !global.confirm)) {
         let check_options = ApplyHunksOptions {
             on_stale: OnStale::Merge,
             allow_conflicts: true,
@@ -310,9 +310,10 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         }
         emit_patch_files_output(global, all_ok, &results)?;
-        return Ok(if results.iter().any(|r| r.status == "conflict") {
+        let has_conflicts = results.iter().any(|r| r.status == "conflict");
+        return Ok(if has_conflicts && !apply_options.allow_conflicts {
             exit::CONFLICTS
-        } else if all_ok {
+        } else if all_ok || (has_conflicts && apply_options.allow_conflicts) {
             exit::SUCCESS
         } else {
             exit::AMBIGUOUS

--- a/src/write.rs
+++ b/src/write.rs
@@ -412,7 +412,7 @@ fn dedent_by_n(lines: &[&str], n: usize, in_range: &dyn Fn(usize) -> bool) -> St
             if !in_range(i) || line.trim().is_empty() {
                 line.to_string()
             } else {
-                let leading_spaces = line.len() - line.trim_start_matches(' ').len();
+                let leading_spaces = line.len() - line.trim_start().len();
                 let strip = n.min(leading_spaces);
                 line[strip..].to_string()
             }

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -674,6 +674,14 @@ mod dedent_indent {
     }
 
     #[test]
+    fn dedent_auto_tab_indented_file() {
+        // Auto dedent must handle tab-indented files, not just space-indented.
+        let input = "\t\tline1\n\t\t\tline2\n\t\tline3\n";
+        let result = dedent_content(input, "auto", None);
+        assert_eq!(result, "line1\n\tline2\nline3\n");
+    }
+
+    #[test]
     fn dedent_with_line_range() {
         let input = "    line1\n    line2\n    line3\n    line4\n";
         let result = dedent_content(input, "4", Some((2, Some(3))));

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -313,6 +313,32 @@ fn test_patch_merge_check_exits_8_on_conflict() {
 }
 
 #[test]
+fn test_patch_merge_check_allow_conflicts_exits_0() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
+    let patch_file = dir.path().join("stale.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
+    )
+    .unwrap();
+    // With --allow-conflicts, --check should predict that apply would succeed
+    // (conflicts are acceptable), so exit 0 instead of 8.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("merge")
+        .arg(&patch_file)
+        .arg("--check")
+        .arg("--allow-conflicts")
+        .assert()
+        .code(0);
+}
+
+#[test]
 fn test_patch_merge_allow_conflicts_writes_markers() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
Code audit Round 25: 3 bugs fixed.

## Fixes

1. **patch merge --check --allow-conflicts exit code**: Returned exit code 8 (CONFLICTS) even though the actual `--apply` would succeed with `--allow-conflicts`. The check mode should predict what apply would do. Fix: consult the CLI `allow_conflicts` flag when deciding the exit code.

2. **tidy fix --dedent auto with tabs**: Auto dedent measured indent using `trim_start()` (all whitespace including tabs) but only stripped spaces via `trim_start_matches(' ')`. Tab-indented files silently got zero dedent. Fix: use `trim_start()` consistently in `dedent_by_n`.

3. **patch merge --confirm double-prompt**: `should_apply()` was called in the condition that decides whether to show the merge preview, prompting the user before any preview was shown. If the user said "yes", they would be prompted again at the actual apply point. Fix: use flag-only check (`global.confirm`) for the preview branch condition.

## Tests

- `test_patch_merge_check_allow_conflicts_exits_0`: verifies exit 0 with `--check --allow-conflicts`
- `dedent_auto_tab_indented_file`: verifies auto dedent works on tab-indented content
- Existing `test_patch_merge_check_exits_8_on_conflict` still passes (no `--allow-conflicts` = exit 8)