### PR TITLE
test: remove 14 duplicate test functions from fixloop sessions

### DIFF
--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -183,34 +183,6 @@ mod basic {
         assert_eq!(output, "5");
     }
 
-    // -- parse_value --------------------------------------------------------
-
-    #[test]
-    fn parse_value_bare_string() {
-        assert_eq!(parse_value("hello"), serde_json::json!("hello"));
-    }
-
-    #[test]
-    fn parse_value_integer() {
-        assert_eq!(parse_value("42"), serde_json::json!(42));
-    }
-
-    #[test]
-    fn parse_value_bool() {
-        assert_eq!(parse_value("true"), serde_json::json!(true));
-    }
-
-    #[test]
-    fn parse_value_null() {
-        assert_eq!(parse_value("null"), serde_json::Value::Null);
-    }
-
-    #[test]
-    fn parse_value_json_object() {
-        let v = parse_value(r#"{"a":1}"#);
-        assert_eq!(v, serde_json::json!({"a": 1}));
-    }
-
     // -- set ----------------------------------------------------------------
 
     #[test]

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -477,9 +477,9 @@ fn parse_multi_document_yaml(content: &str) -> anyhow::Result<serde_json::Value>
         resolve_yaml_merge_keys(&mut val);
         docs.push(val);
     }
-    if docs.is_empty() {
-        anyhow::bail!("empty multi-document YAML");
-    }
+    // Precondition: is_multi_document_yaml() returned true, so content has
+    // ---  separators and the YAML deserializer always yields at least one doc.
+    debug_assert!(!docs.is_empty(), "multi-doc YAML produced zero documents");
     Ok(serde_json::Value::Array(docs))
 }
 

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -384,21 +384,6 @@ mod basic {
     }
 
     #[test]
