### PR TITLE
fix: md --check JSON now reports actual has_changes value

### DIFF
--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -142,7 +142,7 @@ fn execute_md_op(
             ok: true,
             path: file_owned.clone(),
             has_changes: match phase {
-                WritePhase::Check => Some(true),
+                WritePhase::Check(changed) => Some(changed),
                 _ => None,
             },
             diff,
@@ -398,7 +398,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                             ok: true,
                             path: file_owned.clone(),
                             has_changes: match phase {
-                                WritePhase::Check => Some(true),
+                                WritePhase::Check(changed) => Some(changed),
                                 _ => None,
                             },
                             diff,

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -17,8 +17,9 @@ use serde::Serialize;
 /// it to its own `applied` field semantics.
 #[derive(Debug, Clone, Copy)]
 pub enum WritePhase {
-    /// `--check`: no write performed.
-    Check,
+    /// `--check`: no write performed. The `bool` indicates whether changes
+    /// were detected (true = content would change on apply).
+    Check(bool),
     /// `--apply`: write was performed.
     Applied,
     /// `--confirm` + JSON: conditionally applied (bool = whether user confirmed).
@@ -78,7 +79,7 @@ fn execute_via_engine_inner<T: Serialize>(
 
     // --check mode: report what would happen, no mutation.
     if global.check {
-        let output = make_output(WritePhase::Check, None);
+        let output = make_output(WritePhase::Check(result.has_changes), None);
         if !global.emit_json(&output)? && !global.quiet {
             println!("{check_msg}");
         }

--- a/src/cmd/write_dispatch.rs
+++ b/src/cmd/write_dispatch.rs
@@ -39,7 +39,7 @@ pub fn execute_write<T: Serialize>(
 ) -> anyhow::Result<u8> {
     // --check mode: report what would happen, no mutation.
     if global.check {
-        let output = make_output(WritePhase::Check, None);
+        let output = make_output(WritePhase::Check(true), None);
         if !global.emit_json(&output)? && !global.quiet {
             println!("{}", msgs.check);
         }
@@ -122,7 +122,7 @@ mod tests {
 
     fn make_test_output(phase: WritePhase, diff: Option<String>) -> TestOutput {
         let phase_str = match phase {
-            WritePhase::Check => "check".to_string(),
+            WritePhase::Check(_) => "check".to_string(),
             WritePhase::Applied => "applied".to_string(),
             WritePhase::Confirmed(b) => format!("confirmed({b})"),
             WritePhase::Preview => "preview".to_string(),


### PR DESCRIPTION
## Summary

The `has_changes` field in JSON output from md operations in `--check` mode was hardcoded to `true`. MCP agents reading the JSON saw `has_changes: true` even when the operation was a no-op (e.g., upserting a bullet that already exists).

## Root Cause

`WritePhase::Check` was a unit variant with no data. The md output closures matched it with `WritePhase::Check => Some(true)`, always reporting changes. The exit code was already correct (0 for no changes, 2 for changes) because it used `result.has_changes` from the tx engine.

## Fix

`WritePhase::Check` now carries a `bool` (`WritePhase::Check(bool)`) indicating whether changes were detected. The md output closures extract this value instead of hardcoding `true`.

## Testing

- Before fix: `md upsert-bullet --check --json` on existing bullet: `has_changes: true`, EXIT=0
- After fix: `md upsert-bullet --check --json` on existing bullet: `has_changes: false`, EXIT=0
- New bullet: `has_changes: true`, EXIT=2 (correct in both cases)
- `make check-fast` passes (832 unit tests, all feature combos)

Found by running patchloom against md upsert-bullet scenarios in the /fixrealloop runtime bug hunt (Round 12).