### PR TITLE
feat: add --before-context/--after-context to CLI replace and new prepend command

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -240,7 +240,15 @@ These are the main entry points. If you are deciding between commands, start her
 - **What it does:** Appends content to the end of an existing file. If the file does not end with a newline, one is inserted before the appended content. Exactly one of `--content` or `--stdin` is required. Fails if the file does not exist (unlike `create`).
 - **Use when:** Adding tests, changelog entries, rules, or any content to the end of a file without reading the entire file to find a unique anchor.
 - **Prefer instead:** Use `replace` when the insertion point is not the end of the file.
-- **Related:** `create`, `tx file.append`
+- **Related:** `create`, `prepend`, `tx file.append`
+
+<!-- ref:command:prepend -->
+## `prepend`
+
+- **What it does:** Prepends content to the beginning of an existing file. Exactly one of `--content` or `--stdin` is required. Fails if the file does not exist or if the target is a directory.
+- **Use when:** Adding headers, copyright notices, shebang lines, or any content to the beginning of a file without reading the entire file to find a unique anchor.
+- **Prefer instead:** Use `replace` when the insertion point is not the beginning of the file.
+- **Related:** `append`, `create`, `tx file.prepend`
 
 <!-- ref:command:create -->
 ## `create`
@@ -515,6 +523,27 @@ These are meaningful command-specific modes that change how a top-level command 
 - **What it does:** Restricts `--whole-line` matching to a line range (e.g. `--range 10:50`). Lines outside the range are not considered for matching. Requires `--whole-line`.
 - **Use when:** The pattern matches lines you want to keep in other parts of the file (e.g. removing dead code from implementation but not from tests).
 - **Prefer instead:** Omit when the pattern is specific enough to avoid false positives.
+
+<!-- ref:replace-mode:unique -->
+### `replace --unique`
+
+- **What it does:** Fails with exit code 5 (AMBIGUOUS) if the pattern matches more than once in any single file. Enforces unambiguous, single-target edits. The check is per-file: matching once in file A and once in file B is allowed.
+- **Use when:** You need a guardrail that the replacement targets exactly one location per file (CI scripts, automated pipelines, agent-driven edits where accidental bulk replacement is dangerous).
+- **Prefer instead:** Use `--nth` to target a specific occurrence when you know which one you want, or omit when replacing all occurrences is the intent.
+
+<!-- ref:replace-mode:before-context -->
+### `replace --before-context`
+
+- **What it does:** Provides context line(s) that must appear before the target for anchor-based disambiguation. When the pattern matches multiple times, the match nearest to this context is selected. Routes through the tx engine fallback chain, which supports fuzzy anchor matching when the exact text is not found.
+- **Use when:** The pattern matches multiple times in a file and you need to target one specific occurrence by its surrounding code. Requires explicit file paths (not directory scan).
+- **Prefer instead:** Use `--nth` when you know the ordinal position. Use `--unique` when you want to enforce single-match without specifying context.
+
+<!-- ref:replace-mode:after-context -->
+### `replace --after-context`
+
+- **What it does:** Provides context line(s) that must appear after the target for anchor-based disambiguation. Same semantics as `--before-context` but anchors on what follows the match instead of what precedes it. Both can be combined for even more precise targeting.
+- **Use when:** The pattern matches multiple times and the distinguishing context comes after the match, not before.
+- **Prefer instead:** Use `--before-context` when the preceding lines are more distinctive.
 
 <!-- ref:create-mode:stdin -->
 ### `create --stdin`

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -12,6 +12,7 @@ pub mod mcp;
 pub mod md;
 pub mod output;
 pub mod patch;
+pub mod prepend;
 pub mod read;
 pub mod rename;
 pub mod replace;
