### PR TITLE
docs: clarify channel parity in v0.9.0 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,16 +1,16 @@
 # Patchloom 0.9.0
 
-This release adds fuzzy edit matching for library embedders, context-anchored CLI replacements, a new `prepend` command, and fixes a security-relevant path traversal bypass. 3 new features, 6 bug fixes, and 54 new tests across 19 commits.
+This release closes parity gaps across all three channels (CLI, MCP, library API) and fixes a security-relevant path traversal bypass. 3 new features, 6 bug fixes, and 54 new tests across 19 commits.
 
 ## Highlights
 
-Replace operations now support fuzzy fallback at the library API level (`replace_in_content`), so embedders like Bline get automatic Jaro-Winkler similarity matching without writing adapter code. The CLI replace command gains `--before-context` and `--after-context` flags for anchor-based match disambiguation. A path traversal bypass in the containment module was identified and patched, hardening the security boundary for library consumers that use `AllowIfContained` or `AllowAdditionalRoots` policies.
+Fuzzy edit matching, context-anchored replacements, and the prepend operation are now available in every channel. Previously each feature was missing from exactly one surface: fuzzy fallback was only in the tx engine (CLI/MCP/plans), context anchoring was only in MCP and tx plans, and prepend was only in MCP and the library API. This release fills the last gaps. A path traversal bypass in the containment module was also identified and patched, hardening the security boundary for all channels.
 
 ## New features
 
