### PR TITLE
fix: MCP description key/selector, rename backup order, line range end=0, path validation

### DIFF
--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -98,6 +98,7 @@ pub fn apply_patch_file(
     let mut results = Vec::new();
     for pf in &patch_files {
         let file_path = cwd.join(&pf.path);
+        super::ensure_contained(guard, &file_path)?;
         let original = std::fs::read_to_string(&file_path)
             .with_context(|| format!("failed to read {}", file_path.display()))?;
 

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -32,7 +32,7 @@ pub(super) fn new_tool_router() -> ToolRouter<PatchloomService> {
 #[tool_router]
 impl PatchloomService {
     #[tool(
-        description = "Read a value from a JSON, YAML, or TOML file by selector. Example: {\"path\": \"package.json\", \"selector\": \"version\"}"
+        description = "Read a value from a JSON, YAML, or TOML file by key path. Example: {\"path\": \"package.json\", \"key\": \"version\"}"
     )]
     async fn doc_get(
         &self,
@@ -52,7 +52,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Query a JSON, YAML, or TOML file. Actions: \"has\" (check if selector exists, returns true/false), \"keys\" (list object keys at selector), \"len\" (count items at selector), \"select\" (filter array by predicate selector), \"flatten\" (list all leaf paths and values). Example: {\"action\": \"has\", \"path\": \"config.json\", \"selector\": \"database.host\"}"
+        description = "Query a JSON, YAML, or TOML file. Actions: \"has\" (check if key exists, returns true/false), \"keys\" (list object keys at key path), \"len\" (count items at key path), \"select\" (filter array by predicate key), \"flatten\" (list all leaf paths and values). Example: {\"action\": \"has\", \"path\": \"config.json\", \"key\": \"database.host\"}"
     )]
     async fn doc_query(
         &self,

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -298,8 +298,11 @@ pub(super) fn handle_simple_op(
     for v in meta.validations {
         match v {
             FieldValidation::Path(field) => {
-                if let Some(val) = args_obj.get(*field).and_then(|v| v.as_str()) {
-                    service.check_path(val)?;
+                if let Some(val) = args_obj.get(*field) {
+                    let s = val.as_str().ok_or_else(|| {
+                        McpError::invalid_params(format!("{field} must be a string"), None)
+                    })?;
+                    service.check_path(s)?;
                 }
             }
             FieldValidation::ParamSize(field) => {

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -193,8 +193,8 @@ fn run_binary_rename(
             {
                 fs::create_dir_all(parent)?;
             }
-            rename_or_copy(src, dst)?;
             backup.finalize()?;
+            rename_or_copy(src, dst)?;
             Ok(())
         },
         WriteMessages {

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -55,6 +55,9 @@ pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
         let end: usize = end_str
             .parse()
             .map_err(|_| anyhow::anyhow!("invalid end line: {end_str}"))?;
+        if end == 0 {
+            anyhow::bail!("line numbers are 1-based, got 0");
+        }
         if end < start {
             anyhow::bail!("end line {end} is before start line {start}");
         }


### PR DESCRIPTION
Round 4 of the audit fixloop. Five targeted fixes:

1. **handlers.rs doc_get/doc_query descriptions**: Tool description examples used `"selector"` but the schema field is `"key"`. Same class as the registry.rs fix in #1225, but in the two hand-written handlers that were missed.

2. **rename.rs backup finalization order**: Backup manifest was finalized AFTER `rename_or_copy()`. If the rename succeeds but finalize fails (disk full), the file is moved with no undo record. Now finalizes BEFORE mutation, matching the established pattern in `backup_write_files()`.

3. **read.rs line range end=0 validation**: `parse_line_range("5:0")` accepted end=0, causing `select_lines` to silently return empty content with SUCCESS exit code. Line numbers are 1-based; start=0 was already rejected but end=0 was not.

4. **registry.rs FieldValidation::Path defense-in-depth**: Non-string path values (e.g. `"path": 42`) silently skipped the containment check. Serde catches the type error later, but the security-critical guard should not be bypassed. Now returns explicit `invalid_params` error.

5. **api/patch.rs guard containment check**: `apply_patch_file()` read files from patch-embedded paths without checking the PathGuard. In Preview/Check modes, a patch with `../../etc/passwd` paths would read arbitrary files despite the guard. Added `ensure_contained()` before reads.