### PR TITLE
fix: patch check creation, doc move descendant guard, replace exit codes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,7 +385,7 @@ jobs:
         run: |
           bench_txt="$RUNNER_TEMP/bench.txt"
           bench_json="$RUNNER_TEMP/bench-replace-dry-run.json"
-          hyperfine --warmup 3 --min-runs 20 -N \
+          hyperfine --warmup 3 --min-runs 20 -N -i \
             --export-json "$bench_json" \
             "./target/release/patchloom replace hello --new world $bench_txt" \
             --max-runs 100

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -262,15 +262,20 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let original = match std::fs::read_to_string(&file_path) {
                 Ok(s) => s,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    let msg = format!("file not found: {}", file_path.display());
-                    results.push(PatchFileResult {
-                        path: pf.path.clone(),
-                        status: "missing",
-                        error: Some(msg.clone()),
-                        conflicts: None,
-                    });
-                    all_clean = false;
-                    continue;
+                    if pf.is_creation {
+                        // Creation patch: file should not exist yet.
+                        String::new()
+                    } else {
+                        let msg = format!("file not found: {}", file_path.display());
+                        results.push(PatchFileResult {
+                            path: pf.path.clone(),
+                            status: "missing",
+                            error: Some(msg.clone()),
+                            conflicts: None,
+                        });
+                        all_clean = false;
+                        continue;
+                    }
                 }
                 Err(e) => {
                     let msg = format!("failed to read {}: {}", file_path.display(), e);

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -442,9 +442,10 @@ fn replace_output(
         if global.show_status() {
             eprintln!("replaced {total_matches} match(es) in {file_count} file(s)");
         }
+        return Ok(exit::SUCCESS);
     }
 
-    Ok(exit::SUCCESS)
+    Ok(exit::CHANGES_DETECTED)
 }
 
 /// Context-based replace: routes through the tx engine where
@@ -539,9 +540,10 @@ fn run_context_replace(
     if global.should_apply() {
         result.commit()?;
         crate::write::run_format_command(global, cwd)?;
+        return Ok(exit::SUCCESS);
     }
 
-    Ok(exit::SUCCESS)
+    Ok(exit::CHANGES_DETECTED)
 }
 
 #[path = "replace_tests.rs"]

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -253,6 +253,11 @@ pub fn move_at_path(
         return Ok(());
     }
 
+    // Reject moving a path into its own descendant (would silently destroy data).
+    if to_segments.len() > from_segments.len() && to_segments.starts_with(from_segments) {
+        anyhow::bail!("cannot move a path into its own descendant: destination is under source");
+    }
+
     let (from_parent, from_last) = split_last(from_segments);
     let (to_parent, to_last) = split_last(to_segments);
 

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -857,7 +857,7 @@ fn test_verbose_replace_emits_trace() {
         .arg("--cwd")
         .arg(dir.path())
         .assert()
-        .success()
+        .code(2) // CHANGES_DETECTED: preview mode
         .stderr(predicate::str::contains("[patchloom] replace:"));
 }
 

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -64,7 +64,7 @@ fn test_replace_dry_run_does_not_modify_file() {
         .arg("new_text")
         .arg(&file)
         .assert()
-        .code(0);
+        .code(2); // CHANGES_DETECTED: preview shows changes, not applied
 
     let content = fs::read_to_string(&file).unwrap();
     assert!(
@@ -1039,7 +1039,7 @@ fn test_replace_format_flag_skipped_in_diff_mode() {
             &shell_touch(&marker),
         ])
         .assert()
-        .code(0);
+        .code(2); // CHANGES_DETECTED: preview mode, not applied
 
     assert!(
         !marker.exists(),

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -445,7 +445,7 @@ fn test_smoke_quickstart_command_flow() {
         .arg("new_function")
         .arg("src/")
         .assert()
-        .success()
+        .code(2) // CHANGES_DETECTED: preview mode, not applied
         .stdout(predicate::str::contains("new_function"));
     assert!(
         fs::read_to_string(&lib_path)


### PR DESCRIPTION
## Summary

Three bug fixes found by fixloop Round 3 audit.

## Changes

### 1. patch check: creation patches reported as missing (MEDIUM)

`patch check` incorrectly reported creation patches (`--- /dev/null`) as `"missing"` when the target file didn't exist yet. The file not existing is the *expected* condition for creation patches. Now uses empty string as original, matching the merge/apply path.

### 2. doc move: reject moving to descendant (HIGH)

`move_at_path` used a clone-insert-remove strategy without checking if the destination was a descendant of the source. Moving `settings` to `settings.db.backup` would clone the source, insert it into the source's subtree, then delete the entire source (including the clone). Returns an error now.

### 3. replace: preview exit code consistency (MEDIUM)

`replace` in preview/diff mode (no `--apply`) returned exit code 0 (SUCCESS) even when changes were found. Now returns exit code 2 (CHANGES_DETECTED), consistent with `tidy` and the `--check` flag. Scripts can now distinguish "no changes" from "changes shown but not applied."

## Testing

- All 2,022 unit tests, 855 integration tests, 10 PTY tests pass
- Updated 4 integration tests that expected exit code 0 for replace preview mode
- `make check-fast` green