### PR TITLE
refactor: remove backward-compatibility artifacts

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -57,9 +57,9 @@
 //! );
 //! ```
 //!
-//! **Guard semantics (see also #756):** The guard provides *write-time* enforcement and is only checked for `ApplyMode::Apply` writes (via `ensure_contained` + `write_if_apply`). Reads (e.g. for diff computation, `Preview`/`Check` modes, `doc_get`, search) and pre-write loads may still observe or describe paths outside the guard. This is intentional for trusted library embedding (the host/ caller controls visibility). MCP uses a separate strict pre-check layer on all paths. `execute_plan` now accepts a guard (see its docs; #755) and performs upfront validation on declared paths.
+//! **Guard semantics:** The guard provides *write-time* enforcement and is only checked for `ApplyMode::Apply` writes (via `ensure_contained` + `write_if_apply`). Reads (e.g. for diff computation, `Preview`/`Check` modes, `doc_get`, search) and pre-write loads may still observe or describe paths outside the guard. This is intentional for trusted library embedding (the host/caller controls visibility). MCP uses a separate strict pre-check layer on all paths. `execute_plan` also accepts a guard and performs upfront validation on declared paths.
 //!
-//! ## Guard & WritePolicy contract (#801 exhaustive audit)
+//! ## Guard & WritePolicy contract
 //!
 //! - Every public write API and plan `Operation` (file.create/delete/rename/append, doc.set/merge/append/..., md.*, patch, replace, tidy writes, etc.) goes through `ensure_contained` (Apply only) + `BackupSession` + `atomic_*` + `WritePolicy`.
 //! - Upfront declared paths checked for `execute_plan` under guard.
@@ -237,25 +237,16 @@ pub struct WritePolicyOptions {
     pub collapse_blanks: bool,
 }
 
-/// Backward-compatible alias for [`EolMode`](crate::write::EolMode).
-#[deprecated(
-    since = "0.6.0",
-    note = "use crate::write::EolMode instead (Lf, Crlf, Cr, Keep)"
-)]
-pub type EolNormalization = EolMode;
-
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
 /// Convert user-facing `WritePolicyOptions` to the internal `WritePolicy`.
 ///
-/// Note (for #821): only `tidy` currently accepts `&WritePolicyOptions` at the high-level API.
+/// Only `tidy` currently accepts `&WritePolicyOptions` at the high-level API.
 /// Other mutating functions (`file_append`, `replace_text`, `doc_*`, `md_*`, etc.) default to
