### PR TITLE
refactor: reduce parameter count via InsertContext and TxStateFixture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,7 +365,7 @@ grep -ri "tool_name" --include="*.md" --include="*.rs" --include="*.json" .
 - `make check` is the full gate. Nothing merges unless it passes.
 - All commits require a `Signed-off-by` line (DCO). Use `git commit -s`.
 - Keep `main.rs` thin. No business logic in `main.rs` or `lib.rs`.
-- Prefer returning exit codes over panicking. Never use `unwrap()` in non-test code.
+- Prefer returning exit codes over panicking. Never use `unwrap()` or `expect()` in non-test code; use `?` with `anyhow::Context` or `.ok_or_else(|| anyhow!("msg"))?` instead. Exception: `expect()` is acceptable on infallible internal invariants (e.g. `Mutex::lock`, compile-time-constant `Regex::new`) where failure indicates a logic bug, not a runtime condition.
 - `unsafe_code = "deny"` is enforced via `[lints.rust]` in Cargo.toml. No unsafe Rust.
 - Use `anyhow::Context` to add context to errors rather than custom `.map_err()` chains.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ See the "Adding a new MCP tool" section in [AGENTS.md](./AGENTS.md).
 
 - Run `cargo fmt` before every commit.
 - `cargo clippy --all-targets --all-features -- -D warnings` must produce zero warnings.
-- Never use `unwrap()` in non-test code; use `anyhow::Context` for error context.
+- Never use `unwrap()` or `expect()` in non-test code; use `?` with `anyhow::Context` or `.ok_or_else(|| anyhow!("msg"))?`. Exception: `expect()` is acceptable on infallible internal invariants (e.g. `Mutex::lock`).
 - `unsafe_code = "deny"` is enforced in `Cargo.toml`.
 - All commits require a `Signed-off-by` line ([DCO](https://developercertificate.org/)). Use `git commit -s`.
 

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -12,6 +12,17 @@ pub struct InsertResult {
     pub inserted_at_line: usize,
 }
 
+/// Shared context for insert operations, grouping the common parameters
+/// derived from the source file.
+struct InsertContext<'a> {
+    source: &'a str,
+    content: &'a str,
+    symbols: &'a [SymbolDef],
+    lines: &'a [&'a str],
+    lang: Language,
+    eol: &'a str,
+}
+
 /// Position within a container (module, impl, etc.) to insert code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InsertPosition {
