### PR TITLE
fix: MCP empty pattern, reverse deps precision, rollback logging, backup warning, Windows shell escape

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -257,8 +257,14 @@ pub fn list_sessions(project_root: &Path) -> anyhow::Result<Vec<Manifest>> {
         if manifest_path.exists() {
             let content = std::fs::read_to_string(&manifest_path)
                 .with_context(|| format!("reading {}", manifest_path.display()))?;
-            if let Ok(manifest) = serde_json::from_str::<Manifest>(&content) {
-                sessions.push(manifest);
+            match serde_json::from_str::<Manifest>(&content) {
+                Ok(manifest) => sessions.push(manifest),
+                Err(e) => {
+                    eprintln!(
+                        "warning: corrupted backup manifest {}: {e}",
+                        manifest_path.display()
+                    );
+                }
             }
         }
     }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -358,7 +358,18 @@ pub(super) fn handle_ast_deps(
                 let imports = crate::ast::deps::extract_imports_from_file(path, lang_hint);
                 let matching: Vec<_> = imports
                     .iter()
-                    .filter(|i| i.path.contains(target_name.as_str()))
+                    .filter(|i| {
+                        // Match as a complete path segment to avoid false positives
+                        // (e.g., "lib" should not match "stdlib" or "calibration").
+                        let p = &i.path;
+                        let t = target_name.as_str();
+                        p == t
+                            || p.ends_with(&format!("/{t}"))
+                            || p.ends_with(&format!("::{t}"))
+                            || p.ends_with(&format!("/{t}."))
+                            || p.contains(&format!("/{t}/"))
+                            || p.contains(&format!("::{t}::"))
+                    })
                     .collect();
                 if matching.is_empty() {
                     return None;

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -158,6 +158,9 @@ impl PatchloomService {
                     None,
                 ));
             }
+            if p.pattern.is_empty() {
+                return Err(McpError::invalid_params("pattern must not be empty", None));
+            }
             validate_param_size("pattern", &p.pattern)?;
             for path in &p.paths {
                 svc.check_path(path)?;

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -237,7 +237,12 @@ pub(crate) fn rollback_strict(
         if !existed_before.contains(path) {
             // File was created during this tx. Whether it was also deleted
             // does not matter: it should not exist after rollback.
-            let _ = std::fs::remove_file(path);
+            if let Err(e) = std::fs::remove_file(path) {
+                eprintln!(
+                    "tx: rollback: failed to remove created file {}: {e}",
+                    path.display()
+                );
+            }
         } else if !deletions.contains(path) {
             // File existed before and was modified (not deleted): restore.
             if let Err(e) = atomic_write(path, original, &noop_policy) {

--- a/src/write.rs
+++ b/src/write.rs
@@ -864,17 +864,34 @@ pub fn run_format_command_ext(
 }
 
 /// Shell-escape a file path for safe inclusion in a command string.
+///
+/// - **Unix** (`sh -c`): wraps in single quotes, escaping embedded `'`.
+/// - **Windows** (`cmd /C`): wraps in double quotes, doubling embedded `"`.
 #[cfg(feature = "cli")]
 fn shell_escape(path: &str) -> String {
-    // If the path contains no special characters, return as-is
-    if path
-        .bytes()
-        .all(|b| b.is_ascii_alphanumeric() || b == b'/' || b == b'.' || b == b'_' || b == b'-')
-    {
+    // If the path contains no special characters, return as-is.
+    // On Windows, backslash is a path separator, so treat it as safe.
+    if path.bytes().all(|b| {
+        b.is_ascii_alphanumeric()
+            || b == b'/'
+            || b == b'.'
+            || b == b'_'
+            || b == b'-'
+            || (cfg!(windows) && b == b'\\')
+    }) {
         return path.to_string();
     }
-    // Otherwise, wrap in single quotes (escaping any embedded single quotes)
-    format!("'{}'", path.replace('\'', "'\\''"))
+
+    #[cfg(windows)]
+    {
+        // cmd.exe uses double quotes; escape embedded double quotes by doubling.
+        format!("\"{}\"", path.replace('"', "\"\""))
+    }
+    #[cfg(not(windows))]
+    {
+        // POSIX sh uses single quotes; escape embedded single quotes.
+        format!("'{}'", path.replace('\'', "'\\''"))
+    }
 }
 
 #[path = "write_tests.rs"]

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -884,17 +884,33 @@ mod shell_escape_tests {
 
     #[test]
     fn path_with_spaces_is_quoted() {
+        #[cfg(not(windows))]
         assert_eq!(shell_escape("src/my file.rs"), "'src/my file.rs'");
+        #[cfg(windows)]
+        assert_eq!(shell_escape("src/my file.rs"), "\"src/my file.rs\"");
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn path_with_single_quote_is_escaped() {
         assert_eq!(shell_escape("it's a file.rs"), "'it'\\''s a file.rs'");
     }
 
     #[test]
+    #[cfg(windows)]
+    fn path_with_double_quote_is_escaped() {
+        assert_eq!(shell_escape("a\"b.rs"), "\"a\"\"b.rs\"");
+    }
+
+    #[test]
     fn dots_underscores_hyphens_slashes_safe() {
         assert_eq!(shell_escape("a-b_c.d/e"), "a-b_c.d/e");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn backslash_path_separator_is_safe() {
+        assert_eq!(shell_escape("src\\main.rs"), "src\\main.rs");
     }
 }
 


### PR DESCRIPTION
Fixes from fixloop Round 2 audit.

## Changes

1. **MCP search_files: reject empty patterns** (`src/cmd/mcp/handlers.rs`)
   CLI `search` already rejects empty patterns with a clear error. The MCP `search_files` handler bypassed this check, allowing an empty pattern to match every byte position in every file (unbounded output).

2. **ast_deps reverse mode: path-segment matching** (`src/cmd/mcp/ast_tools.rs`)
   Reverse dependency lookup used `contains()` on the file stem. Searching for reverse deps of `lib.rs` (stem `lib`) would match any import containing the substring "lib" (e.g., `stdlib`, `calibration`). Now uses path-segment matching (`/lib/`, `::lib::`, exact match, etc.).

3. **Rollback: log created-file removal errors** (`src/tx/lifecycle.rs`)
   `rollback_strict` logged errors when restoring modified files (line 244) and deleted files (line 267), but silently discarded errors when removing files created during the transaction (line 240). Now logs consistently.

4. **Backup: warn on corrupted manifests** (`src/backup.rs`)
   `list_sessions` silently skipped backup manifests that failed to deserialize. A corrupted manifest disappeared from `patchloom undo --list` with no indication. Now prints a warning to stderr.

5. **Windows shell_escape** (`src/write.rs`, `src/write_tests.rs`)
   `shell_escape` used Unix single-quote wrapping unconditionally. On Windows where `cmd /C` is used, single quotes have no quoting semantics. Now uses double-quote escaping on Windows and treats backslash as a safe path separator.

Closes #1223