### PR TITLE
fix: 5 bugs found by LLM audit round 5

### DIFF
--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -201,6 +201,7 @@ pub(crate) fn format_results(
         let has_ctx =
             args.context.is_some() || args.before_context.is_some() || args.after_context.is_some();
         let mut prev_end: Option<(usize, usize)> = None; // (match index, last line covered)
+        let mut emitted_up_to: usize = 0; // last 1-based line printed for current file
         for (mi, m) in results.matches.iter().enumerate() {
             if has_ctx {
                 // Only print separator between non-contiguous groups,
@@ -210,7 +211,10 @@ pub(crate) fn format_results(
                     .saturating_sub(m.context_before.as_ref().map_or(0, |b| b.len()));
                 if let Some((prev_idx, prev_last_line)) = prev_end {
                     let prev_path = &results.matches[prev_idx].path;
-                    if **prev_path != *m.path || cur_start > prev_last_line + 1 {
+                    if **prev_path != *m.path {
+                        emitted_up_to = 0;
+                        out.push_str("--\n");
+                    } else if cur_start > prev_last_line + 1 {
                         out.push_str("--\n");
                     }
                 }
@@ -220,6 +224,11 @@ pub(crate) fn format_results(
             if let Some(ref before) = m.context_before {
                 for (j, ctx) in before.iter().enumerate() {
                     let ln = m.line - before.len() + j;
+                    // Skip lines already emitted by the previous match's
+                    // context-after window to avoid duplicates (#1160).
+                    if has_ctx && ln <= emitted_up_to {
+                        continue;
+                    }
                     let _ = writeln!(
                         out,
                         "{path_c}{}{reset}{sep_c}-{reset}{ln_c}{ln}{reset}{sep_c}-{reset}{ctx}",
@@ -232,6 +241,9 @@ pub(crate) fn format_results(
                 "{path_c}{}{reset}{sep_c}:{reset}{ln_c}{}{reset}{sep_c}:{reset}{}{sep_c}:{reset}{}",
                 m.path, m.line, m.column, m.text
             );
+            if has_ctx {
+                emitted_up_to = m.line;
+            }
             if let Some(ref after) = m.context_after {
                 for (j, ctx) in after.iter().enumerate() {
                     let ln = m.line + 1 + j;
@@ -240,6 +252,12 @@ pub(crate) fn format_results(
                         "{path_c}{}{reset}{sep_c}-{reset}{ln_c}{ln}{reset}{sep_c}-{reset}{ctx}",
                         m.path
                     );
+                }
+                if has_ctx {
+                    let last_after_ln = m.line + after.len();
+                    if last_after_ln > emitted_up_to {
+                        emitted_up_to = last_after_ln;
+                    }
                 }
             }
         }
@@ -783,5 +801,38 @@ mod tests {
         args.assert_count = Some(99);
         let code = run(args, &GlobalFlags::test_default()).unwrap();
         assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    /// Overlapping context windows must not produce duplicate lines (#1160).
+    #[test]
+    fn context_no_duplicate_lines() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join("close.txt"),
+            "line1\nmatch_a\nline3\nmatch_b\nline5\n",
+        )
+        .unwrap();
+        let mut args = make_args("match", vec![dir.path().to_string_lossy().into_owned()]);
+        args.context = Some(1);
+        let global = GlobalFlags::test_default();
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    /// Verify plain-text context output does not repeat lines between
+    /// close matches (regression for #1160).
+    #[test]
+    fn context_plain_text_no_repeated_lines() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("close.txt");
+        fs::write(&file, "line1\nmatch_a\nline3\nmatch_b\nline5\n").unwrap();
+        let mut args = make_args("match", vec![file.to_string_lossy().into_owned()]);
+        args.context = Some(1);
+        let global = GlobalFlags::test_default();
+        let output =
+            format_results(collect_matches(&args, &global).unwrap(), &args, &global).unwrap();
+        // "line3" should appear exactly once, not twice.
+        let count = output.matches("line3").count();
+        assert_eq!(count, 1, "line3 should appear once, got: {output}");
     }
 }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -163,7 +163,12 @@ fn commit_and_finalize(
         return handle_commit_error(err, ctx.structured, ctx.compact);
     }
 
-    run_format_command(global, ctx.cwd)?;
+    if let Err(e) = run_format_command(global, ctx.cwd) {
+        // The commit already succeeded; files are written but unformatted.
+        // Warn with a recovery hint instead of a bare error (#1159).
+        let hint = "files were written but formatting failed; run `patchloom undo` to restore";
+        return Err(e.context(hint));
+    }
 
     if show_diffs && !result.changes.is_empty() {
         print_diffs(&result.changes, ctx.cwd, global.should_color());

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -249,23 +249,33 @@ fn line_byte_starts(content: &str) -> Vec<usize> {
     starts
 }
 
-fn normalize_heading_query(heading: &str) -> &str {
+/// Parse a heading query into (optional level, text).
+///
+/// If the query includes ATX-style `#` markers (e.g. `"## API"`), the
+/// level is extracted and used to filter matches. Plain text queries
+/// (e.g. `"API"`) match any heading level (#1158).
+fn normalize_heading_query(heading: &str) -> (Option<usize>, &str) {
     let t = heading.trim();
     let n = t.bytes().take_while(|&b| b == b'#').count();
     if n > 0 && t.len() > n && t.as_bytes()[n] == b' ' {
-        t[n + 1..].trim()
+        (Some(n), t[n + 1..].trim())
     } else {
-        t
+        (None, t)
     }
+}
+
+/// Check whether a heading matches the parsed query (level + text).
+fn heading_matches(h: &HeadingInfo, level: Option<usize>, query: &str) -> bool {
+    h.text.trim() == query && level.is_none_or(|lvl| h.level == lvl)
 }
 
 pub fn find_section(content: &str, heading: &str) -> Option<(usize, usize)> {
     let headings = parse_headings(content);
     let offsets = line_byte_starts(content);
-    let query = normalize_heading_query(heading);
+    let (level, query) = normalize_heading_query(heading);
 
     for h in &headings {
-        if h.text.trim() == query {
+        if heading_matches(h, level, query) {
             let body_start = if h.body_line < offsets.len() {
                 offsets[h.body_line]
             } else {
@@ -290,10 +300,10 @@ pub fn find_section(content: &str, heading: &str) -> Option<(usize, usize)> {
 pub fn section_range(content: &str, heading: &str) -> Option<(usize, usize)> {
     let headings = parse_headings(content);
     let offsets = line_byte_starts(content);
-    let query = normalize_heading_query(heading);
+    let (level, query) = normalize_heading_query(heading);
 
     for h in &headings {
-        if h.text.trim() == query {
+        if heading_matches(h, level, query) {
             let section_start = offsets[h.line_start];
             let section_end = if h.line_end < offsets.len() {
                 offsets[h.line_end]
@@ -423,10 +433,10 @@ pub fn insert_before_heading_in(content: &str, heading: &str, insertion: &str) -
     let eol = crate::write::detect_eol(content);
     let headings = parse_headings(content);
     let offsets = line_byte_starts(content);
-    let query = normalize_heading_query(heading);
+    let (level, query) = normalize_heading_query(heading);
 
     for h in &headings {
-        if h.text.trim() == query {
+        if heading_matches(h, level, query) {
             let heading_start = offsets[h.line_start];
             let mut out = String::with_capacity(content.len() + insertion.len());
             out.push_str(&content[..heading_start]);
@@ -472,9 +482,15 @@ pub fn upsert_bullet_in(content: &str, heading: &str, bullet: &str) -> Option<St
     // Dedup across bullet styles: compare text content without prefix.
     let new_text = strip_bullet_prefix(&normalized);
     for line in body.lines() {
-        let existing_text = strip_bullet_prefix(line.trim());
-        if existing_text == new_text {
-            return Some(content.to_string());
+        // Only dedup against top-level bullets (no leading whitespace).
+        // Indented sub-bullets (e.g. "  - deploy") should not block
+        // insertion of a top-level bullet with the same text (#1157).
+        let trimmed = line.trim_start();
+        if trimmed.len() == line.len() {
+            let existing_text = strip_bullet_prefix(trimmed);
+            if existing_text == new_text {
+                return Some(content.to_string());
+            }
         }
     }
 

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1362,4 +1362,43 @@ body text
             "frontmatter should be preserved: {result}"
         );
     }
+
+    /// Nested sub-bullets must not falsely dedup against top-level bullets (#1157).
+    #[test]
+    fn upsert_bullet_nested_subbullet_no_false_dedup() {
+        let content = "# Tasks\n- parent\n  - deploy\n";
+        let result = upsert_bullet_in(content, "Tasks", "- deploy").unwrap();
+        // The indented "  - deploy" is a sub-bullet; a new top-level
+        // "- deploy" should still be inserted.
+        assert!(
+            result.contains("\n- deploy\n"),
+            "top-level bullet should be added: {result}"
+        );
+        let deploy_count = result.matches("\n- deploy").count();
+        assert_eq!(
+            deploy_count, 1,
+            "exactly one top-level '- deploy' expected: {result}"
+        );
+    }
+
+    /// When the heading query includes `#` markers, find_section must
+    /// respect the heading level, not just the text (#1158).
+    #[test]
+    fn find_section_with_level_filter() {
+        let content = "# API\nGeneral overview\n## API\nDetailed reference\n";
+        // Query with "## API" should match the h2, not the h1.
+        let (start, end) = find_section(content, "## API").unwrap();
+        let body = &content[start..end];
+        assert_eq!(body, "Detailed reference\n");
+    }
+
+    /// A plain text query (no `#` prefix) should match any heading level.
+    #[test]
+    fn find_section_plain_text_matches_any_level() {
+        let content = "## Intro\nSome text\n# Intro\nOther text\n";
+        // Plain "Intro" matches the first occurrence regardless of level.
+        let (start, end) = find_section(content, "Intro").unwrap();
+        let body = &content[start..end];
+        assert_eq!(body, "Some text\n");
+    }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -672,6 +672,16 @@ pub fn atomic_create_new(path: &Path, content: &str, policy: &WritePolicy) -> an
     std::fs::write(tmp.path(), final_content.as_bytes())
         .with_context(|| format!("failed to write to tempfile {}", tmp.path().display()))?;
 
+    // NamedTempFile creates files with 0o600; apply standard 0o644 so
+    // new files are group/world-readable as users expect (#1161).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o644);
+        std::fs::set_permissions(tmp.path(), perms)
+            .with_context(|| format!("failed to set permissions on {}", tmp.path().display()))?;
+    }
+
     tmp.persist_noclobber(path).map_err(|e| {
         if e.error.kind() == std::io::ErrorKind::AlreadyExists {
             anyhow::anyhow!("file already exists: {}", path.display())

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -1070,4 +1070,18 @@ mod format_preservation {
             "collapse_blanks must not be mutated on error"
         );
     }
+
+    /// Files created by `atomic_create_new` must have 0o644 permissions
+    /// on Unix, not the restrictive 0o600 from NamedTempFile (#1161).
+    #[cfg(unix)]
+    #[test]
+    fn atomic_create_new_permissions_644() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("new_file.txt");
+        atomic_create_new(&path, "hello\n", &WritePolicy::default()).unwrap();
+        let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o644, "expected 0o644, got 0o{mode:o}");
+    }
 }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -6892,3 +6892,41 @@ fn test_tx_non_strict_keeps_collateral_files() {
         "in non-strict mode, formatter changes should persist"
     );
 }
+
+/// Global `--format` failure after commit must include a recovery hint
+/// mentioning `patchloom undo` (#1159).
+#[test]
+fn test_tx_global_format_failure_includes_undo_hint() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("target.txt");
+    fs::write(&file, "old\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "replace",
+            "path": portable_path_str(&file),
+            "from": "old",
+            "to": "new"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .arg("--format")
+        .arg("false")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("patchloom undo"),
+        "error should mention `patchloom undo` for recovery: {stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

Five bugs discovered by LLM-driven audit (round 5), each with a targeted regression test.

| # | Area | Bug |
|---|------|-----|
| #1160 | search | Overlapping context lines duplicated in plain-text output for close matches |
| #1157 | md | `upsert_bullet` dedup ignores indentation; nested sub-bullets falsely match top-level bullets |
| #1158 | md | `normalize_heading_query` discards heading level from query; cannot disambiguate `# API` vs `## API` |
| #1161 | write | `atomic_create_new` leaves files with 0o600 permissions instead of 0o644 on Unix |
| #1159 | tx | Global `--format` failure after commit does not report backup session for recovery |

## Testing

- `make check-fast` passes (1829 unit tests + 825 integration + 10 PTY)
- Each fix has a dedicated regression test

Closes #1157
Closes #1158
Closes #1159
Closes #1160
Closes #1161