### PR TITLE
fix: update stale counts and add missing MCP integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,8 +78,8 @@ src/
                        generator, and inline Completions command
   cmd/append.rs        Append content to an existing file
   cmd/batch.rs         Line-oriented batch operations, parses positional args, delegates to tx engine
-  cmd/mcp/mod.rs       MCP server (feature-gated): 19 auto-generated tools via MCP_TOOL_REGISTRY +
-                       24 hand-written #[tool] handlers, dynamic registration via ToolRoute::new_dyn()
+  cmd/mcp/mod.rs       MCP server (feature-gated): 22 auto-generated tools via MCP_TOOL_REGISTRY +
+                       33 hand-written #[tool] handlers, dynamic registration via ToolRoute::new_dyn()
   cmd/mcp/params.rs    Parameter structs for hand-written MCP tool handlers only; simple tools use
                        Operation variant schemas directly via operation_variant_schema()
   cmd/search.rs        Literal/regex search across files with context, count, files-with-matches, -i

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,8 @@ src/
   selector/parser.rs   Path selector parser (key, index, wildcard, predicate segments)
   selector/eval.rs     Evaluate parsed selectors against serde_json::Value trees
   exit.rs              Exit code constants: SUCCESS=0, FAILURE=1, CHANGES_DETECTED=2,
-                       NO_MATCHES=3, PARSE_ERROR=4, AMBIGUOUS=5, VALIDATION_FAILED=6, ROLLBACK=7, CONFLICTS=8
+                       NO_MATCHES=3, PARSE_ERROR=4, AMBIGUOUS=5, VALIDATION_FAILED=6, ROLLBACK=7,
+                       CONFLICTS=8, OPERATION_FAILED=9
   diff.rs              Unified diff generation using similar::TextDiff; FileDiff and DiffResult types
   ops.rs               Shared operation helpers used by cmd/tx.rs, cmd/doc.rs, cmd/md.rs:
                        replace (validation, replacement text, content replacement),

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,8 +98,8 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **1,800+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
-- **22 commands** including MCP server with 43 structured tool calls
+- **2,700+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
+- **22 commands** including MCP server with 53 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -3098,3 +3098,156 @@ async fn test_mcp_md_dedupe_headings() {
     );
     client.cancel().await.unwrap();
 }
+
+// ── MCP ast_insert round-trip ──────────────────────────────────
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_insert_after_symbol() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn existing() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_insert",
+        serde_json::json!({
+            "path": "lib.rs",
+            "content": "fn added() { 42 }",
+            "after": "existing"
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_insert should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_insert ok: {val}");
+
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    assert!(
+        content.contains("fn added()"),
+        "inserted function should appear: {content}"
+    );
+    let existing_pos = content.find("fn existing").unwrap();
+    let added_pos = content.find("fn added").unwrap();
+    assert!(
+        added_pos > existing_pos,
+        "added should come after existing: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+// ── MCP ast_wrap round-trip ────────────────────────────────────
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_wrap_symbols_in_module() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn test_a() {}\nfn test_b() {}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_wrap",
+        serde_json::json!({
+            "path": "lib.rs",
+            "symbols": ["test_a", "test_b"],
+            "wrapper": "mod tests"
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_wrap should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_wrap ok: {val}");
+
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    assert!(
+        content.contains("mod tests"),
+        "wrapper module should appear: {content}"
+    );
+    assert!(
+        content.contains("fn test_a"),
+        "wrapped function test_a should remain: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+// ── MCP ast_imports round-trip ─────────────────────────────────
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_imports_add() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("main.rs"),
+        "use std::io;\n\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_imports",
+        serde_json::json!({
+            "path": "main.rs",
+            "add": ["use std::collections::HashMap;"]
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_imports add should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_imports ok: {val}");
+
+    let content = fs::read_to_string(dir.path().join("main.rs")).unwrap();
+    assert!(
+        content.contains("use std::collections::HashMap"),
+        "added import should appear: {content}"
+    );
+    assert!(
+        content.contains("use std::io"),
+        "existing import should remain: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_imports_list_only() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "use std::io;\nuse std::fs;\n\nfn f() {}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_imports",
+        serde_json::json!({"path": "lib.rs"}),
+    )
+    .await;
+    assert!(!is_error, "ast_imports list should succeed: {val}");
+    // List-only mode returns the imports array rather than ok:true.
+    assert_eq!(val["count"], 2, "should list 2 imports: {val}");
+
+    // File should be unchanged (read-only operation).
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    assert_eq!(
+        content, "use std::io;\nuse std::fs;\n\nfn f() {}\n",
+        "file should be unchanged"
+    );
+    client.cancel().await.unwrap();
+}

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -3188,11 +3188,7 @@ async fn test_mcp_ast_imports_add() {
         return;
     }
     let dir = TempDir::new().unwrap();
-    fs::write(
-        dir.path().join("main.rs"),
-        "use std::io;\n\nfn main() {}\n",
-    )
-    .unwrap();
+    fs::write(dir.path().join("main.rs"), "use std::io;\n\nfn main() {}\n").unwrap();
 
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, val) = call_tool_value(

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -783,13 +783,13 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("1,800+ tests"));
+    assert!(launch.contains("2,700+ tests"));
     assert!(
         launch.contains("22 commands"),
         "launch announcement CLI command count drifted"
     );
     assert!(
-        launch.contains("43 structured tool calls"),
+        launch.contains("53 structured tool calls"),
         "launch announcement MCP tool count drifted"
     );
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
## Summary

Fixes stale documentation counts and adds missing integration test coverage
found during a multi-perspective improvement cycle.

## Changes

### Test coverage
- Add integration tests for `ast_insert`, `ast_wrap`, and `ast_imports` MCP
  tools (previously at zero coverage)

### Documentation accuracy
- Update launch announcement: 1,800+ tests to 2,700+, 43 to 53 MCP tools
- Update AGENTS.md: 19 to 22 auto-generated MCP tools, 24 to 33 hand-written
  MCP tools, add missing `OPERATION_FAILED=9` exit code
- Fix smoke test assertion that validated the old MCP tool count (43 to 53)
