### PR TITLE
fix: create with empty content now actually creates the file

### DIFF
--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -340,6 +340,30 @@ mod tests {
     }
 
     #[test]
+    fn execute_single_create_empty_file() {
+        let dir = TempDir::new().unwrap();
+        let global = GlobalFlags::test_default();
+
+        let op = Operation::FileCreate {
+            path: "empty.txt".to_string(),
+            content: String::new(),
+            force: None,
+        };
+
+        let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
+        assert!(
+            result.has_changes,
+            "creating a new file with empty content is still a change"
+        );
+
+        result.commit().unwrap();
+        assert!(
+            dir.path().join("empty.txt").exists(),
+            "empty file should exist after commit"
+        );
+    }
+
+    #[test]
     fn execute_single_no_changes() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("stable.txt");

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -1421,7 +1421,11 @@ pub(crate) fn execute_and_collect(
         }
         let write_policy = build_write_policy(plan, global, path)?;
         let final_content = apply_policy(current, &write_policy);
-        if *original != *final_content {
+        // A file creation with empty content still has original == final == "",
+        // but must be treated as an effective change because the file does not
+        // exist on disk yet (#create-empty-file).
+        let is_new_file = !existed_before.contains(path);
+        if *original != *final_content || is_new_file {
             changes.push((path.clone(), original.clone(), final_content.into_owned()));
         }
     }


### PR DESCRIPTION
When creating a file with empty content (`--content ''`), the tx engine compared original (`""`) with final content (`""`) and concluded there were no effective changes, skipping the file creation. The CLI still printed `created empty.txt` but no file was produced on disk.

The fix checks whether the file is new (not in `existed_before`) and always treats new file creations as effective changes regardless of content equality.

Found by runtime testing patchloom CLI in temp directories (`/fixrealloop` round 1).