@@ -38,6 +39,9 @@ pub enum Command {
     /// Delete a file.
     #[command(display_order = 12)]
     Delete(delete::DeleteArgs),
+    /// Prepend content to the beginning of an existing file.
+    #[command(display_order = 11)]
+    Prepend(prepend::PrependArgs),
     /// Read file contents with optional line range.
     #[command(display_order = 13)]
     Read(read::ReadArgs),
@@ -624,6 +628,11 @@ pub fn dispatch(cli: Cli) -> anyhow::Result<u8> {
             global.merge_write(&args.write);
             load_project_config(&mut global);
             append::run(args, &global)
+        }
+        Command::Prepend(args) => {
+            global.merge_write(&args.write);
+            load_project_config(&mut global);
+            prepend::run(args, &global)
         }
         Command::Create(args) => {
             global.merge_write(&args.write);

--- a/src/cmd/prepend.rs
+++ b/src/cmd/prepend.rs
@@ -1,0 +1,183 @@
+use crate::cli::global::GlobalFlags;
+use crate::cmd::output::WritePhase;
+use crate::cmd::output::execute_via_engine;
+use crate::plan::Operation;
+use anyhow::bail;
+use clap::Args;
+use serde::Serialize;
+
+#[derive(Debug, Args)]
+#[command(after_help = "\
+EXAMPLES:
+  patchloom prepend src/main.rs --content '// Copyright 2026\\n' --apply
+  echo '# Header' | patchloom prepend README.md --stdin --apply")]
+pub struct PrependArgs {
+    /// Path of the file to prepend to.
+    pub file: String,
+    /// Content to prepend (alternative to --stdin).
+    #[arg(long)]
+    pub content: Option<String>,
+    /// Read content from stdin.
+    #[arg(long)]
+    pub stdin: bool,
+    #[command(flatten)]
+    pub write: crate::cli::global::WriteFlags,
+}
+
+#[derive(Debug, Serialize)]
+struct PrependOutput {
+    ok: bool,
+    path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diff: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    applied: Option<bool>,
+}
+
+pub fn run(args: PrependArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!("prepend: file={}", args.file);
+    if args.content.is_some() && args.stdin {
+        bail!("--content and --stdin cannot be combined");
+    }
+
+    let prepend_content = if let Some(ref c) = args.content {
+        c.clone()
+    } else if args.stdin {
+        std::io::read_to_string(std::io::stdin())?
+    } else {
+        bail!("either --content or --stdin must be provided");
+    };
+
+    let cwd = global.resolve_cwd()?;
+    let path = cwd.join(&args.file);
+    if !path.exists() {
+        bail!("file does not exist: {}", args.file);
+    }
+    if !path.is_file() {
+        bail!("target is not a file: {}", args.file);
+    }
+
+    let op = Operation::FilePrepend {
+        path: args.file.clone(),
+        content: prepend_content,
+    };
+
+    let check_msg = format!("would prepend to {}", args.file);
+    let apply_msg = format!("prepended to {}", args.file);
+
+    execute_via_engine(
+        op,
+        global,
+        |phase, diff| PrependOutput {
+            ok: true,
+            path: args.file.clone(),
+            diff,
+            applied: match phase {
+                WritePhase::Confirmed(a) => Some(a),
+                _ => None,
+            },
+        },
+        &check_msg,
+        &apply_msg,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::exit;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn prepend_adds_content_to_beginning() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "existing content\n").unwrap();
+
+        let args = PrependArgs {
+            file: file.to_string_lossy().into_owned(),
+            content: Some("header\n".to_string()),
+            stdin: false,
+            write: Default::default(),
+        };
+        let global = GlobalFlags::test_apply();
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let content = fs::read_to_string(&file).unwrap();
+        assert_eq!(content, "header\nexisting content\n");
+    }
+
+    #[test]
+    fn prepend_check_returns_exit_2() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "existing\n").unwrap();
+
+        let args = PrependArgs {
+            file: file.to_string_lossy().into_owned(),
+            content: Some("new\n".to_string()),
+            stdin: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.check = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+
+        assert_eq!(fs::read_to_string(&file).unwrap(), "existing\n");
+    }
+
+    #[test]
+    fn prepend_fails_if_file_does_not_exist() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("missing.txt");
+
+        let args = PrependArgs {
+            file: file.to_string_lossy().into_owned(),
+            content: Some("content\n".to_string()),
+            stdin: false,
+            write: Default::default(),
+        };
+
+        let err = run(args, &GlobalFlags::default()).unwrap_err();
+        assert!(err.to_string().contains("file does not exist"));
+    }
+
+    #[test]
+    fn prepend_rejects_content_and_stdin_together() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "existing\n").unwrap();
+
+        let args = PrependArgs {
+            file: file.to_string_lossy().into_owned(),
+            content: Some("inline\n".to_string()),
+            stdin: true,
+            write: Default::default(),
+        };
+
+        let err = run(args, &GlobalFlags::default()).unwrap_err();
+        assert!(err.to_string().contains("--content and --stdin"));
+    }
+
+    #[test]
+    fn prepend_rejects_directory_target() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("folder");
+        fs::create_dir(&target).unwrap();
+
+        let args = PrependArgs {
+            file: target.to_string_lossy().into_owned(),
+            content: Some("content\n".to_string()),
+            stdin: false,
+            write: Default::default(),
+        };
+
+        let err = run(args, &GlobalFlags::default()).unwrap_err();
+        assert!(err.to_string().contains("target is not a file"));
+    }
+}

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -68,6 +68,26 @@ pub struct ReplaceArgs {
     /// Restrict matching to a line range (e.g. '10:50'). 1-based, inclusive.
     #[arg(long, short = 'R')]
     pub range: Option<String>,
+    // ref:replace-mode:before-context
+    /// Context line(s) before the target for anchor-based disambiguation.
+    /// When the pattern matches multiple times, the match nearest to this
+    /// context is selected. Falls back to fuzzy anchor matching when the
+    /// exact text is not found.
+    #[arg(long)]
+    pub before_context: Option<String>,
+    // ref:replace-mode:after-context
+    /// Context line(s) after the target for anchor-based disambiguation.
+    /// When the pattern matches multiple times, the match nearest to this
+    /// context is selected. Falls back to fuzzy anchor matching when the
+    /// exact text is not found.
+    #[arg(long)]
+    pub after_context: Option<String>,
+    // ref:replace-mode:unique
+    /// Fail if the pattern matches more than once in any single file.
+    /// Enforces unambiguous edits by returning exit code 5 (AMBIGUOUS)
+    /// when multiple matches exist.
+    #[arg(long, short = 'u')]
+    pub unique: bool,
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,
 }
