### PR TITLE
revert: remove speculative path validation and patch guard

### DIFF
--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -98,7 +98,6 @@ pub fn apply_patch_file(
     let mut results = Vec::new();
     for pf in &patch_files {
         let file_path = cwd.join(&pf.path);
-        super::ensure_contained(guard, &file_path)?;
         let original = std::fs::read_to_string(&file_path)
             .with_context(|| format!("failed to read {}", file_path.display()))?;
 

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -298,11 +298,8 @@ pub(super) fn handle_simple_op(
     for v in meta.validations {
         match v {
             FieldValidation::Path(field) => {
-                if let Some(val) = args_obj.get(*field) {
-                    let s = val.as_str().ok_or_else(|| {
-                        McpError::invalid_params(format!("{field} must be a string"), None)
-                    })?;
-                    service.check_path(s)?;
+                if let Some(val) = args_obj.get(*field).and_then(|v| v.as_str()) {
+                    service.check_path(val)?;
                 }
             }
             FieldValidation::ParamSize(field) => {


### PR DESCRIPTION
Reverts two changes from #1226 that added code solving non-problems:

1. **registry.rs non-string path check**: serde `from_value` deserialization runs immediately after field validation and already rejects wrong types with a clear error. The added type check was dead code.

2. **api/patch.rs ensure_contained**: `apply_patch_file()` is only called from the MCP handler, which already enforces containment. The guard protected against a hypothetical future caller that doesn't exist.