### PR TITLE
test: fix weak assertion in navigate_mut_error test

### DIFF
--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -513,8 +513,8 @@ mod tests {
             "error should mention the actual type 'string', got: {msg}"
         );
         assert!(
-            msg.contains("a"),
-            "error should mention the key 'a', got: {msg}"
+            msg.contains("'b'"),
+            "error should mention the failing key 'b', got: {msg}"
         );
     }
 }


### PR DESCRIPTION
## Summary

MPI Cycle 2 finding from the Test Auditor perspective.

**The bug:** `navigate_mut_error_on_non_object_intermediate` asserted
`msg.contains("a")` to verify the error mentions the key name.
This was a false-positive assertion: it passed because the letter "a"
appears in the word "at" in `"expected object at key '\''b'\'', found string"`,
not because the key name was present.

The error actually reports key `'\''b'\''` (the segment being navigated into
the non-object), not `'\''a'\''`. The original assertion would have passed
for ANY error message containing the letter "a".

**The fix:** Changed to `msg.contains("'\''b'\''")` which correctly verifies
the error references the failing key name in quotes.

All 1,790 unit tests, 823 integration tests, 10 PTY tests pass.