### PR TITLE
fix: add verbose diagnostic coverage across all commands

### DIFF
--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -35,6 +35,7 @@ struct AppendOutput {
 }
 
 pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!("append: file={}", args.file);
     if args.content.is_some() && args.stdin {
         bail!("--content and --stdin cannot be combined");
     }

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -377,6 +377,7 @@ pub fn tokenize(line: &str) -> anyhow::Result<Vec<String>> {
 }
 
 pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!("batch: input={}", args.input);
     // Read input.
     let input = if args.input == "-" {
         std::io::read_to_string(std::io::stdin())?
@@ -395,6 +396,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         operations.push(parse_line(trimmed, i + 1)?);
     }
 
+    crate::verbose!("batch: parsed {} operations from input", operations.len());
     if operations.is_empty() {
         if global.json || global.jsonl {
             global.emit_json(&serde_json::json!({

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -40,6 +40,7 @@ struct CreateOutput {
 }
 
 pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!("create: file={}, force={}", args.file, args.force);
     if args.content.is_some() && args.stdin {
         bail!("--content and --stdin cannot be combined");
     }

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -25,6 +25,7 @@ struct DeleteOutput {
 }
 
 pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!("delete: file={}", args.file);
     let cwd = global.resolve_cwd()?;
     let path = cwd.join(&args.file);
 

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -171,6 +171,7 @@ fn execute_md_op(
 // ---------------------------------------------------------------------------
 
 pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!("md: action={:?}", std::mem::discriminant(&args.action));
     match args.action {
         MdAction::ReplaceSection {
             file,
@@ -178,6 +179,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             stdin,
             content,
         } => {
+            crate::verbose!("md: replace-section file={}, heading={:?}", file, heading);
             let replacement = read_content(stdin, &content)?;
             let op = Operation::MdReplaceSection {
                 path: file.clone(),
@@ -199,6 +201,11 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             stdin,
             content,
         } => {
+            crate::verbose!(
+                "md: insert-after-heading file={}, heading={:?}",
+                file,
+                heading
+            );
             let insertion = read_content(stdin, &content)?;
             let op = Operation::MdInsertAfterHeading {
                 path: file.clone(),
@@ -220,6 +227,11 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             stdin,
             content,
         } => {
+            crate::verbose!(
+                "md: insert-before-heading file={}, heading={:?}",
+                file,
+                heading
+            );
             let insertion = read_content(stdin, &content)?;
             let op = Operation::MdInsertBeforeHeading {
                 path: file.clone(),
@@ -240,6 +252,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             heading,
             bullet,
         } => {
+            crate::verbose!("md: upsert-bullet file={}, heading={:?}", file, heading);
             let op = Operation::MdUpsertBullet {
                 path: file.clone(),
                 heading: heading.clone(),
@@ -255,6 +268,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
 
         MdAction::DedupeHeadings { file } => {
+            crate::verbose!("md: dedupe-headings file={}", file);
             // Pre-read to compute removed headings for side-channel output,
             // then route the actual write through the engine.
             let cwd = global.resolve_cwd()?;
@@ -321,6 +335,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
 
         MdAction::LintAgents { file } => {
+            crate::verbose!("md: lint-agents file={}", file);
             let cwd = global.resolve_cwd()?;
             let path = cwd.join(&file);
             let content =
@@ -353,6 +368,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
 
         MdAction::TableAppend { file, heading, row } => {
+            crate::verbose!("md: table-append file={}, heading={:?}", file, heading);
             // Pre-validate: distinguish "heading not found" (NO_MATCHES)
             // from "no table under heading" (error), which the engine
             // conflates into a single None.
@@ -405,6 +421,12 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             before,
             after,
         } => {
+            crate::verbose!(
+                "md: move-section file={}, heading={:?}, to={:?}",
+                file,
+                heading,
+                to
+            );
             // Validate exactly one of --before or --after.
             if before.is_none() && after.is_none() {
                 anyhow::bail!("exactly one of --before or --after must be provided");

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -165,6 +165,12 @@ fn emit_patch_files_output(
 }
 
 pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!(
+        "patch: action={:?}, apply={}, check={}",
+        std::mem::discriminant(&args.action),
+        global.apply,
+        global.check
+    );
     let (file, stdin_flag, merge_mode, apply_options) = match &args.action {
         PatchAction::Check { file, stdin } => {
             (file.clone(), *stdin, false, ApplyHunksOptions::default())
@@ -213,6 +219,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     };
 
+    crate::verbose!("patch: diff text length={}", diff_text.len());
     let patch_files = match parse_patch(&diff_text) {
         Ok(pf) => pf,
         Err(msg) => {
@@ -221,6 +228,11 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     };
 
+    crate::verbose!(
+        "patch: parsed {} file(s), merge_mode={}",
+        patch_files.len(),
+        merge_mode
+    );
     let cwd = global.resolve_cwd()?;
 
     if matches!(args.action, PatchAction::Check { .. }) {

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -39,6 +39,12 @@ struct RenameOutput {
 }
 
 pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!(
+        "rename: from={}, to={}, force={}",
+        args.from,
+        args.to,
+        args.force
+    );
     let cwd = global.resolve_cwd()?;
     let src = cwd.join(&args.from);
     let dst = cwd.join(&args.to);

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -119,7 +119,14 @@ pub(crate) fn collect_status(
 }
 
 pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!("status: checking {} path(s)", args.paths.len());
     let out = collect_status(&args.paths, global)?;
+    crate::verbose!(
+        "status: {} modified, {} created, {} deleted",
+        out.modified.len(),
+        out.created.len(),
+        out.deleted.len()
+    );
 
     if !global.emit_json(&out)? && !global.quiet {
         for f in &out.modified {

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -171,8 +171,10 @@ fn render_issues(issues: &[TidyIssue], global: &GlobalFlags) {
 }
 
 pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!("tidy: action={:?}", std::mem::discriminant(&args.action));
     match args.action {
         TidyAction::Check { paths } => {
+            crate::verbose!("tidy: checking {} path(s)", paths.len());
             let issues = collect_issues(&paths, global)?;
             if !global.quiet || global.json || global.jsonl {
                 render_issues(&issues, global);
@@ -189,6 +191,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             indent,
             lines,
         } => {
+            crate::verbose!("tidy: fixing {} path(s)", paths.len());
             if dedent.is_some() && indent.is_some() {
                 anyhow::bail!("--dedent and --indent cannot both be set");
             }
@@ -241,6 +244,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 },
             );
 
+            crate::verbose!("tidy: {} file(s) need fixing", dirty_rel_paths.len());
             if dirty_rel_paths.is_empty() {
                 // No changes: emit structured output (matching old behavior)
                 // and exit.

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -148,6 +148,12 @@ fn commit_and_finalize(
     global: &GlobalFlags,
     show_diffs: bool,
 ) -> anyhow::Result<u8> {
+    crate::verbose!(
+        "tx: committing {} changes, {} deletions, strict={}",
+        result.changes.len(),
+        result.deletions.len(),
+        ctx.strict
+    );
     if let Err(err) = crate::tx::commit_changes(
         &result.changes,
         &result.deletions,
@@ -221,6 +227,12 @@ fn commit_and_finalize(
 pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let structured = global.json || global.jsonl;
     let compact = global.jsonl;
+    crate::verbose!(
+        "tx: plan={}, apply={}, check={}",
+        args.plan,
+        global.apply,
+        global.check
+    );
 
     // 1. Read plan from file or stdin.
     let plan_path = if args.plan == "-" {
@@ -238,6 +250,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             anyhow::anyhow!("failed to read plan file '{}': {e}", plan_path.display())
         })?
     };
+
+    crate::verbose!("tx: plan text length={}", plan_text.len());
 
     // 2. Parse plan (JSON, YAML, or TOML).
     let plan_path_hint = if args.plan == "-" {
@@ -272,6 +286,12 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
         return Ok(exit::PARSE_ERROR);
     }
+
+    crate::verbose!(
+        "tx: parsed plan with {} operations, strict={:?}",
+        plan.operations.len(),
+        plan.strict
+    );
 
     // 3. Validate plan and resolve working directory.
     let (cwd, strict, _resolved_global) =
@@ -346,6 +366,8 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     } else {
         Vec::new()
     };
+
+    crate::verbose!("tx: cwd={}, strict={}", cwd.display(), strict);
 
     // 4. Execute all operations, collecting changes in memory (no writes).
     let mut result =

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -40,6 +40,12 @@ struct UndoPreviewOutput {
 }
 
 pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!(
+        "undo: list={}, session={:?}, apply={}",
+        args.list,
+        args.session,
+        args.apply
+    );
     let cwd = global.resolve_cwd()?;
 
     if args.list {
@@ -137,7 +143,9 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // Apply restore.
+    crate::verbose!("undo: restoring session {}", timestamp);
     let restored = backup::restore_session(&cwd, &timestamp)?;
+    crate::verbose!("undo: restored {} file(s)", restored);
     if global.show_status() {
         eprintln!("restored {restored} file(s) from session {timestamp}");
     }

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -140,6 +140,7 @@ pub fn execute_precomputed(
     changes: Vec<PrecomputedChange>,
     options: ExecuteOptions<'_>,
 ) -> ExecutionResult {
+    crate::verbose!("engine: execute_precomputed changes={}", changes.len());
     use crate::write::{apply_policy, policy_from_flags};
     use std::collections::{HashMap, HashSet};
 
@@ -160,6 +161,10 @@ pub fn execute_precomputed(
     }
 
     let no_effective_changes = result_changes.is_empty();
+    crate::verbose!(
+        "engine: precomputed effective_changes={}",
+        result_changes.len()
+    );
     let exec_result = super::output::TxExecResult {
         changes: result_changes,
         deletions: HashSet::new(),
@@ -185,6 +190,11 @@ fn execute_plan_inner(
     operations: Vec<Operation>,
     options: ExecuteOptions<'_>,
 ) -> anyhow::Result<ExecutionResult> {
+    crate::verbose!(
+        "engine: execute_plan_inner ops={}, guard={}",
+        operations.len(),
+        options.guard.is_some()
+    );
     // Validate TidyFix-specific constraints (dedent + indent mutual exclusion).
     for op in &operations {
         if let Operation::TidyFix { dedent, indent, .. } = op

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -51,6 +51,14 @@ fn run_lifecycle_steps(
 ) -> Result<(), LifecycleError> {
     let lifecycle_cwd = describe_lifecycle_cwd(base_cwd, cwd);
     for (index, (cmd, timeout, required)) in steps.enumerate() {
+        crate::verbose!(
+            "tx: running {} step {}: {:?} (timeout={}s, required={})",
+            label,
+            index + 1,
+            cmd,
+            timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS),
+            required
+        );
         let timeout_secs = timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
         let result = exec::run_with_timeout(&cmd, timeout_secs, cwd);
         match result {

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -10,6 +10,20 @@ use std::path::Path;
 
 /// Execute a replace operation within a transaction.
 pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
+    crate::verbose!(
+        "replace_op: target={}, from_len={}, mode={}",
+        op.declared_paths().first().unwrap_or(&"<glob>"),
+        if let Operation::Replace { from, .. } = op {
+            from.len()
+        } else {
+            0
+        },
+        if let Operation::Replace { mode, .. } = op {
+            mode.as_deref().unwrap_or("literal")
+        } else {
+            "unknown"
+        }
+    );
     let Operation::Replace {
         glob,
         path,

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -9,6 +9,27 @@ use std::path::PathBuf;
 /// If `path` is a directory, walks it (respecting `.gitignore`) and searches
 /// each non-binary file, mirroring the standalone `search` command behavior.
 pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
+    crate::verbose!(
+        "search_op: path={}, pattern_len={}, regex={}, case_insensitive={}",
+        if let Operation::Search { path, .. } = op {
+            path.as_str()
+        } else {
+            "<unknown>"
+        },
+        if let Operation::Search { pattern, .. } = op {
+            pattern.len()
+        } else {
+            0
+        },
+        matches!(op, Operation::Search { regex: true, .. }),
+        matches!(
+            op,
+            Operation::Search {
+                case_insensitive: true,
+                ..
+            }
+        ),
+    );
     let Operation::Search {
         path,
         pattern,

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -836,6 +836,213 @@ fn test_no_verbose_by_default() {
 }
 
 // ---------------------------------------------------------------------------
+// Verbose coverage: verify --verbose emits diagnostic traces for key commands.
+// Each test checks that the command-specific verbose prefix appears on stderr,
+// ensuring the verbose! calls added in #1117 are reachable.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_verbose_replace_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "aaa\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("replace")
+        .arg("aaa")
+        .arg("--to")
+        .arg("bbb")
+        .arg("f.txt")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] replace:"));
+}
+
+#[test]
+fn test_verbose_tx_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "old\n").unwrap();
+
+    let plan =
+        "version: '1'\noperations:\n  - op: replace\n    path: f.txt\n    from: old\n    to: new\n";
+    fs::write(dir.path().join("plan.yaml"), plan).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("tx")
+        .arg(dir.path().join("plan.yaml"))
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stderr(
+            predicate::str::contains("[patchloom] tx:")
+                .and(predicate::str::contains("[patchloom] tx: executing plan")),
+        );
+}
+
+#[test]
+fn test_verbose_create_emits_trace() {
+    let dir = TempDir::new().unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("create")
+        .arg(dir.path().join("new.txt"))
+        .arg("--content")
+        .arg("hello")
+        .arg("--apply")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] create:"));
+}
+
+#[test]
+fn test_verbose_delete_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "x\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("delete")
+        .arg(dir.path().join("f.txt"))
+        .arg("--apply")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] delete:"));
+}
+
+#[test]
+fn test_verbose_tidy_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "no newline").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("tidy")
+        .arg("check")
+        .arg(dir.path().join("f.txt"))
+        .assert()
+        .stderr(predicate::str::contains("[patchloom] tidy:"));
+}
+
+#[test]
+fn test_verbose_batch_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "aaa\n").unwrap();
+
+    let batch_input = "replace f.txt aaa bbb\n";
+    fs::write(dir.path().join("ops.batch"), batch_input).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("batch")
+        .arg(dir.path().join("ops.batch"))
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] batch:"));
+}
+
+#[test]
+fn test_verbose_md_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("doc.md"),
+        "# Title\n\nHello\n\n## Section\n\nBody\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("md")
+        .arg("replace-section")
+        .arg(dir.path().join("doc.md"))
+        .arg("--heading")
+        .arg("Section")
+        .arg("--content")
+        .arg("New body\n")
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] md:"));
+}
+
+#[test]
+fn test_verbose_patch_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "line1\nline2\nline3\n").unwrap();
+
+    let diff_text = "--- a/f.txt\n+++ b/f.txt\n@@ -1,3 +1,3 @@\n line1\n-line2\n+LINE2\n line3\n";
+    fs::write(dir.path().join("fix.patch"), diff_text).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("patch")
+        .arg("apply")
+        .arg(dir.path().join("fix.patch"))
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] patch:"));
+}
+
+#[test]
+fn test_verbose_status_emits_trace() {
+    // status requires a git repo
+    let dir = TempDir::new().unwrap();
+
+    // init a git repo
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.email", "test@test.com"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["config", "user.name", "Test"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    fs::write(dir.path().join("f.txt"), "initial\n").unwrap();
+    std::process::Command::new("git")
+        .args(["add", "."])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("status")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] status:"));
+}
+
+// ---------------------------------------------------------------------------
 // schema command
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Add `crate::verbose!()` traces to all CLI commands and tx engine internals so users can diagnose issues with `--verbose` or `PATCHLOOM_LOG=1`.

## Commands covered

| Layer | Files |
|-------|-------|
| CLI commands | append, batch, create, delete, md (8 actions), patch, rename, status, tidy, tx, undo |
| TX engine | execute_plan_inner, execute_precomputed, execute_and_collect loop, lifecycle steps |
| TX operations | execute_replace_op, execute_search_op |

## Tests

10 new integration tests verify verbose output for: replace, tx, create, delete, tidy, batch, md, patch, status (plus 3 existing tests for search, env-var, and default-off).

Closes #1117