### PR TITLE
fix: strengthen weak assertion and replace panic with Result

### DIFF
--- a/src/ast/imports.rs
+++ b/src/ast/imports.rs
@@ -729,7 +729,7 @@ mod tests {
         let imports = list_imports(source, Language::Go);
         assert_eq!(imports.len(), 1, "Go import block should be one entry");
         assert!(imports[0].text.contains("fmt"));
-        assert!(imports[0].text.contains("os"));
+        assert!(imports[0].text.contains("\"os\""));
     }
 
     #[test]

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -121,7 +121,7 @@ impl PatchloomService {
         // its input schema from the corresponding Operation variant and uses
         // the generic `handle_simple_op` dispatcher.
         for meta in MCP_TOOL_REGISTRY {
-            let mut schema = crate::schema::operation_variant_schema(meta.op_name);
+            let mut schema = crate::schema::operation_variant_schema(meta.op_name)?;
             if meta.has_strict {
                 schema = inject_strict_into_schema(schema);
             }

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -232,7 +232,7 @@ mod basic {
         }
 
         fn op_schema_keys(op_name: &str) -> std::collections::BTreeSet<String> {
-            let schema = operation_variant_schema(op_name);
+            let schema = operation_variant_schema(op_name).unwrap();
             schema
                 .get("properties")
                 .and_then(|p| p.as_object())

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -48,8 +48,8 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
 
     let ops = match tier {
-        Some(t) => schema::operations_for_tier(t),
-        None => schema::operation_schemas(),
+        Some(t) => schema::operations_for_tier(t)?,
+        None => schema::operation_schemas()?,
     };
 
     match args.format {
@@ -85,8 +85,8 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
         SchemaFormat::Prompt => {
             let prompt = match tier {
-                Some(t) => schema::system_prompt_for_tier(t),
-                None => schema::system_prompt_for_tier(Tier::Strong),
+                Some(t) => schema::system_prompt_for_tier(t)?,
+                None => schema::system_prompt_for_tier(Tier::Strong)?,
             };
             if global.quiet {
                 return Ok(exit::SUCCESS);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -14,14 +14,15 @@
 //! assert!(schema::is_compatible_version("1"));
 //!
 //! // Get operations for medium-tier models
-//! let ops = schema::operations_for_tier(Tier::Medium);
+//! let ops = schema::operations_for_tier(Tier::Medium).unwrap();
 //! assert!(!ops.is_empty());
 //!
 //! // Generate a system prompt fragment
-//! let prompt = schema::system_prompt_for_tier(Tier::Medium);
+//! let prompt = schema::system_prompt_for_tier(Tier::Medium).unwrap();
 //! assert!(prompt.contains("replace"));
 //! ```
 
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 /// Cached full JSON Schema for `plan::Operation` (tagged enum).
@@ -41,14 +42,14 @@ static OPERATION_FULL_SCHEMA: std::sync::LazyLock<serde_json::Value> =
 /// rename value (e.g., `"doc.set"`). This function finds the matching variant,
 /// clones it, strips the `op` discriminator property (not needed for standalone
 /// schema consumers), and removes top-level `$schema`/`title` for compactness.
-pub fn operation_variant_schema(op_name: &str) -> serde_json::Value {
+pub fn operation_variant_schema(op_name: &str) -> anyhow::Result<serde_json::Value> {
     let schema = &*OPERATION_FULL_SCHEMA;
 
     // Navigate: schema.oneOf[i].properties.op.const == op_name
     let one_of = schema
         .get("oneOf")
         .and_then(|v| v.as_array())
-        .unwrap_or_else(|| panic!("Operation schema missing oneOf array"));
+        .context("Operation schema missing oneOf array")?;
 
     for variant in one_of {
         let op_const = variant
@@ -69,11 +70,11 @@ pub fn operation_variant_schema(op_name: &str) -> serde_json::Value {
                 obj.remove("$schema");
                 obj.remove("title");
             }
-            return v;
+            return Ok(v);
         }
     }
 
-    panic!("Operation variant \'{op_name}\' not found in oneOf schema");
+    anyhow::bail!("Operation variant '{op_name}' not found in oneOf schema");
 }
 
 /// The current intent format version. Consumers check this at startup to
@@ -489,27 +490,29 @@ const AST_OPERATION_REGISTRY: &[OpMeta] = &[
 ];
 
 /// Return the complete registry of all patchloom operations with schemas.
-pub fn operation_schemas() -> Vec<OperationSchema> {
+pub fn operation_schemas() -> anyhow::Result<Vec<OperationSchema>> {
     #[allow(unused_mut)]
     let mut all: Vec<&OpMeta> = OPERATION_REGISTRY.iter().collect();
     #[cfg(feature = "ast")]
     all.extend(AST_OPERATION_REGISTRY.iter());
 
     all.into_iter()
-        .map(|meta| OperationSchema {
-            name: meta.name.into(),
-            description: meta.description.into(),
-            parameters: operation_variant_schema(meta.name),
-            min_tier: meta.tier,
-            examples: meta
-                .examples
-                .iter()
-                .map(|(desc, json)| OperationExample {
-                    description: (*desc).into(),
-                    args: serde_json::from_str(json)
-                        .unwrap_or_else(|e| panic!("bad example JSON for {}: {e}", meta.name)),
-                })
-                .collect(),
+        .map(|meta| {
+            Ok(OperationSchema {
+                name: meta.name.into(),
+                description: meta.description.into(),
+                parameters: operation_variant_schema(meta.name)?,
+                min_tier: meta.tier,
+                examples: meta
+                    .examples
+                    .iter()
+                    .map(|(desc, json)| OperationExample {
+                        description: (*desc).into(),
+                        args: serde_json::from_str(json)
+                            .unwrap_or_else(|e| panic!("bad example JSON for {}: {e}", meta.name)),
+                    })
+                    .collect(),
+            })
         })
         .collect()
 }
@@ -531,11 +534,11 @@ pub fn plan_write_policy_schema() -> serde_json::Value {
 }
 
 /// Get operations available at a given capability tier (includes all lower tiers).
-pub fn operations_for_tier(tier: Tier) -> Vec<OperationSchema> {
-    operation_schemas()
+pub fn operations_for_tier(tier: Tier) -> anyhow::Result<Vec<OperationSchema>> {
+    Ok(operation_schemas()?
         .into_iter()
         .filter(|op| op.min_tier <= tier)
-        .collect()
+        .collect())
 }
 
 /// Extract a human-readable type string from a JSON Schema `type` field.
@@ -559,8 +562,8 @@ fn extract_type_str(schema: &serde_json::Value) -> String {
 /// Generate a system prompt fragment describing available operations at this tier.
 ///
 /// The output is markdown text suitable for inclusion in an LLM system prompt.
-pub fn system_prompt_for_tier(tier: Tier) -> String {
-    let ops = operations_for_tier(tier);
+pub fn system_prompt_for_tier(tier: Tier) -> anyhow::Result<String> {
+    let ops = operations_for_tier(tier)?;
     let mut out = String::new();
 
     out.push_str(&format!(
@@ -637,7 +640,7 @@ pub fn system_prompt_for_tier(tier: Tier) -> String {
         out.push('\n');
     }
 
-    out
+    Ok(out)
 }
 
 #[path = "schema_tests.rs"]

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -34,7 +34,7 @@ mod basic {
 
     #[test]
     fn operation_schemas_non_empty() {
-        let schemas = operation_schemas();
+        let schemas = operation_schemas().unwrap();
         assert!(!schemas.is_empty());
         // Every schema must have a name, description, and valid JSON parameters.
         for schema in &schemas {
@@ -54,7 +54,7 @@ mod basic {
 
     #[test]
     fn operation_schemas_have_unique_names() {
-        let schemas = operation_schemas();
+        let schemas = operation_schemas().unwrap();
         let mut names: Vec<&str> = schemas.iter().map(|s| s.name.as_str()).collect();
         names.sort();
         let original_len = names.len();
@@ -64,8 +64,8 @@ mod basic {
 
     #[test]
     fn weak_tier_returns_subset() {
-        let all = operation_schemas();
-        let weak = operations_for_tier(Tier::Weak);
+        let all = operation_schemas().unwrap();
+        let weak = operations_for_tier(Tier::Weak).unwrap();
         assert!(
             weak.len() < all.len(),
             "weak should be a proper subset of all"
@@ -83,8 +83,8 @@ mod basic {
 
     #[test]
     fn medium_tier_includes_weak() {
-        let weak = operations_for_tier(Tier::Weak);
-        let medium = operations_for_tier(Tier::Medium);
+        let weak = operations_for_tier(Tier::Weak).unwrap();
+        let medium = operations_for_tier(Tier::Medium).unwrap();
         assert!(medium.len() >= weak.len());
         let weak_names: Vec<&str> = weak.iter().map(|o| o.name.as_str()).collect();
         for name in &weak_names {
@@ -97,8 +97,8 @@ mod basic {
 
     #[test]
     fn strong_tier_returns_all() {
-        let all = operation_schemas();
-        let strong = operations_for_tier(Tier::Strong);
+        let all = operation_schemas().unwrap();
+        let strong = operations_for_tier(Tier::Strong).unwrap();
         assert_eq!(
             strong.len(),
             all.len(),
@@ -108,7 +108,7 @@ mod basic {
 
     #[test]
     fn weak_tier_has_expected_ops() {
-        let weak = operations_for_tier(Tier::Weak);
+        let weak = operations_for_tier(Tier::Weak).unwrap();
         let names: Vec<&str> = weak.iter().map(|o| o.name.as_str()).collect();
         assert!(names.contains(&"replace"), "weak tier must include replace");
         assert!(
@@ -127,7 +127,7 @@ mod basic {
 
     #[test]
     fn medium_tier_has_expected_ops() {
-        let medium = operations_for_tier(Tier::Medium);
+        let medium = operations_for_tier(Tier::Medium).unwrap();
         let names: Vec<&str> = medium.iter().map(|o| o.name.as_str()).collect();
         assert!(
             names.contains(&"doc.set"),
@@ -145,7 +145,7 @@ mod basic {
 
     #[test]
     fn strong_tier_has_expected_ops() {
-        let strong = operations_for_tier(Tier::Strong);
+        let strong = operations_for_tier(Tier::Strong).unwrap();
         let names: Vec<&str> = strong.iter().map(|o| o.name.as_str()).collect();
         assert!(names.contains(&"search"), "strong tier must include search");
         assert!(
@@ -156,7 +156,7 @@ mod basic {
 
     #[test]
     fn system_prompt_for_weak_tier() {
-        let prompt = system_prompt_for_tier(Tier::Weak);
+        let prompt = system_prompt_for_tier(Tier::Weak).unwrap();
         assert!(prompt.contains("tier: weak"));
         assert!(prompt.contains("replace"));
         assert!(prompt.contains("file.create"));
@@ -167,7 +167,7 @@ mod basic {
 
     #[test]
     fn system_prompt_for_strong_tier() {
-        let prompt = system_prompt_for_tier(Tier::Strong);
+        let prompt = system_prompt_for_tier(Tier::Strong).unwrap();
         assert!(prompt.contains("tier: strong"));
         assert!(prompt.contains("replace"));
         assert!(prompt.contains("doc.set"));
@@ -186,7 +186,7 @@ mod basic {
 
     #[test]
     fn system_prompt_includes_write_policy() {
-        let prompt = system_prompt_for_tier(Tier::Strong);
+        let prompt = system_prompt_for_tier(Tier::Strong).unwrap();
         assert!(prompt.contains("write_policy"));
         assert!(prompt.contains("collapse_blanks"));
         assert!(prompt.contains("ensure_final_newline"));
@@ -194,13 +194,13 @@ mod basic {
 
     #[test]
     fn system_prompt_includes_version() {
-        let prompt = system_prompt_for_tier(Tier::Medium);
+        let prompt = system_prompt_for_tier(Tier::Medium).unwrap();
         assert!(prompt.contains(&format!("format version: {INTENT_FORMAT_VERSION}")));
     }
 
     #[test]
     fn schemas_have_required_fields() {
-        let schemas = operation_schemas();
+        let schemas = operation_schemas().unwrap();
         for schema in &schemas {
             let required = schema.parameters.get("required");
             assert!(
@@ -213,7 +213,7 @@ mod basic {
 
     #[test]
     fn operation_examples_include_op_field() {
-        for schema in operation_schemas() {
+        for schema in operation_schemas().unwrap() {
             for ex in &schema.examples {
                 let op = ex
                     .args
@@ -236,7 +236,7 @@ mod basic {
 
     #[test]
     fn operation_schema_serializes_to_json() {
-        let schemas = operation_schemas();
+        let schemas = operation_schemas().unwrap();
         let json = serde_json::to_string_pretty(&schemas).unwrap();
         assert!(!json.is_empty());
         // Roundtrip: deserialize back.
@@ -542,7 +542,7 @@ mod basic {
             ));
         }
 
-        let schemas = operation_schemas();
+        let schemas = operation_schemas().unwrap();
         let schema_map: std::collections::HashMap<&str, &OperationSchema> =
             schemas.iter().map(|s| (s.name.as_str(), s)).collect();
 
@@ -626,7 +626,7 @@ mod type_extraction {
     fn system_prompt_does_not_show_any_for_optional_params() {
         // The system prompt should show real types (string, boolean, etc.)
         // for optional parameters, not "any".
-        let prompt = system_prompt_for_tier(Tier::Strong);
+        let prompt = system_prompt_for_tier(Tier::Strong).unwrap();
         // Count occurrences of ": any" — there should be very few.
         let any_count = prompt.matches(": any").count();
         // Some fields genuinely have no type (e.g., `value` in doc.set


### PR DESCRIPTION
## Changes

- **#1126**: Strengthen `contains("os")` to `contains("\"os\"")` in the `list_go_import_block` test so the assertion matches the literal Go import string, not arbitrary substrings.
- **#1127**: Replace `panic!` with `anyhow::Result` in `operation_variant_schema()` and propagate through `operation_schemas()`, `operations_for_tier()`, and `system_prompt_for_tier()`. All non-test call sites use `?`; test call sites use `.unwrap()`.

## Files changed

| File | Change |
|------|--------|
| `src/ast/imports.rs` | Strengthen assertion |
| `src/schema.rs` | Return `anyhow::Result` from 4 public functions, add `use anyhow::Context` |
| `src/schema_tests.rs` | Add `.unwrap()` to all test call sites |
| `src/cmd/schema.rs` | Propagate `?` |
| `src/cmd/mcp/mod.rs` | Propagate `?` |
| `src/cmd/mcp/tests.rs` | Add `.unwrap()` |

Closes #1126
Closes #1127