### PR TITLE
fix: context-based replace now respects --json/--jsonl flags

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -496,7 +496,27 @@ fn run_context_replace(
 
     if !result.has_changes {
         if args.if_exists {
+            if global.json || global.jsonl {
+                let output = ReplaceOutput {
+                    ok: true,
+                    match_count: 0,
+                    file_count: 0,
+                    files: vec![],
+                    diff: None,
+                };
+                global.emit_json(&output)?;
+            }
             return Ok(exit::SUCCESS);
+        }
+        if global.json || global.jsonl {
+            let output = ReplaceOutput {
+                ok: true,
+                match_count: 0,
+                file_count: 0,
+                files: vec![],
+                diff: None,
+            };
+            global.emit_json(&output)?;
         }
         if global.show_status() {
             eprintln!("no matches for '{}' in context-based replace", args.old);
@@ -504,11 +524,32 @@ fn run_context_replace(
         return Ok(exit::NO_MATCHES);
     }
 
-    let total_matches = result.exec_result.changes.len();
+    let files: Vec<ReplaceFileResult> = result
+        .exec_result
+        .changes
+        .iter()
+        .map(|(p, _, _)| ReplaceFileResult {
+            path: crate::files::relative_display(p, cwd)
+                .to_string_lossy()
+                .into_owned(),
+            match_count: 1,
+        })
+        .collect();
+    let total_matches = files.len();
+    let file_count = total_matches;
 
     // --check mode.
     if global.check {
-        if !global.quiet {
+        if global.json {
+            let output = ReplaceOutput {
+                ok: true,
+                match_count: total_matches,
+                file_count,
+                files,
+                diff: None,
+            };
+            global.emit_json(&output)?;
+        } else if !global.emit_json_items(&files)? && !global.quiet {
             println!("{total_matches} file(s) changed");
         }
         return Ok(exit::CHANGES_DETECTED);
@@ -520,17 +561,48 @@ fn run_context_replace(
         result.commit()?;
         crate::write::run_format_command(global, cwd)?;
 
-        if global.diff {
-            print!("{}", render_diffs_colored(&diffs, global.should_color()));
-        } else if !global.quiet {
-            println!("replaced in {total_matches} file(s) (context-based)");
+        let diff_text = if global.diff {
+            Some(render_diffs_plain(&diffs))
+        } else {
+            None
+        };
+        if global.json {
+            let output = ReplaceOutput {
+                ok: true,
+                match_count: total_matches,
+                file_count,
+                files,
+                diff: diff_text,
+            };
+            global.emit_json(&output)?;
+        } else if !global.emit_json_items(&files)? {
+            if global.diff {
+                print!("{}", render_diffs_colored(&diffs, global.should_color()));
+            } else if !global.quiet {
+                println!("replaced in {total_matches} file(s) (context-based)");
+            }
         }
         return Ok(exit::SUCCESS);
     }
 
     // Default / --diff: preview.
     let diffs = result.build_diffs();
-    if !diffs.is_empty() {
+    let diff_text = if !diffs.is_empty() {
+        Some(render_diffs_plain(&diffs))
+    } else {
+        None
+    };
+
+    if global.json {
+        let output = ReplaceOutput {
+            ok: true,
+            match_count: total_matches,
+            file_count,
+            files,
+            diff: diff_text,
+        };
+        global.emit_json(&output)?;
+    } else if !global.emit_json_items(&files)? && !diffs.is_empty() {
         print!("{}", render_diffs_colored(&diffs, global.should_color()));
     }
     if global.show_status() {

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -1152,4 +1152,122 @@ mod context_replace {
         let code = run(args, &GlobalFlags::test_default()).unwrap();
         assert_eq!(code, exit::SUCCESS);
     }
+
+    #[test]
+    fn context_replace_json_output_on_apply() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("config.ini");
+        fs::write(
+            &file,
+            "[server]\nhost = localhost\nport = 8080\n\n[database]\nhost = localhost\nport = 5432\n",
+        )
+        .unwrap();
+
+        let args = ReplaceArgs {
+            old: "host = localhost".to_string(),
+            new: Some("host = db.example.com".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![file.to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: Some("[database]".to_string()),
+            after_context: None,
+            unique: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+        global.json = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        let content = fs::read_to_string(&file).unwrap();
+        assert!(
+            content.contains("[database]\nhost = db.example.com"),
+            "database host should be changed"
+        );
+    }
+
+    #[test]
+    fn context_replace_json_output_on_check() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "aaa\nfoo\nbbb\nccc\nfoo\nddd\n").unwrap();
+
+        let args = ReplaceArgs {
+            old: "foo".to_string(),
+            new: Some("bar".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![file.to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: Some("aaa".to_string()),
+            after_context: None,
+            unique: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.check = true;
+        global.json = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+
+        // File should not be modified in check mode.
+        let content = fs::read_to_string(&file).unwrap();
+        assert!(
+            content.contains("foo"),
+            "file should be unchanged in check mode"
+        );
+    }
+
+    #[test]
+    fn context_replace_json_output_on_no_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.txt");
+        fs::write(&file, "hello world\n").unwrap();
+
+        let args = ReplaceArgs {
+            old: "nonexistent".to_string(),
+            new: Some("replacement".to_string()),
+            insert_before: None,
+            insert_after: None,
+            paths: vec![file.to_string_lossy().into_owned()],
+            literal: true,
+            regex: false,
+            if_exists: false,
+            multiline: false,
+            nth: None,
+            case_insensitive: false,
+            word_boundary: false,
+            whole_line: false,
+            range: None,
+            before_context: Some("hello".to_string()),
+            after_context: None,
+            unique: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.json = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
 }


### PR DESCRIPTION
Found by running patchloom against diverse CLI scenarios (fixrealloop round 1).

`run_context_replace` in `src/cmd/replace.rs` ignored `global.json`/`global.jsonl` flags in all three modes (check, apply, diff/preview), outputting plain text like `replaced in 1 file(s) (context-based)` instead of structured JSON when `--json` was specified.

**Fix:**
- Added JSON output using the same `ReplaceOutput` struct used by the non-context path
- Handles all three modes: `--check`, `--apply`, and default (diff/preview)
- No-match case also emits JSON when `--json` is set

**Tests added:**
- `context_replace_json_output_on_apply`
- `context_replace_json_output_on_check`
- `context_replace_json_output_on_no_match`