### PR TITLE
test: add NO_MATCHES exit code tests for AST subcommands and update rmcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52d21e5b342699bc4de690e6104fc4e43255e4e8420ff0f2cbb963aac09da6f"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c68cec74c5b3ac73ff46375ae49e161637bda80bba70f0d5db641583bb308ee"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1986,7 +1986,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2385,7 +2385,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3083,7 +3083,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -401,6 +401,123 @@ fn test_ast_list_unsupported_file_reports_language() {
         .stderr(predicates::str::contains("Rust"));
 }
 
+// --- NO_MATCHES (exit 3) tests for AST subcommands ---
+// These verify the exit code contract agents rely on for control flow.
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_search_no_match_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, "fn foo() {}\n").unwrap();
+    // Query for class_declaration which does not exist in Rust
+    patchloom_in(dir.path())
+        .args(["ast", "search", "(class_declaration) @cls", "lib.rs"])
+        .assert()
+        .code(3);
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_refs_no_references_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("r.rs");
+    // `lonely` is defined but never called, so refs should find nothing.
+    fs::write(&f, "fn lonely() {}\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "refs", "lonely", "r.rs"])
+        .assert()
+        .code(3);
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_deps_no_imports_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("d.rs");
+    // No use/import statements
+    fs::write(&f, "fn no_deps() {}\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "deps", "d.rs"])
+        .assert()
+        .code(3);
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_map_no_symbols_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("empty.rs");
+    // A file with only a comment has no symbols
+    fs::write(&f, "// just a comment\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "map", "."])
+        .assert()
+        .code(3);
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_replace_missing_symbol_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("test.rs");
+    fs::write(&f, "fn real() {}\n").unwrap();
+    patchloom_in(dir.path())
+        .args([
+            "ast",
+            "replace",
+            "test.rs",
+            "nonexistent",
+            "--old",
+            "x",
+            "--new",
+            "y",
+            "--apply",
+        ])
+        .assert()
+        .code(3);
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_impact_no_refs_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("i.rs");
+    // `isolated` is defined but never referenced
+    fs::write(&f, "fn isolated() {}\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "impact", "isolated", "i.rs"])
+        .assert()
+        .code(3);
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_diff_no_changes_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("same.rs");
+    fs::write(&f, "fn stable() {}\n").unwrap();
+    let git = |args: &[&str]| {
+        std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir.path())
+            .env("GIT_AUTHOR_NAME", "CI")
+            .env("GIT_AUTHOR_EMAIL", "ci@example.com")
+            .env("GIT_COMMITTER_NAME", "CI")
+            .env("GIT_COMMITTER_EMAIL", "ci@example.com")
+            .status()
+            .expect("git command failed to spawn")
+    };
+    assert!(git(&["init", "-q"]).success());
+    assert!(git(&["add", "-A"]).success());
+    assert!(git(&["commit", "-q", "-m", "init"]).success());
+    // File unchanged after commit, so diff should find no structural changes.
+    patchloom_in(dir.path())
+        .args(["ast", "diff", "same.rs", "--from", "HEAD"])
+        .assert()
+        .code(3);
+}
+
 /// `--glob` flag should filter files in AST directory scanning (#1171).
 #[test]
 fn test_ast_list_respects_glob_flag() {

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1924,5 +1924,32 @@ fn test_doc_delete_numeric_dot_notation_on_array() {
 }
 
 // ---------------------------------------------------------------------------
+// NO_MATCHES exit code for write operations (#QA: string-based error guard)
+// ---------------------------------------------------------------------------
+
+/// Write operations that select a non-existent key should exit 3 (NO_MATCHES),
+/// not exit 1 (FAILURE). This guards the `msg.contains("matched nothing")`
+/// classification at doc.rs:736.
+#[test]
+fn test_doc_update_nonexistent_selector_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"a": 1}"#).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "doc",
+            "update",
+            file.to_str().unwrap(),
+            "nonexistent",
+            "99",
+            "--apply",
+        ])
+        .assert()
+        .code(3);
+}
+
+// ---------------------------------------------------------------------------
 // Symlink integration tests (#231 coverage)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Multi-perspective improvement rotation findings:

### Tests (QA Engineer perspective)
Add 8 integration tests for exit code 3 (NO_MATCHES) contract:
- `ast search` with non-matching pattern
- `ast refs` with unreferenced symbol
- `ast deps` on file with no imports
- `ast map` on directory with no symbols
- `ast replace` with missing symbol
- `ast impact` with unreferenced symbol
- `ast diff` with no structural changes
- `doc update` with nonexistent selector

These guard the exit code contract AI agents rely on for control flow.
Previously only `ast list` had a NO_MATCHES exit code test.

### Dependency update (Maintainer perspective)
Update rmcp 2.0.0 -> 2.1.0 (semver-compatible, all 47 MCP tests pass).

### Other perspectives (12 of 14 no-op)
Developer, End User, Ops/SRE, Security, Product Manager, Spec/Contract,
Performance, Backward Compatibility, Adversarial, Architecture, New
Contributor, and Observability all returned no actionable findings.