-/// `WritePolicy::default()` for ergonomics and library backward compat. For full control use a
-/// 1-op plan via `execute_plan` (which supports per-step write_policy) or the lower-level
-/// `write` + `atomic_write` primitives. Differences from MCP (which uses strict pre-checks + defaults)
-/// are intentional.
+/// `WritePolicy::default()`. For full control use a 1-op plan via `execute_plan`
+/// (which supports per-step write_policy) or the lower-level `write` + `atomic_write` primitives.
 pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
     WritePolicy {
         ensure_final_newline: opts.ensure_final_newline,
@@ -340,7 +331,7 @@ fn apply_mutation(
 /// Generalized cross-file mutation helper (for rename and md cross-file moves).
 ///
 /// Handles guard checks and backup for src (and optional dst).
-/// Used to centralize the cross-file logic per code review #839.
+/// Centralizes the cross-file guard and backup logic.
 fn apply_cross_file_mutation(
     src: &Path,
     dst: Option<&Path>,

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -1,8 +1,8 @@
-//! Shared output model for CLI commands (#968).
+//! Shared output model for CLI commands.
 //!
 //! Provides `execute_via_engine`, a generic function that routes CLI write
 //! commands through the tx engine while letting each command provide its own
-//! JSON output struct for backward compatibility.
+//! JSON output struct.
 //!
 //! This replaces per-command boilerplate (backup, write, diff, mode branching)
 //! with a single code path shared across all write commands.

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -29,8 +29,7 @@ struct ReadOutput {
     content: String,
 }
 
-#[allow(unused_imports)]
-pub(crate) use crate::ops::read::{LineRange, SelectedLines, parse_line_range, select_lines};
+pub(crate) use crate::ops::read::{LineRange, parse_line_range, select_lines};
 
 fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, String> {
     let content = fs::read_to_string(path).map_err(|e| format!("{path}: {e}"))?;
@@ -310,6 +309,7 @@ mod tests {
 
     #[test]
     fn select_lines_start_beyond_file_returns_empty() {
+        use crate::ops::read::SelectedLines;
         let content = "line1\nline2\n";
         let result = select_lines(content, (100, Some(200)));
         assert_eq!(result, SelectedLines::empty(2));

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -25,38 +25,14 @@ fn emit_output_json(output: &TxOutput, compact: bool) {
     }
 }
 
-fn legacy_error_prefix(error_kind: &str) -> &str {
-    if error_kind == "format_failed" {
-        "validation_failed"
-    } else {
-        error_kind
-    }
-}
-
-fn emit_error_json_with_prefix(
-    error_kind: &'static str,
-    legacy_error_prefix: &'static str,
-    error: &str,
-    backup_session: Option<&str>,
-    compact: bool,
-) {
-    emit_output_json(
-        &build_error_output(error_kind, legacy_error_prefix, error, backup_session),
-        compact,
-    );
-}
-
 fn emit_error_json(
     error_kind: &'static str,
     error: &str,
     backup_session: Option<&str>,
     compact: bool,
 ) {
-    emit_error_json_with_prefix(
-        error_kind,
-        legacy_error_prefix(error_kind),
-        error,
-        backup_session,
+    emit_output_json(
+        &build_error_output(error_kind, error, backup_session),
         compact,
     );
 }
@@ -92,13 +68,7 @@ fn handle_commit_error(err: CommitError, structured: bool, compact: bool) -> any
     };
     let backup_session = err.backup_session.as_deref();
     if structured {
-        emit_error_json_with_prefix(
-            error_kind,
-            error_kind,
-            &err.message,
-            backup_session,
-            compact,
-        );
+        emit_error_json(error_kind, &err.message, backup_session, compact);
     } else {
         let msg = format_error_with_backup_hint(&err.message, backup_session);
         eprintln!("tx: {msg}");
@@ -193,9 +163,12 @@ fn commit_and_finalize(
                 &result.existed_before,
             );
             crate::tx::restore_collateral_files(&collateral_snapshot);
-            let rollback_msg = format!("strict mode -- all changes reverted ({})", err.message);
+            let rollback_msg = format!(
+                "rollback: strict mode -- all changes reverted ({})",
+                err.message
+            );
             if ctx.structured {
-                emit_error_json_with_prefix(err.kind, "rollback", &rollback_msg, None, ctx.compact);
+                emit_error_json(err.kind, &rollback_msg, None, ctx.compact);
             } else {
                 eprintln!("tx: {rollback_msg}");
             }

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -170,15 +170,8 @@ mod basic {
     }
 
     #[test]
-    fn legacy_error_prefix_maps_format_failed() {
-        assert_eq!(legacy_error_prefix("format_failed"), "validation_failed");
-        assert_eq!(legacy_error_prefix("rollback"), "rollback");
-        assert_eq!(legacy_error_prefix("parse_error"), "parse_error");
-    }
-
-    #[test]
     fn build_error_output_produces_expected_shape() {
-        let output = build_error_output("rollback", "rollback", "disk full", None);
+        let output = build_error_output("rollback", "disk full", None);
         assert!(!output.ok);
         assert_eq!(output.status, "error".to_string());
         assert_eq!(output.error_kind, Some("rollback".to_string()));

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -1,6 +1,3 @@
-#[allow(unused_imports)]
-use anyhow::bail;
-
 #[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) type LineRange = (usize, Option<usize>);
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -132,19 +132,12 @@ pub struct FormatStep {
     pub timeout: Option<u64>,
 }
 
-/// Backward-compatible alias for [`WritePolicyOverride`](crate::write::WritePolicyOverride).
-#[deprecated(
-    since = "0.6.0",
-    note = "use crate::write::WritePolicyOverride instead"
-)]
-pub type PlanWritePolicy = crate::write::WritePolicyOverride;
-
 /// A single operation within a plan.
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
 #[non_exhaustive]
 #[serde(tag = "op")]
 pub enum Operation {
-    #[serde(rename = "replace", alias = "replace_text")]
+    #[serde(rename = "replace")]
     Replace {
         /// Glob pattern to match files (e.g. "src/**/*.rs"). Mutually exclusive with path.
         glob: Option<String>,
@@ -189,7 +182,7 @@ pub enum Operation {
         #[serde(default)]
         unique: bool,
     },
-    #[serde(rename = "doc.set", alias = "doc_set")]
+    #[serde(rename = "doc.set")]
     DocSet {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
@@ -198,21 +191,21 @@ pub enum Operation {
         /// Value to set (any JSON type).
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.delete", alias = "doc_delete")]
+    #[serde(rename = "doc.delete")]
     DocDelete {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path to delete.
         selector: String,
     },
-    #[serde(rename = "doc.merge", alias = "doc_merge")]
+    #[serde(rename = "doc.merge")]
     DocMerge {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Object to deep-merge into the file.
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.append", alias = "doc_append")]
+    #[serde(rename = "doc.append")]
     DocAppend {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
@@ -221,7 +214,7 @@ pub enum Operation {
         /// Value to append to the array.
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.prepend", alias = "doc_prepend")]
+    #[serde(rename = "doc.prepend")]
     DocPrepend {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
@@ -230,7 +223,7 @@ pub enum Operation {
         /// Value to prepend to the array.
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.update", alias = "doc_update")]
+    #[serde(rename = "doc.update")]
     DocUpdate {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
@@ -239,7 +232,7 @@ pub enum Operation {
         /// New value for all matching locations.
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.move", alias = "doc_move")]
+    #[serde(rename = "doc.move")]
     DocMove {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
@@ -248,7 +241,7 @@ pub enum Operation {
         /// Dot-notation destination path.
         to: String,
     },
-    #[serde(rename = "doc.ensure", alias = "doc_ensure")]
+    #[serde(rename = "doc.ensure")]
     DocEnsure {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
@@ -257,7 +250,7 @@ pub enum Operation {
         /// Value to set only if the key does not already exist.
         value: serde_json::Value,
     },
-    #[serde(rename = "doc.delete_where", alias = "doc_delete_where")]
+    #[serde(rename = "doc.delete_where")]
     DocDeleteWhere {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
@@ -266,40 +259,37 @@ pub enum Operation {
         /// Predicate in "field=value" format to match elements for deletion.
         predicate: String,
     },
-    #[serde(rename = "md.replace_section", alias = "md_replace_section")]
+    #[serde(rename = "md.replace_section")]
     MdReplaceSection {
         path: String,
         heading: String,
         content: String,
     },
-    #[serde(rename = "md.insert_after_heading", alias = "md_insert_after_heading")]
+    #[serde(rename = "md.insert_after_heading")]
     MdInsertAfterHeading {
         path: String,
         heading: String,
         content: String,
     },
-    #[serde(
-        rename = "md.insert_before_heading",
-        alias = "md_insert_before_heading"
-    )]
+    #[serde(rename = "md.insert_before_heading")]
     MdInsertBeforeHeading {
         path: String,
         heading: String,
         content: String,
     },
-    #[serde(rename = "md.upsert_bullet", alias = "md_upsert_bullet")]
+    #[serde(rename = "md.upsert_bullet")]
     MdUpsertBullet {
         path: String,
         heading: String,
         bullet: String,
     },
-    #[serde(rename = "md.table_append", alias = "md_table_append")]
+    #[serde(rename = "md.table_append")]
     MdTableAppend {
         path: String,
         heading: String,
         row: String,
     },
-    #[serde(rename = "md.move_section", alias = "md_move_section")]
+    #[serde(rename = "md.move_section")]
     MdMoveSection {
         path: String,
         heading: String,
@@ -310,9 +300,9 @@ pub enum Operation {
         /// Insert after this heading at the destination.
         after: Option<String>,
     },
-    #[serde(rename = "md.dedupe_headings", alias = "md_dedupe_headings")]
+    #[serde(rename = "md.dedupe_headings")]
     MdDedupeHeadings { path: String },
-    #[serde(rename = "tidy.fix", alias = "fix_whitespace")]
+    #[serde(rename = "tidy.fix")]
     TidyFix {
         path: String,
         ensure_final_newline: Option<bool>,
@@ -328,19 +318,19 @@ pub enum Operation {
         /// Line range restriction for dedent/indent: "10:50" (1-based inclusive).
         lines: Option<String>,
     },
-    #[serde(rename = "file.create", alias = "create_file")]
+    #[serde(rename = "file.create")]
     FileCreate {
         path: String,
         content: String,
         force: Option<bool>,
     },
-    #[serde(rename = "file.append", alias = "append_file")]
+    #[serde(rename = "file.append")]
     FileAppend { path: String, content: String },
-    #[serde(rename = "file.prepend", alias = "prepend_file")]
+    #[serde(rename = "file.prepend")]
     FilePrepend { path: String, content: String },
-    #[serde(rename = "file.delete", alias = "delete_file")]
+    #[serde(rename = "file.delete")]
     FileDelete { path: String },
-    #[serde(rename = "file.rename", alias = "move_file")]
+    #[serde(rename = "file.rename")]
     FileRename {
         from: String,
         to: String,
@@ -348,7 +338,7 @@ pub enum Operation {
         #[serde(default)]
         force: bool,
     },
-    #[serde(rename = "patch.apply", alias = "apply_patch")]
+    #[serde(rename = "patch.apply")]
     PatchApply {
         diff: String,
         #[serde(default)]
@@ -356,7 +346,7 @@ pub enum Operation {
         #[serde(default)]
         allow_conflicts: bool,
     },
-    #[serde(rename = "search", alias = "search_files")]
+    #[serde(rename = "search")]
     Search {
         path: String,
         pattern: String,
@@ -386,16 +376,16 @@ pub enum Operation {
         #[serde(default)]
         custom_ignore_filenames: Vec<String>,
     },
-    #[serde(rename = "read", alias = "read_file")]
+    #[serde(rename = "read")]
     Read {
         path: String,
         /// Optional line range (e.g., "10:25").
         lines: Option<String>,
     },
-    #[serde(rename = "md.lint_agents", alias = "md_lint")]
+    #[serde(rename = "md.lint_agents")]
     MdLintAgents { path: String },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.rename", alias = "ast_rename")]
+    #[serde(rename = "ast.rename")]
     AstRename {
         /// File or directory to rename in. Directories are walked recursively.
         path: String,
@@ -408,7 +398,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.replace", alias = "ast_replace")]
+    #[serde(rename = "ast.replace")]
     AstReplace {
         /// File to replace in.
         path: String,
@@ -427,7 +417,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.insert", alias = "ast_insert")]
+    #[serde(rename = "ast.insert")]
     AstInsert {
         /// File to insert code into.
         path: String,
@@ -449,7 +439,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.wrap", alias = "ast_wrap")]
+    #[serde(rename = "ast.wrap")]
     AstWrap {
         path: String,
         /// Symbols to wrap (mutually exclusive with `lines`).
@@ -467,7 +457,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.imports", alias = "ast_imports")]
+    #[serde(rename = "ast.imports")]
     AstImports {
         path: String,
         /// Import statements to add.
@@ -483,7 +473,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.reorder", alias = "ast_reorder")]
+    #[serde(rename = "ast.reorder")]
     AstReorder {
         path: String,
         /// Scope to reorder within (module/impl). Default: top-level.
@@ -495,7 +485,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.group", alias = "ast_group")]
+    #[serde(rename = "ast.group")]
     AstGroup {
         path: String,
         /// Module name to create or append to.
@@ -512,7 +502,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.move", alias = "ast_move")]
+    #[serde(rename = "ast.move")]
     AstMove {
         /// Source file.
         path: String,
@@ -530,7 +520,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.extract_to_file", alias = "ast_extract_to_file")]
+    #[serde(rename = "ast.extract_to_file")]
     AstExtractToFile {
         /// Source file containing the symbol.
         source: String,
@@ -554,7 +544,7 @@ pub enum Operation {
         lang: Option<String>,
     },
     #[cfg(feature = "ast")]
-    #[serde(rename = "ast.split", alias = "ast_split")]
+    #[serde(rename = "ast.split")]
     AstSplit {
         /// The file to split.
         source: String,
@@ -1360,47 +1350,6 @@ mod tests {
         ]}"#;
         let plan = parse_plan(json).unwrap();
         assert_eq!(plan.operations.len(), 45);
-    }
-
-    #[test]
-    #[cfg(feature = "ast")]
-    fn parse_op_aliases_match_mcp_tool_names() {
-        // MCP tools use underscores (doc_set, create_file). Plan ops use dots
-        // (doc.set, file.create). Both forms should parse via serde aliases.
-        let json = r#"{"version": 1, "operations": [
-            {"op": "replace_text", "old": "a", "new": "b"},
-            {"op": "doc_set", "path": "f.json", "selector": "k", "value": 1},
-            {"op": "doc_delete", "path": "f.json", "selector": "k"},
-            {"op": "doc_merge", "path": "f.json", "value": {}},
-            {"op": "doc_append", "path": "f.json", "selector": "arr", "value": 1},
-            {"op": "doc_ensure", "path": "f.json", "selector": "k", "value": 1},
-            {"op": "doc_delete_where", "path": "f.json", "selector": "arr", "predicate": "x=1"},
-            {"op": "md_move_section", "path": "f.md", "heading": "H", "before": "X"},
-            {"op": "md_replace_section", "path": "f.md", "heading": "H", "content": "c"},
-            {"op": "md_upsert_bullet", "path": "f.md", "heading": "H", "bullet": "- item"},
-            {"op": "md_table_append", "path": "f.md", "heading": "H", "row": "| a |"},
-            {"op": "fix_whitespace", "path": "f.txt"},
-            {"op": "append_file", "path": "f.txt", "content": "extra"},
-            {"op": "create_file", "path": "f.txt", "content": "c"},
-            {"op": "delete_file", "path": "f.txt"},
-            {"op": "move_file", "from": "a.txt", "to": "b.txt"},
-            {"op": "apply_patch", "diff": "--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+b"},
-            {"op": "search_files", "path": ".", "pattern": "x"},
-            {"op": "read_file", "path": "f.txt"},
-            {"op": "md_lint", "path": "f.md"},
-            {"op": "ast_rename", "path": "f.rs", "old_name": "A", "new_name": "B"},
-            {"op": "ast_replace", "path": "f.rs", "symbol": "main", "old": "x", "new": "y"},
-            {"op": "ast_insert", "path": "f.rs", "content": "fn x() {}", "inside": "Foo"},
-            {"op": "ast_wrap", "path": "f.rs", "lines": "1:10", "wrapper": "mod m"},
-            {"op": "ast_imports", "path": "f.rs", "remove": ["use old;"]},
-            {"op": "ast_reorder", "path": "f.rs", "order": "reverse"},
-            {"op": "ast_group", "path": "f.rs", "module": "m", "symbols": ["x"]},
-            {"op": "ast_move", "path": "a.rs", "target": "b.rs", "symbols": ["f"]},
-            {"op": "ast_extract_to_file", "source": "a.rs", "symbol": "tests", "target": "a_tests.rs"},
-            {"op": "ast_split", "source": "big.rs", "targets": [{"path": "s.rs", "symbols": ["S"]}]}
-        ]}"#;
-        let plan = parse_plan(json).unwrap();
-        assert_eq!(plan.operations.len(), 30);
     }
 
     /// The CLI uses `selector` as the positional arg name for doc ops,

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -476,15 +476,10 @@ pub(crate) fn validate_and_prepare_plan(
             plan.version,
             crate::plan::SCHEMA_VERSION
         );
-        return Err(build_error_output("parse_error", "parse_error", &msg, None));
+        return Err(build_error_output("parse_error", &msg, None));
     }
     if let Err(e) = validate_plan_operations(plan) {
-        return Err(build_error_output(
-            "parse_error",
-            "parse_error",
-            &e.to_string(),
-            None,
-        ));
+        return Err(build_error_output("parse_error", &e.to_string(), None));
     }
 
     let effective_cwd = resolve_plan_cwd(cwd, plan.cwd.as_deref());
@@ -574,18 +569,12 @@ pub fn execute_plan_direct(
     let mut result = match execute_and_collect(&plan, &effective_cwd, &global, true, true) {
         Ok(r) => r,
         Err(e) => {
-            return Ok(build_error_output(
-                "operation_failed",
-                "operation_failed",
-                &e.to_string(),
-                None,
-            ));
+            return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }
     };
 
     if result.replace_no_matches {
         let output = build_error_output(
-            "no_matches",
             "no_matches",
             result.replace_hint.as_deref().unwrap_or(""),
             None,
@@ -617,12 +606,7 @@ pub fn execute_plan_direct(
         if any_failed {
             let summary = messages.join("\n");
             let msg = format!("verification failed, changes not applied:\n{summary}");
-            return Ok(build_error_output(
-                "verification_failed",
-                "verification_failed",
-                &msg,
-                None,
-            ));
+            return Ok(build_error_output("verification_failed", &msg, None));
         }
     }
 
@@ -638,12 +622,7 @@ pub fn execute_plan_direct(
         } else {
             "rollback_failed"
         };
-        let output = build_error_output(
-            error_kind,
-            error_kind,
-            &err.message,
-            err.backup_session.as_deref(),
-        );
+        let output = build_error_output(error_kind, &err.message, err.backup_session.as_deref());
         return Ok(output);
     }
 
@@ -669,9 +648,9 @@ pub fn execute_plan_direct(
             #[cfg(any(feature = "cli", feature = "files"))]
             restore_collateral_files(&collateral_snapshot);
             let msg = format!("strict mode -- all changes reverted ({})", err.message);
-            return Ok(build_error_output(err.kind, "rollback", &msg, None));
+            return Ok(build_error_output("rollback", &msg, None));
         }
-        return Ok(build_error_output(err.kind, err.kind, &err.message, None));
+        return Ok(build_error_output(err.kind, &err.message, None));
     }
 
     let output = build_full_tx_output("success", &mut result, &effective_cwd);

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -207,7 +207,6 @@ pub(crate) fn format_error_with_backup_hint(error: &str, backup_session: Option<
 
 pub(crate) fn build_error_output(
     error_kind: &'static str,
-    legacy_error_prefix: &str,
     error: &str,
     backup_session: Option<&str>,
 ) -> TxOutput {
@@ -223,7 +222,7 @@ pub(crate) fn build_error_output(
         lints: Vec::new(),
         error_kind: Some(error_kind.to_string()),
         error: Some(format!(
-            "{legacy_error_prefix}: {}",
+            "{error_kind}: {}",
             format_error_with_backup_hint(error, backup_session)
         )),
         backup_session: backup_session.map(str::to_string),
@@ -243,7 +242,7 @@ pub fn exit_code_from_tx_output(report: &TxOutput) -> u8 {
             Some("no_matches") => exit::NO_MATCHES,
             Some("parse_error") => exit::PARSE_ERROR,
             Some("rollback") => exit::ROLLBACK,
-            Some("rollback_failed") => exit::FAILURE, // preserve historical CLI exit for this case
+            Some("rollback_failed") => exit::FAILURE,
             Some("validation_failed") | Some("format_failed") | Some("verification_failed") => {
                 exit::VALIDATION_FAILED
             }
@@ -307,7 +306,7 @@ mod tests {
 
     #[test]
     fn build_error_output_fields() {
-        let out = build_error_output("parse_error", "parse_error", "bad plan", None);
+        let out = build_error_output("parse_error", "bad plan", None);
         assert!(!out.ok);
         assert_eq!(out.status, "error");
         assert_eq!(out.error_kind.as_deref(), Some("parse_error"));
@@ -318,7 +317,7 @@ mod tests {
 
     #[test]
     fn build_error_output_with_backup() {
-        let out = build_error_output("rollback", "rollback", "fail", Some("ts123"));
+        let out = build_error_output("rollback", "fail", Some("ts123"));
         assert_eq!(out.backup_session.as_deref(), Some("ts123"));
         assert!(out.error.as_ref().unwrap().contains("patchloom undo"));
     }

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -1241,7 +1241,7 @@ fn test_verbose_init_emits_trace() {
 #[test]
 fn test_verbose_explain_emits_trace() {
     let dir = TempDir::new().unwrap();
-    let plan = "version: 1\noperations:\n  - op: create_file\n    path: f.txt\n    content: hi\n";
+    let plan = "version: 1\noperations:\n  - op: file.create\n    path: f.txt\n    content: hi\n";
     fs::write(dir.path().join("plan.yaml"), plan).unwrap();
 
     Command::cargo_bin("patchloom")

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -4640,7 +4640,7 @@ fn test_tx_json_output_on_format_failure_redacts_shell_command() {
     assert_eq!(json["ok"], false);
     assert_eq!(json["error_kind"], "format_failed");
     let error = json["error"].as_str().unwrap();
-    assert!(error.contains("validation_failed"));
+    assert!(error.contains("format_failed"));
     assert!(error.contains("format step failed (step 1, exit code 1, cwd: .)"));
     assert!(!error.contains(secret));
 }
@@ -5842,7 +5842,7 @@ fn test_tx_file_prepend_empty_content_is_noop() {
 }
 
 #[test]
-fn test_tx_file_prepend_alias_parsing() {
+fn test_tx_file_prepend_canonical_name() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("x.txt");
     fs::write(&file, "body\n").unwrap();
@@ -5850,7 +5850,7 @@ fn test_tx_file_prepend_alias_parsing() {
     let plan = serde_json::json!({
         "version": 1,
         "operations": [{
-            "op": "prepend_file",
+            "op": "file.prepend",
             "path": portable_path_str(&file),
             "content": "header\n"
         }]


### PR DESCRIPTION
Remove historical backward-compatibility code that is no longer needed (no external consumers yet).

## Changes

- Remove deprecated type aliases (`PlanWritePolicy`, `EolNormalization`)
- Remove all 37 `serde(alias)` attributes from `Operation` enum variants
- Remove `legacy_error_prefix()` and `emit_error_json_with_prefix()` shims
- Simplify `build_error_output` from 4 parameters to 3
- Remove stale issue-number references from doc comments
- Remove dead `allow(unused_imports)` and unused `pub(crate)` re-exports
- Update integration tests to use canonical operation names

Net: -119 lines of compat cruft.

`make check-fast` passes (2020 unit + 855 integration + 10 PTY tests).