### PR TITLE
test: add emit_json and emit_json_items unit tests

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -470,6 +470,57 @@ mod tests {
     use super::*;
 
     #[test]
+    fn emit_json_returns_false_when_neither_flag() {
+        let g = GlobalFlags::test_default();
+        assert!(!g.emit_json(&serde_json::json!({"a":1})).unwrap());
+    }
+
+    #[test]
+    fn emit_json_returns_true_for_json_flag() {
+        let g = GlobalFlags {
+            json: true,
+            ..GlobalFlags::test_default()
+        };
+        assert!(g.emit_json(&serde_json::json!({"a":1})).unwrap());
+    }
+
+    #[test]
+    fn emit_json_returns_true_for_jsonl_flag() {
+        let g = GlobalFlags {
+            jsonl: true,
+            ..GlobalFlags::test_default()
+        };
+        assert!(g.emit_json(&serde_json::json!({"a":1})).unwrap());
+    }
+
+    #[test]
+    fn emit_json_items_returns_false_when_neither_flag() {
+        let g = GlobalFlags::test_default();
+        let items: Vec<serde_json::Value> = vec![];
+        assert!(!g.emit_json_items(&items).unwrap());
+    }
+
+    #[test]
+    fn emit_json_items_returns_true_for_json_flag() {
+        let g = GlobalFlags {
+            json: true,
+            ..GlobalFlags::test_default()
+        };
+        let items = vec![serde_json::json!(1), serde_json::json!(2)];
+        assert!(g.emit_json_items(&items).unwrap());
+    }
+
+    #[test]
+    fn emit_json_items_returns_true_for_jsonl_flag() {
+        let g = GlobalFlags {
+            jsonl: true,
+            ..GlobalFlags::test_default()
+        };
+        let items = vec![serde_json::json!(1), serde_json::json!(2)];
+        assert!(g.emit_json_items(&items).unwrap());
+    }
+
+    #[test]
     fn should_apply_returns_true_when_apply_set() {
         let g = GlobalFlags::test_apply();
         assert!(g.should_apply());

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -316,8 +316,8 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::NO_MATCHES);
         // JSON error object is emitted via global.emit_json which writes to
-        // stdout. We verify the exit code; emit_json correctness is covered
-        // by its own unit tests.
+        // stdout. We verify the exit code; emit_json return-value correctness
+        // is covered by unit tests in cli/global.rs.
     }
 
     #[test]


### PR DESCRIPTION
Add 6 dedicated unit tests for `GlobalFlags::emit_json()` and `GlobalFlags::emit_json_items()` return values.

These methods had zero direct unit tests despite being used across 37+ call sites after the emit_json pattern migration in PR #1326 (which closed #1324). The undo.rs test comments even claimed "emit_json correctness is covered by its own unit tests" before those tests existed.

**Tests added:**
- emit_json returns false when neither --json nor --jsonl is set
- emit_json returns true for --json flag
- emit_json returns true for --jsonl flag
- emit_json_items returns false when neither flag is set
- emit_json_items returns true for --json flag
- emit_json_items returns true for --jsonl flag

Also fixes a misleading comment in undo.rs.

Ref #1324