### PR TITLE
fix: 5 bugs from LLM audit round 7

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -86,6 +86,30 @@ impl Language {
         }
     }
 
+    /// Detect language from a language name or file extension string.
+    /// Tries common language names first (e.g. "rust", "python",
+    /// "typescript"), then falls back to extension matching.
+    pub fn from_name_or_ext(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "rust" => Self::Rust,
+            "typescript" => Self::TypeScript,
+            "javascript" => Self::JavaScript,
+            "python" => Self::Python,
+            "golang" => Self::Go,
+            "java" => Self::Java,
+            "csharp" | "c#" => Self::CSharp,
+            "ruby" => Self::Ruby,
+            "kotlin" => Self::Kotlin,
+            "hcl" | "terraform" => Self::Hcl,
+            "protobuf" => Self::Protobuf,
+            "dockerfile" | "docker" => Self::Dockerfile,
+            "markdown" => Self::Markdown,
+            "c++" => Self::Cpp,
+            "shell" => Self::Shell,
+            _ => Self::from_extension(s),
+        }
+    }
+
     /// Detect language from a file path by its extension.
     pub fn from_path(path: &Path) -> Self {
         // Handle extensionless files by filename.

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -165,6 +165,8 @@ fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     } else if target.is_dir() {
         let paths = collect_source_files(&target, global)?;
+        let glob_matcher = crate::build_glob_matcher_from_global(global)?;
+        let glob_roots = vec![target.clone()];
         crate::verbose!("ast list: scanning {} files in {}", paths.len(), args.path);
 
         struct ListFileResult {
@@ -172,15 +174,16 @@ fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             symbols: Vec<SymbolDef>,
         }
 
-        let results: Vec<ListFileResult> = crate::par_process_files(&paths, None, &[], |path| {
-            let lang = resolve_lang(lang_hint, path);
-            let symbols = symbols::extract_symbols_from_file(path, Some(lang));
-            if symbols.is_empty() {
-                return None;
-            }
-            let display = display_path(path, &cwd);
-            Some(ListFileResult { display, symbols })
-        });
+        let results: Vec<ListFileResult> =
+            crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
+                let lang = resolve_lang(lang_hint, path);
+                let symbols = symbols::extract_symbols_from_file(path, Some(lang));
+                if symbols.is_empty() {
+                    return None;
+                }
+                let display = display_path(path, &cwd);
+                Some(ListFileResult { display, symbols })
+            });
 
         for result in &results {
             let filtered = filter_symbols(&result.symbols, &kind_filter);
@@ -438,15 +441,18 @@ fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::Result<u8> 
         result: crate::ast::validate::ValidationResult,
     }
 
