### PR TITLE
test/docs: MPI cycle 1 improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,10 @@ src/
   lib.rs              Parses CLI with clap, delegates to cmd::dispatch; re-exports modules
   files.rs             File-walking utilities: is_binary, collect_file_paths, build_glob_matcher,
                        matches_glob. Used by search, replace, tidy, and status commands.
+  api/mod.rs           Public library API for embedding patchloom in Rust applications.
+                       CLI-independent interface: replace_text, search_file, doc_set, md_replace_section,
+                       execute_plan, parse_unified_diff, etc. All write ops accept ApplyMode
+                       (Preview/Apply/Check) and optional PathGuard for containment.
   cli/mod.rs           Defines Cli struct (clap Parser) with GlobalFlags and Command subcommand
   cli/global.rs        GlobalFlags (read-only: --json, --jsonl, --quiet, --cwd, --glob,
                        --files-from) and WriteFlags (--diff, --apply, --check,

--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -9,15 +9,21 @@
 
 | Task pattern | Tool to use |
 |---|---|
+| Read file contents (with optional line range) | `read_file` |
+| See uncommitted changes vs git HEAD | `git_status` |
 | Set/get a key in JSON, YAML, or TOML | `doc_set`, `doc_get`, `doc_query` |
+| Delete, merge, or ensure a key exists | `doc_delete`, `doc_merge`, `doc_ensure` |
+| Compare two structured files | `doc_diff` |
 | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |
 | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |
 | Move a heading section (same file or cross-file) | `md_move_section` |
 | Remove duplicate headings | `md_dedupe_headings` |
+| Lint markdown for structural issues | `md_lint` |
 | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |
 | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |
 | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |
 | Search across files | `search_files` |
+| Apply a unified diff patch | `apply_patch` |
 | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace` |
 | Insert, wrap, or manage imports | `ast_insert`, `ast_wrap`, `ast_imports` |
 | Reorder, group, or move symbols | `ast_reorder`, `ast_group`, `ast_move` |
@@ -25,6 +31,7 @@
 | Validate syntax, find refs, or analyze impact | `ast_validate`, `ast_refs`, `ast_impact`, `ast_search` |
 | Repo map, imports, or structural diff | `ast_map`, `ast_deps`, `ast_diff` |
 | Apply same operation to many files | `execute_plan` with `for_each` glob |
+| Get server version and working directory | `server_info` |
 
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2699,6 +2699,22 @@ fn parse_unified_diff_empty_input() {
 }
 
 #[test]
+fn parse_unified_diff_deleted_file() {
+    let diff = "\
+--- a/removed.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-line one
+-line two
+";
+    let files = parse_unified_diff(diff).unwrap();
+    assert_eq!(files.len(), 1);
+    assert!(files[0].is_deletion);
+    assert!(!files[0].is_creation);
+    assert_eq!(files[0].path, "removed.txt");
+}
+
+#[test]
 fn parse_unified_diff_roundtrip_with_text_diff() {
     let original = "hello\nworld\n";
     let modified = "hello\nearth\n";

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -773,6 +773,37 @@ mod server_info_tests {
         );
         client.cancel().await.unwrap();
     }
+
+    #[tokio::test]
+    async fn server_info_handles_unicode_path() {
+        let base = tempfile::TempDir::new().unwrap();
+        let unicode_dir = base.path().join("проект_工作区");
+        std::fs::create_dir(&unicode_dir).unwrap();
+        let client = spawn_test_client(unicode_dir.clone()).await;
+
+        let params = rmcp::model::CallToolRequestParams::new("server_info");
+        let result = client.peer().call_tool(params).await.unwrap();
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "server_info should succeed with unicode path"
+        );
+
+        let text = match result.content.first().unwrap() {
+            rmcp::model::ContentBlock::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        let info: serde_json::Value = serde_json::from_str(text).unwrap();
+        let cwd = info["cwd"].as_str().unwrap();
+        assert!(
+            !cwd.contains('\u{FFFD}'),
+            "cwd should not contain replacement character"
+        );
+        assert!(
+            cwd.contains("проект"),
+            "cwd should preserve unicode characters"
+        );
+        client.cancel().await.unwrap();
+    }
 }
 
 // --- #1270: no_results returns isError: false ---
@@ -832,6 +863,41 @@ mod no_results_tests {
         assert!(
             !result.is_error.unwrap_or(false),
             "ast_list with no symbols should return isError: false, not true"
+        );
+
+        client.cancel().await.unwrap();
+    }
+
+    #[cfg(feature = "ast")]
+    #[tokio::test]
+    async fn ast_refs_no_match_returns_success() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // File has a function definition but nothing references it
+        std::fs::write(dir.path().join("lib.rs"), "fn standalone() {}\n").unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+
+        let params = rmcp::model::CallToolRequestParams::new("ast_refs").with_arguments(
+            serde_json::from_value(serde_json::json!({
+                "path": "lib.rs",
+                "symbol": "standalone"
+            }))
+            .unwrap(),
+        );
+
+        let result = client.peer().call_tool(params).await.unwrap();
+        // #1270: no references is a valid answer, not an error
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "ast_refs with no references should return isError: false (#1270)"
+        );
+
+        let text = match result.content.first().unwrap() {
+            rmcp::model::ContentBlock::Text(t) => &t.text,
+            _ => panic!("expected text content"),
+        };
+        assert!(
+            text.contains("No references found"),
+            "should contain descriptive message, got: {text}"
         );
 
         client.cancel().await.unwrap();

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -219,22 +219,29 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
             "## Tool selection guide\n\n\
              | Task pattern | Tool to use |\n\
              |---|---|\n\
+             | Read file contents (with optional line range) | `read_file` |\n\
+             | See uncommitted changes vs git HEAD | `git_status` |\n\
              | Set/get a key in JSON, YAML, or TOML | `doc_set`, `doc_get`, `doc_query` |\n\
+             | Delete, merge, or ensure a key exists | `doc_delete`, `doc_merge`, `doc_ensure` |\n\
+             | Compare two structured files | `doc_diff` |\n\
              | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |\n\
              | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |\n\
              | Move a heading section (same file or cross-file) | `md_move_section` |\n\
              | Remove duplicate headings | `md_dedupe_headings` |\n\
+             | Lint markdown for structural issues | `md_lint` |\n\
              | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |\n\
              | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |\n\
              | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |\n\
              | Search across files | `search_files` |\n\
+             | Apply a unified diff patch | `apply_patch` |\n\
              | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace` |\n\
              | Insert, wrap, or manage imports | `ast_insert`, `ast_wrap`, `ast_imports` |\n\
              | Reorder, group, or move symbols | `ast_reorder`, `ast_group`, `ast_move` |\n\
              | Extract or split files by symbol | `ast_extract`, `ast_split` |\n\
              | Validate syntax, find refs, or analyze impact | `ast_validate`, `ast_refs`, `ast_impact`, `ast_search` |\n\
              | Repo map, imports, or structural diff | `ast_map`, `ast_deps`, `ast_diff` |\n\
-             | Apply same operation to many files | `execute_plan` with `for_each` glob |\n\n",
+             | Apply same operation to many files | `execute_plan` with `for_each` glob |\n\
+             | Get server version and working directory | `server_info` |\n\n",
         );
     }
     if show_cli {


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle covering all 14 perspectives on the
#1272 changes (server_info, path docs, no-match signaling, parse_unified_diff).

## Changes

### QA Engineer (commit 1)
- Add deletion diff test for `parse_unified_diff`
- Add unicode path test for `server_info`
- Add `ast_refs` no-match test verifying `isError: false` (#1270)

### End User (commit 2)
- Add 6 missing rows to the MCP tool selection guide in `agent-rules`:
  `read_file`, `git_status`, `doc_delete`/`doc_merge`/`doc_ensure`,
  `doc_diff`, `apply_patch`, `md_lint`, `server_info`
- Regenerate PATCHLOOM.md

### New Contributor (commit 3)
- Add `api/` module to AGENTS.md project structure section
  (11 files, not previously documented)

### No-op perspectives (no actionable findings)
Developer, Maintainer, Ops/SRE, Security, PM, Spec/Contract,
Performance, Backward Compat, Adversarial, Architecture, Observability

## Verification
`make check-fast` passes (2830 tests, 0 warnings)