### PR TITLE
feat(mcp): add tool category guide to server instructions

### DIFF
--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -152,6 +152,54 @@ mod basic {
         client.cancel().await.unwrap();
     }
 
+    /// Verify server instructions contain tool category guide (#1273).
+    ///
+    /// Models search for tools by keyword (e.g. "replace_text" for YAML edits)
+    /// and miss better-fit tools (doc_set) when the instructions don't mention
+    /// categories. This test ensures the instructions always include the
+    /// category guide that steers models to the right tool class.
+    #[tokio::test]
+    async fn mcp_instructions_contain_tool_categories() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let info = client.peer_info().expect("peer info should be set");
+        let instructions = info
+            .instructions
+            .as_deref()
+            .expect("server should have instructions");
+        // Must contain category headers
+        assert!(
+            instructions.contains("Document ops"),
+            "instructions must mention Document ops category"
+        );
+        assert!(
+            instructions.contains("Markdown ops"),
+            "instructions must mention Markdown ops category"
+        );
+        assert!(
+            instructions.contains("Text ops"),
+            "instructions must mention Text ops category"
+        );
+        assert!(
+            instructions.contains("AST ops"),
+            "instructions must mention AST ops category"
+        );
+        assert!(
+            instructions.contains("File ops"),
+            "instructions must mention File ops category"
+        );
+        // Must contain the key steering hint from #1273
+        assert!(
+            instructions.contains("doc_set"),
+            "instructions must mention doc_set for discoverability"
+        );
+        assert!(
+            instructions.contains("JSON/YAML/TOML"),
+            "instructions must associate doc_* with JSON/YAML/TOML"
+        );
+        client.cancel().await.unwrap();
+    }
+
     #[tokio::test]
     async fn mcp_example_argument_keys_match_schemas() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -16,7 +16,30 @@ impl ServerHandler for PatchloomService {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(
-                "Use these tools for ALL file operations. Prefer 'execute_plan' (or tx plans) for any multi-op or multi-file work to ensure atomicity and avoid races from parallel calls on the same paths. Use batch_replace/batch_tidy only for uniform ops across files. Per-call success does not guarantee combined success if you issue conflicting parallel writes.",
+                "Use these tools for ALL file operations. Prefer 'execute_plan' (or tx plans) \
+                for any multi-op or multi-file work to ensure atomicity and avoid races from \
+                parallel calls on the same paths. Use batch_replace/batch_tidy only for uniform \
+                ops across files. Per-call success does not guarantee combined success if you \
+                issue conflicting parallel writes.\n\n\
+                Tool categories:\n\
+                - Document ops (JSON/YAML/TOML by key path): doc_set, doc_get, doc_delete, \
+                doc_merge, doc_query, doc_update, doc_ensure, doc_move, doc_append, doc_prepend, \
+                doc_delete_where, doc_diff\n\
+                - Markdown ops (by heading): md_replace_section, md_upsert_bullet, \
+                md_table_append, md_insert_after_heading, md_insert_before_heading, \
+                md_move_section, md_dedupe_headings, md_lint\n\
+                - Text ops: replace_text, batch_replace, search_files, apply_patch\n\
+                - File ops: create_file, read_file, delete_file, move_file, append_file, \
+                prepend_file, fix_whitespace, batch_tidy, git_status\n\
+                - AST ops (code-aware, 20 languages): ast_list, ast_read, ast_rename, \
+                ast_replace, ast_search, ast_refs, ast_impact, ast_deps, ast_diff, ast_imports, \
+                ast_insert, ast_wrap, ast_move, ast_reorder, ast_group, ast_extract_to_file, \
+                ast_split, ast_map, ast_validate\n\
+                - Plan ops: execute_plan\n\
+                - Server: server_info\n\n\
+                Use doc_* tools for parser-backed JSON/YAML/TOML mutations by key path \
+                (e.g. doc_set for setting values, doc_merge for merging objects). Use replace_text \
+                only for literal or regex text replacement where structure does not matter.",
             );
         info.server_info.name = "patchloom".into();
         info.server_info.version = env!("CARGO_PKG_VERSION").into();


### PR DESCRIPTION
## Summary

Adds a categorized tool guide to the MCP server `instructions` field,
which is always in context for connected MCP clients. All 54 tools are
grouped into 7 categories (Document, Markdown, Text, File, AST, Plan,
Server) with a closing hint that steers models toward `doc_*` tools for
JSON/YAML/TOML mutations.

## Problem

In a trace analysis, a model was asked to update 12 YAML values by key
path. It searched for `replace_text`, found it, and used ~950-char
old/new text blocks. It never discovered `doc_set`, which would have
handled each update in a single call like
`doc_set("config.yaml", "database.primary.max_open_conns", 50)`.

The model never searched for `doc` or `yaml` because the server
instructions only said "Use these tools for ALL file operations" with
no category guidance.

## Changes

| File | Change |
|------|--------|
| `src/cmd/mcp/transport.rs` | Enhanced `with_instructions()` to include 7-category tool guide and doc_* steering hint |
| `src/cmd/mcp/tests.rs` | New test `mcp_instructions_contain_tool_categories` verifying category headers and key tool names are present |

## Verification

`make check-fast` passes (2830+ tests, 0 warnings). All 54 tool names
verified present in instructions via automated extraction.

Closes #1273