### PR TITLE
feat: traverse template interpolations in AST rename and refs

### DIFF
--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -63,13 +63,23 @@ const IDENTIFIER_KINDS: &[&str] = &[
 ];
 
 /// Node kinds whose subtrees should be skipped (strings, comments).
+///
+/// Only leaf text nodes and comments belong here. Container nodes like
+/// `template_string`, `string`, and `concatenated_string` are NOT skipped
+/// because they can hold interpolation expressions (JS/TS `${}`, Python
+/// f-string `{}`, Ruby `#{}`) containing identifiers that must be found.
+/// The traversal enters those containers and skips only their literal-text
+/// children listed below.
 const SKIP_KINDS: &[&str] = &[
+    // Leaf string nodes (literal text, no embedded code)
     "string_literal",
     "raw_string_literal",
-    "string",
     "string_content",
     "string_fragment",
-    "template_string",
+    // Python string delimiters
+    "string_start",
+    "string_end",
+    // Comments
     "line_comment",
     "block_comment",
     "comment",
@@ -437,6 +447,84 @@ int main() {
         // Comment should be skipped
         for r in &refs {
             assert!(!r.context.starts_with("//"), "comment should not be a ref");
+        }
+    }
+
+    #[test]
+    fn find_refs_typescript_template_interpolation() {
+        let source = r#"
+function greet(userName: string): string {
+    return `Hello ${userName}, welcome!`;
+}
+const msg = greet(userName);
+"#;
+        let refs = find_refs_in_source(source, "userName", Language::TypeScript, "test.ts");
+        // Should find: param definition, template interpolation ref, call-site ref
+        assert!(
+            refs.len() >= 3,
+            "should find at least 3 refs (param + interpolation + call), got {}",
+            refs.len()
+        );
+        // At least one ref should come from the template string line
+        let template_refs: Vec<_> = refs.iter().filter(|r| r.context.contains('`')).collect();
+        assert!(
+            !template_refs.is_empty(),
+            "should find a ref inside template string interpolation"
+        );
+    }
+
+    #[test]
+    fn find_refs_python_fstring_interpolation() {
+        let source = r#"
+def greet(user_name):
+    return f"Hello {user_name}, welcome!"
+
+msg = greet(user_name)
+"#;
+        let refs = find_refs_in_source(source, "user_name", Language::Python, "test.py");
+        // Should find: param definition, f-string interpolation ref, call-site ref
+        assert!(
+            refs.len() >= 3,
+            "should find at least 3 refs (param + fstring + call), got {}",
+            refs.len()
+        );
+    }
+
+    #[test]
+    fn find_refs_ruby_string_interpolation() {
+        let source = r#"
+def greet(user_name)
+  "Hello #{user_name}, welcome!"
+end
+
+msg = greet(user_name)
+"#;
+        let refs = find_refs_in_source(source, "user_name", Language::Ruby, "test.rb");
+        // Should find: param, string interpolation ref, call-site ref
+        assert!(
+            refs.len() >= 3,
+            "should find at least 3 refs (param + interpolation + call), got {}",
+            refs.len()
+        );
+    }
+
+    #[test]
+    fn find_refs_skips_plain_string_not_interpolation() {
+        // Plain Rust string literals should still be skipped
+        let source = r#"
+fn target() {}
+
+fn main() {
+    let s = "target";
+    target();
+}
+"#;
+        let refs = find_refs_in_source(source, "target", Language::Rust, "test.rs");
+        for r in &refs {
+            assert!(
+                !r.context.contains("\"target\""),
+                "plain string literal should be skipped"
+            );
         }
     }
 

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -18,22 +18,27 @@ const IDENTIFIER_KINDS: &[&str] = &[
 ];
 
 /// Node kinds whose subtrees should be skipped entirely during rename.
+///
+/// Only leaf text nodes and comments belong here. Container nodes like
+/// `template_string`, `string`, and `concatenated_string` are NOT skipped
+/// because they can hold interpolation expressions (JS/TS `${}`, Python
+/// f-string `{}`, Ruby `#{}`) containing identifiers that must be renamed.
+/// The traversal enters those containers and skips only their literal-text
+/// children listed below.
 const SKIP_KINDS: &[&str] = &[
+    // Leaf string nodes (literal text, no embedded code)
     "string_literal",
     "raw_string_literal",
-    "string",
     "string_content",
     "string_fragment",
-    "template_string",
+    // Python string delimiters
+    "string_start",
+    "string_end",
+    // Comments
     "line_comment",
     "block_comment",
     "comment",
     "doc_comment",
-    // Python
-    "string_start",
-    "string_end",
-    "concatenated_string",
-    "interpolation",
 ];
 
 /// Result of an AST-aware rename operation.
@@ -268,6 +273,86 @@ public class Service {
         assert!(result.content.contains("\"processOrder called\""));
         assert!(result.content.contains("// processOrder"));
         assert!(result.replacements >= 3);
+    }
+
+    #[test]
+    fn rename_typescript_template_string_interpolation() {
+        let source = r#"
+function greet(userName: string): string {
+    return `Hello ${userName}, welcome!`;
+}
+const msg = greet(userName);
+"#;
+        let result =
+            rename_in_source(source, "userName", "displayName", Language::TypeScript).unwrap();
+        // Identifiers inside template interpolation `${}` must be renamed
+        assert!(
+            result.content.contains("${displayName}"),
+            "identifier inside template interpolation should be renamed"
+        );
+        // Function parameter and call site should also be renamed
+        assert!(result.content.contains("greet(displayName: string)"));
+        assert!(result.content.contains("greet(displayName)"));
+        // Literal text around interpolation should be untouched
+        assert!(result.content.contains("Hello "));
+        assert!(result.content.contains(", welcome!"));
+        assert!(!result.content.contains("userName"));
+    }
+
+    #[test]
+    fn rename_python_fstring_interpolation() {
+        let source = r#"
+def greet(user_name):
+    return f"Hello {user_name}, welcome!"
+
+msg = greet(user_name)
+"#;
+        let result =
+            rename_in_source(source, "user_name", "display_name", Language::Python).unwrap();
+        // Identifier inside f-string interpolation `{}` must be renamed
+        assert!(
+            result.content.contains("display_name"),
+            "identifier inside f-string should be renamed"
+        );
+        // Function definition and call site must also be renamed
+        assert!(result.content.contains("def greet(display_name)"));
+        assert!(result.content.contains("greet(display_name)"));
+        assert!(!result.content.contains("user_name"));
+    }
+
+    #[test]
+    fn rename_ruby_string_interpolation() {
+        let source = r#"
+def greet(user_name)
+  "Hello #{user_name}, welcome!"
+end
+
+msg = greet(user_name)
+"#;
+        let result = rename_in_source(source, "user_name", "display_name", Language::Ruby).unwrap();
+        // Identifier inside Ruby `#{}` interpolation must be renamed
+        assert!(
+            result.content.contains("display_name"),
+            "identifier inside Ruby string interpolation should be renamed"
+        );
+        assert!(result.content.contains("def greet(display_name)"));
+        assert!(!result.content.contains("user_name"));
+    }
+
+    #[test]
+    fn rename_skips_plain_string_content_not_interpolation() {
+        // Plain strings (no interpolation) should still be skipped
+        let source = r#"
+fn process(item: &str) {
+    let label = "item is processed";
+    println!("{}", item);
+}
+"#;
+        let result = rename_in_source(source, "item", "element", Language::Rust).unwrap();
+        // The identifier in code should be renamed
+        assert!(result.content.contains("fn process(element: &str)"));
+        // The word inside a plain string literal should NOT be renamed
+        assert!(result.content.contains("\"item is processed\""));
     }
 
     #[test]


### PR DESCRIPTION
Restructure SKIP_KINDS in rename.rs and refs.rs to selectively traverse template/interpolation string containers instead of skipping them entirely.

**Problem:** AST-aware rename and find-references skip entire template string subtrees, missing identifiers inside interpolation expressions. For example, renaming `userName` would miss occurrences inside JS/TS `\`Hello ${userName}\``, Python `f"Hello {user_name}"`, and Ruby `"Hello #{user_name}"`.

**Fix:** Remove container node kinds (`template_string`, `string`, `concatenated_string`, `interpolation`) from SKIP_KINDS. Keep leaf text node kinds (`string_literal`, `string_content`, `string_fragment`, `string_start`, `string_end`) in SKIP_KINDS. The traversal now enters string containers to find identifiers in interpolation expressions while still skipping literal text content.

**Languages affected:** TypeScript/JavaScript, Python, Ruby (any language with string interpolation parsed by tree-sitter).

**Tests added (8):**
- `rename_typescript_template_string_interpolation`
- `rename_python_fstring_interpolation`
- `rename_ruby_string_interpolation`
- `rename_skips_plain_string_content_not_interpolation`
- `find_refs_typescript_template_interpolation`
- `find_refs_python_fstring_interpolation`
- `find_refs_ruby_string_interpolation`
- `find_refs_skips_plain_string_not_interpolation`