### PR TITLE
fix: migrate redundant json flag checks to emit_json() return value

### DIFF
--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -407,13 +407,11 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
 
 pub fn run(args: AgentRulesArgs, global: &crate::cli::global::GlobalFlags) -> anyhow::Result<u8> {
     let output = generate_agent_rules(&args);
-    if global.json || global.jsonl {
-        global.emit_json(&serde_json::json!({
-            "ok": true,
-            "format": "markdown",
-            "content": output,
-        }))?;
-    } else {
+    if !global.emit_json(&serde_json::json!({
+        "ok": true,
+        "format": "markdown",
+        "content": output,
+    }))? {
         print!("{output}");
     }
     Ok(exit::SUCCESS)

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -151,9 +151,7 @@ fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                  TOML, YAML, JSON, Shell.",
                 lang, args.path,
             );
-            if global.json || global.jsonl {
-                global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?;
-            } else {
+            if !global.emit_json(&serde_json::json!({"ok": false, "error": msg}))? {
                 eprintln!("{msg}");
             }
             return Ok(exit::NO_MATCHES);
@@ -213,12 +211,10 @@ fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if any_output {
         Ok(exit::SUCCESS)
     } else {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": format!("no symbols found in {}", args.path),
-            }))?;
-        }
+        global.emit_json(&serde_json::json!({
+            "ok": false,
+            "error": format!("no symbols found in {}", args.path),
+        }))?;
         Ok(exit::NO_MATCHES)
     }
 }
@@ -262,19 +258,16 @@ fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         .saturating_sub(args.context.saturating_add(1));
     let end = sym.end_line.saturating_add(args.context).min(lines.len());
 
-    if global.json || global.jsonl {
-        let content: String = lines[start..end].iter().map(|l| format!("{l}\n")).collect();
-        let obj = serde_json::json!({
-            "file": args.path,
-            "symbol": sym.name,
-            "kind": sym.kind.to_string(),
-            "start_line": sym.start_line,
-            "end_line": sym.end_line,
-            "signature": sym.signature,
-            "content": content,
-        });
-        global.emit_json(&obj)?;
-    } else {
+    let content: String = lines[start..end].iter().map(|l| format!("{l}\n")).collect();
+    if !global.emit_json(&serde_json::json!({
+        "file": args.path,
+        "symbol": sym.name,
+        "kind": sym.kind.to_string(),
+        "start_line": sym.start_line,
+        "end_line": sym.end_line,
+        "signature": sym.signature,
+        "content": content,
+    }))? {
         for (i, line) in lines[start..end].iter().enumerate() {
             let line_num = start + i + 1;
             println!("{line_num:>4} | {line}");
@@ -370,12 +363,10 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if operations.is_empty() {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": format!("symbol '{}' not found in {}", args.old_name, args.path),
-            }))?;
-        }
+        global.emit_json(&serde_json::json!({
+            "ok": false,
+            "error": format!("symbol '{}' not found in {}", args.old_name, args.path),
+        }))?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -388,13 +379,10 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let result = crate::tx::engine::execute_operations(operations, options)?;
 
     if global.check {
-        if global.json || global.jsonl {
-            let obj = serde_json::json!({
-                "ok": true,
-                "files_changed": files_changed,
-            });
-            global.emit_json(&obj)?;
-        }
+        global.emit_json(&serde_json::json!({
+            "ok": true,
+            "files_changed": files_changed,
+        }))?;
         return Ok(exit::CHANGES_DETECTED);
     }
 
@@ -403,13 +391,11 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         result.commit()?;
         crate::write::run_format_command(global, &cwd)?;
 
