### PR TITLE
fix: use correct label for non-required validation step failures

### DIFF
--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -66,8 +66,9 @@ fn run_lifecycle_steps(
                 status,
                 stderr_head,
             }) if !status.success() => {
+                let step_label = if required { label } else { error_label };
                 let header = format!(
-                    "{label} failed (step {}, {}, cwd: {})",
+                    "{step_label} failed (step {}, {}, cwd: {})",
                     index + 1,
                     describe_exit_status(status),
                     lifecycle_cwd


### PR DESCRIPTION
Non-required validation steps (`required: false` or default) printed
`required validation failed` in their error message, which was misleading.

The `label` parameter was always `required validation` regardless of the
step's `required` flag. Now uses the `error_label` (just `validation`)
for non-required steps, and `label` (`required validation`) only for
required ones.

**Before:**
```
tx: required validation failed (step 1, exit code 1, cwd: .)
```
(even when the step is not required)

**After:**
```
tx: validation failed (step 1, exit code 1, cwd: .)       # non-required
tx: required validation failed (step 1, exit code 1, cwd: .)  # required
```

Found during fixrealloop runtime testing.