### PR TITLE
fix: enable multi_line(true) on all regex builders for consistent anchor behavior

### DIFF
--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -297,6 +297,7 @@ pub fn search_one_file(
     let re = if opts.regex || opts.case_insensitive || opts.multiline {
         match regex::RegexBuilder::new(&pat)
             .case_insensitive(opts.case_insensitive)
+            .multi_line(true)
             .dot_matches_new_line(opts.multiline)
             .build()
         {

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -49,8 +49,25 @@ pub fn replace_in_symbol(
     // Perform replacement within the body
     let (new_body, count) = if regex {
         let re = regex::RegexBuilder::new(from).multi_line(true).build()?;
-        let count = re.find_iter(&body).count();
-        let new = re.replace_all(&body, to).into_owned();
+        let body_len = body.len();
+        // Filter out phantom zero-length matches at EOF (same as replace_content).
+        let count = re
+            .find_iter(&body)
+            .filter(|m| !(m.start() == body_len && m.end() == body_len))
+            .count();
+        let new = re
+            .replace_all(&body, |caps: &regex::Captures| {
+                if let Some(m) = caps.get(0)
+                    && m.start() == body_len
+                    && m.end() == body_len
+                {
+                    return String::new();
+                }
+                let mut expanded = String::new();
+                caps.expand(to, &mut expanded);
+                expanded
+            })
+            .into_owned();
         (new, count)
     } else {
         let count = body.matches(from).count();

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -48,7 +48,7 @@ pub fn replace_in_symbol(
 
     // Perform replacement within the body
     let (new_body, count) = if regex {
-        let re = regex::Regex::new(from)?;
+        let re = regex::RegexBuilder::new(from).multi_line(true).build()?;
         let count = re.find_iter(&body).count();
         let new = re.replace_all(&body, to).into_owned();
         (new, count)

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -19,6 +19,7 @@ pub fn compile_replace_regex(
         return Ok(Some(
             regex::RegexBuilder::new(&wb_pattern)
                 .case_insensitive(case_insensitive)
+                .multi_line(true)
                 .dot_matches_new_line(multiline)
                 .build()?,
         ));
@@ -32,6 +33,7 @@ pub fn compile_replace_regex(
         Ok(Some(
             regex::RegexBuilder::new(&effective)
                 .case_insensitive(case_insensitive)
+                .multi_line(true)
                 .dot_matches_new_line(multiline)
                 .build()?,
         ))
@@ -39,6 +41,7 @@ pub fn compile_replace_regex(
         Ok(Some(
             regex::RegexBuilder::new(&regex::escape(pattern))
                 .case_insensitive(true)
+                .multi_line(true)
                 .build()?,
         ))
     } else {
@@ -210,9 +213,20 @@ pub fn replace_content<'a>(
     use std::borrow::Cow;
     match (nth, compiled_re) {
         (Some(n), Some(re)) => {
+            let content_len = content.len();
             let mut count = 0usize;
             let mut result = String::with_capacity(content.len());
             for caps in re.captures_iter(content) {
+                // Skip zero-length matches at the very end of the content.
+                // With multi_line(true), patterns like ^$ produce a trailing
+                // match after the final newline that search (line-by-line) does
+                // not see. Dropping it keeps nth consistent with search.
+                if let Some(m) = caps.get(0)
+                    && m.start() == content_len
+                    && m.end() == content_len
+                {
+                    continue;
+                }
                 count += 1;
                 if count != n {
                     continue;
@@ -244,8 +258,19 @@ pub fn replace_content<'a>(
             (Cow::Borrowed(content), 0)
         }
         (None, Some(re)) => {
+            let content_len = content.len();
             let mut count = 0usize;
             let replaced = re.replace_all(content, |caps: &regex::Captures| {
+                // Skip zero-length matches at the very end of the content.
+                // With multi_line(true), patterns like ^$ produce a trailing
+                // match after the final newline that search (line-by-line) does
+                // not see. Dropping it keeps replace consistent with search.
+                if let Some(m) = caps.get(0)
+                    && m.start() == content_len
+                    && m.end() == content_len
+                {
+                    return String::new();
+                }
                 count += 1;
                 expand_regex_replacement(caps, to)
             });

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -255,6 +255,107 @@ mod replace_tests {
         }
 
         #[test]
+        fn regex_anchors_match_at_line_boundaries() {
+            // ^$ should match empty lines within content, not just at the absolute
+            // start/end of the string. This is the core fix for #1253.
+            let re = compile_replace_regex("^$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "hello\n\nworld\n";
+            let (result, count) = replace_content(content, "^$", "BLANK", Some(&re), None);
+            assert_eq!(count, 1, "should match the empty line");
+            assert_eq!(&*result, "hello\nBLANK\nworld\n");
+        }
+
+        #[test]
+        fn regex_caret_matches_line_start() {
+            // ^ should match the start of every line, not just the start of the file.
+            let re = compile_replace_regex("^#", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "# heading\ntext\n# another\n";
+            let (result, count) = replace_content(content, "^#", "##", Some(&re), None);
+            assert_eq!(count, 2, "should match both lines starting with #");
+            assert_eq!(&*result, "## heading\ntext\n## another\n");
+        }
+
+        #[test]
+        fn regex_dollar_matches_line_end() {
+            // $ should match the end of every line, not just the end of the file.
+            let re = compile_replace_regex(";$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "let a = 1;\nlet b = 2\nlet c = 3;\n";
+            let (result, count) = replace_content(content, ";$", "", Some(&re), None);
+            assert_eq!(count, 2, "should match both lines ending with ;");
+            assert_eq!(&*result, "let a = 1\nlet b = 2\nlet c = 3\n");
+        }
+
+        #[test]
+        fn regex_empty_line_pattern_with_whitespace() {
+            let re = compile_replace_regex(r"^\s*$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "hello\n  \nworld\n";
+            let (result, count) = replace_content(content, r"^\s*$", "BLANK", Some(&re), None);
+            assert_eq!(count, 1, "should match the whitespace-only line");
+            assert_eq!(&*result, "hello\nBLANK\nworld\n");
+        }
+
+        #[test]
+        fn regex_anchors_nth_skips_phantom_eof() {
+            // With multi_line(true), ^$ on "hello\n\nworld\n" produces matches:
+            // 1. the empty line (real match)
+            // 2. after the final \n (phantom zero-length EOF match)
+            // nth=2 should NOT land on the phantom match; it should return no-match.
+            let re = compile_replace_regex("^$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "hello\n\nworld\n";
+            let (result, count) = replace_content(content, "^$", "BLANK", Some(&re), Some(2));
+            assert_eq!(count, 0, "nth=2 should not match the phantom EOF");
+            assert_eq!(&*result, content, "content should be unchanged");
+        }
+
+        #[test]
+        fn regex_anchors_nth_first_match() {
+            // nth=1 should hit the real empty-line match.
+            let re = compile_replace_regex("^$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "hello\n\nworld\n";
+            let (result, count) = replace_content(content, "^$", "BLANK", Some(&re), Some(1));
+            assert_eq!(count, 1);
+            assert_eq!(&*result, "hello\nBLANK\nworld\n");
+        }
+
+        #[test]
+        fn regex_anchors_no_trailing_newline() {
+            // Content without a trailing newline should still match ^$ on empty lines.
+            let re = compile_replace_regex("^$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "hello\n\nworld";
+            let (result, count) = replace_content(content, "^$", "BLANK", Some(&re), None);
+            assert_eq!(count, 1, "should match the empty line");
+            assert_eq!(&*result, "hello\nBLANK\nworld");
+        }
+
+        #[test]
+        fn regex_anchors_empty_file() {
+            // An empty file: the only ^$ match is at position (0,0) which equals
+            // content_len, so the trailing-match filter drops it. This is consistent
+            // with search, which iterates lines and finds no lines in empty content.
+            let re = compile_replace_regex("^$", true, false, false, false)
+                .unwrap()
+                .unwrap();
+            let content = "";
+            let (result, count) = replace_content(content, "^$", "BLANK", Some(&re), None);
+            assert_eq!(count, 0, "empty file should produce no matches");
+            assert_eq!(&*result, "");
+        }
+
+        #[test]
         fn whole_lines_delete_literal() {
             let content = "aaa\nbbb\nccc\nbbb\neee\n";
             let (result, count) = replace_whole_lines(content, "bbb", "", None, None, None);

--- a/src/ops/search.rs
+++ b/src/ops/search.rs
@@ -122,11 +122,14 @@ pub fn build_matcher(
     };
     let re = if multiline || case_insensitive {
         regex::RegexBuilder::new(&escaped)
+            .multi_line(true)
             .dot_matches_new_line(multiline)
             .case_insensitive(case_insensitive)
             .build()?
     } else {
-        Regex::new(&escaped)?
+        regex::RegexBuilder::new(&escaped)
+            .multi_line(true)
+            .build()?
     };
     Ok(Matcher::Regex(re))
 }

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -69,6 +69,7 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
     let re = {
         let mut builder = RegexBuilder::new(&pat);
         builder.case_insensitive(*case_insensitive);
+        builder.multi_line(true);
         builder.dot_matches_new_line(*multiline);
         builder.build()?
     };


### PR DESCRIPTION
## Summary

Enable `multi_line(true)` on all `RegexBuilder` sites so that `^` and `$` match at line boundaries, not just at the absolute start/end of file content. Adds a trailing-match filter to skip phantom zero-length EOF matches that `multi_line(true)` produces.

## Changes

**6 files, 150 lines added:**

| File | Change |
|------|--------|
| `src/ops/replace.rs` | Added `.multi_line(true)` to all 3 branches of `compile_replace_regex()`. Added trailing-match filter in both `(None, Some(re))` and `(Some(n), Some(re))` branches of `replace_content()`. |
| `src/ops/search.rs` | Added `.multi_line(true)` to both branches of `build_matcher()`. |
| `src/tx/search_op.rs` | Added `.multi_line(true)` to the tx engine search regex builder. |
| `src/api/search.rs` | Added `.multi_line(true)` to the library API search regex builder. |
| `src/ast/replace.rs` | Changed `Regex::new()` to `RegexBuilder::new().multi_line(true).build()` with phantom-match filter. |
| `src/ops/replace_tests.rs` | 8 new tests covering anchor matching at line boundaries, nth+phantom skipping, no-trailing-newline, and empty file. |

## Root cause

`search --regex '^$'` iterates line-by-line, so `^` and `$` naturally match at line boundaries. `replace --regex '^$'` used `re.replace_all(content)` against full file content without `multi_line(true)`, so `^$/$` only matched the absolute string start/end, returning NO_MATCHES (exit 3) while search found matches (exit 0).

## Testing

- 1953 unit tests pass
- 834 integration tests pass
- 10 PTY tests pass
- `make check-fast` passes

Closes #1253