### PR TITLE
fix: strict rollback restores collateral files from format steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2500%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2600%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-2500+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+2600+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -163,6 +163,16 @@ fn commit_and_finalize(
         print_diffs(&result.changes, ctx.cwd, global.should_color());
     }
 
+    // Snapshot non-tx files before lifecycle steps so we can restore
+    // collateral changes on strict rollback (#1111.7).
+    let collateral_snapshot = if ctx.strict && ctx.plan.has_lifecycle_steps() {
+        let tx_paths: std::collections::HashSet<PathBuf> =
+            result.changes.iter().map(|(p, _, _)| p.clone()).collect();
+        crate::tx::snapshot_non_tx_files(ctx.cwd, &tx_paths)
+    } else {
+        std::collections::HashMap::new()
+    };
+
     if let Some(err) = run_lifecycle(ctx.plan, ctx.base_cwd, ctx.cwd) {
         if ctx.strict {
             crate::tx::rollback_strict(
@@ -171,6 +181,7 @@ fn commit_and_finalize(
                 &result.deletions,
                 &result.existed_before,
             );
+            crate::tx::restore_collateral_files(&collateral_snapshot);
             let rollback_msg = format!("strict mode -- all changes reverted ({})", err.message);
             if ctx.structured {
                 emit_error_json_with_prefix(err.kind, "rollback", &rollback_msg, None, ctx.compact);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -47,6 +47,15 @@ pub struct Plan {
     pub for_each: Option<ForEach>,
 }
 
+impl Plan {
+    /// Returns `true` if the plan has any format or validate steps that could
+    /// modify files outside the transaction scope.
+    pub fn has_lifecycle_steps(&self) -> bool {
+        self.format.as_ref().is_some_and(|v| !v.is_empty())
+            || self.validate.as_ref().is_some_and(|v| !v.is_empty())
+    }
+}
+
 /// Glob-driven batch expansion: apply the same set of operations to every
 /// file matching a glob pattern, with template variable substitution.
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -1027,6 +1036,77 @@ mod tests {
         assert_eq!(json_escape("he said \"hi\"\n"), r#"he said \"hi\"\n"#);
         // Plain string (no escaping needed)
         assert_eq!(json_escape("hello"), "hello");
+    }
+
+    #[test]
+    fn has_lifecycle_steps_none() {
+        let plan = Plan {
+            version: SCHEMA_VERSION.to_string(),
+            operations: Vec::new(),
+            format: None,
+            validate: None,
+            verify: None,
+            cwd: None,
+            strict: None,
+            write_policy: None,
+            for_each: None,
+        };
+        assert!(!plan.has_lifecycle_steps());
+    }
+
+    #[test]
+    fn has_lifecycle_steps_empty_vecs() {
+        let plan = Plan {
+            version: SCHEMA_VERSION.to_string(),
+            operations: Vec::new(),
+            format: Some(Vec::new()),
+            validate: Some(Vec::new()),
+            verify: None,
+            cwd: None,
+            strict: None,
+            write_policy: None,
+            for_each: None,
+        };
+        assert!(!plan.has_lifecycle_steps());
+    }
+
+    #[test]
+    fn has_lifecycle_steps_with_format() {
+        let plan = Plan {
+            version: SCHEMA_VERSION.to_string(),
+            operations: Vec::new(),
+            format: Some(vec![FormatStep {
+                cmd: "cargo fmt".into(),
+                timeout: None,
+            }]),
+            validate: None,
+            verify: None,
+            cwd: None,
+            strict: None,
+            write_policy: None,
+            for_each: None,
+        };
+        assert!(plan.has_lifecycle_steps());
+    }
+
+    #[test]
+    fn has_lifecycle_steps_with_validate() {
+        let plan = Plan {
+            version: SCHEMA_VERSION.to_string(),
+            operations: Vec::new(),
+            format: None,
+            validate: Some(vec![ValidationStep {
+                cmd: "cargo clippy".into(),
+                timeout: None,
+                required: Some(true),
+            }]),
+            verify: None,
+            cwd: None,
+            strict: None,
+            write_policy: None,
+            for_each: None,
+        };
+        assert!(plan.has_lifecycle_steps());
     }
 
     #[test]

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -9,6 +9,8 @@ use crate::exec;
 use crate::plan::{self, Plan};
 use crate::write::{WritePolicy, atomic_create_new, atomic_write};
 use anyhow::Context;
+#[cfg(any(feature = "cli", feature = "files"))]
+use ignore::WalkBuilder;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -115,6 +117,105 @@ pub(crate) fn run_validate_steps(
         "validation",
         "validation_failed",
     )
+}
+
+/// Maximum file size (in bytes) to include in the collateral snapshot.
+/// Files above this threshold are extremely unlikely to be reformatted by
+/// standard formatters and snapshotting them wastes memory.
+const COLLATERAL_SNAPSHOT_MAX_SIZE: u64 = 1_048_576; // 1 MiB
+
+/// Snapshot the content of non-binary text files under `cwd` that are NOT
+/// already tracked by the transaction. This captures the pre-format state of
+/// files that a format step (e.g. `cargo fmt`) might modify as a side effect.
+///
+/// Only called when `strict` mode is active and the plan has format or
+/// validate steps, so the cost is opt-in.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub(crate) fn snapshot_non_tx_files(
+    cwd: &Path,
+    tx_paths: &HashSet<PathBuf>,
+) -> HashMap<PathBuf, String> {
+    let mut snapshot = HashMap::new();
+    crate::verbose!(
+        "tx: collateral snapshot: walking {} (tx_paths: {})",
+        cwd.display(),
+        tx_paths.len()
+    );
+    let walker = WalkBuilder::new(cwd).hidden(false).build();
+    for entry in walker.flatten() {
+        let path = entry.path().to_path_buf();
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        if tx_paths.contains(&path) {
+            crate::verbose!(
+                "tx: collateral snapshot: skipping tx file {}",
+                path.display()
+            );
+            continue;
+        }
+        // Skip files above the size threshold.
+        if let Ok(meta) = std::fs::metadata(&path)
+            && meta.len() > COLLATERAL_SNAPSHOT_MAX_SIZE
+        {
+            crate::verbose!(
+                "tx: collateral snapshot: skipping large file {} ({} bytes)",
+                path.display(),
+                meta.len()
+            );
+            continue;
+        }
+        // Read bytes and skip binary files.
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if crate::files::is_binary(&bytes) {
+            continue;
+        }
+        if let Ok(content) = String::from_utf8(bytes) {
+            crate::verbose!(
+                "tx: collateral snapshot: captured {} ({} bytes)",
+                path.display(),
+                content.len()
+            );
+            snapshot.insert(path, content);
+        }
+    }
+    crate::verbose!("tx: collateral snapshot: {} files captured", snapshot.len());
+    snapshot
+}
+
+/// Restore any files that were modified by format/validate steps but were
+/// not part of the transaction. Compares current content against the
+/// snapshot and writes back the original content for any files that changed.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub(crate) fn restore_collateral_files(snapshot: &HashMap<PathBuf, String>) {
+    let noop_policy = WritePolicy::default();
+    let mut restored = 0usize;
+    for (path, original) in snapshot {
+        let current = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if current != *original {
+            crate::verbose!(
+                "tx: collateral restore: reverting {} (changed by formatter)",
+                path.display()
+            );
+            if let Err(e) = atomic_write(path, original, &noop_policy) {
+                eprintln!(
+                    "tx: rollback: failed to restore collateral file {}: {e}",
+                    path.display()
+                );
+            } else {
+                restored += 1;
+            }
+        }
+    }
+    if restored > 0 {
+        crate::verbose!("tx: collateral restore: reverted {} file(s)", restored);
+    }
 }
 
 pub(crate) fn rollback_strict(
@@ -533,6 +634,16 @@ pub fn execute_plan_direct(
         return Ok(output);
     }
 
+    // Snapshot non-tx files before format/validate steps so we can restore
+    // collateral changes on strict rollback (#1111.7).
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let collateral_snapshot = if strict && plan.has_lifecycle_steps() {
+        let tx_paths: HashSet<PathBuf> = result.changes.iter().map(|(p, _, _)| p.clone()).collect();
+        snapshot_non_tx_files(&effective_cwd, &tx_paths)
+    } else {
+        HashMap::new()
+    };
+
     // Run format steps, then validation steps.
     if let Some(err) = run_lifecycle(&plan, cwd, &effective_cwd) {
         if strict {
@@ -542,6 +653,8 @@ pub fn execute_plan_direct(
                 &result.deletions,
                 &result.existed_before,
             );
+            #[cfg(any(feature = "cli", feature = "files"))]
+            restore_collateral_files(&collateral_snapshot);
             let msg = format!("strict mode -- all changes reverted ({})", err.message);
             return Ok(build_error_output(err.kind, "rollback", &msg, None));
         }
@@ -802,5 +915,112 @@ mod tests {
         };
         let cwd = Path::new("/tmp");
         assert!(run_lifecycle(&plan, cwd, cwd).is_none());
+    }
+
+    // ---- snapshot / restore collateral (#1111.7) ----
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn snapshot_non_tx_files_captures_text_skips_binary_and_tx() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // A text file not in the tx (should be captured).
+        let collateral = dir.path().join("other.rs");
+        std::fs::write(&collateral, "fn main() {}").unwrap();
+
+        // A binary file (should be skipped).
+        let binary = dir.path().join("image.png");
+        std::fs::write(&binary, b"\x89PNG\x00\x00").unwrap();
+
+        // A file that IS in the tx (should be skipped).
+        let tx_file = dir.path().join("changed.rs");
+        std::fs::write(&tx_file, "// changed").unwrap();
+
+        let mut tx_paths = HashSet::new();
+        tx_paths.insert(tx_file.clone());
+
+        let snapshot = snapshot_non_tx_files(dir.path(), &tx_paths);
+
+        assert!(
+            snapshot.contains_key(&collateral),
+            "collateral text file should be in snapshot"
+        );
+        assert_eq!(snapshot[&collateral], "fn main() {}");
+        assert!(
+            !snapshot.contains_key(&binary),
+            "binary file should not be in snapshot"
+        );
+        assert!(
+            !snapshot.contains_key(&tx_file),
+            "tx file should not be in snapshot"
+        );
+    }
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn restore_collateral_files_reverts_changed_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("bystander.rs");
+        std::fs::write(&file, "original content").unwrap();
+
+        // Build a snapshot with the original content.
+        let mut snapshot = HashMap::new();
+        snapshot.insert(file.clone(), "original content".to_string());
+
+        // Simulate a formatter modifying the file.
+        std::fs::write(&file, "reformatted content").unwrap();
+        assert_eq!(
+            std::fs::read_to_string(&file).unwrap(),
+            "reformatted content"
+        );
+
+        // Restore should revert the file.
+        restore_collateral_files(&snapshot);
+        assert_eq!(
+            std::fs::read_to_string(&file).unwrap(),
+            "original content",
+            "collateral file should be restored to pre-format content"
+        );
+    }
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn restore_collateral_skips_unchanged_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("untouched.rs");
+        std::fs::write(&file, "same content").unwrap();
+
+        let mut snapshot = HashMap::new();
+        snapshot.insert(file.clone(), "same content".to_string());
+
+        // File was not modified by the formatter. restore should be a no-op.
+        restore_collateral_files(&snapshot);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "same content");
+    }
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn snapshot_skips_large_files() {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        // Create a file just above the 1 MiB threshold.
+        let big_file = dir.path().join("huge.txt");
+        let big_content = "x".repeat(COLLATERAL_SNAPSHOT_MAX_SIZE as usize + 1);
+        std::fs::write(&big_file, &big_content).unwrap();
+
+        // Create a small file that should be captured.
+        let small_file = dir.path().join("small.txt");
+        std::fs::write(&small_file, "tiny").unwrap();
+
+        let snapshot = snapshot_non_tx_files(dir.path(), &HashSet::new());
+
+        assert!(
+            !snapshot.contains_key(&big_file),
+            "file above size cap should not be in snapshot"
+        );
+        assert!(
+            snapshot.contains_key(&small_file),
+            "small file should be in snapshot"
+        );
     }
 }

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -46,6 +46,8 @@ pub use lifecycle::{CommitError, RestoreFailGuard, execute_plan_direct};
 pub(crate) use lifecycle::{
     commit_changes, rollback_strict, run_lifecycle, validate_and_prepare_plan,
 };
