### PR TITLE
fix: merge-check exit code masked by --allow-conflicts, find_match_global panic

### DIFF
--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -310,13 +310,14 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         }
         emit_patch_files_output(global, all_ok, &results)?;
+        let has_errors = results.iter().any(|r| r.status == "error");
         let has_conflicts = results.iter().any(|r| r.status == "conflict");
-        return Ok(if has_conflicts && !apply_options.allow_conflicts {
-            exit::CONFLICTS
-        } else if all_ok || (has_conflicts && apply_options.allow_conflicts) {
-            exit::SUCCESS
-        } else {
+        return Ok(if has_errors {
             exit::AMBIGUOUS
+        } else if has_conflicts && !apply_options.allow_conflicts {
+            exit::CONFLICTS
+        } else {
+            exit::SUCCESS
         });
     }
 

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -590,7 +590,10 @@ fn find_match_global(haystack: &[&str], needle: &[&str]) -> Option<usize> {
     if needle.is_empty() {
         return Some(0);
     }
-    let max_start = haystack.len().saturating_sub(needle.len());
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    let max_start = haystack.len() - needle.len();
     for pos in 0..=max_start {
         if haystack[pos..pos + needle.len()] == *needle {
             return Some(pos);

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -609,6 +609,19 @@ mod edge_cases {
         assert_eq!(find_match_global(&haystack, &needle), None);
     }
 
+    // Regression: needle longer than haystack caused a panic because
+    // saturating_sub produced 0 as max_start, then the loop tried to
+    // slice haystack[0..needle.len()] which was out of bounds.
+    #[test]
+    fn find_match_global_needle_longer_than_haystack() {
+        let haystack: Vec<&str> = vec![];
+        let needle: Vec<&str> = vec!["A", "B", "C"];
+        assert_eq!(find_match_global(&haystack, &needle), None);
+
+        let short_haystack: Vec<&str> = vec!["A"];
+        assert_eq!(find_match_global(&short_haystack, &needle), None);
+    }
+
     #[test]
     fn locate_by_context_anchors_no_context_returns_none() {
         // Hunk has no context lines at all → cannot locate

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -616,6 +616,54 @@ fn test_patch_malformed_file_fails() {
         .stderr(predicate::str::contains("parse error"));
 }
 
+// Regression: merge-check exit code was SUCCESS when both a conflict (resolved
+// via --allow-conflicts) and a hard error (hunk not locatable) occurred in a
+// multi-file patch.  The error was masked because `has_conflicts && allow_conflicts`
+// short-circuited before checking for errors.
+#[test]
+fn test_patch_merge_check_allow_conflicts_still_exits_5_on_error() {
+    let dir = TempDir::new().unwrap();
+    // File A: will produce a conflict (content diverged from patch context).
+    let file_a = dir.path().join("a.txt");
+    fs::write(&file_a, "line1\ncompletely different\nline3\n").unwrap();
+    // File B: does not exist, so merge will fail entirely (error status).
+
+    let patch_file = dir.path().join("multi.patch");
+    fs::write(
+        &patch_file,
+        "\
+--- a/a.txt
++++ b/a.txt
+@@ -1,3 +1,3 @@
+ line1
+-old line
++new line
+ line3
+--- a/b.txt
++++ b/b.txt
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++gamma
+ delta
+",
+    )
+    .unwrap();
+    // With --allow-conflicts, the conflict on a.txt is acceptable, but the
+    // error on b.txt should still produce a non-zero exit code (AMBIGUOUS=5).
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("merge")
+        .arg(&patch_file)
+        .arg("--check")
+        .arg("--allow-conflicts")
+        .assert()
+        .code(5);
+}
+
 // ---------------------------------------------------------------------------
 // --jsonl + count/files-with-matches (bug fix: count_only + jsonl)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two code-audit fixes from Round 27:

1. **Merge-check exit code masked by `--allow-conflicts`**: When a multi-file patch in merge mode produced both a hard error (hunk not locatable at all) and a conflict (content diverged), `--allow-conflicts` caused the exit code to be SUCCESS (0) instead of AMBIGUOUS (5). The condition `has_conflicts && allow_conflicts` evaluated to true before checking for errors. Fixed by checking for errors first.

2. **`find_match_global` panic on empty/short haystack**: When the needle was longer than the haystack (e.g., applying a patch to a non-existent file read as empty string), `saturating_sub` produced 0 as `max_start`, then the loop tried to slice `haystack[0..needle.len()]` which panicked with index out of range. Fixed by returning `None` early when `needle.len() > haystack.len()`.

## Tests

- 1 integration test for merge-check exit code with errors + conflicts + `--allow-conflicts`
- 1 unit test for `find_match_global` with needle longer than haystack (both empty and short cases)

`make check-fast` passes (1706 unit + 791 integration + 10 PTY tests).