### PR TITLE
fix: add dedicated Ruby AST symbol extractor

### DIFF
--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -571,6 +571,7 @@ fn try_extract_symbol(
         Language::Hcl => extract_hcl(node, source)?,
         Language::Protobuf => extract_proto(node, source)?,
         Language::Shell => extract_bash(node, source)?,
+        Language::Ruby => extract_ruby(node, source)?,
         _ => extract_generic(node, source)?,
     };
 
@@ -912,6 +913,25 @@ fn extract_bash(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind
     }
     let name = child_text_by_kinds(node, &["word", "name", "identifier"], source)?;
     Some((SymbolKind::Function, name.to_string()))
+}
+
+fn extract_ruby(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {
+    match node.kind() {
+        "class" => {
+            // Ruby class names use `constant` nodes, not `identifier`.
+            let name = child_text_by_kinds(node, &["constant", "scope_resolution"], source)?;
+            Some((SymbolKind::Class, name.to_string()))
+        }
+        "module" => {
+            let name = child_text_by_kinds(node, &["constant", "scope_resolution"], source)?;
+            Some((SymbolKind::Module, name.to_string()))
+        }
+        "method" | "singleton_method" => {
+            let name = child_text_by_kinds(node, &["identifier", "setter", "operator"], source)?;
+            Some((SymbolKind::Method, name.to_string()))
+        }
+        _ => None,
+    }
 }
 
 // Generic extractor for languages without a hand-tuned extractor


### PR DESCRIPTION
Ruby tree-sitter uses node kinds `class`, `method`, `module`, and `singleton_method` (not `class_definition`, `method_definition`, etc.) with `constant` child nodes for class/module names (not `identifier`). The generic extractor did not match any of these, causing `ast list`, `ast read`, and related commands to return no symbols for Ruby files despite the language being listed as supported.

**What changed:**

Add `extract_ruby()` that handles:
- `class` with name from `constant` or `scope_resolution`
- `module` with name from `constant` or `scope_resolution`
- `method` and `singleton_method` with name from `identifier`, `setter`, or `operator`

**Before:** `patchloom ast list app.rb` returned exit 3 (no matches).
**After:** correctly lists classes, modules, methods with proper nesting.

```
app.rb
  class Animal [1:12]
    method initialize [4:7]
    method speak [9:11]
  class Dog [14:18]
    method fetch [15:17]
  mod Helpers [20:24]
    method greet [21:23]
```

All 834 unit tests + 10 PTY tests pass.