### PR TITLE
fix: 5 bugs from LLM audit round 6

### DIFF
--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -1077,7 +1077,23 @@ pub fn get_git_file_content(
 // ---------------------------------------------------------------------------
 
 pub fn lang_from_str(s: &str) -> Language {
-    Language::from_extension(s)
+    // Try language name aliases first, then fall back to extension matching.
+    match s.to_lowercase().as_str() {
+        "rust" => Language::Rust,
+        "typescript" => Language::TypeScript,
+        "javascript" => Language::JavaScript,
+        "python" => Language::Python,
+        "golang" => Language::Go,
+        "java" => Language::Java,
+        "csharp" | "c#" => Language::CSharp,
+        "ruby" => Language::Ruby,
+        "kotlin" => Language::Kotlin,
+        "hcl" | "terraform" => Language::Hcl,
+        "protobuf" | "proto" => Language::Protobuf,
+        "dockerfile" | "docker" => Language::Dockerfile,
+        "markdown" => Language::Markdown,
+        _ => Language::from_extension(s),
+    }
 }
 
 pub use symbols::{filter_symbols, parse_kind_filter};
@@ -1184,6 +1200,22 @@ mod tests {
         assert_eq!(lang_from_str("rs"), Language::Rust);
         assert_eq!(lang_from_str("py"), Language::Python);
         assert_eq!(lang_from_str("go"), Language::Go);
+    }
+
+    /// Language names (not just extensions) should be accepted (#1165).
+    #[test]
+    fn lang_from_str_language_names() {
+        assert_eq!(lang_from_str("rust"), Language::Rust);
+        assert_eq!(lang_from_str("python"), Language::Python);
+        assert_eq!(lang_from_str("typescript"), Language::TypeScript);
+        assert_eq!(lang_from_str("javascript"), Language::JavaScript);
+        assert_eq!(lang_from_str("golang"), Language::Go);
+        assert_eq!(lang_from_str("csharp"), Language::CSharp);
+        assert_eq!(lang_from_str("ruby"), Language::Ruby);
+        assert_eq!(lang_from_str("kotlin"), Language::Kotlin);
+        assert_eq!(lang_from_str("terraform"), Language::Hcl);
+        assert_eq!(lang_from_str("markdown"), Language::Markdown);
+        assert_eq!(lang_from_str("Rust"), Language::Rust); // case-insensitive
     }
 
     // -----------------------------------------------------------------------

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -136,6 +136,11 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     }
 
+    // Partial failure: some files succeeded, some failed (#1166).
+    if !errors.is_empty() {
+        return Ok(exit::FAILURE);
+    }
+
     Ok(exit::SUCCESS)
 }
 
@@ -322,5 +327,25 @@ mod tests {
         assert_eq!(result.content, "beta\ngamma\n");
         assert_eq!(result.start_line, 2);
         assert_eq!(result.end_line, 3);
+    }
+
+    /// Partial failure (some files exist, some don't) must return FAILURE (#1166).
+    #[test]
+    fn partial_read_failure_returns_failure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let exists = dir.path().join("exists.txt");
+        std::fs::write(&exists, "hello\n").unwrap();
+        let missing = dir.path().join("missing.txt");
+
+        let args = ReadArgs {
+            files: vec![
+                exists.to_string_lossy().into_owned(),
+                missing.to_string_lossy().into_owned(),
+            ],
+            lines: None,
+        };
+        let global = GlobalFlags::test_default();
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 }

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -60,12 +60,18 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         anyhow::bail!("destination is not a file: {}", args.to);
     }
 
-    // Same-file no-op check.
-    if src == dst
-        || matches!(
-            (src.canonicalize(), dst.canonicalize()),
-            (Ok(ref s), Ok(ref d)) if s == d
-        )
+    // Same-file no-op check. On case-insensitive filesystems (macOS APFS),
+    // canonicalize() treats case differences as identical. Allow the rename
+    // when only the case differs so users can change filename casing (#1167).
+    let is_case_only_change = src != dst
+        && src.file_name().map(|n| n.to_ascii_lowercase())
+            == dst.file_name().map(|n| n.to_ascii_lowercase());
+    if !is_case_only_change
+        && (src == dst
+            || matches!(
+                (src.canonicalize(), dst.canonicalize()),
+                (Ok(ref s), Ok(ref d)) if s == d
+            ))
     {
         let output = RenameOutput {
             ok: true,
@@ -81,7 +87,7 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::SUCCESS);
     }
 
