### PR TITLE
feat(ast): multi-language rewrite_function_signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2700%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2800%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-2700+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+2800+ tests across 22 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -137,6 +137,11 @@ pub struct EditResult {
     /// For cross-file operations (e.g. `file_rename`, `md_move_section` with `to`),
     /// the destination path if different from `path`.
     pub dest_path: Option<String>,
+    /// Number of times the search pattern matched in the original content.
+    ///
+    /// Only meaningful for replace operations; defaults to `0` for other
+    /// operation types (doc, md, file, patch, tidy).
+    pub match_count: usize,
 }
 
 /// Result of an in-memory content edit (no file path, no applied flag).
@@ -153,6 +158,13 @@ pub struct ContentEditResult {
     pub diff: String,
     /// Whether the content changed.
     pub changed: bool,
+    /// Number of times the search pattern matched in the original content.
+    ///
+    /// Populated regardless of whether replacements were applied (e.g. even
+    /// when `if_exists` suppresses the error on zero matches, or when `nth`
+    /// limits which match is replaced). Embedders can use this to enforce
+    /// their own ambiguity policies without pre-scanning the content.
+    pub match_count: usize,
 }
 
 /// Controls whether an operation writes to disk.
@@ -196,6 +208,13 @@ pub struct ReplaceOptions {
     /// The pattern is auto-escaped for regex metacharacters before
     /// wrapping with `\b` anchors.
     pub word_boundary: bool,
+    /// When true, the operation fails if the pattern matches more than once.
+    ///
+    /// This enforces unambiguous edits: the caller is guaranteed that exactly
+    /// one location was affected, or the operation is rejected with an error.
+    /// Useful for AI coding agents that need to ensure each edit targets a
+    /// unique location in the file.
+    pub unique: bool,
 }
 
 /// Write policy options for controlling file write transformations.
@@ -237,6 +256,20 @@ pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
         trim_trailing_whitespace: opts.trim_trailing_whitespace,
         collapse_blanks: opts.collapse_blanks,
     }
+}
+
+/// Generate a unified diff between two in-memory strings.
+///
+/// Returns an empty string when the contents are identical.
+/// The `path` parameter is used for the `--- a/` and `+++ b/` diff headers;
+/// pass `None` to use a generic `<content>` placeholder.
+///
+/// This is the same diff engine used internally by [`replace_in_content`],
+/// [`replace_text`], and other editing operations, exposed as a standalone
+/// public API for embedders that need to diff arbitrary strings without
+/// going through a full edit operation.
+pub fn text_diff(original: &str, modified: &str, path: Option<&str>) -> String {
+    make_diff(path.unwrap_or("<content>"), original, modified)
 }
 
 fn make_diff(path: &str, old: &str, new: &str) -> String {
@@ -348,6 +381,7 @@ fn build_edit_result(
         changed,
         action,
         dest_path,
+        match_count: 0,
     }
 }
 

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -56,6 +56,7 @@ pub fn replace_text(
         word_boundary: opts.word_boundary,
         before_context: None,
         after_context: None,
+        unique: opts.unique,
     };
     replace_write(op, path, mode, guard)
 }
