### PR TITLE
fix: tighten error matching, explain flags, and MCP doc examples

### DIFF
--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -166,6 +166,8 @@ fn describe_operation(op: &Operation) -> String {
             whole_line,
             range,
             word_boundary,
+            multiline,
+            if_exists,
             ..
         } => {
             let target = path.as_deref().or(glob.as_deref()).unwrap_or("(all files)");
@@ -198,8 +200,10 @@ fn describe_operation(op: &Operation) -> String {
                 .as_deref()
                 .map(|r| format!(", lines {r}"))
                 .unwrap_or_default();
+            let ml_str = if *multiline { ", multiline" } else { "" };
+            let ie_str = if *if_exists { ", if-exists" } else { "" };
             format!(
-                "Replace \"{old}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{wb_str}{range_str})"
+                "Replace \"{old}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{wb_str}{ml_str}{ie_str}{range_str})"
             )
         }
         Operation::DocSet { path, key, value } => {

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -46,7 +46,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_set",
         op_name: "doc.set",
-        description: "Set a value in a JSON, YAML, or TOML file. Parser-backed, preserves comments. Use dot notation for nested paths. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"package.json\", \"selector\": \"version\", \"value\": \"2.0.0\"}",
+        description: "Set a value in a JSON, YAML, or TOML file. Parser-backed, preserves comments. Use dot notation for nested paths. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"package.json\", \"key\": \"version\", \"value\": \"2.0.0\"}",
         has_strict: true,
         validations: &[
             FieldValidation::Path("path"),
@@ -57,7 +57,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_delete",
         op_name: "doc.delete",
-        description: "Delete a value from a JSON, YAML, or TOML file. Example: {\"path\": \"package.json\", \"selector\": \"scripts.test\"}",
+        description: "Delete a value from a JSON, YAML, or TOML file. Example: {\"path\": \"package.json\", \"key\": \"scripts.test\"}",
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -77,7 +77,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_append",
         op_name: "doc.append",
-        description: "Append a value to an array in a JSON, YAML, or TOML file. Example: {\"path\": \"package.json\", \"selector\": \"dependencies\", \"value\": \"new-pkg\"}",
+        description: "Append a value to an array in a JSON, YAML, or TOML file. Example: {\"path\": \"package.json\", \"key\": \"dependencies\", \"value\": \"new-pkg\"}",
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -99,7 +99,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_ensure",
         op_name: "doc.ensure",
-        description: "Set a value in JSON/YAML/TOML only if it does not already exist. Idempotent: no-op if present. Example: {\"path\": \"config.json\", \"selector\": \"debug\", \"value\": false}",
+        description: "Set a value in JSON/YAML/TOML only if it does not already exist. Idempotent: no-op if present. Example: {\"path\": \"config.json\", \"key\": \"debug\", \"value\": false}",
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -110,7 +110,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_delete_where",
         op_name: "doc.delete_where",
-        description: "Remove array items matching a predicate from JSON/YAML/TOML. Example: {\"path\": \"config.yaml\", \"selector\": \"users\", \"predicate\": \"role=admin\"}",
+        description: "Remove array items matching a predicate from JSON/YAML/TOML. Example: {\"path\": \"config.yaml\", \"key\": \"users\", \"predicate\": \"role=admin\"}",
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -121,7 +121,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_update",
         op_name: "doc.update",
-        description: "Update all items matching a wildcard selector in a JSON, YAML, or TOML file. Example: {\"path\": \"config.yaml\", \"selector\": \"servers[*].port\", \"value\": 8080}",
+        description: "Update all items matching a wildcard key in a JSON, YAML, or TOML file. Example: {\"path\": \"config.yaml\", \"key\": \"servers[*].port\", \"value\": 8080}",
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -157,7 +157,7 @@ fn execute_md_op(
         Ok(code) => Ok(code),
         Err(e) => {
             let msg = e.to_string();
-            if msg.contains("not found") {
+            if msg.contains("heading") && msg.contains("not found") {
                 Ok(exit::NO_MATCHES)
             } else {
                 Err(e)

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -321,7 +321,13 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let mut all_ok = true;
         for pf in &patch_files {
             let file_path = cwd.join(&pf.path);
-            let original = std::fs::read_to_string(&file_path).unwrap_or_default();
+            let original = match std::fs::read_to_string(&file_path) {
+                Ok(s) => s,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+                Err(e) => {
+                    anyhow::bail!("patch check: cannot read {}: {e}", pf.path);
+                }
+            };
             match apply_patch_file(&original, &pf.hunks, check_options) {
                 Ok(applied) => {
                     if applied.status == ApplyHunksStatus::Conflict {
@@ -372,7 +378,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             // The engine error from apply_patch_with_loader already includes
             // "patch apply: <path> -- <detail>", so we add the STALE/MERGE
             // FAILED label to match the original CLI format.
-            let exit_code = if msg.contains("conflict") {
+            let exit_code = if msg.contains("conflict(s)") {
                 exit::CONFLICTS
             } else {
                 exit::AMBIGUOUS


### PR DESCRIPTION
Round 3 of the audit fixloop. Five targeted fixes:

1. **patch.rs conflict matching**: `msg.contains("conflict")` matched file paths containing "conflict", giving CONFLICTS exit code instead of AMBIGUOUS. Now matches `"conflict(s)"` which is the actual engine error.

2. **patch.rs merge-check I/O**: `unwrap_or_default()` silently treated permission errors and disk failures as empty files. Now surfaces I/O errors (NotFound still returns empty for new-file patches).

3. **explain.rs Replace flags**: `describe_operation` omitted `multiline` and `if_exists` flags from the human-readable explain output.

4. **md.rs error matching**: `msg.contains("not found")` caught unrelated errors like "directory not found". Now requires both "heading" and "not found" in the message.

5. **registry.rs MCP descriptions**: Six doc tool description examples used `"selector"` but the actual Operation schema field is `"key"`. Agents following the examples would pass the wrong parameter name.