### PR TITLE
fix: upsert_bullet trailing space trim, tidy empty file, git add ./, doc merge conflict

### DIFF
--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -285,6 +285,9 @@ fn action_to_operation(action: &DocAction) -> anyhow::Result<Operation> {
             predicate: predicate.clone(),
         }),
         DocAction::Merge { file, stdin, value } => {
+            if *stdin && value.is_some() {
+                anyhow::bail!("merge: --stdin and --value are mutually exclusive");
+            }
             let merge_str = if *stdin {
                 std::io::read_to_string(std::io::stdin())?
             } else if let Some(v) = value {

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -377,6 +377,27 @@ mod basic {
     }
 
     #[test]
+    fn merge_rejects_stdin_and_value_together() {
+        // Regression: --stdin and --value are mutually exclusive. Previously
+        // providing both silently ignored --value.
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"a": 1}"#);
+        let action = DocAction::Merge {
+            file: path,
+            stdin: true,
+            value: Some(r#"{"b": 2}"#.into()),
+        };
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let result = run_doc(action, &global);
+        assert!(result.is_err(), "merge --stdin --value should fail");
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("mutually exclusive"),
+            "error should mention mutual exclusivity: {err_msg}"
+        );
+    }
+
+    #[test]
     fn ensure_creates_missing_key() {
         let dir = TempDir::new().unwrap();
         let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);

--- a/src/cmd/md_tests.rs
+++ b/src/cmd/md_tests.rs
@@ -700,6 +700,16 @@ mod security {
     }
 
     #[test]
+    fn has_dangerous_git_add_dot_slash() {
+        // "git add ./" is equivalent to "git add ." and should be caught.
+        assert!(has_dangerous_git_add_dot("git add ./"));
+        assert!(has_dangerous_git_add_dot("git add ./ && git commit"));
+        // But "git add ./foo" is explicit file staging and is safe.
+        assert!(!has_dangerous_git_add_dot("git add ./foo"));
+        assert!(!has_dangerous_git_add_dot("git add ./src/main.rs"));
+    }
+
+    #[test]
     fn lint_agents_allows_git_add_dotfile() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("AGENTS.md");

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -59,7 +59,7 @@ fn check_file(path: &Path, quiet: bool) -> Vec<TidyIssue> {
     let mut issues = Vec::new();
 
     // Check missing final newline.
-    if !data.ends_with(b"\n") {
+    if !data.is_empty() && !data.ends_with(b"\n") {
         issues.push(TidyIssue {
             path: path_str.clone(),
             issue: "missing final newline",
@@ -387,6 +387,21 @@ mod tests {
         assert!(
             issues.iter().any(|i| i.issue == "missing final newline"),
             "expected missing final newline issue, got: {issues:?}"
+        );
+    }
+
+    #[test]
+    fn empty_file_no_missing_newline() {
+        // Regression: empty files should not be flagged for "missing final newline"
+        // since they have no content at all.
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("empty.txt");
+        std::fs::write(&file, b"").unwrap();
+
+        let issues = check_file(&file, true);
+        assert!(
+            !issues.iter().any(|i| i.issue == "missing final newline"),
+            "empty file should not be flagged for missing final newline: {issues:?}"
         );
     }
 

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -427,7 +427,7 @@ pub fn upsert_bullet_in(content: &str, heading: &str, bullet: &str) -> Option<St
     // Find the end of actual content within the body, before any trailing
     // blank lines. This ensures the new bullet is grouped with existing
     // bullets rather than placed after a blank line separator.
-    let trimmed_body = body.trim_end_matches(['\n', '\r', ' ']);
+    let trimmed_body = body.trim_end_matches(['\n', '\r']);
     let content_end = body_start + trimmed_body.len();
     // Find the next line boundary after content_end (include the trailing \n of
     // the last non-blank line so the bullet goes on a new line, not appended).
@@ -644,6 +644,13 @@ pub(crate) fn has_dangerous_git_add_dot(line: &str) -> bool {
         let after = abs + needle.len();
         if after >= line.len() || line.as_bytes()[after].is_ascii_whitespace() {
             return true;
+        }
+        // "git add ./" is equivalent to "git add ." — catch it too.
+        if line.as_bytes()[after] == b'/' {
+            let after_slash = after + 1;
+            if after_slash >= line.len() || line.as_bytes()[after_slash].is_ascii_whitespace() {
+                return true;
+            }
         }
         start = abs + 1;
     }

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1212,4 +1212,16 @@ body text
         let headings = parse_headings(content);
         assert_eq!(headings.len(), 0, "4-space indent should NOT be a heading");
     }
+
+    #[test]
+    fn upsert_bullet_trailing_spaces_on_content_line() {
+        // Regression: trim_end_matches included ' ' which would strip trailing
+        // spaces from the last content line, corrupting the insertion point.
+        let content = "# List\n- item with trailing spaces   \n";
+        let result = upsert_bullet_in(content, "List", "- new item").unwrap();
+        assert!(
+            result.contains("- item with trailing spaces   \n- new item\n"),
+            "trailing spaces must be preserved: {result}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Round 31 of the code audit loop. Four bugs fixed with regression tests:

1. **upsert_bullet_in trailing space corruption** (`src/ops/md.rs`): `trim_end_matches` included `' '` which stripped trailing spaces from content lines, corrupting the bullet insertion point. Fixed by removing space from the trim pattern.

2. **tidy empty file false positive** (`src/cmd/tidy.rs`): Empty files were flagged for "missing final newline" even though they have no content. Added `!data.is_empty()` guard.

3. **has_dangerous_git_add_dot misses `git add ./`** (`src/ops/md.rs`): The lint function detected `git add .` but missed the equivalent `git add ./` (trailing slash). Added check for `/` after the dot, distinguishing `git add ./` (dangerous) from `git add ./foo` (safe).

4. **doc merge --stdin --value silent conflict** (`src/cmd/doc.rs`): When both `--stdin` and `--value` were provided, `--value` was silently ignored. Added mutual exclusivity validation.

## Tests

- `upsert_bullet_trailing_spaces_on_content_line`: verifies trailing spaces preserved
- `empty_file_no_missing_newline`: verifies empty files not flagged
- `has_dangerous_git_add_dot_slash`: verifies `git add ./` caught, `git add ./foo` allowed
- `merge_rejects_stdin_and_value_together`: verifies error on conflict