### PR TITLE
fix: strip orphaned YAML comments that migrate inline after key deletion

### DIFF
--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -105,15 +105,73 @@ pub fn serialize_value_preserving(
     }
 }
 
-/// Clean up whitespace artifacts left by `yaml_edit` CST mutations.
+/// Clean up whitespace and comment artifacts left by `yaml_edit` CST mutations.
 ///
-/// `Mapping::remove()` can leave trailing whitespace on lines and may
-/// drop the final newline. This trims each line's trailing spaces and
-/// ensures the output ends with exactly one newline.
-fn cleanup_yaml_cst_whitespace(text: &str) -> String {
+/// `Mapping::remove()` can leave trailing whitespace on lines, drop the final
+/// newline, and migrate standalone comments (that preceded the removed key)
+/// onto the end of the previous key's line as spurious inline comments.
+///
+/// When `original` is provided, standalone comment lines that disappeared
+/// from the output but whose text reappears as a newly-introduced inline
+/// comment are stripped. This catches the case where `  # Worker count` on
+/// its own line is absorbed into `port: 8080  # Worker count` after the key
+/// below it is removed.
+fn cleanup_yaml_cst_whitespace(text: &str, original: Option<&str>) -> String {
+    use std::collections::HashSet;
+
+    // Collect standalone comment bodies from the original (lines that are
+    // ONLY a comment) and inline comment bodies that were already present.
+    // We strip an inline comment only if its body matches a standalone
+    // comment AND was NOT already inline in the original.
+    let (standalone_bodies, original_inline_bodies): (HashSet<String>, HashSet<String>) = original
+        .map(|orig| {
+            let mut standalone = HashSet::new();
+            let mut inline = HashSet::new();
+            for line in orig.lines() {
+                let trimmed = line.trim_start();
+                if trimmed.starts_with('#') {
+                    let body = trimmed.trim_start_matches('#').trim_start().to_string();
+                    standalone.insert(body);
+                } else if let Some(hash_pos) = line.find(" #") {
+                    let before = line[..hash_pos].trim_end();
+                    if !before.is_empty() {
+                        let body = line[hash_pos..]
+                            .trim_start()
+                            .trim_start_matches('#')
+                            .trim_start()
+                            .to_string();
+                        inline.insert(body);
+                    }
+                }
+            }
+            (standalone, inline)
+        })
+        .unwrap_or_default();
+
     let mut result: String = text
         .lines()
-        .map(|line| line.trim_end())
+        .map(|line| {
+            let trimmed = line.trim_end();
+            if !standalone_bodies.is_empty()
+                && let Some(hash_pos) = trimmed.find(" #")
+            {
+                let before = trimmed[..hash_pos].trim_end();
+                if !before.is_empty() && !trimmed.trim_start().starts_with('#') {
+                    let body = trimmed[hash_pos..]
+                        .trim_start()
+                        .trim_start_matches('#')
+                        .trim_start()
+                        .to_string();
+                    // Strip if the comment body came from a standalone
+                    // line and was NOT already inline in the original.
+                    if standalone_bodies.contains(&body) && !original_inline_bodies.contains(&body)
+                    {
+                        return before.to_string();
+                    }
+                }
+            }
+            trimmed.to_string()
+        })
         .collect::<Vec<_>>()
         .join("\n");
     if !result.ends_with('\n') {
@@ -137,7 +195,13 @@ fn try_preserve_yaml(
     if let Some(doc) = file.document() {
         if let Some(mapping) = doc.as_mapping() {
             if old_value.is_object() && new_value.is_object() {
-                return try_preserve_yaml_object(&file, &mapping, old_value, new_value);
+                return try_preserve_yaml_object(
+                    &file,
+                    &mapping,
+                    old_value,
+                    new_value,
+                    original_content,
+                );
             }
         } else if let Some(seq) = doc.as_sequence()
             && let (Some(old_arr), Some(new_arr)) = (old_value.as_array(), new_value.as_array())
@@ -160,13 +224,14 @@ fn try_preserve_yaml_object(
     mapping: &yaml_edit::Mapping,
     old_value: &serde_json::Value,
     new_value: &serde_json::Value,
+    original_content: &str,
 ) -> anyhow::Result<Option<String>> {
     let has_array_growth = yaml_splice::has_array_growth_diffs(old_value, new_value);
     let all_cst_applied = apply_yaml_mapping_diff(mapping, old_value, new_value)?;
     // yaml_edit's Mapping::remove() can leave trailing whitespace on the
-    // line preceding the removed key. Clean it up so the output file does
-    // not contain spurious trailing spaces or a missing final newline.
-    let result = cleanup_yaml_cst_whitespace(&file.to_string());
+    // line preceding the removed key, and may migrate standalone comments
+    // onto the previous line as spurious inline comments. Clean both up.
+    let result = cleanup_yaml_cst_whitespace(&file.to_string(), Some(original_content));
 
     if let Ok(reparsed) = serde_yaml_ng::from_str::<serde_json::Value>(&result)
         && reparsed.is_object()
@@ -206,7 +271,7 @@ fn try_preserve_yaml_array(
         false
     };
     if applied {
-        let result = cleanup_yaml_cst_whitespace(&file.to_string());
+        let result = cleanup_yaml_cst_whitespace(&file.to_string(), Some(original_content));
         if serde_yaml_ng::from_str::<serde_json::Value>(&result).is_ok_and(|v| v == *new_value) {
             return Ok(Some(result));
         }

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1083,6 +1083,48 @@ mod yaml_cst_cleanup {
         assert!(result.contains("url: pg"));
         assert!(!result.contains("pool"));
     }
+
+    #[test]
+    fn delete_key_with_preceding_standalone_comment() {
+        let yaml = "server:\n  host: localhost\n  port: 8080\n  # Worker count\n  workers: 4\n";
+        let old = json!({"server": {"host": "localhost", "port": 8080, "workers": 4}});
+        let new = json!({"server": {"host": "localhost", "port": 8080}});
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        // The standalone comment should NOT leak onto the previous line.
+        for line in result.lines() {
+            if line.contains("port") {
+                assert!(
+                    !line.contains('#'),
+                    "standalone comment leaked onto port line: {:?}",
+                    line
+                );
+            }
+        }
+        assert!(
+            !result.contains("Worker count"),
+            "orphaned comment should be removed"
+        );
+        assert!(!result.contains("workers"), "deleted key should be gone");
+        assert!(result.contains("port: 8080"));
+    }
+
+    #[test]
+    fn delete_key_preserves_legitimate_inline_comments() {
+        let yaml = "server:\n  host: localhost # primary host\n  port: 8080\n  # Remove this\n  workers: 4\n";
+        let old = json!({"server": {"host": "localhost", "port": 8080, "workers": 4}});
+        let new = json!({"server": {"host": "localhost", "port": 8080}});
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        // Legitimate inline comment on host should be preserved.
+        assert!(
+            result.contains("# primary host"),
+            "legitimate inline comment was incorrectly removed"
+        );
+        // Orphaned standalone comment should not appear inline.
+        assert!(
+            !result.contains("# Remove this"),
+            "orphaned comment should be removed"
+        );
+    }
 }
 
 mod format_preservation {


### PR DESCRIPTION
When `doc delete` removes a YAML key that has a preceding standalone comment (e.g. `# Worker count` above `workers: 4`), yaml_edit's `Mapping::remove()` absorbs the comment into the previous key's line, producing output like `port: 8080  # Worker count`.

This enhances `cleanup_yaml_cst_whitespace` to accept the original content and compare standalone vs inline comments. If a comment body existed only as a standalone line in the original but appears as a new inline comment in the output, it is stripped. Legitimate pre-existing inline comments (e.g. `port: 8080 # default`) are preserved.

**Testing:**
- Two new unit tests: orphaned comment removal, legitimate inline comment preservation
- All 1901 unit tests pass
- All 834 integration tests pass
- All 10 PTY tests pass