-    fn parse_value_plain_string() {
-        let result = parse_value("hello");
-        assert_eq!(result, json!("hello"));
-        assert!(result.is_string());
-    }
-
-    #[test]
-    fn parse_value_true_is_bool() {
-        // "true" is recognized as boolean, not left as a string.
-        let result = parse_value("true");
-        assert_eq!(result, json!(true));
-        assert!(result.is_boolean());
-    }
-
-    #[test]
     fn parse_value_false_is_bool() {
         let result = parse_value("false");
         assert_eq!(result, json!(false));
@@ -505,13 +490,6 @@ mod edge_cases {
     fn delete_at_selector_missing_returns_false() {
         let mut root = json!({"a": 1});
         let sel = crate::selector::parse("nonexistent").unwrap();
-        assert!(!delete_at_selector(&mut root, &sel).unwrap());
-    }
-
-    #[test]
-    fn delete_at_selector_empty_returns_false() {
-        let mut root = json!({"a": 1});
-        let sel: Vec<crate::selector::Segment> = vec![];
         assert!(!delete_at_selector(&mut root, &sel).unwrap());
     }
 
@@ -715,20 +693,6 @@ mod error_handling {
         let mut root = json!({"items": [1]});
         let sel = crate::selector::parse("items[5]").unwrap();
         assert!(set_at_path(&mut root, &sel, json!(99)).is_err());
-    }
-
-    #[test]
-    fn set_at_path_empty_selector_fails() {
-        let mut root = json!({});
-        let sel: Vec<crate::selector::Segment> = vec![];
-        assert!(set_at_path(&mut root, &sel, json!(1)).is_err());
-    }
-
-    #[test]
-    fn delete_where_invalid_predicate_fails() {
-        let mut root = json!({"items": [{"name": "a"}]});
-        let sel = crate::selector::parse("items").unwrap();
-        assert!(delete_where(&mut root, &sel, "no-equals-sign").is_err());
     }
 
     #[test]

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -670,31 +670,10 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn needs_quoting_booleans_and_null() {
-        assert!(needs_yaml_quoting("true"));
-        assert!(needs_yaml_quoting("True"));
-        assert!(needs_yaml_quoting("yes"));
-        assert!(needs_yaml_quoting("null"));
-        assert!(needs_yaml_quoting("~"));
-    }
-
-    #[test]
-    fn needs_quoting_numbers() {
-        assert!(needs_yaml_quoting("42"));
-        assert!(needs_yaml_quoting("3.14"));
-    }
-
-    #[test]
     fn needs_quoting_special_chars() {
         assert!(needs_yaml_quoting("# comment"));
         assert!(needs_yaml_quoting("a: b"));
         assert!(needs_yaml_quoting(""));
-    }
-
-    #[test]
-    fn needs_quoting_trailing_colon() {
-        assert!(needs_yaml_quoting("host:"));
-        assert!(needs_yaml_quoting("value:"));
     }
 
     #[test]

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1444,17 +1444,6 @@ body text
     }
 
     #[test]
-    fn table_append_no_table_returns_no_table_error() {
-        let content = "# API\nJust text\n";
-        let (start, end) = find_section(content, "API").unwrap();
-        let err = table_append_in(content, start, end, "| b | 2 |").unwrap_err();
-        assert!(
-            matches!(err, TableAppendError::NoTable),
-            "expected NoTable, got: {err:?}"
-        );
-    }
-
-    #[test]
     fn upsert_bullet_does_not_dedup_against_paragraph() {
         let content = "# Rules\nRun make check\n";
         let out = upsert_bullet_in(content, "Rules", "- Run make check")

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -281,9 +281,8 @@ pub fn replace_content<'a>(
         }
         (None, None) => {
             // Single-pass using SIMD-accelerated memchr::memmem::Finder.
-            if from.is_empty() {
-                return (Cow::Borrowed(content), 0);
-            }
+            // All callers validate `from` is non-empty via validate_replace_args().
+            debug_assert!(!from.is_empty(), "replace_content called with empty `from`");
             let finder = memchr::memmem::Finder::new(from.as_bytes());
             let bytes = content.as_bytes();
             let mut result = String::with_capacity(content.len());

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -577,14 +577,6 @@ mod replace_tests {
         }
 
         #[test]
-        fn replace_content_empty_from_returns_borrowed() {
-            let (out, count) = replace_content("hello", "", "y", None, None);
-            assert_eq!(out, "hello");
-            assert_eq!(count, 0);
-            assert!(matches!(out, std::borrow::Cow::Borrowed(_)));
-        }
-
-        #[test]
         fn replace_content_regex_nth_no_match_returns_borrowed() {
             let re = regex::Regex::new(r"\d+").unwrap();
             let (out, count) = replace_content("no digits here", "unused", "N", Some(&re), Some(1));


### PR DESCRIPTION
## Summary

Clean up test and code accumulated during iterative fixloop/fixrealloop bug-hunting sessions (#1086-#1253).

### Commit 1: Remove 14 duplicate test functions

Tests added during fixloop rounds without checking for pre-existing coverage:

| Category | Count | Files |
|----------|-------|-------|
| Same-file exact duplicates | 3 | `md_tests.rs`, `doc/tests.rs` |
| Cross-module pure-function duplicates | 5 | `cmd/doc_tests.rs` |
| Cross-file duplicates (doc/tests copies of navigate.rs) | 3 | `doc/tests.rs` |
| Subsumed by more thorough versions | 3 | `yaml_splice.rs` |

### Commit 2: Replace 2 dead defensive guards with debug_assert

Guards that protect against states unreachable through any public API path:

1. **`replace_content()` empty-from guard** (`ops/replace.rs`): All callers validate `from` non-empty via `validate_replace_args()` before calling. The guard and its test (`replace_content_empty_from_returns_borrowed`) exercised this dead path by calling the internal function directly with empty input.

2. **`parse_multi_document_yaml()` empty-docs guard** (`ops/doc/mod.rs`): Only called when `is_multi_document_yaml()` returns true, which guarantees the YAML deserializer produces at least one document.

Both guards are replaced with `debug_assert!()` to document the invariant without carrying dead runtime code.

### What was verified reachable and NOT removed

- TidyFix dedent+indent guard in `engine.rs`: reachable via library API `execute_single()`
- navigate.rs wildcard/predicate write guards: reachable through selector parser
- fallback.rs empty-input guards: public API for library consumers
- All fixloop edge-case tests (YAML, CRLF, frontmatter, AST, patch): legitimate for an MCP tool accepting untrusted LLM input

## Verification

- All unit, integration, and PTY tests pass
- `make check-fast` passes
- Zero coverage loss