### PR TITLE
fix: resolve symlinks in atomic_write, surface specific table_append errors

### DIFF
--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -64,7 +64,25 @@ fn md_write(
             heading, bullet, ..
         } => ops::md::upsert_bullet_in(&original, &heading, &bullet),
         Operation::MdTableAppend { heading, row, .. } => {
-            ops::md::table_append_for_tx(&original, &heading, &row)
+            let (body_start, body_end) = ops::md::find_section(&original, &heading)
+                .ok_or_else(|| anyhow::anyhow!("heading not found in {path_str}"))?;
+            return match ops::md::table_append_in(&original, body_start, body_end, &row) {
+                Ok(new_content) => {
+                    let policy = WritePolicy::default();
+                    let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;
+                    Ok(super::build_edit_result(
+                        &path_str,
+                        original,
+                        new_content,
+                        applied,
+                        action,
+                        None,
+                    ))
+                }
+                Err(e) => Err(anyhow::anyhow!(
+                    "{e} under heading {heading:?} in {path_str}"
+                )),
+            };
         }
         _ => None,
     }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -629,6 +629,48 @@ fn md_table_append_adds_row() {
 }
 
 #[test]
+fn md_table_append_column_mismatch_gives_specific_error() {
+    // #1231: library path should report "column mismatch", not "heading not found"
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("table.md");
+    fs::write(
+        &file,
+        "# Data\n\n| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |\n",
+    )
+    .unwrap();
+
+    let err = md_table_append(&file, "# Data", "| x |", ApplyMode::Preview, None).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("column"),
+        "error should mention column mismatch, got: {msg}"
+    );
+    assert!(
+        !msg.contains("heading not found"),
+        "error should NOT say 'heading not found': {msg}"
+    );
+}
+
+#[test]
+fn md_table_append_no_table_gives_specific_error() {
+    // #1231: library path should report "no markdown table", not "heading not found"
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(&file, "# Data\n\nJust text, no table.\n").unwrap();
+
+    let err = md_table_append(&file, "# Data", "| x |", ApplyMode::Preview, None).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no markdown table"),
+        "error should mention 'no markdown table', got: {msg}"
+    );
+    assert!(
+        !msg.contains("heading not found"),
+        "error should NOT say 'heading not found': {msg}"
+    );
+}
+
+#[test]
 fn md_insert_before_heading_works() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("doc.md");

--- a/src/write.rs
+++ b/src/write.rs
@@ -708,17 +708,22 @@ pub fn atomic_create_new(path: &Path, content: &str, policy: &WritePolicy) -> an
 pub fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow::Result<()> {
     let final_content = apply_policy(content, policy);
 
-    // Capture the original file's permissions before overwriting.
-    // Use symlink_metadata so that when `path` is a symlink we get the
-    // symlink entry's metadata, not the target's. persist() replaces the
-    // path entry (the symlink) with a regular file, so carrying over the
-    // target's permissions would be wrong.
-    let original_perms = std::fs::symlink_metadata(path)
-        .ok()
-        .filter(|m| !m.file_type().is_symlink())
-        .map(|m| m.permissions());
+    // Resolve symlinks: write to the target file, not the symlink entry (#1230).
+    // Without this, persist() (rename) replaces the symlink directory entry
+    // with a regular file, destroying the symlink and leaving the target unchanged.
+    let resolved;
+    let write_path = if path.is_symlink() {
+        resolved = std::fs::canonicalize(path)
+            .with_context(|| format!("failed to resolve symlink {}", path.display()))?;
+        resolved.as_path()
+    } else {
+        path
+    };
 
-    let parent = path
+    // Capture the original file's permissions before overwriting.
+    let original_perms = std::fs::metadata(write_path).ok().map(|m| m.permissions());
+
+    let parent = write_path
         .parent()
         .context("cannot determine parent directory of target path")?;
 
@@ -735,8 +740,8 @@ pub fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow:
             .with_context(|| format!("failed to set permissions on {}", tmp.path().display()))?;
     }
 
-    tmp.persist(path)
-        .with_context(|| format!("failed to persist tempfile to {}", path.display()))?;
+    tmp.persist(write_path)
+        .with_context(|| format!("failed to persist tempfile to {}", write_path.display()))?;
 
     Ok(())
 }

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -839,6 +839,96 @@ mod dedent_indent {
     }
 }
 