-        if global.json || global.jsonl {
-            let obj = serde_json::json!({
-                "ok": true,
-                "files_changed": diffs.len(),
-            });
-            global.emit_json(&obj)?;
-        } else if !global.quiet {
+        if !global.emit_json(&serde_json::json!({
+            "ok": true,
+            "files_changed": diffs.len(),
+        }))? && !global.quiet
+        {
             for d in &diffs {
                 eprintln!("{}: renamed", d.path);
             }
@@ -477,21 +463,20 @@ fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::Result<u8> 
         if !vr.result.valid {
             all_valid = false;
         }
-        if global.json || global.jsonl {
-            let obj = serde_json::json!({
-                "file": vr.display,
-                "valid": vr.result.valid,
-                "language": vr.result.language,
-                "errors": vr.result.errors,
-            });
-            global.emit_json(&obj)?;
-        } else if !vr.result.valid {
-            eprintln!("{}: INVALID ({})", vr.display, vr.result.language);
-            for err in &vr.result.errors {
-                eprintln!("  line {}:{}: {}", err.line, err.column, err.text.trim());
+        if !global.emit_json(&serde_json::json!({
+            "file": vr.display,
+            "valid": vr.result.valid,
+            "language": vr.result.language,
+            "errors": vr.result.errors,
+        }))? {
+            if !vr.result.valid {
+                eprintln!("{}: INVALID ({})", vr.display, vr.result.language);
+                for err in &vr.result.errors {
+                    eprintln!("  line {}:{}: {}", err.line, err.column, err.text.trim());
+                }
+            } else if !global.quiet {
+                eprintln!("{}: OK ({})", vr.display, vr.result.language);
             }
-        } else if !global.quiet {
-            eprintln!("{}: OK ({})", vr.display, vr.result.language);
         }
     }
 
@@ -577,16 +562,13 @@ fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     'outer: for result in &file_results {
         for m in &result.matches {
             total_matches += 1;
-            if global.json || global.jsonl {
-                let obj = serde_json::json!({
-                    "file": result.display,
-                    "line": m.line,
-                    "column": m.column,
-                    "text": m.text,
-                    "captures": m.captures,
-                });
-                global.emit_json(&obj)?;
-            } else {
+            if !global.emit_json(&serde_json::json!({
+                "file": result.display,
+                "line": m.line,
+                "column": m.column,
+                "text": m.text,
+                "captures": m.captures,
+            }))? {
                 println!(
                     "{}:{}:{}: {}",
                     result.display,
@@ -607,12 +589,10 @@ fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if total_matches == 0 {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": format!("no matches for pattern in {}", args.path),
-            }))?;
-        }
+        global.emit_json(&serde_json::json!({
+            "ok": false,
+            "error": format!("no matches for pattern in {}", args.path),
+        }))?;
         Ok(exit::NO_MATCHES)
     } else {
         Ok(exit::SUCCESS)
@@ -663,23 +643,18 @@ fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if all_refs.is_empty() {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": format!("no references found for '{}' in {}", args.symbol, args.path),
-            }))?;
-        }
+        global.emit_json(&serde_json::json!({
+            "ok": false,
+            "error": format!("no references found for '{}' in {}", args.symbol, args.path),
+        }))?;
         return Ok(exit::NO_MATCHES);
     }
 