@@ -44,57 +55,43 @@ pub fn insert_code(
     let symbols = extract_symbols(source, lang);
     let lines: Vec<&str> = source.lines().collect();
 
+    let ctx = InsertContext {
+        source,
+        content,
+        symbols: &symbols,
+        lines: &lines,
+        lang,
+        eol,
+    };
+
     if let Some(container_name) = inside {
-        insert_inside(
-            source,
-            content,
-            container_name,
-            position,
-            &symbols,
-            &lines,
-            eol,
-        )
+        insert_inside(&ctx, container_name, position)
     } else if let Some(after_name) = after {
-        insert_adjacent(
-            source, content, after_name, true, &symbols, &lines, lang, eol,
-        )
+        insert_adjacent(&ctx, after_name, true)
     } else {
         let before_name = before.unwrap();
-        insert_adjacent(
-            source,
-            content,
-            before_name,
-            false,
-            &symbols,
-            &lines,
-            lang,
-            eol,
-        )
+        insert_adjacent(&ctx, before_name, false)
     }
 }
 
 /// Insert content inside a named container (mod, impl, struct, etc.).
 fn insert_inside(
-    source: &str,
-    content: &str,
+    ctx: &InsertContext<'_>,
     container_name: &str,
     position: InsertPosition,
-    symbols: &[SymbolDef],
-    lines: &[&str],
-    eol: &str,
 ) -> anyhow::Result<InsertResult> {
-    let sym = find_symbol(symbols, container_name)
+    let sym = find_symbol(ctx.symbols, container_name)
         .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", container_name))?;
 
     let start_idx = sym.start_line.saturating_sub(1);
-    let end_idx = sym.end_line.min(lines.len());
+    let end_idx = sym.end_line.min(ctx.lines.len());
 
     // Single-line container (e.g. `mod foo {}`): the opening `{` and closing
     // `}` are on the same line.  Both Start and End behave the same: split
     // the line at the braces and insert content between them.
     let close_line_idx = end_idx.saturating_sub(1);
     if close_line_idx <= start_idx {
-        let container_line = lines[start_idx];
+        let container_line = ctx.lines[start_idx];
         if let Some(open) = container_line.find('{')
             && let Some(close_rel) = container_line[open + 1..].rfind('}')
         {
@@ -105,27 +102,27 @@ fn insert_inside(
             // Use container line indent + 4 spaces for the body.
             let line_indent = container_line.len() - container_line.trim_start().len();
             let body_indent = format!("{}{}", &container_line[..line_indent], "    ");
-            let adjusted = indent_content(content, &body_indent, eol);
+            let adjusted = indent_content(ctx.content, &body_indent, ctx.eol);
 
             let mut result = String::new();
-            for line in &lines[..start_idx] {
+            for line in &ctx.lines[..start_idx] {
                 result.push_str(line);
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
             result.push_str(before_brace);
-            result.push_str(eol);
+            result.push_str(ctx.eol);
             result.push_str(&adjusted);
             if !adjusted.ends_with('\n') {
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
             result.push_str(after_brace);
-            result.push_str(eol);
-            for line in &lines[start_idx + 1..] {
+            result.push_str(ctx.eol);
+            for line in &ctx.lines[start_idx + 1..] {
                 result.push_str(line);
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
-            if !source.ends_with('\n') && result.ends_with('\n') {
-                result.truncate(result.len() - eol.len());
+            if !ctx.source.ends_with('\n') && result.ends_with('\n') {
+                result.truncate(result.len() - ctx.eol.len());
             }
             return Ok(InsertResult {
                 content: result,
@@ -135,8 +132,8 @@ fn insert_inside(
     }
 
     // Detect the indentation level inside the container.
-    let container_indent = detect_indent(lines, start_idx, end_idx);
-    let adjusted = indent_content(content, &container_indent, eol);
+    let container_indent = detect_indent(ctx.lines, start_idx, end_idx);
+    let adjusted = indent_content(ctx.content, &container_indent, ctx.eol);
 
     let mut result = String::new();
 
@@ -145,30 +142,30 @@ fn insert_inside(
             // Insert before the closing brace of the container.
             // The closing brace is typically on end_line (1-based), i.e. end_idx - 1 (0-based).
 
-            for line in &lines[..close_line_idx] {
+            for line in &ctx.lines[..close_line_idx] {
                 result.push_str(line);
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
 
             // Add a blank line before if the previous content doesn't end with one
-            if close_line_idx > 0 && !lines[close_line_idx - 1].trim().is_empty() {
-                result.push_str(eol);
+            if close_line_idx > 0 && !ctx.lines[close_line_idx - 1].trim().is_empty() {
+                result.push_str(ctx.eol);
             }
             result.push_str(&adjusted);
             if !adjusted.ends_with('\n') {
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
 
-            for line in &lines[close_line_idx..] {
+            for line in &ctx.lines[close_line_idx..] {
                 result.push_str(line);
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
 
             let inserted_at = close_line_idx + 1; // 1-based
 
             // Preserve trailing newline behavior
-            if !source.ends_with('\n') && result.ends_with('\n') {
-                result.truncate(result.len() - eol.len());
+            if !ctx.source.ends_with('\n') && result.ends_with('\n') {
+                result.truncate(result.len() - ctx.eol.len());
             }
 
             Ok(InsertResult {
@@ -179,33 +176,34 @@ fn insert_inside(
         InsertPosition::Start => {
             // Insert after the opening brace/line of the container.
             // We look for the first line after start_line that ends with '{' or ':'
-            let insert_after_idx = find_opening_line(lines, start_idx, end_idx);
+            let insert_after_idx = find_opening_line(ctx.lines, start_idx, end_idx);
 
-            for line in &lines[..=insert_after_idx] {
+            for line in &ctx.lines[..=insert_after_idx] {
                 result.push_str(line);
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
 
             result.push_str(&adjusted);
             if !adjusted.ends_with('\n') {
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
 
             // Add blank line if next line is not blank
-            if insert_after_idx + 1 < lines.len() && !lines[insert_after_idx + 1].trim().is_empty()
+            if insert_after_idx + 1 < ctx.lines.len()
+                && !ctx.lines[insert_after_idx + 1].trim().is_empty()
             {
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
 
-            for line in &lines[insert_after_idx + 1..] {
+            for line in &ctx.lines[insert_after_idx + 1..] {
                 result.push_str(line);
-                result.push_str(eol);
+                result.push_str(ctx.eol);
             }
 
             let inserted_at = insert_after_idx + 2; // 1-based
 
-            if !source.ends_with('\n') && result.ends_with('\n') {
-                result.truncate(result.len() - eol.len());
+            if !ctx.source.ends_with('\n') && result.ends_with('\n') {
+                result.truncate(result.len() - ctx.eol.len());
             }
 
             Ok(InsertResult {
@@ -217,72 +215,66 @@ fn insert_inside(
 }
 
 /// Insert content after or before a named symbol.
-#[allow(clippy::too_many_arguments)]
 fn insert_adjacent(
-    source: &str,
-    content: &str,
+    ctx: &InsertContext<'_>,
     symbol_name: &str,
     after: bool,
-    symbols: &[SymbolDef],
-    lines: &[&str],
-    lang: Language,
-    eol: &str,
 ) -> anyhow::Result<InsertResult> {
-    let sym = find_symbol(symbols, symbol_name)
+    let sym = find_symbol(ctx.symbols, symbol_name)
         .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", symbol_name))?;
 
     // Use the symbol's indentation level for the new content
     let sym_start_idx = sym.start_line.saturating_sub(1);
-    let indent = if sym_start_idx < lines.len() {
-        let line = lines[sym_start_idx];
+    let indent = if sym_start_idx < ctx.lines.len() {
+        let line = ctx.lines[sym_start_idx];
         let trimmed = line.trim_start();
         &line[..line.len() - trimmed.len()]
     } else {
         ""
     };
-    let adjusted = indent_content(content, indent, eol);
+    let adjusted = indent_content(ctx.content, indent, ctx.eol);
 
     let mut result = String::new();
     let inserted_at;
 
     if after {
-        let end_idx = sym.end_line.min(lines.len());
-        for line in &lines[..end_idx] {
+        let end_idx = sym.end_line.min(ctx.lines.len());
+        for line in &ctx.lines[..end_idx] {
             result.push_str(line);
-            result.push_str(eol);
+            result.push_str(ctx.eol);
         }
-        result.push_str(eol);
+        result.push_str(ctx.eol);
         result.push_str(&adjusted);
         if !adjusted.ends_with('\n') {
-            result.push_str(eol);
+            result.push_str(ctx.eol);
         }
         inserted_at = end_idx + 1; // 1-based
-        for line in &lines[end_idx..] {
+        for line in &ctx.lines[end_idx..] {
             result.push_str(line);
-            result.push_str(eol);
+            result.push_str(ctx.eol);
         }
     } else {
-        // Before — use full_symbol_span to include attributes and doc comments.
-        let (full_start, _) = full_symbol_span(source, sym, lang);
+        // Before: use full_symbol_span to include attributes and doc comments.
+        let (full_start, _) = full_symbol_span(ctx.source, sym, ctx.lang);
         let start_idx = full_start.saturating_sub(1);
-        for line in &lines[..start_idx] {
+        for line in &ctx.lines[..start_idx] {
             result.push_str(line);
-            result.push_str(eol);
+            result.push_str(ctx.eol);
         }
         result.push_str(&adjusted);
         if !adjusted.ends_with('\n') {
-            result.push_str(eol);
+            result.push_str(ctx.eol);
         }
-        result.push_str(eol);
+        result.push_str(ctx.eol);
         inserted_at = start_idx + 1; // 1-based
-        for line in &lines[start_idx..] {
+        for line in &ctx.lines[start_idx..] {
             result.push_str(line);
-            result.push_str(eol);
+            result.push_str(ctx.eol);
         }
     }
 
-    if !source.ends_with('\n') && result.ends_with('\n') {
-        result.truncate(result.len() - eol.len());
+    if !ctx.source.ends_with('\n') && result.ends_with('\n') {
+        result.truncate(result.len() - ctx.eol.len());
     }
 
     Ok(InsertResult {

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -246,6 +246,53 @@ pub(crate) struct TxState<'a> {
     pub(crate) structured: bool,
 }
 
+/// Test fixture that owns all the storage behind a `TxState`, avoiding
+/// the need to declare 8+ `let mut` bindings in every test.
+#[cfg(test)]
+pub(crate) struct TxStateFixture {
+    pub pending: HashMap<PathBuf, (String, String)>,
+    pub deletions: HashSet<PathBuf>,
+    pub existed_before: HashSet<PathBuf>,
+    pub doc_cache: HashMap<PathBuf, CachedDoc>,
+    pub reads: Vec<TxReadResult>,
+    pub searches: Vec<TxSearchResult>,
+    pub lints: Vec<TxLintResult>,
+    pub write_targets: HashSet<PathBuf>,
+}
+
+#[cfg(test)]
+impl TxStateFixture {
+    pub fn new() -> Self {
+        Self {
+            pending: HashMap::new(),
+            deletions: HashSet::new(),
+            existed_before: HashSet::new(),
+            doc_cache: HashMap::new(),
+            reads: Vec::new(),
+            searches: Vec::new(),
+            lints: Vec::new(),
+            write_targets: HashSet::new(),
+        }
+    }
+
+    pub fn state<'a>(&'a mut self, cwd: &'a Path) -> TxState<'a> {
+        TxState {
+            pending: &mut self.pending,
+            deletions: &mut self.deletions,
+            existed_before: &mut self.existed_before,
+            doc_cache: &mut self.doc_cache,
+            tx_reads: &mut self.reads,
+            tx_searches: &mut self.searches,
+            tx_lints: &mut self.lints,
+            write_targets: &mut self.write_targets,
+            replace_hint: None,
+            cwd,
+            quiet: true,
+            structured: false,
+        }
+    }
+}
+
 // execute_replace_op extracted to tx/replace_op.rs (#906).
 pub(crate) use super::replace_op::execute_replace_op;
 

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -39,6 +39,8 @@ pub(crate) use validate::validate_operation;
 pub(crate) use execute::execute_and_collect;
 // Test-only re-exports for src/cmd/tx.rs tests
 #[cfg(test)]
+pub(crate) use execute::TxStateFixture;
+#[cfg(test)]
 pub(crate) use execute::{path_err, read_and_probe, read_file_content, update_file_content};
 
 // lifecycle.rs

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -238,39 +238,8 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
 mod tests {
     use super::*;
     use crate::plan::Operation;
-    use crate::tx::execute::{CachedDoc, TxState};
-    use crate::tx::output::{TxLintResult, TxReadResult, TxSearchResult};
-    use std::collections::{HashMap, HashSet};
-    use std::path::PathBuf;
+    use crate::tx::TxStateFixture;
     use tempfile::TempDir;
-
-    #[allow(clippy::too_many_arguments)]
-    fn make_tx_state<'a>(
-        pending: &'a mut HashMap<PathBuf, (String, String)>,
-        deletions: &'a mut HashSet<PathBuf>,
-        existed_before: &'a mut HashSet<PathBuf>,
-        doc_cache: &'a mut HashMap<PathBuf, CachedDoc>,
-        reads: &'a mut Vec<TxReadResult>,
-        searches: &'a mut Vec<TxSearchResult>,
-        lints: &'a mut Vec<TxLintResult>,
-        write_targets: &'a mut HashSet<PathBuf>,
-        cwd: &'a Path,
-    ) -> TxState<'a> {
-        TxState {
-            pending,
-            deletions,
-            existed_before,
-            doc_cache,
-            tx_reads: reads,
-            tx_searches: searches,
-            tx_lints: lints,
-            write_targets,
-            replace_hint: None,
-            cwd,
-            quiet: true,
-            structured: false,
-        }
-    }
 
     #[test]
     fn replace_literal_match() {
@@ -297,30 +266,12 @@ mod tests {
             if_exists: false,
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
         assert_eq!(count, 1);
-        assert_eq!(pending[&file].1, "goodbye world");
+        assert_eq!(f.pending[&file].1, "goodbye world");
     }
 
     #[test]
@@ -348,27 +299,8 @@ mod tests {
             if_exists: false,
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let count = execute_replace_op(&op, &mut tx).unwrap();
         assert_eq!(count, 0);
     }
@@ -398,30 +330,12 @@ mod tests {
             if_exists: false,
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
         assert_eq!(count, 1);
-        assert_eq!(pending[&file].1, "fooNUMbar");
+        assert_eq!(f.pending[&file].1, "fooNUMbar");
     }
 
     #[test]
@@ -449,30 +363,12 @@ mod tests {
             if_exists: false,
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
         assert_eq!(count, 1);
-        assert_eq!(pending[&file].1, "hi World");
+        assert_eq!(f.pending[&file].1, "hi World");
     }
 
     #[test]
@@ -498,27 +394,8 @@ mod tests {
             if_exists: false,
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let result = execute_replace_op(&op, &mut tx);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("'path' or 'glob'"));
@@ -550,31 +427,13 @@ mod tests {
             if_exists: false,
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
         assert_eq!(count, 2); // a.txt and b.txt matched
         // c.rs should not be modified
-        assert!(!pending.contains_key(&dir.path().join("c.rs")));
+        assert!(!f.pending.contains_key(&dir.path().join("c.rs")));
     }
 
     #[test]
@@ -604,30 +463,12 @@ mod tests {
             if_exists: false,
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
         assert_eq!(count, 1);
-        let result = &pending[&file].1;
+        let result = &f.pending[&file].1;
         assert!(
             result.contains("fn process(input: Vec<u8>)"),
             "original function signature must be preserved, got: {result}"
@@ -665,26 +506,8 @@ mod tests {
             if_exists: false,
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let err = execute_replace_op(&op, &mut tx).unwrap_err();
         assert!(
             err.to_string().contains("range requires whole_line"),

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -242,39 +242,8 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tx::execute::{CachedDoc, TxState};
-    use crate::tx::output::{TxLintResult, TxReadResult, TxSearchResult};
-    use std::collections::{HashMap, HashSet};
-    use std::path::Path;
+    use crate::tx::TxStateFixture;
     use tempfile::TempDir;
-
-    #[allow(clippy::too_many_arguments)]
-    fn make_tx_state<'a>(
-        pending: &'a mut HashMap<PathBuf, (String, String)>,
-        deletions: &'a mut HashSet<PathBuf>,
-        existed_before: &'a mut HashSet<PathBuf>,
-        doc_cache: &'a mut HashMap<PathBuf, CachedDoc>,
-        reads: &'a mut Vec<TxReadResult>,
-        searches: &'a mut Vec<TxSearchResult>,
-        lints: &'a mut Vec<TxLintResult>,
-        write_targets: &'a mut HashSet<PathBuf>,
-        cwd: &'a Path,
-    ) -> TxState<'a> {
-        TxState {
-            pending,
-            deletions,
-            existed_before,
-            doc_cache,
-            tx_reads: reads,
-            tx_searches: searches,
-            tx_lints: lints,
-            write_targets,
-            replace_hint: None,
-            cwd,
-            quiet: true,
-            structured: false,
-        }
-    }
 
     fn search_op(path: &str, pattern: &str) -> Operation {
         Operation::Search {
@@ -304,31 +273,13 @@ mod tests {
 
         let op = search_op("test.txt", "two");
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
-        assert_eq!(searches.len(), 1);
-        assert_eq!(searches[0].match_count, 1);
-        assert_eq!(searches[0].matches[0].line, 2);
+        drop(tx);
+        assert_eq!(f.searches.len(), 1);
+        assert_eq!(f.searches[0].match_count, 1);
+        assert_eq!(f.searches[0].matches[0].line, 2);
     }
 
     #[test]
@@ -339,29 +290,11 @@ mod tests {
 
         let op = search_op("test.txt", "nonexistent");
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
-        assert_eq!(searches[0].match_count, 0);
+        drop(tx);
+        assert_eq!(f.searches[0].match_count, 0);
     }
 
     #[test]
@@ -388,29 +321,11 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
-        assert_eq!(searches[0].match_count, 2);
+        drop(tx);
+        assert_eq!(f.searches[0].match_count, 2);
     }
 
     #[test]
@@ -437,29 +352,11 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
-        assert_eq!(searches[0].match_count, 1);
+        drop(tx);
+        assert_eq!(f.searches[0].match_count, 1);
     }
 
     #[test]
@@ -486,29 +383,11 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
-        assert_eq!(searches[0].match_count, 2); // "keep" and "keep too"
+        drop(tx);
+        assert_eq!(f.searches[0].match_count, 2); // "keep" and "keep too"
     }
 
     #[test]
@@ -535,27 +414,8 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let result = execute_search_op(&op, &mut tx);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("assert_count"));
@@ -584,27 +444,8 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         let result = execute_search_op(&op, &mut tx);
         assert!(result.is_err());
     }
@@ -633,29 +474,11 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
-        let m = &searches[0].matches[0];
+        drop(tx);
+        let m = &f.searches[0].matches[0];
         assert_eq!(m.line, 3);
         assert_eq!(m.context_before, vec!["bbb"]);
         assert_eq!(m.context_after, vec!["ddd"]);
@@ -685,32 +508,14 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
+        drop(tx);
         // match_count reports the true total (5 matches), not the truncated count
-        assert_eq!(searches[0].match_count, 5);
+        assert_eq!(f.searches[0].match_count, 5);
         // matches vec is truncated to max_results
-        assert_eq!(searches[0].matches.len(), 2);
+        assert_eq!(f.searches[0].matches.len(), 2);
     }
 
     #[test]
@@ -738,32 +543,14 @@ mod tests {
             custom_ignore_filenames: Vec::new(),
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
+        drop(tx);
         // match_count reports the true total, not the truncated count
-        assert_eq!(searches[0].match_count, 3);
+        assert_eq!(f.searches[0].match_count, 3);
         // matches is truncated to max_results
-        assert_eq!(searches[0].matches.len(), 1);
+        assert_eq!(f.searches[0].matches.len(), 1);
     }
 
     #[test]
@@ -791,30 +578,12 @@ mod tests {
             custom_ignore_filenames: vec![],
         };
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
-
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         // Should not panic even when match is near end of file
         execute_search_op(&op, &mut tx).unwrap();
-        assert_eq!(searches[0].match_count, 1);
+        drop(tx);
+        assert_eq!(f.searches[0].match_count, 1);
     }
 
     #[test]
@@ -827,28 +596,12 @@ mod tests {
 
         // Pattern "foo.bar" should match both lines (dot is regex wildcard)
         let op = search_op("test.txt", "foo.bar");
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
+        drop(tx);
         assert_eq!(
-            searches[0].match_count, 2,
+            f.searches[0].match_count, 2,
             "regex dot should match any char, yielding 2 matches"
         );
     }
@@ -878,28 +631,12 @@ mod tests {
             exclude_patterns: Vec::new(),
             custom_ignore_filenames: Vec::new(),
         };
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-        let mut tx = make_tx_state(
-            &mut pending,
-            &mut deletions,
-            &mut existed,
-            &mut doc_cache,
-            &mut reads,
-            &mut searches,
-            &mut lints,
-            &mut write_targets,
-            dir.path(),
-        );
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
         execute_search_op(&op, &mut tx).unwrap();
-        assert_eq!(searches[0].match_count, 1);
-        let ctx_after = &searches[0].matches[0].context_after;
+        drop(tx);
+        assert_eq!(f.searches[0].match_count, 1);
+        let ctx_after = &f.searches[0].matches[0].context_after;
         assert_eq!(
             ctx_after,
             &["eee"],


### PR DESCRIPTION
## Summary

Eliminate all `#[allow(clippy::too_many_arguments)]` suppressions from the codebase by introducing two focused abstractions:

1. **`InsertContext`** (src/ast/insert.rs): Groups the 6 shared parameters (`source`, `content`, `symbols`, `lines`, `lang`, `eol`) derived from the source file into a struct. Both `insert_inside` (7 -> 3 params) and `insert_adjacent` (8 -> 3 params) now take `&InsertContext<'_>` instead of individual arguments.

2. **`TxStateFixture`** (src/tx/execute.rs): Owns all storage behind a `TxState`, replacing the duplicate `make_tx_state` helper functions in `replace_op.rs` and `search_op.rs` test modules. Eliminates ~400 lines of boilerplate across 21 call sites.

Also updates AGENTS.md and CONTRIBUTING.md with the `expect()` convention clarification from the previous MPI session (PR #1121).

**Net result:** -399 lines, zero `too_many_arguments` suppressions remaining.

Closes #1122