+#[cfg(any(feature = "cli", feature = "files"))]
+pub(crate) use lifecycle::{restore_collateral_files, snapshot_non_tx_files};
 
 #[cfg(feature = "cli")]
 use clap::Args;

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -6777,3 +6777,118 @@ fn test_tx_for_each_mixed_escaped_and_template_vars() {
         "mixed escaped and template vars: {content}"
     );
 }
+
+// ---- #1111.7: strict rollback restores collateral files ----
+
+/// Regression (#1111.7): when a format step modifies files outside the
+/// transaction and a subsequent validate step fails, strict mode should
+/// restore not only the tx-tracked files but also the collateral files
+/// that the formatter touched.
+#[test]
+fn test_tx_strict_rollback_restores_collateral_files() {
+    let dir = TempDir::new().unwrap();
+
+    // File modified by the tx.
+    let tx_file = dir.path().join("target.txt");
+    fs::write(&tx_file, "original tx content\n").unwrap();
+
+    // Bystander file that the "formatter" will modify.
+    let bystander = dir.path().join("bystander.txt");
+    fs::write(&bystander, "original bystander content\n").unwrap();
+
+    // The format step modifies the bystander then succeeds.
+    // The validate step fails, triggering strict rollback.
+    // Use relative paths so the plan cwd (the tempdir) is the walk root.
+    let format_cmd = "printf 'reformatted bystander\\n' > bystander.txt";
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "strict": true,
+        "operations": [{
+            "op": "replace",
+            "path": "target.txt",
+            "from": "original tx content",
+            "to": "modified tx content"
+        }],
+        "format": [{
+            "cmd": format_cmd
+        }],
+        "validate": [{
+            "cmd": shell_exit_1(),
+            "required": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("tx")
+        .arg("plan.json")
+        .arg("--apply")
+        .assert()
+        .code(7); // ROLLBACK
+
+    // The tx file should be restored.
+    assert_eq!(
+        fs::read_to_string(&tx_file).unwrap(),
+        "original tx content\n",
+        "tx file should be restored on strict rollback"
+    );
+    // The bystander (collateral) file should also be restored.
+    assert_eq!(
+        fs::read_to_string(&bystander).unwrap(),
+        "original bystander content\n",
+        "collateral file modified by formatter should be restored on strict rollback"
+    );
+}
+
+/// Verify that when strict mode is off, collateral files are NOT restored
+/// (the formatter's changes are kept).
+#[test]
+fn test_tx_non_strict_keeps_collateral_files() {
+    let dir = TempDir::new().unwrap();
+
+    let tx_file = dir.path().join("target.txt");
+    fs::write(&tx_file, "original\n").unwrap();
+
+    let bystander = dir.path().join("bystander.txt");
+    fs::write(&bystander, "untouched\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "strict": false,
+        "operations": [{
+            "op": "replace",
+            "path": "target.txt",
+            "from": "original",
+            "to": "changed"
+        }],
+        "format": [{
+            "cmd": "printf 'formatted\\n' > bystander.txt"
+        }],
+        "validate": [{
+            "cmd": shell_exit_1(),
+            "required": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("tx")
+        .arg("plan.json")
+        .arg("--apply")
+        .assert()
+        .code(6); // VALIDATION_FAILED, not ROLLBACK
+
+    // In non-strict mode, the formatter's changes are kept.
+    assert_eq!(
+        fs::read_to_string(&bystander).unwrap(),
+        "formatted\n",
+        "in non-strict mode, formatter changes should persist"
+    );
+}


### PR DESCRIPTION
## Summary

Fix item 7 from #1111: `rollback_strict` now restores files modified by format steps that are not tracked by the transaction.

## Problem

Format steps (e.g. `cargo fmt`) can modify files outside the transaction scope. When strict mode triggers a rollback on format/validate failure, only tx-tracked files were restored. Collateral changes to bystander files persisted, violating the strict rollback contract.

## Solution

Before running lifecycle steps (format + validate), snapshot all non-tx text files in the working directory. On strict rollback, compare current content against the snapshot and restore any files that changed.

- `snapshot_non_tx_files()`: walks cwd via `ignore::WalkBuilder` (respects .gitignore), captures text files not in the tx changes map, skips binary files and files above 1 MiB
- `restore_collateral_files()`: reverts any snapshotted files whose content changed
- `Plan::has_lifecycle_steps()`: helper to check if snapshot is needed
- Both code paths patched: `execute_plan_direct` (library/MCP) and `commit_and_finalize` (CLI tx command)
- Verbose logging via `crate::verbose!()` for diagnostics (`--verbose` or `PATCHLOOM_LOG=1`)

The snapshot is only taken when `strict=true` AND the plan has format or validate steps, so there is zero cost for the common case.

## Tests

- 4 unit tests: snapshot captures text, skips binary/tx/large files; restore reverts/skips correctly
- 4 unit tests: `Plan::has_lifecycle_steps()` for None, empty, format, validate cases
- 2 integration tests: strict rollback restores collateral files; non-strict keeps them

## Items 1-6

Already fixed in PRs #1112 and #1113.

Closes #1111