-    if !args.force && dst.exists() {
+    if !args.force && !is_case_only_change && dst.exists() {
         anyhow::bail!("destination already exists: {}", args.to);
     }
 
@@ -97,6 +103,14 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         crate::files::is_binary(&buf[..n])
     };
     if is_binary {
+        return run_binary_rename(&args, global, &cwd, &src, &dst);
+    }
+
+    // Case-only renames on case-insensitive filesystems (e.g. macOS APFS)
+    // cannot go through the tx engine because its write-then-delete approach
+    // would delete the destination (same inode as source). Use fs::rename
+    // directly, which handles case changes atomically (#1167).
+    if is_case_only_change {
         return run_binary_rename(&args, global, &cwd, &src, &dst);
     }
 

--- a/src/selector/mod.rs
+++ b/src/selector/mod.rs
@@ -17,6 +17,7 @@ pub fn value_matches_str(field: &serde_json::Value, pred_val: &str) -> bool {
         serde_json::Value::String(s) => s == pred_val,
         serde_json::Value::Number(n) => n.to_string() == pred_val,
         serde_json::Value::Bool(b) => b.to_string() == pred_val,
+        serde_json::Value::Null => pred_val == "null",
         _ => false,
     }
 }
@@ -45,9 +46,11 @@ mod tests {
         assert!(!value_matches_str(&json!(true), "false"));
     }
 
+    /// Null values match the string "null" (#1164).
     #[test]
-    fn value_matches_str_null_returns_false() {
-        assert!(!value_matches_str(&json!(null), "null"));
+    fn value_matches_str_null_matches_null_string() {
+        assert!(value_matches_str(&json!(null), "null"));
+        assert!(!value_matches_str(&json!(null), "other"));
     }
 
     #[test]

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -465,7 +465,23 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             let created_in_tx = match tx.pending.get(&file_path) {
                 Some((original, _)) => original.is_empty() && !file_path.exists(),
                 None => {
-                    let _ = read_file_content(tx.pending, tx.existed_before, &file_path)?;
+                    if !file_path.exists() {
+                        anyhow::bail!("file not found: {path}");
+                    }
+                    tx.existed_before.insert(file_path.clone());
+                    // Try to read as text for strict rollback; fall back to
+                    // empty for binary files that cannot be represented as
+                    // UTF-8 (#1163).
+                    match std::fs::read_to_string(&file_path) {
+                        Ok(content) => {
+                            tx.pending
+                                .insert(file_path.clone(), (content.clone(), content));
+                        }
+                        Err(_) => {
+                            tx.pending
+                                .insert(file_path.clone(), (String::new(), String::new()));
+                        }
+                    }
                     false
                 }
             };
@@ -500,11 +516,16 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             }
 
             // If source and destination resolve to the same file, no-op.
-            if src_path == dst_path
-                || matches!(
-                    (src_path.canonicalize(), dst_path.canonicalize()),
-                    (Ok(ref s), Ok(ref d)) if s == d
-                )
+            // Allow case-only renames on case-insensitive filesystems (#1167).
+            let case_only = src_path != dst_path
+                && src_path.file_name().map(|n| n.to_ascii_lowercase())
+                    == dst_path.file_name().map(|n| n.to_ascii_lowercase());
+            if !case_only
+                && (src_path == dst_path
+                    || matches!(
+                        (src_path.canonicalize(), dst_path.canonicalize()),
+                        (Ok(ref s), Ok(ref d)) if s == d
+                    ))
             {
                 return Ok(0);
             }
@@ -512,8 +533,9 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // Read source content into pending (validates it exists).
             let content = read_file_content(tx.pending, tx.existed_before, &src_path)?.to_string();
 