-    let results: Vec<ValidateFileResult> = crate::par_process_files(&paths, None, &[], |path| {
-        let lang = resolve_lang(lang_hint, path);
-        if !lang.has_grammar() {
-            return None;
-        }
-        let result = crate::ast::validate::validate_file(path, Some(lang)).ok()?;
-        let display = display_path(path, &cwd);
-        Some(ValidateFileResult { display, result })
-    });
+    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
+    let glob_roots = vec![cwd.join(&args.path)];
+    let results: Vec<ValidateFileResult> =
+        crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
+            let lang = resolve_lang(lang_hint, path);
+            if !lang.has_grammar() {
+                return None;
+            }
+            let result = crate::ast::validate::validate_file(path, Some(lang)).ok()?;
+            let display = display_path(path, &cwd);
+            Some(ValidateFileResult { display, result })
+        });
 
     for vr in &results {
         if !vr.result.valid {
@@ -520,21 +526,25 @@ fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         matches: Vec<crate::ast::search::SearchMatch>,
     }
 
-    let file_results: Vec<SearchFileResult> = crate::par_process_files(&paths, None, &[], |path| {
-        let lang = resolve_lang(lang_hint, path);
-        let query_str = if args.pattern {
-            crate::ast::search::compile_pattern_query(&args.query, lang).ok()?
-        } else {
-            args.query.clone()
-        };
-        let matches =
-            crate::ast::search::search_file(path, &query_str, Some(lang), args.max_results).ok()?;
-        if matches.is_empty() {
-            return None;
-        }
-        let display = display_path(path, &cwd);
-        Some(SearchFileResult { display, matches })
-    });
+    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
+    let glob_roots = vec![cwd.join(&args.path)];
+    let file_results: Vec<SearchFileResult> =
+        crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
+            let lang = resolve_lang(lang_hint, path);
+            let query_str = if args.pattern {
+                crate::ast::search::compile_pattern_query(&args.query, lang).ok()?
+            } else {
+                args.query.clone()
+            };
+            let matches =
+                crate::ast::search::search_file(path, &query_str, Some(lang), args.max_results)
+                    .ok()?;
+            if matches.is_empty() {
+                return None;
+            }
+            let display = display_path(path, &cwd);
+            Some(SearchFileResult { display, matches })
+        });
 
     'outer: for result in &file_results {
         for m in &result.matches {
@@ -602,8 +612,10 @@ fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!("ast refs: symbol={}, target={}", args.symbol, args.path);
     crate::verbose!("ast refs: scanning {} files", paths.len());
 
+    let glob_matcher = crate::build_glob_matcher_from_global(global)?;
+    let glob_roots = vec![cwd.join(&args.path)];
     let per_file_refs: Vec<Vec<crate::ast::refs::SymbolRef>> =
-        crate::par_process_files(&paths, None, &[], |path| {
+        crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let display = display_path(path, &cwd);
             let lang = lang_hint.map(lang_from_str);
             let refs = crate::ast::refs::find_refs_in_file(path, &args.symbol, lang, &display);
@@ -723,14 +735,17 @@ fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             imports: Vec<crate::ast::deps::Import>,
         }
 
-        let results: Vec<DepsFileResult> = crate::par_process_files(&paths, None, &[], |path| {
-            let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
-            if imports.is_empty() {
-                return None;
-            }
-            let display = display_path(path, &cwd);
-            Some(DepsFileResult { display, imports })
-        });
+        let glob_matcher = crate::build_glob_matcher_from_global(global)?;
+        let glob_roots = vec![cwd.join(&args.path)];
+        let results: Vec<DepsFileResult> =
+            crate::par_process_files(&paths, glob_matcher.as_ref(), &glob_roots, |path| {
+                let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
+                if imports.is_empty() {
+                    return None;
+                }
+                let display = display_path(path, &cwd);
+                Some(DepsFileResult { display, imports })
+            });
 
         for result in &results {
             any_output = true;
@@ -1077,23 +1092,7 @@ pub fn get_git_file_content(
 // ---------------------------------------------------------------------------
 
 pub fn lang_from_str(s: &str) -> Language {
-    // Try language name aliases first, then fall back to extension matching.
-    match s.to_lowercase().as_str() {
-        "rust" => Language::Rust,
-        "typescript" => Language::TypeScript,
-        "javascript" => Language::JavaScript,
-        "python" => Language::Python,
-        "golang" => Language::Go,
-        "java" => Language::Java,
-        "csharp" | "c#" => Language::CSharp,
-        "ruby" => Language::Ruby,
-        "kotlin" => Language::Kotlin,
-        "hcl" | "terraform" => Language::Hcl,
-        "protobuf" | "proto" => Language::Protobuf,
-        "dockerfile" | "docker" => Language::Dockerfile,
-        "markdown" => Language::Markdown,
-        _ => Language::from_extension(s),
-    }
+    Language::from_name_or_ext(s)
 }
 
 pub use symbols::{filter_symbols, parse_kind_filter};

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -64,6 +64,7 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // canonicalize() treats case differences as identical. Allow the rename
     // when only the case differs so users can change filename casing (#1167).
     let is_case_only_change = src != dst
+        && src.parent() == dst.parent()
         && src.file_name().map(|n| n.to_ascii_lowercase())
             == dst.file_name().map(|n| n.to_ascii_lowercase());
     if !is_case_only_change

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -485,8 +485,12 @@ pub fn upsert_bullet_in(content: &str, heading: &str, bullet: &str) -> Option<St
         // Only dedup against top-level bullets (no leading whitespace).
         // Indented sub-bullets (e.g. "  - deploy") should not block
         // insertion of a top-level bullet with the same text (#1157).
+        // Only compare against actual bullet lines, not plain paragraphs
+        // that happen to match the bullet text (#1173).
         let trimmed = line.trim_start();
-        if trimmed.len() == line.len() {
+        if trimmed.len() == line.len()
+            && (trimmed.starts_with("- ") || trimmed.starts_with("* ") || trimmed.starts_with("+ "))
+        {
             let existing_text = strip_bullet_prefix(trimmed);
             if existing_text == new_text {
                 return Some(content.to_string());
@@ -629,6 +633,26 @@ pub fn table_append_in(
     }
 
     let insert_pos = last_data_end?;
+
+    // Validate that the new row has the same column count as the existing
+    // table to prevent silent corruption of markdown tables (#1172).
+    let expected_cols = {
+        let section = &content[body_start..body_end];
+        section
+            .lines()
+            .find(|l| is_separator_row(l))
+            .map(|sep| sep.trim().matches('|').count().saturating_sub(1))
+    };
+    if let Some(expected) = expected_cols {
+        let actual = if is_table_row(row) {
+            row.trim().matches('|').count().saturating_sub(1)
+        } else {
+            0
+        };
+        if actual != expected {
+            return None;
+        }
+    }
 
     let mut out = String::with_capacity(content.len() + row.len() + 2);
     out.push_str(&content[..insert_pos]);

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1401,4 +1401,42 @@ body text
         let body = &content[start..end];
         assert_eq!(body, "Some text\n");
     }
+
+    #[test]
+    fn table_append_wrong_column_count_returns_none() {
+        let content = "# T\n| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |\n";
+        let (start, end) = find_section(content, "T").unwrap();
+        // Row with only 1 column should be rejected.
+        assert!(table_append_in(content, start, end, "| x |").is_none());
+    }
+
+    #[test]
+    fn table_append_correct_column_count_succeeds() {
+        let content = "# T\n| A | B |\n|---|---|\n| 1 | 2 |\n";
+        let (start, end) = find_section(content, "T").unwrap();
+        let result = table_append_in(content, start, end, "| 3 | 4 |");
+        assert!(result.is_some());
+        assert!(result.unwrap().contains("| 3 | 4 |"));
+    }
+
+    #[test]
+    fn upsert_bullet_does_not_dedup_against_paragraph() {
+        let content = "# Rules\nRun make check\n";
+        let result = upsert_bullet_in(content, "Rules", "- Run make check");
+        assert!(result.is_some());
+        let out = result.unwrap();
+        assert!(
+            out.contains("- Run make check"),
+            "bullet should be inserted"
+        );
+    }
+
+    #[test]
+    fn upsert_bullet_still_dedups_against_actual_bullet() {
+        let content = "# Rules\n- Run make check\n";
+        let result = upsert_bullet_in(content, "Rules", "- Run make check");
+        assert!(result.is_some());
+        // Should return unchanged content (dedup).
+        assert_eq!(result.unwrap(), content);
+    }
 }

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -518,6 +518,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // If source and destination resolve to the same file, no-op.
             // Allow case-only renames on case-insensitive filesystems (#1167).
             let case_only = src_path != dst_path
+                && src_path.parent() == dst_path.parent()
                 && src_path.file_name().map(|n| n.to_ascii_lowercase())
                     == dst_path.file_name().map(|n| n.to_ascii_lowercase());
             if !case_only
@@ -835,7 +836,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let content = read_file_content(tx.pending, tx.existed_before, &abs)?;
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
             let result =
                 crate::ast::rename::rename_in_source(content, old_name, new_name, lang_val);
@@ -887,7 +888,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let content = read_file_content(tx.pending, tx.existed_before, &abs)?;
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
             let result = crate::ast::replace::replace_in_symbol(
                 content, symbol, from, to, *regex, lang_val,
@@ -927,7 +928,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
             let pos = match position.as_deref() {
                 Some("start") => crate::ast::insert::InsertPosition::Start,
@@ -965,7 +966,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
             let result = crate::ast::wrap::wrap_code(
                 file_content,
@@ -998,7 +999,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                 read_file_content(tx.pending, tx.existed_before, &abs)?.to_string();
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
             let mut total_changes = 0usize;
 
@@ -1041,7 +1042,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
             let strategy = crate::ast::reorder::parse_strategy(order)?;
             let result = crate::ast::reorder::reorder_symbols(
@@ -1075,7 +1076,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let file_content = read_file_content(tx.pending, tx.existed_before, &abs)?;
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
             let pos = match position.as_deref() {
                 Some("end") => crate::ast::group::GroupPosition::End,
@@ -1126,7 +1127,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             };
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
             let pos = crate::ast::move_symbols::parse_position(position.as_deref());
             let result = crate::ast::move_symbols::move_symbols(
@@ -1175,7 +1176,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let source_content = read_file_content(tx.pending, tx.existed_before, &abs_source)?;
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
             let do_unwrap = unwrap.unwrap_or(true);
             let result = crate::ast::extract::extract_to_file(
@@ -1217,7 +1218,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let source_content = read_file_content(tx.pending, tx.existed_before, &abs_source)?;
             let lang_val = lang
                 .as_deref()
-                .map(crate::ast::Language::from_extension)
+                .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
             let split_targets: Vec<crate::ast::split::SplitTarget> = targets
                 .iter()

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -400,3 +400,32 @@ fn test_ast_list_unsupported_file_reports_language() {
         .stderr(predicates::str::contains("Unsupported language"))
         .stderr(predicates::str::contains("Rust"));
 }
+
+/// `--glob` flag should filter files in AST directory scanning (#1171).
+#[test]
+fn test_ast_list_respects_glob_flag() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn foo() {}\n").unwrap();
+    fs::write(dir.path().join("main.py"), "def bar(): pass\n").unwrap();
+
+    // Without glob: both files should produce output.
+    let out_all = patchloom_in(dir.path())
+        .args(["ast", "list", "."])
+        .output()
+        .unwrap();
+    let stdout_all = String::from_utf8_lossy(&out_all.stdout);
+    assert!(stdout_all.contains("foo"), "should list foo from lib.rs");
+    assert!(stdout_all.contains("bar"), "should list bar from main.py");
+
+    // With glob *.rs: only Rust file should produce output.
+    let out_rs = patchloom_in(dir.path())
+        .args(["ast", "list", ".", "--glob", "*.rs"])
+        .output()
+        .unwrap();
+    let stdout_rs = String::from_utf8_lossy(&out_rs.stdout);
+    assert!(stdout_rs.contains("foo"), "should list foo from lib.rs");
+    assert!(
+        !stdout_rs.contains("bar"),
+        "should NOT list bar from main.py"
+    );
+}

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -901,5 +901,71 @@ fn test_md_check_json_produces_structured_output() {
 }
 
 // ---------------------------------------------------------------------------
+// table-append column count validation (#1172)
+// ---------------------------------------------------------------------------
+
+/// Table append with wrong column count should fail (#1172).
+#[test]
+fn test_md_table_append_wrong_column_count_fails() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.md");
+    fs::write(
+        &file,
+        "# API\n| Name | Value | Status |\n|------|-------|--------|\n| a | 1 | ok |\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "md",
+            "table-append",
+            file.to_str().unwrap(),
+            "--heading",
+            "API",
+            "--row",
+            "| b |",
+            "--apply",
+        ])
+        .assert()
+        .code(1);
+
+    // File should be unchanged.
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        !content.contains("| b |"),
+        "wrong-column row should NOT be appended"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// upsert-bullet dedup only against actual bullets (#1173)
+// ---------------------------------------------------------------------------
+
+/// Paragraph text matching bullet content should not prevent insertion (#1173).
+#[test]
+fn test_md_upsert_bullet_does_not_dedup_against_paragraphs() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("rules.md");
+    fs::write(&file, "# Rules\nRun make check\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["md", "upsert-bullet"])
+        .arg(file.to_str().unwrap())
+        .args(["--heading", "Rules", "--bullet"])
+        .arg("* Run make check")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("* Run make check"),
+        "bullet should be inserted even when paragraph has same text"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // doc --check produces stdout output (#544)
 // ---------------------------------------------------------------------------

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -705,3 +705,33 @@ fn test_rename_case_only_change() {
         entries[0]
     );
 }
+
+/// Cross-directory rename with case-similar filenames must NOT bypass
+/// the destination-exists check (#1169).
+#[test]
+fn test_rename_cross_dir_case_similar_requires_force() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join("src")).unwrap();
+    fs::create_dir(dir.path().join("lib")).unwrap();
+    fs::write(dir.path().join("src/Foo.txt"), "A\n").unwrap();
+    fs::write(dir.path().join("lib/foo.txt"), "B\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["rename", "--apply"])
+        .arg(dir.path().join("src/Foo.txt").to_str().unwrap())
+        .arg(dir.path().join("lib/foo.txt").to_str().unwrap())
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("destination already exists"));
+
+    // Original files untouched.
+    assert_eq!(
+        fs::read_to_string(dir.path().join("src/Foo.txt")).unwrap(),
+        "A\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("lib/foo.txt")).unwrap(),
+        "B\n"
+    );
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -6930,3 +6930,40 @@ fn test_tx_global_format_failure_includes_undo_hint() {
         "error should mention `patchloom undo` for recovery: {stderr}"
     );
 }
+
+/// TX engine should resolve lang hint via lang_from_str (language names),
+/// not just from_extension (#1170).
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_list_with_lang_name_hint() {
+    let dir = TempDir::new().unwrap();
+    // File with non-standard extension but valid Rust code.
+    let file = dir.path().join("code.txt");
+    fs::write(&file, "fn hello() { let x = 1; }\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": "1",
+        "operations": [{
+            "op": "ast.rename",
+            "path": portable_path_str(&file),
+            "old_name": "hello",
+            "new_name": "world",
+            "lang": "rust"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("world"),
+        "lang hint 'rust' should work via lang_from_str: {content}"
+    );
+}


### PR DESCRIPTION
## Summary

Five bugs found and fixed via LLM-driven audit (round 7).

## Fixes

| Issue | Bug | Fix |
|-------|-----|-----|
| #1169 | Case-only rename check ignores parent directory | Add parent directory equality check so cross-directory renames with case-similar filenames still require --force |
| #1170 | TX engine uses from_extension instead of language name resolution for --lang | Add Language::from_name_or_ext() that tries language names before extensions; use in all 10 AST tx handlers |
| #1171 | AST directory-scanning commands ignore --glob flag | Build and pass glob matcher in all 5 AST directory commands (list, validate, search, refs, deps) |
| #1172 | md table-append accepts wrong column count silently | Validate new row column count against separator row before appending |
| #1173 | md upsert-bullet false-positive dedup against non-bullet lines | Only compare against lines that start with bullet prefixes (-, *, +) |

## Testing

- All 1836 unit tests pass
- All 832 integration tests pass (includes new tests for each fix)
- All 10 PTY tests pass
- Library hygiene tests pass (no-default-features, ast-only)
- `make check-fast` passes

Closes #1169
Closes #1170
Closes #1171
Closes #1172
Closes #1173