### PR TITLE
fix: 5 bugs found by LLM audit round 4

### DIFF
--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -35,12 +35,8 @@ pub fn replace_in_symbol(
         None => return Ok(None),
     };
 
-    // Detect dominant line ending to preserve it in the output.
-    let eol = if source.contains("\r\n") {
-        "\r\n"
-    } else {
-        "\n"
-    };
+    // Use canonical majority-vote detection, consistent with all other AST modules.
+    let eol = crate::write::detect_eol(source);
     let lines: Vec<&str> = source.lines().collect();
     let start_idx = sym.start_line.saturating_sub(1);
     let end_idx = sym.end_line.min(lines.len());
@@ -181,6 +177,26 @@ fn bar() {
         // Verify no bare LF where CRLF was expected
         let without_cr = result.content.replace("\r\n", "");
         assert!(!without_cr.contains('\n'), "no bare LF in CRLF content");
+    }
+
+    /// Regression: a majority-LF file with one stray CRLF must stay LF,
+    /// not be converted to all-CRLF by the inline `contains("\r\n")` check.
+    #[test]
+    fn replace_majority_lf_with_stray_crlf_preserves_lf() {
+        // 3 LF lines + 1 CRLF line: majority is LF.
+        let source = "fn foo() {\n    let x = 1;\r\n    let y = 2;\n}\n";
+        let result = replace_in_symbol(source, "foo", "1", "42", false, Language::Rust)
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.replacements, 1);
+        // The output should use LF (majority vote), not CRLF.
+        let lines: Vec<&str> = result.content.split('\n').collect();
+        let crlf_count = result.content.matches("\r\n").count();
+        let lf_count = lines.len().saturating_sub(1).saturating_sub(crlf_count);
+        assert!(
+            lf_count > crlf_count,
+            "majority-LF file should stay LF after replace, got {crlf_count} CRLF vs {lf_count} LF"
+        );
     }
 
     #[test]

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -315,7 +315,12 @@ fn doc_readonly(action: &crate::cmd::doc::DocAction) -> Result<CallToolResult, M
         crate::cmd::doc::execute_with_mode(action, crate::cmd::doc::OutputMode::Json)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
     // CHANGES_DETECTED (2) is a valid success for doc diff (differences found).