-- **Fuzzy fallback for `replace_in_content`.** The in-memory replace API now accepts `fuzzy: true` in `ReplaceOptions`. When exact match fails, patchloom automatically tries Jaro-Winkler similarity matching, then returns suggestions if fuzzy also fails. This eliminates ~15 lines of manual fallback glue that library embedders previously needed. (#1292)
-- **`--before-context` / `--after-context` on CLI replace.** Anchor text that disambiguates which match to target when a pattern appears multiple times in a file. Supports fuzzy anchor matching as a fallback. (#1290)
-- **`prepend` command.** New CLI command that prepends content to the beginning of an existing file, bringing CLI parity with the MCP `prepend_file` tool. Accepts `--content` or `--stdin` (mutually exclusive). (#1290)
+- **Fuzzy fallback for `replace_in_content` (library API parity).** The in-memory replace API now accepts `fuzzy: true` in `ReplaceOptions`. When exact match fails, patchloom automatically tries Jaro-Winkler similarity matching, then returns suggestions if fuzzy also fails. This eliminates ~15 lines of manual fallback glue that library embedders previously needed. The tx engine (CLI, MCP, and plans) already had this capability. (#1292)
+- **`--before-context` / `--after-context` on CLI replace (CLI parity).** Anchor text that disambiguates which match to target when a pattern appears multiple times in a file. The MCP `replace_text` tool and tx plans already supported these fields; this adds them as CLI flags. Supports fuzzy anchor matching as a fallback. (#1290)
+- **`prepend` command (CLI parity).** New CLI command that prepends content to the beginning of an existing file. The MCP `prepend_file` tool and library `file_prepend` API already existed; this completes the CLI surface. Accepts `--content` or `--stdin` (mutually exclusive). (#1290)
 
 ## Bug fixes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@ This release closes parity gaps across all three channels (CLI, MCP, library API
 
 ## Highlights
 
-Fuzzy edit matching, context-anchored replacements, and the prepend operation are now available in every channel. Previously each feature was missing from exactly one surface: fuzzy fallback was only in the tx engine (CLI/MCP/plans), context anchoring was only in MCP and tx plans, and prepend was only in MCP and the library API. This release fills the last gaps. A path traversal bypass in the containment module was also identified and patched, hardening the security boundary for all channels.
+Fuzzy edit matching, context-anchored replacements, and the prepend operation each had one channel missing. This release fills those gaps: fuzzy fallback reaches the library API, context anchoring reaches the CLI, and prepend reaches the CLI. The library API does not yet expose `before_context`/`after_context` on `ReplaceOptions` (#1310); the tx engine supports it, so library consumers can use `execute_plan` as a workaround. A path traversal bypass in the containment module was also identified and patched, hardening the security boundary for all channels.
 
 ## New features
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,12 +4,12 @@ This release closes parity gaps across all three channels (CLI, MCP, library API
 
 ## Highlights
 
-Fuzzy edit matching, context-anchored replacements, and the prepend operation each had one channel missing. This release fills those gaps: fuzzy fallback reaches the library API, context anchoring reaches the CLI, and prepend reaches the CLI. The library API does not yet expose `before_context`/`after_context` on `ReplaceOptions` (#1310); the tx engine supports it, so library consumers can use `execute_plan` as a workaround. A path traversal bypass in the containment module was also identified and patched, hardening the security boundary for all channels.
+Fuzzy edit matching, context-anchored replacements, and the prepend operation each had one channel missing. This release fills all the gaps: fuzzy fallback reaches the library API, context anchoring reaches both the CLI and library API, and prepend reaches the CLI. Every replacement feature is now available in all three channels. A path traversal bypass in the containment module was also identified and patched, hardening the security boundary for all channels.
 
 ## New features
 
 - **Fuzzy fallback for `replace_in_content` (library API parity).** The in-memory replace API now accepts `fuzzy: true` in `ReplaceOptions`. When exact match fails, patchloom automatically tries Jaro-Winkler similarity matching, then returns suggestions if fuzzy also fails. This eliminates ~15 lines of manual fallback glue that library embedders previously needed. The tx engine (CLI, MCP, and plans) already had this capability. (#1292)
-- **`--before-context` / `--after-context` on CLI replace (CLI parity).** Anchor text that disambiguates which match to target when a pattern appears multiple times in a file. The MCP `replace_text` tool and tx plans already supported these fields; this adds them as CLI flags. Supports fuzzy anchor matching as a fallback. (#1290)
+- **`before_context` / `after_context` for replace (CLI and library API parity).** Anchor text that disambiguates which match to target when a pattern appears multiple times in a file. The MCP `replace_text` tool and tx plans already supported these fields; this release adds CLI flags (`--before-context`, `--after-context`) and exposes them in the library API's `ReplaceOptions`. Supports fuzzy anchor matching as a fallback. (#1290, #1310)
 - **`prepend` command (CLI parity).** New CLI command that prepends content to the beginning of an existing file. The MCP `prepend_file` tool and library `file_prepend` API already existed; this completes the CLI surface. Accepts `--content` or `--stdin` (mutually exclusive). (#1290)
 
 ## Bug fixes

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -222,6 +222,14 @@ pub struct ReplaceOptions {
     /// On fuzzy failure, the error includes "did you mean?" suggestions.
     /// Only applies to literal (non-regex) patterns.
     pub fuzzy: bool,
+    /// Context line(s) before the target for anchor-based fallback matching.
+    /// When the pattern matches multiple times, the match nearest to this
+    /// anchor text is selected.
+    pub before_context: Option<String>,
+    /// Context line(s) after the target for anchor-based fallback matching.
+    /// When the pattern matches multiple times, the match nearest to this
+    /// anchor text is selected.
+    pub after_context: Option<String>,
 }
 
 /// Write policy options for controlling file write transformations.

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -54,8 +54,8 @@ pub fn replace_text(
         whole_line: opts.whole_line,
         range: range_str,
         word_boundary: opts.word_boundary,
-        before_context: None,
-        after_context: None,
+        before_context: opts.before_context.clone(),
+        after_context: opts.after_context.clone(),
         unique: opts.unique,
     };
     replace_write(op, path, mode, guard)

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2951,3 +2951,49 @@ fn replace_text_unique_fails_on_ambiguity() {
         "expected ambiguous error, got: {msg}"
     );
 }
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_before_context_disambiguates() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "alpha\nTODO: fix\nbeta\ngamma\nTODO: fix\ndelta\n").unwrap();
+
+    // "TODO: fix" appears twice; before_context selects the one after "gamma".
+    let opts = ReplaceOptions {
+        before_context: Some("gamma".to_string()),
+        ..Default::default()
+    };
+    let result = replace_text(&file, "TODO: fix", "DONE", &opts, ApplyMode::Apply, None).unwrap();
+    assert!(result.changed);
+    let content = fs::read_to_string(&file).unwrap();
+    // First occurrence should be untouched, second replaced.
+    assert!(
+        content.contains("TODO: fix"),
+        "first occurrence should remain"
+    );
+    assert!(content.contains("DONE"), "second should be replaced");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_after_context_disambiguates() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "alpha\nTODO: fix\nbeta\ngamma\nTODO: fix\ndelta\n").unwrap();
+
+    // after_context="beta" selects the first "TODO: fix" (the one before "beta").
+    let opts = ReplaceOptions {
+        after_context: Some("beta".to_string()),
+        ..Default::default()
+    };
+    let result = replace_text(&file, "TODO: fix", "DONE", &opts, ApplyMode::Apply, None).unwrap();
+    assert!(result.changed);
+    let content = fs::read_to_string(&file).unwrap();
+    // First occurrence replaced, second should remain.
+    assert!(
+        content.contains("TODO: fix"),
+        "second occurrence should remain"
+    );
+    assert!(content.contains("DONE"), "first should be replaced");
+}


### PR DESCRIPTION
Fixes misleading framing in RELEASE_NOTES.md that implied features were channel-exclusive.

All three features in 0.9.0 are parity completions, not new capabilities:
- Fuzzy fallback already existed in the tx engine; 0.9.0 adds it to `replace_in_content` (library API)
- before/after_context already existed in MCP and tx plans; 0.9.0 adds CLI flags and library API fields
- prepend already existed as MCP tool and library API; 0.9.0 adds the CLI command

Also exposes `before_context`/`after_context` in library `ReplaceOptions` so all replacement features are available in all three channels.

Closes #1310