+mod symlink_handling {
+    use super::*;
+
+    #[test]
+    #[cfg(unix)]
+    fn atomic_write_through_symlink_preserves_symlink() {
+        // #1230: atomic_write through a symlink should modify the target,
+        // not replace the symlink with a regular file.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real.txt");
+        fs::write(&target, "original content\n").unwrap();
+
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let policy = WritePolicy::default();
+        atomic_write(&link, "modified content\n", &policy).unwrap();
+
+        // The symlink must still be a symlink.
+        assert!(
+            link.is_symlink(),
+            "link.txt should still be a symlink after atomic_write"
+        );
+        // The target file must have the new content.
+        let target_content = fs::read_to_string(&target).unwrap();
+        assert_eq!(target_content, "modified content\n");
+        // Reading through the symlink should also show the new content.
+        let link_content = fs::read_to_string(&link).unwrap();
+        assert_eq!(link_content, "modified content\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn atomic_write_through_symlink_chain() {
+        // Symlink chain: link2 -> link1 -> real.txt
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real.txt");
+        fs::write(&target, "deep target\n").unwrap();
+
+        let link1 = dir.path().join("link1.txt");
+        std::os::unix::fs::symlink(&target, &link1).unwrap();
+        let link2 = dir.path().join("link2.txt");
+        std::os::unix::fs::symlink(&link1, &link2).unwrap();
+
+        let policy = WritePolicy::default();
+        atomic_write(&link2, "chain modified\n", &policy).unwrap();
+
+        assert!(link2.is_symlink(), "link2 should still be a symlink");
+        assert!(link1.is_symlink(), "link1 should still be a symlink");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "chain modified\n");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn atomic_write_through_dangling_symlink_fails() {
+        // A dangling symlink (target does not exist) should produce
+        // a clear error, not silently create a file at the symlink path.
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("dangling.txt");
+        std::os::unix::fs::symlink(dir.path().join("nonexistent.txt"), &link).unwrap();
+
+        let policy = WritePolicy::default();
+        let err = atomic_write(&link, "content\n", &policy).unwrap_err();
+        assert!(
+            err.to_string().contains("resolve symlink") || err.to_string().contains("No such file"),
+            "expected symlink resolution error, got: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn atomic_write_through_symlink_preserves_target_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real.txt");
+        fs::write(&target, "original\n").unwrap();
+        let perms = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(&target, perms).unwrap();
+
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let policy = WritePolicy::default();
+        atomic_write(&link, "modified\n", &policy).unwrap();
+
+        let meta = std::fs::metadata(&target).unwrap();
+        assert_eq!(meta.permissions().mode() & 0o777, 0o755);
+    }
+}
+
 mod error_handling {
     use super::*;
 
@@ -1047,18 +1137,19 @@ mod format_preservation {
         );
     }
 
-    /// Regression (#1062): when `path` is a symlink, atomic_write should not
-    /// carry over the symlink target's permissions to the new regular file.
+    /// After #1230: when `path` is a symlink, atomic_write resolves it and
+    /// writes to the target file. The symlink is preserved, the target gets
+    /// new content, and the target's permissions are carried over (since we
+    /// are writing to the actual target, not creating a new file at the
+    /// symlink entry).
     #[test]
     #[cfg(unix)]
-    fn atomic_write_symlink_does_not_carry_target_permissions() {
+    fn atomic_write_symlink_writes_to_target_preserves_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
         let target = dir.path().join("target.txt");
         fs::write(&target, "content").unwrap();
-        // Use 0o444 (read-only) which is distinctive from default tempfile
-        // permissions (typically 0o600).
         fs::set_permissions(&target, std::fs::Permissions::from_mode(0o444)).unwrap();
 
         let link = dir.path().join("link.txt");
@@ -1067,16 +1158,15 @@ mod format_preservation {
         let policy = WritePolicy::default();
         atomic_write(&link, "new content", &policy).unwrap();
 
-        // The link should now be a regular file, not a symlink.
-        assert!(!link.symlink_metadata().unwrap().file_type().is_symlink());
-        // The original target should be untouched.
-        assert_eq!(fs::read_to_string(&target).unwrap(), "content");
-        // The new file should NOT have the target's 0o444 permissions forced
-        // on it; it should have the default tempfile permissions instead.
-        let mode = fs::metadata(&link).unwrap().permissions().mode() & 0o777;
-        assert_ne!(
+        // The symlink must still be a symlink (#1230).
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+        // The target file now has the new content.
+        assert_eq!(fs::read_to_string(&target).unwrap(), "new content");
+        // The target's original permissions are preserved.
+        let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
             mode, 0o444,
-            "symlink target permissions should not be carried over"
+            "target permissions should be preserved when writing through symlink"
         );
     }
 

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -839,11 +839,11 @@ mod dedent_indent {
     }
 }
 
+#[cfg(unix)]
 mod symlink_handling {
     use super::*;
 
     #[test]
-    #[cfg(unix)]
     fn atomic_write_through_symlink_preserves_symlink() {
         // #1230: atomic_write through a symlink should modify the target,
         // not replace the symlink with a regular file.
@@ -871,7 +871,6 @@ mod symlink_handling {
     }
 
     #[test]
-    #[cfg(unix)]
     fn atomic_write_through_symlink_chain() {
         // Symlink chain: link2 -> link1 -> real.txt
         let dir = tempfile::tempdir().unwrap();
@@ -892,7 +891,6 @@ mod symlink_handling {
     }
 
     #[test]
-    #[cfg(unix)]
     fn atomic_write_through_dangling_symlink_fails() {
         // A dangling symlink (target does not exist) should produce
         // a clear error, not silently create a file at the symlink path.
@@ -909,7 +907,6 @@ mod symlink_handling {
     }
 
     #[test]
-    #[cfg(unix)]
     fn atomic_write_through_symlink_preserves_target_permissions() {
         use std::os::unix::fs::PermissionsExt;
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Two targeted fixes for correctness bugs found during runtime testing.

### Symlink-aware atomic writes (#1230)

`atomic_write()` now resolves symlinks before creating the tempfile and persisting. Previously, the rename replaced the symlink directory entry with a regular file, leaving the target unchanged. Now:
- Symlinks are resolved via `std::fs::canonicalize()`
- The tempfile is created in the resolved target's parent directory
- The target file gets the new content; the symlink is preserved
- Dangling symlinks produce a clear "failed to resolve symlink" error
- Symlink chains are fully resolved

### Specific table_append errors in library API (#1231)

The library-only fallback path (`--no-default-features`, without `cli`/`files` features) for `MdTableAppend` now calls `find_section()` + `table_append_in()` directly instead of routing through `table_append_for_tx()` which swallowed the specific `TableAppendError` via `.ok()`. Library consumers now get "row has 2 column(s), table has 3" or "no markdown table found" instead of the misleading "heading not found".

### Tests

- 4 symlink tests: basic preservation, chain resolution, dangling error, permission preservation
- 2 table_append error tests: column mismatch gives specific error, no-table gives specific error
- Updated existing symlink permission test to match the new (correct) behavior

Closes #1230
Closes #1231