### PR TITLE
refactor: deduplicate append/prepend and API edit helpers

### DIFF
--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -42,7 +42,7 @@ fn doc_write(
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action)
+    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action, None)
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -28,7 +28,7 @@ fn file_write(
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action)
+    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action, None)
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]
@@ -86,7 +86,9 @@ fn file_write(
                 None,
             ))
         }
-        Operation::FileAppend { content, .. } => {
+        Operation::FileAppend { ref content, .. } | Operation::FilePrepend { ref content, .. } => {
+            let is_append = matches!(op, Operation::FileAppend { .. });
+            let content = content.clone();
             let path_str = path.to_string_lossy();
             if path.exists() && !path.is_file() {
                 bail!("target is not a file: {}", path.display());
@@ -96,24 +98,11 @@ fn file_write(
             }
             let original = std::fs::read_to_string(path)
                 .with_context(|| format!("failed to read {}", path.display()))?;
-            let combined = crate::ops::file::append_content(&original, &content);
-            let policy = crate::write::WritePolicy::default();
-            let applied = super::write_if_apply(path, &combined, mode, &policy, guard)?;
-            Ok(super::build_edit_result(
-                &path_str, original, combined, applied, action, None,
-            ))
-        }
-        Operation::FilePrepend { content, .. } => {
-            let path_str = path.to_string_lossy();
-            if path.exists() && !path.is_file() {
-                bail!("target is not a file: {}", path.display());
-            }
-            if !path.exists() {
-                bail!("file does not exist: {}", path.display());
-            }
-            let original = std::fs::read_to_string(path)
-                .with_context(|| format!("failed to read {}", path.display()))?;
-            let combined = crate::ops::file::prepend_content(&original, &content);
+            let combined = if is_append {
+                crate::ops::file::append_content(&original, &content)
+            } else {
+                crate::ops::file::prepend_content(&original, &content)
+            };
             let policy = crate::write::WritePolicy::default();
             let applied = super::write_if_apply(path, &combined, mode, &policy, guard)?;
             Ok(super::build_edit_result(
@@ -134,7 +123,7 @@ fn file_write_cross(
     action: &'static str,
     dest_path: Option<String>,
 ) -> anyhow::Result<EditResult> {
-    super::execute_cross_file_as_edit_result(op, mode, cwd_from_path(src), guard, action, dest_path)
+    super::execute_as_edit_result(op, mode, cwd_from_path(src), guard, action, dest_path)
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -29,7 +29,7 @@ fn md_write(
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action)
+    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action, None)
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -424,28 +424,11 @@ fn build_edit_result(
 /// `EditResult`) and the tx engine (which uses `GlobalFlags` and returns
 /// `ExecutionResult`). All API write functions can delegate to this adapter
 /// instead of reimplementing read-transform-write-backup independently.
+///
+/// For cross-file operations (rename, move) pass `dest_path` to report the
+/// destination; single-file operations pass `None`.
 #[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn execute_as_edit_result(
-    op: crate::plan::Operation,
-    mode: ApplyMode,
-    cwd: &Path,
-    guard: Option<&PathGuard>,
-    action: &'static str,
-) -> anyhow::Result<EditResult> {
-    let global = mode_to_global_flags(mode);
-    let options = crate::tx::engine::ExecuteOptions {
-        cwd,
-        global: &global,
-        guard,
-    };
-    let result = crate::tx::engine::execute_single(op, options)?;
-    execution_result_to_edit_result(result, mode, cwd, action, None)
-}
-
-/// Like `execute_as_edit_result` but for cross-file operations (rename, move)
-/// where the destination path differs from the source.
-#[cfg(any(feature = "cli", feature = "files"))]
-pub(crate) fn execute_cross_file_as_edit_result(
     op: crate::plan::Operation,
     mode: ApplyMode,
     cwd: &Path,

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -37,7 +37,7 @@ fn patch_write(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd, guard, "patch")
+    super::execute_as_edit_result(op, mode, cwd, guard, "patch", None)
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -70,7 +70,7 @@ fn replace_write(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     let cwd = path.parent().unwrap_or_else(|| Path::new("."));
-    super::execute_as_edit_result(op, mode, cwd, guard, "replace")
+    super::execute_as_edit_result(op, mode, cwd, guard, "replace", None)
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2137,7 +2137,8 @@ fn adapter_preview_does_not_write() {
     };
 
     let result =
-        super::execute_as_edit_result(op, ApplyMode::Preview, dir.path(), None, "doc.set").unwrap();
+        super::execute_as_edit_result(op, ApplyMode::Preview, dir.path(), None, "doc.set", None)
+            .unwrap();
 
     assert!(result.changed, "content should differ");
     assert!(!result.applied, "preview should not write");
@@ -2160,7 +2161,8 @@ fn adapter_apply_writes_to_disk() {
     };
 
     let result =
-        super::execute_as_edit_result(op, ApplyMode::Apply, dir.path(), None, "doc.set").unwrap();
+        super::execute_as_edit_result(op, ApplyMode::Apply, dir.path(), None, "doc.set", None)
+            .unwrap();
 
     assert!(result.changed);
     assert!(result.applied);
@@ -2182,7 +2184,8 @@ fn adapter_check_does_not_write() {
     };
 
     let result =
-        super::execute_as_edit_result(op, ApplyMode::Check, dir.path(), None, "doc.set").unwrap();
+        super::execute_as_edit_result(op, ApplyMode::Check, dir.path(), None, "doc.set", None)
+            .unwrap();
 
     assert!(result.changed);
     assert!(!result.applied, "check should not write");
@@ -2210,9 +2213,15 @@ fn adapter_respects_guard() {
         value: serde_json::json!("new"),
     };
 
-    let result =
-        super::execute_as_edit_result(op, ApplyMode::Apply, dir.path(), Some(&guard), "doc.set")
-            .unwrap();
+    let result = super::execute_as_edit_result(
+        op,
+        ApplyMode::Apply,
+        dir.path(),
+        Some(&guard),
+        "doc.set",
+        None,
+    )
+    .unwrap();
 
     assert!(result.applied);
     assert!(result.changed);
@@ -2236,8 +2245,14 @@ fn adapter_guard_rejects_outside_path() {
         value: serde_json::json!("new"),
     };
 
-    let err =
-        super::execute_as_edit_result(op, ApplyMode::Apply, dir.path(), Some(&guard), "doc.set");
+    let err = super::execute_as_edit_result(
+        op,
+        ApplyMode::Apply,
+        dir.path(),
+        Some(&guard),
+        "doc.set",
+        None,
+    );
 
     assert!(err.is_err(), "guard should reject path outside workspace");
 }
@@ -2272,7 +2287,8 @@ fn adapter_unchanged_returns_no_diff() {
     };
 
     let result =
-        super::execute_as_edit_result(op, ApplyMode::Preview, dir.path(), None, "replace").unwrap();
+        super::execute_as_edit_result(op, ApplyMode::Preview, dir.path(), None, "replace", None)
+            .unwrap();
 
     assert!(
         !result.changed,

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -80,7 +80,7 @@ fn tidy_write(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     let cwd = path.parent().unwrap_or_else(|| Path::new("."));
-    super::execute_as_edit_result(op, mode, cwd, guard, "tidy")
+    super::execute_as_edit_result(op, mode, cwd, guard, "tidy", None)
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -24,8 +24,27 @@ pub struct AppendArgs {
     pub write: crate::cli::global::WriteFlags,
 }
 
+pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    run_content_inject(
+        &args.file,
+        args.content.as_deref(),
+        args.stdin,
+        ContentPosition::Append,
+        global,
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Shared append/prepend implementation
+// ---------------------------------------------------------------------------
+
+pub(crate) enum ContentPosition {
+    Append,
+    Prepend,
+}
+
 #[derive(Debug, Serialize)]
-struct AppendOutput {
+struct ContentInjectOutput {
     ok: bool,
     path: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -34,45 +53,61 @@ struct AppendOutput {
     applied: Option<bool>,
 }
 
-pub fn run(args: AppendArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
-    crate::verbose!("append: file={}", args.file);
-    if args.content.is_some() && args.stdin {
+pub(crate) fn run_content_inject(
+    file: &str,
+    content: Option<&str>,
+    stdin: bool,
+    position: ContentPosition,
+    global: &GlobalFlags,
+) -> anyhow::Result<u8> {
+    let verb = match position {
+        ContentPosition::Append => "append",
+        ContentPosition::Prepend => "prepend",
+    };
+
+    crate::verbose!("{verb}: file={file}");
+    if content.is_some() && stdin {
         bail!("--content and --stdin cannot be combined");
     }
 
-    let append_content = if let Some(ref c) = args.content {
-        c.clone()
-    } else if args.stdin {
+    let inject_content = if let Some(c) = content {
+        c.to_string()
+    } else if stdin {
         std::io::read_to_string(std::io::stdin())?
     } else {
         bail!("either --content or --stdin must be provided");
     };
 
-    // Pre-validation: the engine's FileAppend op checks existence too,
-    // but we validate here for consistent CLI error messages.
     let cwd = global.resolve_cwd()?;
-    let path = cwd.join(&args.file);
+    let path = cwd.join(file);
     if !path.exists() {
-        bail!("file does not exist: {}", args.file);
+        bail!("file does not exist: {file}");
     }
     if !path.is_file() {
-        bail!("target is not a file: {}", args.file);
+        bail!("target is not a file: {file}");
     }
 
-    let op = Operation::FileAppend {
-        path: args.file.clone(),
-        content: append_content,
+    let op = match position {
+        ContentPosition::Append => Operation::FileAppend {
+            path: file.to_string(),
+            content: inject_content,
+        },
+        ContentPosition::Prepend => Operation::FilePrepend {
+            path: file.to_string(),
+            content: inject_content,
+        },
     };
 
-    let check_msg = format!("would append to {}", args.file);
-    let apply_msg = format!("appended to {}", args.file);
+    let check_msg = format!("would {verb} to {file}");
+    let apply_msg = format!("{verb}ed to {file}");
+    let file_owned = file.to_string();
 
     execute_via_engine(
         op,
         global,
-        |phase, diff| AppendOutput {
+        |phase, diff| ContentInjectOutput {
             ok: true,
-            path: args.file.clone(),
+            path: file_owned.clone(),
             diff,
             applied: match phase {
                 WritePhase::Confirmed(a) => Some(a),

--- a/src/cmd/prepend.rs
+++ b/src/cmd/prepend.rs
@@ -1,10 +1,6 @@
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::WritePhase;
-use crate::cmd::output::execute_via_engine;
-use crate::plan::Operation;
-use anyhow::bail;
+use crate::cmd::append::{ContentPosition, run_content_inject};
 use clap::Args;
-use serde::Serialize;
 
 #[derive(Debug, Args)]
 #[command(after_help = "\
@@ -24,61 +20,13 @@ pub struct PrependArgs {
     pub write: crate::cli::global::WriteFlags,
 }
 
-#[derive(Debug, Serialize)]
-struct PrependOutput {
-    ok: bool,
-    path: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    diff: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    applied: Option<bool>,
-}
-
 pub fn run(args: PrependArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
-    crate::verbose!("prepend: file={}", args.file);
-    if args.content.is_some() && args.stdin {
-        bail!("--content and --stdin cannot be combined");
-    }
-
-    let prepend_content = if let Some(ref c) = args.content {
-        c.clone()
-    } else if args.stdin {
-        std::io::read_to_string(std::io::stdin())?
-    } else {
-        bail!("either --content or --stdin must be provided");
-    };
-
-    let cwd = global.resolve_cwd()?;
-    let path = cwd.join(&args.file);
-    if !path.exists() {
-        bail!("file does not exist: {}", args.file);
-    }
-    if !path.is_file() {
-        bail!("target is not a file: {}", args.file);
-    }
-
-    let op = Operation::FilePrepend {
-        path: args.file.clone(),
-        content: prepend_content,
-    };
-
-    let check_msg = format!("would prepend to {}", args.file);
-    let apply_msg = format!("prepended to {}", args.file);
-
-    execute_via_engine(
-        op,
+    run_content_inject(
+        &args.file,
+        args.content.as_deref(),
+        args.stdin,
+        ContentPosition::Prepend,
         global,
-        |phase, diff| PrependOutput {
-            ok: true,
-            path: args.file.clone(),
-            diff,
-            applied: match phase {
-                WritePhase::Confirmed(a) => Some(a),
-                _ => None,
-            },
-        },
-        &check_msg,
-        &apply_msg,
     )
 }
 


### PR DESCRIPTION
Eliminate code duplication identified by architecture audit.

## Changes

- Extract shared `run_content_inject()` from `cmd/append.rs`; `cmd/prepend.rs` now delegates to it (eliminates ~60 lines of duplicated `run()` logic, boilerplate output struct, and identical validation)
- Merge `execute_cross_file_as_edit_result()` into `execute_as_edit_result()` with optional `dest_path` parameter (eliminates a near-identical 10-line function that only differed by one argument)
- Merge `FileAppend`/`FilePrepend` match arms in `api/file.rs` fallback path using `ref content` binding + `matches!` discriminant check (eliminates ~15 duplicated lines)

Net: -29 lines. All tests pass (`make check-fast`: 2022 unit + 855 integration + 10 PTY).