### PR TITLE
refactor: address reviewer findings from #1114

### DIFF
--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -402,7 +402,7 @@ mod tests {
     }
 
     #[test]
-    fn move_overlapping_spans_errors() {
+    fn move_adjacent_decorated_symbols_succeeds() {
         // Simulate two adjacent decorated functions where doc comments could
         // cause span overlap. In practice the spans from tree-sitter should
         // not overlap for well-formed code, but if full_symbol_span extends

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -1021,7 +1021,7 @@ pub fn check_no_overlapping_spans(spans: &[(usize, usize)], names: &[&str]) -> a
     let mut overlaps: Vec<String> = Vec::new();
     for window in indexed.windows(2) {
         let (s1, e1, i1) = window[0];
-        let (s2, _e2, i2) = window[1];
+        let (s2, e2, i2) = window[1];
         // Overlap: second span starts before first span ends
         if s2 < e1 {
             let n1 = names.get(i1).copied().unwrap_or("?");
@@ -1033,7 +1033,7 @@ pub fn check_no_overlapping_spans(spans: &[(usize, usize)], names: &[&str]) -> a
                 e1,
                 n2,
                 s2 + 1,
-                _e2
+                e2
             ));
         }
     }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -865,14 +865,6 @@ pub fn parse_plan_auto(
 // for_each expansion
 // ---------------------------------------------------------------------------
 
-/// Expand a plan's `for_each` block: match files via glob, apply exclude/filter,
-/// substitute template variables into each operation, and flatten the result into
-/// `plan.operations`. After this call, `plan.for_each` is `None`.
-///
-/// Doubled braces (`{{` / `}}`) are treated as escape sequences and produce
-/// literal `{` / `}` in the output. For example, `{{path}}` becomes the
-/// literal string `{path}` rather than being substituted with the file path.
-///
 /// Escape a string for safe embedding inside a JSON string literal.
 ///
 /// The template substitution operates on the serialized JSON, replacing
@@ -887,7 +879,15 @@ fn json_escape(s: &str) -> String {
     quoted[1..quoted.len() - 1].to_string()
 }
 
+/// Expand a plan's `for_each` block: match files via glob, apply exclude/filter,
+/// substitute template variables into each operation, and flatten the result into
+/// `plan.operations`. After this call, `plan.for_each` is `None`.
+///
 /// Template variables: `{path}`, `{dir}`, `{stem}`, `{ext}`, `{name}`.
+///
+/// Doubled braces (`{{` / `}}`) are treated as escape sequences and produce
+/// literal `{` / `}` in the output. For example, `{{path}}` becomes the
+/// literal string `{path}` rather than being substituted with the file path.
 #[cfg(feature = "cli")]
 pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result<()> {
     let fe = match plan.for_each.take() {
@@ -954,6 +954,14 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
     // 4. Serialize template operations once, then substitute per file.
     let template_ops_json = serde_json::to_string(&plan.operations)?;
 
+    // Protect escaped doubles `{{` / `}}` so they become literal braces
+    // in the output rather than being interpreted as template variables.
+    // Sentinel chars (\x00) are safe because they cannot appear in valid JSON.
+    // Hoisted outside the loop since template_ops_json is invariant.
+    let protected = template_ops_json
+        .replace("{{", "\x00LBRACE\x00")
+        .replace("}}", "\x00RBRACE\x00");
+
     let mut expanded = Vec::with_capacity(matched.len() * plan.operations.len());
     for file_path in &matched {
         let rel = file_path
@@ -978,13 +986,6 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
             .extension()
             .map(|e| e.to_string_lossy().into_owned())
             .unwrap_or_default();
-
-        // Protect escaped doubles `{{` / `}}` so they become literal braces
-        // in the output rather than being interpreted as template variables.
-        // Sentinel chars (\x00) are safe because they cannot appear in valid JSON.
-        let protected = template_ops_json
-            .replace("{{", "\x00LBRACE\x00")
-            .replace("}}", "\x00RBRACE\x00");
 
         // JSON-escape all substitution values so file paths containing
         // quotes, backslashes, or control characters don't produce invalid JSON.


### PR DESCRIPTION
## Summary

Follow-up polish from the reviewer pass on PR #1114 (for_each escape mechanism, AST span overlap detection).

### Changes

1. **Fix doc comment misattribution**: The `expand_for_each` documentation was syntactically attached to `json_escape` because both doc blocks were in one continuous `///` sequence. Moved the `expand_for_each` description down to its function, leaving only the escaping docs on `json_escape`.

2. **Hoist loop-invariant work**: The sentinel protection step (`template_ops_json.replace("{{"...)`) was inside the per-file loop but operates on the invariant `template_ops_json`. Hoisted outside the loop to avoid redundant work.

3. **Fix misleading underscore prefix**: `_e2` in `check_no_overlapping_spans` had an underscore prefix ("intentionally unused" convention) but was actually used in the format string. Renamed to `e2`.

4. **Fix misleading test name**: `move_overlapping_spans_errors` tested the success path (non-overlapping symbols), not the error path. Renamed to `move_adjacent_decorated_symbols_succeeds`.

Ref #1106
Ref #1109