### PR TITLE
chore: upgrade rmcp from 1.8.0 to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
 dependencies = [
  "async-trait",
  "base64",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ anyhow = "1"
 anstream = { version = "1", optional = true }
 ec4rs = { version = "1", optional = true }
 clap_complete = { version = "4", optional = true }
-rmcp = { version = "1", features = ["server", "transport-io", "macros"], optional = true }
+rmcp = { version = "2", features = ["server", "transport-io", "macros"], optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "io-std", "macros"], optional = true }
 axum = { version = "0.8", features = ["http1", "tokio"], default-features = false, optional = true }
 axum-server = { version = "0.8", features = ["tls-rustls"], default-features = false, optional = true }
@@ -131,7 +131,7 @@ predicates = "3"
 proptest = "1"
 rcgen = "0.14"
 reqwest = { version = "0.13", features = ["rustls"], default-features = false }
-rmcp = { version = "1", features = ["client", "transport-io", "transport-child-process", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "2", features = ["client", "transport-io", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 tokio = { version = "1", features = ["full"] }
 
 [[bin]]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -3,7 +3,7 @@
 //! Each `pub(super)` function contains the logic for one AST MCP tool.
 //! The `#[tool]` stubs in `mod.rs` delegate directly to these functions.
 
-use rmcp::model::{CallToolResult, Content, ErrorData as McpError};
+use rmcp::model::{CallToolResult, ContentBlock, ErrorData as McpError};
 
 use crate::cli::global::GlobalFlags;
 use crate::exit;
@@ -82,7 +82,7 @@ pub(super) fn handle_ast_list(
     }
     let json = serde_json::to_string_pretty(&results)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_read(
@@ -124,7 +124,7 @@ pub(super) fn handle_ast_read(
     });
     let json = serde_json::to_string_pretty(&obj)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_rename(
@@ -223,7 +223,7 @@ pub(super) fn handle_ast_validate(
     }
     let json = serde_json::to_string_pretty(&results)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_search(
@@ -278,7 +278,7 @@ pub(super) fn handle_ast_search(
     }
     let json = serde_json::to_string_pretty(&all_matches)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_refs(
@@ -318,7 +318,7 @@ pub(super) fn handle_ast_refs(
     });
     let json = serde_json::to_string_pretty(&obj)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_deps(
@@ -401,7 +401,7 @@ pub(super) fn handle_ast_deps(
     }
     let json = serde_json::to_string_pretty(&results)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_map(
@@ -450,7 +450,7 @@ pub(super) fn handle_ast_map(
 
     let json = serde_json::to_string_pretty(&entries)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_diff(
@@ -492,7 +492,7 @@ pub(super) fn handle_ast_diff(
     });
     let json = serde_json::to_string_pretty(&obj)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_impact(
@@ -534,7 +534,7 @@ pub(super) fn handle_ast_impact(
     });
     let json = serde_json::to_string_pretty(&obj)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![Content::text(json)]))
+    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
 }
 
 pub(super) fn handle_ast_replace(
@@ -617,7 +617,7 @@ pub(super) fn handle_ast_imports(
         });
         let json = serde_json::to_string_pretty(&obj)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-        return Ok(CallToolResult::success(vec![Content::text(json)]));
+        return Ok(CallToolResult::success(vec![ContentBlock::text(json)]));
     }
 
     let op = crate::plan::Operation::AstImports {
@@ -728,17 +728,17 @@ pub(super) fn handle_ast_split(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rmcp::model::RawContent;
+    use rmcp::model::ContentBlock;
     use tempfile::TempDir;
 
     fn make_service(dir: &TempDir) -> PatchloomService {
         PatchloomService::new(dir.path().to_path_buf(), None).unwrap()
     }
 
-    /// Extract text from the first Content item in a CallToolResult.
+    /// Extract text from the first ContentBlock item in a CallToolResult.
     fn extract_text(result: &CallToolResult) -> String {
-        match &result.content[0].raw {
-            RawContent::Text(t) => t.text.clone(),
+        match &result.content[0] {
+            ContentBlock::Text(t) => t.text.clone(),
             other => panic!("expected text content, got {other:?}"),
         }
     }

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -6,7 +6,7 @@
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::model::{CallToolResult, Content, ErrorData as McpError};
+use rmcp::model::{CallToolResult, ContentBlock, ErrorData as McpError};
 use rmcp::{tool, tool_router};
 
 use crate::cli::global::GlobalFlags;
@@ -333,7 +333,7 @@ impl PatchloomService {
                         .collect::<Vec<_>>()
                         .join("\n")
                 );
-                tool_result.content.push(Content::text(warning_text));
+                tool_result.content.push(ContentBlock::text(warning_text));
             }
 
             Ok(tool_result)
@@ -394,7 +394,7 @@ impl PatchloomService {
             let issues = crate::ops::md::lint_agents_content(&content);
             let json = serde_json::to_string_pretty(&issues)
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            Ok(CallToolResult::success(vec![Content::text(json)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
         })
         .await
     }
@@ -849,7 +849,7 @@ impl PatchloomService {
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
             let json = serde_json::to_string_pretty(&status)
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-            Ok(CallToolResult::success(vec![Content::text(json)]))
+            Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
         })
         .await
     }

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -16,7 +16,7 @@
 
 use rmcp::handler::server::router::tool::{ToolRoute, ToolRouter};
 use rmcp::handler::server::tool::ToolCallContext;
-use rmcp::model::{CallToolResult, Content, ErrorData as McpError, JsonObject, Tool};
+use rmcp::model::{CallToolResult, ContentBlock, ErrorData as McpError, JsonObject, Tool};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -304,9 +304,9 @@ fn exit_code_to_result(code: u8, output: &str, fallback: &str) -> Result<CallToo
         output.trim().to_string()
     };
     if code == exit::SUCCESS {
-        Ok(CallToolResult::success(vec![Content::text(msg)]))
+        Ok(CallToolResult::success(vec![ContentBlock::text(msg)]))
     } else {
-        Ok(CallToolResult::error(vec![Content::text(msg)]))
+        Ok(CallToolResult::error(vec![ContentBlock::text(msg)]))
     }
 }
 

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -636,8 +636,8 @@ async fn call_tool_text(
     let text = result
         .content
         .first()
-        .and_then(|c| match &c.raw {
-            rmcp::model::RawContent::Text(t) => Some(t.text.clone()),
+        .and_then(|c| match c {
+            rmcp::model::ContentBlock::Text(t) => Some(t.text.clone()),
             _ => None,
         })
         .unwrap_or_default();

--- a/tests/integration/mcp_tests.rs
+++ b/tests/integration/mcp_tests.rs
@@ -195,8 +195,8 @@ async fn test_mcp_https_search_files_round_trip() {
     let text = result
         .content
         .first()
-        .and_then(|c| match &c.raw {
-            rmcp::model::RawContent::Text(t) => Some(t.text.clone()),
+        .and_then(|c| match c {
+            rmcp::model::ContentBlock::Text(t) => Some(t.text.clone()),
             _ => None,
         })
         .unwrap_or_default();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -6018,8 +6018,8 @@ async fn test_mcp_http_search_files_round_trip() {
     let text = result
         .content
         .first()
-        .and_then(|c| match &c.raw {
-            rmcp::model::RawContent::Text(t) => Some(t.text.clone()),
+        .and_then(|c| match c {
+            rmcp::model::ContentBlock::Text(t) => Some(t.text.clone()),
             _ => None,
         })
         .unwrap_or_default();


### PR DESCRIPTION
## Summary

Upgrade the `rmcp` MCP protocol SDK from 1.8.0 to 2.0.0, the only outdated dependency.

Closes #1220

## Changes

rmcp 2.0.0 aligns the crate with the MCP 2025-11-25 specification. The only breaking change affecting patchloom is the unified content model:

- `Content` is replaced by `ContentBlock` (same API surface: `ContentBlock::text(msg)`)
- `RawContent` is removed; `ContentBlock` variants are matched directly without a `.raw` field

### Files changed

| File | Change |
|------|--------|
| `Cargo.toml` | Bump rmcp version from 1 to 2 (both dep and dev-dep) |
| `src/cmd/mcp/mod.rs` | `Content` -> `ContentBlock` in imports and usage |
| `src/cmd/mcp/handlers.rs` | `Content` -> `ContentBlock` in imports and usage |
| `src/cmd/mcp/ast_tools.rs` | `Content` -> `ContentBlock`, `RawContent` -> `ContentBlock` in tests |
| `tests/integration/main.rs` | `RawContent::Text` -> `ContentBlock::Text` |
| `tests/integration/mcp_tests.rs` | `RawContent::Text` -> `ContentBlock::Text` |
| `tests/integration/tx_tests.rs` | `RawContent::Text` -> `ContentBlock::Text` |

## Verification

- `make check` passes (fmt, clippy, 2721 tests, integration, PTY, readme, patchloom.md)