### PR TITLE
test: increase PTY expect timeout to fix flakiness under load

### DIFF
--- a/tests/pty.rs
+++ b/tests/pty.rs
@@ -28,9 +28,14 @@ fn patchloom_cmd(cwd: &std::path::Path) -> Command {
 }
 
 /// Spawn a PTY session with a generous timeout for CI reliability.
+///
+/// The 30-second timeout is deliberately long: under normal conditions each
+/// `expect()` call returns in milliseconds, so the timeout adds zero latency.
+/// But when PTY tests run right after 800+ integration tests in `make check-fast`,
+/// system load can delay process startup enough to hit a 10-second ceiling.
 fn spawn_pty(cmd: Command) -> OsSession {
     let mut session = OsSession::spawn(cmd).expect("failed to spawn PTY session");
-    session.set_expect_timeout(Some(Duration::from_secs(10)));
+    session.set_expect_timeout(Some(Duration::from_secs(30)));
     session
 }
 


### PR DESCRIPTION
## Summary

Increases the PTY expect timeout from 10s to 30s to eliminate flaky test failures.

### Problem

When PTY tests run right after 800+ integration tests in `make check-fast`, system load can delay process startup inside the PTY enough to exceed the 10-second expect timeout, causing spurious `FAILED. 9 passed; 1 failed` results (total runtime ~18s = one test hitting the 10s ceiling).

### Fix

Increase the per-expect timeout from 10s to 30s. This adds zero latency under normal conditions (each `expect()` returns immediately on pattern match) but provides enough headroom for loaded systems.

### Verification

- PTY tests pass 50/50 under load (unit + integration tests immediately before)
- All runs complete in ~1.5s (timeout is never reached under normal conditions)
- `make check-fast` passes