### PR TITLE
fix: 5 LLM-audit round 3 bugs across write, config, rename, schema, verify

### DIFF
--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -87,11 +87,14 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // Binary files can't go through the tx engine (it reads as UTF-8 text).
     // Use a direct fs::rename (or copy+delete) for binary renames.
-    // Distinguish actual binary (non-UTF-8) from I/O errors like permission denied.
-    let is_binary = match fs::read_to_string(&src) {
-        Ok(_) => false,
-        Err(e) if e.kind() == std::io::ErrorKind::InvalidData => true,
-        Err(e) => return Err(e.into()),
+    // Only read the first 8 KiB instead of the entire file to avoid
+    // unnecessary memory allocation on large binaries.
+    let is_binary = {
+        use std::io::Read;
+        let mut file = fs::File::open(&src)?;
+        let mut buf = [0u8; 8192];
+        let n = file.read(&mut buf)?;
+        crate::files::is_binary(&buf[..n])
     };
     if is_binary {
         return run_binary_rename(&args, global, &cwd, &src, &dst);

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,7 @@ pub fn apply_config(global: &mut crate::cli::global::GlobalFlags, config: &Proje
             Some("lf") => global.normalize_eol = Some(crate::cli::global::EolMode::Lf),
             Some("crlf") => global.normalize_eol = Some(crate::cli::global::EolMode::Crlf),
             Some("cr") => global.normalize_eol = Some(crate::cli::global::EolMode::Cr),
+            Some("keep") => {} // explicit keep = default behavior, no-op
             Some(invalid) => {
                 eprintln!("{}", invalid_normalize_eol_warning(invalid));
             }
@@ -717,6 +718,46 @@ rs = "rustfmt"
         assert!(global.format.is_none());
         apply_config(&mut global, &config);
         assert_eq!(global.format.as_deref(), Some("treefmt"));
+    }
+
+    /// Regression: normalize_eol = "keep" in config must be accepted (no-op).
+    #[test]
+    #[cfg(feature = "cli")]
+    fn apply_config_keep_eol_is_noop() {
+        let config = ProjectConfig {
+            write_policy: WritePolicyOverride {
+                normalize_eol: Some("keep".into()),
+                ..WritePolicyOverride::default()
+            },
+            ..ProjectConfig::default()
+        };
+        let mut global = crate::cli::global::GlobalFlags::default();
+        apply_config(&mut global, &config);
+
+        // "keep" means "don't normalize" which is the default (None).
+        assert!(
+            global.normalize_eol.is_none(),
+            "keep should not set normalize_eol"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn apply_config_cr_eol() {
+        let config = ProjectConfig {
+            write_policy: WritePolicyOverride {
+                normalize_eol: Some("cr".into()),
+                ..WritePolicyOverride::default()
+            },
+            ..ProjectConfig::default()
+        };
+        let mut global = crate::cli::global::GlobalFlags::default();
+        apply_config(&mut global, &config);
+
+        assert!(matches!(
+            global.normalize_eol,
+            Some(crate::cli::global::EolMode::Cr)
+        ));
     }
 
     #[test]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -69,6 +69,12 @@ pub fn operation_variant_schema(op_name: &str) -> anyhow::Result<serde_json::Val
                 // Strip metadata keys for compactness.
                 obj.remove("$schema");
                 obj.remove("title");
+                // Copy $defs from root schema so $ref pointers resolve
+                // (e.g. patch.apply references OnStale, ast.split references
+                // SplitTargetSpec).
+                if let Some(defs) = schema.get("$defs") {
+                    obj.insert("$defs".to_string(), defs.clone());
+                }
             }
             return Ok(v);
         }

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -585,6 +585,34 @@ mod basic {
             missing.join("\n  ")
         );
     }
+
+    /// Regression: operation_variant_schema must include $defs from the root
+    /// schema so that $ref pointers (e.g. OnStale in patch.apply) resolve.
+    #[test]
+    fn variant_schema_includes_defs_for_patch_apply() {
+        let schema = operation_variant_schema("patch.apply").unwrap();
+        // patch.apply references $defs/OnStale for the on_stale field.
+        // Without $defs propagation, $ref pointers dangle.
+        if OPERATION_FULL_SCHEMA.get("$defs").is_some() {
+            assert!(
+                schema.get("$defs").is_some(),
+                "variant schema must include $defs from root when root has $defs"
+            );
+        }
+    }
+
+    /// Verify that $defs includes the referenced types.
+    #[test]
+    #[cfg(feature = "ast")]
+    fn variant_schema_defs_include_split_target_spec() {
+        let schema = operation_variant_schema("ast.split").unwrap();
+        if let Some(defs) = schema.get("$defs").and_then(|d| d.as_object()) {
+            assert!(
+                defs.contains_key("SplitTargetSpec"),
+                "$defs should contain SplitTargetSpec for ast.split"
+            );
+        }
+    }
 }
 
 mod error_handling {

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -30,7 +30,42 @@ pub(crate) struct SnappedSymbol {
     pub(crate) kind: symbols::SymbolKind,
 }
 
+/// Returns true when a path string contains glob metacharacters (`*`, `?`, `[`).
+fn is_glob_pattern(s: &str) -> bool {
+    s.contains('*') || s.contains('?') || s.contains('[')
+}
+
+/// Walk `dir` recursively, adding files whose relative path (from `root`)
+/// matches `matcher` to `out`.
+#[cfg(feature = "files")]
+fn walk_and_match(
+    root: &Path,
+    dir: &Path,
+    matcher: &globset::GlobMatcher,
+    out: &mut HashSet<PathBuf>,
+) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            walk_and_match(root, &path, matcher, out);
+        } else if path.is_file()
+            && let Ok(rel) = path.strip_prefix(root)
+            && matcher.is_match(rel)
+        {
+            out.insert(path);
+        }
+    }
+}
+
 /// Collect all file paths declared by operations in a plan.
