### PR TITLE
fix: clean trailing whitespace from YAML CST after key deletion

### DIFF
--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -105,6 +105,23 @@ pub fn serialize_value_preserving(
     }
 }
 
+/// Clean up whitespace artifacts left by `yaml_edit` CST mutations.
+///
+/// `Mapping::remove()` can leave trailing whitespace on lines and may
+/// drop the final newline. This trims each line's trailing spaces and
+/// ensures the output ends with exactly one newline.
+fn cleanup_yaml_cst_whitespace(text: &str) -> String {
+    let mut result: String = text
+        .lines()
+        .map(|line| line.trim_end())
+        .collect::<Vec<_>>()
+        .join("\n");
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
 /// Attempt CST-preserving update for YAML. Returns Some(result) on success,
 /// None if a text-level fallback (or plain serialize) is required.
 fn try_preserve_yaml(
@@ -146,7 +163,10 @@ fn try_preserve_yaml_object(
 ) -> anyhow::Result<Option<String>> {
     let has_array_growth = yaml_splice::has_array_growth_diffs(old_value, new_value);
     let all_cst_applied = apply_yaml_mapping_diff(mapping, old_value, new_value)?;
-    let result = file.to_string();
+    // yaml_edit's Mapping::remove() can leave trailing whitespace on the
+    // line preceding the removed key. Clean it up so the output file does
+    // not contain spurious trailing spaces or a missing final newline.
+    let result = cleanup_yaml_cst_whitespace(&file.to_string());
 
     if let Ok(reparsed) = serde_yaml_ng::from_str::<serde_json::Value>(&result)
         && reparsed.is_object()
@@ -186,7 +206,7 @@ fn try_preserve_yaml_array(
         false
     };
     if applied {
-        let result = file.to_string();
+        let result = cleanup_yaml_cst_whitespace(&file.to_string());
         if serde_yaml_ng::from_str::<serde_json::Value>(&result).is_ok_and(|v| v == *new_value) {
             return Ok(Some(result));
         }

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1043,6 +1043,48 @@ mod regression {
     }
 }
 
+mod yaml_cst_cleanup {
+    use super::*;
+
+    #[test]
+    fn delete_last_key_no_trailing_whitespace() {
+        let yaml = "top:\n  first: aaa\n  second: bbb\n  third: ccc\n";
+        let old = json!({"top": {"first": "aaa", "second": "bbb", "third": "ccc"}});
+        let new = json!({"top": {"first": "aaa", "second": "bbb"}});
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        // No line should have trailing whitespace
+        for line in result.lines() {
+            assert_eq!(
+                line,
+                line.trim_end(),
+                "trailing whitespace found in: {:?}",
+                line
+            );
+        }
+        // Must end with exactly one newline
+        assert!(result.ends_with('\n'), "missing final newline");
+        assert!(
+            !result.ends_with("\n\n"),
+            "double final newline: {:?}",
+            &result[result.len().saturating_sub(4)..]
+        );
+    }
+
+    #[test]
+    fn delete_last_key_in_nested_section() {
+        let yaml = "server:\n  host: localhost\n  port: 8080\n  workers: 4\n\ndb:\n  url: pg\n  pool: 10\n";
+        let old = json!({"server": {"host": "localhost", "port": 8080, "workers": 4}, "db": {"url": "pg", "pool": 10}});
+        let new = json!({"server": {"host": "localhost", "port": 8080, "workers": 4}, "db": {"url": "pg"}});
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        for line in result.lines() {
+            assert_eq!(line, line.trim_end(), "trailing whitespace: {:?}", line);
+        }
+        assert!(result.ends_with('\n'));
+        assert!(result.contains("url: pg"));
+        assert!(!result.contains("pool"));
+    }
+}
+
 mod format_preservation {
     use super::*;
     use ::proptest::prelude::*;


### PR DESCRIPTION
## Problem

`doc delete` on the **last key** of a YAML mapping section produces output with:
1. **Trailing whitespace** on the line preceding the removed key
2. **Missing final newline** at end of file

### Reproduction

```yaml
top:
  first: aaa
  second: bbb
  third: ccc
```

`patchloom doc delete file.yaml top.third --apply` produces:

```
top:
  first: aaa
  second: bbb  \ <- two trailing spaces
```                \ <- no final newline

### Root cause

`yaml_edit`'s `Mapping::remove()` leaves trailing whitespace artifacts in the CST when removing the last entry. The CST-to-text serialization preserves these artifacts.

## Fix

Add `cleanup_yaml_cst_whitespace()` that trims trailing whitespace from each line and ensures the output ends with exactly one newline. Applied in both `try_preserve_yaml_object` and `try_preserve_yaml_array` code paths.

## Testing

- 2 new unit tests: `delete_last_key_no_trailing_whitespace` and `delete_last_key_in_nested_section`
- All 1899 unit tests pass
- All 834 integration tests pass