### PR TITLE
refactor: unify parse_line_range and tighten cmd helper visibility

### DIFF
--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -128,7 +128,7 @@ fn tidy_write(
         // Apply dedent/indent after policy normalization.
         let line_range = lines
             .as_deref()
-            .map(crate::write::parse_line_range)
+            .map(crate::ops::read::parse_line_range)
             .transpose()?;
         if let Some(ref spec) = dedent {
             new_content = crate::write::dedent_content(&new_content, spec, line_range);

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -82,8 +82,10 @@ pub struct AstArgs {
     pub command: AstCommand,
 }
 
-pub fn display_path(path: &Path, cwd: &Path) -> String {
-    path.strip_prefix(cwd).unwrap_or(path).display().to_string()
+pub(crate) fn display_path(path: &Path, cwd: &Path) -> String {
+    crate::files::relative_display(path, cwd)
+        .display()
+        .to_string()
 }
 
 pub fn run(args: AstArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
@@ -294,7 +296,7 @@ pub struct RenameArgs {
     pub write: crate::cli::global::WriteFlags,
 }
 
-pub fn resolve_target_paths(
+pub(crate) fn resolve_target_paths(
     target: &std::path::Path,
     path_arg: &str,
     global: &GlobalFlags,
@@ -1075,7 +1077,7 @@ fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     Ok(exit::SUCCESS)
 }
 
-pub fn get_git_file_content(
+pub(crate) fn get_git_file_content(
     cwd: &std::path::Path,
     file_path: &str,
     git_ref: &str,
@@ -1100,13 +1102,13 @@ pub fn get_git_file_content(
 // Helpers
 // ---------------------------------------------------------------------------
 
-pub fn lang_from_str(s: &str) -> Language {
+pub(crate) fn lang_from_str(s: &str) -> Language {
     Language::from_name_or_ext(s)
 }
 
 pub use symbols::{filter_symbols, parse_kind_filter};
 
-pub fn collect_source_files(
+pub(crate) fn collect_source_files(
     dir: &std::path::Path,
     global: &GlobalFlags,
 ) -> anyhow::Result<Vec<std::path::PathBuf>> {
@@ -1167,7 +1169,7 @@ fn print_symbols_json(
     Ok(())
 }
 
-pub fn symbol_to_json(sym: &SymbolDef, path: &str) -> serde_json::Value {
+pub(crate) fn symbol_to_json(sym: &SymbolDef, path: &str) -> serde_json::Value {
     let children: Vec<serde_json::Value> = sym
         .children
         .iter()

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -313,7 +313,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             // Parse line range once (shared across all files).
             let line_range = lines
                 .as_deref()
-                .map(crate::write::parse_line_range)
+                .map(crate::ops::read::parse_line_range)
                 .transpose()?;
 
             // Parallel read+compute phase: identify which files need fixing.

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -1,4 +1,3 @@
-#[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) type LineRange = (usize, Option<usize>);
 
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -23,7 +22,6 @@ impl SelectedLines {
 }
 
 /// Parse a line range spec like "10", "10:20", "10-20".
-#[cfg(any(feature = "cli", feature = "files"))]
 pub(crate) fn parse_line_range(spec: &str) -> anyhow::Result<LineRange> {
     // Accept both ':' and '-' as range separators so `--lines 1:10` and
     // `--lines 1-10` both work (the help examples show the dash form).

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -834,7 +834,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             // Apply dedent/indent after policy normalization.
             let line_range = lines
                 .as_deref()
-                .map(crate::write::parse_line_range)
+                .map(crate::ops::read::parse_line_range)
                 .transpose()?;
             if let Some(spec) = dedent {
                 new = crate::write::dedent_content(&new, spec, line_range);

--- a/src/write.rs
+++ b/src/write.rs
@@ -451,45 +451,6 @@ fn dedent_by_n(lines: &[&str], n: usize, in_range: &dyn Fn(usize) -> bool) -> St
     result.join("\n")
 }
 
-/// Parse a line range specification like `"10:50"` into `(start, Option<end>)`.
-///
-/// Both start and end are 1-based inclusive. Examples:
-/// - `"10:50"` → `(10, Some(50))`
-/// - `"5:"` → `(5, None)` (open-ended)
-/// - `"3"` → `(3, Some(3))` (single line)
-pub fn parse_line_range(spec: &str) -> anyhow::Result<(usize, Option<usize>)> {
-    if let Some((left, right)) = spec.split_once(':') {
-        let start: usize = left
-            .parse()
-            .map_err(|_| anyhow::anyhow!("invalid line range start: '{left}'"))?;
-        if start == 0 {
-            anyhow::bail!("line numbers are 1-based, got start=0");
-        }
-        if right.is_empty() {
-            Ok((start, None))
-        } else {
-            let end: usize = right
-                .parse()
-                .map_err(|_| anyhow::anyhow!("invalid line range end: '{right}'"))?;
-            if end == 0 {
-                anyhow::bail!("line numbers are 1-based, got end=0");
-            }
-            if end < start {
-                anyhow::bail!("inverted line range: start ({start}) > end ({end})");
-            }
-            Ok((start, Some(end)))
-        }
-    } else {
-        let line: usize = spec
-            .parse()
-            .map_err(|_| anyhow::anyhow!("invalid line number: '{spec}'"))?;
-        if line == 0 {
-            anyhow::bail!("line numbers are 1-based, got 0");
-        }
-        Ok((line, Some(line)))
-    }
-}
-
 /// Indent content by adding leading whitespace.
 ///
 /// `spec` accepts:

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -785,51 +785,6 @@ mod dedent_indent {
     }
 
     #[test]
-    fn parse_line_range_full() {
-        let (start, end) = parse_line_range("10:50").unwrap();
-        assert_eq!(start, 10);
-        assert_eq!(end, Some(50));
-    }
-
-    #[test]
-    fn parse_line_range_open_ended() {
-        let (start, end) = parse_line_range("5:").unwrap();
-        assert_eq!(start, 5);
-        assert_eq!(end, None);
-    }
-
-    #[test]
-    fn parse_line_range_single_line() {
-        let (start, end) = parse_line_range("3").unwrap();
-        assert_eq!(start, 3);
-        assert_eq!(end, Some(3));
-    }
-
-    #[test]
-    fn parse_line_range_invalid() {
-        assert!(parse_line_range("abc").is_err());
-        assert!(parse_line_range("1:xyz").is_err());
-    }
-
-    #[test]
-    fn parse_line_range_rejects_zero() {
-        // Line numbers are 1-based; 0 is invalid.
-        assert!(parse_line_range("0").is_err());
-        assert!(parse_line_range("0:5").is_err());
-        assert!(parse_line_range("1:0").is_err());
-    }
-
-    #[test]
-    fn parse_line_range_rejects_inverted() {
-        // start > end is an error, not a silent no-op.
-        let err = parse_line_range("50:10").unwrap_err();
-        assert!(
-            err.to_string().contains("inverted"),
-            "should mention inverted range: {err}"
-        );
-    }
-
-    #[test]
     fn dedent_auto_line_range() {
         // Only dedent lines 2-3; leave lines 1 and 4 alone.
         let input = "    a\n        b\n        c\n    d\n";


### PR DESCRIPTION
## Summary

Two tech-debt fixes from the codebase architecture audit:

1. **Unify divergent `parse_line_range`** -- removes the duplicate from `write.rs`, unifies all callers to `ops/read.rs` which accepts both `:` and `-` separators with better error messages. The `tidy --lines 1-10` form now works consistently across all commands.

2. **Tighten `pub` to `pub(crate)`** on 6 internal helpers in `cmd/ast.rs` (`display_path`, `resolve_target_paths`, `get_git_file_content`, `lang_from_str`, `collect_source_files`, `symbol_to_json`). Also deduplicates `display_path` to delegate to `files::relative_display`.

`batch::tokenize` remains `pub` because the fuzz target uses it.

Closes #1302
Closes #1303