### PR TITLE
test: MPI improvements - verbose tests, assertion hygiene, expect fixes, tree-sitter update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
 dependencies = [
  "cc",
  "regex",

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -57,8 +57,8 @@ fn doc_write(
     use crate::write::WritePolicy;
 
     // Extract the mutation from the operation.
-    let (_, mutation) =
-        crate::plan::op_to_doc_mutation(&op).expect("doc_write called with non-doc operation");
+    let (_, mutation) = crate::plan::op_to_doc_mutation(&op)
+        .ok_or_else(|| anyhow::anyhow!("doc_write called with non-doc operation"))?;
 
     let path_str = path.to_string_lossy().into_owned();
     let format = ops::doc::detect_format(&path_str)?;

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -428,8 +428,7 @@ mod tests {
             position: GroupPosition::FirstSymbol,
         };
         let result = group_symbols(source, &spec, Language::Rust);
-        assert!(result.is_ok());
-        let r = result.unwrap();
+        let r = result.expect("group_symbols should succeed");
         assert_eq!(r.symbols_moved, 2);
         assert!(r.content.contains("mod m {"));
     }

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -420,8 +420,7 @@ mod tests {
             Language::Rust,
         );
         // These two should NOT overlap (they have a blank line separator)
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().symbols_moved, 2);
+        assert_eq!(result.expect("move should succeed").symbols_moved, 2);
     }
 
     #[test]

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -385,8 +385,7 @@ mod tests {
             true,
             Language::Rust,
         );
-        assert!(result.is_ok());
-        let r = result.unwrap();
+        let r = result.expect("split should succeed");
         assert_eq!(r.symbols_distributed, 2);
         assert!(r.targets[0].1.contains("/// Doc A"));
         assert!(r.targets[1].1.contains("/// Doc B"));

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -1224,7 +1224,7 @@ mod tests {
         // Non-overlapping spans should pass
         let spans = vec![(0, 3), (4, 7), (8, 10)];
         let names = vec!["a", "b", "c"];
-        assert!(check_no_overlapping_spans(&spans, &names).is_ok());
+        check_no_overlapping_spans(&spans, &names).unwrap();
     }
 
     #[test]
@@ -1232,7 +1232,7 @@ mod tests {
         // Adjacent (touching but not overlapping) spans should pass
         let spans = vec![(0, 3), (3, 6), (6, 9)];
         let names = vec!["a", "b", "c"];
-        assert!(check_no_overlapping_spans(&spans, &names).is_ok());
+        check_no_overlapping_spans(&spans, &names).unwrap();
     }
 
     #[test]
@@ -1267,12 +1267,12 @@ mod tests {
         // Single span should always pass
         let spans = vec![(0, 5)];
         let names = vec!["only"];
-        assert!(check_no_overlapping_spans(&spans, &names).is_ok());
+        check_no_overlapping_spans(&spans, &names).unwrap();
     }
 
     #[test]
     fn check_no_overlapping_spans_empty_ok() {
-        assert!(check_no_overlapping_spans(&[], &[]).is_ok());
+        check_no_overlapping_spans(&[], &[]).unwrap();
     }
 
     #[test]

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -789,4 +789,23 @@ mod security {
         }
         assert!(cursor.is_object());
     }
+
+    #[test]
+    fn execute_with_mode_rejects_write_action() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "t.json", r#"{"a":1}"#);
+        let action = DocAction::Delete {
+            file: path,
+            selector: "a".into(),
+        };
+        let result = execute_with_mode(&action, OutputMode::Text);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("write operations require"),
+            "should reject write actions routed through execute_with_mode"
+        );
+    }
 }

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -302,8 +302,8 @@ fn op_needs_doc_flush(op: &Operation) -> bool {
 }
 
 pub(crate) fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<()> {
-    let (path, mutation) =
-        crate::plan::op_to_doc_mutation(op).expect("execute_doc_op called with non-doc operation");
+    let (path, mutation) = crate::plan::op_to_doc_mutation(op)
+        .ok_or_else(|| anyhow::anyhow!("execute_doc_op called with non-doc operation"))?;
     let root = get_doc_root(tx.pending, tx.existed_before, tx.doc_cache, path, tx.cwd)
         .map_err(path_err(path))?;
 

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -1185,6 +1185,60 @@ fn test_verbose_doc_flatten_emits_trace() {
 }
 
 #[test]
+fn test_verbose_doc_len_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("d.json"), r#"{"items": [1, 2, 3]}"#).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("doc")
+        .arg("len")
+        .arg("d.json")
+        .arg("items")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] doc: len"));
+}
+
+#[test]
+fn test_verbose_doc_diff_emits_trace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.json"), r#"{"x": 1}"#).unwrap();
+    fs::write(dir.path().join("b.json"), r#"{"x": 2}"#).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("doc")
+        .arg("diff")
+        .arg("a.json")
+        .arg("b.json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .stderr(predicate::str::contains("[patchloom] doc: diff"));
+}
+
+#[test]
+fn test_verbose_init_emits_trace() {
+    let dir = TempDir::new().unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--verbose")
+        .arg("init")
+        .arg("--yes")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("[patchloom] init:"));
+}
+
+#[test]
 fn test_verbose_explain_emits_trace() {
     let dir = TempDir::new().unwrap();
     let plan = "version: '1'\noperations:\n  - op: create_file\n    path: f.txt\n    content: hi\n";


### PR DESCRIPTION
## Summary

Multi-perspective improvement rotation findings and fixes.

## Changes

**QA Engineer + Developer (iterations 1-2):**
- Add integration tests for verbose output: `doc len`, `doc diff`, `init`
- Add unit test for `execute_with_mode` rejecting write actions
- Replace `expect()` with proper `anyhow` error in `api/doc.rs` (`doc_write`)

**Maintainer (iteration 4):**
- Update tree-sitter 0.26.9 to 0.26.10 (patch release)

**Test Auditor (cycle 2):**
- Strengthen 7 bare `assert!(x.is_ok())` assertions to `unwrap()`/`expect()` in ast/split.rs, ast/group.rs, ast/move_symbols.rs, ast/symbols.rs
- Replace `expect()` with proper `anyhow` error in `tx/execute.rs` (`execute_doc_op`)

**All other perspectives:** reviewed, no actionable findings.

## Verification

- `make check-fast` passes (all tests green)
- All clippy warnings resolved
- Formatting clean