### PR TITLE
refactor: remove #[non_exhaustive] and tighten write.rs visibility

### DIFF
--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -12,7 +12,6 @@ use serde::Deserialize;
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct ReplaceParams {
     /// File path (relative to working directory).
     pub path: String,
@@ -65,7 +64,6 @@ pub(crate) struct ReplaceParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct DocGetParams {
     /// File path (relative to working directory).
     pub path: String,
@@ -75,7 +73,6 @@ pub(crate) struct DocGetParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct MdLintAgentsParams {
     /// Markdown file path, relative to working directory (typically AGENTS.md).
     pub path: String,
@@ -83,7 +80,6 @@ pub(crate) struct MdLintAgentsParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct MdMoveSectionParams {
     /// Source file path containing the section to move (relative to working directory).
     pub path: String,
@@ -102,7 +98,6 @@ pub(crate) struct MdMoveSectionParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct TidyParams {
     /// File path to normalize (relative to working directory).
     pub path: String,
@@ -122,7 +117,6 @@ pub(crate) struct TidyParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct PatchParams {
     pub diff: String,
     #[serde(default)]
@@ -136,7 +130,6 @@ pub(crate) struct PatchParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct SearchParams {
     /// Pattern to search for.
     pub pattern: String,
@@ -185,7 +178,6 @@ pub(crate) struct SearchParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct DocQueryParams {
     /// Query action: "has" (check existence), "keys" (list keys), "len" (count),
     /// "select" (filter array), or "flatten" (list all paths).
@@ -198,7 +190,6 @@ pub(crate) struct DocQueryParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct DocDiffParams {
     /// First file path (relative to working directory).
     pub file_a: String,
@@ -212,7 +203,6 @@ pub(crate) struct DocDiffParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct BatchReplaceParams {
     /// File paths to apply the replacement to (relative to working directory).
     pub files: Vec<String>,
@@ -245,7 +235,6 @@ pub(crate) struct BatchReplaceParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct BatchTidyParams {
     /// File paths to normalize (relative to working directory).
     pub files: Vec<String>,
@@ -261,7 +250,6 @@ pub(crate) struct BatchTidyParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstListParams {
     /// File or directory to list symbols from (relative to working directory).
     pub path: String,
@@ -274,7 +262,6 @@ pub(crate) struct AstListParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstReadParams {
     /// File to read from (relative to working directory).
     pub path: String,
@@ -290,7 +277,6 @@ pub(crate) struct AstReadParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstRenameParams {
     /// The identifier to rename.
     pub old_name: String,
@@ -305,7 +291,6 @@ pub(crate) struct AstRenameParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstValidateParams {
     /// File or directory to validate syntax (relative to working directory).
     pub path: String,
@@ -316,7 +301,6 @@ pub(crate) struct AstValidateParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstSearchParams {
     /// Tree-sitter S-expression query, or a code pattern (with pattern=true).
     pub query: String,
@@ -334,7 +318,6 @@ pub(crate) struct AstSearchParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstRefsParams {
     /// Symbol name to find references for.
     pub symbol: String,
@@ -350,7 +333,6 @@ pub(crate) struct AstRefsParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstDepsParams {
     /// File or directory to analyze (relative to working directory).
     pub path: String,
@@ -364,7 +346,6 @@ pub(crate) struct AstDepsParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstMapParams {
     /// Directory to map (relative to working directory).
     pub path: String,
@@ -387,7 +368,6 @@ fn default_map_max_tokens() -> usize {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstDiffParams {
     /// File to diff (relative to working directory).
     pub path: String,
@@ -408,7 +388,6 @@ fn default_head() -> String {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstImpactParams {
     /// Symbol name to analyze.
     pub symbol: String,
@@ -427,7 +406,6 @@ fn default_impact_depth() -> usize {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstReplaceParams {
     /// File containing the symbol (relative to working directory).
     pub path: String,
@@ -448,7 +426,6 @@ pub(crate) struct AstReplaceParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstInsertParams {
     /// File to insert code into (relative to working directory).
     pub path: String,
@@ -473,7 +450,6 @@ pub(crate) struct AstInsertParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstWrapParams {
     /// File to modify (relative to working directory).
     pub path: String,
@@ -495,7 +471,6 @@ pub(crate) struct AstWrapParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstImportsParams {
     /// File to modify (relative to working directory).
     pub path: String,
@@ -515,7 +490,6 @@ pub(crate) struct AstImportsParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstReorderParams {
     /// File to reorder symbols in (relative to working directory).
     pub path: String,
@@ -531,7 +505,6 @@ pub(crate) struct AstReorderParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstGroupParams {
     /// File to modify (relative to working directory).
     pub path: String,
@@ -552,7 +525,6 @@ pub(crate) struct AstGroupParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstMoveParams {
     /// Source file (relative to working directory).
     pub path: String,
@@ -573,7 +545,6 @@ pub(crate) struct AstMoveParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstExtractToFileParams {
     /// Source file containing the symbol.
     pub source: String,
@@ -600,7 +571,6 @@ pub(crate) struct AstExtractToFileParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct AstSplitParams {
     /// The file to split.
     pub source: String,
@@ -640,14 +610,12 @@ pub(crate) struct AstSplitTargetParam {
 /// `type: "object"` field, which `serde_json::Value` does not provide.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct EmptyParams {}
 
 /// Parameters for executing a full multi-step transaction plan.
 /// This is the MCP equivalent of `patchloom tx`.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-#[non_exhaustive]
 pub(crate) struct ExecutePlanParams {
     /// Full inline plan object (preferred for agents; same schema as CLI tx plans).
     /// Must contain at minimum "version" and "operations".

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -26,7 +26,6 @@ pub struct PatchArgs {
 }
 
 #[derive(Debug, clap::Subcommand)]
-#[non_exhaustive]
 pub enum PatchAction {
     Check {
         // ref:patch-mode:file

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,6 @@ use crate::write::WritePolicyOverride;
 /// Project-level configuration loaded from `.patchloom.toml`.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-#[non_exhaustive]
 pub struct ProjectConfig {
     pub write_policy: WritePolicyOverride,
     pub exclude: Exclude,
@@ -23,7 +22,6 @@ pub struct ProjectConfig {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-#[non_exhaustive]
 pub struct Defaults {
     /// Default to --apply mode. When true, write commands apply changes without needing --apply flag.
     pub apply: Option<bool>,
@@ -34,7 +32,6 @@ pub struct Defaults {
 /// Format configuration: per-extension formatters and auto-format toggle.
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-#[non_exhaustive]
 pub struct FormatConfig {
     /// When true, run formatters automatically after --apply without needing --format.
     pub auto: Option<bool>,
@@ -48,14 +45,12 @@ pub struct FormatConfig {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-#[non_exhaustive]
 pub struct TxConfig {
     pub strict: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-#[non_exhaustive]
 pub struct Exclude {
     #[serde(default)]
     pub globs: Vec<String>,
@@ -63,7 +58,6 @@ pub struct Exclude {
 
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-#[non_exhaustive]
 pub struct Output {
     pub color: Option<String>,
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -30,7 +30,6 @@ pub fn effective_strict(
 
 /// A transaction plan containing multiple operations to execute atomically.
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
-#[non_exhaustive]
 pub struct Plan {
     /// Schema version. Defaults to 1 when omitted.
     #[serde(default = "default_version")]
@@ -125,7 +124,6 @@ impl VerifyCheck {
 
 /// A format step to run after applying operations but before validation.
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
-#[non_exhaustive]
 pub struct FormatStep {
     pub cmd: String,
     /// Timeout in seconds (default: 60).
@@ -134,7 +132,6 @@ pub struct FormatStep {
 
 /// A single operation within a plan.
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
-#[non_exhaustive]
 #[serde(tag = "op")]
 pub enum Operation {
     #[serde(rename = "replace")]
@@ -878,7 +875,6 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<&str> {
 
 /// A validation step to run after applying operations.
 #[derive(Debug, Deserialize, Serialize, schemars::JsonSchema)]
-#[non_exhaustive]
 pub struct ValidationStep {
     pub cmd: String,
     pub required: Option<bool>,

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -56,7 +56,6 @@ use clap::Args;
 
 #[cfg(feature = "cli")]
 #[derive(Debug, Args)]
-#[non_exhaustive]
 #[command(after_help = "\
 EXAMPLES:
   patchloom tx plan.json

--- a/src/write.rs
+++ b/src/write.rs
@@ -102,7 +102,6 @@ impl Default for WritePolicy {
 /// that needs to partially override write transformations.
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 #[serde(default, deny_unknown_fields)]
-#[non_exhaustive]
 pub struct WritePolicyOverride {
     pub ensure_final_newline: Option<bool>,
     pub normalize_eol: Option<String>,
@@ -665,7 +664,11 @@ pub fn policy_from_flags(
 /// partial content is never visible. `persist_noclobber` uses
 /// `link` + `unlink` (or platform equivalent) to fail if the target already
 /// exists, preserving the exclusive-create semantics.
-pub fn atomic_create_new(path: &Path, content: &str, policy: &WritePolicy) -> anyhow::Result<()> {
+pub(crate) fn atomic_create_new(
+    path: &Path,
+    content: &str,
+    policy: &WritePolicy,
+) -> anyhow::Result<()> {
     let final_content = apply_policy(content, policy);
 
     let parent = path
@@ -705,7 +708,7 @@ pub fn atomic_create_new(path: &Path, content: &str, policy: &WritePolicy) -> an
 /// A temporary file is created in the same directory as `path`, written to, then
 /// renamed over `path`. This guarantees the target file is never in a
 /// partially-written state (assuming the same filesystem).
-pub fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow::Result<()> {
+pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow::Result<()> {
     let final_content = apply_policy(content, policy);
 
     // Resolve symlinks: write to the target file, not the symlink entry (#1230).
@@ -759,7 +762,7 @@ pub fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow:
 /// write operation already succeeded and the files are correct, just
 /// not yet formatted.
 #[cfg(feature = "cli")]
-pub fn run_format_command(
+pub(crate) fn run_format_command(
     global: &crate::cli::global::GlobalFlags,
     cwd: &std::path::Path,
 ) -> anyhow::Result<()> {
@@ -772,7 +775,7 @@ pub fn run_format_command(
 /// `modified_paths` are relative paths (as stored by the tx engine).
 /// `format_config` provides per-extension formatter commands.
 #[cfg(feature = "cli")]
-pub fn run_format_command_ext(
+pub(crate) fn run_format_command_ext(
     global: &crate::cli::global::GlobalFlags,
     cwd: &std::path::Path,
     modified_paths: Option<&[&str]>,


### PR DESCRIPTION
Remove unnecessary defensive API markers and tighten internal visibility.

## Changes

- Remove all 45 `#[non_exhaustive]` attributes across 6 files (plan.rs, config.rs, write.rs, params.rs, patch.rs, tx/mod.rs). No external consumers exist; these only added friction to internal code and were pointless on `pub(crate)` types.
- Tighten `write.rs` functions from `pub` to `pub(crate)`: `atomic_write`, `atomic_create_new`, `run_format_command`, `run_format_command_ext` are only used within the crate.

Net: -41 lines. All tests pass (`make check-fast`: 2020 unit + 855 integration + 10 PTY).