### PR TITLE
fix: address AI code quality findings (3 real, 5 false positives)

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -124,10 +124,11 @@ CLI flags override config values. The file is searched upward from the working d
 ### Rename a function across a codebase
 
 ```bash
-# Find all occurrences first
-patchloom search --count "old_function_name" src/
+# Prefer AST-aware rename for code identifiers (skips strings/comments)
+patchloom ast rename old_function_name new_function_name src/ --apply
 
-# Replace in all matching files
+# Fallback: text-based workflow when AST mode is unavailable
+patchloom search --count "old_function_name" src/
 patchloom replace "old_function_name" --new "new_function_name" src/ --apply
 ```
 

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -275,7 +275,9 @@ impl PatchloomService {
 /// Execute a plan whose paths have already been validated by the caller.
 ///
 /// Each individual MCP tool validates paths via `check_path` before calling
-/// this function, so no redundant validation is needed here.
+/// this function, so this wrapper does not repeat that pre-validation.
+/// The `guard` is still passed through so `execute_plan_direct` can enforce
+/// containment checks during actual writes.
 fn execute_plan_validated(
     plan: Plan,
     cwd: &std::path::Path,

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -103,12 +103,9 @@ pub(crate) fn run_mcp_http_server(
         config = config.disable_allowed_hosts();
     }
 
-    let log_clone = log;
+    let log_path = log;
     let service = StreamableHttpService::new(
-        move || {
-            PatchloomService::new(cwd.clone(), log_clone.clone())
-                .map_err(|e| std::io::Error::other(e.to_string()))
-        },
+        move || PatchloomService::new(cwd.clone(), log_path.clone()).map_err(std::io::Error::other),
         std::sync::Arc::new(LocalSessionManager::default()),
         config,
     );

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -384,9 +384,10 @@ fn generate_agent_rules(args: &AgentRulesArgs) -> String {
         out.push_str(
             "### Rename a function across a codebase\n\n\
              ```bash\n\
-             # Find all occurrences first\n\
-             patchloom search --count \"old_function_name\" src/\n\n\
-             # Replace in all matching files\n\
+             # Prefer AST-aware rename for code identifiers (skips strings/comments)\n\
+             patchloom ast rename old_function_name new_function_name src/ --apply\n\n\
+             # Fallback: text-based workflow when AST mode is unavailable\n\
+             patchloom search --count \"old_function_name\" src/\n\
              patchloom replace \"old_function_name\" --new \"new_function_name\" src/ --apply\n\
              ```\n\n",
         );


### PR DESCRIPTION
## Summary

Triaged all 8 GitHub AI code quality findings across 5 files. Fixed the 3 real/cosmetic issues, documented 5 false positives.

### Fixed

| File | Finding | Fix |
|------|---------|-----|
| `mcp/mod.rs:278` | Doc comment says "no validation needed" but guard is passed through | Clarified that pre-validation is not repeated, but guard enforces containment during writes |
| `mcp/transport.rs:106` | `log_clone` is misleading (it is a move, not a clone) | Renamed to `log_path` |
| `mcp/transport.rs:110` | `.to_string()` loses error type info | Simplified to `std::io::Error::other` directly (anyhow::Error implements the required trait) |
| `cmd/mod.rs:387` | Rename workflow example does not mention `ast rename` | Added `ast rename` as primary recommendation, text-based as fallback |

### False positives (not fixed)

| File | Finding | Reason |
|------|---------|--------|
| `rename.rs:191` | `is_empty()` check is redundant | Wrong: `Path::new("file.txt").parent()` returns `Some("")` in Rust, so the guard prevents `create_dir_all("")` |
| `transport.rs:12` | Magic number 5 for shutdown timeout | Premature constant extraction for a value used exactly once |
| `smoke_tests.rs:786` | Hardcoded test count is fragile | Intentional: drift detection assertion, updated via `make update-readme` |
| `smoke_tests.rs:788` | Hardcoded command/tool counts are fragile | Intentional: these assertions SHOULD break when counts change to force doc updates |