### PR TITLE
test: replace bare is_ok() assertions with expect()

### DIFF
--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -1465,9 +1465,9 @@ async fn test_mcp_concurrent_doc_set() {
     );
 
     // All three must succeed now that files are distinct (no shared rename race).
-    assert!(r1.is_ok(), "a.json write failed: {r1:?}");
-    assert!(r2.is_ok(), "b.json write failed: {r2:?}");
-    assert!(r3.is_ok(), "c.json write failed: {r3:?}");
+    r1.expect("a.json write failed");
+    r2.expect("b.json write failed");
+    r3.expect("c.json write failed");
 
     // Verify each file.
     for (key, expected_new) in [("a", "new_a"), ("b", "new_b"), ("c", "new_c")] {


### PR DESCRIPTION
Replace 3 `assert!(r.is_ok(), ...)` with `r.expect(...)` in `test_mcp_concurrent_doc_set`.

The `is_ok()` pattern discards the Err value on failure, printing only `assertion failed`. The `expect()` pattern shows the actual error, improving diagnostics.

Found during MPI Cycle 2 post-cycle anti-rationalization audit. Originally dismissed as 'acceptable because they include {r1:?} debug output' but that was a rationalization: `.expect()` is simpler and equally diagnostic.