### PR TITLE
fix: ast rename NoMatchError handler, dedup run_context_replace, add integration tests

### DIFF
--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -376,7 +376,18 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         global,
         guard: None,
     };
-    let result = crate::tx::engine::execute_operations(operations, options)?;
+    let result = match crate::tx::engine::execute_operations(operations, options) {
+        Ok(r) => r,
+        Err(e) if exit::is_no_match(&e) => {
+            let msg = e.to_string();
+            if !global.emit_json(&serde_json::json!({"ok": false, "error": msg}))? && !global.quiet
+            {
+                eprintln!("{msg}");
+            }
+            return Ok(exit::NO_MATCHES);
+        }
+        Err(e) => return Err(e),
+    };
 
     if global.check {
         global.emit_json(&serde_json::json!({

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -478,25 +478,17 @@ fn run_context_replace(
     let result = execute_operations(ops, options)?;
 
     if !result.has_changes {
-        if args.if_exists {
-            let output = ReplaceOutput {
-                ok: true,
-                match_count: 0,
-                file_count: 0,
-                files: vec![],
-                diff: None,
-            };
-            global.emit_json(&output)?;
-            return Ok(exit::SUCCESS);
-        }
-        let output = ReplaceOutput {
+        let empty = ReplaceOutput {
             ok: true,
             match_count: 0,
             file_count: 0,
             files: vec![],
             diff: None,
         };
-        global.emit_json(&output)?;
+        global.emit_json(&empty)?;
+        if args.if_exists {
+            return Ok(exit::SUCCESS);
+        }
         if global.show_status() {
             eprintln!("no matches for '{}' in context-based replace", args.old);
         }
@@ -517,17 +509,18 @@ fn run_context_replace(
     let total_matches = files.len();
     let file_count = total_matches;
 
+    let build_output = |diff: Option<String>| ReplaceOutput {
+        ok: true,
+        match_count: total_matches,
+        file_count,
+        files: files.clone(),
+        diff,
+    };
+
     // --check mode.
     if global.check {
         if global.json {
-            let output = ReplaceOutput {
-                ok: true,
-                match_count: total_matches,
-                file_count,
-                files,
-                diff: None,
-            };
-            global.emit_json(&output)?;
+            global.emit_json(&build_output(None))?;
         } else if !global.emit_json_items(&files)? && !global.quiet {
             println!("{total_matches} file(s) changed");
         }
@@ -546,14 +539,7 @@ fn run_context_replace(
             None
         };
         if global.json {
-            let output = ReplaceOutput {
-                ok: true,
-                match_count: total_matches,
-                file_count,
-                files,
-                diff: diff_text,
-            };
-            global.emit_json(&output)?;
+            global.emit_json(&build_output(diff_text))?;
         } else if !global.emit_json_items(&files)? {
             if global.diff {
                 print!("{}", render_diffs_colored(&diffs, global.should_color()));
@@ -573,14 +559,7 @@ fn run_context_replace(
     };
 
     if global.json {
-        let output = ReplaceOutput {
-            ok: true,
-            match_count: total_matches,
-            file_count,
-            files,
-            diff: diff_text,
-        };
-        global.emit_json(&output)?;
+        global.emit_json(&build_output(diff_text))?;
     } else if !global.emit_json_items(&files)? && !diffs.is_empty() {
         print!("{}", render_diffs_colored(&diffs, global.should_color()));
     }

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -458,6 +458,78 @@ fn test_ast_map_no_symbols_exits_3() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_rename_apply_exits_0() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("rename.rs");
+    fs::write(&f, "fn old_name() {}\nfn caller() { old_name(); }\n").unwrap();
+    patchloom_in(dir.path())
+        .args([
+            "ast",
+            "rename",
+            "old_name",
+            "new_name",
+            "rename.rs",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+    let content = fs::read_to_string(&f).unwrap();
+    assert!(
+        content.contains("new_name"),
+        "ast rename --apply should rename symbol: {content}"
+    );
+    assert!(
+        !content.contains("old_name"),
+        "old symbol name should be replaced: {content}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_rename_nonexistent_symbol_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("rename.rs");
+    fs::write(&f, "fn real() {}\n").unwrap();
+    patchloom_in(dir.path())
+        .args([
+            "ast",
+            "rename",
+            "nonexistent",
+            "new_name",
+            "rename.rs",
+            "--apply",
+        ])
+        .assert()
+        .code(3);
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_rename_check_mode_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("rename.rs");
+    fs::write(&f, "fn old_name() {}\n").unwrap();
+    patchloom_in(dir.path())
+        .args([
+            "ast",
+            "rename",
+            "old_name",
+            "new_name",
+            "rename.rs",
+            "--check",
+        ])
+        .assert()
+        .code(2);
+    // File should be unchanged in check mode.
+    let content = fs::read_to_string(&f).unwrap();
+    assert!(
+        content.contains("old_name"),
+        "check mode should not modify file: {content}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_replace_missing_symbol_exits_3() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("test.rs");

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -904,6 +904,33 @@ fn test_md_check_json_produces_structured_output() {
 // table-append column count validation (#1172)
 // ---------------------------------------------------------------------------
 
+/// Table append with nonexistent heading returns exit 3 (#1331 follow-up).
+#[test]
+fn test_md_table_append_nonexistent_heading_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.md");
+    fs::write(
+        &file,
+        "# API\n| Name | Value |\n|------|-------|\n| a | 1 |\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "md",
+            "table-append",
+            file.to_str().unwrap(),
+            "--heading",
+            "Nonexistent",
+            "--row",
+            "| b | 2 |",
+            "--apply",
+        ])
+        .assert()
+        .code(3);
+}
+
 /// Table append with wrong column count should fail (#1172).
 #[test]
 fn test_md_table_append_wrong_column_count_fails() {


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle findings: a code defect in ast rename exit code handling, missing integration tests for ast rename CLI, and remaining `ReplaceOutput` duplication in `run_context_replace`.

## Changes

### Bug fix
- **`src/cmd/ast.rs`**: Add `is_no_match` handler to `run_rename` so it returns exit code 3 (NO_MATCHES) instead of exit code 1 (FAILURE) when the tx engine produces a `NoMatchError`. Matches the existing pattern in `run_replace_in_symbol`.

### Refactoring
- **`src/cmd/replace.rs`**: Deduplicate `run_context_replace`: combine two identical no-changes `ReplaceOutput` into one, add `build_output` closure for the 3 remaining has-changes constructions. Net -21 lines.

### New integration tests
- **`tests/integration/ast_tests.rs`**: 3 tests for `ast rename` CLI dispatch: apply exits 0, nonexistent symbol exits 3, check mode exits 2.
- **`tests/integration/md_tests.rs`**: 1 test for `md table-append` with nonexistent heading returning exit 3.

## Testing

`make check-fast` passes: 2076 unit tests, 869 integration tests, 10 PTY tests.