### PR TITLE
feat: implement Bline issues #1287, #1288, #1289

### DIFF
--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -20,31 +20,53 @@ pub fn navigate_mut<'a>(
     for seg in segments {
         current = match seg {
             selector::Segment::Key(k) => {
-                if create {
-                    // Convert null or non-object intermediates to an empty
-                    // object so child keys can be created.
-                    if current.is_null() {
-                        *current = serde_json::Value::Object(serde_json::Map::new());
-                    } else if !current.is_object() {
+                // Numeric dot-notation: if the current node is an array and
+                // the key is a valid non-negative integer, treat it as an
+                // array index (e.g. `env.0.value` → `env[0].value`). (#1288)
+                if current.is_array() {
+                    if let Ok(idx) = k.parse::<usize>() {
+                        let len = current.as_array().map_or(0, |a| a.len());
+                        current.get_mut(idx).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "array index {idx} out of bounds (length {len}) at '{k}'"
+                            )
+                        })?
+                    } else {
                         anyhow::bail!(
                             "expected object at key '{k}', found {}",
                             value_type_name(current)
                         );
                     }
-                    let needs_create = match current.as_object() {
-                        Some(obj) => !obj.contains_key(k.as_str()),
-                        None => false,
-                    };
-                    if needs_create {
-                        current
-                            .as_object_mut()
-                            .ok_or_else(|| anyhow::anyhow!("not an object at key '{k}'"))?
-                            .insert(k.clone(), serde_json::Value::Object(serde_json::Map::new()));
+                } else {
+                    if create {
+                        // Convert null or non-object intermediates to an empty
+                        // object so child keys can be created.
+                        if current.is_null() {
+                            *current = serde_json::Value::Object(serde_json::Map::new());
+                        } else if !current.is_object() {
+                            anyhow::bail!(
+                                "expected object at key '{k}', found {}",
+                                value_type_name(current)
+                            );
+                        }
+                        let needs_create = match current.as_object() {
+                            Some(obj) => !obj.contains_key(k.as_str()),
+                            None => false,
+                        };
+                        if needs_create {
+                            current
+                                .as_object_mut()
+                                .ok_or_else(|| anyhow::anyhow!("not an object at key '{k}'"))?
+                                .insert(
+                                    k.clone(),
+                                    serde_json::Value::Object(serde_json::Map::new()),
+                                );
+                        }
                     }
+                    current
+                        .get_mut(k.as_str())
+                        .ok_or_else(|| anyhow::anyhow!("key not found: {k}"))?
                 }
-                current
-                    .get_mut(k.as_str())
-                    .ok_or_else(|| anyhow::anyhow!("key not found: {k}"))?
             }
             selector::Segment::Index(i) => current
                 .get_mut(*i)
@@ -83,6 +105,23 @@ pub fn set_at_path(
 
     match last {
         selector::Segment::Key(k) => {
+            // Numeric dot-notation on arrays (#1288).
+            if parent.is_array()
+                && let Ok(idx) = k.parse::<usize>()
+            {
+                let arr = parent.as_array_mut().unwrap();
+                if idx < arr.len() {
+                    arr[idx] = value;
+                } else {
+                    anyhow::bail!(
+                        "array index {} out of bounds (length {}) at '{}'",
+                        idx,
+                        arr.len(),
+                        k
+                    );
+                }
+                return Ok(());
+            }
             parent
                 .as_object_mut()
                 .ok_or_else(|| anyhow::anyhow!("parent is not an object"))?
@@ -119,6 +158,18 @@ pub fn delete_at_selector(
     };
     match last {
         selector::Segment::Key(k) => {
+            // Numeric dot-notation on arrays (#1288).
+            if parent.is_array()
+                && let Ok(idx) = k.parse::<usize>()
+            {
+                if let Some(arr) = parent.as_array_mut()
+                    && idx < arr.len()
+                {
+                    arr.remove(idx);
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
             if let Some(obj) = parent.as_object_mut() {
                 Ok(obj.remove(k.as_str()).is_some())
             } else {
@@ -231,11 +282,29 @@ pub fn move_at_path(
     let cloned = {
         let parent = navigate_mut(root, from_parent, false)?;
         match from_last {
-            selector::Segment::Key(k) => parent
-                .as_object()
-                .and_then(|obj| obj.get(k.as_str()))
-                .ok_or_else(|| anyhow::anyhow!("source key '{k}' not found"))?
-                .clone(),
+            selector::Segment::Key(k) => {
+                // Numeric dot-notation on arrays (#1288).
+                if parent.is_array() {
+                    if let Ok(idx) = k.parse::<usize>() {
+                        let arr = parent
+                            .as_array()
+                            .ok_or_else(|| anyhow::anyhow!("source parent is not an array"))?;
+                        if idx < arr.len() {
+                            arr[idx].clone()
+                        } else {
+                            anyhow::bail!("source index {idx} out of bounds");
+                        }
+                    } else {
+                        anyhow::bail!("source key '{k}' not found (parent is array)");
+                    }
+                } else {
+                    parent
+                        .as_object()
+                        .and_then(|obj| obj.get(k.as_str()))
+                        .ok_or_else(|| anyhow::anyhow!("source key '{k}' not found"))?
+                        .clone()
+                }
+            }
             selector::Segment::Index(i) => {
                 let arr = parent
                     .as_array()
@@ -255,10 +324,26 @@ pub fn move_at_path(
         let parent = navigate_mut(root, to_parent, true)?;
         match to_last {
             selector::Segment::Key(k) => {
-                parent
-                    .as_object_mut()
-                    .ok_or_else(|| anyhow::anyhow!("target parent is not an object"))?
-                    .insert(k.clone(), cloned);
+                // Numeric dot-notation on arrays (#1288).
+                if parent.is_array() {
+                    if let Ok(idx) = k.parse::<usize>() {
+                        let arr = parent
+                            .as_array_mut()
+                            .ok_or_else(|| anyhow::anyhow!("target parent is not an array"))?;
+                        if idx <= arr.len() {
+                            arr.insert(idx, cloned);
+                        } else {
+                            anyhow::bail!("target index {idx} out of bounds");
+                        }
+                    } else {
+                        anyhow::bail!("target key '{k}' not valid (parent is array)");
+                    }
+                } else {
+                    parent
+                        .as_object_mut()
+                        .ok_or_else(|| anyhow::anyhow!("target parent is not an object"))?
+                        .insert(k.clone(), cloned);
+                }
             }
             selector::Segment::Index(i) => {
                 let arr = parent
@@ -279,9 +364,19 @@ pub fn move_at_path(
         let parent = navigate_mut(root, from_parent, false)?;
         match from_last {
             selector::Segment::Key(k) => {
-                parent
-                    .as_object_mut()
-                    .and_then(|obj| obj.remove(k.as_str()));
+                // Numeric dot-notation on arrays (#1288).
+                if parent.is_array() {
+                    if let Ok(idx) = k.parse::<usize>()
+                        && let Some(arr) = parent.as_array_mut()
+                        && idx < arr.len()
+                    {
+                        arr.remove(idx);
+                    }
+                } else {
+                    parent
+                        .as_object_mut()
+                        .and_then(|obj| obj.remove(k.as_str()));
+                }
             }
             selector::Segment::Index(i) => {
                 let arr = parent
@@ -334,6 +429,14 @@ pub fn update_matching(
         selector::Segment::Key(k) => {
             if let Some(child) = value.get_mut(k.as_str()) {
                 update_matching(child, rest, new_val)
+            } else if value.is_array() {
+                // Numeric dot-notation (#1288).
+                if let Ok(idx) = k.parse::<usize>()
+                    && let Some(child) = value.get_mut(idx)
+                {
+                    return update_matching(child, rest, new_val);
+                }
+                0
             } else {
                 0
             }
@@ -655,6 +758,57 @@ mod tests {
         let mut root = json!({"arr": [10, 20, 30]});
         move_at_path(&mut root, &segs("arr[2]"), &segs("arr[0]")).unwrap();
         assert_eq!(root["arr"], json!([30, 10, 20]));
+    }
+
+    // ── #1288: numeric dot-notation on arrays ──────────────────────
+
+    #[test]
+    fn navigate_mut_numeric_dot_notation_on_array() {
+        let mut root = json!({"env": [{"value": "A"}, {"value": "B"}]});
+        let val = navigate_mut(&mut root, &segs("env.0.value"), false).unwrap();
+        assert_eq!(val, &json!("A"));
+    }
+
+    #[test]
+    fn set_at_path_numeric_dot_notation() {
+        let mut root = json!({"items": [10, 20, 30]});
+        set_at_path(&mut root, &segs("items.1"), json!(99)).unwrap();
+        assert_eq!(root["items"][1], json!(99));
+    }
+
+    #[test]
+    fn set_at_path_numeric_dot_notation_out_of_bounds() {
+        let mut root = json!({"items": [10, 20]});
+        let result = set_at_path(&mut root, &segs("items.99"), json!(0));
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("out of bounds"),
+            "should report out of bounds"
+        );
+    }
+
+    #[test]
+    fn delete_at_selector_numeric_dot_notation() {
+        let mut root = json!({"arr": ["a", "b", "c"]});
+        let removed = delete_at_selector(&mut root, &segs("arr.1")).unwrap();
+        assert!(removed);
+        assert_eq!(root["arr"], json!(["a", "c"]));
+    }
+
+    #[test]
+    fn update_matching_numeric_dot_notation() {
+        let mut root = json!({"env": [{"name": "A"}, {"name": "B"}]});
+        let count = update_matching(&mut root, &segs("env.0.name"), &json!("X"));
+        assert_eq!(count, 1);
+        assert_eq!(root["env"][0]["name"], json!("X"));
+    }
+
+    #[test]
+    fn move_at_path_numeric_dot_notation() {
+        let mut root = json!({"src": ["a", "b"], "dst": {}});
+        move_at_path(&mut root, &segs("src.0"), &segs("dst.moved")).unwrap();
+        assert_eq!(root["dst"]["moved"], json!("a"));
+        assert_eq!(root["src"], json!(["b"]));
     }
 
     /// #1196: Moving a key to itself must be a no-op, not a deletion.

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -146,22 +146,34 @@ pub type PlanWritePolicy = crate::write::WritePolicyOverride;
 pub enum Operation {
     #[serde(rename = "replace", alias = "replace_text")]
     Replace {
+        /// Glob pattern to match files (e.g. "src/**/*.rs"). Mutually exclusive with path.
         glob: Option<String>,
+        /// File path to replace in. Mutually exclusive with glob.
         path: Option<String>,
+        /// Treat `old` as a regex pattern.
         #[serde(default)]
         regex: bool,
+        /// Pattern to find (literal string or regex).
         old: String,
+        /// Replacement text. Supports $1/$2 capture group references in regex mode.
         #[serde(rename = "new")]
         new_text: Option<String>,
+        /// Replace only the Nth occurrence (1-based).
         nth: Option<usize>,
+        /// Insert text before each match instead of replacing.
         insert_before: Option<String>,
+        /// Insert text after each match instead of replacing.
         insert_after: Option<String>,
+        /// Case-insensitive matching.
         #[serde(default)]
         case_insensitive: bool,
+        /// Enable multiline matching (dot matches newlines in regex mode).
         #[serde(default)]
         multiline: bool,
+        /// Return success even if no matches found (idempotent mode).
         #[serde(default)]
         if_exists: bool,
+        /// Replace the entire line containing each match, not just the matched span.
         #[serde(default)]
         whole_line: bool,
         /// Line range restriction (e.g. "10:50"). Only valid with whole_line.
@@ -179,51 +191,79 @@ pub enum Operation {
     },
     #[serde(rename = "doc.set", alias = "doc_set")]
     DocSet {
+        /// Path to the JSON, YAML, or TOML file.
         path: String,
+        /// Dot-notation path to the key (e.g. "server.port", "env.0.value").
         key: String,
+        /// Value to set (any JSON type).
         value: serde_json::Value,
     },
     #[serde(rename = "doc.delete", alias = "doc_delete")]
-    DocDelete { path: String, key: String },
+    DocDelete {
+        /// Path to the JSON, YAML, or TOML file.
+        path: String,
+        /// Dot-notation path to the key to delete.
+        key: String,
+    },
     #[serde(rename = "doc.merge", alias = "doc_merge")]
     DocMerge {
+        /// Path to the JSON, YAML, or TOML file.
         path: String,
+        /// Object to deep-merge into the file.
         value: serde_json::Value,
     },
     #[serde(rename = "doc.append", alias = "doc_append")]
     DocAppend {
+        /// Path to the JSON, YAML, or TOML file.
         path: String,
+        /// Dot-notation path to an array key.
         key: String,
+        /// Value to append to the array.
         value: serde_json::Value,
     },
     #[serde(rename = "doc.prepend", alias = "doc_prepend")]
     DocPrepend {
+        /// Path to the JSON, YAML, or TOML file.
         path: String,
+        /// Dot-notation path to an array key.
         key: String,
+        /// Value to prepend to the array.
         value: serde_json::Value,
     },
     #[serde(rename = "doc.update", alias = "doc_update")]
     DocUpdate {
+        /// Path to the JSON, YAML, or TOML file.
         path: String,
+        /// Dot-notation path to the key to update (supports wildcards and predicates).
         key: String,
+        /// New value for all matching locations.
         value: serde_json::Value,
     },
     #[serde(rename = "doc.move", alias = "doc_move")]
     DocMove {
+        /// Path to the JSON, YAML, or TOML file.
         path: String,
+        /// Dot-notation source path.
         from: String,
+        /// Dot-notation destination path.
         to: String,
     },
     #[serde(rename = "doc.ensure", alias = "doc_ensure")]
     DocEnsure {
+        /// Path to the JSON, YAML, or TOML file.
         path: String,
+        /// Dot-notation path to the key.
         key: String,
+        /// Value to set only if the key does not already exist.
         value: serde_json::Value,
     },
     #[serde(rename = "doc.delete_where", alias = "doc_delete_where")]
     DocDeleteWhere {
+        /// Path to the JSON, YAML, or TOML file.
         path: String,
+        /// Dot-notation path to an array.
         key: String,
+        /// Predicate in "field=value" format to match elements for deletion.
         predicate: String,
     },
     #[serde(rename = "md.replace_section", alias = "md_replace_section")]
@@ -357,29 +397,41 @@ pub enum Operation {
     #[cfg(feature = "ast")]
     #[serde(rename = "ast.rename", alias = "ast_rename")]
     AstRename {
+        /// File or directory to rename in. Directories are walked recursively.
         path: String,
+        /// The identifier to rename.
         old_name: String,
+        /// The new identifier name.
         new_name: String,
+        /// Language hint (e.g. "rust", "go"). Overrides extension-based detection.
         #[serde(default)]
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
     #[serde(rename = "ast.replace", alias = "ast_replace")]
     AstReplace {
+        /// File to replace in.
         path: String,
+        /// Symbol name to scope the replacement to.
         symbol: String,
+        /// Text or pattern to find within the symbol body.
         old: String,
+        /// Replacement text.
         #[serde(rename = "new")]
         new_text: String,
+        /// Treat `old` as a regex pattern.
         #[serde(default)]
         regex: bool,
+        /// Language hint (e.g. "rust", "go"). Overrides extension-based detection.
         #[serde(default)]
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
     #[serde(rename = "ast.insert", alias = "ast_insert")]
     AstInsert {
+        /// File to insert code into.
         path: String,
+        /// Code to insert.
         content: String,
         /// Module/impl/struct to insert into.
         #[serde(default)]

--- a/src/selector/eval.rs
+++ b/src/selector/eval.rs
@@ -15,6 +15,12 @@ pub fn eval<'a>(value: &'a serde_json::Value, selector: &Selector) -> Vec<&'a se
                 Segment::Key(key) => {
                     if let Some(v) = val.get(key.as_str()) {
                         next.push(v);
+                    } else if val.is_array()
+                        // Numeric dot-notation: `env.0.value` → `env[0].value` (#1288)
+                        && let Ok(idx) = key.parse::<usize>()
+                        && let Some(v) = val.get(idx)
+                    {
+                        next.push(v);
                     }
                 }
                 Segment::Index(idx) => {
@@ -212,5 +218,44 @@ mod tests {
         let sel = parse("config[*].debug").unwrap();
         let results = eval(&data, &sel);
         assert_eq!(results.len(), 2);
+    }
+
+    // ── #1288: numeric dot-notation as array index ─────────────────
+
+    #[test]
+    fn eval_numeric_dot_notation_as_array_index() {
+        let data = json!({"env": [{"name": "A", "value": "1"}, {"name": "B", "value": "2"}]});
+        let sel = parse("env.0.value").unwrap();
+        let results = eval(&data, &sel);
+        let expected = json!("1");
+        assert_eq!(results, vec![&expected]);
+    }
+
+    #[test]
+    fn eval_numeric_dot_notation_second_element() {
+        let data = json!({"items": ["alpha", "beta", "gamma"]});
+        let sel = parse("items.1").unwrap();
+        let results = eval(&data, &sel);
+        let expected = json!("beta");
+        assert_eq!(results, vec![&expected]);
+    }
+
+    #[test]
+    fn eval_numeric_dot_notation_out_of_bounds_returns_empty() {
+        let data = json!({"items": [10, 20]});
+        let sel = parse("items.99").unwrap();
+        let results = eval(&data, &sel);
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn eval_numeric_key_on_object_prefers_object_key() {
+        // When an object has a key that is a numeric string, it should
+        // be treated as an object key, not an array index.
+        let data = json!({"data": {"0": "zero-key", "1": "one-key"}});
+        let sel = parse("data.0").unwrap();
+        let results = eval(&data, &sel);
+        let expected = json!("zero-key");
+        assert_eq!(results, vec![&expected]);
     }
 }

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -101,6 +101,34 @@ pub(crate) fn mark_write_target(write_targets: &mut HashSet<PathBuf>, path: &Pat
 }
 
 // ---------------------------------------------------------------------------
+// AST directory expansion (#1287)
+// ---------------------------------------------------------------------------
+
+/// Walk a directory and collect files that have a tree-sitter grammar.
+/// Used by ast.rename/ast.replace in execute_plan when the path is a directory.
+#[cfg(feature = "ast")]
+fn collect_ast_source_files(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_ast_source_files_recursive(dir, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+#[cfg(feature = "ast")]
+fn collect_ast_source_files_recursive(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_ast_source_files_recursive(&path, out)?;
+        } else if path.is_file() && crate::ast::Language::from_path(&path).has_grammar() {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Operation execution
 // ---------------------------------------------------------------------------
 
@@ -583,6 +611,53 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
     Ok(0)
 }
 
+/// Rename identifiers in a single file using AST-aware renaming with
+/// word-boundary fallback. Used by the AstRename handler (both single-file
+/// and directory expansion paths).
+#[cfg(feature = "ast")]
+fn ast_rename_single_file(
+    tx: &mut TxState<'_>,
+    abs: &Path,
+    old_name: &str,
+    new_name: &str,
+    lang_hint: Option<&str>,
+) -> anyhow::Result<usize> {
+    let content = read_file_content(tx.pending, tx.existed_before, abs)?;
+    let lang_val = lang_hint
+        .map(crate::ast::Language::from_name_or_ext)
+        .unwrap_or_else(|| crate::ast::Language::from_path(abs));
+    let result = crate::ast::rename::rename_in_source(content, old_name, new_name, lang_val);
+    match result {
+        Some(r) if r.replacements > 0 => {
+            update_file_content(tx.pending, tx.deletions, tx.write_targets, abs, r.content);
+            Ok(r.replacements)
+        }
+        Some(_) => {
+            anyhow::bail!("no matches for '{}' in {}", old_name, abs.display());
+        }
+        None => {
+            // Tree-sitter couldn't parse. Fallback to word-boundary replace.
+            let re =
+                crate::ops::replace::compile_replace_regex(old_name, false, false, false, true)?;
+            if let Some(re) = re {
+                let new_content = re.replace_all(content, new_name).to_string();
+                let count = re.find_iter(content).count();
+                if count > 0 {
+                    update_file_content(
+                        tx.pending,
+                        tx.deletions,
+                        tx.write_targets,
+                        abs,
+                        new_content,
+                    );
+                    return Ok(count);
+                }
+            }
+            anyhow::bail!("no matches for '{}' in {}", old_name, abs.display());
+        }
+    }
+}
+
 pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
     // Guard is enforced upfront in execute_plan_direct (for library plans) and via MCP pre-checks.
     // Single-op api::* uses ensure_contained inside write paths.
@@ -850,54 +925,28 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             lang,
         } => {
             let abs = tx.cwd.join(path);
-            let content = read_file_content(tx.pending, tx.existed_before, &abs)?;
-            let lang_val = lang
-                .as_deref()
-                .map(crate::ast::Language::from_name_or_ext)
-                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
-            let result =
-                crate::ast::rename::rename_in_source(content, old_name, new_name, lang_val);
-            match result {
-                Some(r) if r.replacements > 0 => {
-                    update_file_content(
-                        tx.pending,
-                        tx.deletions,
-                        tx.write_targets,
-                        &abs,
-                        r.content,
-                    );
-                    return Ok(r.replacements);
+
+            // Directory support (#1287): expand to individual files.
+            if abs.is_dir() {
+                let files = collect_ast_source_files(&abs)?;
+                if files.is_empty() {
+                    anyhow::bail!("no source files found in {}", path);
                 }
-                Some(_) => {
-                    // Tree-sitter parsed successfully but found 0 identifier
-                    // matches. Do NOT fall through to regex; tree-sitter
-                    // correctly determined the name only exists in
-                    // strings/comments (#1187).
-                    anyhow::bail!("no matches for '{}' in {}", old_name, path);
-                }
-                None => {
-                    // Tree-sitter couldn't parse (no grammar or parse
-                    // failure). Fallback to word-boundary replace.
-                    let re = crate::ops::replace::compile_replace_regex(
-                        old_name, false, false, false, true,
-                    )?;
-                    if let Some(re) = re {
-                        let new_content = re.replace_all(content, new_name.as_str()).to_string();
-                        let count = re.find_iter(content).count();
-                        if count > 0 {
-                            update_file_content(
-                                tx.pending,
-                                tx.deletions,
-                                tx.write_targets,
-                                &abs,
-                                new_content,
-                            );
-                            return Ok(count);
-                        }
+                let mut total = 0usize;
+                for file_path in &files {
+                    let count =
+                        ast_rename_single_file(tx, file_path, old_name, new_name, lang.as_deref());
+                    if let Ok(n) = count {
+                        total += n;
                     }
+                }
+                if total == 0 {
                     anyhow::bail!("no matches for '{}' in {}", old_name, path);
                 }
+                return Ok(total);
             }
+
+            return ast_rename_single_file(tx, &abs, old_name, new_name, lang.as_deref());
         }
 
         #[cfg(feature = "ast")]

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1860,5 +1860,69 @@ fn test_doc_json_failure_structured_on_stdout() {
 }
 
 // ---------------------------------------------------------------------------
+// #1288: numeric dot-notation as array index
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_doc_set_numeric_dot_notation_on_array() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.json");
+    fs::write(
+        &file,
+        r#"{"env": [{"name": "A", "value": "old"}, {"name": "B", "value": "keep"}]}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "doc",
+            "set",
+            file.to_str().unwrap(),
+            "env.0.value",
+            "new",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+
+    let content: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert_eq!(content["env"][0]["value"], "new");
+    assert_eq!(content["env"][1]["value"], "keep");
+}
+
+#[test]
+fn test_doc_get_numeric_dot_notation_on_array() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"items": ["alpha", "beta", "gamma"]}"#).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "get", file.to_str().unwrap(), "items.1"])
+        .assert()
+        .code(0)
+        .stdout(predicate::str::contains("beta"));
+}
+
+#[test]
+fn test_doc_delete_numeric_dot_notation_on_array() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"arr": [1, 2, 3]}"#).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "delete", file.to_str().unwrap(), "arr.0", "--apply"])
+        .assert()
+        .code(0);
+
+    let content: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert_eq!(content["arr"], serde_json::json!([2, 3]));
+}
+
+// ---------------------------------------------------------------------------
 // Symlink integration tests (#231 coverage)
 // ---------------------------------------------------------------------------

--- a/tests/integration/schema_tests.rs
+++ b/tests/integration/schema_tests.rs
@@ -195,5 +195,77 @@ fn test_schema_invalid_tier_fails() {
 }
 
 // ---------------------------------------------------------------------------
+// #1289: Operation field descriptions in schema
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_schema_operation_fields_have_descriptions() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["schema", "--format", "json"])
+        .assert()
+        .code(0);
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let ops = parsed["operations"].as_array().unwrap();
+
+    // Spot-check key operations that must have field descriptions.
+    let checks: &[(&str, &[&str])] = &[
+        ("doc.set", &["path", "key", "value"]),
+        ("doc.delete", &["path", "key"]),
+        ("replace", &["old", "new"]),
+    ];
+
+    for (op_name, required_fields) in checks {
+        let op = ops
+            .iter()
+            .find(|o| o["name"].as_str() == Some(op_name))
+            .unwrap_or_else(|| panic!("operation '{op_name}' not found in schema"));
+        let props = op["parameters"]["properties"]
+            .as_object()
+            .unwrap_or_else(|| panic!("no properties for {op_name}"));
+
+        for field in *required_fields {
+            let field_schema = props
+                .get(*field)
+                .unwrap_or_else(|| panic!("field '{field}' missing from {op_name} parameters"));
+            let desc = field_schema.get("description").and_then(|d| d.as_str());
+            assert!(
+                desc.is_some_and(|d| !d.is_empty()),
+                "field '{field}' in operation '{op_name}' must have a non-empty description"
+            );
+        }
+    }
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_schema_ast_rename_path_description_mentions_directory() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["schema", "--format", "json"])
+        .assert()
+        .code(0);
+
+    let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let ops = parsed["operations"].as_array().unwrap();
+
+    let ast_rename = ops
+        .iter()
+        .find(|o| o["name"].as_str() == Some("ast.rename"))
+        .expect("ast.rename must be in schema");
+    let path_desc = ast_rename
+        .pointer("/parameters/properties/path/description")
+        .and_then(|d| d.as_str())
+        .expect("ast.rename path field must have a description");
+    assert!(
+        path_desc.to_lowercase().contains("director"),
+        "ast.rename path description should mention directory support: {path_desc}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // md --check produces stdout output (#544)
 // ---------------------------------------------------------------------------

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -6967,3 +6967,121 @@ fn test_tx_ast_list_with_lang_name_hint() {
         "lang hint 'rust' should work via lang_from_str: {content}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// #1287: ast.rename with directory path walks recursively
+// ---------------------------------------------------------------------------
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_rename_directory_walks_recursively() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(src.join("nested")).unwrap();
+    fs::write(src.join("lib.rs"), "fn old_func() {\n    old_func();\n}\n").unwrap();
+    fs::write(
+        src.join("nested").join("mod.rs"),
+        "fn old_func() -> i32 { 0 }\n",
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rename",
+            "path": "src",
+            "old_name": "old_func",
+            "new_name": "new_func"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let lib_content = fs::read_to_string(src.join("lib.rs")).unwrap();
+    assert!(
+        lib_content.contains("new_func"),
+        "lib.rs should contain renamed identifier: {lib_content}"
+    );
+    assert!(
+        !lib_content.contains("old_func"),
+        "lib.rs should not contain old identifier: {lib_content}"
+    );
+
+    let mod_content = fs::read_to_string(src.join("nested").join("mod.rs")).unwrap();
+    assert!(
+        mod_content.contains("new_func"),
+        "nested/mod.rs should contain renamed identifier: {mod_content}"
+    );
+    assert!(
+        !mod_content.contains("old_func"),
+        "nested/mod.rs should not contain old identifier: {mod_content}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_rename_directory_no_matches_fails() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("lib.rs"), "fn keep_me() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rename",
+            "path": "src",
+            "old_name": "nonexistent_func",
+            "new_name": "renamed"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(9); // OPERATION_FAILED
+
+    // File must be unchanged.
+    assert_eq!(
+        fs::read_to_string(src.join("lib.rs")).unwrap(),
+        "fn keep_me() {}\n"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_rename_empty_directory_fails() {
+    let dir = TempDir::new().unwrap();
+    let empty = dir.path().join("empty");
+    fs::create_dir_all(&empty).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rename",
+            "path": "empty",
+            "old_name": "x",
+            "new_name": "y"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(9); // OPERATION_FAILED
+}


### PR DESCRIPTION
## Summary

Three fixes requested by Bline (heavy patchloom user):

### #1287: ast.rename directory support in tx engine

The tx engine's `AstRename` handler now detects directory paths and walks them recursively, renaming identifiers across all source files with recognized tree-sitter grammars. Previously, passing a directory path to `ast.rename` in a tx plan would fail because `read_file_content()` cannot read a directory.

### #1288: numeric dot-notation as array index

Selectors like `env.0.value` now resolve the numeric segment as an array index when the current node is an array. This works in:
- Selector evaluation (`eval()`)
- Mutable navigation (`navigate_mut`)
- Set, delete, update, and move operations

Object keys that happen to be numeric strings still take precedence (tested).

### #1289: Operation field descriptions in schema

Added `///` doc comments to all meaningful fields on Operation enum variants (`Replace`, `DocSet`, `DocDelete`, `DocMerge`, `AstRename`, etc.) so schemars generates descriptions in the `execute_plan` JSON schema. This helps agents understand parameter semantics without reading docs.

## Tests

- 3 integration tests for #1287 (directory walk, no-matches error, empty directory error)
- 4 unit tests in selector eval + 6 unit tests in navigate for #1288
- 3 CLI integration tests for #1288 (doc set/get/delete with numeric dot-notation)
- 2 schema integration tests for #1289 (field descriptions exist, ast.rename mentions directory)

`make check-fast` passes (2008 unit + 846 integration + 10 PTY tests).

Closes #1287
Closes #1288
Closes #1289