### PR TITLE
fix: fallback replace path ignores context/fuzzy + Unicode tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2800%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-2900%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -428,7 +428,7 @@ flowchart LR
 
 ## Status
 
-2800+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+2900+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -58,7 +58,7 @@ pub fn replace_text(
         after_context: opts.after_context.clone(),
         unique: opts.unique,
     };
-    replace_write(op, path, mode, guard)
+    replace_write(op, path, mode, guard, opts.fuzzy)
 }
 
 /// Unified write path for replace operations.
@@ -68,6 +68,7 @@ fn replace_write(
     path: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
+    _fuzzy: bool,
 ) -> anyhow::Result<EditResult> {
     let cwd = path.parent().unwrap_or_else(|| Path::new("."));
     super::execute_as_edit_result(op, mode, cwd, guard, "replace", None)
@@ -75,10 +76,11 @@ fn replace_write(
 
 #[cfg(not(any(feature = "cli", feature = "files")))]
 fn replace_write(
-    _op: Operation,
+    op: Operation,
     path: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
+    fuzzy: bool,
 ) -> anyhow::Result<EditResult> {
     use crate::ops;
     use anyhow::{Context, bail};
@@ -98,8 +100,10 @@ fn replace_write(
         word_boundary,
         nth,
         unique,
+        before_context,
+        after_context,
         ..
-    } = _op
+    } = op
     {
         let path_str = path.to_string_lossy();
         let original = std::fs::read_to_string(path)
@@ -153,14 +157,113 @@ fn replace_write(
         } else {
             ops::replace::replace_content(&original, &old, &replacement, compiled_re.as_ref(), nth)
         };
+
+        // Context disambiguation: when multiple exact matches and context is
+        // provided, select the match nearest to the context instead of
+        // replacing all (mirrors tx engine logic in replace_op.rs).
+        if count > 1
+            && nth.is_none()
+            && !whole_line
+            && !is_regex
+            && (before_context.is_some() || after_context.is_some())
+        {
+            if let Some(target_offset) = ops::replace::context_filtered_offset(
+                &original,
+                &old,
+                before_context.as_deref(),
+                after_context.as_deref(),
+            ) {
+                let ctx_content = format!(
+                    "{}{}{}",
+                    &original[..target_offset],
+                    &replacement,
+                    &original[target_offset + old.len()..],
+                );
+                let policy = crate::write::WritePolicy::default();
+                let applied = super::write_if_apply(path, &ctx_content, mode, &policy, guard)?;
+                let mut result = super::build_edit_result(
+                    &path_str,
+                    original,
+                    ctx_content,
+                    applied,
+                    "replace",
+                    None,
+                );
+                result.match_count = 1;
+                return Ok(result);
+            }
+        }
+
         let new_content = new_content.into_owned();
 
+        // Note: context disambiguation runs BEFORE unique, so context can
+        // resolve ambiguity even with unique=true. This diverges from the tx
+        // engine (which bails on unique before context), but is intentional:
+        // context-resolved results are unambiguous by definition.
         if unique && count > 1 {
             bail!(
                 "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
                 old,
                 count
             );
+        }
+
+        // Fuzzy/context fallback: when exact match fails and fuzzy or context
+        // is enabled, try resolve_with_fallback for anchor/similarity matching
+        // (mirrors tx engine fallback in replace_op.rs).
+        if count == 0 && !is_regex && (fuzzy || before_context.is_some() || after_context.is_some())
+        {
+            use crate::fallback;
+            match fallback::resolve_with_fallback(
+                &original,
+                &old,
+                before_context.as_deref(),
+                after_context.as_deref(),
+            ) {
+                Ok(anchor) => {
+                    let to_text = if let Some(ib) = &insert_before {
+                        format!("{}{}", ib, anchor.matched_text)
+                    } else if let Some(ia) = &insert_after {
+                        format!("{}{}", anchor.matched_text, ia)
+                    } else {
+                        new_text.as_deref().unwrap_or("").to_string()
+                    };
+                    let fb_content = format!(
+                        "{}{}{}",
+                        &original[..anchor.start_offset],
+                        to_text,
+                        &original[anchor.start_offset + anchor.matched_text.len()..],
+                    );
+                    let policy = crate::write::WritePolicy::default();
+                    let applied = super::write_if_apply(path, &fb_content, mode, &policy, guard)?;
+                    let mut result = super::build_edit_result(
+                        &path_str, original, fb_content, applied, "replace", None,
+                    );
+                    result.match_count = 1;
+                    return Ok(result);
+                }
+                Err(edit_error) => {
+                    if if_exists {
+                        return Ok(super::build_edit_result(
+                            &path_str,
+                            original.clone(),
+                            original,
+                            false,
+                            "replace",
+                            None,
+                        ));
+                    }
+                    let similar = fallback::find_similar_targets(&original, &old, 3);
+                    let mut msg = format!("no matches for {:?}", old);
+                    if let Some(suggestion) = &edit_error.suggestion {
+                        msg.push_str(&format!(" (suggestion: {})", suggestion));
+                    }
+                    if !similar.is_empty() {
+                        msg.push_str(&format!(" (did you mean: {}?)", similar.join(", ")));
+                    }
+                    bail!("{msg}");
+                }
+            }
         }
 
         if count == 0 && if_exists {
@@ -248,6 +351,38 @@ pub fn replace_in_content(
     } else {
         ops::replace::replace_content(content, from, &replacement, compiled_re.as_ref(), opts.nth)
     };
+
+    // Context disambiguation (#1315): when multiple exact matches and context
+    // is provided, select the match nearest to the context instead of
+    // replacing all (mirrors replace_write and tx engine logic).
+    if count > 1
+        && opts.nth.is_none()
+        && !opts.whole_line
+        && !is_regex
+        && (opts.before_context.is_some() || opts.after_context.is_some())
+        && let Some(target_offset) = ops::replace::context_filtered_offset(
+            content,
+            from,
+            opts.before_context.as_deref(),
+            opts.after_context.as_deref(),
+        )
+    {
+        let ctx_content = format!(
+            "{}{}{}",
+            &content[..target_offset],
+            &replacement,
+            &content[target_offset + from.len()..],
+        );
+        let diff = super::make_diff("<content>", content, &ctx_content);
+        return Ok(ContentEditResult {
+            original: content.to_string(),
+            new_content: ctx_content,
+            diff,
+            changed: true,
+            match_count: 1,
+        });
+    }
+
     let new_content = new_content.into_owned();
 
     if opts.unique && count > 1 {
@@ -258,9 +393,13 @@ pub fn replace_in_content(
         );
     }
 
-    // Fuzzy fallback (#1286): when exact match fails and fuzzy is enabled,
-    // try resolve_with_fallback for anchor/similarity matching.
-    if count == 0 && opts.fuzzy && !is_regex {
+    // Fuzzy/context fallback (#1286, #1315): when exact match fails and fuzzy
+    // or context is enabled, try resolve_with_fallback for anchor/similarity
+    // matching (matches replace_write and tx engine behavior).
+    if count == 0
+        && !is_regex
+        && (opts.fuzzy || opts.before_context.is_some() || opts.after_context.is_some())
+    {
         use crate::fallback;
         match fallback::resolve_with_fallback(
             content,

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3039,3 +3039,398 @@ fn replace_text_after_context_disambiguates() {
     );
     assert!(content.contains("DONE"), "first should be replaced");
 }
+
+// ── #1314: Unicode/multibyte text tests for replace_in_content ──
+
+#[test]
+fn replace_in_content_unicode_cjk_literal() {
+    let content = "fn greet() { println!(\"こんにちは世界\"); }\n";
+    let result = replace::replace_in_content(
+        content,
+        "こんにちは世界",
+        "你好世界",
+        &ReplaceOptions::default(),
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert!(result.new_content.contains("你好世界"));
+    assert!(!result.new_content.contains("こんにちは世界"));
+    assert_eq!(result.match_count, 1);
+}
+
+#[test]
+fn replace_in_content_unicode_emoji() {
+    let content = "status: 🔴 failing\nother: 🟢 passing\n";
+    let result = replace::replace_in_content(
+        content,
+        "🔴 failing",
+        "🟢 passing",
+        &ReplaceOptions::default(),
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert_eq!(
+        result.new_content, "status: 🟢 passing\nother: 🟢 passing\n",
+        "emoji replacement should preserve byte boundaries"
+    );
+    assert_eq!(result.match_count, 1);
+}
+
+#[test]
+fn replace_in_content_unicode_combining_marks() {
+    // e\u{0301} is "e" + combining acute accent = "é" (2 code points)
+    let content = "caf\u{0065}\u{0301} au lait\n";
+    let result = replace::replace_in_content(
+        content,
+        "caf\u{0065}\u{0301}",
+        "coffee",
+        &ReplaceOptions::default(),
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert!(result.new_content.contains("coffee au lait"));
+    assert_eq!(result.match_count, 1);
+}
+
+#[test]
+fn replace_in_content_unicode_mixed_scripts() {
+    let content = "name: Привет мир\ntag: hello\n";
+    let result = replace::replace_in_content(
+        content,
+        "Привет мир",
+        "Здравствуй мир",
+        &ReplaceOptions::default(),
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert!(result.new_content.contains("Здравствуй мир"));
+    assert_eq!(result.match_count, 1);
+}
+
+#[test]
+fn replace_in_content_unicode_regex() {
+    let content = "price: ¥1000\nprice: ¥2000\n";
+    let opts = ReplaceOptions {
+        regex: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(content, r"¥\d+", "€999", &opts).unwrap();
+    assert!(result.changed);
+    assert_eq!(result.match_count, 2);
+    assert_eq!(result.new_content, "price: €999\nprice: €999\n");
+}
+
+#[test]
+fn replace_in_content_unicode_case_insensitive() {
+    // Turkish dotless i: İ (U+0130) lowercases to i in Unicode-aware mode
+    let content = "ÜBER cool\n";
+    let opts = ReplaceOptions {
+        case_insensitive: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(content, "über", "super", &opts).unwrap();
+    assert!(result.changed);
+    assert!(result.new_content.contains("super cool"));
+}
+
+#[test]
+fn replace_in_content_unicode_word_boundary() {
+    // Word boundary with CJK: CJK chars don't have \b boundaries like Latin,
+    // but the pattern should still work for Latin words in mixed content.
+    let content = "日本語 hello 中文\n";
+    let opts = ReplaceOptions {
+        word_boundary: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(content, "hello", "world", &opts).unwrap();
+    assert!(result.changed);
+    assert_eq!(result.new_content, "日本語 world 中文\n");
+}
+
+#[test]
+fn replace_in_content_unicode_whole_line() {
+    let content = "普通の行\n削除する行\nもう一つの行\n";
+    let opts = ReplaceOptions {
+        whole_line: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(content, "削除する", "", &opts).unwrap();
+    assert!(result.changed);
+    assert!(!result.new_content.contains("削除する行"));
+    assert!(result.new_content.contains("普通の行"));
+    assert!(result.new_content.contains("もう一つの行"));
+}
+
+#[test]
+fn replace_in_content_unicode_nth() {
+    let content = "café café café\n";
+    let opts = ReplaceOptions {
+        nth: Some(2),
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(content, "café", "tea", &opts).unwrap();
+    assert!(result.changed);
+    assert_eq!(result.new_content, "café tea café\n");
+}
+
+#[test]
+fn replace_in_content_unicode_insert_after() {
+    let content = "use 标准库;\n";
+    let opts = ReplaceOptions {
+        insert_after: Some("\nuse 扩展库;".to_string()),
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(content, "use 标准库;", "", &opts).unwrap();
+    assert!(result.changed);
+    assert!(result.new_content.contains("use 标准库;\nuse 扩展库;"));
+}
+
+#[test]
+fn replace_in_content_unicode_multiline_regex() {
+    let content = "struct 数据 {\n    名前: String,\n}\n";
+    let opts = ReplaceOptions {
+        regex: true,
+        multiline: true,
+        ..Default::default()
+    };
+    let result =
+        replace::replace_in_content(content, r"struct 数据 \{[^}]+\}", "struct Data {}", &opts)
+            .unwrap();
+    assert!(result.changed);
+    assert!(result.new_content.contains("struct Data {}"));
+}
+
+#[test]
+fn replace_in_content_unicode_unique() {
+    let content = "α β α γ\n";
+    let opts = ReplaceOptions {
+        unique: true,
+        ..Default::default()
+    };
+    let err = replace::replace_in_content(content, "α", "x", &opts).unwrap_err();
+    assert!(err.to_string().contains("ambiguous"));
+}
+
+#[test]
+fn replace_in_content_unicode_fuzzy() {
+    // Fuzzy match with Unicode: "процесс" vs "процесс" (typo: extra с)
+    let content = "fn процесс_данных() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(
+        content,
+        "fn процесс_данныхх() {}",
+        "fn обработка() {}",
+        &opts,
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert!(result.new_content.contains("обработка"));
+}
+
+// ── #1315: replace_in_content context disambiguation and fallback ──
+
+#[test]
+fn replace_in_content_context_disambiguates_multi_match() {
+    let content =
+        "[database]\nhost = localhost\nport = 5432\n\n[cache]\nhost = localhost\nport = 6379\n";
+    let opts = ReplaceOptions {
+        before_context: Some("[database]".to_string()),
+        ..Default::default()
+    };
+    let result =
+        replace::replace_in_content(content, "host = localhost", "host = db.primary", &opts)
+            .unwrap();
+    assert!(result.changed);
+    assert_eq!(result.match_count, 1);
+    assert!(result.new_content.contains("host = db.primary"));
+    assert!(
+        result.new_content.matches("host = localhost").count() == 1,
+        "only one occurrence should be replaced"
+    );
+}
+
+#[test]
+fn replace_in_content_context_fallback_on_zero_match() {
+    // context alone (without fuzzy) should trigger fallback on zero match.
+    let content = "fn header() {}\nfn process(x: Vec<u8>) {}\nfn footer() {}\n";
+    let opts = ReplaceOptions {
+        before_context: Some("fn header()".to_string()),
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(
+        content,
+        "fn process(x: Vec<i32>) {}",
+        "fn process(x: Vec<u8>, flag: bool) {}",
+        &opts,
+    )
+    .unwrap();
+    assert!(result.changed, "context fallback should find a match");
+    assert_eq!(result.match_count, 1);
+    assert!(result.new_content.contains("flag: bool"));
+}
+
+// ── #1315: replace_text fallback path tests (context + fuzzy) ──
+// These tests exercise replace_text (file-based) with context and fuzzy
+// options. Under --all-features they go through the tx engine; under
+// --no-default-features they exercise the fixed fallback path.
+
+#[test]
+fn replace_text_before_context_disambiguates_any_path() {
+    // Tests both full and fallback paths depending on features.
+    // Full path: tx engine handles context via context_filtered_offset.
+    // Fallback path: our fix in replace_write handles it directly.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.ini");
+    fs::write(
+        &file,
+        "[database]\nhost = localhost\nport = 5432\n\n[cache]\nhost = localhost\nport = 6379\n",
+    )
+    .unwrap();
+
+    let opts = ReplaceOptions {
+        before_context: Some("[database]".to_string()),
+        ..Default::default()
+    };
+    let result = replace_text(
+        &file,
+        "host = localhost",
+        "host = db.primary",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert!(
+        result.new_content.contains("host = db.primary"),
+        "database host should be replaced"
+    );
+    assert!(
+        result.new_content.matches("host = localhost").count() == 1,
+        "cache host should remain unchanged"
+    );
+}
+
+#[test]
+fn replace_text_after_context_disambiguates_any_path() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.ini");
+    fs::write(
+        &file,
+        "[database]\nhost = localhost\nport = 5432\n\n[cache]\nhost = localhost\nport = 6379\n",
+    )
+    .unwrap();
+
+    let opts = ReplaceOptions {
+        after_context: Some("port = 5432".to_string()),
+        ..Default::default()
+    };
+    let result = replace_text(
+        &file,
+        "host = localhost",
+        "host = db.primary",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(result.changed);
+    assert!(result.new_content.contains("[database]\nhost = db.primary"));
+    assert!(result.new_content.contains("[cache]\nhost = localhost"));
+}
+
+#[test]
+fn replace_text_context_fallback_on_no_match_any_path() {
+    // When exact match fails but context is provided, resolve_with_fallback
+    // should find an anchor match. Both full and fallback paths support this.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(
+        &file,
+        "fn header() {\n}\nfn process(input: Vec<u8>) {\n}\nfn footer() {\n}\n",
+    )
+    .unwrap();
+
+    let opts = ReplaceOptions {
+        before_context: Some("fn process".to_string()),
+        ..Default::default()
+    };
+    // Stale pattern (Vec<i32> instead of Vec<u8>): exact match fails,
+    // context fallback should find the similar line.
+    let result = replace_text(
+        &file,
+        "fn process(input: Vec<i32>) {",
+        "fn process(input: Vec<u8>, flag: bool) {",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(result.changed, "context fallback should find a match");
+    assert!(
+        result.new_content.contains("flag: bool"),
+        "replacement should be applied"
+    );
+}
+
+#[test]
+fn replace_text_fuzzy_with_context_any_path() {
+    // fuzzy + context: when exact match fails, both paths use
+    // resolve_with_fallback to find the anchor match.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(
+        &file,
+        "fn setup() {}\nfn process_data(x: i32) {}\nfn cleanup() {}\n",
+    )
+    .unwrap();
+
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        before_context: Some("fn setup()".to_string()),
+        ..Default::default()
+    };
+    let result = replace_text(
+        &file,
+        "fn proccess_data(x: i32) {}",
+        "fn handle_data(x: i32) {}",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(result.changed, "fuzzy+context should resolve the typo");
+    assert!(
+        result.new_content.contains("handle_data"),
+        "replacement should be applied: {}",
+        result.new_content
+    );
+}
+
+#[test]
+fn replace_text_fuzzy_with_if_exists_any_path() {
+    // fuzzy + if_exists + context: when all fail, no error.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "fn alpha() {}\nfn beta() {}\n").unwrap();
+
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        if_exists: true,
+        before_context: Some("fn alpha()".to_string()),
+        ..Default::default()
+    };
+    let result = replace_text(
+        &file,
+        "fn completely_unrelated_xyz() {}",
+        "fn replaced() {}",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(!result.changed);
+}


### PR DESCRIPTION
## Summary

Fix two issues in the replace API:

**#1315 (bug):** The no-default-features fallback path in `replace_write()` silently discarded `before_context`, `after_context` (via `..` destructuring), and never received the `fuzzy` option from `ReplaceOptions`. Library users compiling with `--no-default-features` got no disambiguation, no fallback matching, and no error.

**#1314 (testing):** Add Unicode/multibyte text tests for `replace_in_content` API.

## Changes

### Bug fix (src/api/replace.rs)

- Destructure `before_context` and `after_context` explicitly in the fallback `replace_write` path instead of using `..`
- Pass `fuzzy` from `ReplaceOptions` through to the fallback path
- Add context disambiguation via `context_filtered_offset()` when multiple exact matches exist with context provided
- Add fuzzy/context fallback via `resolve_with_fallback()` when exact match fails and fuzzy or context is enabled
- Fix the same parity gap in `replace_in_content()`: add context disambiguation for multi-match and widen zero-match fallback to trigger on context presence (not just fuzzy)

### Tests (src/api/tests.rs)

- 13 Unicode/multibyte tests for `replace_in_content`: CJK, emoji, combining marks, Cyrillic, Greek, regex, case insensitive, word boundary, whole line, nth, insert after, multiline regex, unique, fuzzy
- 2 context disambiguation tests for `replace_in_content` (multi-match and zero-match fallback)
- 5 cross-path tests for `replace_text` verifying context disambiguation and fuzzy fallback on both the full (tx engine) and fallback (no-cli/files) paths

## Verification

`make check-fast` passes: fmt-check, clippy, test (2043 lib tests), test-no-default, test-ast-only, test-library-hygiene, integration-test, pty-test.

Closes #1314
Closes #1315