### PR TITLE
feat: add fuzzy fallback to replace_in_content

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -216,6 +216,12 @@ pub struct ReplaceOptions {
     /// Useful for AI coding agents that need to ensure each edit targets a
     /// unique location in the file.
     pub unique: bool,
+    /// When true and the exact match fails (0 matches), attempt fuzzy
+    /// resolution via `resolve_with_fallback` (anchor + similarity matching).
+    /// On fuzzy success, the matched text is used for the replacement.
+    /// On fuzzy failure, the error includes "did you mean?" suggestions.
+    /// Only applies to literal (non-regex) patterns.
+    pub fuzzy: bool,
 }
 
 /// Write policy options for controlling file write transformations.

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -257,6 +257,57 @@ pub fn replace_in_content(
         );
     }
 
+    // Fuzzy fallback (#1286): when exact match fails and fuzzy is enabled,
+    // try resolve_with_fallback for anchor/similarity matching.
+    if count == 0 && opts.fuzzy && !is_regex {
+        use crate::fallback;
+        match fallback::resolve_with_fallback(content, from, None, None) {
+            Ok(anchor) => {
+                let to_text = if let Some(ib) = &opts.insert_before {
+                    format!("{}{}", ib, anchor.matched_text)
+                } else if let Some(ia) = &opts.insert_after {
+                    format!("{}{}", anchor.matched_text, ia)
+                } else {
+                    to.to_string()
+                };
+                let fuzzy_content = format!(
+                    "{}{}{}",
+                    &content[..anchor.start_offset],
+                    to_text,
+                    &content[anchor.start_offset + anchor.matched_text.len()..]
+                );
+                let diff = super::make_diff("<content>", content, &fuzzy_content);
+                return Ok(ContentEditResult {
+                    original: content.to_string(),
+                    new_content: fuzzy_content,
+                    diff,
+                    changed: true,
+                    match_count: 1,
+                });
+            }
+            Err(edit_error) => {
+                if opts.if_exists {
+                    return Ok(ContentEditResult {
+                        original: content.to_string(),
+                        new_content: content.to_string(),
+                        diff: String::new(),
+                        changed: false,
+                        match_count: 0,
+                    });
+                }
+                let similar = fallback::find_similar_targets(content, from, 3);
+                let mut msg = format!("no matches for {:?}", from);
+                if let Some(suggestion) = &edit_error.suggestion {
+                    msg.push_str(&format!(" (suggestion: {})", suggestion));
+                }
+                if !similar.is_empty() {
+                    msg.push_str(&format!(" (did you mean: {}?)", similar.join(", ")));
+                }
+                bail!("{msg}");
+            }
+        }
+    }
+
     if count == 0 && opts.if_exists {
         return Ok(ContentEditResult {
             original: content.to_string(),

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2623,6 +2623,197 @@ fn replace_in_content_unique_with_word_boundary() {
     assert_eq!(result.match_count, 1);
 }
 
+// ── replace_in_content fuzzy fallback (#1286) ────────────────
+
+#[test]
+fn replace_in_content_fuzzy_resolves_typo() {
+    // "proccess_data" is a typo for "process_data"; fuzzy should match
+    // via Jaro-Winkler similarity (> 0.85).
+    let content = "fn setup() {}\nfn process_data(x: i32) {}\nfn cleanup() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(
+        content,
+        "fn proccess_data(x: i32) {}",
+        "fn handle_data(x: i32) {}",
+        &opts,
+    )
+    .unwrap();
+    assert!(result.changed, "fuzzy should find a match for the typo");
+    assert_eq!(result.match_count, 1);
+    assert!(
+        result.new_content.contains("handle_data"),
+        "replacement should be applied: {}",
+        result.new_content
+    );
+    assert!(
+        !result.new_content.contains("process_data"),
+        "original should be replaced: {}",
+        result.new_content
+    );
+}
+
+#[test]
+fn replace_in_content_fuzzy_exact_match_preferred() {
+    // When the exact match succeeds, fuzzy should not change behavior.
+    let content = "fn hello() {}\nfn world() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        ..Default::default()
+    };
+    let result =
+        replace::replace_in_content(content, "fn hello() {}", "fn greet() {}", &opts).unwrap();
+    assert!(result.changed);
+    assert_eq!(result.match_count, 1);
+    assert!(result.new_content.contains("fn greet()"));
+}
+
+#[test]
+fn replace_in_content_fuzzy_no_match_returns_error_with_hints() {
+    // When fuzzy also fails, the error should include suggestions.
+    let content = "fn alpha() {}\nfn beta() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        ..Default::default()
+    };
+    let err = replace::replace_in_content(
+        content,
+        "fn completely_unrelated_name_xyz() {}",
+        "fn replaced() {}",
+        &opts,
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no matches"),
+        "error should say no matches: {msg}"
+    );
+}
+
+#[test]
+fn replace_in_content_fuzzy_with_if_exists_suppresses_error() {
+    // fuzzy + if_exists: when fuzzy also fails, no error.
+    let content = "fn alpha() {}\nfn beta() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        if_exists: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(
+        content,
+        "fn completely_unrelated_name_xyz() {}",
+        "fn replaced() {}",
+        &opts,
+    )
+    .unwrap();
+    assert!(!result.changed);
+    assert_eq!(result.match_count, 0);
+}
+
+#[test]
+fn replace_in_content_fuzzy_disabled_by_default() {
+    // Default ReplaceOptions has fuzzy: false, so a near-miss should fail.
+    let content = "fn process_data() {}\n";
+    let result = replace::replace_in_content(
+        content,
+        "fn proccess_data() {}",
+        "fn handle() {}",
+        &ReplaceOptions::default(),
+    )
+    .unwrap();
+    // Without fuzzy, the typo doesn't match and count == 0.
+    assert!(!result.changed);
+    assert_eq!(result.match_count, 0);
+}
+
+#[test]
+fn replace_in_content_fuzzy_not_applied_in_regex_mode() {
+    // fuzzy should be ignored when regex mode is enabled.
+    let content = "fn process_data() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        regex: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(
+        content,
+        "fn proccess_data\\(\\) \\{\\}",
+        "fn handle() {}",
+        &opts,
+    )
+    .unwrap();
+    assert!(!result.changed, "regex mode should bypass fuzzy");
+}
+
+#[test]
+fn replace_in_content_fuzzy_with_unique() {
+    // fuzzy + unique: fuzzy finds exactly one match, so unique is satisfied.
+    let content = "fn setup() {}\nfn process_data(x: i32) {}\nfn cleanup() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        unique: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(
+        content,
+        "fn proccess_data(x: i32) {}",
+        "fn handle_data(x: i32) {}",
+        &opts,
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert_eq!(result.match_count, 1);
+}
+
+#[test]
+fn replace_in_content_fuzzy_with_insert_before() {
+    // fuzzy + insert_before: the matched text should be preserved after
+    // the inserted text.
+    let content = "fn process_data() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        insert_before: Some("// TODO: refactor\n".to_string()),
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(
+        content,
+        "fn proccess_data() {}",
+        "", // ignored when insert_before is set
+        &opts,
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert!(
+        result.new_content.contains("// TODO: refactor\n"),
+        "insert_before text should appear: {}",
+        result.new_content
+    );
+    assert!(
+        result.new_content.contains("fn process_data() {}"),
+        "original matched text should be preserved: {}",
+        result.new_content
+    );
+}
+
+#[test]
+fn replace_in_content_fuzzy_with_insert_after() {
+    let content = "fn process_data() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        insert_after: Some("\n// end".to_string()),
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(content, "fn proccess_data() {}", "", &opts).unwrap();
+    assert!(result.changed);
+    assert!(
+        result.new_content.contains("fn process_data() {}\n// end"),
+        "insert_after text should appear after matched text: {}",
+        result.new_content
+    );
+}
+
 #[test]
 fn parse_unified_diff_basic() {
     let diff = "\


### PR DESCRIPTION
## Summary

Adds a `fuzzy: bool` field to `ReplaceOptions` so that `replace_in_content` (the in-memory API) has the same fuzzy fallback that the file-based `replace_text` path already has via the tx engine.

### Problem

`replace_text` (file-based) automatically tries `resolve_with_fallback` when an exact match fails, handling minor whitespace/formatting differences from LLM-generated edit targets. `replace_in_content` (in-memory) did not have this, forcing embedders like Bline to manually glue together ~15 lines of adapter code to get the same resilience.

### Solution

When `fuzzy: true` and the exact match returns 0 results (literal mode only):

1. Call `resolve_with_fallback(content, from, None, None)`
2. On success: use the matched text for replacement (supports `insert_before`/`insert_after` modes)
3. On failure + `if_exists`: return unchanged content (no error)
4. On failure: return error with `find_similar_targets` suggestions

### Before (Bline's manual fallback)

```rust
match ploom::replace_in_content(content, target, new_content, &opts) {
    Ok(result) if result.changed => return Ok(result.new_content),
    _ => {}
}
// 15 lines of manual resolve_with_fallback + find_similar_targets glue
```

### After

```rust
let opts = ReplaceOptions { fuzzy: true, unique: true, ..Default::default() };
ploom::replace_in_content(content, target, new_content, &opts)
```

## Tests

9 unit tests covering:
- Fuzzy resolves typos via Jaro-Winkler similarity
- Exact match still preferred when it succeeds
- Error with hints when fuzzy also fails
- `if_exists` suppresses error on fuzzy failure
- Fuzzy disabled by default (backward compatible)
- Fuzzy ignored in regex mode
- Compatible with `unique: true`
- Works with `insert_before` and `insert_after` modes

`make check-fast` passes (2019 unit + 846 integration + 10 PTY tests).

Closes #1286