-    if global.json || global.jsonl {
-        let obj = serde_json::json!({
-            "symbol": args.symbol,
-            "references": all_refs,
-            "count": all_refs.len(),
-        });
-        global.emit_json(&obj)?;
-    } else {
+    if !global.emit_json(&serde_json::json!({
+        "symbol": args.symbol,
+        "references": all_refs,
+        "count": all_refs.len(),
+    }))? {
         for r in &all_refs {
             let kind_label = match r.kind {
                 crate::ast::refs::RefKind::Definition => "def",
@@ -755,13 +730,12 @@ fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
             if global.json || global.jsonl {
                 for imp in &matching {
-                    let obj = serde_json::json!({
+                    global.emit_json(&serde_json::json!({
                         "file": display,
                         "imports": imp.path,
                         "line": imp.line,
                         "raw": imp.raw,
-                    });
-                    global.emit_json(&obj)?;
+                    }))?;
                 }
             } else {
                 for imp in &matching {
@@ -789,13 +763,10 @@ fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
         for result in &results {
             any_output = true;
-            if global.json || global.jsonl {
-                let obj = serde_json::json!({
-                    "file": result.display,
-                    "imports": result.imports,
-                });
-                global.emit_json(&obj)?;
-            } else {
+            if !global.emit_json(&serde_json::json!({
+                "file": result.display,
+                "imports": result.imports,
+            }))? {
                 println!("{}", result.display);
                 println!("  imports:");
                 for imp in &result.imports {
@@ -809,12 +780,10 @@ fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if any_output {
         Ok(exit::SUCCESS)
     } else {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": format!("no imports found in {}", args.path),
-            }))?;
-        }
+        global.emit_json(&serde_json::json!({
+            "ok": false,
+            "error": format!("no imports found in {}", args.path),
+        }))?;
         Ok(exit::NO_MATCHES)
     }
 }
@@ -873,22 +842,14 @@ fn run_map(args: MapArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let entries = crate::ast::map::generate_map(&file_pairs, &opts);
 
     if entries.is_empty() {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": format!("no symbols found in {}", args.path),
-            }))?;
-        }
+        global.emit_json(&serde_json::json!({
+            "ok": false,
+            "error": format!("no symbols found in {}", args.path),
+        }))?;
         return Ok(exit::NO_MATCHES);
     }
 
-    if global.jsonl {
-        for entry in &entries {
-            global.emit_json(entry)?;
-        }
-    } else if global.json {
-        global.emit_json(&entries)?;
-    } else {
+    if !global.emit_json_items(&entries)? {
         print!("{}", crate::ast::map::render_tree(&entries));
     }
 
@@ -980,9 +941,9 @@ fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("not found") || msg.contains("no matches") {
-                if global.json || global.jsonl {
-                    global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?;
-                } else if !global.quiet {
+                if !global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?
+                    && !global.quiet
+                {
                     eprintln!("{msg}");
                 }
                 Ok(exit::NO_MATCHES)
@@ -1030,26 +991,22 @@ fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let nodes = crate::ast::impact::compute_impact(&args.symbol, &file_pairs, args.depth);
 
     if nodes.is_empty() {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": format!("no references found for '{}'", args.symbol),
-            }))?;
-        } else if !global.quiet {
+        if !global.emit_json(&serde_json::json!({
+            "ok": false,
+            "error": format!("no references found for '{}'", args.symbol),
+        }))? && !global.quiet
+        {
             eprintln!("no references found for '{}'", args.symbol);
         }
         return Ok(exit::NO_MATCHES);
     }
 
-    if global.json || global.jsonl {
-        let obj = serde_json::json!({
-            "symbol": args.symbol,
-            "depth": args.depth,
-            "impact": nodes,
-            "direct_count": nodes.len(),
-        });
-        global.emit_json(&obj)?;
-    } else {
+    if !global.emit_json(&serde_json::json!({
+        "symbol": args.symbol,
+        "depth": args.depth,
+        "impact": nodes,
+        "direct_count": nodes.len(),
+    }))? {
         print!(
             "{}",
             crate::ast::impact::render_impact_tree(&args.symbol, &nodes, 0)
@@ -1104,26 +1061,22 @@ fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
 
     if changes.is_empty() {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": "no structural changes",
-            }))?;
-        } else if !global.quiet {
+        if !global.emit_json(&serde_json::json!({
+            "ok": false,
+            "error": "no structural changes",
+        }))? && !global.quiet
+        {
             eprintln!("no structural changes");
         }
         return Ok(exit::NO_MATCHES);
     }
 
-    if global.json || global.jsonl {
-        let obj = serde_json::json!({
-            "file": args.path,
-            "from": args.from,
-            "to": args.to.as_deref().unwrap_or("working tree"),
-            "changes": changes,
-        });
-        global.emit_json(&obj)?;
-    } else {
+    if !global.emit_json(&serde_json::json!({
+        "file": args.path,
+        "from": args.from,
+        "to": args.to.as_deref().unwrap_or("working tree"),
+        "changes": changes,
+    }))? {
         print!("{}", crate::ast::diff::render_changes(&args.path, &changes));
     }
 

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -405,16 +405,15 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     crate::verbose!("batch: parsed {} operations from input", operations.len());
     if operations.is_empty() {
-        if global.json || global.jsonl {
-            global.emit_json(&serde_json::json!({
-                "ok": true,
-                "status": "success",
-                "files_changed": 0,
-                "files_created": 0,
-                "files_deleted": 0,
-                "changes": []
-            }))?;
-        } else if !global.quiet {
+        if !global.emit_json(&serde_json::json!({
+            "ok": true,
+            "status": "success",
+            "files_changed": 0,
+            "files_created": 0,
+            "files_deleted": 0,
+            "changes": []
+        }))? && !global.quiet
+        {
             eprintln!("batch: no operations found in input");
         }
         return Ok(exit::SUCCESS);

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -734,16 +734,13 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             Err(e) => {
                 let msg = e.to_string();
                 if msg.contains("matched nothing") {
-                    if global.json || global.jsonl {
-                        global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?;
-                    }
+                    global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?;
                     return Ok(exit::NO_MATCHES);
                 }
                 // TypeError or other engine error → FAILURE
-                if global.json || global.jsonl {
-                    let err_obj = serde_json::json!({"ok": false, "error": &msg});
-                    global.emit_json(&err_obj)?;
-                } else if !global.quiet {
+                if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))?
+                    && !global.quiet
+                {
                     eprintln!("{msg}");
                 }
                 return Ok(exit::FAILURE);

--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -59,10 +59,7 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         .unwrap_or(None);
     let strict = crate::plan::effective_strict(plan.strict, config_strict, false);
 
-    if global.json || global.jsonl {
-        let summary = build_json_summary(&plan, strict);
-        global.emit_json(&summary)?;
-    } else if !global.quiet {
+    if !global.emit_json(&build_json_summary(&plan, strict))? && !global.quiet {
         print_human_summary(&plan, strict);
     }
 

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -158,12 +158,10 @@ fn execute_md_op(
         Err(e) => {
             let msg = e.to_string();
             if msg.contains("heading") && msg.contains("not found") {
-                if global.json || global.jsonl {
-                    global.emit_json(&serde_json::json!({
-                        "ok": false,
-                        "error": &msg,
-                    }))?;
-                }
+                global.emit_json(&serde_json::json!({
+                    "ok": false,
+                    "error": &msg,
+                }))?;
                 Ok(exit::NO_MATCHES)
             } else {
                 Err(e)
@@ -284,13 +282,9 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let (_new, removed) = dedupe_headings_in(&original);
 
             // Emit removed headings as side-channel output.
-            if !removed.is_empty() {
-                if global.json || global.jsonl {
-                    global.emit_json_items(&removed)?;
-                } else if !global.quiet {
-                    for h in &removed {
-                        eprintln!("md: removed duplicate: {h}");
-                    }
+            if !removed.is_empty() && !global.emit_json_items(&removed)? && !global.quiet {
+                for h in &removed {
+                    eprintln!("md: removed duplicate: {h}");
                 }
             }
 
@@ -348,9 +342,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 std::fs::read_to_string(&path).with_context(|| format!("reading {file}"))?;
             let issues = lint_agents_content(&content);
 
-            if global.json || global.jsonl {
-                global.emit_json_items(&issues)?;
-            } else if !global.quiet {
+            if !global.emit_json_items(&issues)? && !global.quiet {
                 for issue in &issues {
                     match (issue.line, &issue.heading) {
                         (Some(ln), Some(h)) => {
@@ -384,12 +376,10 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 std::fs::read_to_string(&path).with_context(|| format!("reading {file}"))?;
             match find_section(&content, &heading) {
                 None => {
-                    if global.json || global.jsonl {
-                        global.emit_json(&serde_json::json!({
-                            "ok": false,
-                            "error": format!("heading {:?} not found in {file}", heading),
-                        }))?;
-                    }
+                    global.emit_json(&serde_json::json!({
+                        "ok": false,
+                        "error": format!("heading {:?} not found in {file}", heading),
+                    }))?;
                     Ok(exit::NO_MATCHES)
                 }
                 Some((body_start, body_end)) => {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -253,19 +253,17 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if args.unique {
         for r in &replacements {
             if r.match_count > 1 {
-                if global.json || global.jsonl {
-                    let output = ReplaceOutput {
-                        ok: false,
+                let output = ReplaceOutput {
+                    ok: false,
+                    match_count: r.match_count,
+                    file_count: 1,
+                    files: vec![ReplaceFileResult {
+                        path: r.display_path.clone(),
                         match_count: r.match_count,
-                        file_count: 1,
-                        files: vec![ReplaceFileResult {
-                            path: r.display_path.clone(),
-                            match_count: r.match_count,
-                        }],
-                        diff: None,
-                    };
-                    global.emit_json(&output)?;
-                }
+                    }],
+                    diff: None,
+                };
+                global.emit_json(&output)?;
                 if global.show_status() {
                     eprintln!(
                         "ambiguous match: pattern {:?} matches {} times in {}; use --nth or add context to disambiguate",
@@ -281,19 +279,6 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if replacements.is_empty() {
         if args.if_exists {
-            if global.json || global.jsonl {
-                let output = ReplaceOutput {
-                    ok: true,
-                    match_count: 0,
-                    file_count: 0,
-                    files: vec![],
-                    diff: None,
-                };
-                global.emit_json(&output)?;
-            }
-            return Ok(exit::SUCCESS);
-        }
-        if global.json || global.jsonl {
             let output = ReplaceOutput {
                 ok: true,
                 match_count: 0,
@@ -302,7 +287,16 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 diff: None,
             };
             global.emit_json(&output)?;
+            return Ok(exit::SUCCESS);
         }
+        let output = ReplaceOutput {
+            ok: true,
+            match_count: 0,
+            file_count: 0,
+            files: vec![],
+            diff: None,
+        };
+        global.emit_json(&output)?;
         if global.show_status() {
             let path_desc = if args.paths.is_empty() {
                 ".".to_string()
@@ -496,19 +490,6 @@ fn run_context_replace(
 
     if !result.has_changes {
         if args.if_exists {
-            if global.json || global.jsonl {
-                let output = ReplaceOutput {
-                    ok: true,
-                    match_count: 0,
-                    file_count: 0,
-                    files: vec![],
-                    diff: None,
-                };
-                global.emit_json(&output)?;
-            }
-            return Ok(exit::SUCCESS);
-        }
-        if global.json || global.jsonl {
             let output = ReplaceOutput {
                 ok: true,
                 match_count: 0,
@@ -517,7 +498,16 @@ fn run_context_replace(
                 diff: None,
             };
             global.emit_json(&output)?;
+            return Ok(exit::SUCCESS);
         }
+        let output = ReplaceOutput {
+            ok: true,
+            match_count: 0,
+            file_count: 0,
+            files: vec![],
+            diff: None,
+        };
+        global.emit_json(&output)?;
         if global.show_status() {
             eprintln!("no matches for '{}' in context-based replace", args.old);
         }

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -51,18 +51,14 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if args.list {
         let sessions = backup::list_sessions(&cwd)?;
         if sessions.is_empty() {
-            if global.json || global.jsonl {
-                let empty: Vec<()> = vec![];
-                global.emit_json(&empty)?;
-            } else if global.show_status() {
+            let empty: Vec<()> = vec![];
+            if !global.emit_json(&empty)? && global.show_status() {
                 eprintln!("no backup sessions found");
             }
             return Ok(exit::NO_MATCHES);
         }
 
-        if global.json || global.jsonl {
-            global.emit_json_items(&sessions)?;
-        } else if !global.quiet {
+        if !global.emit_json_items(&sessions)? && !global.quiet {
             for s in &sessions {
                 let file_count = s.entries.len();
                 let actions: Vec<String> = s
@@ -87,12 +83,11 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         // Use the most recent session.
         let sessions = backup::list_sessions(&cwd)?;
         if sessions.is_empty() {
-            if global.json || global.jsonl {
-                global.emit_json(&serde_json::json!({
-                    "ok": false,
-                    "error": "no backup sessions found",
-                }))?;
-            } else if global.show_status() {
+            if !global.emit_json(&serde_json::json!({
+                "ok": false,
+                "error": "no backup sessions found",
+            }))? && global.show_status()
+            {
                 eprintln!("no backup sessions found");
             }
             return Ok(exit::NO_MATCHES);
@@ -122,22 +117,20 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             })
             .collect();
 
-        if global.json || global.jsonl {
-            let output = UndoPreviewOutput {
-                ok: true,
-                status: "changes_detected",
-                session: timestamp.clone(),
-                file_count: entries.len(),
-                entries,
-            };
-            global.emit_json(&output)?;
-        } else if !global.quiet {
+        let output = UndoPreviewOutput {
+            ok: true,
+            status: "changes_detected",
+            session: timestamp.clone(),
+            file_count: entries.len(),
+            entries,
+        };
+        if !global.emit_json(&output)? && !global.quiet {
             println!(
                 "Would restore session {} ({} file(s)):",
                 timestamp,
                 session.entries.len()
             );
-            for entry in &entries {
+            for entry in &output.entries {
                 println!("  {} -> {}", entry.path, entry.action);
             }
         }
@@ -154,14 +147,13 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // the next-oldest session instead of replaying the same one.
     backup::remove_session(&cwd, &timestamp)?;
     crate::verbose!("undo: restored {} file(s)", restored);
-    if global.json || global.jsonl {
-        global.emit_json(&serde_json::json!({
-            "ok": true,
-            "status": "restored",
-            "session": timestamp,
-            "file_count": restored,
-        }))?;
-    } else if global.show_status() {
+    if !global.emit_json(&serde_json::json!({
+        "ok": true,
+        "status": "restored",
+        "session": timestamp,
+        "file_count": restored,
+    }))? && global.show_status()
+    {
         eprintln!("restored {restored} file(s) from session {timestamp}");
     }
 


### PR DESCRIPTION
Replace `if global.json || global.jsonl { global.emit_json(...)? } else { ... }` with `if !global.emit_json(...)? { ... }` across 8 files.

The `emit_json()` method already checks `json`/`jsonl` internally and returns `Ok(true)` when JSON was emitted, making the outer flag checks redundant.

**Migrated 37 sites across 8 files:**

| File | Sites | Description |
|------|-------|-------------|
| `agent_rules.rs` | 1 | JSON output with text fallback |
| `ast.rs` | 18 | read, rename, validate, search, refs, deps, map, replace, impact, diff |
| `batch.rs` | 1 | Empty operations |
| `doc.rs` | 2 | Matched-nothing and engine error handlers |
| `explain.rs` | 1 | Human summary |
| `md.rs` | 4 | Heading errors, dedupe, lint, table-append |
| `replace.rs` | 5 | Unique check, if_exists, no-match, context replace |
| `undo.rs` | 5 | List empty, list sessions, no-sessions, preview, apply |

**Not migrated (legitimate routing guards):**
- 3-way json/compact/human branching in `ast list`
- Multi-item loop emission in `ast deps reverse`
- Pre-formatted output guards in `doc`/`search`/`patch`

Net: -84 lines (-268 removed, +184 added). All 2060 unit tests pass.

Closes #1324