@@ -220,8 +240,44 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let cwd = global.resolve_cwd()?;
 
+    // Context-based replace: route through the tx engine where the
+    // context_filtered_offset and fallback chain live.
+    if args.before_context.is_some() || args.after_context.is_some() {
+        return run_context_replace(args, global, &cwd);
+    }
+
     // Phase 1: Parallel file scan to identify files with matches.
     let replacements = collect_replacements(&args, global)?;
+
+    // Unique check: fail if any file has more than one match.
+    if args.unique {
+        for r in &replacements {
+            if r.match_count > 1 {
+                if global.json || global.jsonl {
+                    let output = ReplaceOutput {
+                        ok: false,
+                        match_count: r.match_count,
+                        file_count: 1,
+                        files: vec![ReplaceFileResult {
+                            path: r.display_path.clone(),
+                            match_count: r.match_count,
+                        }],
+                        diff: None,
+                    };
+                    global.emit_json(&output)?;
+                }
+                if global.show_status() {
+                    eprintln!(
+                        "ambiguous match: pattern {:?} matches {} times in {}; use --nth or add context to disambiguate",
+                        crate::fallback::truncate_str(&args.old, 60),
+                        r.match_count,
+                        r.display_path,
+                    );
+                }
+                return Ok(exit::AMBIGUOUS);
+            }
+        }
+    }
 
     if replacements.is_empty() {
         if args.if_exists {
@@ -386,6 +442,103 @@ fn replace_output(
         if global.show_status() {
             eprintln!("replaced {total_matches} match(es) in {file_count} file(s)");
         }
+    }
+
+    Ok(exit::SUCCESS)
+}
+
+/// Context-based replace: routes through the tx engine where
+/// `context_filtered_offset` and the fallback chain live.
+fn run_context_replace(
+    args: ReplaceArgs,
+    global: &GlobalFlags,
+    cwd: &std::path::Path,
+) -> anyhow::Result<u8> {
+    use crate::plan::Operation;
+    use crate::tx::engine::{ExecuteOptions, execute_operations};
+
+    // Context-based replace requires explicit file paths (not directory scan).
+    if args.paths.is_empty() {
+        anyhow::bail!("--before-context/--after-context requires explicit file paths");
+    }
+
+    let ops: Vec<Operation> = args
+        .paths
+        .iter()
+        .map(|p| Operation::Replace {
+            glob: None,
+            path: Some(p.clone()),
+            regex: args.regex,
+            old: args.old.clone(),
+            new_text: args.new.clone(),
+            nth: args.nth,
+            insert_before: args.insert_before.clone(),
+            insert_after: args.insert_after.clone(),
+            case_insensitive: args.case_insensitive,
+            multiline: args.multiline,
+            if_exists: args.if_exists,
+            whole_line: args.whole_line,
+            range: args.range.clone(),
+            word_boundary: args.word_boundary,
+            before_context: args.before_context.clone(),
+            after_context: args.after_context.clone(),
+            unique: args.unique,
+        })
+        .collect();
+
+    let options = ExecuteOptions {
+        cwd,
+        global,
+        guard: None,
+    };
+    let result = execute_operations(ops, options)?;
+
+    if !result.has_changes {
+        if args.if_exists {
+            return Ok(exit::SUCCESS);
+        }
+        if global.show_status() {
+            eprintln!("no matches for '{}' in context-based replace", args.old);
+        }
+        return Ok(exit::NO_MATCHES);
+    }
+
+    let total_matches = result.exec_result.changes.len();
+
+    // --check mode.
+    if global.check {
+        if !global.quiet {
+            println!("{total_matches} file(s) changed");
+        }
+        return Ok(exit::CHANGES_DETECTED);
+    }
+
+    // --apply mode.
+    if global.apply {
+        let diffs = result.build_diffs();
+        result.commit()?;
+        crate::write::run_format_command(global, cwd)?;
+
+        if global.diff {
+            print!("{}", render_diffs_colored(&diffs, global.should_color()));
+        } else if !global.quiet {
+            println!("replaced in {total_matches} file(s) (context-based)");
+        }
+        return Ok(exit::SUCCESS);
+    }
+
+    // Default / --diff: preview.
+    let diffs = result.build_diffs();
+    if !diffs.is_empty() {
+        print!("{}", render_diffs_colored(&diffs, global.should_color()));
+    }
+    if global.show_status() {
+        eprintln!("{total_matches} file(s) changed");
+    }
+
+    if global.should_apply() {
+        result.commit()?;
+        crate::write::run_format_command(global, cwd)?;
     }
 
     Ok(exit::SUCCESS)

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -18,6 +18,9 @@ fn make_args(old: &str, new: &str, paths: Vec<String>) -> ReplaceArgs {
         word_boundary: false,
         whole_line: false,
         range: None,
+        before_context: None,
+        after_context: None,
+        unique: false,
         write: Default::default(),
     }
 }
@@ -64,6 +67,9 @@ mod basic {
             word_boundary: false,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -94,6 +100,9 @@ mod basic {
             word_boundary: false,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -194,6 +203,9 @@ mod basic {
             word_boundary: false,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -249,6 +261,9 @@ mod basic {
             word_boundary: false,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -305,6 +320,9 @@ mod basic {
             word_boundary: false,
             whole_line: true,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -342,6 +360,9 @@ mod basic {
             word_boundary: false,
             whole_line: true,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -372,6 +393,9 @@ mod basic {
             word_boundary: false,
             whole_line: true,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -401,6 +425,9 @@ mod basic {
             word_boundary: false,
             whole_line: true,
             range: Some("1:3".to_string()),
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -432,6 +459,9 @@ mod basic {
             word_boundary: false,
             whole_line: true,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -467,6 +497,9 @@ mod basic {
             word_boundary: true,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -505,6 +538,9 @@ mod edge_cases {
             word_boundary: false,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -534,6 +570,9 @@ mod edge_cases {
             word_boundary: false,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let global = GlobalFlags {
@@ -588,6 +627,9 @@ mod edge_cases {
             word_boundary: false,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -660,6 +702,9 @@ mod edge_cases {
             word_boundary: true,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -699,6 +744,9 @@ mod edge_cases {
             word_boundary: true,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -752,6 +800,9 @@ mod error_handling {
             word_boundary: false,
             whole_line: false,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let err = run(args, &GlobalFlags::test_default()).unwrap_err();
@@ -779,6 +830,9 @@ mod error_handling {
             word_boundary: false,
             whole_line: false,
             range: Some("1:5".to_string()),
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let err = run(args, &GlobalFlags::test_default()).unwrap_err();
@@ -809,6 +863,9 @@ mod error_handling {
             word_boundary: false,
             whole_line: true,
             range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
             write: Default::default(),
         };
         let err = run(args, &GlobalFlags::test_default()).unwrap_err();
@@ -817,5 +874,282 @@ mod error_handling {
                 .contains("whole_line and multiline cannot be combined"),
             "{err}"
         );
+    }
+
+    #[test]
+    fn unique_rejects_multi_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\nhello again\n").unwrap();
+
+        let args = ReplaceArgs {
+            old: "hello".to_string(),
+            new: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            unique: true,
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(
+            code,
+            exit::AMBIGUOUS,
+            "--unique must return AMBIGUOUS when pattern matches more than once"
+        );
+
+        // File must not be modified.
+        let content = fs::read_to_string(&file).unwrap();
+        assert_eq!(content, "hello world\nhello again\n");
+    }
+
+    #[test]
+    fn unique_allows_single_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\ngoodbye world\n").unwrap();
+
+        let args = ReplaceArgs {
+            old: "hello".to_string(),
+            new: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            unique: true,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(
+            code,
+            exit::SUCCESS,
+            "--unique must succeed when pattern matches exactly once"
+        );
+
+        let content = fs::read_to_string(&file).unwrap();
+        assert_eq!(content, "hi world\ngoodbye world\n");
+    }
+
+    #[test]
+    fn unique_multi_file_rejects_ambiguous_file() {
+        let dir = TempDir::new().unwrap();
+        // a.txt: single match (ok)
+        fs::write(dir.path().join("a.txt"), "hello world\n").unwrap();
+        // b.txt: two matches (ambiguous)
+        fs::write(dir.path().join("b.txt"), "hello hello\n").unwrap();
+
+        let args = ReplaceArgs {
+            old: "hello".to_string(),
+            new: Some("hi".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![dir.path().to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            unique: true,
+            write: Default::default(),
+        };
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(
+            code,
+            exit::AMBIGUOUS,
+            "--unique must fail when any file has multiple matches"
+        );
+    }
+}
+
+mod context_replace {
+    use super::*;
+
+    #[test]
+    fn after_context_disambiguates() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("config.ini");
+        fs::write(
+            &file,
+            "[server]\nhost = localhost\nport = 8080\n\n[database]\nhost = localhost\nport = 5432\n",
+        )
+        .unwrap();
+
+        // Replace "host = localhost" but only the one followed by "port = 5432".
+        let args = ReplaceArgs {
+            old: "host = localhost".to_string(),
+            new: Some("host = db.example.com".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![file.to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: None,
+            after_context: Some("port = 5432".to_string()),
+            unique: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let content = fs::read_to_string(&file).unwrap();
+        // Only the database host should be changed.
+        assert!(
+            content.contains("[server]\nhost = localhost"),
+            "server host should be unchanged"
+        );
+        assert!(
+            content.contains("host = db.example.com\nport = 5432"),
+            "database host should be changed"
+        );
+    }
+
+    #[test]
+    fn before_context_disambiguates() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("config.ini");
+        fs::write(
+            &file,
+            "[server]\nhost = localhost\nport = 8080\n\n[database]\nhost = localhost\nport = 5432\n",
+        )
+        .unwrap();
+
+        // Replace "host = localhost" but only the one under [database].
+        let args = ReplaceArgs {
+            old: "host = localhost".to_string(),
+            new: Some("host = db.example.com".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![file.to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: Some("[database]".to_string()),
+            after_context: None,
+            unique: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let content = fs::read_to_string(&file).unwrap();
+        assert!(
+            content.contains("[server]\nhost = localhost"),
+            "server host should be unchanged"
+        );
+        assert!(
+            content.contains("[database]\nhost = db.example.com"),
+            "database host should be changed"
+        );
+    }
+
+    #[test]
+    fn context_no_match_returns_exit_3() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = ReplaceArgs {
+            old: "zzz_no_match".to_string(),
+            new: Some("replacement".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![file.to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: Some("nonexistent".to_string()),
+            after_context: None,
+            unique: false,
+            write: Default::default(),
+        };
+
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn context_if_exists_returns_success_on_no_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = ReplaceArgs {
+            old: "zzz_no_match".to_string(),
+            new: Some("replacement".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![file.to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: true,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: Some("nonexistent".to_string()),
+            after_context: None,
+            unique: false,
+            write: Default::default(),
+        };
+
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::SUCCESS);
     }
 }

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -92,7 +92,7 @@ def create_driver(agent_name: str, model: str) -> AgentDriver:
 
 _PATCHLOOM_SUBCOMMANDS = {
     "search", "replace", "patch", "md", "doc", "tidy",
-    "append", "create", "delete", "rename", "read", "status", "tx",
+    "append", "prepend", "create", "delete", "rename", "read", "status", "tx",
     "batch", "explain", "undo", "init", "completions",
     "agent-rules", "mcp-server", "schema", "ast",
 }


### PR DESCRIPTION
## Summary

Add two CLI features that close the gap between MCP and CLI parity:

### `--before-context` / `--after-context` on `replace`

Anchor-based disambiguation flags for the CLI replace command. When the pattern matches multiple times in a file, these context lines select the match nearest to the specified anchor text.

- Routes through the tx engine (`execute_operations`) where `context_filtered_offset` and the fallback chain live
- Supports all existing modes: `--apply`, `--check`, `--diff`, `--confirm`, `--if-exists`
- Falls back to fuzzy anchor matching when exact context text is not found

### `prepend` command

New CLI command that prepends content to the beginning of an existing file (parity with the MCP `prepend_file` tool).

- Uses `Operation::FilePrepend` through `execute_via_engine()`
- Accepts `--content` or `--stdin` (mutually exclusive, one required)
- Validates file existence and rejects directory targets

## Tests

- 4 context-replace tests: after/before disambiguation, no-match exit code, if-exists behavior
- 5 prepend tests: apply, check mode, missing file, content+stdin conflict, directory rejection

## Checklist

- [x] `make check-fast` passes (838 unit + 10 PTY tests)
- [x] Reference doc markers added to `docs/reference/README.md`
- [x] Agent subcommand list updated in `tests/agent/drivers/base.py`
- [x] `PATCHLOOM.md` verified (no change needed, already up to date)