### PR TITLE
fix: skip permission-based tests when running as root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,17 @@ All subcommands receive a `&GlobalFlags` reference. Read-only flags (`--json`, `
 - For non-existent file paths in tests, use `nonexistent_path("name")` which returns a platform-appropriate path.
 - `cargo test --lib` runs tests in parallel (CI too). For test-only failure-injection hooks, use `thread_local!` plus an RAII guard (e.g. `RestoreFailGuard`, defined in `src/tx.rs` and re-exported via `cmd::tx` for CLI/test paths), not a process-global `static`. Verify hook-related unit tests with `cargo test --lib <filter> -- --test-threads=16` before push.
 - Integration tests that need `#[cfg(test)]` hooks on tx commit/rollback paths must call in-process helpers such as `execute_plan_direct()` in `tests/integration.rs`. `assert_cmd::cargo_bin` subprocesses load the release binary and cannot see library `cfg(test)` hooks.
+- **Permission-based tests (`chmod 000`) must include a root-skip guard.** Root bypasses UNIX permission checks, so `from_mode(0o000)` tests fail inside Docker containers and root CI runners. After setting mode 000, try to read the file; if the read succeeds, restore permissions and return early. This tests actual behavior rather than checking the UID:
+
+```rust
+fs::set_permissions(&file, fs::Permissions::from_mode(0o000)).unwrap();
+// Root (common in Docker) can still read mode-000 files. Skip when
+// permissions do not actually block reading.
+if fs::read_to_string(&file).is_ok() {
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).unwrap();
+    return;
+}
+```
 
 ### Writes
 

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -465,6 +465,13 @@ mod tests {
         std::fs::write(&file, "line1\nline2\nline3\n").unwrap();
         std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o000)).unwrap();
 
+        // Root (common in Docker) can still read mode-000 files. Skip when
+        // permissions do not actually block reading (#1276).
+        if std::fs::read_to_string(&file).is_ok() {
+            std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+            return;
+        }
+
         let diff_path = tmp.path().join("fix.patch");
         std::fs::write(
             &diff_path,

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -545,6 +545,13 @@ mod tests {
         fs::write(&src, "hello\n").unwrap();
         fs::set_permissions(&src, fs::Permissions::from_mode(0o000)).unwrap();
 
+        // Root (common in Docker) can still read mode-000 files. Skip when
+        // permissions do not actually block reading (#1276).
+        if fs::read_to_string(&src).is_ok() {
+            fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+            return;
+        }
+
         let mut global = GlobalFlags::test_with_cwd(dir.path());
         global.apply = true;
         let args = RenameArgs {


### PR DESCRIPTION
## Summary

Two tests fail when running as root (e.g., inside Docker containers)
because root bypasses UNIX permission checks. The tests `chmod 000` a
file and expect a permission error, which never arrives as root.

## Fix

Apply the same runtime-skip pattern already used by
`file_create_force_propagates_read_error` in `src/api/tests.rs:289`:
after setting mode 000, attempt to read the file. If the read succeeds
(meaning permissions do not actually block access), restore permissions
and return early. This tests actual behavior rather than checking the UID,
so it also handles edge cases like ACLs or capabilities.

## Changed tests

| Test | File |
|------|------|
| `merge_check_surfaces_io_error_for_unreadable_file` | `src/cmd/patch.rs` |
| `rename_unreadable_file_propagates_io_error` | `src/cmd/rename.rs` |

A third test (`file_create_force_propagates_read_error` in
`src/api/tests.rs`) already had this fix, which is where the pattern
comes from.

## Verification

`make check-fast` passes. All three permission tests pass as non-root.

Closes #1276