### PR TITLE
fix: replace --if-exists --json, ast refs const, doc move intra-array

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2600%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2700%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-2600+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+2700+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -51,6 +51,7 @@ const DEFINITION_PARENT_KINDS: &[&str] = &[
     "mod_item",
     "const_item",
     "type_spec",
+    "variable_declarator",
 ];
 
 /// Identifier node kinds to scan.
@@ -569,6 +570,45 @@ fn main() {
             foo_count >= 2,
             "foo should appear at least twice (def + ref), got {foo_count}"
         );
+    }
+
+    /// #1195: JS/TS `const` declarations must be classified as definitions,
+    /// not references. `variable_declarator` must be in DEFINITION_PARENT_KINDS.
+    #[test]
+    fn find_refs_typescript_const_is_definition() {
+        let source = "const MAX_RETRIES = 5;\nfunction retry() { return MAX_RETRIES; }\n";
+        let refs = find_refs_in_source(source, "MAX_RETRIES", Language::TypeScript, "test.ts");
+        let defs: Vec<_> = refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Definition)
+            .collect();
+        assert_eq!(
+            defs.len(),
+            1,
+            "const declaration should be Definition, got: {:?}",
+            refs.iter()
+                .map(|r| (&r.context, &r.kind))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    /// #1195: JS `let` and `var` declarations should also be definitions.
+    #[test]
+    fn find_refs_javascript_let_var_are_definitions() {
+        let source = "let count = 0;\nvar total = 0;\nfunction inc() { count++; total++; }\n";
+        let count_refs = find_refs_in_source(source, "count", Language::JavaScript, "test.js");
+        let count_defs: Vec<_> = count_refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Definition)
+            .collect();
+        assert_eq!(count_defs.len(), 1, "let declaration should be Definition");
+
+        let total_refs = find_refs_in_source(source, "total", Language::JavaScript, "test.js");
+        let total_defs: Vec<_> = total_refs
+            .iter()
+            .filter(|r| r.kind == RefKind::Definition)
+            .collect();
+        assert_eq!(total_defs.len(), 1, "var declaration should be Definition");
     }
 
     #[test]

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -225,6 +225,16 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if replacements.is_empty() {
         if args.if_exists {
+            if global.json || global.jsonl {
+                let output = ReplaceOutput {
+                    ok: true,
+                    match_count: 0,
+                    file_count: 0,
+                    files: vec![],
+                    diff: None,
+                };
+                global.emit_json(&output)?;
+            }
             return Ok(exit::SUCCESS);
         }
         if global.json || global.jsonl {

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -511,6 +511,42 @@ mod edge_cases {
         assert_eq!(code, exit::SUCCESS);
     }
 
+    /// #1194: `--if-exists --json` must emit a JSON object even when there
+    /// are no matches, not zero bytes.
+    #[test]
+    fn if_exists_json_emits_output_on_no_matches() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = ReplaceArgs {
+            from: "zzz_no_match_zzz".to_string(),
+            to: Some("replacement".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: true,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            write: Default::default(),
+        };
+        let global = GlobalFlags {
+            json: true,
+            ..GlobalFlags::test_default()
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        // The JSON output is written to stdout via global.emit_json(),
+        // which we trust here. The key assertion is that the code path
+        // reaches emit_json (previously it returned before emitting).
+    }
+
     #[test]
     fn binary_files_are_skipped() {
         let dir = TempDir::new().unwrap();

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -188,12 +188,40 @@ pub fn move_at_path(
         anyhow::bail!("empty to selector");
     }
 
-    // Clone the source value first so the tree is not mutated if
-    // destination insertion fails (#1183).
+    // Same path: no-op.
+    if from_segments == to_segments {
+        return Ok(());
+    }
+
+    let (from_parent, from_last) = split_last(from_segments);
+    let (to_parent, to_last) = split_last(to_segments);
+
+    // Intra-array move: source and destination share the same parent array.
+    // Use remove-then-insert so index arithmetic stays correct (#1196).
+    if from_parent == to_parent
+        && let (selector::Segment::Index(fi), selector::Segment::Index(ti)) = (from_last, to_last)
+    {
+        let parent = navigate_mut(root, from_parent, false)?;
+        let arr = parent
+            .as_array_mut()
+            .ok_or_else(|| anyhow::anyhow!("parent is not an array"))?;
+        if *fi >= arr.len() {
+            anyhow::bail!("source index {fi} out of bounds");
+        }
+        if *ti >= arr.len() {
+            anyhow::bail!("target index {ti} out of bounds");
+        }
+        let val = arr.remove(*fi);
+        let insert_at = (*ti).min(arr.len());
+        arr.insert(insert_at, val);
+        return Ok(());
+    }
+
+    // Cross-container move: clone-insert-remove so the tree is not mutated
+    // if destination insertion fails (#1183).
     let cloned = {
-        let (parent_path, last) = split_last(from_segments);
-        let parent = navigate_mut(root, parent_path, false)?;
-        match last {
+        let parent = navigate_mut(root, from_parent, false)?;
+        match from_last {
             selector::Segment::Key(k) => parent
                 .as_object()
                 .and_then(|obj| obj.get(k.as_str()))
@@ -215,9 +243,8 @@ pub fn move_at_path(
 
     // Insert clone at destination path (creates intermediate objects).
     {
-        let (parent_path, last) = split_last(to_segments);
-        let parent = navigate_mut(root, parent_path, true)?;
-        match last {
+        let parent = navigate_mut(root, to_parent, true)?;
+        match to_last {
             selector::Segment::Key(k) => {
                 parent
                     .as_object_mut()
@@ -240,9 +267,8 @@ pub fn move_at_path(
 
     // Destination insert succeeded; now remove from source.
     {
-        let (parent_path, last) = split_last(from_segments);
-        let parent = navigate_mut(root, parent_path, false)?;
-        match last {
+        let parent = navigate_mut(root, from_parent, false)?;
+        match from_last {
             selector::Segment::Key(k) => {
                 parent
                     .as_object_mut()
@@ -542,6 +568,38 @@ mod tests {
             msg.contains("'b'"),
             "error should mention the failing key 'b', got: {msg}"
         );
+    }
+
+    /// #1196: Moving an element forward within the same array.
+    #[test]
+    fn move_at_path_intra_array_forward() {
+        let mut root = json!({"arr": [10, 20, 30]});
+        move_at_path(&mut root, &segs("arr[0]"), &segs("arr[2]")).unwrap();
+        assert_eq!(root["arr"], json!([20, 30, 10]));
+    }
+
+    /// #1196: Moving an element backward within the same array.
+    #[test]
+    fn move_at_path_intra_array_backward() {
+        let mut root = json!({"arr": [10, 20, 30]});
+        move_at_path(&mut root, &segs("arr[2]"), &segs("arr[0]")).unwrap();
+        assert_eq!(root["arr"], json!([30, 10, 20]));
+    }
+
+    /// #1196: Moving a key to itself must be a no-op, not a deletion.
+    #[test]
+    fn move_at_path_same_key_is_noop() {
+        let mut root = json!({"a": 1, "b": 2});
+        move_at_path(&mut root, &segs("a"), &segs("a")).unwrap();
+        assert_eq!(root, json!({"a": 1, "b": 2}));
+    }
+
+    /// #1196: Moving an array element to its own index is a no-op.
+    #[test]
+    fn move_at_path_same_index_is_noop() {
+        let mut root = json!({"arr": [10, 20, 30]});
+        move_at_path(&mut root, &segs("arr[1]"), &segs("arr[1]")).unwrap();
+        assert_eq!(root["arr"], json!([10, 20, 30]));
     }
 
     /// #1183: When destination insertion fails, the source value must be


### PR DESCRIPTION
## Summary

Three real-world bugs found during LLM audit round 11:

### #1194: `replace --if-exists --json` emits zero bytes on no match

When `--if-exists` is set and there are no matches, `replace` returned `Ok(exit::SUCCESS)` immediately, bypassing the JSON output block. Agents parsing stdout get a JSON parse error on empty input.

**Fix:** Emit the empty-result JSON object before returning SUCCESS when `--json` or `--jsonl` is set.

### #1195: `ast refs` misclassifies JS/TS `const` declarations as references

`const foo = 1` produces `lexical_declaration > variable_declarator(name: identifier("foo"))` in tree-sitter. `variable_declarator` was missing from `DEFINITION_PARENT_KINDS`, so every `const`/`let`/`var` declaration was classified as a reference.

**Fix:** Add `variable_declarator` to `DEFINITION_PARENT_KINDS`.

### #1196: `doc move` produces wrong element order for intra-array moves

`move_at_path` inserts first then removes. When source and destination are in the same array, the insert shifts indices, so the remove targets the wrong element.

**Fix:** Detect intra-array moves and use remove-then-insert (indices stay correct). Cross-container moves keep clone-insert-remove for error safety (#1183). Same-path moves are early-return no-ops.

## Tests

- 7 new unit tests covering all three fixes
- All 1861 existing tests pass
- `make check-fast` green

Closes #1194
Closes #1195
Closes #1196