### PR TITLE
fix: md replace-section preserves blank line before next heading

### DIFF
--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -410,11 +410,26 @@ pub fn replace_section_in(content: &str, heading: &str, replacement: &str) -> Op
     // The heading is already preserved in content[..body_start].
     let replacement = strip_leading_heading(replacement, heading);
 
+    // Check whether the original body had a trailing blank line before
+    // the next heading. If so, preserve that separator so the output
+    // remains well-formatted markdown.
+    let original_body = &content[body_start..body_end];
+    let had_trailing_blank = original_body.ends_with("\n\n") || original_body.ends_with("\r\n\r\n");
+
     let mut out = String::with_capacity(content.len());
     out.push_str(&content[..body_start]);
     if !replacement.is_empty() {
         out.push_str(replacement);
         if !replacement.ends_with('\n') {
+            out.push_str(eol);
+        }
+        // Restore the blank-line separator before the next heading when
+        // the original content had one and the replacement does not.
+        if had_trailing_blank
+            && !replacement.ends_with("\n\n")
+            && !replacement.ends_with("\r\n\r\n")
+            && body_end < content.len()
+        {
             out.push_str(eol);
         }
     }

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -131,6 +131,25 @@ mod basic {
     }
 
     #[test]
+    fn replace_section_preserves_blank_line_before_next_heading() {
+        let content =
+            "# Project\n\nIntro.\n\n## Section A\n\nContent A.\n\n## Section B\n\nContent B.\n";
+        let result = replace_section_in(content, "## Section A", "New A.").unwrap();
+        assert_eq!(
+            result,
+            "# Project\n\nIntro.\n\n## Section A\nNew A.\n\n## Section B\n\nContent B.\n"
+        );
+    }
+
+    #[test]
+    fn replace_section_no_extra_blank_when_original_had_none() {
+        // When the original had no blank line before the next heading, don't add one.
+        let content = "# Title\nOld body\n# Next\nKeep\n";
+        let result = replace_section_in(content, "# Title", "New body").unwrap();
+        assert_eq!(result, "# Title\nNew body\n# Next\nKeep\n");
+    }
+
+    #[test]
     fn insert_after_heading() {
         let content = "# Title\nExisting\n";
         let result = insert_after_heading_in(content, "Title", "Inserted\n").unwrap();
@@ -1081,8 +1100,8 @@ mod format_preservation {
         let content = "Title\n=====\n\nOld body\n\nNext\n=====\nKeep\n";
         let result = replace_section_in(content, "Title", "New body").unwrap();
         assert_eq!(
-            result, "Title\n=====\nNew body\nNext\n=====\nKeep\n",
-            "underline must be preserved: {result}"
+            result, "Title\n=====\nNew body\n\nNext\n=====\nKeep\n",
+            "underline must be preserved and blank line before next heading kept: {result}"
         );
     }
 


### PR DESCRIPTION
When a section's original body had a trailing blank line before the next heading (standard markdown formatting), replacing the section content would drop that separator. The replacement content was inserted without restoring the blank line, causing the next heading to run directly into the new content.

**Before:**
```markdown
## Section A
New content A.
## Section B
```

**After (fixed):**
```markdown
## Section A
New content A.

## Section B
```

**Changes:**
- `replace_section_in()` now detects trailing blank lines in the original body and preserves the separator
- 2 new tests: blank-line preservation and no-extra-blank when original had none
- Updated setext heading test expectation to match corrected behavior

**Testing:** `make check-fast` passes (2019 unit + 10 PTY tests, clippy, fmt).

Found by runtime scenario testing (fixrealloop Round 2).