### PR TITLE
fix: MCP replace_text false warnings with case_insensitive, add md_dedupe_headings tool

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -13,6 +13,7 @@
 | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |
 | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |
 | Move a heading section (same file or cross-file) | `md_move_section` |
+| Remove duplicate headings | `md_dedupe_headings` |
 | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |
 | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |
 | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -99,6 +99,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `md_insert_after_heading` | Insert content after a markdown heading |
 | `md_insert_before_heading` | Insert content before a markdown heading |
 | `md_move_section` | Move a heading section (same file reorder or cross-file) |
+| `md_dedupe_headings` | Remove duplicate markdown headings in a file |
 | `md_lint` | Lint an AGENTS.md file for common issues |
 | `fix_whitespace` | Fix whitespace and line endings in a text file. Binary and invalid UTF-8 files are skipped |
 | `create_file` | Create a new file with content |

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -277,7 +277,10 @@ impl PatchloomService {
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
 
             // Tier 2: pre-validate structured file edits and collect warnings.
-            let validation_warnings = if !p.regex {
+            // Skip when case_insensitive or word_boundary is set: validate_edit_nth
+            // uses literal `content.contains(from)` which is case-sensitive and
+            // ignores word boundaries, producing false "pattern not found" errors.
+            let validation_warnings = if !p.regex && !p.case_insensitive && !p.word_boundary {
                 let abs = svc.cwd().join(&p.path);
                 if let Ok(content) = std::fs::read_to_string(&abs) {
                     let to_str = p.to.as_deref().unwrap_or("");

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -198,6 +198,13 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         ],
     },
     McpToolMeta {
+        tool_name: "md_dedupe_headings",
+        op_name: "md.dedupe_headings",
+        description: "Remove duplicate markdown headings in a file. Keeps the first occurrence of each heading. Example: {\"path\": \"README.md\"}",
+        has_strict: false,
+        validations: &[FieldValidation::Path("path")],
+    },
+    McpToolMeta {
         tool_name: "move_file",
         op_name: "file.rename",
         description: "Move or rename a file. Use force=true to overwrite existing. Example: {\"from\": \"old.txt\", \"to\": \"new.txt\"}",

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -117,7 +117,11 @@ mod basic {
         );
         assert!(names.contains(&"ast_split"), "missing ast_split tool");
         // 32 base tools + 14 AST tools = 46
-        assert_eq!(names.len(), 52, "expected 52 tools, got {}", names.len());
+        assert!(
+            names.contains(&"md_dedupe_headings"),
+            "missing md_dedupe_headings tool"
+        );
+        assert_eq!(names.len(), 53, "expected 53 tools, got {}", names.len());
         client.cancel().await.unwrap();
     }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -223,6 +223,7 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |\n\
              | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |\n\
              | Move a heading section (same file or cross-file) | `md_move_section` |\n\
+             | Remove duplicate headings | `md_dedupe_headings` |\n\
              | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |\n\
              | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |\n\
              | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |\n\

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2973,3 +2973,80 @@ async fn test_mcp_execute_plan_for_each() {
     assert_eq!(b.trim(), "new", "b.txt should be updated: {b}");
     client.cancel().await.unwrap();
 }
+
+#[tokio::test]
+async fn test_mcp_replace_case_insensitive_no_false_warnings() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    // File has uppercase "TODO" but the replace uses lowercase "todo" with
+    // case_insensitive=true. Before the fix, validate_edit_nth would report
+    // a false "pattern not found" warning because it uses case-sensitive
+    // content.contains(from).
+    fs::write(dir.path().join("code.rs"), "// TODO: fix this\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "code.rs",
+            "from": "todo",
+            "to": "DONE",
+            "case_insensitive": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "case-insensitive replace should succeed: {val}");
+    assert_eq!(val["ok"], true, "replace ok field: {val}");
+    assert_eq!(val["files_changed"], 1, "should change file: {val}");
+
+    // Verify the replacement actually happened.
+    let content = fs::read_to_string(dir.path().join("code.rs")).unwrap();
+    assert!(
+        content.contains("DONE"),
+        "case-insensitive replace should have replaced TODO: {content}"
+    );
+
+    // Verify no spurious warning text in the response.
+    let response_text = format!("{val}");
+    assert!(
+        !response_text.contains("not found"),
+        "should not produce false 'pattern not found' warning: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_md_dedupe_headings() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("doc.md"),
+        "# Title\n\nFirst content\n\n# Title\n\nDuplicate content\n\n## Sub\n\nBody\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "md_dedupe_headings",
+        serde_json::json!({"path": "doc.md"}),
+    )
+    .await;
+    assert!(!is_error, "md_dedupe_headings should succeed: {val}");
+    assert_eq!(val["ok"], true, "md_dedupe ok: {val}");
+
+    let content = fs::read_to_string(dir.path().join("doc.md")).unwrap();
+    // Count occurrences of "# Title" (level-1 heading).
+    let title_count =
+        content.matches("\n# Title").count() + if content.starts_with("# Title") { 1 } else { 0 };
+    assert_eq!(
+        title_count, 1,
+        "should have removed duplicate heading, got: {content}"
+    );
+    client.cancel().await.unwrap();
+}


### PR DESCRIPTION
## Summary

Two fixes from code audit round 33:

### 1. MCP replace_text false warnings with case_insensitive/word_boundary

The `replace_text` MCP handler runs `validate_edit_nth` as a pre-validation step before executing the actual replacement. This pre-validator uses literal `content.contains(from)` which is case-sensitive and does not account for word boundary semantics. When `case_insensitive: true` was set with a differently-cased pattern (e.g., `from: "todo"` in a file containing `TODO`), the pre-validator would emit false "pattern not found" warnings even though the replacement would succeed.

**Fix:** Skip the pre-validation when `case_insensitive` or `word_boundary` is set, since these flags change matching semantics that the pre-validator cannot replicate.

### 2. Missing md_dedupe_headings MCP tool

The `md.dedupe_headings` operation existed in the CLI (`patchloom md --dedupe-headings`), the tx engine, the batch parser, and the schema registry, but had no corresponding MCP tool. Agents had to construct raw `execute_plan` calls to use this functionality.

**Fix:** Added `md_dedupe_headings` entry to `MCP_TOOL_REGISTRY` with appropriate path validation.

### Tests

- Integration test verifying case-insensitive replace produces no false warnings
- Integration test verifying md_dedupe_headings removes duplicate headings via MCP
- Updated tool count expectation (52 -> 53)