### PR TITLE
refactor: MPI improvements - TxStateFixture migration, unwrap removal, clippy cleanup

### DIFF
--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -140,7 +140,10 @@ pub fn doc_get(path: &Path, selector: &str) -> anyhow::Result<serde_json::Value>
 
     match query_get(&value, selector)? {
         QueryResult::NoMatch => bail!("selector '{}' matched nothing", selector),
-        QueryResult::Values(vals) if vals.len() == 1 => Ok(vals.into_iter().next().unwrap()),
+        QueryResult::Values(vals) if vals.len() == 1 => Ok(vals
+            .into_iter()
+            .next()
+            .expect("len()==1 guarantees element")),
         QueryResult::Values(vals) => Ok(serde_json::Value::Array(vals)),
     }
 }

--- a/src/api/plan.rs
+++ b/src/api/plan.rs
@@ -36,7 +36,6 @@ pub fn parse_plan(input: &str) -> anyhow::Result<crate::plan::Plan> {
 /// Available with the `files` feature (for pure library use without the
 /// CLI) or the `cli` feature.
 #[cfg(any(feature = "cli", feature = "files"))]
-#[allow(clippy::result_large_err)]
 pub fn execute_plan(
     plan: crate::plan::Plan,
     cwd: &Path,

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -69,7 +69,7 @@ pub fn insert_code(
     } else if let Some(after_name) = after {
         insert_adjacent(&ctx, after_name, true)
     } else {
-        let before_name = before.unwrap();
+        let before_name = before.expect("mode_count==1 guarantees Some");
         insert_adjacent(&ctx, before_name, false)
     }
 }

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -38,7 +38,10 @@ pub fn wrap_code(
     let (start_idx, end_idx) = if let Some(symbol_names) = symbols_arg {
         find_symbol_range(source, symbol_names, lang)?
     } else {
-        parse_line_range_to_indices(lines_arg.unwrap(), source_lines.len())?
+        parse_line_range_to_indices(
+            lines_arg.expect("mode_count==1 guarantees Some"),
+            source_lines.len(),
+        )?
     };
 
     // Extract the code to wrap

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -368,11 +368,11 @@ impl GlobalFlags {
 
     /// Test helper with cwd set (simulates --cwd for cmd unit tests).
     /// Builds on with_cwd and forces color=Never for test determinism.
-    #[allow(clippy::field_reassign_with_default)]
     pub fn test_with_cwd(dir: &std::path::Path) -> Self {
-        let mut g = Self::with_cwd(dir);
-        g.color = ColorMode::Never;
-        g
+        GlobalFlags {
+            color: ColorMode::Never,
+            ..Self::with_cwd(dir)
+        }
     }
 
     /// Test helper with apply=true (for write cmd tests that want mutation).

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -649,7 +649,7 @@ pub(crate) fn strip_inline_code(line: &str) -> Cow<'_, str> {
         } else {
             // Advance by one UTF-8 character, not one byte.
             // `bytes[i] as char` corrupts multi-byte UTF-8 (e.g. é → Ã©).
-            let ch = line[i..].chars().next().unwrap();
+            let ch = line[i..].chars().next().expect("i < len guarantees char");
             result.push(ch);
             i += ch.len_utf8();
         }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -544,10 +544,10 @@ pub fn operations_for_tier(tier: Tier) -> Vec<OperationSchema> {
 /// (nullable, produced by schemars for `Option<T>` fields).
 fn extract_type_str(schema: &serde_json::Value) -> String {
     match schema.get("type") {
-        Some(t) if t.is_string() => t.as_str().unwrap().to_string(),
+        Some(t) if t.is_string() => t.as_str().expect("is_string guard").to_string(),
         Some(t) if t.is_array() => t
             .as_array()
-            .unwrap()
+            .expect("is_array guard")
             .iter()
             .filter_map(|v| v.as_str())
             .collect::<Vec<_>>()

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -1648,33 +1648,12 @@ mod tests {
         let file = dir.path().join("victim.txt");
         std::fs::write(&file, "original").unwrap();
 
-        let mut pending = HashMap::new();
-        let mut existed_before = HashSet::new();
-        let mut deletions = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut tx_reads = Vec::new();
-        let mut tx_searches = Vec::new();
-        let mut tx_lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
+        let mut f = TxStateFixture::new();
         // Simulate: file was loaded and then deleted in this tx.
-        let _ = read_file_content(&mut pending, &mut existed_before, &file).unwrap();
-        deletions.insert(file.clone());
+        let _ = read_file_content(&mut f.pending, &mut f.existed_before, &file).unwrap();
+        f.deletions.insert(file.clone());
 
-        let mut tx = TxState {
-            cwd: dir.path(),
-            pending: &mut pending,
-            existed_before: &mut existed_before,
-            deletions: &mut deletions,
-            doc_cache: &mut doc_cache,
-            tx_reads: &mut tx_reads,
-            tx_searches: &mut tx_searches,
-            tx_lints: &mut tx_lints,
-            write_targets: &mut write_targets,
-            replace_hint: None,
-            quiet: false,
-            structured: false,
-        };
+        let mut tx = f.state(dir.path());
 
         let op = Operation::FileAppend {
             path: "victim.txt".into(),
@@ -1699,32 +1678,11 @@ mod tests {
         let file = dir.path().join("victim.txt");
         std::fs::write(&file, "original").unwrap();
 
-        let mut pending = HashMap::new();
-        let mut existed_before = HashSet::new();
-        let mut deletions = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut tx_reads = Vec::new();
-        let mut tx_searches = Vec::new();
-        let mut tx_lints = Vec::new();
-        let mut write_targets = HashSet::new();
+        let mut f = TxStateFixture::new();
+        let _ = read_file_content(&mut f.pending, &mut f.existed_before, &file).unwrap();
+        f.deletions.insert(file.clone());
 
-        let _ = read_file_content(&mut pending, &mut existed_before, &file).unwrap();
-        deletions.insert(file.clone());
-
-        let mut tx = TxState {
-            cwd: dir.path(),
-            pending: &mut pending,
-            existed_before: &mut existed_before,
-            deletions: &mut deletions,
-            doc_cache: &mut doc_cache,
-            tx_reads: &mut tx_reads,
-            tx_searches: &mut tx_searches,
-            tx_lints: &mut tx_lints,
-            write_targets: &mut write_targets,
-            replace_hint: None,
-            quiet: false,
-            structured: false,
-        };
+        let mut tx = f.state(dir.path());
 
         let op = Operation::FilePrepend {
             path: "victim.txt".into(),
@@ -1746,29 +1704,8 @@ mod tests {
         let file = dir.path().join("doc.md");
         std::fs::write(&file, "# A\ntext a\n# B\ntext b\n").unwrap();
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
-        let mut tx = TxState {
-            pending: &mut pending,
-            deletions: &mut deletions,
-            existed_before: &mut existed,
-            doc_cache: &mut doc_cache,
-            tx_reads: &mut reads,
-            tx_searches: &mut searches,
-            tx_lints: &mut lints,
-            write_targets: &mut write_targets,
-            replace_hint: None,
-            cwd: dir.path(),
-            quiet: false,
-            structured: false,
-        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
 
         let op = Operation::MdMoveSection {
             path: "doc.md".into(),
@@ -1778,8 +1715,9 @@ mod tests {
             after: Some("# B".into()),
         };
         execute_operation(&op, &mut tx).unwrap();
+        drop(tx);
         // Section A should appear after B, not be duplicated
-        let content = &pending[&file].1;
+        let content = &f.pending[&file].1;
         let a_pos = content.find("# A").unwrap();
         let b_pos = content.find("# B").unwrap();
         assert!(a_pos > b_pos, "section A should be after B: {content}");
@@ -1799,34 +1737,14 @@ mod tests {
         let file = dir.path().join("victim.txt");
         std::fs::write(&file, "content").unwrap();
 
-        let mut pending = HashMap::new();
-        let mut deletions = HashSet::new();
-        let mut existed = HashSet::new();
-        let mut doc_cache = HashMap::new();
-        let mut reads = Vec::new();
-        let mut searches = Vec::new();
-        let mut lints = Vec::new();
-        let mut write_targets = HashSet::new();
-
+        let mut f = TxStateFixture::new();
         // Simulate deletion
-        pending.insert(file.clone(), ("content".to_string(), String::new()));
-        deletions.insert(file);
-        existed.insert(dir.path().join("victim.txt"));
+        f.pending
+            .insert(file.clone(), ("content".to_string(), String::new()));
+        f.deletions.insert(file);
+        f.existed_before.insert(dir.path().join("victim.txt"));
 
-        let mut tx = TxState {
-            pending: &mut pending,
-            deletions: &mut deletions,
-            existed_before: &mut existed,
-            doc_cache: &mut doc_cache,
-            tx_reads: &mut reads,
-            tx_searches: &mut searches,
-            tx_lints: &mut lints,
-            write_targets: &mut write_targets,
-            replace_hint: None,
-            cwd: dir.path(),
-            quiet: false,
-            structured: false,
-        };
+        let mut tx = f.state(dir.path());
 
         let op = Operation::FileRename {
             from: "victim.txt".into(),

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -493,7 +493,6 @@ pub(crate) fn validate_and_prepare_plan(
     Ok((effective_cwd, strict, global))
 }
 
-#[allow(clippy::result_large_err)]
 pub fn execute_plan_direct(
     plan: Plan,
     cwd: &Path,


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle covering 14 perspectives. Three commits:

1. **TxStateFixture migration** (QA perspective): migrated 4 test functions in `tx/execute.rs` from manual TxState construction to TxStateFixture, removed 2 unnecessary `#[allow(clippy::result_large_err)]` suppressions (-84 lines net)

2. **Production unwrap() removal** (Developer perspective): replaced 6 remaining production `unwrap()` calls with `expect()` containing invariant messages across `api/doc.rs`, `ast/insert.rs`, `ast/wrap.rs`, `ops/md.rs`, `schema.rs`

3. **Clippy suppression cleanup** (post-cycle gate): removed `#[allow(clippy::field_reassign_with_default)]` in `cli/global.rs` by using struct update syntax

After these changes, only 2 justified lint suppressions remain in the entire codebase:
- `result_large_err` on `validate_and_prepare_plan` (TxOutput is genuinely large)
- `unsafe_code` on POSIX `killpg` FFI call (process group cleanup)

All 1,790 unit tests, 823 integration tests, and 10 PTY tests pass. `make check-fast` clean.