### PR TITLE
fix: systematic CRLF preservation, frontmatter parsing, decorator spans, multi-declarator const, YAML comments, replace count isolation

### DIFF
--- a/src/ast/extract.rs
+++ b/src/ast/extract.rs
@@ -28,6 +28,7 @@ pub fn extract_to_file(
     prepend: Option<&str>,
     lang: Language,
 ) -> anyhow::Result<ExtractResult> {
+    let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols(source, lang);
     let sym = find_symbol(&symbols, symbol)
         .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", symbol))?;
@@ -39,7 +40,7 @@ pub fn extract_to_file(
 
     // Extract the symbol's content for the target file
     let target_body = if unwrap && sym.kind == SymbolKind::Module {
-        unwrap_module_body(&lines, sym.start_line.saturating_sub(1), end_0)
+        unwrap_module_body(&lines, sym.start_line.saturating_sub(1), end_0, eol)
     } else {
         let text = extract_symbol_text(source, sym, lang);
         text.to_string()
@@ -52,13 +53,13 @@ pub fn extract_to_file(
     if let Some(pre) = prepend {
         target_content.push_str(pre);
         if !pre.ends_with('\n') {
-            target_content.push('\n');
+            target_content.push_str(eol);
         }
-        target_content.push('\n');
+        target_content.push_str(eol);
     }
     target_content.push_str(&target_body);
     if !target_content.ends_with('\n') {
-        target_content.push('\n');
+        target_content.push_str(eol);
     }
 
     // Build source content with the symbol removed or replaced
@@ -78,9 +79,9 @@ pub fn extract_to_file(
         }
     }
 
-    let mut source_content = source_lines.join("\n");
+    let mut source_content = source_lines.join(eol);
     if source.ends_with('\n') && !source_content.ends_with('\n') {
-        source_content.push('\n');
+        source_content.push_str(eol);
     }
 
     Ok(ExtractResult {
@@ -91,7 +92,7 @@ pub fn extract_to_file(
 }
 
 /// Extract the body of a module, removing the wrapper and un-indenting.
-fn unwrap_module_body(lines: &[&str], sym_start_0: usize, sym_end_0: usize) -> String {
+fn unwrap_module_body(lines: &[&str], sym_start_0: usize, sym_end_0: usize, eol: &str) -> String {
     // Find the opening brace line
     let mut body_start = sym_start_0;
     let mut brace_line_tail: Option<&str> = None;
@@ -167,7 +168,7 @@ fn unwrap_module_body(lines: &[&str], sym_start_0: usize, sym_end_0: usize) -> S
         }
     }));
 
-    parts.join("\n")
+    parts.join(eol)
 }
 
 #[cfg(test)]
@@ -270,6 +271,34 @@ mod tests {
             result.target_content
         );
         assert!(result.target_content.contains("fn test_a()"));
+    }
+
+    #[test]
+    fn extract_preserves_crlf_line_endings() {
+        let source = "fn foo() {\r\n    42\r\n}\r\n\r\nfn bar() {}\r\n";
+        let result = extract_to_file(source, "foo", None, false, None, Language::Rust).unwrap();
+        // Source content should preserve CRLF
+        let bytes = result.source_content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF in source at byte {i}: {:?}",
+                    result.source_content
+                );
+            }
+        }
+        // Target content should preserve CRLF
+        let target_bytes = result.target_content.as_bytes();
+        for (i, &b) in target_bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && target_bytes[i - 1] == b'\r',
+                    "bare LF in target at byte {i}: {:?}",
+                    result.target_content
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -37,6 +37,7 @@ pub fn group_symbols(
     spec: &GroupSpec,
     lang: Language,
 ) -> anyhow::Result<GroupResult> {
+    let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols(source, lang);
     let lines: Vec<&str> = source.lines().collect();
 
@@ -90,8 +91,9 @@ pub fn group_symbols(
     // Build the module content: indent each symbol by 4 spaces
     let mut module_body = String::new();
     if let Some(preamble) = &spec.preamble {
-        module_body.push_str(&indent_text(preamble, "    "));
-        module_body.push_str("\n\n");
+        module_body.push_str(&indent_text(preamble, "    ", eol));
+        module_body.push_str(eol);
+        module_body.push_str(eol);
     }
 
     // Collect texts in original order (we sorted descending for removal)
@@ -103,11 +105,11 @@ pub fn group_symbols(
 
     for (i, (_, text)) in texts_in_order.iter().enumerate() {
         if i > 0 {
-            module_body.push('\n');
+            module_body.push_str(eol);
         }
         let trimmed = text.trim_end_matches('\n');
-        module_body.push_str(&indent_text(trimmed, "    "));
-        module_body.push('\n');
+        module_body.push_str(&indent_text(trimmed, "    ", eol));
+        module_body.push_str(eol);
     }
 
     // Remove symbols from source (in reverse order to preserve offsets)
@@ -124,7 +126,7 @@ pub fn group_symbols(
     if module_exists {
         // Find the existing module's closing brace in modified_lines
         // Re-parse to find the module in modified source
-        let modified_source = modified_lines.join("\n");
+        let modified_source = modified_lines.join(eol);
         let mod_symbols = extract_symbols(&modified_source, lang);
         if let Some(mod_sym) = find_symbol(&mod_symbols, &spec.module) {
             let close_line_0 = mod_sym.end_line.saturating_sub(1);
@@ -143,9 +145,9 @@ pub fn group_symbols(
                 }
                 result_lines.push(line.to_string());
             }
-            let mut result = result_lines.join("\n");
+            let mut result = result_lines.join(eol);
             if source.ends_with('\n') && !result.ends_with('\n') {
-                result.push('\n');
+                result.push_str(eol);
             }
             return Ok(GroupResult {
                 content: result,
@@ -156,7 +158,7 @@ pub fn group_symbols(
     }
 
     // Build the module block for a new module
-    let module_block = format!("mod {} {{\n{}}}\n", spec.module, module_body);
+    let module_block = format!("mod {} {{{eol}{}}}{eol}", spec.module, module_body);
 
     // Insert new module at the specified position
     let insert_idx = match &spec.position {
@@ -185,7 +187,7 @@ pub fn group_symbols(
         }
         GroupPosition::End => modified_lines.len(),
         GroupPosition::After(sym_name) => {
-            let modified_source = modified_lines.join("\n");
+            let modified_source = modified_lines.join(eol);
             let mod_symbols = extract_symbols(&modified_source, lang);
             if let Some(sym) = find_symbol(&mod_symbols, sym_name) {
                 sym.end_line.min(modified_lines.len())
@@ -215,12 +217,12 @@ pub fn group_symbols(
         }
     }
 
-    let mut result = modified_lines.join("\n");
+    let mut result = modified_lines.join(eol);
     if source.ends_with('\n') && !result.ends_with('\n') {
-        result.push('\n');
+        result.push_str(eol);
     }
     if !source.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
+        result.truncate(result.len() - eol.len());
     }
 
     Ok(GroupResult {
@@ -230,7 +232,7 @@ pub fn group_symbols(
     })
 }
 
-fn indent_text(text: &str, indent: &str) -> String {
+fn indent_text(text: &str, indent: &str, eol: &str) -> String {
     text.lines()
         .map(|line| {
             if line.trim().is_empty() {
@@ -240,7 +242,7 @@ fn indent_text(text: &str, indent: &str) -> String {
             }
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join(eol)
 }
 
 #[cfg(test)]
@@ -370,6 +372,28 @@ mod tests {
         assert!(mod_pos < trailing_pos);
         assert!(result.module_created);
         assert_eq!(result.symbols_moved, 1);
+    }
+
+    #[test]
+    fn group_preserves_crlf_line_endings() {
+        let source = "fn foo() {}\r\n\r\nfn bar() {}\r\n\r\nfn baz() {}\r\n";
+        let spec = GroupSpec {
+            module: "helpers".into(),
+            symbols: vec!["foo".into(), "bar".into()],
+            preamble: None,
+            position: GroupPosition::FirstSymbol,
+        };
+        let result = group_symbols(source, &spec, Language::Rust).unwrap();
+        let bytes = result.content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF at byte {i} in: {:?}",
+                    result.content
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ast/imports.rs
+++ b/src/ast/imports.rs
@@ -46,6 +46,7 @@ pub fn list_imports(source: &str, lang: Language) -> Vec<ImportStatement> {
 /// Skips imports that already exist. Inserts at the appropriate position
 /// (after existing imports, or after module doc comments).
 pub fn add_imports(source: &str, imports_to_add: &[String], lang: Language) -> ImportsResult {
+    let eol = crate::write::detect_eol(source);
     let lines: Vec<&str> = source.lines().collect();
     let existing = list_imports(source, lang);
     let existing_texts: std::collections::HashSet<String> =
@@ -80,23 +81,23 @@ pub fn add_imports(source: &str, imports_to_add: &[String], lang: Language) -> I
     if insert_after.is_none() && !lines.is_empty() {
         for new_imp in &new_imports {
             result.push_str(new_imp);
-            result.push('\n');
+            result.push_str(eol);
         }
-        result.push('\n');
+        result.push_str(eol);
     }
 
     for (i, line) in lines.iter().enumerate() {
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
 
         if insert_after == Some(i) {
             // If there were no imports before, add a blank line
             if existing.is_empty() && !line.is_empty() {
-                result.push('\n');
+                result.push_str(eol);
             }
             for new_imp in &new_imports {
                 result.push_str(new_imp);
-                result.push('\n');
+                result.push_str(eol);
             }
         }
     }
@@ -105,13 +106,13 @@ pub fn add_imports(source: &str, imports_to_add: &[String], lang: Language) -> I
     if lines.is_empty() {
         for new_imp in &new_imports {
             result.push_str(new_imp);
-            result.push('\n');
+            result.push_str(eol);
         }
     }
 
     // Preserve trailing newline behavior
     if !source.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
+        result.truncate(result.len() - eol.len());
     }
 
     ImportsResult {
@@ -124,6 +125,7 @@ pub fn add_imports(source: &str, imports_to_add: &[String], lang: Language) -> I
 
 /// Remove specific import statements from source code.
 pub fn remove_imports(source: &str, imports_to_remove: &[String], lang: Language) -> ImportsResult {
+    let eol = crate::write::detect_eol(source);
     let lines: Vec<&str> = source.lines().collect();
     let remove_set: std::collections::HashSet<String> = imports_to_remove
         .iter()
@@ -140,12 +142,12 @@ pub fn remove_imports(source: &str, imports_to_remove: &[String], lang: Language
             continue;
         }
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
     }
 
     // Preserve trailing newline behavior
     if !source.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
+        result.truncate(result.len() - eol.len());
     }
 
     ImportsResult {
@@ -158,6 +160,7 @@ pub fn remove_imports(source: &str, imports_to_remove: &[String], lang: Language
 
 /// Deduplicate import statements in source code.
 pub fn dedupe_imports(source: &str, lang: Language) -> ImportsResult {
+    let eol = crate::write::detect_eol(source);
     let lines: Vec<&str> = source.lines().collect();
     let mut seen = std::collections::HashSet::new();
     let mut result = String::new();
@@ -174,12 +177,12 @@ pub fn dedupe_imports(source: &str, lang: Language) -> ImportsResult {
             seen.insert(normalized);
         }
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
     }
 
     // Preserve trailing newline behavior
     if !source.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
+        result.truncate(result.len() - eol.len());
     }
 
     ImportsResult {
@@ -439,6 +442,57 @@ mod tests {
             "scoped use should be preserved: {}",
             result.content
         );
+    }
+
+    #[test]
+    fn add_import_preserves_crlf() {
+        let source = "use std::io;\r\n\r\nfn main() {}\r\n";
+        let result = add_imports(source, &["use std::fs".into()], Language::Rust);
+        assert_eq!(result.added, 1);
+        let bytes = result.content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF at byte {i} in: {:?}",
+                    result.content
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn remove_import_preserves_crlf() {
+        let source = "use std::io;\r\nuse std::fs;\r\n\r\nfn main() {}\r\n";
+        let result = remove_imports(source, &["use std::io".into()], Language::Rust);
+        assert_eq!(result.removed, 1);
+        let bytes = result.content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF at byte {i} in: {:?}",
+                    result.content
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn dedupe_import_preserves_crlf() {
+        let source = "use std::io;\r\nuse std::fs;\r\nuse std::io;\r\n\r\nfn main() {}\r\n";
+        let result = dedupe_imports(source, Language::Rust);
+        assert_eq!(result.deduped, 1);
+        let bytes = result.content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF at byte {i} in: {:?}",
+                    result.content
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -105,27 +105,27 @@ fn insert_inside(
             // Use container line indent + 4 spaces for the body.
             let line_indent = container_line.len() - container_line.trim_start().len();
             let body_indent = format!("{}{}", &container_line[..line_indent], "    ");
-            let adjusted = indent_content(content, &body_indent);
+            let adjusted = indent_content(content, &body_indent, eol);
 
             let mut result = String::new();
             for line in &lines[..start_idx] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
             result.push_str(before_brace);
-            result.push('\n');
+            result.push_str(eol);
             result.push_str(&adjusted);
             if !adjusted.ends_with('\n') {
-                result.push('\n');
+                result.push_str(eol);
             }
             result.push_str(after_brace);
-            result.push('\n');
+            result.push_str(eol);
             for line in &lines[start_idx + 1..] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
             if !source.ends_with('\n') && result.ends_with('\n') {
-                result.pop();
+                result.truncate(result.len() - eol.len());
             }
             return Ok(InsertResult {
                 content: result,

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -40,16 +40,36 @@ pub fn insert_code(
         anyhow::bail!("exactly one of 'inside', 'after', or 'before' must be specified");
     }
 
+    let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols(source, lang);
     let lines: Vec<&str> = source.lines().collect();
 
     if let Some(container_name) = inside {
-        insert_inside(source, content, container_name, position, &symbols, &lines)
+        insert_inside(
+            source,
+            content,
+            container_name,
+            position,
+            &symbols,
+            &lines,
+            eol,
+        )
     } else if let Some(after_name) = after {
-        insert_adjacent(source, content, after_name, true, &symbols, &lines, lang)
+        insert_adjacent(
+            source, content, after_name, true, &symbols, &lines, lang, eol,
+        )
     } else {
         let before_name = before.unwrap();
-        insert_adjacent(source, content, before_name, false, &symbols, &lines, lang)
+        insert_adjacent(
+            source,
+            content,
+            before_name,
+            false,
+            &symbols,
+            &lines,
+            lang,
+            eol,
+        )
     }
 }
 
@@ -61,6 +81,7 @@ fn insert_inside(
     position: InsertPosition,
     symbols: &[SymbolDef],
     lines: &[&str],
+    eol: &str,
 ) -> anyhow::Result<InsertResult> {
     let sym = find_symbol(symbols, container_name)
         .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", container_name))?;
@@ -115,7 +136,7 @@ fn insert_inside(
 
     // Detect the indentation level inside the container.
     let container_indent = detect_indent(lines, start_idx, end_idx);
-    let adjusted = indent_content(content, &container_indent);
+    let adjusted = indent_content(content, &container_indent, eol);
 
     let mut result = String::new();
 
@@ -126,28 +147,28 @@ fn insert_inside(
 
             for line in &lines[..close_line_idx] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
 
             // Add a blank line before if the previous content doesn't end with one
             if close_line_idx > 0 && !lines[close_line_idx - 1].trim().is_empty() {
-                result.push('\n');
+                result.push_str(eol);
             }
             result.push_str(&adjusted);
             if !adjusted.ends_with('\n') {
-                result.push('\n');
+                result.push_str(eol);
             }
 
             for line in &lines[close_line_idx..] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
 
             let inserted_at = close_line_idx + 1; // 1-based
 
             // Preserve trailing newline behavior
             if !source.ends_with('\n') && result.ends_with('\n') {
-                result.pop();
+                result.truncate(result.len() - eol.len());
             }
 
             Ok(InsertResult {
@@ -162,29 +183,29 @@ fn insert_inside(
 
             for line in &lines[..=insert_after_idx] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
 
             result.push_str(&adjusted);
             if !adjusted.ends_with('\n') {
-                result.push('\n');
+                result.push_str(eol);
             }
 
             // Add blank line if next line is not blank
             if insert_after_idx + 1 < lines.len() && !lines[insert_after_idx + 1].trim().is_empty()
             {
-                result.push('\n');
+                result.push_str(eol);
             }
 
             for line in &lines[insert_after_idx + 1..] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
 
             let inserted_at = insert_after_idx + 2; // 1-based
 
             if !source.ends_with('\n') && result.ends_with('\n') {
-                result.pop();
+                result.truncate(result.len() - eol.len());
             }
 
             Ok(InsertResult {
@@ -196,6 +217,7 @@ fn insert_inside(
 }
 
 /// Insert content after or before a named symbol.
+#[allow(clippy::too_many_arguments)]
 fn insert_adjacent(
     source: &str,
     content: &str,
@@ -204,6 +226,7 @@ fn insert_adjacent(
     symbols: &[SymbolDef],
     lines: &[&str],
     lang: Language,
+    eol: &str,
 ) -> anyhow::Result<InsertResult> {
     let sym = find_symbol(symbols, symbol_name)
         .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", symbol_name))?;
@@ -217,7 +240,7 @@ fn insert_adjacent(
     } else {
         ""
     };
-    let adjusted = indent_content(content, indent);
+    let adjusted = indent_content(content, indent, eol);
 
     let mut result = String::new();
     let inserted_at;
@@ -226,17 +249,17 @@ fn insert_adjacent(
         let end_idx = sym.end_line.min(lines.len());
         for line in &lines[..end_idx] {
             result.push_str(line);
-            result.push('\n');
+            result.push_str(eol);
         }
-        result.push('\n');
+        result.push_str(eol);
         result.push_str(&adjusted);
         if !adjusted.ends_with('\n') {
-            result.push('\n');
+            result.push_str(eol);
         }
         inserted_at = end_idx + 1; // 1-based
         for line in &lines[end_idx..] {
             result.push_str(line);
-            result.push('\n');
+            result.push_str(eol);
         }
     } else {
         // Before — use full_symbol_span to include attributes and doc comments.
@@ -244,22 +267,22 @@ fn insert_adjacent(
         let start_idx = full_start.saturating_sub(1);
         for line in &lines[..start_idx] {
             result.push_str(line);
-            result.push('\n');
+            result.push_str(eol);
         }
         result.push_str(&adjusted);
         if !adjusted.ends_with('\n') {
-            result.push('\n');
+            result.push_str(eol);
         }
-        result.push('\n');
+        result.push_str(eol);
         inserted_at = start_idx + 1; // 1-based
         for line in &lines[start_idx..] {
             result.push_str(line);
-            result.push('\n');
+            result.push_str(eol);
         }
     }
 
     if !source.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
+        result.truncate(result.len() - eol.len());
     }
 
     Ok(InsertResult {
@@ -310,7 +333,7 @@ fn detect_indent(lines: &[&str], start_idx: usize, end_idx: usize) -> String {
 ///
 /// Strips the common leading whitespace from the content, then prepends
 /// the target indentation to each line.
-fn indent_content(content: &str, target_indent: &str) -> String {
+fn indent_content(content: &str, target_indent: &str, eol: &str) -> String {
     let lines: Vec<&str> = content.lines().collect();
     if lines.is_empty() {
         return String::new();
@@ -335,7 +358,7 @@ fn indent_content(content: &str, target_indent: &str) -> String {
             }
         })
         .collect::<Vec<_>>()
-        .join("\n")
+        .join(eol)
 }
 
 #[cfg(test)]
@@ -529,6 +552,58 @@ mod tests {
         )
         .unwrap();
         assert!(result.content.contains("def new_method"));
+    }
+
+    #[test]
+    fn insert_preserves_crlf_line_endings() {
+        let source = "mod tests {\r\n    fn existing() {}\r\n}\r\n";
+        let content = "fn new_fn() {}";
+        let result = insert_code(
+            source,
+            content,
+            Some("tests"),
+            None,
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        let bytes = result.content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF at byte {i} in: {:?}",
+                    result.content
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn insert_after_preserves_crlf() {
+        let source = "fn foo() {\r\n    let x = 1;\r\n}\r\n\r\nfn bar() {}\r\n";
+        let content = "fn baz() {}";
+        let result = insert_code(
+            source,
+            content,
+            None,
+            Some("foo"),
+            None,
+            InsertPosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        let bytes = result.content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF at byte {i} in: {:?}",
+                    result.content
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -45,6 +45,7 @@ pub fn move_symbols(
     position: MovePosition,
     lang: Language,
 ) -> anyhow::Result<MoveResult> {
+    let eol = crate::write::detect_eol(source);
     let src_symbols = extract_symbols(source, lang);
     let lines: Vec<&str> = source.lines().collect();
 
@@ -98,23 +99,24 @@ pub fn move_symbols(
         src_lines.drain(*start_0..drain_end);
     }
 
-    let mut source_result = src_lines.join("\n");
+    let mut source_result = src_lines.join(eol);
     if source.ends_with('\n') && !source_result.ends_with('\n') {
-        source_result.push('\n');
+        source_result.push_str(eol);
     }
 
     // Build text to insert into target
     let mut insert_text = String::new();
     for (i, text) in ordered_texts.iter().enumerate() {
         if i > 0 {
-            insert_text.push('\n');
+            insert_text.push_str(eol);
         }
         insert_text.push_str(text.trim_end_matches('\n'));
-        insert_text.push('\n');
+        insert_text.push_str(eol);
     }
 
-    // Insert into target
-    let target_result = insert_into_target(target, &insert_text, &position, lang)?;
+    // Insert into target (use target's EOL style, not source's)
+    let target_eol = crate::write::detect_eol(target);
+    let target_result = insert_into_target(target, &insert_text, &position, lang, target_eol)?;
 
     Ok(MoveResult {
         source_content: source_result,
@@ -128,6 +130,7 @@ fn insert_into_target(
     insert_text: &str,
     position: &MovePosition,
     lang: Language,
+    eol: &str,
 ) -> anyhow::Result<String> {
     if target.is_empty() {
         return Ok(insert_text.to_string());
@@ -139,15 +142,15 @@ fn insert_into_target(
         MovePosition::End => {
             let mut result = target.to_string();
             if !result.ends_with('\n') {
-                result.push('\n');
+                result.push_str(eol);
             }
-            result.push('\n');
+            result.push_str(eol);
             result.push_str(insert_text);
             Ok(result)
         }
         MovePosition::Start => {
             let mut result = insert_text.to_string();
-            result.push('\n');
+            result.push_str(eol);
             result.push_str(target);
             Ok(result)
         }
@@ -159,16 +162,16 @@ fn insert_into_target(
             let mut result = String::new();
             for line in &lines[..end_0] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
-            result.push('\n');
+            result.push_str(eol);
             result.push_str(insert_text);
             for line in &lines[end_0..] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
             if !target.ends_with('\n') && result.ends_with('\n') {
-                result.pop();
+                result.truncate(result.len() - eol.len());
             }
             Ok(result)
         }
@@ -181,16 +184,16 @@ fn insert_into_target(
             let mut result = String::new();
             for line in &lines[..start_0] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
             result.push_str(insert_text);
-            result.push('\n');
+            result.push_str(eol);
             for line in &lines[start_0..] {
                 result.push_str(line);
-                result.push('\n');
+                result.push_str(eol);
             }
             if !target.ends_with('\n') && result.ends_with('\n') {
-                result.pop();
+                result.truncate(result.len() - eol.len());
             }
             Ok(result)
         }
@@ -341,6 +344,42 @@ mod tests {
         let last_pos = result.target_content.find("fn last").unwrap();
         assert!(first_pos < moved_pos);
         assert!(moved_pos < last_pos);
+    }
+
+    #[test]
+    fn move_preserves_crlf_line_endings() {
+        let source = "fn foo() {}\r\n\r\nfn bar() {}\r\n";
+        let target = "fn existing() {}\r\n";
+        let result = move_symbols(
+            source,
+            target,
+            &["foo".into()],
+            MovePosition::End,
+            Language::Rust,
+        )
+        .unwrap();
+        // Source content should preserve CRLF
+        let bytes = result.source_content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF in source at byte {i}: {:?}",
+                    result.source_content
+                );
+            }
+        }
+        // Target content should preserve CRLF
+        let target_bytes = result.target_content.as_bytes();
+        for (i, &b) in target_bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && target_bytes[i - 1] == b'\r',
+                    "bare LF in target at byte {i}: {:?}",
+                    result.target_content
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -35,6 +35,7 @@ pub fn reorder_symbols(
     strategy: &ReorderStrategy,
     lang: Language,
 ) -> anyhow::Result<ReorderResult> {
+    let eol = crate::write::detect_eol(source);
     let all_symbols = extract_symbols(source, lang);
     let lines: Vec<&str> = source.lines().collect();
 
@@ -93,7 +94,7 @@ pub fn reorder_symbols(
     // Collect the text of each symbol (spans are already in new order after sort).
     let mut sym_texts: Vec<(&str, String)> = Vec::new();
     for span in &spans {
-        let text: String = lines[span.start_0..span.end_0].join("\n");
+        let text: String = lines[span.start_0..span.end_0].join(eol);
         sym_texts.push((&span.name, text));
     }
 
@@ -117,40 +118,40 @@ pub fn reorder_symbols(
     // Lines before the scope (container preamble when using `inside`)
     for line in &lines[..scope_start_0] {
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
     }
 
     // Scope prefix: non-symbol lines inside the scope before the first symbol
     // (use statements, module-level comments, extern crate, etc.)
     for line in &lines[scope_start_0..first_sym_start] {
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
     }
 
     // Emit symbols in new order with blank line separators
     for (i, (_name, text)) in sym_texts.iter().enumerate() {
         if i > 0 {
-            result.push('\n');
+            result.push_str(eol);
         }
         result.push_str(text);
-        result.push('\n');
+        result.push_str(eol);
     }
 
     // Scope suffix: non-symbol lines inside the scope after the last symbol
     for line in &lines[last_sym_end..scope_end_0] {
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
     }
 
     // Lines after the scope (closing brace, trailing content)
     for line in &lines[scope_end_0..] {
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
     }
 
     // Preserve trailing newline behavior
     if !source.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
+        result.truncate(result.len() - eol.len());
     }
 
     Ok(ReorderResult {
@@ -448,6 +449,35 @@ mod tests {
             use_pos < alpha_pos,
             "use statement should remain before symbols"
         );
+    }
+
+    #[test]
+    fn reorder_preserves_crlf_line_endings() {
+        let source = "fn charlie() {}\r\n\r\nfn alpha() {}\r\n\r\nfn bravo() {}\r\n";
+        let result =
+            reorder_symbols(source, None, &ReorderStrategy::Alphabetical, Language::Rust).unwrap();
+        // All line endings in the output must be CRLF
+        assert!(
+            !result.content.contains("\n\n") || result.content.contains("\r\n"),
+            "CRLF line endings should be preserved: {:?}",
+            result.content
+        );
+        assert!(
+            result.content.contains("\r\n"),
+            "output should contain CRLF: {:?}",
+            result.content
+        );
+        // Verify no bare LF (every \n must be preceded by \r)
+        let bytes = result.content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF at byte {i} in: {:?}",
+                    result.content
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -35,6 +35,7 @@ pub fn split_file(
     require_exhaustive: bool,
     lang: Language,
 ) -> anyhow::Result<SplitResult> {
+    let eol = crate::write::detect_eol(source);
     let all_symbols = extract_symbols(source, lang);
     let lines: Vec<&str> = source.lines().collect();
 
@@ -81,10 +82,10 @@ pub fn split_file(
         if let Some(&target_idx) = sym_to_target.get(sym.name.as_str()) {
             let text = extract_symbol_text(source, sym, lang);
             if !target_contents[target_idx].is_empty() {
-                target_contents[target_idx].push('\n');
+                target_contents[target_idx].push_str(eol);
             }
             target_contents[target_idx].push_str(text.trim_end_matches('\n'));
-            target_contents[target_idx].push('\n');
+            target_contents[target_idx].push_str(eol);
 
             let (full_start, full_end) = full_symbol_span(source, sym, lang);
             spans_to_remove.push((full_start.saturating_sub(1), full_end.min(lines.len())));
@@ -120,9 +121,9 @@ pub fn split_file(
         }
     }
 
-    let mut source_content = src_lines.join("\n");
+    let mut source_content = src_lines.join(eol);
     if source.ends_with('\n') && !source_content.ends_with('\n') {
-        source_content.push('\n');
+        source_content.push_str(eol);
     }
 
     // Build final target contents with prepend
@@ -134,13 +135,13 @@ pub fn split_file(
             if let Some(pre) = &spec.prepend {
                 final_content.push_str(pre);
                 if !pre.ends_with('\n') {
-                    final_content.push('\n');
+                    final_content.push_str(eol);
                 }
-                final_content.push('\n');
+                final_content.push_str(eol);
             }
             final_content.push_str(content);
             if !final_content.ends_with('\n') {
-                final_content.push('\n');
+                final_content.push_str(eol);
             }
             (spec.path.clone(), final_content)
         })
@@ -303,6 +304,48 @@ mod tests {
         .unwrap();
         assert!(result.targets[0].1.contains("/// Alpha doc."));
         assert!(result.targets[0].1.contains("#[test]"));
+    }
+
+    #[test]
+    fn split_preserves_crlf_line_endings() {
+        let source = "fn alpha() {}\r\n\r\nfn beta() {}\r\n\r\nfn gamma() {}\r\n";
+        let targets = vec![SplitTarget {
+            path: "a.rs".into(),
+            symbols: vec!["alpha".into()],
+            prepend: None,
+        }];
+        let result = split_file(
+            source,
+            &targets,
+            &["beta".into(), "gamma".into()],
+            None,
+            None,
+            true,
+            Language::Rust,
+        )
+        .unwrap();
+        // Source content should preserve CRLF
+        let bytes = result.source_content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF in source at byte {i}: {:?}",
+                    result.source_content
+                );
+            }
+        }
+        // Target content should preserve CRLF
+        let target_bytes = result.targets[0].1.as_bytes();
+        for (i, &b) in target_bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && target_bytes[i - 1] == b'\r',
+                    "bare LF in target at byte {i}: {:?}",
+                    result.targets[0].1
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -715,20 +715,21 @@ fn extract_ts_js(
             let name = child_text_by_kinds(node, &["type_identifier", "identifier"], source)?;
             Some((SymbolKind::Enum, name.to_string()))
         }
-        "lexical_declaration" => {
-            let mut cursor = node.walk();
-            for child in node.children(&mut cursor) {
-                if child.kind() == "variable_declarator" {
-                    if let Some(first) = node.child(0)
-                        && first.utf8_text(source.as_bytes()).ok() != Some("const")
-                    {
-                        return None;
-                    }
-                    let name = child_text_by_kind(child, "identifier", source)?;
-                    return Some((SymbolKind::Const, name.to_string()));
-                }
+        // Match individual variable_declarator nodes instead of the parent
+        // lexical_declaration so that `const a = 1, b = 2` emits one symbol
+        // per declarator (#1104). visit_node recurses into lexical_declaration
+        // children naturally (same pattern as Go grouped type declarations).
+        "variable_declarator" => {
+            if let Some(parent) = node.parent()
+                && parent.kind() == "lexical_declaration"
+                && let Some(first) = parent.child(0)
+                && first.utf8_text(source.as_bytes()).ok() == Some("const")
+            {
+                let name = child_text_by_kind(node, "identifier", source)?;
+                Some((SymbolKind::Const, name.to_string()))
+            } else {
+                None
             }
-            None
         }
         _ => None,
     }
@@ -983,6 +984,20 @@ pub fn full_symbol_span(source: &str, sym: &SymbolDef, lang: Language) -> (usize
                 continue;
             }
             break;
+        } else if lang == Language::Python
+            || lang == Language::TypeScript
+            || lang == Language::JavaScript
+            || lang == Language::Java
+            || lang == Language::Kotlin
+        {
+            // Check if this line is a continuation of a multiline decorator,
+            // e.g. `@decorator(\n  arg1,\n  arg2\n)` (#1103).
+            if let Some(dec_start) = find_multiline_decorator_start(&lines, i) {
+                first_line_0 = dec_start;
+                i = dec_start;
+                continue;
+            }
+            break;
         } else {
             break;
         }
@@ -1050,6 +1065,32 @@ fn find_rust_multiline_attr_start(lines: &[&str], from_0: usize) -> Option<usize
             return Some(j);
         }
         // Safety: don't walk more than 20 lines back for a single attribute
+        if from_0 - j > 20 {
+            break;
+        }
+    }
+    None
+}
+
+/// Check whether the lines starting at `from_0` form the interior/closing
+/// of a multiline decorator (e.g. `@decorator(\n  arg1,\n  arg2\n)`).
+///
+/// Scans backwards from `from_0`, tracking parenthesis depth. If we reach
+/// a line starting with `@` and parens balance, returns that line index.
+fn find_multiline_decorator_start(lines: &[&str], from_0: usize) -> Option<usize> {
+    let mut depth: i32 = 0;
+    for j in (0..=from_0).rev() {
+        let trimmed = lines[j].trim();
+        for ch in trimmed.chars() {
+            if ch == ')' {
+                depth += 1;
+            } else if ch == '(' {
+                depth -= 1;
+            }
+        }
+        if trimmed.starts_with('@') && depth <= 0 {
+            return Some(j);
+        }
         if from_0 - j > 20 {
             break;
         }
@@ -1400,6 +1441,35 @@ const MAX_RETRIES = 5;
         assert_eq!(status.kind, SymbolKind::Enum);
     }
 
+    /// Multi-declarator `const a = 1, b = 2, c = 3;` should emit one symbol
+    /// per declarator, not just the first one (#1104).
+    #[test]
+    fn extract_typescript_multi_declarator_const() {
+        let source = "const a = 1, b = 2, c = 3;\n";
+        let symbols = extract_symbols(source, Language::TypeScript);
+        let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
+        assert!(names.contains(&"a"), "should find const a: {names:?}");
+        assert!(names.contains(&"b"), "should find const b: {names:?}");
+        assert!(names.contains(&"c"), "should find const c: {names:?}");
+        assert_eq!(
+            symbols.len(),
+            3,
+            "exactly 3 symbols for 3 declarators: {names:?}"
+        );
+    }
+
+    /// `let` and `var` declarators should NOT be extracted (only `const`).
+    #[test]
+    fn extract_typescript_let_var_not_extracted() {
+        let source = "let x = 1, y = 2;\nvar z = 3;\n";
+        let symbols = extract_symbols(source, Language::TypeScript);
+        assert!(
+            symbols.is_empty(),
+            "let/var should not produce symbols: {:?}",
+            symbols.iter().map(|s| &s.name).collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn extract_java_symbols() {
         let source = r#"
@@ -1657,6 +1727,46 @@ struct Point {
         let sym = &symbols[0];
         let (start, _) = full_symbol_span(source, sym, Language::Python);
         assert_eq!(start, 1);
+    }
+
+    // Regression: multi-line Python decorators with continuation lines
+    // were truncated because only lines starting with '@' matched (#1103).
+    #[test]
+    fn full_span_python_multiline_decorator() {
+        let source = "\
+@decorator(
+    arg1,
+    arg2
+)
+def foo():
+    pass
+";
+        let symbols = extract_symbols(source, Language::Python);
+        let sym = symbols.iter().find(|s| s.name == "foo").unwrap();
+        let (start, _) = full_symbol_span(source, sym, Language::Python);
+        assert_eq!(
+            start, 1,
+            "multiline @decorator(...) should be included in foo's span"
+        );
+    }
+
+    #[test]
+    fn full_span_python_stacked_multiline_decorator() {
+        let source = "\
+@first_decorator
+@second_decorator(
+    option=True
+)
+def bar():
+    pass
+";
+        let symbols = extract_symbols(source, Language::Python);
+        let sym = symbols.iter().find(|s| s.name == "bar").unwrap();
+        let (start, _) = full_symbol_span(source, sym, Language::Python);
+        assert_eq!(
+            start, 1,
+            "both decorators (including multiline) should be included"
+        );
     }
 
     // Regression: //! inner doc comments belong to the module, not the

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -107,30 +107,24 @@ pub fn extract_symbols_from_file(path: &Path, lang_hint: Option<Language>) -> Ve
 
 /// Find a symbol by name, optionally qualified (e.g. "Impl::method").
 pub fn find_symbol<'a>(symbols: &'a [SymbolDef], name: &str) -> Option<&'a SymbolDef> {
-    if let Some((parent, child)) = name.split_once("::") {
-        // Qualified name: find parent, then child
+    if let Some((parent, rest)) = name.split_once("::") {
+        // Qualified name: find parent, then recurse into children
         for sym in symbols {
             if sym.name == parent {
-                for c in &sym.children {
-                    if c.name == child {
-                        return Some(c);
-                    }
-                }
+                return find_symbol(&sym.children, rest);
             }
         }
         None
     } else {
-        // Unqualified: search top-level, then children
+        // Unqualified: search top-level first (BFS), then recurse
         for sym in symbols {
             if sym.name == name {
                 return Some(sym);
             }
         }
         for sym in symbols {
-            for c in &sym.children {
-                if c.name == name {
-                    return Some(c);
-                }
+            if let Some(found) = find_symbol(&sym.children, name) {
+                return Some(found);
             }
         }
         None
@@ -1333,6 +1327,47 @@ impl Server {
 "#;
         let symbols = extract_symbols(source, Language::Rust);
         find_symbol(&symbols, "start").expect("should find 'start' via unqualified search");
+    }
+
+    /// find_symbol should recurse into deeply nested children, not just
+    /// one level (#1111 item 5).
+    #[test]
+    fn find_symbol_deeply_nested() {
+        // Build a 3-level hierarchy: mod > struct > method
+        let inner = SymbolDef {
+            name: "deep_method".into(),
+            kind: SymbolKind::Method,
+            start_line: 3,
+            end_line: 4,
+            signature: "fn deep_method()".into(),
+            children: Vec::new(),
+            depth: 2,
+        };
+        let mid = SymbolDef {
+            name: "MidStruct".into(),
+            kind: SymbolKind::Struct,
+            start_line: 2,
+            end_line: 5,
+            signature: "struct MidStruct".into(),
+            children: vec![inner],
+            depth: 1,
+        };
+        let outer = SymbolDef {
+            name: "outer_mod".into(),
+            kind: SymbolKind::Module,
+            start_line: 1,
+            end_line: 6,
+            signature: "mod outer_mod".into(),
+            children: vec![mid],
+            depth: 0,
+        };
+        let symbols = vec![outer];
+
+        // Unqualified search should find a deeply nested symbol
+        find_symbol(&symbols, "deep_method").expect("should find deeply nested symbol");
+
+        // Qualified search with multiple :: should work recursively
+        find_symbol(&symbols, "outer_mod::MidStruct").expect("should find qualified nested symbol");
     }
 
     #[test]

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -31,6 +31,7 @@ pub fn wrap_code(
         anyhow::bail!("exactly one of 'symbols' or 'lines' must be specified");
     }
 
+    let eol = crate::write::detect_eol(source);
     let source_lines: Vec<&str> = source.lines().collect();
 
     // Determine the range of lines to wrap (0-based indices).
@@ -59,54 +60,54 @@ pub fn wrap_code(
     let wrapper_opening = format_wrapper_opening(wrapper);
     wrapped.push_str(base_indent);
     wrapped.push_str(&wrapper_opening);
-    wrapped.push('\n');
+    wrapped.push_str(eol);
 
     // Preamble (if any)
     if let Some(pre) = preamble {
         for pline in pre.lines() {
             if pline.trim().is_empty() {
-                wrapped.push('\n');
+                wrapped.push_str(eol);
             } else {
                 wrapped.push_str(base_indent);
                 wrapped.push_str("    ");
                 wrapped.push_str(pline.trim());
-                wrapped.push('\n');
+                wrapped.push_str(eol);
             }
         }
-        wrapped.push('\n');
+        wrapped.push_str(eol);
     }
 
     // Indented body
     for line in target_lines {
         if line.trim().is_empty() {
-            wrapped.push('\n');
+            wrapped.push_str(eol);
         } else {
             wrapped.push_str("    ");
             wrapped.push_str(line);
-            wrapped.push('\n');
+            wrapped.push_str(eol);
         }
     }
 
     // Closing brace
     wrapped.push_str(base_indent);
     wrapped.push('}');
-    wrapped.push('\n');
+    wrapped.push_str(eol);
 
     // Reconstruct the file
     let mut result = String::new();
     for line in &source_lines[..start_idx] {
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
     }
     result.push_str(&wrapped);
     for line in &source_lines[end_idx..] {
         result.push_str(line);
-        result.push('\n');
+        result.push_str(eol);
     }
 
     // Preserve trailing newline behavior
     if !source.ends_with('\n') && result.ends_with('\n') {
-        result.pop();
+        result.truncate(result.len() - eol.len());
     }
 
     Ok(WrapResult { content: result })
@@ -336,6 +337,30 @@ mod tests {
             "attribute should be inside wrapper: {}",
             result.content
         );
+    }
+
+    #[test]
+    fn wrap_preserves_crlf_line_endings() {
+        let source = "fn helper_a() {}\r\n\r\nfn helper_b() {}\r\n";
+        let result = wrap_code(
+            source,
+            Some(&["helper_a".into(), "helper_b".into()]),
+            None,
+            "mod helpers",
+            None,
+            Language::Rust,
+        )
+        .unwrap();
+        let bytes = result.content.as_bytes();
+        for (i, &b) in bytes.iter().enumerate() {
+            if b == b'\n' {
+                assert!(
+                    i > 0 && bytes[i - 1] == b'\r',
+                    "bare LF at byte {i} in: {:?}",
+                    result.content
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -141,89 +141,53 @@ pub(super) fn handle_ast_rename(
     let target = cwd.join(&p.path);
     let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
 
-    let mut global = GlobalFlags::with_cwd_and_json(&cwd);
-    global.apply = true;
+    let global = GlobalFlags::with_cwd_and_json(&cwd);
 
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
-    let mut total_replacements = 0usize;
-    let mut files_changed = 0usize;
-    let mut backup = crate::backup::BackupSession::new(&cwd)
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
+    // Pre-filter to files with matches, build one AstRename op per file,
+    // then execute as a batch through the tx engine for backup/rollback (#1100).
+    let mut operations = Vec::new();
     for path in &paths {
-        svc.check_path(
-            &path
-                .strip_prefix(&cwd)
-                .unwrap_or(path)
-                .display()
-                .to_string(),
-        )?;
+        let rel = path
+            .strip_prefix(&cwd)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .into_owned();
+        svc.check_path(&rel)?;
 
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
         let source = std::fs::read_to_string(path)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
 
-        let result = if lang.has_grammar() {
+        let has_match = if lang.has_grammar() {
             crate::ast::rename::rename_in_source(&source, &p.old_name, &p.new_name, lang)
+                .is_some_and(|r| r.replacements > 0)
         } else {
-            None
+            false
+        } || {
+            crate::ops::replace::compile_replace_regex(&p.old_name, false, false, false, true)
+                .ok()
+                .flatten()
+                .is_some_and(|re| re.is_match(&source))
         };
 
-        let (new_content, count) = match result {
-            Some(r) if r.replacements > 0 => (r.content, r.replacements),
-            Some(_) => continue, // grammar parsed but no code identifiers found; skip file
-            None => {
-                // Try word-boundary fallback
-                let re = crate::ops::replace::compile_replace_regex(
-                    &p.old_name,
-                    false,
-                    false,
-                    false,
-                    true,
-                )
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-                if let Some(re) = re {
-                    let count = re.find_iter(&source).count();
-                    if count > 0 {
-                        let new = re.replace_all(&source, p.new_name.as_str());
-                        (new.into_owned(), count)
-                    } else {
-                        continue;
-                    }
-                } else {
-                    continue;
-                }
-            }
-        };
-
-        total_replacements += count;
-        files_changed += 1;
-        let policy = crate::write::policy_from_flags(&global, Some(path));
-        backup
-            .save_before_write(path)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        crate::write::atomic_write(path, &new_content, &policy)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        if has_match {
+            operations.push(crate::plan::Operation::AstRename {
+                path: rel,
+                old_name: p.old_name.clone(),
+                new_name: p.new_name.clone(),
+                lang: p.lang.clone(),
+            });
+        }
     }
 
-    backup
-        .finalize()
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-    if total_replacements == 0 {
+    if operations.is_empty() {
         return exit_code_to_result(exit::NO_MATCHES, "", "No matches found.");
     }
 
-    let obj = serde_json::json!({
-        "ok": true,
-        "files_changed": files_changed,
-        "replacements": total_replacements,
-    });
-    let json = serde_json::to_string_pretty(&obj)
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    svc.run_ops(operations, None)
 }
 
 pub(super) fn handle_ast_validate(
@@ -581,58 +545,16 @@ pub(super) fn handle_ast_replace(
     validate_param_size("from", &p.from)?;
     validate_content_size("to", &p.to)?;
     validate_param_size("symbol", &p.symbol)?;
-    let cwd = svc.cwd().to_path_buf();
-    let target = cwd.join(&p.path);
-    let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-    let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
-
-    let source = std::fs::read_to_string(&target)
-        .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
-
-    let result =
-        crate::ast::replace::replace_in_symbol(&source, &p.symbol, &p.from, &p.to, p.regex, lang)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-    let result = match result {
-        Some(r) => r,
-        None => {
-            return exit_code_to_result(
-                exit::NO_MATCHES,
-                "",
-                &format!("Symbol '{}' not found in {}.", p.symbol, p.path),
-            );
-        }
+    // Route through the tx engine for backup/rollback safety (#1100).
+    let op = crate::plan::Operation::AstReplace {
+        path: p.path,
+        symbol: p.symbol,
+        from: p.from,
+        to: p.to,
+        regex: p.regex,
+        lang: p.lang,
     };
-
-    if result.replacements == 0 {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No matches within symbol.");
-    }
-
-    // Write the file
-    let mut global = GlobalFlags::with_cwd(&cwd);
-    global.apply = true;
-    let policy = crate::write::policy_from_flags(&global, Some(&target));
-    let mut backup = crate::backup::BackupSession::new(&cwd)
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    backup
-        .save_before_write(&target)
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    crate::write::atomic_write(&target, &result.content, &policy)
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    backup
-        .finalize()
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-
-    let obj = serde_json::json!({
-        "ok": true,
-        "symbol": p.symbol,
-        "replacements": result.replacements,
-        "start_line": result.start_line,
-        "end_line": result.end_line,
-    });
-    let json = serde_json::to_string_pretty(&obj)
-        .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    svc.run_one_op(op, None)
 }
 
 pub(super) fn handle_ast_insert(

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -200,12 +200,23 @@ pub(crate) fn format_results(
         };
         let has_ctx =
             args.context.is_some() || args.before_context.is_some() || args.after_context.is_some();
-        let mut first = true;
-        for m in &results.matches {
-            if has_ctx && !first {
-                out.push_str("--\n");
+        let mut prev_end: Option<(usize, usize)> = None; // (match index, last line covered)
+        for (mi, m) in results.matches.iter().enumerate() {
+            if has_ctx {
+                // Only print separator between non-contiguous groups,
+                // matching standard grep/ripgrep behavior (#1111).
+                let cur_start = m
+                    .line
+                    .saturating_sub(m.context_before.as_ref().map_or(0, |b| b.len()));
+                if let Some((prev_idx, prev_last_line)) = prev_end {
+                    let prev_path = &results.matches[prev_idx].path;
+                    if **prev_path != *m.path || cur_start > prev_last_line + 1 {
+                        out.push_str("--\n");
+                    }
+                }
+                let after_ctx_len = m.context_after.as_ref().map_or(0, |a| a.len());
+                prev_end = Some((mi, m.line + after_ctx_len));
             }
-            first = false;
             if let Some(ref before) = m.context_before {
                 for (j, ctx) in before.iter().enumerate() {
                     let ln = m.line - before.len() + j;

--- a/src/ops/doc/preserve.rs
+++ b/src/ops/doc/preserve.rs
@@ -1,6 +1,7 @@
 /// Small extracted helper for #840 thinning demo.
 /// Full preserving can be moved here over time.
 pub(crate) fn hoist_comments(original: &str, body: &str) -> String {
+    let eol = crate::write::detect_eol(original);
     let comments: String = original
         .lines()
         .filter(|l| {
@@ -8,7 +9,7 @@ pub(crate) fn hoist_comments(original: &str, body: &str) -> String {
             t.is_empty() || t.starts_with('#')
         })
         .collect::<Vec<_>>()
-        .join("\n");
+        .join(eol);
     if !comments.trim().is_empty() {
         let sep = if comments.ends_with('\n') || body.starts_with('\n') {
             ""
@@ -65,6 +66,17 @@ mod tests {
         assert!(
             result.contains("# comment\nkey = 2"),
             "separator newline between comment and body: {result}"
+        );
+    }
+
+    #[test]
+    fn hoist_comments_preserves_crlf_line_endings() {
+        let original = "# top comment\r\n\r\n# second\r\nkey = \"val\"\r\n";
+        let body = "key = \"new\"\r\n";
+        let result = hoist_comments(original, body);
+        assert!(
+            result.contains("# top comment\r\n\r\n# second"),
+            "CRLF should be preserved in comment join: {result:?}"
         );
     }
 }

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -186,66 +186,75 @@ fn splice_array_lines(
     cur_arr: &[serde_json::Value],
     tgt_arr: &[serde_json::Value],
 ) -> anyhow::Result<Option<String>> {
+    let eol = crate::write::detect_eol(text);
     let cur_len = cur_arr.len();
     let tgt_len = tgt_arr.len();
 
     // Pure prepend: old array appears at the end of target.
     if tgt_len > cur_len && tgt_arr[tgt_len - cur_len..] == *cur_arr {
         let new_entries = &tgt_arr[..tgt_len - cur_len];
-        let new_text = serialize_block_entries(new_entries, entry_indent)?;
+        let new_text = serialize_block_entries(new_entries, entry_indent, eol)?;
         return Ok(Some(insert_text_at_line(
             text,
             lines,
             first_entry,
             &new_text,
+            eol,
         )));
     }
 
     // Pure append: old array appears at the start of target.
     if tgt_len > cur_len && tgt_arr[..cur_len] == *cur_arr {
         let new_entries = &tgt_arr[cur_len..];
-        let new_text = serialize_block_entries(new_entries, entry_indent)?;
+        let new_text = serialize_block_entries(new_entries, entry_indent, eol)?;
         return Ok(Some(insert_text_at_line(
             text,
             lines,
             last_entry_end,
             &new_text,
+            eol,
         )));
     }
 
     // General restructuring: replace all entry lines.
-    let new_text = serialize_block_entries(tgt_arr, entry_indent)?;
+    let new_text = serialize_block_entries(tgt_arr, entry_indent, eol)?;
     let mut out = String::new();
     for (i, line) in lines.iter().enumerate() {
         if i < first_entry || i >= last_entry_end {
             out.push_str(line);
-            out.push('\n');
+            out.push_str(eol);
         } else if i == first_entry {
             out.push_str(&new_text);
         }
     }
     if !text.ends_with('\n') && out.ends_with('\n') {
-        out.pop();
+        out.truncate(out.len() - eol.len());
     }
     Ok(Some(out))
 }
 
 /// Insert `new_text` before line `line_idx`, preserving all existing lines.
-fn insert_text_at_line(text: &str, lines: &[&str], line_idx: usize, new_text: &str) -> String {
+fn insert_text_at_line(
+    text: &str,
+    lines: &[&str],
+    line_idx: usize,
+    new_text: &str,
+    eol: &str,
+) -> String {
     let mut out = String::new();
     for (i, line) in lines.iter().enumerate() {
         if i == line_idx {
             out.push_str(new_text);
         }
         out.push_str(line);
-        out.push('\n');
+        out.push_str(eol);
     }
     // Handle insertion after the last line (for append).
     if line_idx >= lines.len() {
         out.push_str(new_text);
     }
     if !text.ends_with('\n') && out.ends_with('\n') {
-        out.pop();
+        out.truncate(out.len() - eol.len());
     }
     out
 }
@@ -354,25 +363,30 @@ fn find_block_entries_end(lines: &[&str], first_entry: usize, entry_indent: &str
 }
 
 /// Serialize `entries` as block-style YAML array entries at `indent`.
-fn serialize_block_entries(entries: &[serde_json::Value], indent: &str) -> anyhow::Result<String> {
+fn serialize_block_entries(
+    entries: &[serde_json::Value],
+    indent: &str,
+    eol: &str,
+) -> anyhow::Result<String> {
     let mut out = String::new();
     for entry in entries {
         match entry {
             serde_json::Value::Null => {
                 out.push_str(indent);
-                out.push_str("- null\n");
+                out.push_str("- null");
+                out.push_str(eol);
             }
             serde_json::Value::Bool(b) => {
                 out.push_str(indent);
                 out.push_str("- ");
                 out.push_str(if *b { "true" } else { "false" });
-                out.push('\n');
+                out.push_str(eol);
             }
             serde_json::Value::Number(n) => {
                 out.push_str(indent);
                 out.push_str("- ");
                 out.push_str(&n.to_string());
-                out.push('\n');
+                out.push_str(eol);
             }
             serde_json::Value::String(s) => {
                 out.push_str(indent);
@@ -388,7 +402,7 @@ fn serialize_block_entries(entries: &[serde_json::Value], indent: &str) -> anyho
                 } else {
                     out.push_str(s);
                 }
-                out.push('\n');
+                out.push_str(eol);
             }
             serde_json::Value::Object(_) | serde_json::Value::Array(_) => {
                 // Serialize compound value, then re-indent.
@@ -402,7 +416,7 @@ fn serialize_block_entries(entries: &[serde_json::Value], indent: &str) -> anyho
                         out.push_str("  ");
                     }
                     out.push_str(line);
-                    out.push('\n');
+                    out.push_str(eol);
                 }
             }
         }
@@ -596,7 +610,7 @@ mod tests {
             serde_json::json!(42),
             serde_json::json!("hello"),
         ];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         assert!(result.contains("  - null\n"));
         assert!(result.contains("  - true\n"));
         assert!(result.contains("  - 42\n"));
@@ -606,7 +620,7 @@ mod tests {
     #[test]
     fn serialize_string_needing_quoting() {
         let entries = vec![serde_json::json!("true"), serde_json::json!("")];
-        let result = serialize_block_entries(&entries, "").unwrap();
+        let result = serialize_block_entries(&entries, "", "\n").unwrap();
         assert!(result.contains("- 'true'\n"));
         assert!(result.contains("- ''\n"));
     }
@@ -614,7 +628,7 @@ mod tests {
     #[test]
     fn serialize_object_entry() {
         let entries = vec![serde_json::json!({"name": "a", "value": 1})];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         // First line should be "  - ..." and continuation "    ..."
         let first_line = result.lines().next().unwrap();
         assert!(first_line.starts_with("  - "));
@@ -721,7 +735,7 @@ mod tests {
     fn serialize_string_with_newline_uses_double_quote() {
         use serde_json::json;
         let entries = vec![json!("hello\nworld")];
-        let result = serialize_block_entries(&entries, "").unwrap();
+        let result = serialize_block_entries(&entries, "", "\n").unwrap();
         // Must use double-quoting to preserve the newline.
         assert!(
             result.contains('"'),
@@ -759,7 +773,7 @@ mod tests {
     fn serialize_nested_object() {
         use serde_json::json;
         let entries = vec![json!({"name": "main", "env": [{"name": "KEY", "value": "val"}]})];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         // First line starts with "  - "
         let first_line = result.lines().next().unwrap();
         assert!(
@@ -785,7 +799,7 @@ mod tests {
     fn serialize_array_of_arrays() {
         use serde_json::json;
         let entries = vec![json!([1, 2, 3])];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         let first_line = result.lines().next().unwrap();
         assert!(
             first_line.starts_with("  - "),
@@ -799,7 +813,7 @@ mod tests {
     fn serialize_empty_object() {
         use serde_json::json;
         let entries = vec![json!({})];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         assert!(
             result.starts_with("  - "),
             "expected '  - ' prefix, got: {result}"
@@ -812,7 +826,7 @@ mod tests {
     fn serialize_empty_array() {
         use serde_json::json;
         let entries = vec![json!([])];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         assert!(
             result.starts_with("  - "),
             "expected '  - ' prefix, got: {result}"
@@ -825,7 +839,7 @@ mod tests {
     fn serialize_object_with_keys_needing_quoting() {
         use serde_json::json;
         let entries = vec![json!({"true": "val", "null": "x"})];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         // The keys "true" and "null" must be quoted in the output so that
         // YAML parsers treat them as strings, not booleans/null.
         let parsed: Vec<serde_json::Value> = serde_yaml_ng::from_str(&result).unwrap();
@@ -851,7 +865,7 @@ mod tests {
         // must both trigger `needs_yaml_quoting` AND contain a single quote.
         // "# it's a comment" starts with '#' (needs quoting) and has a quote.
         let entries = vec![json!("# it's a comment")];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         assert!(
             result.starts_with("  - "),
             "expected '  - ' prefix, got: {result}"
@@ -869,9 +883,43 @@ mod tests {
     fn serialize_unicode_string() {
         use serde_json::json;
         let entries = vec![json!("café"), json!("こんにちは")];
-        let result = serialize_block_entries(&entries, "  ").unwrap();
+        let result = serialize_block_entries(&entries, "  ", "\n").unwrap();
         let parsed: Vec<serde_json::Value> = serde_yaml_ng::from_str(&result).unwrap();
         assert_eq!(parsed, vec![json!("café"), json!("こんにちは")]);
+    }
+
+    #[test]
+    fn serialize_block_entries_crlf() {
+        let entries = vec![serde_json::json!("alpha"), serde_json::json!("beta")];
+        let result = serialize_block_entries(&entries, "  ", "\r\n").unwrap();
+        assert!(
+            result.contains("- alpha\r\n"),
+            "should use CRLF line endings: {result:?}"
+        );
+        assert!(
+            !result.contains("- alpha\n\r\n"),
+            "should not double-terminate: {result:?}"
+        );
+    }
+
+    #[test]
+    fn splice_preserves_crlf_line_endings() {
+        use serde_json::json;
+        let yaml = "items:\r\n  - one\r\n  - two\r\n";
+        let current: serde_json::Value = serde_yaml_ng::from_str(yaml).unwrap();
+        let mut target = current.clone();
+        target["items"].as_array_mut().unwrap().push(json!("three"));
+        let result = splice_yaml_array_diffs(yaml, &current, &target).unwrap();
+        if let Some(spliced) = result {
+            assert!(
+                spliced.contains("\r\n"),
+                "CRLF should be preserved in splice output: {spliced:?}"
+            );
+            assert!(
+                !spliced.contains("\n\r\n"),
+                "should not have double line-endings: {spliced:?}"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -325,8 +325,10 @@ fn find_block_entries_end(lines: &[&str], first_entry: usize, entry_indent: &str
             end = i + 1;
             continue;
         }
-        if trimmed.starts_with('#') && cur_indent >= indent_len {
-            // Comment at or deeper than entry indent: part of the array.
+        if trimmed.starts_with('#') {
+            // Comment line: include regardless of indentation. YAML
+            // comments between entries often have reduced indent (e.g.
+            // a top-level comment between indented entries).
             end = i + 1;
             continue;
         }
@@ -564,6 +566,22 @@ mod tests {
         let lines: Vec<&str> = yaml.lines().collect();
         // Should NOT include the blank line between array and next key.
         assert_eq!(find_block_entries_end(&lines, 1, "  "), 3);
+    }
+
+    #[test]
+    fn find_block_entries_end_comment_at_reduced_indent() {
+        // A comment with less indentation than the entries should NOT
+        // prematurely end the block (#1110).
+        let yaml = "items:\n  - one\n# reduced indent comment\n  - two\nnext: val\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        assert_eq!(find_block_entries_end(&lines, 1, "  "), 4);
+    }
+
+    #[test]
+    fn find_block_entries_end_comment_at_entry_indent() {
+        let yaml = "items:\n  - one\n  # same indent comment\n  - two\nnext: val\n";
+        let lines: Vec<&str> = yaml.lines().collect();
+        assert_eq!(find_block_entries_end(&lines, 1, "  "), 4);
     }
 
     // -----------------------------------------------------------------------

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -15,13 +15,36 @@ pub struct HeadingInfo {
     pub line_end: usize,
 }
 
-/// Iterate over lines that are NOT inside fenced code blocks.
+/// Iterate over lines that are NOT inside fenced code blocks or YAML
+/// frontmatter.
 /// Yields `(0-based line index, line content)` pairs, skipping lines
-/// within ```` ``` ```` or `~~~` fenced regions.
+/// within ```` ``` ```` or `~~~` fenced regions, and skipping YAML
+/// frontmatter (`---` delimited block at the very start of the file).
 pub fn non_fenced_lines(content: &str) -> impl Iterator<Item = (usize, &str)> {
     // Track the fence character and minimum length required to close.
     let mut fence: Option<(u8, usize)> = None;
+    // Detect YAML frontmatter: first line must be exactly `---` (with
+    // optional trailing whitespace). If present, skip until the closing
+    // `---` delimiter.
+    let mut in_frontmatter = false;
+    let mut is_first_line = true;
     content.lines().enumerate().filter(move |(_, line)| {
+        // YAML frontmatter handling: must start on the very first line.
+        if is_first_line {
+            is_first_line = false;
+            let trimmed = line.trim();
+            if trimmed == "---" {
+                in_frontmatter = true;
+                return false;
+            }
+        } else if in_frontmatter {
+            let trimmed = line.trim();
+            if trimmed == "---" || trimmed == "..." {
+                in_frontmatter = false;
+            }
+            return false;
+        }
+
         // CommonMark: fences can be indented 0-3 spaces.
         let trimmed = line.trim_start_matches(' ');
         let indent = line.len() - trimmed.len();

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1224,4 +1224,48 @@ body text
             "trailing spaces must be preserved: {result}"
         );
     }
+
+    // -----------------------------------------------------------------------
+    // YAML frontmatter (#1102)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn yaml_frontmatter_not_misinterpreted_as_setext_heading() {
+        // The closing `---` of YAML frontmatter was being interpreted as
+        // a setext underline, creating a phantom heading from the last
+        // frontmatter field (#1102).
+        let content = "---\ntitle: Hello\n---\n\n# Real Heading\n\nBody text.\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1, "only the ATX heading should be parsed");
+        assert_eq!(headings[0].text, "Real Heading");
+    }
+
+    #[test]
+    fn yaml_frontmatter_with_dots_closing_delimiter() {
+        // YAML spec allows `...` as an alternative closing delimiter.
+        let content = "---\ntitle: Hello\n...\n\n# Heading\n\nBody.\n";
+        let headings = parse_headings(content);
+        assert_eq!(headings.len(), 1);
+        assert_eq!(headings[0].text, "Heading");
+    }
+
+    #[test]
+    fn replace_section_with_frontmatter() {
+        // Section operations should work correctly even with frontmatter.
+        let content = "---\ntitle: Doc\n---\n\n# Section A\n\nOld body.\n\n# Section B\n\nKeep.\n";
+        let result = replace_section_in(content, "Section A", "New body.\n").unwrap();
+        assert!(
+            result.contains("# Section A\nNew body.\n"),
+            "section A should be replaced: {result}"
+        );
+        assert!(
+            result.contains("# Section B"),
+            "section B should be preserved: {result}"
+        );
+        // Frontmatter must remain intact
+        assert!(
+            result.starts_with("---\ntitle: Doc\n---"),
+            "frontmatter should be preserved: {result}"
+        );
+    }
 }

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -614,13 +614,7 @@ fn join_lines_with(lines: &[String], final_newline: bool, eol: &str) -> String {
 
 /// Detect dominant line ending in the original text.
 fn detect_eol(text: &str) -> &'static str {
-    let crlf = text.matches("\r\n").count();
-    let lf_only = text.matches('\n').count().saturating_sub(crlf);
-    if crlf > 0 && crlf >= lf_only {
-        "\r\n"
-    } else {
-        "\n"
-    }
+    crate::write::detect_eol(text)
 }
 
 fn find_match(haystack: &[&str], needle: &[&str], expected: isize, fuzz: usize) -> Option<usize> {

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -1111,7 +1111,12 @@ pub(crate) fn execute_and_collect(
                     "tx: operation {} succeeded (replace_matches: {count})",
                     i + 1
                 );
-                total_replace_matches += count;
+                // Only accumulate Replace matches; other operation types
+                // may return non-zero counts (e.g. AST symbol counts) that
+                // would mask a genuine Replace no-match condition (#1105).
+                if matches!(op, Operation::Replace { .. }) {
+                    total_replace_matches += count;
+                }
                 if replace_hint.is_none() {
                     replace_hint = tx.replace_hint.take();
                 }

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -277,6 +277,10 @@ pub(crate) fn commit_changes(
         }
     }
     for path in deletions {
+        // Skip files already backed up in the changes loop above (#1111).
+        if changes.iter().any(|(p, _, _)| p == path) {
+            continue;
+        }
         backup
             .save_before_delete(path)
             .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;

--- a/src/write.rs
+++ b/src/write.rs
@@ -5,6 +5,24 @@ use std::path::Path;
 use anyhow::Context;
 use tempfile::NamedTempFile;
 
+/// Detect the dominant line ending in `text`.
+///
+/// Returns `"\r\n"` when CRLF sequences are present and at least as common
+/// as bare LF; otherwise returns `"\n"`.
+///
+/// This is the canonical implementation used by all AST and ops modules
+/// to preserve the original file's line ending style during content
+/// reconstruction.
+pub fn detect_eol(text: &str) -> &'static str {
+    let crlf = text.matches("\r\n").count();
+    let lf_only = text.matches('\n').count().saturating_sub(crlf);
+    if crlf > 0 && crlf >= lf_only {
+        "\r\n"
+    } else {
+        "\n"
+    }
+}
+
 /// Line ending normalization mode.
 ///
 /// This type is re-exported at the crate root level of `write` for library use

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -8,6 +8,40 @@ fn test_global_flags() -> GlobalFlags {
     GlobalFlags::test_default()
 }
 
+mod detect_eol_tests {
+    use super::*;
+
+    #[test]
+    fn detect_eol_lf_only() {
+        assert_eq!(detect_eol("line1\nline2\nline3\n"), "\n");
+    }
+
+    #[test]
+    fn detect_eol_crlf_only() {
+        assert_eq!(detect_eol("line1\r\nline2\r\nline3\r\n"), "\r\n");
+    }
+
+    #[test]
+    fn detect_eol_mixed_crlf_dominant() {
+        assert_eq!(detect_eol("line1\r\nline2\nline3\r\n"), "\r\n");
+    }
+
+    #[test]
+    fn detect_eol_mixed_lf_dominant() {
+        assert_eq!(detect_eol("line1\nline2\r\nline3\n"), "\n");
+    }
+
+    #[test]
+    fn detect_eol_empty_string() {
+        assert_eq!(detect_eol(""), "\n");
+    }
+
+    #[test]
+    fn detect_eol_no_newlines() {
+        assert_eq!(detect_eol("no newlines here"), "\n");
+    }
+}
+
 mod basic {
     use super::*;
 

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -630,6 +630,63 @@ fn test_search_asymmetric_context() {
         .stdout(predicate::str::contains("bbb").not());
 }
 
+/// Adjacent matches with context should NOT have `--` separators (#1111).
+#[test]
+fn test_search_context_no_separator_for_adjacent_matches() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    // Lines 1-6; matches on lines 2 and 3 are adjacent.
+    fs::write(&file, "aaa\nmatch1\nmatch2\nbbb\nccc\nmatch3\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("-C")
+        .arg("1")
+        .arg("match")
+        .arg(&file)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Between match1 (line 2) and match2 (line 3): adjacent, no separator.
+    // Between match2 (line 3, after-ctx=line 4) and match3 (line 6, before-ctx=line 5):
+    // line 5 is one past line 4, so they are contiguous -- no separator either
+    // with -C 1.
+    let separator_count = stdout.matches("\n--\n").count();
+    assert_eq!(
+        separator_count, 0,
+        "adjacent/contiguous matches should not have separators: {stdout}"
+    );
+}
+
+/// Non-adjacent matches with context SHOULD have `--` separators.
+#[test]
+fn test_search_context_separator_for_distant_matches() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    // Matches on lines 1 and 7 with 5 lines gap.
+    fs::write(
+        &file,
+        "match_a\nfiller1\nfiller2\nfiller3\nfiller4\nfiller5\nmatch_b\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("-C")
+        .arg("1")
+        .arg("match_")
+        .arg(&file)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--"),
+        "distant matches should have a separator: {stdout}"
+    );
+}
+
 #[test]
 fn test_search_literal_flag() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2818,6 +2818,47 @@ fn test_tx_replace_no_match_does_not_hide_other_changes() {
     assert_eq!(config_value["version"], "1.0");
 }
 
+/// Non-Replace operations that return non-zero counts must not mask a
+/// Replace no-match condition.  Before #1105, `total_replace_matches`
+/// mixed counts from all operations, so a plan with a read-only
+/// operation (which returns a non-zero count) plus a failing Replace
+/// would exit 0 instead of 3.
+#[test]
+fn test_tx_non_replace_count_does_not_mask_replace_no_match() {
+    let dir = TempDir::new().unwrap();
+    let txt_file = dir.path().join("target.txt");
+    fs::write(&txt_file, "hello world\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [
+            {
+                "op": "search",
+                "path": txt_file.to_str().unwrap(),
+                "pattern": "hello"
+            },
+            {
+                "op": "replace",
+                "path": txt_file.to_str().unwrap(),
+                "from": "nonexistent_string_xyz",
+                "to": "replacement"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    // Should exit 3 (NO_MATCHES) because Replace found no matches,
+    // regardless of search returning a non-zero match count.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--check")
+        .assert()
+        .code(3);
+}
+
 #[test]
 fn test_tx_patch_apply_in_plan() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Systematic fix for 6 bugs found during code audit rounds. The root cause for 
the largest fix (#1099) was every AST content-reconstruction path using 
hardcoded `\n` instead of preserving the original line ending style.

## Changes

### Shared utility (src/write.rs)
- Added `detect_eol()` that counts CRLF vs bare LF and returns the dominant style
- Existing `detect_eol` in `src/ops/patch.rs` now delegates to this shared version

### CRLF preservation (#1099) - 8 AST modules fixed
All content-reconstruction paths in reorder, split, group, insert, wrap, 
extract, move_symbols, and imports now call `detect_eol()` on the source 
and use the detected EOL for all `.join()`, `.push_str()`, and format 
string operations.

### YAML frontmatter (#1102)
`non_fenced_lines()` in `src/ops/md.rs` now detects and skips YAML 
frontmatter (`---` delimited block at file start). Previously the closing 
`---` was misinterpreted as a setext heading underline.

### Replace count isolation (#1105)
`total_replace_matches` in `src/tx/execute.rs` now only accumulates counts 
from `Operation::Replace` variants. Previously, non-Replace operations 
(search, AST ops) inflated the counter, masking genuine Replace no-match 
exit codes.

### YAML comment handling (#1110)
`find_block_entries_end()` in `src/ops/doc/yaml_splice.rs` now includes 
comment lines regardless of indentation. Previously, comments with less 
indentation than the entry indent prematurely terminated the block.

### Multi-line decorators (#1103)
Added `find_multiline_decorator_start()` in `src/ast/symbols.rs` for 
Python, TypeScript, JavaScript, Java, and Kotlin. Uses parenthesis depth 
tracking (same pattern as existing `find_rust_multiline_attr_start()`).

### Multi-declarator const (#1104)
Changed TS/JS symbol extraction to match `variable_declarator` nodes 
directly instead of `lexical_declaration`. This follows the same pattern 
as Go grouped type declarations: tree-sitter recursion visits each 
declarator individually.

## Tests added (25 new tests)
- 11 CRLF preservation tests across all 8 AST modules
- 6 `detect_eol` unit tests (LF, CRLF, mixed, empty, no-newlines)
- 3 YAML frontmatter tests (ATX heading after frontmatter, `...` delimiter, section replace with frontmatter)
- 2 YAML comment indentation tests (reduced indent, same indent)
- 2 multi-line Python decorator tests (single, stacked)
- 1 multi-declarator const test + 1 let/var exclusion test
- 1 replace count isolation integration test

## Issues

Closes #1099
Closes #1102
Closes #1103
Closes #1104
Closes #1105
Closes #1110

### MCP tx engine routing (#1100)
`ast_rename` and `ast_replace` MCP handlers now route through the tx
engine via `run_ops`/`run_one_op` instead of writing files directly.
This provides backup/rollback safety and format/validate lifecycle.

### Extended CRLF coverage
Additional CRLF-to-LF sites found by systematic grep: yaml_splice.rs
(splice_array_lines, insert_text_at_line, serialize_block_entries) and
preserve.rs (hoist_comments). 3 new CRLF tests added.

Closes #1100