### PR TITLE
fix: convention violations and stale doc comments from #1208 rename

### DIFF
--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -2337,12 +2337,10 @@ func (c *Cat) Speak() string { return \"meow\" }
 ";
         let syms = extract_symbols(source, Language::Go);
         // Qualified lookup should disambiguate
-        let dog_speak = find_symbol(&syms, "Dog::Speak")
-            .expect("Dog::Speak should be found");
+        let dog_speak = find_symbol(&syms, "Dog::Speak").expect("Dog::Speak should be found");
         assert!(dog_speak.signature.contains("Dog"));
 
-        let cat_speak = find_symbol(&syms, "Cat::Speak")
-            .expect("Cat::Speak should be found");
+        let cat_speak = find_symbol(&syms, "Cat::Speak").expect("Cat::Speak should be found");
         assert!(cat_speak.signature.contains("Cat"));
     }
 

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -2337,13 +2337,13 @@ func (c *Cat) Speak() string { return \"meow\" }
 ";
         let syms = extract_symbols(source, Language::Go);
         // Qualified lookup should disambiguate
-        let dog_speak = find_symbol(&syms, "Dog::Speak");
-        assert!(dog_speak.is_some(), "Dog::Speak should be found");
-        assert!(dog_speak.unwrap().signature.contains("Dog"));
+        let dog_speak = find_symbol(&syms, "Dog::Speak")
+            .expect("Dog::Speak should be found");
+        assert!(dog_speak.signature.contains("Dog"));
 
-        let cat_speak = find_symbol(&syms, "Cat::Speak");
-        assert!(cat_speak.is_some(), "Cat::Speak should be found");
-        assert!(cat_speak.unwrap().signature.contains("Cat"));
+        let cat_speak = find_symbol(&syms, "Cat::Speak")
+            .expect("Cat::Speak should be found");
+        assert!(cat_speak.signature.contains("Cat"));
     }
 
     #[test]

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -863,7 +863,7 @@ pub struct ReplaceArgs {
     #[arg(long = "new")]
     pub new_text: String,
 
-    /// Treat --from as a regex pattern.
+    /// Treat --old as a regex pattern.
     #[arg(long)]
     pub regex: bool,
 

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -515,20 +515,20 @@ mod doc_completeness {
         // Verify by parsing them (if parse_line accepts them, the
         // operation is implemented).
         let result = parse_line(r#"file.append test.txt "new content""#, 1);
-        assert!(result.is_ok(), "file.append should be a valid operation");
+        result.expect("file.append should be a valid operation");
 
         let result = parse_line(r#"file.prepend test.txt "new content""#, 1);
-        assert!(result.is_ok(), "file.prepend should be a valid operation");
+        result.expect("file.prepend should be a valid operation");
     }
 
     #[test]
     fn doc_comment_lists_ast_rename_and_replace() {
         // #1178: AST operations must be documented in the batch help text.
         let result = parse_line(r#"ast.rename test.rs old_fn new_fn"#, 1);
-        assert!(result.is_ok(), "ast.rename should be a valid operation");
+        result.expect("ast.rename should be a valid operation");
 
         let result = parse_line(r#"ast.replace test.rs my_fn "old" "new""#, 1);
-        assert!(result.is_ok(), "ast.replace should be a valid operation");
+        result.expect("ast.replace should be a valid operation");
     }
 }
 

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -135,8 +135,9 @@ impl PatchloomService {
                     .unwrap_or_default(),
             );
 
-            let input_schema: JsonObject = serde_json::from_value(schema)
-                .map_err(|e| anyhow::anyhow!("operation_variant_schema must produce a valid JSON object: {e}"))?;
+            let input_schema: JsonObject = serde_json::from_value(schema).map_err(|e| {
+                anyhow::anyhow!("operation_variant_schema must produce a valid JSON object: {e}")
+            })?;
 
             tool_router.add_route(ToolRoute::new_dyn(
                 Tool::new(meta.tool_name, meta.description, Arc::new(input_schema)),

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -136,7 +136,7 @@ impl PatchloomService {
             );
 
             let input_schema: JsonObject = serde_json::from_value(schema)
-                .expect("operation_variant_schema must produce a valid JSON object");
+                .map_err(|e| anyhow::anyhow!("operation_variant_schema must produce a valid JSON object: {e}"))?;
 
             tool_router.add_route(ToolRoute::new_dyn(
                 Tool::new(meta.tool_name, meta.description, Arc::new(input_schema)),

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -435,7 +435,7 @@ pub(crate) struct AstReplaceParams {
     /// Replacement text.
     #[serde(rename = "new")]
     pub new_text: String,
-    /// Treat --from as a regex pattern.
+    /// Treat `old` as a regex pattern.
     #[serde(default)]
     pub regex: bool,
     /// Language hint.

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -335,7 +335,7 @@ mod basic {
             allow_conflicts: false,
         }];
         let result = validate_operation_paths(&ops, dir.path());
-        assert!(result.is_ok(), "PatchApply with safe paths should pass");
+        result.expect("PatchApply with safe paths should pass");
     }
 
     #[tokio::test]

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -55,7 +55,7 @@ pub struct ReplaceArgs {
     pub case_insensitive: bool,
     // ref:replace-mode:whole-line
     /// Replace the entire line containing each match, not just the matched span.
-    /// Useful for deleting lines (--whole-line --to '') or replacing full lines.
+    /// Useful for deleting lines (--whole-line --new '') or replacing full lines.
     #[arg(long, short = 'L')]
     pub whole_line: bool,
     // ref:replace-mode:word-boundary

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1415,16 +1415,15 @@ body text
         let content = "# T\n| A | B |\n|---|---|\n| 1 | 2 |\n";
         let (start, end) = find_section(content, "T").unwrap();
         let result = table_append_in(content, start, end, "| 3 | 4 |");
-        assert!(result.is_some());
-        assert!(result.unwrap().contains("| 3 | 4 |"));
+        let out = result.expect("table_append_in should return Some");
+        assert!(out.contains("| 3 | 4 |"));
     }
 
     #[test]
     fn upsert_bullet_does_not_dedup_against_paragraph() {
         let content = "# Rules\nRun make check\n";
-        let result = upsert_bullet_in(content, "Rules", "- Run make check");
-        assert!(result.is_some());
-        let out = result.unwrap();
+        let out = upsert_bullet_in(content, "Rules", "- Run make check")
+            .expect("upsert_bullet_in should return Some for non-bullet paragraph");
         assert!(
             out.contains("- Run make check"),
             "bullet should be inserted"
@@ -1434,9 +1433,9 @@ body text
     #[test]
     fn upsert_bullet_still_dedups_against_actual_bullet() {
         let content = "# Rules\n- Run make check\n";
-        let result = upsert_bullet_in(content, "Rules", "- Run make check");
-        assert!(result.is_some());
+        let out = upsert_bullet_in(content, "Rules", "- Run make check")
+            .expect("upsert_bullet_in should return Some for dedup case");
         // Should return unchanged content (dedup).
-        assert_eq!(result.unwrap(), content);
+        assert_eq!(out, content);
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -512,12 +512,14 @@ pub fn operation_schemas() -> anyhow::Result<Vec<OperationSchema>> {
                 examples: meta
                     .examples
                     .iter()
-                    .map(|(desc, json)| OperationExample {
-                        description: (*desc).into(),
-                        args: serde_json::from_str(json)
-                            .unwrap_or_else(|e| panic!("bad example JSON for {}: {e}", meta.name)),
+                    .map(|(desc, json)| {
+                        Ok(OperationExample {
+                            description: (*desc).into(),
+                            args: serde_json::from_str(json)
+                                .with_context(|| format!("bad example JSON for {}", meta.name))?,
+                        })
                     })
-                    .collect(),
+                    .collect::<anyhow::Result<Vec<_>>>()?,
             })
         })
         .collect()


### PR DESCRIPTION
Multi-perspective improvement cycle fixes.

**Convention violations (QA + Developer perspectives):**
- `src/schema.rs`: `unwrap_or_else(|e| panic!(...))` in `operation_schemas()` which returns `anyhow::Result`. Replaced with `.with_context()?`.
- `src/cmd/mcp/mod.rs`: `expect()` in `PatchloomService::new()` which returns `anyhow::Result`. Replaced with `.map_err()?`.

**Stale doc comments from #1208 rename (End User perspective):**
- `src/cmd/replace.rs`: help text referenced `--to` (now `--new`)
- `src/cmd/ast.rs`: help text referenced `--from` (now `--old`)
- `src/cmd/mcp/params.rs`: help text referenced `--from` (now `old`)

`make check-fast` passes (2721 tests).