+///
+/// Handles three cases for each declared path:
+/// 1. Literal file path: include directly.
+/// 2. Directory path: scan for source files (when `ast` + `cli` features).
+/// 3. Glob pattern (contains `*`, `?`, `[`): expand against `cwd`.
 pub(crate) fn affected_file_paths(plan: &crate::plan::Plan, cwd: &Path) -> Vec<PathBuf> {
     let mut paths = HashSet::new();
     for op in &plan.operations {
@@ -48,6 +83,14 @@ pub(crate) fn affected_file_paths(plan: &crate::plan::Plan, cwd: &Path) -> Vec<P
                     for f in files {
                         paths.insert(f);
                     }
+                }
+            } else if is_glob_pattern(p) {
+                // Expand glob patterns against cwd so verification
+                // covers files targeted by glob-based operations.
+                #[cfg(feature = "files")]
+                if let Ok(glob) = globset::Glob::new(p) {
+                    let matcher = glob.compile_matcher();
+                    walk_and_match(cwd, cwd, &matcher, &mut paths);
                 }
             }
         }
@@ -402,6 +445,68 @@ fn check_no_orphans(before: &SymbolSnapshot, after: &SymbolSnapshot, cwd: &Path)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression: affected_file_paths must expand glob patterns instead
+    /// of silently skipping them (which would cause --verify to miss files).
+    #[test]
+    fn affected_file_paths_expands_globs() {
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("src");
+        std::fs::create_dir_all(&src).unwrap();
+        std::fs::write(src.join("main.rs"), "fn main() {}\n").unwrap();
+        std::fs::write(src.join("lib.rs"), "pub fn lib() {}\n").unwrap();
+        std::fs::write(dir.path().join("README.md"), "# Hello\n").unwrap();
+
+        let plan = crate::plan::Plan {
+            version: "1".into(),
+            cwd: None,
+            strict: None,
+            operations: vec![crate::plan::Operation::Replace {
+                glob: Some("src/*.rs".into()),
+                path: None,
+                mode: None,
+                from: "old".into(),
+                to: Some("new".into()),
+                nth: None,
+                insert_before: None,
+                insert_after: None,
+                case_insensitive: false,
+                multiline: false,
+                if_exists: false,
+                whole_line: false,
+                range: None,
+                word_boundary: false,
+                before_context: None,
+                after_context: None,
+            }],
+            write_policy: None,
+            format: None,
+            validate: None,
+            verify: None,
+            for_each: None,
+        };
+
+        let affected = affected_file_paths(&plan, dir.path());
+        let names: Vec<String> = affected
+            .iter()
+            .map(|p| p.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+
+        assert!(
+            names.contains(&"main.rs".to_string()),
+            "glob should match main.rs, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"lib.rs".to_string()),
+            "glob should match lib.rs, got: {names:?}"
+        );
+        assert!(
+            !names.contains(&"README.md".to_string()),
+            "glob should not match README.md"
+        );
+    }
 
     #[test]
     #[cfg(feature = "cli")]

--- a/src/write.rs
+++ b/src/write.rs
@@ -60,12 +60,19 @@ impl WritePolicy {
     }
 
     /// Apply an override, setting only the fields that are `Some`.
+    /// Validates all fields before mutating to avoid partial state on error.
     pub fn apply_override(&mut self, ov: &WritePolicyOverride) -> anyhow::Result<()> {
+        // Validate first: parse normalize_eol before touching any field.
+        let parsed_eol = match ov.normalize_eol {
+            Some(ref s) => Some(parse_eol_mode(s)?),
+            None => None,
+        };
+        // All validation passed; now mutate.
         if let Some(v) = ov.ensure_final_newline {
             self.ensure_final_newline = v;
         }
-        if let Some(ref s) = ov.normalize_eol {
-            self.normalize_eol = parse_eol_mode(s)?;
+        if let Some(eol) = parsed_eol {
+            self.normalize_eol = eol;
         }
         if let Some(v) = ov.trim_trailing_whitespace {
             self.trim_trailing_whitespace = v;

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -1036,4 +1036,38 @@ mod format_preservation {
             "symlink target permissions should not be carried over"
         );
     }
+
+    /// Regression: apply_override must validate all fields before mutating any.
+    /// An invalid normalize_eol must not leave other fields partially applied.
+    #[test]
+    fn apply_override_invalid_eol_no_partial_mutation() {
+        let mut policy = WritePolicy::default();
+        assert!(!policy.ensure_final_newline);
+        assert!(!policy.trim_trailing_whitespace);
+
+        let ov = WritePolicyOverride {
+            ensure_final_newline: Some(true),
+            normalize_eol: Some("INVALID".into()),
+            trim_trailing_whitespace: Some(true),
+            collapse_blanks: Some(true),
+            respect_editorconfig: None,
+        };
+
+        let result = policy.apply_override(&ov);
+        assert!(result.is_err(), "invalid eol should produce an error");
+
+        // All fields must remain at their defaults (no partial mutation).
+        assert!(
+            !policy.ensure_final_newline,
+            "ensure_final_newline must not be mutated on error"
+        );
+        assert!(
+            !policy.trim_trailing_whitespace,
+            "trim_trailing_whitespace must not be mutated on error"
+        );
+        assert!(
+            !policy.collapse_blanks,
+            "collapse_blanks must not be mutated on error"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Five bugs found by LLM-driven audit (round 3), each with targeted regression tests.

### Fixes

| Issue | File | Bug | Fix |
|-------|------|-----|-----|
| #1145 | `src/write.rs` | `apply_override` partially mutated policy on invalid eol | Validate all fields before any mutation |
| #1146 | `src/config.rs` | Config `normalize_eol = "keep"` rejected as invalid | Added explicit `Some("keep") => {}` arm |
| #1147 | `src/cmd/rename.rs` | Binary detection read entire file into memory | Replaced with 8KB streaming probe using `files::is_binary` |
| #1148 | `src/schema.rs` | `operation_variant_schema()` dropped `$defs`, leaving `$ref` dangling | Copy `$defs` from root schema into extracted variant |
| #1149 | `src/tx/verify.rs` | `affected_file_paths()` silently skipped glob patterns | Added glob expansion via `walk_and_match` with `globset` |

### Tests Added

- `apply_override_invalid_eol_no_partial_mutation` (write_tests.rs)
- `apply_config_keep_eol_is_noop` + `apply_config_cr_eol` (config.rs)
- `variant_schema_includes_defs_for_patch_apply` + `variant_schema_defs_include_split_target_spec` (schema_tests.rs)
- `affected_file_paths_expands_globs` (verify.rs)

Closes #1145
Closes #1146
Closes #1147
Closes #1148
Closes #1149