### PR TITLE
fix: preserve YAML quote styles on doc set scalar updates

### DIFF
--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -67,7 +67,25 @@ pub(crate) fn apply_yaml_mapping_diff(
                 }
                 // Type changed or scalar change.
                 _ => {
-                    mapping.set(key.as_str(), json_to_yaml_node(new_val)?);
+                    // Preserve quote style when updating a scalar string.
+                    if let Some(new_str) = new_val.as_str()
+                        && let Some(existing) = mapping.get(key.as_str())
+                        && let Some(scalar) = existing.as_scalar()
+                        && scalar.is_quoted()
+                    {
+                        let raw = scalar.value();
+                        let quote_char = raw.chars().next().unwrap_or('"');
+                        let quoted = if quote_char == '\'' {
+                            // Single-quoted: escape internal single quotes as ''
+                            format!("'{}'", new_str.replace('\'', "''"))
+                        } else {
+                            // Double-quoted: escape internal backslashes and double quotes
+                            format!("\"{}\"", new_str.replace('\\', "\\\\").replace('"', "\\\""))
+                        };
+                        scalar.set_value(&quoted);
+                    } else {
+                        mapping.set(key.as_str(), json_to_yaml_node(new_val)?);
+                    }
                 }
             }
         } else {
@@ -503,5 +521,45 @@ mod tests {
         // wrong; fixed by fix_yaml_block_indentation in the caller).
         assert!(result.contains("\"my-app\""));
         assert!(result.contains("\"8080\""));
+    }
+
+    #[test]
+    fn scalar_set_preserves_double_quote_style() {
+        let yaml = "name: \"John Doe\"\nage: 30\n";
+        let old = json!({"name": "John Doe", "age": 30});
+        let new = json!({"name": "Jane Doe", "age": 30});
+        let result = apply_and_serialize(yaml, &old, &new);
+        assert!(
+            result.contains("\"Jane Doe\""),
+            "double quotes not preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn scalar_set_preserves_single_quote_style() {
+        let yaml = "path: '/usr/local'\nname: plain\n";
+        let old = json!({"path": "/usr/local", "name": "plain"});
+        let new = json!({"path": "/opt/bin", "name": "plain"});
+        let result = apply_and_serialize(yaml, &old, &new);
+        assert!(
+            result.contains("'/opt/bin'"),
+            "single quotes not preserved: {result}"
+        );
+    }
+
+    #[test]
+    fn scalar_set_preserves_plain_style() {
+        let yaml = "name: Alice\nage: 30\n";
+        let old = json!({"name": "Alice", "age": 30});
+        let new = json!({"name": "Bob", "age": 30});
+        let result = apply_and_serialize(yaml, &old, &new);
+        assert!(
+            result.contains("name: Bob"),
+            "plain style should not add quotes: {result}"
+        );
+        assert!(
+            !result.contains("\"Bob\"") && !result.contains("'Bob'"),
+            "plain value should not get quoted: {result}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

`doc set` on YAML keys with double-quoted or single-quoted values stripped the quotes, producing plain scalars. For example, `name: "John Doe"` became `name: Jane Doe` after updating.

## Root cause

The CST update path for scalar changes in `apply_yaml_mapping_diff` (line 68-71 of `yaml_cst.rs`) used `json_to_yaml_node()`, which serializes through `serde_yaml_ng`. That serializer always emits plain scalars for simple strings, losing the original quote style.

## Fix

Detect quoted scalars via `yaml_edit::Scalar::is_quoted()` and use the in-place `set_value()` method for token replacement that preserves quoting. The existing `json_to_yaml_node()` path is used only for non-string or unquoted values.

## Tests

Added 3 unit tests:
- Double-quoted style preservation
- Single-quoted style preservation
- Plain style remains unquoted

Found via runtime testing (/fixrealloop round 1).