### PR TITLE
fix: patch check reports stale files in human-readable mode, suppress false would-modify

### DIFF
--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -80,7 +80,7 @@ fn execute_via_engine_inner<T: Serialize>(
     // --check mode: report what would happen, no mutation.
     if global.check {
         let output = make_output(WritePhase::Check(result.has_changes), None);
-        if !global.emit_json(&output)? && !global.quiet {
+        if !global.emit_json(&output)? && !global.quiet && result.has_changes {
             println!("{check_msg}");
         }
         return if result.has_changes {
@@ -142,7 +142,7 @@ fn execute_via_engine_inner<T: Serialize>(
     if !global.emit_json(&output)? {
         if !diffs.is_empty() {
             print!("{}", render_diffs_colored(&diffs, global.should_color()));
-        } else if !global.quiet {
+        } else if result.has_changes && !global.quiet {
             println!("{check_msg}");
         }
     }

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -160,6 +160,25 @@ fn emit_patch_files_output(
         global.emit_json(&output)?;
     } else if global.jsonl {
         global.emit_json_items(results)?;
+    } else if !global.quiet {
+        for r in results {
+            let label = match r.status {
+                "clean" => "clean",
+                "stale" => "STALE",
+                "missing" => "MISSING",
+                "error" => "ERROR",
+                "conflict" => "CONFLICT",
+                "applied" => "applied",
+                other => other,
+            };
+            if let Some(err) = &r.error {
+                eprintln!("patch check: {} -- {}: {}", r.path, label, err);
+            } else if let Some(n) = r.conflicts {
+                eprintln!("patch check: {} -- {} ({} conflicts)", r.path, label, n);
+            } else if r.status != "clean" && r.status != "applied" {
+                eprintln!("patch check: {} -- {}", r.path, label);
+            }
+        }
     }
     Ok(())
 }

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -290,6 +290,31 @@ fn test_patch_check_exits_5_when_stale() {
 }
 
 #[test]
+fn test_patch_check_stale_human_readable_output() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
+
+    let patch_file = dir.path().join("stale.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("check")
+        .arg(&patch_file)
+        .assert()
+        .code(5)
+        .stderr(predicates::str::contains("STALE"));
+}
+
+#[test]
 fn test_patch_merge_check_exits_8_on_conflict() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
Two runtime bugs found by testing patchloom against diverse scenarios:

## Bug 1: patch check silent in human-readable mode

`patchloom patch check my.patch` produced NO output in non-JSON mode. Users got only an exit code with zero explanation of what happened. The `emit_patch_files_output()` function only emitted for JSON/JSONL, leaving the non-JSON path completely silent.

**Fix:** Added human-readable stderr output for stale, missing, error, and conflict results. Clean files stay silent (like `diff`).

**Before:**
```
$ patchloom patch check stale.patch
$ echo $?
5
```

**After:**
```
$ patchloom patch check stale.patch
patch check: target.txt -- STALE
$ echo $?
5
```

## Bug 2: false "would modify" for no-op doc operations

`doc ensure` and `doc set` printed "would modify" in preview and check modes even when the operation was a no-op (key already exists for ensure, value already matches for set).

**Root cause:** `execute_via_engine_inner()` printed `check_msg` unconditionally in both the check path and the preview path without checking `result.has_changes`.

**Fix:** Gate the `check_msg` output on `result.has_changes` in both code paths.

## Tests

- Added `test_patch_check_stale_human_readable_output` integration test verifying stderr contains "STALE"