### PR TITLE
fix: support file creation and deletion in patch apply

### DIFF
--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -20,6 +20,10 @@ pub struct Hunk {
 pub struct PatchFile {
     pub path: String,
     pub hunks: Vec<Hunk>,
+    /// `true` when the `---` line is `/dev/null` (new file creation).
+    pub is_creation: bool,
+    /// `true` when the `+++` line is `/dev/null` (file deletion).
+    pub is_deletion: bool,
 }
 
 /// Check whether line `idx` is a real file header ("--- " followed by "+++"),
@@ -74,12 +78,11 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
         }
 
         // For deletions the `+++` line is `/dev/null`; take path from `---`.
+        let minus_path = parse_file_path(lines[i]);
         let plus_path = parse_file_path(lines[i + 1]);
-        let path = if plus_path == "/dev/null" {
-            parse_file_path(lines[i])
-        } else {
-            plus_path
-        };
+        let is_creation = minus_path == "/dev/null";
+        let is_deletion = plus_path == "/dev/null";
+        let path = if is_deletion { minus_path } else { plus_path };
         i += 2;
 
         let mut hunks: Vec<Hunk> = Vec::new();
@@ -124,7 +127,12 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
             return Err(format!("no hunks found for file {path}"));
         }
 
-        files.push(PatchFile { path, hunks });
+        files.push(PatchFile {
+            path,
+            hunks,
+            is_creation,
+            is_deletion,
+        });
     }
 
     if files.is_empty() {
@@ -268,6 +276,10 @@ pub struct PatchApplyFileResult {
     pub content: String,
     pub status: ApplyHunksStatus,
     pub conflicts: Vec<ConflictRange>,
+    /// `true` when the patch creates a new file (`--- /dev/null`).
+    pub is_creation: bool,
+    /// `true` when the patch deletes a file (`+++ /dev/null`).
+    pub is_deletion: bool,
 }
 
 pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, String> {
@@ -699,7 +711,24 @@ where
         parse_patch(diff_text).map_err(|msg| anyhow::anyhow!("patch parse error: {msg}"))?;
     let mut results = Vec::new();
     for pf in &patch_files {
-        let original = load_original(&pf.path)?;
+        // New file creation: original is empty, don't try to load from disk.
+        let original = if pf.is_creation {
+            String::new()
+        } else {
+            load_original(&pf.path)?
+        };
+        // File deletion: result is empty string (caller handles removal).
+        if pf.is_deletion {
+            results.push(PatchApplyFileResult {
+                path: pf.path.clone(),
+                content: String::new(),
+                status: ApplyHunksStatus::Clean,
+                conflicts: Vec::new(),
+                is_creation: false,
+                is_deletion: true,
+            });
+            continue;
+        }
         let applied = apply_hunks_with_options(&original, &pf.hunks, options)
             .map_err(|msg| anyhow::anyhow!("patch apply: {} -- {msg}", pf.path))?;
         results.push(PatchApplyFileResult {
@@ -707,6 +736,8 @@ where
             content: applied.content,
             status: applied.status,
             conflicts: applied.conflicts,
+            is_creation: pf.is_creation,
+            is_deletion: false,
         });
     }
     Ok(results)

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -807,13 +807,19 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                     );
                 }
                 let file_path = tx.cwd.join(&result.path);
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &file_path,
-                    result.content,
-                );
+                if result.is_deletion {
+                    // File deletion via patch: mark for deletion.
+                    tx.deletions.insert(file_path.clone());
+                    tx.write_targets.insert(file_path);
+                } else {
+                    update_file_content(
+                        tx.pending,
+                        tx.deletions,
+                        tx.write_targets,
+                        &file_path,
+                        result.content,
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
Patches with `--- /dev/null` (new file creation) failed with `No such file or directory (STALE)` because the loader tried to read a non-existent file from disk. Patches with `+++ /dev/null` (file deletion) exited 0 but left the file on disk because the executor only updated content to empty string instead of marking the file for deletion.

**Changes:**
- Add `is_creation`/`is_deletion` flags to `PatchFile` and `PatchApplyFileResult`
- Skip file loading for creation patches (use empty string as original)
- Mark deletion patches in the tx deletion set instead of updating content

Found by runtime testing patchloom `patch apply` with `/dev/null` patches (`/fixrealloop` round 4).