-            // Check destination does not already exist (unless force).
-            if !force {
+            // Check destination does not already exist (unless force or
+            // case-only rename on case-insensitive FS).
+            if !force && !case_only {
                 let dst_exists = (tx.pending.contains_key(&dst_path)
                     && !tx.deletions.contains(&dst_path))
                     || (!tx.deletions.contains(&dst_path) && dst_path.exists());
@@ -525,7 +547,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // If destination exists on disk, load it into pending first so
             // existed_before is populated and commit uses atomic_write (not
             // atomic_create_new which would fail on existing files).
-            if *force && !tx.pending.contains_key(&dst_path) && dst_path.exists() {
+            if (*force || case_only) && !tx.pending.contains_key(&dst_path) && dst_path.exists() {
                 let _ = read_file_content(tx.pending, tx.existed_before, &dst_path)?;
             }
 

--- a/tests/integration/delete_tests.rs
+++ b/tests/integration/delete_tests.rs
@@ -303,3 +303,20 @@ fn test_delete_apply_undo_restores_file() {
     assert!(file.exists(), "undo should restore the deleted file");
     assert_eq!(fs::read_to_string(&file).unwrap(), "precious data\n");
 }
+
+/// Binary files must be deletable without UTF-8 errors (#1163).
+#[test]
+fn test_delete_binary_file_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("binary.bin");
+    fs::write(&file, b"\x00\x01\x02\xff\xfe").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["delete", "--apply"])
+        .arg(file.to_str().unwrap())
+        .assert()
+        .code(0);
+
+    assert!(!file.exists(), "binary file should be deleted");
+}

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -206,7 +206,8 @@ fn test_read_multiple_files_json_partial_failure_keeps_array() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    // Partial failure returns FAILURE exit code (#1166), but still outputs JSON.
+    assert_eq!(output.status.code(), Some(1));
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert!(json.is_array());
     assert_eq!(json.as_array().unwrap().len(), 1);
@@ -245,18 +246,19 @@ fn test_read_multiple_files_jsonl() {
 }
 
 #[test]
-fn test_read_partial_failure_succeeds() {
+fn test_read_partial_failure_returns_failure() {
     let dir = TempDir::new().unwrap();
     let f1 = dir.path().join("exists.txt");
     fs::write(&f1, "hello\n").unwrap();
 
+    // Partial failure now returns FAILURE exit code (#1166).
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("read")
         .arg(f1.to_str().unwrap())
         .arg(nonexistent_path("no-such-file-xyz"))
         .assert()
-        .success()
+        .code(1)
         .stdout(predicates::str::contains("hello"));
 }
 

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -671,3 +671,37 @@ fn test_rename_apply_creates_backup_session() {
         "backup dir should exist after rename --apply"
     );
 }
+
+/// Case-only renames should work on case-insensitive filesystems (#1167).
+#[test]
+fn test_rename_case_only_change() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("readme.md");
+    fs::write(&file, "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["rename", "--apply"])
+        .arg(file.to_str().unwrap())
+        .arg(dir.path().join("README.md").to_str().unwrap())
+        .assert()
+        .code(0);
+
+    // Verify the rename happened by reading the directory.
+    let entries: Vec<String> = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.ends_with(".md"))
+        .collect();
+
+    // On case-insensitive FS, there should be exactly one .md file.
+    assert_eq!(entries.len(), 1);
+    // On case-sensitive FS, the new name should be README.md.
+    // On case-insensitive FS, the dir entry shows whatever case was set last.
+    assert!(
+        entries[0] == "README.md" || entries[0] == "readme.md",
+        "expected README.md or readme.md, got: {}",
+        entries[0]
+    );
+}


### PR DESCRIPTION
## Summary

Five bugs found and fixed via LLM-driven audit (round 6).

## Fixes

| Issue | Bug | Fix |
|-------|-----|-----|
| #1163 | Binary file deletion fails in tx engine | Try read_to_string first, fall back to empty for binary files so strict rollback preserves text content |
| #1164 | Null values don't match "null" in selector predicates | Add Null arm to value_matches_str |
| #1165 | AST operations reject language names like "rust", "python" | lang_from_str tries language names before falling back to extension lookup |
| #1166 | Read command returns SUCCESS when some files fail | Return FAILURE exit code on partial failure |
| #1167 | Case-only rename fails on case-insensitive filesystems | Bypass tx engine for case-only renames (write-then-delete fails when both names map to same inode) |

## Testing

- All 1831 unit tests pass
- All 827 integration tests pass (includes new tests for each fix)
- All 10 PTY tests pass
- `make check-fast` passes

Closes #1163
Closes #1164
Closes #1165
Closes #1166
Closes #1167