### PR TITLE
fix: retry TLS connection in HTTPS MCP test to handle startup race

### DIFF
--- a/tests/integration/mcp_tests.rs
+++ b/tests/integration/mcp_tests.rs
@@ -166,13 +166,32 @@ async fn test_mcp_https_search_files_round_trip() {
         .expect("build reqwest client");
 
     // Connect an MCP client over Streamable HTTPS.
+    // Retry the TLS connection: axum_server prints the banner when the TCP
+    // listener binds, but the TLS acceptor may not be fully initialized yet.
+    // On macOS this race is hit consistently; on Linux it rarely occurs.
     use rmcp::ServiceExt;
-    let config =
-        rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig::with_uri(url);
-    let transport =
-        rmcp::transport::StreamableHttpClientTransport::with_client(http_client, config);
-    let client: rmcp::service::RunningService<rmcp::RoleClient, ()> =
-        ().serve(transport).await.expect("HTTPS client connect");
+    let mut client_opt = None;
+    for attempt in 0..10 {
+        let config =
+            rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig::with_uri(
+                url,
+            );
+        let transport = rmcp::transport::StreamableHttpClientTransport::with_client(
+            http_client.clone(),
+            config,
+        );
+        match ().serve(transport).await {
+            Ok(c) => {
+                client_opt = Some(c);
+                break;
+            }
+            Err(_) if attempt < 9 => {
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            }
+            Err(e) => panic!("HTTPS client connect failed after 10 attempts: {e}"),
+        }
+    }
+    let client: rmcp::service::RunningService<rmcp::RoleClient, ()> = client_opt.unwrap();
 
     // List tools.
     let tools = client.peer().list_all_tools().await.unwrap();


### PR DESCRIPTION
## Summary

Fixes the HTTPS MCP integration test that consistently failed on macOS but passed in CI (Ubuntu).

### Root cause

`axum_server` prints the listening banner when the TCP listener binds, but the TLS acceptor may not be fully initialized yet. The test parses the port from the banner and immediately attempts a TLS handshake, which hits a `BrokenPipe` because the server-side TLS layer is not ready.

On Linux the TLS setup completes fast enough that the race is never hit. On macOS it is hit consistently (100% failure rate).

### Fix

Add a retry loop (up to 10 attempts with 200ms delay) around the MCP client TLS connection. When the server is ready immediately (Linux, fast macOS), the first attempt succeeds with zero added latency. When the TLS startup race occurs, the retry absorbs it gracefully.

### Verification

- Passes 5/5 runs in isolation on macOS (was 0/5 before)
- `make check-fast` passes clean (1,938 unit + 834 integration + 10 PTY)
- No regression expected on Linux CI

Closes #1258