### PR TITLE
fix: wire by_extension formatters from .patchloom.toml to run_format_command

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -171,6 +171,12 @@ These flags affect how Patchloom reports results or chooses which files to touch
 - **Use when:** You need to override the default terminal detection, for example forcing color into a pager or disabling it in a terminal that renders escape codes literally.
 - **Prefer instead:** Set the `NO_COLOR` environment variable when you want a global, tool-agnostic way to disable color across all CLI tools.
 
+<!-- ref:global-flag:format-config -->
+### `format_config` (internal)
+
+- **What it does:** Carries the per-extension formatter configuration loaded from `.patchloom.toml` (`[format.by_extension]` table) so that post-write formatting can run the correct formatter for each file type.
+- **Use when:** You configure `[format] auto = true` and `[format.by_extension]` in `.patchloom.toml`. The field is populated automatically; it is not set via CLI flags.
+
 <!-- ref:global-flag:verbose -->
 ### `--verbose`
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -96,6 +96,11 @@ pub struct GlobalFlags {
     pub format_timeout: Option<u64>,
     #[cfg_attr(feature = "cli", clap(skip))]
     pub no_format: bool,
+
+    /// Per-extension format config from `.patchloom.toml`.
+    /// Populated by `apply_config`, not by CLI flags.
+    #[cfg_attr(feature = "cli", clap(skip))]
+    pub format_config: Option<crate::config::FormatConfig>,
 }
 
 /// Write-only flags exposed in subcommands that mutate files.
@@ -453,6 +458,7 @@ impl GlobalFlags {
             no_format: base.no_format,
             format: base.format.clone(),
             format_timeout: base.format_timeout,
+            format_config: base.format_config.clone(),
             verbose: base.verbose,
             color: base.color,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,6 +158,13 @@ pub fn apply_config(global: &mut crate::cli::global::GlobalFlags, config: &Proje
         }
     }
 
+    // Store per-extension format config so run_format_command can use it.
+    if config.format.auto == Some(true)
+        && (!config.format.by_extension.is_empty() || config.format.command.is_some())
+    {
+        global.format_config = Some(config.format.clone());
+    }
+
     // Exclude globs: prepend config globs before user excludes.
     if !config.exclude.globs.is_empty() {
         let mut merged = config.exclude.globs.clone();
@@ -718,6 +725,53 @@ rs = "rustfmt"
         assert!(global.format.is_none());
         apply_config(&mut global, &config);
         assert_eq!(global.format.as_deref(), Some("treefmt"));
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn apply_config_stores_format_config_for_by_extension() {
+        let mut by_ext = std::collections::HashMap::new();
+        by_ext.insert("rs".into(), "rustfmt".into());
+        by_ext.insert("py".into(), "black".into());
+        let config = ProjectConfig {
+            format: FormatConfig {
+                auto: Some(true),
+                command: None,
+                by_extension: by_ext,
+            },
+            ..ProjectConfig::default()
+        };
+        let mut global = crate::cli::global::GlobalFlags::default();
+        assert!(global.format_config.is_none());
+        apply_config(&mut global, &config);
+        let fc = global
+            .format_config
+            .as_ref()
+            .expect("format_config should be set");
+        assert_eq!(fc.auto, Some(true));
+        assert_eq!(fc.by_extension.len(), 2);
+        assert_eq!(fc.by_extension.get("rs").unwrap(), "rustfmt");
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn apply_config_skips_format_config_when_auto_false() {
+        let mut by_ext = std::collections::HashMap::new();
+        by_ext.insert("rs".into(), "rustfmt".into());
+        let config = ProjectConfig {
+            format: FormatConfig {
+                auto: None,
+                command: None,
+                by_extension: by_ext,
+            },
+            ..ProjectConfig::default()
+        };
+        let mut global = crate::cli::global::GlobalFlags::default();
+        apply_config(&mut global, &config);
+        assert!(
+            global.format_config.is_none(),
+            "format_config should not be set when auto != true"
+        );
     }
 
     /// Regression: normalize_eol = "keep" in config must be accepted (no-op).

--- a/src/write.rs
+++ b/src/write.rs
@@ -763,7 +763,7 @@ pub fn run_format_command(
     global: &crate::cli::global::GlobalFlags,
     cwd: &std::path::Path,
 ) -> anyhow::Result<()> {
-    run_format_command_ext(global, cwd, None, None)
+    run_format_command_ext(global, cwd, None, global.format_config.as_ref())
 }
 
 /// Extended format runner that accepts an optional list of modified paths
@@ -827,9 +827,22 @@ pub fn run_format_command_ext(
         return Ok(());
     }
 
-    let paths = match modified_paths {
+    // When modified_paths are not passed explicitly, discover them via
+    // `git diff --name-only HEAD`. This covers CLI commands (replace, md,
+    // ast replace, etc.) that call run_format_command without tracking
+    // which files they touched.
+    let discovered: Vec<String>;
+    let discovered_refs: Vec<&str>;
+    let paths: &[&str] = match modified_paths {
         Some(p) => p,
-        None => return Ok(()),
+        None => {
+            discovered = discover_modified_files(cwd);
+            if discovered.is_empty() {
+                return Ok(());
+            }
+            discovered_refs = discovered.iter().map(|s| s.as_str()).collect();
+            &discovered_refs
+        }
     };
 
     // Group modified files by extension
@@ -866,6 +879,25 @@ pub fn run_format_command_ext(
     }
 
     Ok(())
+}
+
+/// Discover files modified since the last commit by running
+/// `git diff --name-only HEAD` in `cwd`. Returns relative paths.
+/// Falls back to an empty list on any error (not a git repo, etc.).
+#[cfg(feature = "cli")]
+fn discover_modified_files(cwd: &std::path::Path) -> Vec<String> {
+    let output = std::process::Command::new("git")
+        .args(["diff", "--name-only", "HEAD"])
+        .current_dir(cwd)
+        .output();
+    match output {
+        Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| l.to_string())
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 /// Shell-escape a file path for safe inclusion in a command string.


### PR DESCRIPTION
## Problem

The `[format.by_extension]` table in `.patchloom.toml` was parsed and validated but never actually used. All commands called `run_format_command(global, cwd)` which forwarded `None` for `format_config`, making per-extension formatters dead code.

## Fix

- Add `format_config: Option<FormatConfig>` field to `GlobalFlags`
- Populate it in `apply_config` when `auto=true` and by_extension entries or command exist
- Pass `global.format_config.as_ref()` from `run_format_command` to the extended runner
- When `modified_paths` are not provided (CLI commands don't track them), discover modified files via `git diff --name-only HEAD`
- Add reference doc marker for the new internal field

## Verification

- `make check-fast` passes (838 integration + 10 PTY tests)
- End-to-end: `replace` with `by_extension.rs = rustfmt` auto-formats after --apply
- `--no-format` correctly skips
- Catch-all `command` path also works