### PR TITLE
fix: JSON output for no-match cases across doc, search, and md commands

### DIFF
--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -462,7 +462,16 @@ pub(crate) fn execute_with_mode(
             let root = load_file(file)?;
             match crate::ops::doc::query::query_get(&root, selector)? {
                 crate::ops::doc::query::QueryResult::NoMatch => {
-                    Ok((String::new(), exit::NO_MATCHES))
+                    let output = match output_mode {
+                        OutputMode::Json => serde_json::to_string_pretty(
+                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
+                        )?,
+                        OutputMode::Jsonl => serde_json::to_string(
+                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
+                        )?,
+                        OutputMode::Text => String::new(),
+                    };
+                    Ok((output, exit::NO_MATCHES))
                 }
                 crate::ops::doc::query::QueryResult::Values(vals) => {
                     let refs: Vec<&serde_json::Value> = vals.iter().collect();
@@ -495,7 +504,16 @@ pub(crate) fn execute_with_mode(
             let root = load_file(file)?;
             match crate::ops::doc::query::query_keys(&root, selector)? {
                 crate::ops::doc::query::QueryKeysResult::NoMatch => {
-                    Ok((String::new(), exit::NO_MATCHES))
+                    let output = match output_mode {
+                        OutputMode::Json => serde_json::to_string_pretty(
+                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
+                        )?,
+                        OutputMode::Jsonl => serde_json::to_string(
+                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
+                        )?,
+                        OutputMode::Text => String::new(),
+                    };
+                    Ok((output, exit::NO_MATCHES))
                 }
                 crate::ops::doc::query::QueryKeysResult::NotAnObject => Ok((
                     format!("doc keys: target at '{selector}' is not an object"),
@@ -521,7 +539,16 @@ pub(crate) fn execute_with_mode(
             let root = load_file(file)?;
             match crate::ops::doc::query::query_len(&root, selector)? {
                 crate::ops::doc::query::QueryLenResult::NoMatch => {
-                    Ok((String::new(), exit::NO_MATCHES))
+                    let output = match output_mode {
+                        OutputMode::Json => serde_json::to_string_pretty(
+                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
+                        )?,
+                        OutputMode::Jsonl => serde_json::to_string(
+                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
+                        )?,
+                        OutputMode::Text => String::new(),
+                    };
+                    Ok((output, exit::NO_MATCHES))
                 }
                 crate::ops::doc::query::QueryLenResult::NotArrayOrObject => Ok((
                     format!("doc len: target at '{selector}' is not an array or object"),
@@ -545,7 +572,16 @@ pub(crate) fn execute_with_mode(
             let mut path_buf = String::new();
             flatten_value(&root, &mut path_buf, &mut entries);
             if entries.is_empty() {
-                return Ok((String::new(), exit::NO_MATCHES));
+                let output = match output_mode {
+                    OutputMode::Json => serde_json::to_string_pretty(
+                        &serde_json::json!({"ok": false, "error": "document has no leaf values to flatten"}),
+                    )?,
+                    OutputMode::Jsonl => serde_json::to_string(
+                        &serde_json::json!({"ok": false, "error": "document has no leaf values to flatten"}),
+                    )?,
+                    OutputMode::Text => String::new(),
+                };
+                return Ok((output, exit::NO_MATCHES));
             }
             match output_mode {
                 OutputMode::Json => {

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -670,6 +670,51 @@ mod error_handling {
         assert!(output.is_empty());
     }
 
+    #[test]
+    fn get_missing_selector_json_emits_error_object() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Get {
+            file: path,
+            selector: "nonexistent".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+        let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(v["ok"], false);
+        assert!(v["error"].as_str().unwrap().contains("no match"));
+    }
+
+    #[test]
+    fn keys_missing_selector_json_emits_error_object() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Keys {
+            file: path,
+            selector: "nonexistent".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+        let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(v["ok"], false);
+        assert!(v["error"].as_str().unwrap().contains("no match"));
+    }
+
+    #[test]
+    fn len_missing_selector_json_emits_error_object() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let action = DocAction::Len {
+            file: path,
+            selector: "nonexistent".into(),
+        };
+        let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+        let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(v["ok"], false);
+        assert!(v["error"].as_str().unwrap().contains("no match"));
+    }
+
     // -- error path tests ---------------------------------------------------
 
     #[test]

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -158,6 +158,12 @@ fn execute_md_op(
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("heading") && msg.contains("not found") {
+                if global.json || global.jsonl {
+                    global.emit_json(&serde_json::json!({
+                        "ok": false,
+                        "error": &msg,
+                    }))?;
+                }
                 Ok(exit::NO_MATCHES)
             } else {
                 Err(e)
@@ -377,7 +383,15 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let content =
                 std::fs::read_to_string(&path).with_context(|| format!("reading {file}"))?;
             match find_section(&content, &heading) {
-                None => Ok(exit::NO_MATCHES),
+                None => {
+                    if global.json || global.jsonl {
+                        global.emit_json(&serde_json::json!({
+                            "ok": false,
+                            "error": format!("heading {:?} not found in {file}", heading),
+                        }))?;
+                    }
+                    Ok(exit::NO_MATCHES)
+                }
                 Some((body_start, body_end)) => {
                     // Verify the table exists and the row is valid.
                     if let Err(e) =

--- a/src/cmd/md_tests.rs
+++ b/src/cmd/md_tests.rs
@@ -508,6 +508,50 @@ mod error_handling {
     }
 
     #[test]
+    fn replace_section_missing_heading_json_emits_error() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\ncontent\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::ReplaceSection {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Missing".into(),
+                stdin: false,
+                content: Some("new".into()),
+            },
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_apply();
+        global.json = true;
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+        // The JSON error is emitted via global.emit_json which writes to
+        // stdout. We verify the exit code; the unit tests in output.rs
+        // verify that emit_json produces valid JSON.
+    }
+
+    #[test]
+    fn table_append_missing_heading_json_emits_error() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("test.md");
+        fs::write(&file, "# Title\n| H1 |\n|---|\n| A |\n").unwrap();
+
+        let args = MdArgs {
+            action: MdAction::TableAppend {
+                file: file.to_str().unwrap().to_string(),
+                heading: "Missing".into(),
+                row: "| X |".into(),
+            },
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_apply();
+        global.json = true;
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
+    }
+
+    #[test]
     fn table_append_no_table_returns_error() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("test.md");

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -68,8 +68,17 @@ pub struct SearchArgs {
 struct SearchOutput {
     ok: bool,
     matches: Vec<SearchMatch>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    files: Vec<SearchFileEntry>,
     match_count: usize,
     file_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct SearchFileEntry {
+    path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    count: Option<usize>,
 }
 
 #[derive(Debug, Serialize)]
@@ -142,11 +151,33 @@ pub(crate) fn format_results(
     let mut out = String::new();
 
     if global.json {
+        let files: Vec<SearchFileEntry> = if args.files_with_matches {
+            results
+                .file_match_counts
+                .keys()
+                .map(|p| SearchFileEntry {
+                    path: p.to_string(),
+                    count: None,
+                })
+                .collect()
+        } else if args.count {
+            results
+                .file_match_counts
+                .iter()
+                .map(|(p, c)| SearchFileEntry {
+                    path: p.to_string(),
+                    count: Some(*c),
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
         let payload = SearchOutput {
             ok: true,
             match_count: results.file_match_counts.values().sum(),
             file_count: results.file_match_counts.len(),
             matches: results.matches,
+            files,
         };
         out = serde_json::to_string_pretty(&payload)?;
         out.push('\n');
@@ -331,6 +362,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             match_count: 0,
             file_count: 0,
             matches: vec![],
+            files: vec![],
         };
         global.emit_json(&payload)?;
         if global.show_status() {
@@ -740,6 +772,44 @@ mod tests {
             1,
             "second match column"
         );
+    }
+
+    #[test]
+    fn json_files_with_matches_lists_file_paths() {
+        let dir = make_test_dir();
+        let mut args = make_args("Hello", vec![dir.path().to_string_lossy().into_owned()]);
+        args.files_with_matches = true;
+        let mut global = GlobalFlags::test_default();
+        global.json = true;
+        let results = collect_matches(&args, &global).unwrap();
+        let output = format_results(results, &args, &global).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert_eq!(v["ok"], serde_json::json!(true));
+        assert_eq!(v["file_count"], serde_json::json!(1));
+        // matches is empty in files-with-matches mode (by design).
+        assert_eq!(v["matches"].as_array().unwrap().len(), 0);
+        // files array must contain the matching file paths.
+        let files = v["files"].as_array().expect("files array must be present");
+        assert_eq!(files.len(), 1);
+        assert!(files[0]["path"].as_str().unwrap().ends_with("hello.txt"));
+    }
+
+    #[test]
+    fn json_count_lists_file_counts() {
+        let dir = make_test_dir();
+        let mut args = make_args("Hello", vec![dir.path().to_string_lossy().into_owned()]);
+        args.count = true;
+        let mut global = GlobalFlags::test_default();
+        global.json = true;
+        let results = collect_matches(&args, &global).unwrap();
+        let output = format_results(results, &args, &global).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert_eq!(v["ok"], serde_json::json!(true));
+        // files array must contain the per-file counts.
+        let files = v["files"].as_array().expect("files array must be present");
+        assert_eq!(files.len(), 1);
+        assert!(files[0]["path"].as_str().unwrap().ends_with("hello.txt"));
+        assert_eq!(files[0]["count"], serde_json::json!(2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three related JSON output contract bugs found by running patchloom CLI against diverse runtime scenarios. All follow the same pattern: commands return zero bytes on stdout when `--json`/`--jsonl` is set and the operation finds no match, leaving agents with no structured signal.

### Bug 1: doc read-only commands (commit 1)

`doc get`, `doc keys`, `doc len`, and `doc flatten` returned zero bytes on stdout when the selector matched nothing.

Now emit `{"ok": false, "error": "no match for selector: <selector>"}`.

### Bug 2: search --json aggregation modes (commit 2)

`search --json --files-with-matches` and `search --json --count` returned `matches: []` with correct counts but no way to identify which files matched.

Now both modes populate a `files` array: `[{"path": "...", "count": N}]`.

### Bug 3: md heading-not-found (commit 3)

`md replace-section`, `insert-before-heading`, `insert-after-heading`, `upsert-bullet`, and `table-append` returned zero bytes when the target heading was not found.

Now emit `{"ok": false, "error": "heading ... not found ..."}`.

## Testing

- 7 new unit tests covering all three bugs
- `make check-fast` passes (2054 tests)
- Verified with runtime CLI scenarios in temp dirs