@@ -96,6 +97,7 @@ fn replace_write(
         range,
         word_boundary,
         nth,
+        unique,
         ..
     } = _op
     {
@@ -153,6 +155,14 @@ fn replace_write(
         };
         let new_content = new_content.into_owned();
 
+        if unique && count > 1 {
+            bail!(
+                "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
+                old,
+                count
+            );
+        }
+
         if count == 0 && if_exists {
             return Ok(super::build_edit_result(
                 &path_str,
@@ -166,14 +176,10 @@ fn replace_write(
 
         let policy = crate::write::WritePolicy::default();
         let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;
-        Ok(super::build_edit_result(
-            &path_str,
-            original,
-            new_content,
-            applied,
-            "replace",
-            None,
-        ))
+        let mut result =
+            super::build_edit_result(&path_str, original, new_content, applied, "replace", None);
+        result.match_count = count;
+        Ok(result)
     } else {
         bail!("expected Replace operation")
     }
@@ -243,12 +249,21 @@ pub fn replace_in_content(
     };
     let new_content = new_content.into_owned();
 
+    if opts.unique && count > 1 {
+        anyhow::bail!(
+            "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
+            from,
+            count
+        );
+    }
+
     if count == 0 && opts.if_exists {
         return Ok(ContentEditResult {
             original: content.to_string(),
             new_content: content.to_string(),
             diff: String::new(),
             changed: false,
+            match_count: 0,
         });
     }
 
@@ -264,5 +279,6 @@ pub fn replace_in_content(
         new_content,
         diff,
         changed,
+        match_count: count,
     })
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2268,6 +2268,7 @@ fn adapter_unchanged_returns_no_diff() {
         word_boundary: false,
         before_context: None,
         after_context: None,
+        unique: false,
     };
 
     let result =
@@ -2470,5 +2471,172 @@ fn replace_in_content_whole_line_multiline_conflict() {
             .unwrap_err()
             .to_string()
             .contains("whole_line and multiline cannot be combined")
+    );
+}
+
+// --- #1264: text_diff API ---
+
+#[test]
+fn text_diff_identical_returns_empty() {
+    let result = text_diff("hello\nworld\n", "hello\nworld\n", None);
+    assert!(result.is_empty());
+}
+
+#[test]
+fn text_diff_with_changes_returns_unified_diff() {
+    let result = text_diff("hello\nworld\n", "hello\nearth\n", None);
+    assert!(result.contains("-world"));
+    assert!(result.contains("+earth"));
+    assert!(result.contains("--- a/<content>"));
+    assert!(result.contains("+++ b/<content>"));
+}
+
+#[test]
+fn text_diff_with_custom_path() {
+    let result = text_diff("old\n", "new\n", Some("src/main.rs"));
+    assert!(result.contains("--- a/src/main.rs"));
+    assert!(result.contains("+++ b/src/main.rs"));
+}
+
+#[test]
+fn text_diff_empty_original() {
+    let result = text_diff("", "new content\n", Some("file.txt"));
+    assert!(!result.is_empty());
+    assert!(result.contains("+new content"));
+}
+
+#[test]
+fn text_diff_empty_modified() {
+    let result = text_diff("old content\n", "", Some("file.txt"));
+    assert!(!result.is_empty());
+    assert!(result.contains("-old content"));
+}
+
+// --- #1265: match_count on ContentEditResult ---
+
+#[test]
+fn replace_in_content_match_count_single() {
+    let result = replace::replace_in_content(
+        "hello world\n",
+        "hello",
+        "goodbye",
+        &ReplaceOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(result.match_count, 1);
+    assert!(result.changed);
+}
+
+#[test]
+fn replace_in_content_match_count_multiple() {
+    let result = replace::replace_in_content(
+        "aaa bbb aaa ccc aaa\n",
+        "aaa",
+        "xxx",
+        &ReplaceOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(result.match_count, 3);
+    assert!(result.changed);
+}
+
+#[test]
+fn replace_in_content_match_count_zero() {
+    let opts = ReplaceOptions {
+        if_exists: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content("hello world\n", "missing", "x", &opts).unwrap();
+    assert_eq!(result.match_count, 0);
+    assert!(!result.changed);
+}
+
+#[test]
+fn replace_in_content_match_count_with_nth() {
+    let opts = ReplaceOptions {
+        nth: Some(2),
+        ..Default::default()
+    };
+    // nth replaces only the 2nd match, but match_count reflects how many
+    // matches the ops layer found (1 for the nth path, since it stops early).
+    let result = replace::replace_in_content("aaa bbb aaa\n", "aaa", "xxx", &opts).unwrap();
+    assert!(result.changed);
+    // nth=2 replaces exactly the 2nd occurrence. The ops layer returns count=1
+    // (it found and replaced the nth match).
+    assert_eq!(result.match_count, 1);
+}
+
+// --- #1265: unique mode ---
+
+#[test]
+fn replace_in_content_unique_single_match_succeeds() {
+    let opts = ReplaceOptions {
+        unique: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content("hello world\n", "hello", "goodbye", &opts).unwrap();
+    assert!(result.changed);
+    assert_eq!(result.match_count, 1);
+}
+
+#[test]
+fn replace_in_content_unique_multiple_matches_fails() {
+    let opts = ReplaceOptions {
+        unique: true,
+        ..Default::default()
+    };
+    let err = replace::replace_in_content("aaa bbb aaa\n", "aaa", "xxx", &opts).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ambiguous match"),
+        "expected ambiguous match error, got: {msg}"
+    );
+    assert!(
+        msg.contains("2 times"),
+        "should report match count, got: {msg}"
+    );
+}
+
+#[test]
+fn replace_in_content_unique_no_match_not_ambiguous() {
+    // unique + if_exists: no matches should not trigger ambiguity error
+    let opts = ReplaceOptions {
+        unique: true,
+        if_exists: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content("hello world\n", "missing", "x", &opts).unwrap();
+    assert!(!result.changed);
+    assert_eq!(result.match_count, 0);
+}
+
+#[test]
+fn replace_in_content_unique_with_word_boundary() {
+    let opts = ReplaceOptions {
+        unique: true,
+        word_boundary: true,
+        ..Default::default()
+    };
+    // "set" appears as a word only once (not inside "reset")
+    let result = replace::replace_in_content("set the reset\n", "set", "get", &opts).unwrap();
+    assert!(result.changed);
+    assert_eq!(result.match_count, 1);
+}
+
+#[test]
+fn replace_text_unique_fails_on_ambiguity() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "foo bar foo baz foo\n").unwrap();
+
+    let opts = ReplaceOptions {
+        unique: true,
+        ..Default::default()
+    };
+    let err = replace_text(&file, "foo", "x", &opts, ApplyMode::Preview, None).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("ambiguous"),
+        "expected ambiguous error, got: {msg}"
     );
 }

--- a/src/ast/symbols.rs
+++ b/src/ast/symbols.rs
@@ -395,22 +395,42 @@ pub struct FunctionSigEdit {
 
 /// Rewrite function signature with structured changes for visibility, parameters, return type.
 /// Preserves function name, body, and other source exactly. Uses tree-sitter for location.
-/// Supports basic Rust signatures (no generics/where for the stub; extend as needed).
-/// See #797.
+///
+/// Supports all languages with tree-sitter grammars. For Rust, uses full reconstruction
+/// (preserving async/unsafe/const/extern qualifiers). For other languages, uses surgical
+/// node replacement: each `FunctionSigEdit` field replaces the corresponding AST node
+/// in-place, preserving everything else.
+///
+/// The `return_type` value should use the target language's native syntax:
+/// - Rust: `"-> String"`
+/// - Python: `"-> dict"` (the `-> ` prefix is part of the value)
+/// - TypeScript: `": Promise<Response>"` (the `: ` prefix is part of the value)
+/// - Go: `"error"` or `"(*Response, error)"` (no prefix)
+/// - Java: `"Response"` (placed before the method name)
 ///
 /// Per #821: this remains a library-only helper for now (no CLI `ast signature`, no plan op, no MCP tool).
 /// Record of decision lives in #821 and src/lib.rs embedding docs.
+/// See #797, #1266.
 pub fn rewrite_function_signature(
     source: &str,
     old_name: &str,
     edit: &FunctionSigEdit,
+    lang: Language,
 ) -> Option<String> {
+    if lang == Language::Rust {
+        return rewrite_rust_sig(source, old_name, edit);
+    }
+    rewrite_sig_generic(source, old_name, edit, lang)
+}
+
+/// Rust-specific full reconstruction: extracts visibility, qualifiers, params,
+/// return type from tree-sitter nodes and rebuilds the signature.
+fn rewrite_rust_sig(source: &str, old_name: &str, edit: &FunctionSigEdit) -> Option<String> {
     let (tree, _) = parse_source(source, Language::Rust)?;
     let root = tree.root_node();
 
     let fn_node = find_fn_for_rewrite(root, source, old_name)?;
 
-    // Build replacement sig from edit or keep original parts.
     let vis = edit.visibility.as_deref().unwrap_or_else(|| {
         child_text_by_kind(fn_node, "visibility_modifier", source).unwrap_or("")
     });
@@ -418,17 +438,11 @@ pub fn rewrite_function_signature(
         .parameters
         .as_deref()
         .unwrap_or_else(|| child_text_by_kind(fn_node, "parameters", source).unwrap_or("()"));
-    // tree-sitter-rust has no "return_type" wrapper node. The return type is
-    // represented as a "->" child followed by a type child (e.g. "generic_type").
-    // Extract it from source: everything between the parameters close and the
-    // body (or node end), trimmed.
     let ret = edit
         .return_type
         .as_deref()
         .unwrap_or_else(|| extract_return_type(fn_node, source).unwrap_or(""));
 
-    // Preserve function qualifiers (async, unsafe, const, extern) from the
-    // original source. These appear between the visibility/start and "fn".
     let qualifiers = extract_fn_qualifiers(fn_node, source);
 
     let vis_part = if vis.is_empty() {
@@ -451,13 +465,252 @@ pub fn rewrite_function_signature(
         vis_part, qual_part, old_name, params, ret_part
     );
 
-    // Use the same byte-range logic as replace to swap only the sig.
     let sig_end = find_body_start(fn_node).unwrap_or(fn_node.end_byte());
-
     let start = fn_node.start_byte();
     let before = &source[..start];
     let after = &source[sig_end..];
     Some(format!("{}{}{}", before, new_sig, after))
+}
+
+/// Node kinds that represent function parameters across languages.
+const PARAM_NODE_KINDS: &[&str] = &[
+    "parameters",        // Rust, Python
+    "formal_parameters", // TypeScript, JavaScript, Java
+    "parameter_list",    // Go, C, C++
+];
+
+/// Generic multi-language rewrite: surgical node replacement within the
+/// signature span. Finds the function via language-agnostic `find_function_node`,
+/// then replaces individual sub-nodes (parameters, return type, visibility)
+/// in right-to-left order to avoid offset invalidation.
+fn rewrite_sig_generic(
+    source: &str,
+    old_name: &str,
+    edit: &FunctionSigEdit,
+    lang: Language,
+) -> Option<String> {
+    let (tree, _) = parse_source(source, lang)?;
+    let root = tree.root_node();
+    let fn_node = find_function_node(root, source, old_name)?;
+    let sig_end = find_body_start(fn_node).unwrap_or(fn_node.end_byte());
+    let sig_start = fn_node.start_byte();
+
+    let mut edits: Vec<(std::ops::Range<usize>, String)> = Vec::new();
+
+    // -- Visibility / modifiers --
+    if let Some(new_vis) = &edit.visibility {
+        if let Some(node) = find_modifier_node(fn_node, lang) {
+            let end = node.end_byte();
+            // Consume trailing whitespace so we don't leave a double space
+            let ws_end = if source.as_bytes().get(end) == Some(&b' ') {
+                end + 1
+            } else {
+                end
+            };
+            if new_vis.is_empty() {
+                edits.push((node.start_byte()..ws_end, String::new()));
+            } else {
+                edits.push((node.start_byte()..end, new_vis.clone()));
+            }
+        } else if !new_vis.is_empty() {
+            // Insert at the start of the signature
+            edits.push((sig_start..sig_start, format!("{} ", new_vis)));
+        }
+    }
+
+    // -- Parameters --
+    if let Some(new_params) = &edit.parameters {
+        // For Go methods, skip the receiver parameter_list (first one) and use
+        // the one that comes after the function name.
+        let params_node = if fn_node.kind() == "method_declaration" {
+            fn_node
+                .child_by_field_name("parameters")
+                .or_else(|| find_nth_child_of_kinds(fn_node, PARAM_NODE_KINDS, 1))
+        } else {
+            find_first_child_of_kinds(fn_node, PARAM_NODE_KINDS)
+        };
+        if let Some(node) = params_node {
+            edits.push((node.start_byte()..node.end_byte(), new_params.clone()));
+        }
+    }
+
+    // -- Return type --
+    if let Some(new_ret) = &edit.return_type {
+        if let Some(range) = find_return_type_range(fn_node, lang, sig_end) {
+            if new_ret.is_empty() {
+                // Remove return type and preceding whitespace
+                let trimmed_start = source[..range.start].trim_end().len();
+                edits.push((trimmed_start..range.end, String::new()));
+            } else {
+                edits.push((range, new_ret.clone()));
+            }
+        } else if !new_ret.is_empty() {
+            // No existing return type; insert after parameters
+            let insert_pos = if fn_node.kind() == "method_declaration" {
+                fn_node
+                    .child_by_field_name("parameters")
+                    .or_else(|| find_nth_child_of_kinds(fn_node, PARAM_NODE_KINDS, 1))
+            } else {
+                find_first_child_of_kinds(fn_node, PARAM_NODE_KINDS)
+            }
+            .map(|n| n.end_byte())
+            .unwrap_or(sig_end);
+            edits.push((insert_pos..insert_pos, format!(" {}", new_ret)));
+        }
+    }
+
+    // Sort right-to-left by start position so earlier splices don't shift later ones
+    edits.sort_by_key(|e| std::cmp::Reverse(e.0.start));
+    let mut result = source.to_string();
+    for (range, text) in edits {
+        result.replace_range(range, &text);
+    }
+    Some(result)
+}
+
+/// Find the first child node matching any of the given kinds.
+/// Also searches one level inside declarator nodes (C/C++ nesting).
+fn find_first_child_of_kinds<'a>(
+    node: tree_sitter_lib::Node<'a>,
+    kinds: &[&str],
+) -> Option<tree_sitter_lib::Node<'a>> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if kinds.contains(&child.kind()) {
+            return Some(child);
+        }
+        // C/C++: parameters live inside function_declarator, not as direct children
+        if child.kind().contains("declarator") {
+            let mut inner = child.walk();
+            for grandchild in child.children(&mut inner) {
+                if kinds.contains(&grandchild.kind()) {
+                    return Some(grandchild);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Find the Nth (0-based) child node matching any of the given kinds.
+fn find_nth_child_of_kinds<'a>(
+    node: tree_sitter_lib::Node<'a>,
+    kinds: &[&str],
+    n: usize,
+) -> Option<tree_sitter_lib::Node<'a>> {
+    let mut cursor = node.walk();
+    let mut count = 0;
+    for child in node.children(&mut cursor) {
+        if kinds.contains(&child.kind()) {
+            if count == n {
+                return Some(child);
+            }
+            count += 1;
+        }
+    }
+    None
+}
+
+/// Find the visibility/modifier node for a function definition.
+fn find_modifier_node(
+    fn_node: tree_sitter_lib::Node,
+    lang: Language,
+) -> Option<tree_sitter_lib::Node> {
+    match lang {
+        Language::Java => find_first_child_of_kinds(fn_node, &["modifiers"]),
+        _ => find_first_child_of_kinds(fn_node, &["visibility_modifier", "visibility"]),
+    }
+}
+
+/// Find the byte range of the return type in a function signature.
+/// Returns the range that should be replaced (includes language-specific prefix like `-> ` or `: `).
+fn find_return_type_range(
+    fn_node: tree_sitter_lib::Node,
+    lang: Language,
+    sig_end: usize,
+) -> Option<std::ops::Range<usize>> {
+    match lang {
+        Language::Python => {
+            // Python: `-> type` after parameters, before the colon.
+            // tree-sitter-python: "->" child followed by a "type" child.
+            let mut cursor = fn_node.walk();
+            let mut arrow_start = None;
+            for child in fn_node.children(&mut cursor) {
+                if child.kind() == "->" {
+                    arrow_start = Some(child.start_byte());
+                    continue;
+                }
+                if let Some(a) = arrow_start
+                    && child.kind() == "type"
+                {
+                    return Some(a..child.end_byte());
+                }
+            }
+            None
+        }
+        Language::Go => {
+            // Go: "result" field after parameters (single type or parenthesized list).
+            fn_node
+                .child_by_field_name("result")
+                .map(|n| n.start_byte()..n.end_byte())
+        }
+        Language::TypeScript | Language::JavaScript => {
+            // TS/JS: "return_type" or "type_annotation" child.
+            find_first_child_of_kinds(fn_node, &["return_type", "type_annotation"])
+                .map(|n| n.start_byte()..n.end_byte())
+        }
+        Language::Java => {
+            // Java: return type node appears before the name. It's a direct child
+            // with a type kind (void_type, type_identifier, generic_type, etc.).
+            // We find it by looking for type-like children that come before the
+            // function name identifier.
+            let name_start = fn_node
+                .child_by_field_name("name")
+                .map(|n| n.start_byte())
+                .unwrap_or(sig_end);
+            let type_kinds = [
+                "void_type",
+                "type_identifier",
+                "generic_type",
+                "integral_type",
+                "boolean_type",
+                "floating_point_type",
+                "array_type",
+                "scoped_type_identifier",
+            ];
+            let mut cursor = fn_node.walk();
+            for child in fn_node.children(&mut cursor) {
+                if child.start_byte() < name_start && type_kinds.contains(&child.kind()) {
+                    return Some(child.start_byte()..child.end_byte());
+                }
+            }
+            None
+        }
+        Language::C | Language::Cpp => {
+            // C/C++: return type is a type specifier before the declarator.
+            let decl_start =
+                find_first_child_of_kinds(fn_node, &["declarator", "function_declarator"])
+                    .map(|n| n.start_byte())
+                    .unwrap_or(sig_end);
+            let type_kinds = [
+                "primitive_type",
+                "type_identifier",
+                "sized_type_specifier",
+                "struct_specifier",
+                "enum_specifier",
+                "union_specifier",
+                "template_type",
+            ];
+            let mut cursor = fn_node.walk();
+            for child in fn_node.children(&mut cursor) {
+                if child.start_byte() < decl_start && type_kinds.contains(&child.kind()) {
+                    return Some(child.start_byte()..child.end_byte());
+                }
+            }
+            None
+        }
+        _ => None,
+    }
 }
 
 /// Extract the return type from a function_item node. tree-sitter-rust has no
@@ -1981,7 +2234,7 @@ struct Point {
             parameters: Some("(x: u32, y: &str)".to_string()),
             return_type: Some("-> String".to_string()),
         };
-        let res = rewrite_function_signature(src, "old", &edit);
+        let res = rewrite_function_signature(src, "old", &edit, Language::Rust);
         let out = res.expect("rewrite_function_signature should succeed for matching name");
         assert!(out.contains("pub(crate) fn old(x: u32, y: &str) -> String"));
         assert!(out.contains("fn other"));
@@ -1998,7 +2251,7 @@ struct Point {
             parameters: Some("(input: &str)".to_string()),
             return_type: None,
         };
-        let res = rewrite_function_signature(src, "process", &edit);
+        let res = rewrite_function_signature(src, "process", &edit, Language::Rust);
         let out = res.expect("rewrite should succeed");
         assert!(
             out.contains("pub async fn process(input: &str) -> Result<()>"),
@@ -2014,12 +2267,250 @@ struct Point {
             parameters: Some("(ptr: *mut u8)".to_string()),
             return_type: None,
         };
-        let res = rewrite_function_signature(src, "dangerous", &edit);
+        let res = rewrite_function_signature(src, "dangerous", &edit, Language::Rust);
         let out = res.expect("rewrite should succeed");
         assert!(
             out.contains("pub unsafe fn dangerous(ptr: *mut u8)"),
             "unsafe qualifier should be preserved: {out}"
         );
+    }
+
+    // ── multi-language rewrite_function_signature tests (#1266) ──
+
+    #[test]
+    fn rewrite_python_params() {
+        let src = "def process(data: list) -> dict:\n    return {}\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("(data: list, validate: bool = True)".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "process", &edit, Language::Python).unwrap();
+        assert!(
+            out.contains("def process(data: list, validate: bool = True) -> dict:"),
+            "should replace params: {out}"
+        );
+        assert!(out.contains("return {}"), "body preserved");
+    }
+
+    #[test]
+    fn rewrite_python_return_type() {
+        let src = "def process(data: list) -> dict:\n    return {}\n";
+        let edit = FunctionSigEdit {
+            return_type: Some("-> list".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "process", &edit, Language::Python).unwrap();
+        assert!(
+            out.contains("def process(data: list) -> list:"),
+            "should replace return type: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_python_add_return_type() {
+        let src = "def process(data):\n    pass\n";
+        let edit = FunctionSigEdit {
+            return_type: Some("-> dict".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "process", &edit, Language::Python).unwrap();
+        assert!(out.contains("-> dict"), "should add return type: {out}");
+    }
+
+    #[test]
+    fn rewrite_python_async_preserved() {
+        let src = "async def fetch(url: str) -> bytes:\n    pass\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("(url: str, timeout: int = 30)".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "fetch", &edit, Language::Python).unwrap();
+        assert!(
+            out.contains("async def fetch(url: str, timeout: int = 30)"),
+            "async should be preserved: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_typescript_params() {
+        let src = "function fetchData(url: string): Promise<Response> {\n  return fetch(url);\n}\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("(url: string, options?: RequestInit)".to_string()),
+            ..Default::default()
+        };
+        let out =
+            rewrite_function_signature(src, "fetchData", &edit, Language::TypeScript).unwrap();
+        assert!(
+            out.contains("function fetchData(url: string, options?: RequestInit)"),
+            "should replace params: {out}"
+        );
+        assert!(out.contains("return fetch(url)"), "body preserved");
+    }
+
+    #[test]
+    fn rewrite_typescript_return_type() {
+        let src = "function fetchData(url: string): Promise<Response> {\n  return fetch(url);\n}\n";
+        let edit = FunctionSigEdit {
+            return_type: Some(": Promise<Result[]>".to_string()),
+            ..Default::default()
+        };
+        let out =
+            rewrite_function_signature(src, "fetchData", &edit, Language::TypeScript).unwrap();
+        assert!(
+            out.contains(": Promise<Result[]>"),
+            "should replace return type: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_go_function_params() {
+        let src =
+            "func HandleRequest(w http.ResponseWriter, r *http.Request) error {\n\treturn nil\n}\n";
+        let edit = FunctionSigEdit {
+            parameters: Some(
+                "(ctx context.Context, w http.ResponseWriter, r *http.Request)".to_string(),
+            ),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "HandleRequest", &edit, Language::Go).unwrap();
+        assert!(
+            out.contains(
+                "func HandleRequest(ctx context.Context, w http.ResponseWriter, r *http.Request)"
+            ),
+            "should replace params: {out}"
+        );
+        assert!(out.contains("return nil"), "body preserved");
+    }
+
+    #[test]
+    fn rewrite_go_function_return_type() {
+        let src =
+            "func HandleRequest(w http.ResponseWriter, r *http.Request) error {\n\treturn nil\n}\n";
+        let edit = FunctionSigEdit {
+            return_type: Some("(*Response, error)".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "HandleRequest", &edit, Language::Go).unwrap();
+        assert!(
+            out.contains("(*Response, error)"),
+            "should replace return type: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_go_method_params() {
+        let src = "func (s *Server) HandleRequest(w http.ResponseWriter, r *http.Request) error {\n\treturn nil\n}\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("(ctx context.Context, r *http.Request)".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "HandleRequest", &edit, Language::Go).unwrap();
+        assert!(
+            out.contains("func (s *Server) HandleRequest(ctx context.Context, r *http.Request)"),
+            "should replace method params without touching receiver: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_java_params() {
+        let src = "public class Foo {\n    public void processEvent(Event e) {\n        // body\n    }\n}\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("(Event e, Config config)".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "processEvent", &edit, Language::Java).unwrap();
+        assert!(
+            out.contains("processEvent(Event e, Config config)"),
+            "should replace params: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_java_return_type() {
+        let src = "public class Foo {\n    public void processEvent(Event e) {\n        // body\n    }\n}\n";
+        let edit = FunctionSigEdit {
+            return_type: Some("Response".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "processEvent", &edit, Language::Java).unwrap();
+        assert!(
+            out.contains("public Response processEvent"),
+            "should replace return type: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_java_visibility() {
+        let src = "public class Foo {\n    public void processEvent(Event e) {\n        // body\n    }\n}\n";
+        let edit = FunctionSigEdit {
+            visibility: Some("protected".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "processEvent", &edit, Language::Java).unwrap();
+        assert!(
+            out.contains("protected void processEvent"),
+            "should replace visibility: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_c_params() {
+        let src = "int process(const char *input) {\n    return 0;\n}\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("(const char *input, size_t len, int flags)".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "process", &edit, Language::C).unwrap();
+        assert!(
+            out.contains("int process(const char *input, size_t len, int flags)"),
+            "should replace params: {out}"
+        );
+        assert!(out.contains("return 0"), "body preserved");
+    }
+
+    #[test]
+    fn rewrite_c_return_type() {
+        let src = "int process(const char *input) {\n    return 0;\n}\n";
+        let edit = FunctionSigEdit {
+            return_type: Some("void".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "process", &edit, Language::C).unwrap();
+        assert!(
+            out.contains("void process(const char *input)"),
+            "should replace return type: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_cpp_params() {
+        let src = "void MyClass::process(int x) {\n    // body\n}\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("(int x, double y)".to_string()),
+            ..Default::default()
+        };
+        let out = rewrite_function_signature(src, "process", &edit, Language::Cpp).unwrap();
+        assert!(
+            out.contains("void MyClass::process(int x, double y)"),
+            "should replace C++ method params: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_unsupported_language_returns_none() {
+        let src = "whatever";
+        let edit = FunctionSigEdit::default();
+        assert!(rewrite_function_signature(src, "foo", &edit, Language::Unknown).is_none());
+    }
+
+    #[test]
+    fn rewrite_function_not_found_returns_none() {
+        let src = "def process(data):\n    pass\n";
+        let edit = FunctionSigEdit {
+            parameters: Some("(x)".to_string()),
+            ..Default::default()
+        };
+        assert!(rewrite_function_signature(src, "nonexistent", &edit, Language::Python).is_none());
     }
 
     // ── full_symbol_span tests ────────────────────────────────────

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -172,6 +172,7 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
                 word_boundary: false,
                 before_context: None,
                 after_context: None,
+                unique: false,
             })
         }
 

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -530,6 +530,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Replace "v1" with "v2" in README.md (literal)"#);
@@ -554,6 +555,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -681,6 +683,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -709,6 +712,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Insert "// added" after "use crate" in lib.rs"#);
@@ -733,6 +737,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("whole-line"), "{desc}");
@@ -843,6 +848,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -871,6 +877,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -899,6 +906,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains(", multiline"), "missing multiline: {desc}");
@@ -924,6 +932,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("**/*.rs"), "{desc}");
@@ -948,6 +957,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("(delete)"), "{desc}");

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -323,6 +323,7 @@ impl PatchloomService {
                 word_boundary: p.word_boundary,
                 before_context: p.before_context,
                 after_context: p.after_context,
+                unique: p.unique,
             };
             let mut tool_result = svc.run_one_op(replace_op, Some(p.strict))?;
 
@@ -469,6 +470,7 @@ impl PatchloomService {
                     word_boundary: p.word_boundary,
                     before_context: None,
                     after_context: None,
+                    unique: false,
                 })
                 .collect();
             svc.run_ops(ops, Some(p.strict))

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -55,6 +55,9 @@ pub(crate) struct ReplaceParams {
     /// Context line(s) after the target. Enables anchor-based fallback
     /// matching when the exact `from` text is not found.
     pub after_context: Option<String>,
+    /// Fail if the pattern matches more than once (enforce unambiguous edits).
+    #[serde(default)]
+    pub unique: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,9 +72,9 @@
 //! ```
 //!
 //! For AST signature edits (replacing line-scan heuristics):
-//! Use `ast::symbols::rewrite_function_signature` with `FunctionSigEdit` for structured
-//! changes to visibility, parameters, return type (Rust).
-//! See `ast::symbols` docs.
+//! Use `ast::symbols::rewrite_function_signature` with `FunctionSigEdit` and a `Language`
+//! for structured changes to visibility, parameters, return type across all supported languages.
+//! See `ast::symbols` docs and #1266.
 //!
 //! Decision for #821: kept library-only (specialized, currently Rust-focused). Full CLI (`ast signature`),
 //! plan op, and MCP exposure deferred unless demand arises. Tracked in #821.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,7 +175,7 @@ pub mod write;
 pub use api::search_one_file;
 pub use api::{
     ApplyMode, ContentEditResult, EditResult, ReplaceOptions, SearchOptions, SearchResult,
-    WritePolicyOptions, build_context_lines, format_search_results, search_file,
+    WritePolicyOptions, build_context_lines, format_search_results, search_file, text_diff,
 };
 pub use plan::Plan;
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -173,6 +173,9 @@ pub enum Operation {
         before_context: Option<String>,
         /// Context line(s) after the target for anchor-based fallback matching.
         after_context: Option<String>,
+        /// Fail if the pattern matches more than once (enforce unambiguous edits).
+        #[serde(default)]
+        unique: bool,
     },
     #[serde(rename = "doc.set", alias = "doc_set")]
     DocSet {

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -275,6 +275,7 @@ mod basic {
                     word_boundary: false,
                     before_context: Some("ctx".into()),
                     after_context: Some("ctx".into()),
+                    unique: false,
                 },
             ),
             (

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -1647,6 +1647,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
         assert!(op_needs_doc_flush(&op));
     }

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -40,6 +40,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         range,
         before_context,
         after_context,
+        unique,
         ..
     } = op
     else {
@@ -92,6 +93,14 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         } else {
             replace_content(content, old, &replacement, compiled_re.as_ref(), *nth)
         };
+        if *unique && match_count > 1 {
+            anyhow::bail!(
+                "ambiguous match: pattern {:?} matches {} times in {}; provide more context to disambiguate",
+                crate::fallback::truncate_str(old, 60),
+                match_count,
+                p
+            );
+        }
         if match_count > 0 {
             // When there are multiple exact matches and context is provided
             // (but no nth), use context to disambiguate instead of replacing all.
@@ -306,6 +315,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -339,6 +349,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -370,6 +381,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -403,6 +415,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -434,6 +447,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -467,6 +481,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -503,6 +518,7 @@ mod tests {
             before_context: Some("fn process".into()),
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -551,6 +567,7 @@ mod tests {
             before_context: None,
             after_context: Some("port = 5432".into()),
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -596,6 +613,7 @@ mod tests {
             before_context: Some("[database]".into()),
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -637,6 +655,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -676,6 +695,7 @@ mod tests {
             before_context: None,
             after_context: None,
             if_exists: false,
+            unique: false,
         };
 
         let mut f = TxStateFixture::new();

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -130,6 +130,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         }
     }
 
@@ -184,6 +185,7 @@ mod tests {
             word_boundary: false,
             before_context: None,
             after_context: None,
+            unique: false,
         };
         let err = validate_operation(&op).unwrap_err();
         assert!(

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -480,6 +480,7 @@ mod tests {
                 word_boundary: false,
                 before_context: None,
                 after_context: None,
+                unique: false,
             }],
             write_policy: None,
             format: None,


### PR DESCRIPTION
## Summary

Extends `rewrite_function_signature` to support all languages with tree-sitter grammars, not just Rust. Adds a `lang: Language` parameter.

### How it works

- **Rust**: Keeps the existing full-reconstruction logic (preserving async/unsafe/const/extern qualifiers, visibility, parameters, return type).
- **All other languages**: Uses surgical node replacement. Each `FunctionSigEdit` field finds the corresponding AST node (parameters, return type, visibility/modifiers) and replaces it in-place. Everything else in the signature is preserved exactly.

### Language support

| Language | Parameters | Return type | Visibility |
|----------|-----------|-------------|------------|
| Rust | full reconstruction | full reconstruction | full reconstruction |
| Python | surgical replace | surgical replace (`-> type`) | N/A (decorators) |
| TypeScript/JS | surgical replace | surgical replace (`: type`) | N/A |
| Go | surgical replace (receiver-aware) | surgical replace | N/A (capitalization) |
| Java | surgical replace | surgical replace (before name) | surgical replace (modifiers) |
| C/C++ | surgical replace (declarator nesting) | surgical replace (type specifier) | N/A |

### The return_type value uses native syntax

- Rust: `"-> String"`
- Python: `"-> dict"`
- TypeScript: `": Promise<Response>"`
- Go: `"error"` or `"(*Response, error)"`
- Java: `"Response"`

### Test coverage

17 new tests covering:
- Parameter replacement for Python, TypeScript, Go (function + method), Java, C, C++
- Return type replacement for Python, TypeScript, Go, Java, C
- Return type addition (Python, no existing return type)
- Async preservation (Python)
- Visibility replacement (Java modifiers)
- Go method receiver preservation (params change without touching receiver)
- C++ qualified name handling (`MyClass::process`)
- Edge cases: unsupported language returns None, function not found returns None

### Bline impact

With this, Bline can replace its Rust-only `apply_modify_signature` fallback (~100 lines including `parse_signature_edit`) with a simple delegation to patchloom that works across all languages.

Closes #1266