### PR TITLE
fix: validate whole-line+insert conflict, MCP context size, multiline attrs

### DIFF
--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -956,6 +956,18 @@ pub fn full_symbol_span(source: &str, sym: &SymbolDef, lang: Language) -> (usize
 
         if is_annotation_line(trimmed, lang) {
             first_line_0 = i;
+        } else if lang == Language::Rust {
+            // Check if this line is part of a multiline `#[...]` attribute.
+            // E.g., `#[cfg_attr(\n  feature = "serde",\n  derive(Serialize)\n)]`
+            // Line `)]` doesn't match is_annotation_line but is the closing
+            // of a multiline attribute block.
+            if let Some(attr_start) = find_rust_multiline_attr_start(&lines, i) {
+                first_line_0 = attr_start;
+                // Jump the backward walk past all lines we've consumed
+                i = attr_start;
+                continue;
+            }
+            break;
         } else {
             break;
         }
@@ -996,6 +1008,38 @@ fn is_annotation_line(trimmed: &str, lang: Language) -> bool {
         }
         _ => false,
     }
+}
+
+/// Check whether the lines starting at `from_0` (0-indexed, walking backwards)
+/// form the interior/closing of a multiline Rust `#[...]` attribute.
+///
+/// Scans backwards from `from_0`, tracking bracket depth (`[` / `]`). If
+/// we reach a line that starts with `#[` and bracket depth balances to zero,
+/// this is a multiline attribute and we return the 0-based index of the
+/// opening `#[` line. Otherwise returns `None`.
+fn find_rust_multiline_attr_start(lines: &[&str], from_0: usize) -> Option<usize> {
+    // Count `]` minus `[` on the starting line. A closing `)]` has depth +1.
+    let mut depth: i32 = 0;
+    for j in (0..=from_0).rev() {
+        let trimmed = lines[j].trim();
+        // Count brackets on this line (] increases depth, [ decreases it
+        // since we're walking backwards from the closing side).
+        for ch in trimmed.chars() {
+            if ch == ']' {
+                depth += 1;
+            } else if ch == '[' {
+                depth -= 1;
+            }
+        }
+        if trimmed.starts_with("#[") && depth <= 0 {
+            return Some(j);
+        }
+        // Safety: don't walk more than 20 lines back for a single attribute
+        if from_0 - j > 20 {
+            break;
+        }
+    }
+    None
 }
 
 /// Extract the text of a symbol from source, using the full span (including
