### PR TITLE
fix: md replace-section strips duplicate heading from replacement content

### DIFF
--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -404,6 +404,12 @@ pub fn move_section_in(
 pub fn replace_section_in(content: &str, heading: &str, replacement: &str) -> Option<String> {
     let eol = crate::write::detect_eol(content);
     let (body_start, body_end) = find_section(content, heading)?;
+
+    // If the replacement starts with the same heading line, strip it so the
+    // caller does not have to know whether the heading is included or not.
+    // The heading is already preserved in content[..body_start].
+    let replacement = strip_leading_heading(replacement, heading);
+
     let mut out = String::with_capacity(content.len());
     out.push_str(&content[..body_start]);
     if !replacement.is_empty() {
@@ -414,6 +420,23 @@ pub fn replace_section_in(content: &str, heading: &str, replacement: &str) -> Op
     }
     out.push_str(&content[body_end..]);
     Some(out)
+}
+
+/// Strip a leading heading line from `text` if it matches `heading`.
+/// Handles optional trailing whitespace and newlines after the heading line.
+fn strip_leading_heading<'a>(text: &'a str, heading: &str) -> &'a str {
+    let (level, query) = normalize_heading_query(heading);
+    let first_line = text.lines().next().unwrap_or("");
+    let (first_level, first_text) = normalize_heading_query(first_line);
+    if first_text == query && (level.is_none() || first_level == level) {
+        let after_line = &text[first_line.len()..];
+        // Skip the newline(s) after the heading line
+        after_line
+            .strip_prefix("\r\n")
+            .unwrap_or_else(|| after_line.strip_prefix('\n').unwrap_or(after_line))
+    } else {
+        text
+    }
 }
 
 pub fn insert_after_heading_in(content: &str, heading: &str, insertion: &str) -> Option<String> {

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -105,6 +105,32 @@ mod basic {
     }
 
     #[test]
+    fn replace_section_strips_duplicate_heading() {
+        // When replacement starts with the same heading, strip it to avoid duplication.
+        let content = "# Title\nOld body\n# Next\nKeep\n";
+        let result = replace_section_in(content, "# Title", "# Title\n\nNew body").unwrap();
+        assert_eq!(result, "# Title\n\nNew body\n# Next\nKeep\n");
+        // No double heading
+        assert_eq!(result.matches("# Title").count(), 1);
+    }
+
+    #[test]
+    fn replace_section_strips_duplicate_heading_level2() {
+        let content = "# Doc\n\n## Usage\n\nOld usage.\n\n## Contributing\n\nPRs welcome.\n";
+        let result = replace_section_in(content, "## Usage", "## Usage\n\nNew usage.").unwrap();
+        assert_eq!(result.matches("## Usage").count(), 1);
+        assert!(result.contains("New usage."));
+    }
+
+    #[test]
+    fn replace_section_no_strip_when_heading_differs() {
+        // If the replacement heading is different, do NOT strip it.
+        let content = "# Title\nOld body\n# Next\nKeep\n";
+        let result = replace_section_in(content, "# Title", "# Different\nStuff").unwrap();
+        assert!(result.contains("# Title\n# Different"));
+    }
+
+    #[test]
     fn insert_after_heading() {
         let content = "# Title\nExisting\n";
         let result = insert_after_heading_in(content, "Title", "Inserted\n").unwrap();


### PR DESCRIPTION
When replacement content starts with the same heading that is being replaced (e.g. `content='## Usage\n\nUpdated.'` for `heading='## Usage'`), the heading line is now stripped automatically to prevent duplication. The heading is already preserved in the original document; the caller should not need to know whether to include it or not.

**Changes:**
- `replace_section_in()` now calls `strip_leading_heading()` to detect and remove a leading heading that matches the target
- 3 new tests: level-1 heading, level-2 heading, and non-matching heading (no strip)

**Testing:** `make check-fast` passes (2017 unit + 10 PTY tests, clippy, fmt).