### PR TITLE
fix: replace unreachable!() with bail!() and propagate schema errors

### DIFF
--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -56,19 +56,19 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         SchemaFormat::Json => {
             let ops_json: Vec<serde_json::Value> = if args.examples {
                 ops.iter()
-                    .map(|op| serde_json::to_value(op).unwrap_or_default())
-                    .collect()
+                    .map(serde_json::to_value)
+                    .collect::<serde_json::Result<Vec<_>>>()?
             } else {
                 // Strip examples from the output.
                 ops.iter()
                     .map(|op| {
-                        let mut v = serde_json::to_value(op).unwrap_or_default();
+                        let mut v = serde_json::to_value(op)?;
                         if let Some(obj) = v.as_object_mut() {
                             obj.remove("examples");
                         }
-                        v
+                        Ok(v)
                     })
-                    .collect()
+                    .collect::<serde_json::Result<Vec<_>>>()?
             };
             let envelope = serde_json::json!({
                 "version": schema::INTENT_FORMAT_VERSION,

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -280,7 +280,7 @@ pub fn move_at_path(
                     .ok_or_else(|| anyhow::anyhow!("source parent is not an array"))?;
                 arr.remove(*i);
             }
-            _ => unreachable!("already validated above"),
+            _ => anyhow::bail!("cannot remove from wildcard/predicate selector"),
         }
     }
 

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -578,7 +578,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             }
         }
 
-        _ => unreachable!("execute_file_op called with non-file operation"),
+        _ => anyhow::bail!("execute_file_op called with non-file operation"),
     }
     Ok(0)
 }

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -42,7 +42,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         ..
     } = op
     else {
-        unreachable!()
+        anyhow::bail!("execute_replace_op called with non-Replace operation")
     };
     let regex_mode = *regex_mode;
     let word_boundary = matches!(

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -48,7 +48,7 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
         custom_ignore_filenames,
     } = op
     else {
-        unreachable!()
+        anyhow::bail!("execute_search_op called with non-Search operation")
     };
 
     if *invert_match && *multiline {


### PR DESCRIPTION
Replace `unreachable!()` panics with `anyhow::bail!()` error returns in 4 `pub(crate)` tx engine functions, and replace `unwrap_or_default()` with `?` error propagation in the schema command.

## Changes

- **src/tx/execute.rs**: `execute_file_op` match arm
- **src/tx/replace_op.rs**: `execute_replace_op` let-else guard
- **src/tx/search_op.rs**: `execute_search_op` let-else guard
- **src/ops/doc/navigate.rs**: doc move match arm
- **src/cmd/schema.rs**: `serde_json::to_value().unwrap_or_default()` replaced with `?` propagation via `.collect::<serde_json::Result<Vec<_>>>()?`

## Why

- `unreachable!()` panics crash the MCP server process on internal dispatch errors. `bail!()` returns a proper error, enabling graceful recovery.
- `unwrap_or_default()` on serialization produces `Value::Null` entries in schema JSON output. Error propagation surfaces the actual issue.

All functions already return `anyhow::Result`, so these are mechanical replacements with no signature changes.