### PR TITLE
fix: use numeric version in agent-rules tx plan example

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -166,7 +166,7 @@ patchloom patch merge changes.patch --apply --allow-conflicts
 ```bash
 # Same via transaction plan (JSON):
 patchloom tx - --apply <<'EOF'
-{"version": "1", "operations": [
+{"version": 1, "operations": [
 {"op": "patch.apply", "diff": "...", "on_stale": "merge", "allow_conflicts": true}
 ]}
 EOF

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -291,7 +291,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                 "```bash\n\
                  # Same via transaction plan (JSON):\n\
                  patchloom tx - --apply <<'EOF'\n\
-                 {\"version\": \"1\", \"operations\": [\n\
+                 {\"version\": 1, \"operations\": [\n\
                    {\"op\": \"patch.apply\", \"diff\": \"...\", \"on_stale\": \"merge\", \"allow_conflicts\": true}\n\
                  ]}\n\
                  EOF\n\


### PR DESCRIPTION
## Problem

The patch recovery example in `agent-rules` output used `"version": "1"` (string), but `Plan.version` is `u32`. Agents that copy the example verbatim get:

```
tx: plan parse error: invalid type: string "1", expected u32
```

The multi-file refactoring example on line 318 already used the correct `"version": 1` (numeric).

## Fix

Change `"version": "1"` to `"version": 1` in the patch recovery example. Regenerated PATCHLOOM.md via `make sync-patchloom-md`.

Found by fixrealloop Round 4 runtime testing.