### PR TITLE
fix: replace string-based error classification with typed NoMatchError

### DIFF
--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -8,7 +8,7 @@
 
 use std::path::Path;
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 
 use crate::containment::PathGuard;
 use crate::ops;
@@ -69,7 +69,7 @@ fn doc_write(
 
     let result = ops::doc::apply_doc_mutation(&mut new_value, mutation)?;
     if let MutationResult::TypeError(msg) = result {
-        bail!("{msg}");
+        anyhow::bail!("{msg}");
     }
 
     let new_content = ops::doc::serialize_value_preserving(&original, &value, &new_value, &format)?;
@@ -139,7 +139,10 @@ pub fn doc_get(path: &Path, selector: &str) -> anyhow::Result<serde_json::Value>
     let value = load_doc_value(path)?;
 
     match query_get(&value, selector)? {
-        QueryResult::NoMatch => bail!("selector '{}' matched nothing", selector),
+        QueryResult::NoMatch => Err(crate::exit::NoMatchError {
+            msg: format!("selector '{}' matched nothing", selector),
+        }
+        .into()),
         QueryResult::Values(vals) if vals.len() == 1 => Ok(vals
             .into_iter()
             .next()

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1346,8 +1346,8 @@ fn doc_get_zero_match_error() {
 
     let err = doc_get(&file, "nonexistent").unwrap_err();
     assert!(
-        err.to_string().contains("matched nothing"),
-        "expected zero-match error, got: {err}"
+        err.downcast_ref::<crate::exit::NoMatchError>().is_some(),
+        "expected NoMatchError, got: {err}"
     );
 }
 

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -939,8 +939,8 @@ fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     ) {
         Ok(code) => Ok(code),
         Err(e) => {
-            let msg = e.to_string();
-            if msg.contains("not found") || msg.contains("no matches") {
+            if exit::is_no_match(&e) {
+                let msg = e.to_string();
                 if !global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?
                     && !global.quiet
                 {

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -448,6 +448,23 @@ fn format_values(values: &[&serde_json::Value], mode: OutputMode) -> anyhow::Res
     }
 }
 
+/// Format a no-match result for the given output mode.
+///
+/// Used by read-only doc subcommands (get, keys, len, flatten) to produce
+/// consistent no-match output without repeating the Json/Jsonl/Text match.
+fn format_no_match(error_msg: &str, mode: OutputMode) -> anyhow::Result<(String, u8)> {
+    let output = match mode {
+        OutputMode::Json => {
+            serde_json::to_string_pretty(&serde_json::json!({"ok": false, "error": error_msg}))?
+        }
+        OutputMode::Jsonl => {
+            serde_json::to_string(&serde_json::json!({"ok": false, "error": error_msg}))?
+        }
+        OutputMode::Text => String::new(),
+    };
+    Ok((output, exit::NO_MATCHES))
+}
+
 // ---------------------------------------------------------------------------
 // Core execution (returns output text + exit code for testability)
 // ---------------------------------------------------------------------------
@@ -462,16 +479,7 @@ pub(crate) fn execute_with_mode(
             let root = load_file(file)?;
             match crate::ops::doc::query::query_get(&root, selector)? {
                 crate::ops::doc::query::QueryResult::NoMatch => {
-                    let output = match output_mode {
-                        OutputMode::Json => serde_json::to_string_pretty(
-                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
-                        )?,
-                        OutputMode::Jsonl => serde_json::to_string(
-                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
-                        )?,
-                        OutputMode::Text => String::new(),
-                    };
-                    Ok((output, exit::NO_MATCHES))
+                    format_no_match(&format!("no match for selector: {selector}"), output_mode)
                 }
                 crate::ops::doc::query::QueryResult::Values(vals) => {
                     let refs: Vec<&serde_json::Value> = vals.iter().collect();
@@ -504,16 +512,7 @@ pub(crate) fn execute_with_mode(
             let root = load_file(file)?;
             match crate::ops::doc::query::query_keys(&root, selector)? {
                 crate::ops::doc::query::QueryKeysResult::NoMatch => {
-                    let output = match output_mode {
-                        OutputMode::Json => serde_json::to_string_pretty(
-                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
-                        )?,
-                        OutputMode::Jsonl => serde_json::to_string(
-                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
-                        )?,
-                        OutputMode::Text => String::new(),
-                    };
-                    Ok((output, exit::NO_MATCHES))
+                    format_no_match(&format!("no match for selector: {selector}"), output_mode)
                 }
                 crate::ops::doc::query::QueryKeysResult::NotAnObject => Ok((
                     format!("doc keys: target at '{selector}' is not an object"),
@@ -539,16 +538,7 @@ pub(crate) fn execute_with_mode(
             let root = load_file(file)?;
             match crate::ops::doc::query::query_len(&root, selector)? {
                 crate::ops::doc::query::QueryLenResult::NoMatch => {
-                    let output = match output_mode {
-                        OutputMode::Json => serde_json::to_string_pretty(
-                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
-                        )?,
-                        OutputMode::Jsonl => serde_json::to_string(
-                            &serde_json::json!({"ok": false, "error": format!("no match for selector: {selector}")}),
-                        )?,
-                        OutputMode::Text => String::new(),
-                    };
-                    Ok((output, exit::NO_MATCHES))
+                    format_no_match(&format!("no match for selector: {selector}"), output_mode)
                 }
                 crate::ops::doc::query::QueryLenResult::NotArrayOrObject => Ok((
                     format!("doc len: target at '{selector}' is not an array or object"),
@@ -572,16 +562,7 @@ pub(crate) fn execute_with_mode(
             let mut path_buf = String::new();
             flatten_value(&root, &mut path_buf, &mut entries);
             if entries.is_empty() {
-                let output = match output_mode {
-                    OutputMode::Json => serde_json::to_string_pretty(
-                        &serde_json::json!({"ok": false, "error": "document has no leaf values to flatten"}),
-                    )?,
-                    OutputMode::Jsonl => serde_json::to_string(
-                        &serde_json::json!({"ok": false, "error": "document has no leaf values to flatten"}),
-                    )?,
-                    OutputMode::Text => String::new(),
-                };
-                return Ok((output, exit::NO_MATCHES));
+                return format_no_match("document has no leaf values to flatten", output_mode);
             }
             match output_mode {
                 OutputMode::Json => {
@@ -732,12 +713,13 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         ) {
             Ok(code) => return Ok(code),
             Err(e) => {
-                let msg = e.to_string();
-                if msg.contains("matched nothing") {
+                if exit::is_no_match(&e) {
+                    let msg = e.to_string();
                     global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?;
                     return Ok(exit::NO_MATCHES);
                 }
                 // TypeError or other engine error → FAILURE
+                let msg = e.to_string();
                 if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))?
                     && !global.quiet
                 {

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -843,3 +843,35 @@ mod security {
         );
     }
 }
+
+// -- format_no_match helper tests ------------------------------------------
+
+mod format_no_match_tests {
+    use super::*;
+
+    #[test]
+    fn json_mode_returns_structured_error() {
+        let (output, code) = format_no_match("selector missed", OutputMode::Json).unwrap();
+        assert_eq!(code, crate::exit::NO_MATCHES);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["ok"], false);
+        assert_eq!(parsed["error"], "selector missed");
+    }
+
+    #[test]
+    fn jsonl_mode_returns_compact_error() {
+        let (output, code) = format_no_match("selector missed", OutputMode::Jsonl).unwrap();
+        assert_eq!(code, crate::exit::NO_MATCHES);
+        // JSONL output should be a single compact line (no internal newlines).
+        assert!(!output.contains('\n'));
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["ok"], false);
+    }
+
+    #[test]
+    fn text_mode_returns_empty_string() {
+        let (output, code) = format_no_match("selector missed", OutputMode::Text).unwrap();
+        assert_eq!(code, crate::exit::NO_MATCHES);
+        assert!(output.is_empty());
+    }
+}

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -156,8 +156,8 @@ fn execute_md_op(
     ) {
         Ok(code) => Ok(code),
         Err(e) => {
-            let msg = e.to_string();
-            if msg.contains("heading") && msg.contains("not found") {
+            if exit::is_no_match(&e) {
+                let msg = e.to_string();
                 global.emit_json(&serde_json::json!({
                     "ok": false,
                     "error": &msg,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -352,17 +352,19 @@ fn replace_output(
     file_count: usize,
     cwd: &std::path::Path,
 ) -> anyhow::Result<u8> {
+    // Build the base output struct once; mode-specific fields are set below.
+    let build_output = |diff: Option<String>| ReplaceOutput {
+        ok: true,
+        match_count: total_matches,
+        file_count,
+        files: files.to_vec(),
+        diff,
+    };
+
     // --check mode: report summary, exit 2 if changes needed.
     if global.check {
         if global.json {
-            let output = ReplaceOutput {
-                ok: true,
-                match_count: total_matches,
-                file_count,
-                files: files.to_vec(),
-                diff: None,
-            };
-            global.emit_json(&output)?;
+            global.emit_json(&build_output(None))?;
         } else if !global.emit_json_items(files)? && !global.quiet {
             println!("{total_matches} match(es) in {file_count} file(s)");
             for f in files {
@@ -372,9 +374,11 @@ fn replace_output(
         return Ok(exit::CHANGES_DETECTED);
     }
 
+    // Build diffs (needed for apply+diff and for default/preview mode).
+    let diffs = result.build_diffs();
+
     // --apply mode: commit, then report.
     if global.apply {
-        let diffs = result.build_diffs();
         result.commit()?;
         crate::write::run_format_command(global, cwd)?;
 
@@ -384,14 +388,7 @@ fn replace_output(
             None
         };
         if global.json {
-            let output = ReplaceOutput {
-                ok: true,
-                match_count: total_matches,
-                file_count,
-                files: files.to_vec(),
-                diff: diff_text,
-            };
-            global.emit_json(&output)?;
+            global.emit_json(&build_output(diff_text))?;
         } else if !global.emit_json_items(files)? {
             if global.diff {
                 print!("{}", render_diffs_colored(&diffs, global.should_color()));
@@ -406,7 +403,6 @@ fn replace_output(
     }
 
     // Default / --diff mode: preview diffs.
-    let diffs = result.build_diffs();
     let diff_text = if !diffs.is_empty() {
         Some(render_diffs_plain(&diffs))
     } else {
@@ -414,14 +410,7 @@ fn replace_output(
     };
 
     if global.json {
-        let output = ReplaceOutput {
-            ok: true,
-            match_count: total_matches,
-            file_count,
-            files: files.to_vec(),
-            diff: diff_text,
-        };
-        global.emit_json(&output)?;
+        global.emit_json(&build_output(diff_text))?;
     } else if !global.emit_json_items(files)? && !diffs.is_empty() {
         print!("{}", render_diffs_colored(&diffs, global.should_color()));
     }

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -10,6 +10,35 @@ pub const FAILURE: u8 = 1;
 pub const CHANGES_DETECTED: u8 = 2;
 /// Search or replace found zero matches.
 pub const NO_MATCHES: u8 = 3;
+
+/// Typed error for no-match conditions in tx engine operations.
+///
+/// Commands check for this via `anyhow::Error::downcast_ref::<NoMatchError>()`
+/// instead of fragile `msg.contains(...)` string matching on error messages.
+/// This decouples exit-code classification from error message wording.
+#[derive(Debug)]
+pub struct NoMatchError {
+    pub msg: String,
+}
+
+impl std::fmt::Display for NoMatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for NoMatchError {}
+
+/// Check whether an `anyhow::Error` chain contains a `NoMatchError`.
+///
+/// The tx engine wraps operation errors with context (e.g.
+/// "operation 1 (doc.update) failed"), so the `NoMatchError` may not be
+/// the top-level error. This walks the full chain via `anyhow::Chain`.
+pub fn is_no_match(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<NoMatchError>().is_some())
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.
@@ -39,6 +68,57 @@ mod tests {
         assert_eq!(ROLLBACK, 7);
         assert_eq!(CONFLICTS, 8);
         assert_eq!(OPERATION_FAILED, 9);
+    }
+
+    #[test]
+    fn no_match_error_downcast() {
+        let err: anyhow::Error = NoMatchError {
+            msg: "selector 'x' matched nothing".to_string(),
+        }
+        .into();
+        assert!(
+            err.downcast_ref::<NoMatchError>().is_some(),
+            "NoMatchError should be downcastable from anyhow::Error"
+        );
+    }
+
+    #[test]
+    fn no_match_error_display() {
+        let err = NoMatchError {
+            msg: "test message".to_string(),
+        };
+        assert_eq!(err.to_string(), "test message");
+    }
+
+    #[test]
+    fn non_no_match_error_not_downcast() {
+        let err = anyhow::anyhow!("some other error");
+        assert!(
+            err.downcast_ref::<NoMatchError>().is_none(),
+            "plain anyhow error should not downcast to NoMatchError"
+        );
+    }
+
+    #[test]
+    fn is_no_match_finds_wrapped_error() {
+        let err: anyhow::Error = NoMatchError {
+            msg: "selector matched nothing".to_string(),
+        }
+        .into();
+        let wrapped = err.context("operation 1 (doc.update) failed");
+        assert!(
+            is_no_match(&wrapped),
+            "is_no_match should find NoMatchError through .context() wrapper"
+        );
+    }
+
+    #[test]
+    fn is_no_match_rejects_wrapped_non_no_match() {
+        let err = anyhow::anyhow!("some other error").context("operation 1 failed");
+        assert!(
+            !is_no_match(&err),
+            "is_no_match should return false for non-NoMatchError in chain"
+        );
     }
 
     #[test]

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -180,8 +180,10 @@ pub(crate) fn apply_md_heading_op(
 ) -> anyhow::Result<()> {
     let file_path = tx.cwd.join(path);
     let file_content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
-    let new_content = op(file_content, heading, extra)
-        .ok_or_else(|| anyhow::anyhow!("{err_label} not found: {heading}"))?;
+    let new_content =
+        op(file_content, heading, extra).ok_or_else(|| crate::exit::NoMatchError {
+            msg: format!("{err_label} not found: {heading}"),
+        })?;
     update_file_content(
         tx.pending,
         tx.deletions,
@@ -388,7 +390,9 @@ pub(crate) fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         MutationResult::Applied | MutationResult::AlreadyExists => Ok(()),
         MutationResult::NoMatch if strict_no_match => {
             let label = op_label(op);
-            anyhow::bail!("{path}: {label} matched nothing");
+            Err(crate::exit::NoMatchError {
+                msg: format!("{path}: {label} matched nothing"),
+            })?
         }
         MutationResult::NoMatch => Ok(()),
         MutationResult::TypeError(msg) => {
@@ -632,9 +636,10 @@ fn ast_rename_single_file(
             update_file_content(tx.pending, tx.deletions, tx.write_targets, abs, r.content);
             Ok(r.replacements)
         }
-        Some(_) => {
-            anyhow::bail!("no matches for '{}' in {}", old_name, abs.display());
+        Some(_) => Err(crate::exit::NoMatchError {
+            msg: format!("no matches for '{}' in {}", old_name, abs.display()),
         }
+        .into()),
         None => {
             // Tree-sitter couldn't parse. Fallback to word-boundary replace.
             let re =
@@ -653,7 +658,10 @@ fn ast_rename_single_file(
                     return Ok(count);
                 }
             }
-            anyhow::bail!("no matches for '{}' in {}", old_name, abs.display());
+            Err(crate::exit::NoMatchError {
+                msg: format!("no matches for '{}' in {}", old_name, abs.display()),
+            }
+            .into())
         }
     }
 }
@@ -729,7 +737,9 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             let file_path = tx.cwd.join(path);
             let file_content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let (body_start, body_end) = crate::ops::md::find_section(file_content, heading)
-                .ok_or_else(|| anyhow::anyhow!("heading not found: {heading}"))?;
+                .ok_or_else(|| crate::exit::NoMatchError {
+                    msg: format!("heading not found: {heading}"),
+                })?;
             let new_content =
                 crate::ops::md::table_append_in(file_content, body_start, body_end, row)
                     .map_err(|e| anyhow::anyhow!("{e} under heading {heading:?}"))?;
@@ -772,8 +782,8 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
             };
             let (new_source, new_dest) =
                 move_section_in(&source_content, heading, &dest_content, position, same_file)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("md.move_section: heading or target not found")
+                    .ok_or_else(|| crate::exit::NoMatchError {
+                        msg: "md.move_section: heading or target not found".to_string(),
                     })?;
             update_file_content(
                 tx.pending,
@@ -941,7 +951,10 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                     }
                 }
                 if total == 0 {
-                    anyhow::bail!("no matches for '{}' in {}", old_name, path);
+                    return Err(crate::exit::NoMatchError {
+                        msg: format!("no matches for '{}' in {}", old_name, path),
+                    }
+                    .into());
                 }
                 return Ok(total);
             }
@@ -978,13 +991,21 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
                     );
                     return Ok(r.replacements);
                 }
-                Some(_) => anyhow::bail!(
-                    "no matches for '{}' in symbol '{}' in {}",
-                    old,
-                    symbol,
-                    path
-                ),
-                None => anyhow::bail!("symbol '{}' not found in {}", symbol, path),
+                Some(_) => {
+                    return Err(crate::exit::NoMatchError {
+                        msg: format!(
+                            "no matches for '{}' in symbol '{}' in {}",
+                            old, symbol, path
+                        ),
+                    }
+                    .into());
+                }
+                None => {
+                    return Err(crate::exit::NoMatchError {
+                        msg: format!("symbol '{}' not found in {}", symbol, path),
+                    }
+                    .into());
+                }
             }
         }
 
@@ -1454,6 +1475,13 @@ pub(crate) fn execute_and_collect(
             }
             Err(e) => {
                 crate::verbose!("tx: operation {} failed: {e}", i + 1);
+                if e.downcast_ref::<crate::exit::NoMatchError>().is_some() {
+                    return Err(e.context(format!(
+                        "operation {} ({}) failed",
+                        i + 1,
+                        op_label(op)
+                    )));
+                }
                 anyhow::bail!("operation {} ({}) failed: {e}", i + 1, op_label(op));
             }
         }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1928,8 +1928,8 @@ fn test_doc_delete_numeric_dot_notation_on_array() {
 // ---------------------------------------------------------------------------
 
 /// Write operations that select a non-existent key should exit 3 (NO_MATCHES),
-/// not exit 1 (FAILURE). This guards the `msg.contains("matched nothing")`
-/// classification at doc.rs:736.
+/// not exit 1 (FAILURE). Classification uses `NoMatchError` downcast (#1331),
+/// not string matching.
 #[test]
 fn test_doc_update_nonexistent_selector_exits_3() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Replace fragile `msg.contains()` string matching for no-match error classification with a typed `NoMatchError` and chain-walking `is_no_match()` helper. Deduplicate formatting logic in doc.rs and replace.rs.

## Changes

- **`src/exit.rs`**: Add `NoMatchError` type and `is_no_match()` chain walker with unit tests
- **`src/tx/execute.rs`**: Emit `NoMatchError` from doc, md, and ast operation handlers; preserve error chain through context wrapping
- **`src/api/doc.rs`**: Emit `NoMatchError` instead of plain `bail!` for selector-matched-nothing
- **`src/cmd/doc.rs`**: Replace `msg.contains("matched nothing")` with `is_no_match()`; extract `format_no_match()` helper eliminating 4 duplicated formatting blocks
- **`src/cmd/ast.rs`**: Replace string-based error classification with `is_no_match()`
- **`src/cmd/md.rs`**: Replace string-based error classification with `is_no_match()`
- **`src/cmd/replace.rs`**: Extract `build_output` closure deduplicating 3 identical `ReplaceOutput` constructions
- **`src/api/tests.rs`**, **`src/cmd/doc_tests.rs`**, **`tests/integration/doc_tests.rs`**: Updated and new tests

## Testing

All gates pass: 2076 unit tests, 865 integration tests, 10 PTY tests (`make check-fast`).

Closes #1331
Closes #1332
Closes #1333