### PR TITLE
fix: doc operations no longer reformat unchanged JSON files

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1139,10 +1139,10 @@ fn concurrent_edits_to_different_files() {
     let dir = TempDir::new().unwrap();
     let num_threads = 8;
 
-    // Create files for each thread.
+    // Create files for each thread (start at 1 so i*100 always differs).
     for i in 0..num_threads {
         let file = dir.path().join(format!("file_{i}.json"));
-        fs::write(&file, format!(r#"{{"value": {i}}}"#)).unwrap();
+        fs::write(&file, format!(r#"{{"value": {}}}"#, i + 1)).unwrap();
     }
 
     // Edit all files concurrently.
@@ -1154,7 +1154,7 @@ fn concurrent_edits_to_different_files() {
                 let result = doc_set(
                     &file,
                     "value",
-                    serde_json::json!(i * 100),
+                    serde_json::json!(i * 100 + 999),
                     ApplyMode::Apply,
                     None,
                 )
@@ -1170,7 +1170,7 @@ fn concurrent_edits_to_different_files() {
         let file = dir.path().join(format!("file_{i}.json"));
         let content = fs::read_to_string(&file).unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-        assert_eq!(parsed["value"], serde_json::json!(i * 100));
+        assert_eq!(parsed["value"], serde_json::json!(i * 100 + 999));
     }
 }
 

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -93,8 +93,15 @@ pub fn serialize_value_preserving(
                 Ok(preserve::hoist_comments(original_content, &body))
             }
         }
-        // JSON has no comments.
-        _ => serialize_value(new_value, format),
+        // JSON has no comments; return the original text when unchanged
+        // to avoid spurious formatting diffs (e.g. array compaction changes).
+        _ => {
+            if old_value == new_value {
+                Ok(original_content.to_string())
+            } else {
+                serialize_value(new_value, format)
+            }
+        }
     }
 }
 

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -192,10 +192,7 @@ pub(crate) fn get_doc_root<'a>(
         let content = read_file_content(pending, existed_before, &file_path)?;
         let format = detect_format(path).map_err(path_err(path))?;
         let root = parse_doc(content, &format).map_err(path_err(path))?;
-        let old_value = match format {
-            FileFormat::Json => serde_json::Value::Null,
-            _ => root.clone(),
-        };
+        let old_value = root.clone();
         let original_text = content.to_owned();
         doc_cache.insert(
             file_path.clone(),


### PR DESCRIPTION
When a doc operation (ensure, set, delete, etc.) leaves a JSON file's
semantic value unchanged, the file now retains its original formatting.
Previously, the re-serialization always reformatted the entire document
(e.g. expanding inline arrays to multi-line), producing format-only
diffs even though no values changed.

**Root cause:** the tx engine stored `Value::Null` as `old_value` for
JSON format in the doc cache, so `serialize_value_preserving` could not
detect no-change. The fix stores the actual pre-mutation value (same as
YAML/TOML) and adds an early-return in the JSON serialization path when
`old_value == new_value`.

**Changes:**
- Store `root.clone()` as `old_value` for all formats (not `Value::Null` for JSON)
- Add unchanged-value guard in `serialize_value_preserving` JSON branch
- Fix `concurrent_edits_to_different_files` test values to always differ

Found by running patchloom against real-world scenarios with `doc ensure`
on files that already had the target value.