### PR TITLE
feat(mcp): path descriptions, server_info tool, parse_unified_diff API, no-match fix

### DIFF
--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -99,7 +99,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 ## By the numbers
 
 - **2,700+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
-- **22 commands** including MCP server with 53 structured tool calls
+- **22 commands** including MCP server with 54 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -91,6 +91,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `doc_diff` | Compare two structured files (read-only) |
 | `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes. Binary and invalid UTF-8 files are skipped (read-only) |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
+| `server_info` | Return the server's working directory so the agent can discover the root path before file operations (read-only) |
 | `read_file` | Read file contents with optional line range |
 | `replace_text` | Replace text in a text file (literal or regex). Binary and invalid UTF-8 files are skipped |
 | `md_upsert_bullet` | Add a bullet under a markdown heading |

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -82,6 +82,7 @@ use std::path::Path;
 use crate::backup::BackupSession;
 use crate::containment::PathGuard;
 use crate::diff::{DiffResult, format_diff_result, unified_diff};
+pub use crate::ops::patch::{Hunk, PatchFile, PatchLine};
 use crate::write::{EolMode, WritePolicy, atomic_write};
 
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -270,6 +271,28 @@ pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
 /// going through a full edit operation.
 pub fn text_diff(original: &str, modified: &str, path: Option<&str>) -> String {
     make_diff(path.unwrap_or("<content>"), original, modified)
+}
+
+/// Parse unified diff text into structured patch files and hunks.
+///
+/// Handles standard unified diff format (`--- a/` / `+++ b/` / `@@`).
+/// Tolerant of embedded diffs in prose (only recognizes headers with
+/// `a/`/`b/` prefixes, `/dev/null`, tab timestamps, or `diff ` context).
+///
+/// Returns one [`PatchFile`] per file in the diff, each containing
+/// [`Hunk`]s with [`PatchLine`]s for context, added, and removed lines.
+///
+/// This complements [`text_diff`] (which generates diffs) and
+/// `apply_patch` (which applies diffs to files) by providing a
+/// parse-only step for embedders that need structured diff data
+/// without applying it.
+///
+/// # Errors
+///
+/// Returns an error if the diff text contains malformed hunk headers
+/// or is otherwise unparseable.
+pub fn parse_unified_diff(text: &str) -> Result<Vec<PatchFile>, String> {
+    crate::ops::patch::parse_patch(text)
 }
 
 fn make_diff(path: &str, old: &str, new: &str) -> String {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2624,6 +2624,94 @@ fn replace_in_content_unique_with_word_boundary() {
 }
 
 #[test]
+fn parse_unified_diff_basic() {
+    let diff = "\
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -1,3 +1,3 @@
+ fn main() {
+-    println!(\"hello\");
++    println!(\"world\");
+ }
+";
+    let files = parse_unified_diff(diff).unwrap();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path, "src/main.rs");
+    assert_eq!(files[0].hunks.len(), 1);
+    let hunk = &files[0].hunks[0];
+    assert_eq!(hunk.old_start, 1);
+    assert_eq!(hunk.old_count, 3);
+    assert_eq!(hunk.new_start, 1);
+    assert_eq!(hunk.new_count, 3);
+    assert!(
+        hunk.lines
+            .contains(&PatchLine::Remove("    println!(\"hello\");".into()))
+    );
+    assert!(
+        hunk.lines
+            .contains(&PatchLine::Add("    println!(\"world\");".into()))
+    );
+}
+
+#[test]
+fn parse_unified_diff_multiple_files() {
+    let diff = "\
+--- a/foo.txt
++++ b/foo.txt
+@@ -1 +1 @@
+-old
++new
+--- a/bar.txt
++++ b/bar.txt
+@@ -1,2 +1,2 @@
+ keep
+-remove
++add
+";
+    let files = parse_unified_diff(diff).unwrap();
+    assert_eq!(files.len(), 2);
+    assert_eq!(files[0].path, "foo.txt");
+    assert_eq!(files[1].path, "bar.txt");
+}
+
+#[test]
+fn parse_unified_diff_new_file() {
+    let diff = "\
+--- /dev/null
++++ b/new_file.txt
+@@ -0,0 +1,2 @@
++line one
++line two
+";
+    let files = parse_unified_diff(diff).unwrap();
+    assert_eq!(files.len(), 1);
+    assert!(files[0].is_creation);
+    assert_eq!(files[0].path, "new_file.txt");
+}
+
+#[test]
+fn parse_unified_diff_empty_input() {
+    let err = parse_unified_diff("").unwrap_err();
+    assert!(
+        err.contains("no files"),
+        "empty input should report no files, got: {err}"
+    );
+}
+
+#[test]
+fn parse_unified_diff_roundtrip_with_text_diff() {
+    let original = "hello\nworld\n";
+    let modified = "hello\nearth\n";
+    let diff_text = text_diff(original, modified, Some("test.txt"));
+    let files = parse_unified_diff(&diff_text).unwrap();
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path, "test.txt");
+    let hunk = &files[0].hunks[0];
+    assert!(hunk.lines.contains(&PatchLine::Remove("world".into())));
+    assert!(hunk.lines.contains(&PatchLine::Add("earth".into())));
+}
+
+#[test]
 fn replace_text_unique_fails_on_ambiguity() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -9,7 +9,9 @@ use crate::cli::global::GlobalFlags;
 use crate::exit;
 
 use super::params::*;
-use super::{PatchloomService, exit_code_to_result, validate_content_size, validate_param_size};
+use super::{
+    PatchloomService, exit_code_to_result, no_results, validate_content_size, validate_param_size,
+};
 
 pub(super) fn handle_ast_list(
     svc: &PatchloomService,
@@ -78,7 +80,7 @@ pub(super) fn handle_ast_list(
     }
 
     if results.is_empty() {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No symbols found.");
+        return no_results("No symbols found.");
     }
     let json = serde_json::to_string_pretty(&results)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
@@ -184,7 +186,7 @@ pub(super) fn handle_ast_rename(
     }
 
     if operations.is_empty() {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No matches found.");
+        return no_results("No matches found.");
     }
 
     svc.run_ops(operations, None)
@@ -219,7 +221,7 @@ pub(super) fn handle_ast_validate(
     });
 
     if results.is_empty() {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No files with grammars found.");
+        return no_results("No files with grammars found.");
     }
     let json = serde_json::to_string_pretty(&results)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
@@ -274,7 +276,7 @@ pub(super) fn handle_ast_search(
         par_results.into_iter().flat_map(|r| r.entries).collect();
 
     if all_matches.is_empty() {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No matches found.");
+        return no_results("No matches found.");
     }
     let json = serde_json::to_string_pretty(&all_matches)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
@@ -308,7 +310,7 @@ pub(super) fn handle_ast_refs(
     }
 
     if all_refs.is_empty() {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No references found.");
+        return no_results("No references found.");
     }
 
     let obj = serde_json::json!({
@@ -408,7 +410,7 @@ pub(super) fn handle_ast_deps(
     }
 
     if results.is_empty() {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No imports found.");
+        return no_results("No imports found.");
     }
     let json = serde_json::to_string_pretty(&results)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
@@ -456,7 +458,7 @@ pub(super) fn handle_ast_map(
     let entries = crate::ast::map::generate_map(&file_pairs, &opts);
 
     if entries.is_empty() {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No symbols found.");
+        return no_results("No symbols found.");
     }
 
     let json = serde_json::to_string_pretty(&entries)
@@ -492,7 +494,7 @@ pub(super) fn handle_ast_diff(
     let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
 
     if changes.is_empty() {
-        return exit_code_to_result(exit::NO_MATCHES, "", "No structural changes.");
+        return no_results("No structural changes.");
     }
 
     let obj = serde_json::json!({
@@ -530,11 +532,7 @@ pub(super) fn handle_ast_impact(
     let nodes = crate::ast::impact::compute_impact(&p.symbol, &file_pairs, p.depth);
 
     if nodes.is_empty() {
-        return exit_code_to_result(
-            exit::NO_MATCHES,
-            "",
-            &format!("No references found for '{}'.", p.symbol),
-        );
+        return no_results(&format!("No references found for '{}'.", p.symbol));
     }
 
     let obj = serde_json::json!({

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -17,7 +17,7 @@ use crate::plan::Operation;
 use super::ast_tools;
 use super::params::*;
 use super::{
-    PatchloomService, doc_readonly, execute_plan_validated, exit_code_to_result,
+    PatchloomService, doc_readonly, execute_plan_validated, exit_code_to_result, no_results,
     validate_batch_size, validate_content_size, validate_param_size,
 };
 
@@ -229,7 +229,7 @@ impl PatchloomService {
                 results.has_matches()
             };
             if !has_matches {
-                return exit_code_to_result(exit::NO_MATCHES, "", "No matches found.");
+                return no_results("No matches found.");
             }
 
             let output = crate::cmd::search::format_results(results, &search_args, &global)
@@ -857,6 +857,20 @@ impl PatchloomService {
             Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
         })
         .await
+    }
+
+    #[tool(
+        description = "Return the server's working directory. Use this to discover the root path before file operations. All path parameters in other tools are relative to this directory."
+    )]
+    async fn server_info(
+        &self,
+        Parameters(_p): Parameters<EmptyParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let cwd = self.cwd().to_string_lossy().to_string();
+        let info = serde_json::json!({ "cwd": cwd });
+        let json = serde_json::to_string_pretty(&info)
+            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
     }
 
     // move_file, append_file, create_file, and delete_file are auto-generated

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -287,6 +287,16 @@ fn execute_plan_validated(
     exit_code_to_result(code, &json, "Operation completed successfully.")
 }
 
+/// Return a successful result with a "no results" message.
+///
+/// Use for valid queries that produce no matches (e.g. `ast_refs` finding no
+/// references, `search_files` with no hits). These are correct answers, not
+/// errors. Returning `isError: false` prevents LLM agents from entering
+/// unnecessary recovery mode. See #1270.
+fn no_results(msg: &str) -> Result<CallToolResult, McpError> {
+    Ok(CallToolResult::success(vec![ContentBlock::text(msg)]))
+}
+
 /// Convert an exit code + output string into a `CallToolResult`.
 ///
 /// When `output` is non-empty it is used as-is. Otherwise `fallback` is used

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -14,7 +14,7 @@ use serde::Deserialize;
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct ReplaceParams {
-    /// File path.
+    /// File path (relative to working directory).
     pub path: String,
     /// Text to find.
     pub old: String,
@@ -77,7 +77,7 @@ pub(crate) struct DocGetParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct MdLintAgentsParams {
-    /// Markdown file path (typically AGENTS.md).
+    /// Markdown file path, relative to working directory (typically AGENTS.md).
     pub path: String,
 }
 
@@ -85,11 +85,11 @@ pub(crate) struct MdLintAgentsParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct MdMoveSectionParams {
-    /// Source file path containing the section to move.
+    /// Source file path containing the section to move (relative to working directory).
     pub path: String,
     /// Heading of the section to move (e.g., "## FAQ").
     pub heading: String,
-    /// Destination file path. Omit for same-file reorder.
+    /// Destination file path (relative to working directory). Omit for same-file reorder.
     #[serde(default)]
     pub to: Option<String>,
     /// Insert before this heading at the destination.
@@ -104,7 +104,7 @@ pub(crate) struct MdMoveSectionParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct TidyParams {
-    /// File path to normalize.
+    /// File path to normalize (relative to working directory).
     pub path: String,
     /// Dedent: remove leading whitespace. Values: "auto", "tab", or a number (e.g. "4").
     #[serde(default)]
@@ -140,7 +140,7 @@ pub(crate) struct PatchParams {
 pub(crate) struct SearchParams {
     /// Pattern to search for.
     pub pattern: String,
-    /// Paths to search in (defaults to current directory).
+    /// Paths to search in, relative to working directory (defaults to working directory root).
     #[serde(default)]
     pub paths: Vec<String>,
     /// Treat pattern as a literal string instead of regex.
@@ -200,9 +200,9 @@ pub(crate) struct DocQueryParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct DocDiffParams {
-    /// First file path.
+    /// First file path (relative to working directory).
     pub file_a: String,
-    /// Second file path.
+    /// Second file path (relative to working directory).
     pub file_b: String,
 }
 
@@ -263,7 +263,7 @@ pub(crate) struct BatchTidyParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstListParams {
-    /// File or directory to list symbols from.
+    /// File or directory to list symbols from (relative to working directory).
     pub path: String,
     /// Filter by symbol kind (comma-separated: function,struct,enum,class,method,trait,impl,const,type,interface,module).
     pub kind: Option<String>,
@@ -276,7 +276,7 @@ pub(crate) struct AstListParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstReadParams {
-    /// File to read from.
+    /// File to read from (relative to working directory).
     pub path: String,
     /// Symbol name (e.g. "run" or "Server::start").
     pub symbol: String,
@@ -296,7 +296,7 @@ pub(crate) struct AstRenameParams {
     pub old_name: String,
     /// The new identifier name.
     pub new_name: String,
-    /// File or directory to rename in.
+    /// File or directory to rename in (relative to working directory).
     pub path: String,
     /// Language hint.
     pub lang: Option<String>,
@@ -307,7 +307,7 @@ pub(crate) struct AstRenameParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstValidateParams {
-    /// File or directory to validate syntax.
+    /// File or directory to validate syntax (relative to working directory).
     pub path: String,
     /// Language hint.
     pub lang: Option<String>,
@@ -320,7 +320,7 @@ pub(crate) struct AstValidateParams {
 pub(crate) struct AstSearchParams {
     /// Tree-sitter S-expression query, or a code pattern (with pattern=true).
     pub query: String,
-    /// File or directory to search.
+    /// File or directory to search (relative to working directory).
     pub path: String,
     /// Treat the query as a code pattern with meta-variables ($VAR, $$$MULTI).
     #[serde(default)]
@@ -338,7 +338,7 @@ pub(crate) struct AstSearchParams {
 pub(crate) struct AstRefsParams {
     /// Symbol name to find references for.
     pub symbol: String,
-    /// File or directory to search.
+    /// File or directory to search (relative to working directory).
     pub path: String,
     /// Include the definition site in results.
     #[serde(default)]
@@ -352,7 +352,7 @@ pub(crate) struct AstRefsParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstDepsParams {
-    /// File or directory to analyze.
+    /// File or directory to analyze (relative to working directory).
     pub path: String,
     /// Show reverse dependencies (what imports this file).
     #[serde(default)]
@@ -366,7 +366,7 @@ pub(crate) struct AstDepsParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstMapParams {
-    /// Directory to map.
+    /// Directory to map (relative to working directory).
     pub path: String,
     /// Maximum approximate token count for output.
     #[serde(default = "default_map_max_tokens")]
@@ -389,7 +389,7 @@ fn default_map_max_tokens() -> usize {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstDiffParams {
-    /// File to diff.
+    /// File to diff (relative to working directory).
     pub path: String,
     /// Git ref for the "old" version (default: HEAD).
     #[serde(default = "default_head")]
@@ -412,7 +412,7 @@ fn default_head() -> String {
 pub(crate) struct AstImpactParams {
     /// Symbol name to analyze.
     pub symbol: String,
-    /// Directory to scan for references.
+    /// Directory to scan for references (relative to working directory).
     pub path: String,
     /// Maximum traversal depth (1 = direct refs only).
     #[serde(default = "default_impact_depth")]
@@ -429,7 +429,7 @@ fn default_impact_depth() -> usize {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstReplaceParams {
-    /// File containing the symbol.
+    /// File containing the symbol (relative to working directory).
     pub path: String,
     /// Symbol name to scope the replacement to.
     pub symbol: String,
@@ -450,7 +450,7 @@ pub(crate) struct AstReplaceParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstInsertParams {
-    /// File to insert code into.
+    /// File to insert code into (relative to working directory).
     pub path: String,
     /// Code to insert.
     pub content: String,
@@ -475,7 +475,7 @@ pub(crate) struct AstInsertParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstWrapParams {
-    /// File to modify.
+    /// File to modify (relative to working directory).
     pub path: String,
     /// Symbols to wrap (mutually exclusive with lines).
     #[serde(default)]
@@ -497,7 +497,7 @@ pub(crate) struct AstWrapParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstImportsParams {
-    /// File to modify.
+    /// File to modify (relative to working directory).
     pub path: String,
     /// Import statements to add (idempotent; skips if already present).
     #[serde(default)]
@@ -517,7 +517,7 @@ pub(crate) struct AstImportsParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstReorderParams {
-    /// File to reorder symbols in.
+    /// File to reorder symbols in (relative to working directory).
     pub path: String,
     /// Scope to reorder within (module/impl). Default: top-level.
     #[serde(default)]
@@ -533,7 +533,7 @@ pub(crate) struct AstReorderParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstGroupParams {
-    /// File to modify.
+    /// File to modify (relative to working directory).
     pub path: String,
     /// Module name to create or append to.
     pub module: String,
@@ -554,7 +554,7 @@ pub(crate) struct AstGroupParams {
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
 pub(crate) struct AstMoveParams {
-    /// Source file.
+    /// Source file (relative to working directory).
     pub path: String,
     /// Target file.
     pub target: String,
@@ -626,7 +626,7 @@ pub(crate) struct AstSplitParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AstSplitTargetParam {
-    /// Target file path.
+    /// Target file path (relative to working directory).
     pub path: String,
     /// Symbols to move into this file.
     pub symbols: Vec<String>,

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -121,7 +121,7 @@ mod basic {
             names.contains(&"md_dedupe_headings"),
             "missing md_dedupe_headings tool"
         );
-        assert_eq!(names.len(), 53, "expected 53 tools, got {}", names.len());
+        assert_eq!(names.len(), 54, "expected 54 tools, got {}", names.len());
         client.cancel().await.unwrap();
     }
 
@@ -727,5 +727,127 @@ mod integrity {
         assert_eq!(content, "world");
 
         client.cancel().await.unwrap();
+    }
+}
+
+// --- #1267: server_info tool ---
+
+mod server_info_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn server_info_returns_cwd() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+
+        let params = rmcp::model::CallToolRequestParams::new("server_info");
+        let result = client.peer().call_tool(params).await.unwrap();
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "server_info should succeed"
+        );
+
+        let text = result.content.first().unwrap();
+        let text = match text {
+            rmcp::model::ContentBlock::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        let info: serde_json::Value = serde_json::from_str(text).unwrap();
+        let cwd = info["cwd"].as_str().unwrap();
+        assert_eq!(
+            std::path::Path::new(cwd).canonicalize().unwrap(),
+            dir.path().canonicalize().unwrap(),
+            "server_info cwd should match the server's working directory"
+        );
+    }
+
+    #[tokio::test]
+    async fn server_info_listed_in_tools() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let tools = client.peer().list_all_tools().await.unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+        assert!(
+            names.contains(&"server_info"),
+            "server_info should be listed in tools"
+        );
+        client.cancel().await.unwrap();
+    }
+}
+
+// --- #1270: no_results returns isError: false ---
+
+mod no_results_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn search_no_match_returns_success() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("hello.txt"), "hello world\n").unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+
+        let params = rmcp::model::CallToolRequestParams::new("search_files").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "pattern": "NONEXISTENT_PATTERN_xyz"
+            }))
+            .unwrap(),
+        );
+
+        let result = client.peer().call_tool(params).await.unwrap();
+        // #1270: no-match should NOT be an error
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "search with no matches should return isError: false, not true"
+        );
+
+        let text = match result.content.first().unwrap() {
+            rmcp::model::ContentBlock::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        assert!(
+            text.contains("No matches"),
+            "should contain 'No matches' message, got: {text}"
+        );
+
+        client.cancel().await.unwrap();
+    }
+
+    #[cfg(feature = "ast")]
+    #[tokio::test]
+    async fn ast_list_no_symbols_returns_success() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // Create a file with no symbol definitions
+        std::fs::write(dir.path().join("empty.py"), "# just a comment\n").unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+
+        let params = rmcp::model::CallToolRequestParams::new("ast_list").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "path": "empty.py"
+            }))
+            .unwrap(),
+        );
+
+        let result = client.peer().call_tool(params).await.unwrap();
+        // #1270: empty result should NOT be an error
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "ast_list with no symbols should return isError: false, not true"
+        );
+
+        client.cancel().await.unwrap();
+    }
+
+    #[test]
+    fn no_results_helper_returns_success() {
+        let result = no_results("No matches found.").unwrap();
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "no_results should return isError: false"
+        );
+        let text = match result.content.first().unwrap() {
+            rmcp::model::ContentBlock::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        assert_eq!(text, "No matches found.");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,8 +174,9 @@ pub mod write;
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use api::search_one_file;
 pub use api::{
-    ApplyMode, ContentEditResult, EditResult, ReplaceOptions, SearchOptions, SearchResult,
-    WritePolicyOptions, build_context_lines, format_search_results, search_file, text_diff,
+    ApplyMode, ContentEditResult, EditResult, Hunk, PatchFile, PatchLine, ReplaceOptions,
+    SearchOptions, SearchResult, WritePolicyOptions, build_context_lines, format_search_results,
+    parse_unified_diff, search_file, text_diff,
 };
 pub use plan::Plan;
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -330,8 +330,9 @@ async fn test_mcp_doc_get_reads_value() {
     client.cancel().await.unwrap();
 }
 
-/// Regression test for #939: search_files with zero matches must return a
-/// descriptive "No matches found." message, not the generic exit-code text.
+/// Regression test for #939 / #1270: search_files with zero matches must
+/// return a descriptive "No matches found." message as a success (isError:
+/// false), not an error. Empty results are valid answers, not failures.
 #[tokio::test]
 async fn test_mcp_search_no_match_returns_descriptive_message() {
     if !has_mcp_support() {
@@ -347,7 +348,10 @@ async fn test_mcp_search_no_match_returns_descriptive_message() {
         serde_json::json!({"pattern": "zzz_nonexistent_pattern_zzz"}),
     )
     .await;
-    assert!(is_error, "search with no matches should return error");
+    assert!(
+        !is_error,
+        "search with no matches should return isError: false (#1270)"
+    );
     assert!(
         text.contains("No matches found"),
         "response should say 'No matches found', got: {text}"
@@ -2749,8 +2753,9 @@ async fn test_mcp_ast_list_unsupported_file_names_language() {
     client.cancel().await.unwrap();
 }
 
-/// Regression test for #939: NO_MATCHES results must return the descriptive
-/// fallback message, not the generic "Operation failed with exit code 3."
+/// Regression test for #939 / #1270: NO_MATCHES results must return the
+/// descriptive fallback message as a success (isError: false), not an error.
+/// Empty results are valid answers that should not trigger agent recovery mode.
 #[tokio::test]
 #[cfg(feature = "ast")]
 async fn test_mcp_no_matches_returns_descriptive_message() {
@@ -2768,7 +2773,10 @@ async fn test_mcp_no_matches_returns_descriptive_message() {
         serde_json::json!({"path": "lib.rs", "symbol": "nonexistent_symbol_xyz"}),
     )
     .await;
-    assert!(is_error, "ast_refs on missing symbol should return error");
+    assert!(
+        !is_error,
+        "ast_refs on missing symbol should return isError: false (#1270)"
+    );
     assert!(
         text.contains("No references found"),
         "response should contain descriptive message, not generic exit code: {text}"

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -789,7 +789,7 @@ fn test_smoke_readme_command_examples() {
         "launch announcement CLI command count drifted"
     );
     assert!(
-        launch.contains("53 structured tool calls"),
+        launch.contains("54 structured tool calls"),
         "launch announcement MCP tool count drifted"
     );
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
Address three Bline-reported issues for MCP usability and library API:

## Changes

### #1267: MCP path descriptions + server_info tool
- Updated all MCP tool path parameter descriptions to explicitly state paths are relative to the working directory
- Added `server_info` zero-arg tool that returns the server's cwd for path discovery
- Tool count: 53 -> 54

### #1268: Public parse_unified_diff API
- Added `parse_unified_diff()` to the library API, exposing patchloom's internal diff parser
- Re-exports `PatchFile`, `Hunk`, `PatchLine` types through `patchloom::api` and `patchloom::`
- Complements `text_diff` (generate) and `apply_patch` (apply) with parse-only access

### #1270: NO_MATCHES as empty result, not isError
- Changed 10+ MCP handlers from returning `isError: true` to `isError: false` for valid queries with no matches
- Added `no_results()` helper that returns `CallToolResult::success()`
- Kept `isError: true` only for genuine input errors (unsupported language, identical rename)
- Prevents LLM agents from entering unnecessary recovery mode on empty results

## Tests

- 5 new API tests for `parse_unified_diff` (basic, multi-file, new file, empty, roundtrip)
- 2 new MCP tests for `server_info` (returns cwd, listed in tools)
- 3 new MCP tests for `no_results` behavior (search no-match success, ast_list no-match success, helper unit test)
- Updated 2 existing integration tests to expect `isError: false` on no-match

Closes #1267
Closes #1268
Closes #1270