-    let effective = if code == exit::CHANGES_DETECTED {
+    // NO_MATCHES (3) with non-empty output is a valid answer (e.g. "has"
+    // returning "false", "len" returning "0"). Only treat it as an error
+    // when the output is empty (genuinely no result).
+    let effective = if code == exit::CHANGES_DETECTED
+        || (code == exit::NO_MATCHES && !output.trim().is_empty())
+    {
         exit::SUCCESS
     } else {
         code

--- a/src/ops/doc/preserve.rs
+++ b/src/ops/doc/preserve.rs
@@ -14,7 +14,7 @@ pub(crate) fn hoist_comments(original: &str, body: &str) -> String {
         let sep = if comments.ends_with('\n') || body.starts_with('\n') {
             ""
         } else {
-            "\n"
+            eol
         };
         format!("{}{}{}", comments, sep, body)
     } else {
@@ -77,6 +77,28 @@ mod tests {
         assert!(
             result.contains("# top comment\r\n\r\n# second"),
             "CRLF should be preserved in comment join: {result:?}"
+        );
+    }
+
+    /// Regression: the separator between comments and body must use
+    /// the detected EOL, not a hardcoded "\n", to avoid mixed endings.
+    #[test]
+    fn hoist_comments_separator_uses_detected_eol() {
+        // CRLF file where comments don't end with \n and body doesn't
+        // start with \n, triggering the separator path.
+        let original = "# config\r\nkey: value\r\n";
+        let body = "key: new\r\n";
+        let result = hoist_comments(original, body);
+        // The separator between "# config" and "key: new" must be \r\n.
+        assert!(
+            result.contains("# config\r\nkey: new"),
+            "separator must use CRLF for CRLF files: {result:?}"
+        );
+        // No bare LF should exist (would indicate mixed endings).
+        let without_crlf = result.replace("\r\n", "");
+        assert!(
+            !without_crlf.contains('\n'),
+            "no bare LF should exist in CRLF output: {result:?}"
         );
     }
 }

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -22,19 +22,22 @@ pub struct PatchFile {
     pub hunks: Vec<Hunk>,
 }
 
+/// Check whether line `idx` is a real file header ("--- " followed by "+++"),
+/// not a removed line whose content happens to start with "-- " (e.g. SQL
+/// comments produce `--- comment text` in the diff).
+fn is_file_header(lines: &[&str], idx: usize) -> bool {
+    lines[idx].starts_with("--- ") && idx + 1 < lines.len() && lines[idx + 1].starts_with("+++ ")
+}
+
 pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
     let lines: Vec<&str> = input.lines().collect();
     let mut files: Vec<PatchFile> = Vec::new();
     let mut i = 0;
 
     while i < lines.len() {
-        if !lines[i].starts_with("--- ") {
+        if !is_file_header(&lines, i) {
             i += 1;
             continue;
-        }
-
-        if i + 1 >= lines.len() || !lines[i + 1].starts_with("+++ ") {
-            return Err(format!("expected +++ line after --- at line {}", i + 1));
         }
 
         // For deletions the `+++` line is `/dev/null`; take path from `---`.
@@ -47,7 +50,7 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
         i += 2;
 
         let mut hunks: Vec<Hunk> = Vec::new();
-        while i < lines.len() && !lines[i].starts_with("--- ") {
+        while i < lines.len() && !is_file_header(&lines, i) {
             if lines[i].starts_with("@@ ") {
                 let hunk = parse_hunk_header(lines[i])?;
                 let mut hunk_lines: Vec<PatchLine> = Vec::new();
@@ -55,7 +58,7 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
 
                 while i < lines.len()
                     && !lines[i].starts_with("@@ ")
-                    && !lines[i].starts_with("--- ")
+                    && !is_file_header(&lines, i)
                     && !lines[i].starts_with("diff ")
                 {
                     let line = lines[i];

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1031,4 +1031,29 @@ mod regression {
         );
         assert_eq!(result, "line1\r\nreplaced\r\nline3\r\n");
     }
+
+    /// Regression: a removed line whose content starts with "-- " (SQL comment)
+    /// must not be treated as a file header boundary. The diff line becomes
+    /// "--- comment text" which previously matched the "--- " termination check.
+    #[test]
+    fn parse_patch_removed_sql_comment_line() {
+        let diff = "\
+--- a/query.sql
++++ b/query.sql
+@@ -1,3 +1,2 @@
+ SELECT 1;
+--- This query is slow
+ SELECT 2;
+";
+        let files = parse_patch(diff).expect("should parse successfully");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "query.sql");
+        assert_eq!(files[0].hunks.len(), 1);
+        assert_eq!(files[0].hunks[0].lines.len(), 3);
+        // The "-- This query is slow" line should be a Remove, not a header
+        assert!(
+            matches!(&files[0].hunks[0].lines[1], PatchLine::Remove(s) if s == "-- This query is slow"),
+            "SQL comment removal must be parsed as a Remove line"
+        );
+    }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -913,8 +913,12 @@ fn substitute_single_pass(template: &str, vars: &[(&str, String)]) -> String {
                 i += 1;
             }
         } else {
-            result.push(bytes[i] as char);
-            i += 1;
+            // Advance by one full UTF-8 character, not one byte.
+            // `bytes[i] as char` would interpret each byte of a multi-byte
+            // sequence as a Latin-1 code point, corrupting non-ASCII text.
+            let ch = template[i..].chars().next().unwrap();
+            result.push(ch);
+            i += ch.len_utf8();
         }
     }
     result
@@ -1097,6 +1101,20 @@ mod tests {
         let vars: &[(&str, String)] = &[("{path}", "src/main.rs".into()), ("{dir}", "src".into())];
         let result = substitute_single_pass(template, vars);
         assert_eq!(result, "file: src/main.rs, dir: src");
+    }
+
+    /// Regression: substitute_single_pass must handle multi-byte UTF-8
+    /// characters correctly (not corrupt them via byte-as-char casting).
+    #[cfg(feature = "cli")]
+    #[test]
+    fn substitute_single_pass_preserves_utf8() {
+        let template = r#"{"path": "{path}", "to": "résumé café"}"#;
+        let vars: &[(&str, String)] = &[("{path}", "src/main.rs".into())];
+        let result = substitute_single_pass(template, vars);
+        assert_eq!(
+            result, r#"{"path": "src/main.rs", "to": "résumé café"}"#,
+            "multi-byte UTF-8 characters must survive template expansion"
+        );
     }
 
     #[test]

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -277,6 +277,35 @@ async fn test_mcp_doc_has_existing_key() {
     client.cancel().await.unwrap();
 }
 
+/// Regression: doc_query "has" for a missing key must return is_error=false
+/// with value "false", not is_error=true. The "has" action's purpose is to
+/// check existence; "false" is a valid answer, not an error.
+#[tokio::test]
+async fn test_mcp_doc_has_missing_key_not_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("data.json"), r#"{"name":"alice"}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_query",
+        serde_json::json!({"action": "has", "path": "data.json", "selector": "missing_key"}),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "doc_query has for missing key should NOT be an error: {val}"
+    );
+    assert_eq!(
+        val, false,
+        "doc_query has should return false for missing key: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_doc_get_reads_value() {
     if !has_mcp_support() {


### PR DESCRIPTION
## Summary

Five bugs discovered by LLM-driven audit (round 4), each with a targeted regression test.

| # | Area | Bug |
|---|------|-----|
| #1151 | plan | `substitute_single_pass` corrupts multi-byte UTF-8 by advancing one byte instead of one character |
| #1152 | mcp | `doc_readonly` returns MCP error for `has` queries on missing keys (valid "false" result treated as failure) |
| #1153 | patch | `parse_patch` prematurely splits on content lines starting with `--- ` |
| #1154 | ast | `replace` uses `contains("\r\n")` instead of canonical `detect_eol`, giving wrong EOL when minority CRLF present |
| #1155 | doc | YAML comment hoisting hardcodes `"\n"` separator instead of using detected EOL |

## Testing

- `make check-fast` passes (1823 unit tests + integration + PTY)
- Each fix has a dedicated regression test

Closes #1151
Closes #1152
Closes #1153
Closes #1154
Closes #1155