@@ -1621,6 +1665,49 @@ struct Point {
         let foo = symbols.iter().find(|s| s.name == "foo").unwrap();
         let (start, _) = full_symbol_span(source, foo, Language::Rust);
         assert_eq!(start, 3); // #[test] on line 3, not line 1
+    }
+
+    // Regression: multiline Rust attributes like #[cfg_attr(\n  ...\n)]
+    // were not recognized by the backward walk because is_annotation_line
+    // only matches lines starting with #[.  The fix uses bracket depth
+    // tracking to find the opening #[ from interior/closing lines.
+    #[test]
+    fn full_span_multiline_rust_attribute() {
+        let source = "\
+#[cfg_attr(
+    feature = \"serde\",
+    derive(Serialize, Deserialize)
+)]
+struct Config {
+    name: String,
+}
+";
+        let symbols = extract_symbols(source, Language::Rust);
+        let sym = symbols.iter().find(|s| s.name == "Config").unwrap();
+        let (start, _) = full_symbol_span(source, sym, Language::Rust);
+        assert_eq!(
+            start, 1,
+            "multiline #[cfg_attr(...)] should be included in Config's span"
+        );
+    }
+
+    #[test]
+    fn full_span_multiline_attribute_with_stacked_single() {
+        let source = "\
+#[derive(Debug)]
+#[cfg_attr(
+    feature = \"serde\",
+    derive(Serialize)
+)]
+pub struct Foo {}
+";
+        let symbols = extract_symbols(source, Language::Rust);
+        let sym = symbols.iter().find(|s| s.name == "Foo").unwrap();
+        let (start, _) = full_symbol_span(source, sym, Language::Rust);
+        assert_eq!(
+            start, 1,
+            "both #[derive(Debug)] and the multiline #[cfg_attr] should be included"
+        );
     }
 
     #[test]

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -255,6 +255,12 @@ impl PatchloomService {
             if let Some(ref ia) = p.insert_after {
                 validate_content_size("insert_after", ia)?;
             }
+            if let Some(ref bc) = p.before_context {
+                validate_content_size("before_context", bc)?;
+            }
+            if let Some(ref ac) = p.after_context {
+                validate_content_size("after_context", ac)?;
+            }
 
             crate::ops::replace::validate_replace_args(
                 &crate::ops::replace::ReplaceValidationParams {

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -73,6 +73,7 @@ pub enum ReplaceValidationError {
     NthZero,
     RangeRequiresWholeLine,
     WholeLineMultilineConflict,
+    WholeLineInsertConflict,
     Mode(ReplaceModeError),
 }
 
@@ -89,6 +90,12 @@ impl std::fmt::Display for ReplaceValidationError {
             Self::RangeRequiresWholeLine => write!(f, "range requires whole_line"),
             Self::WholeLineMultilineConflict => {
                 write!(f, "whole_line and multiline cannot be combined")
+            }
+            Self::WholeLineInsertConflict => {
+                write!(
+                    f,
+                    "whole_line cannot be combined with insert_before or insert_after (would drop non-matched line content)"
+                )
             }
             Self::Mode(e) => match e {
                 ReplaceModeError::MissingMode => {
@@ -138,6 +145,9 @@ pub fn validate_replace_args(
     }
     if p.whole_line && p.multiline {
         return Err(ReplaceValidationError::WholeLineMultilineConflict);
+    }
+    if p.whole_line && (p.has_insert_before || p.has_insert_after) {
+        return Err(ReplaceValidationError::WholeLineInsertConflict);
     }
     validate_replace_mode(p.has_to, p.has_insert_before, p.has_insert_after)
         .map_err(ReplaceValidationError::Mode)

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -619,5 +619,44 @@ mod replace_tests {
             let result = compile_replace_regex("(unclosed", true, false, false, false);
             assert!(result.is_err());
         }
+
+        // Regression: --whole-line + --insert-before/after silently drops
+        // non-matched line content because replace_whole_lines replaces the
+        // entire line with just the insert+match text.
+        #[test]
+        fn validate_args_whole_line_insert_before_conflict() {
+            let p = ReplaceValidationParams {
+                pattern: "needle",
+                has_to: false,
+                has_insert_before: true,
+                has_insert_after: false,
+                nth: None,
+                whole_line: true,
+                multiline: false,
+                has_range: false,
+            };
+            assert_eq!(
+                validate_replace_args(&p),
+                Err(ReplaceValidationError::WholeLineInsertConflict)
+            );
+        }
+
+        #[test]
+        fn validate_args_whole_line_insert_after_conflict() {
+            let p = ReplaceValidationParams {
+                pattern: "needle",
+                has_to: false,
+                has_insert_before: false,
+                has_insert_after: true,
+                nth: None,
+                whole_line: true,
+                multiline: false,
+                has_range: false,
+            };
+            assert_eq!(
+                validate_replace_args(&p),
+                Err(ReplaceValidationError::WholeLineInsertConflict)
+            );
+        }
     }
 }

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1888,6 +1888,35 @@ async fn test_mcp_replace_whole_line_with_range_round_trip() {
     client.cancel().await.unwrap();
 }
 
+// Regression: before_context and after_context were not validated for size
+// in the replace_text MCP handler, while from/to/insert_before/insert_after were.
+#[tokio::test]
+async fn test_mcp_replace_whole_line_insert_before_rejected() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("data.txt"), "prefix needle suffix\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "data.txt",
+            "from": "needle",
+            "insert_before": "BEFORE\n",
+            "whole_line": true
+        }),
+    )
+    .await;
+    assert!(
+        is_error,
+        "whole_line + insert_before should be rejected: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_append_file_round_trip() {
     if !has_mcp_support() {


### PR DESCRIPTION
## Summary

Three code-audit fixes from Round 26:

1. **Reject `--whole-line` + `--insert-before/after`**: The combination silently drops non-matched line content because `replace_whole_lines` replaces the entire line with only the insert+match text. Added `WholeLineInsertConflict` validation error.

2. **MCP `replace_text` context size validation**: `before_context` and `after_context` were not validated for size, while all other string parameters (`from`, `to`, `insert_before`, `insert_after`) were. Added `validate_content_size` calls.

3. **Multiline Rust attribute span**: `full_symbol_span` only recognized lines starting with `#[` as attributes, missing continuation lines of multiline attributes like `#[cfg_attr(...)]`. Added bracket-depth tracking to find the opening `#[` from interior lines.

## Tests

- 2 unit tests for whole-line+insert validation (before and after variants)
- 1 integration test for MCP whole-line+insert rejection
- 2 unit tests for multiline attribute span (single and stacked)

`make check-fast` passes (1704 unit + 790 integration + 10 PTY tests).