### PR TITLE
fix: update stale API field names in bench script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ Or use a JSON plan with format and validate lifecycle:
 
 ```json
 {
-  "version": "1",
+  "version": 1,
   "operations": [
-    { "op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0" },
+    { "op": "doc.set", "path": "config.json", "key": "version", "value": "2.0" },
     { "op": "md.upsert_bullet", "path": "AGENTS.md", "heading": "Rules", "bullet": "- Always test" },
-    { "op": "replace", "path": "src/main.rs", "from": "v1", "to": "v2" }
+    { "op": "replace", "path": "src/main.rs", "old": "v1", "new": "v2" }
   ],
   "format": [{ "cmd": "cargo fmt --all" }],
   "validate": [{ "cmd": "cargo test", "required": true }]
@@ -255,7 +255,7 @@ After [installing with MCP support](#install), start the server:
 patchloom mcp-server
 ```
 
-MCP-capable agents call patchloom tools directly as structured JSON, with no shell quoting or command construction. The agent sends `{"path": "config.json", "selector": "version", "value": "2.0"}` instead of building `patchloom doc set config.json version '"2.0"' --apply`.
+MCP-capable agents call patchloom tools directly as structured JSON, with no shell quoting or command construction. The agent sends `{"path": "config.json", "key": "version", "value": "2.0"}` instead of building `patchloom doc set config.json version '"2.0"' --apply`.
 
 See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent configuration and the full security model.
 

--- a/benches/cli/run.sh
+++ b/benches/cli/run.sh
@@ -131,7 +131,7 @@ EOF
     hyperfine --warmup 1 --min-runs 5 \
         --prepare "cd $DIR && grep -rl 'v2.0.0' . 2>/dev/null | xargs -r sed -i 's/v2.0.0/v1.0.0/g' || true" \
         --export-markdown /dev/stdout \
-        -n "patchloom replace" "$PATCHLOOM replace v1.0.0 --to v2.0.0 $DIR --apply" \
+        -n "patchloom replace" "$PATCHLOOM replace v1.0.0 --new v2.0.0 $DIR --apply" \
         -n "find + sed" "find $DIR -type f -exec sed -i 's/v1.0.0/v2.0.0/g' {} +" \
         2>/dev/null | tee -a "$OUTFILE"
 
@@ -219,11 +219,11 @@ BATCHEOF
     TX_PLAN="$DIR/_tx_plan.json"
     cat > "$TX_PLAN" <<TXEOF
 {
-  "version": "1",
+  "version": 1,
   "operations": [
-    {"op": "doc.set", "path": "config.json", "selector": "version", "value": "v2.0.0"},
-    {"op": "doc.set", "path": "config.yaml", "selector": "app.version", "value": "v2.0.0"},
-    {"op": "replace", "path": "VERSION", "from": "v1.0.0", "to": "v2.0.0"},
+    {"op": "doc.set", "path": "config.json", "key": "version", "value": "v2.0.0"},
+    {"op": "doc.set", "path": "config.yaml", "key": "app.version", "value": "v2.0.0"},
+    {"op": "replace", "path": "VERSION", "old": "v1.0.0", "new": "v2.0.0"},
     {"op": "md.upsert_bullet", "path": "README.md", "heading": "Changelog", "bullet": "- v2.0.0 release"}
   ]
 }


### PR DESCRIPTION
After #1208 renamed `from`/`to` to `old`/`new`, `selector` to `key`, and `Plan.version` from String to u32, two files still used the old names.

**benches/cli/run.sh (#1215):**
- `--to` flag renamed to `--new` (line 134)
- `selector` field renamed to `key` in doc.set ops (lines 224-225)
- `from`/`to` renamed to `old`/`new` in replace op (line 226)
- `version` changed from string `"1"` to integer `1` (line 222)

**README.md (#1216):**
- tx plan JSON example: `selector` to `key`, `from`/`to` to `old`/`new`, version string to integer (lines 232-237)
- MCP inline example: `selector` to `key` (line 258)

`make check` passes locally (2721 tests).

Closes #1215
Closes #1216