### PR TITLE
fix: suppress misleading 'modified' message when apply has no changes

### DIFF
--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -92,6 +92,7 @@ fn execute_via_engine_inner<T: Serialize>(
 
     // --apply mode: commit, then report.
     if global.apply {
+        let has_changes = result.has_changes;
         let diffs = result.build_diffs();
         result.commit()?;
         crate::write::run_format_command(global, &cwd)?;
@@ -103,7 +104,7 @@ fn execute_via_engine_inner<T: Serialize>(
         };
 
         let output = make_output(WritePhase::Applied, diff_text);
-        if !global.emit_json(&output)? {
+        if !global.emit_json(&output)? && has_changes {
             if global.diff {
                 print!("{}", render_diffs_colored(&diffs, global.should_color()));
             } else if !global.quiet {


### PR DESCRIPTION
When a write command runs with `--apply` but the operation produces no effective changes (e.g. `upsert-bullet` for an already-present bullet), the CLI printed the apply message ('modified X') even though nothing was written. This confused agents parsing the output into thinking a change occurred.

The fix checks `has_changes` before printing the apply message. When there are no changes, the command exits silently with exit 0 (same as before), but no longer prints a misleading success message.

Found by runtime testing patchloom `md upsert-bullet` with duplicate bullets (`/fixrealloop` round 3).