### PR TITLE
test/docs: MPI cycle 1 improvements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ src/
                        generator, and inline Completions command
   cmd/append.rs        Append content to an existing file
   cmd/batch.rs         Line-oriented batch operations, parses positional args, delegates to tx engine
-  cmd/mcp/mod.rs       MCP server (feature-gated): 22 auto-generated tools via MCP_TOOL_REGISTRY +
+  cmd/mcp/mod.rs       MCP server (feature-gated): 21 auto-generated tools via MCP_TOOL_REGISTRY +
                        33 hand-written #[tool] handlers, dynamic registration via ToolRoute::new_dyn()
   cmd/mcp/params.rs    Parameter structs for hand-written MCP tool handlers only; simple tools use
                        Operation variant schemas directly via operation_variant_schema()

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -98,7 +98,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **2,700+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
+- **2,800+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
 - **23 commands** including MCP server with 54 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -116,7 +116,7 @@ mod basic {
             "missing ast_extract_to_file tool"
         );
         assert!(names.contains(&"ast_split"), "missing ast_split tool");
-        // 32 base tools + 14 AST tools = 46
+        // 21 auto-generated (registry) + 33 hand-written (#[tool]) = 54
         assert!(
             names.contains(&"md_dedupe_headings"),
             "missing md_dedupe_headings tool"

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -457,3 +457,32 @@ fn test_batch_file_prepend() {
         "batch file.prepend should prepend: {content}"
     );
 }
+
+#[test]
+fn test_batch_multi_op_rollback_on_second_failure() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"name":"original"}"#).unwrap();
+    // Do NOT create missing.json.
+
+    let ops = dir.path().join("ops.txt");
+    fs::write(
+        &ops,
+        "doc.set data.json name \"changed\"\ndoc.set missing.json version \"1.0\"\n",
+    )
+    .unwrap();
+
+    patchloom_in(dir.path())
+        .arg("batch")
+        .arg(&ops)
+        .arg("--apply")
+        .assert()
+        .code(9); // OPERATION_FAILED
+
+    // data.json must be rolled back to original content.
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("original"),
+        "data.json should be rolled back after second op fails: {content}"
+    );
+}

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -151,3 +151,61 @@ fn test_append_format_flag_runs_after_apply() {
         "--format command should have run after append --apply"
     );
 }
+
+// ---------------------------------------------------------------------------
+// prepend CLI (direct subcommand, not via tx/doc)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_prepend_cli_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("log.txt");
+    fs::write(&file, "line two\n").unwrap();
+
+    patchloom_in(dir.path())
+        .args(["prepend", "log.txt", "--content", "line one\n", "--apply"])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, "line one\nline two\n");
+}
+
+#[test]
+fn test_prepend_cli_check_returns_exit_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("log.txt");
+    fs::write(&file, "existing\n").unwrap();
+
+    patchloom_in(dir.path())
+        .args(["prepend", "log.txt", "--content", "new\n", "--check"])
+        .assert()
+        .code(2);
+
+    // File must be unchanged.
+    assert_eq!(fs::read_to_string(&file).unwrap(), "existing\n");
+}
+
+#[test]
+fn test_prepend_cli_missing_file_fails() {
+    let dir = TempDir::new().unwrap();
+
+    patchloom_in(dir.path())
+        .args(["prepend", "nope.txt", "--content", "data\n", "--apply"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("does not exist"));
+}
+
+#[test]
+fn test_prepend_cli_diff_shows_unified_diff() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("log.txt");
+    fs::write(&file, "second\n").unwrap();
+
+    patchloom_in(dir.path())
+        .args(["prepend", "log.txt", "--content", "first\n"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("+first"));
+}

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1046,3 +1046,119 @@ fn test_replace_format_flag_skipped_in_diff_mode() {
         "--format should NOT run in diff-only mode"
     );
 }
+
+#[test]
+fn test_replace_before_context_disambiguates() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    // Two identical "port = 8080" lines; before_context picks the right one.
+    fs::write(&file, "[server]\nport = 8080\n\n[database]\nport = 8080\n").unwrap();
+
+    patchloom_in(dir.path())
+        .arg("replace")
+        .arg("port = 8080")
+        .arg("--new")
+        .arg("port = 9090")
+        .arg("--before-context")
+        .arg("[database]")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    assert!(
+        result.contains("[server]\nport = 8080"),
+        "server port should be unchanged: {result}"
+    );
+    assert!(
+        result.contains("[database]\nport = 9090"),
+        "database port should be updated: {result}"
+    );
+}
+
+#[test]
+fn test_replace_after_context_disambiguates() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(
+        &file,
+        "name = alpha\nrole = admin\n\nname = beta\nrole = user\n",
+    )
+    .unwrap();
+
+    patchloom_in(dir.path())
+        .arg("replace")
+        .arg("name = alpha")
+        .arg("--new")
+        .arg("name = gamma")
+        .arg("--after-context")
+        .arg("role = admin")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    assert!(
+        result.contains("name = gamma\nrole = admin"),
+        "first name should be updated: {result}"
+    );
+    assert!(
+        result.contains("name = beta"),
+        "second name should be unchanged: {result}"
+    );
+}
+
+#[test]
+fn test_replace_context_requires_explicit_file() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "hello\n").unwrap();
+
+    // No file paths at all (only --cwd is set via patchloom_in).
+    patchloom_in(dir.path())
+        .arg("replace")
+        .arg("hello")
+        .arg("--new")
+        .arg("world")
+        .arg("--before-context")
+        .arg("ctx")
+        .arg("--apply")
+        .assert()
+        .code(1)
+        .stderr(predicates::str::contains("explicit file paths"));
+}
+
+#[test]
+fn test_replace_context_in_tx_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("conf.ini");
+    fs::write(&file, "[a]\nval = 1\n\n[b]\nval = 1\n").unwrap();
+
+    let plan = dir.path().join("plan.json");
+    fs::write(
+        &plan,
+        format!(
+            r#"{{"version":1,"operations":[{{"op":"replace","path":"{}","old":"val = 1","new":"val = 2","before_context":"[b]"}}]}}"#,
+            portable_path_str(&file)
+        ),
+    )
+    .unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    assert!(
+        result.contains("[a]\nval = 1"),
+        "section [a] should be unchanged: {result}"
+    );
+    assert!(
+        result.contains("[b]\nval = 2"),
+        "section [b] should be updated: {result}"
+    );
+}

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -783,7 +783,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("2,700+ tests"));
+    assert!(launch.contains("2,800+ tests"));
     assert!(
         launch.contains("23 commands"),
         "launch announcement CLI command count drifted"


### PR DESCRIPTION
Multi-perspective improvement rotation (4 cycles, 14 perspectives each).

## Changes

### Tests (9 new integration tests)
- Context-based replace: `--before-context` and `--after-context` disambiguation (2 tests)
- Context validation: explicit file path requirement (1 test)
- Context in tx plans: `before_context` field in JSON plan (1 test)
- Batch rollback: multi-op rollback when second operation fails (1 test)
- Prepend CLI: direct subcommand tests for apply, check, missing file, diff (4 tests)

### Doc accuracy fixes
- AGENTS.md: MCP auto-generated tool count 22 -> 21 (actual registry entries)
- launch-announcement.md: test count 2,700+ -> 2,800+ (actual: 2,885)
- smoke test assertion updated to match
- MCP test comment: stale "32 base + 14 AST = 46" -> "21 auto-generated + 33 hand-written = 54"

## Verification
`make check-fast` passes (2,885 tests: 2,020 unit + 855 integration + 10 PTY).