### PR TITLE
fix: node_signature destructuring brace, flatten_value dot-key quoting

### DIFF
--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -587,7 +587,22 @@ fn node_signature(node: tree_sitter_lib::Node, source: &str) -> String {
         end -= 1;
     }
     let raw = &source[start..end];
-    let sig = match raw.find('{') {
+    // Find the body-opening `{` that is NOT inside parentheses or brackets.
+    // This avoids truncating at destructured parameters like `function foo({a, b}) {`.
+    let mut depth: i32 = 0;
+    let mut body_brace = None;
+    for (i, ch) in raw.char_indices() {
+        match ch {
+            '(' | '[' => depth += 1,
+            ')' | ']' => depth = (depth - 1).max(0),
+            '{' if depth == 0 => {
+                body_brace = Some(i);
+                break;
+            }
+            _ => {}
+        }
+    }
+    let sig = match body_brace {
         Some(brace) => raw[..brace].trim(),
         None => raw.lines().next().unwrap_or(raw).trim(),
     };
@@ -1909,6 +1924,23 @@ pub struct Foo {}
             !text.contains("fn first()"),
             "extracted text should not contain 'fn first()', got: {:?}",
             text
+        );
+    }
+
+    #[test]
+    fn node_signature_skips_destructuring_brace() {
+        // Regression: node_signature truncated at the first '{' which is the
+        // destructuring brace in JS/TS, not the body brace.
+        let source = "function foo({a, b}) {\n  return a + b;\n}\n";
+        let syms = extract_symbols(source, Language::JavaScript);
+        let foo = syms
+            .iter()
+            .find(|s| s.name == "foo")
+            .expect("foo not found");
+        assert!(
+            foo.signature.contains("{a, b}"),
+            "signature should include destructured params: {:?}",
+            foo.signature
         );
     }
 }

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -262,6 +262,18 @@ pub fn parse_value(s: &str) -> serde_json::Value {
 /// allocating a new `String` via `format!()` at every recursion level.
 /// The buffer is extended and truncated as the recursion descends and
 /// ascends, so only leaf paths produce a final `String::clone()`.
+/// Append a key to the path buffer, quoting it if it contains separator
+/// characters (`.`, `[`, `]`) to prevent ambiguity in flattened paths.
+fn push_key_quoted(buf: &mut String, k: &str) {
+    if k.contains('.') || k.contains('[') || k.contains(']') || k.contains('"') {
+        buf.push('"');
+        buf.push_str(&k.replace('"', "\\\""));
+        buf.push('"');
+    } else {
+        buf.push_str(k);
+    }
+}
+
 pub fn flatten_value<'a>(
     value: &'a serde_json::Value,
     buf: &mut String,
@@ -274,7 +286,7 @@ pub fn flatten_value<'a>(
                 if !buf.is_empty() {
                     buf.push('.');
                 }
-                buf.push_str(k);
+                push_key_quoted(buf, k);
                 flatten_value(v, buf, out);
                 buf.truncate(restore);
             }
@@ -323,7 +335,7 @@ pub fn diff_values(
                 if !buf.is_empty() {
                     buf.push('.');
                 }
-                buf.push_str(k);
+                push_key_quoted(buf, k);
                 if let Some(vb) = mb.get(k) {
                     diff_values(va, vb, buf, out);
                 } else {
@@ -342,7 +354,7 @@ pub fn diff_values(
                     if !buf.is_empty() {
                         buf.push('.');
                     }
-                    buf.push_str(k);
+                    push_key_quoted(buf, k);
                     out.push(DiffEntry {
                         path: buf.clone(),
                         kind: "added",

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -418,6 +418,24 @@ mod basic {
     }
 
     #[test]
+    fn flatten_value_quotes_dot_keys() {
+        // Regression: keys containing '.' were unquoted, making "a.b" (single
+        // key) indistinguishable from nested a -> b.
+        let val = json!({"a.b": 1, "normal": {"nested": 2}});
+        let mut buf = String::new();
+        let mut out = Vec::new();
+        flatten_value(&val, &mut buf, &mut out);
+        let paths: Vec<&str> = out.iter().map(|(p, _)| p.as_str()).collect();
+        // Dot-key should be quoted
+        assert!(
+            paths.contains(&r#""a.b""#),
+            "dot-containing key should be quoted: {paths:?}"
+        );
+        // Normal nested path should NOT be quoted
+        assert!(paths.contains(&"normal.nested"));
+    }
+
+    #[test]
     fn diff_values_detects_changes() {
         let a = json!({"x": 1, "y": 2});
         let b = json!({"x": 1, "y": 3, "z": 4});


### PR DESCRIPTION
## Summary

Round 32 of the code audit loop. Two bugs fixed with regression tests:

1. **node_signature truncation at destructuring `{`** (`src/ast/symbols.rs`): The `node_signature` function found the first `{` in the node text to truncate the signature before the body. For JS/TS functions with destructured parameters like `function foo({a, b}) {`, the first `{` is the destructuring brace, not the body brace. The signature was truncated to `function foo(` instead of `function foo({a, b})`. Fixed by tracking paren/bracket depth and only using `{` at depth 0.

2. **flatten_value/diff_values ambiguous dot-key paths** (`src/ops/doc/mod.rs`): Keys containing `.`, `[`, `]`, or `"` produced ambiguous flattened paths. A key `"a.b"` at the root was rendered as `a.b`, indistinguishable from nested path `a` -> `b`. Fixed by quoting such keys in the output path (e.g. `"a.b"`).

## Tests

- `node_signature_skips_destructuring_brace`: JS function with destructured params retains full signature
- `flatten_value_quotes_dot_keys`: keys with dots are quoted in flattened paths