### PR TITLE
refactor: deduplicate json error emission via emit_error_json helper

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -315,6 +315,19 @@ impl GlobalFlags {
         }
     }
 
+    /// Emit a `{"ok": false, "error": msg}` payload in structured format,
+    /// with a stderr fallback in text mode (unless `--quiet`).
+    ///
+    /// This is the standard error-reporting pattern for NO_MATCHES and
+    /// similar error paths. In JSON/JSONL mode the payload is printed to
+    /// stdout; in text mode the message goes to stderr.
+    pub fn emit_error_json(&self, msg: &str) -> anyhow::Result<()> {
+        if !self.emit_json(&serde_json::json!({"ok": false, "error": msg}))? && !self.quiet {
+            eprintln!("{msg}");
+        }
+        Ok(())
+    }
+
     /// Emit a collection of items in structured format.
     ///
     /// In `--json` mode, emits a pretty-printed JSON array of all items.
@@ -491,6 +504,30 @@ mod tests {
             ..GlobalFlags::test_default()
         };
         assert!(g.emit_json(&serde_json::json!({"a":1})).unwrap());
+    }
+
+    #[test]
+    fn emit_error_json_does_not_panic_in_text_mode() {
+        let g = GlobalFlags::test_default();
+        g.emit_error_json("something went wrong").unwrap();
+    }
+
+    #[test]
+    fn emit_error_json_does_not_panic_in_json_mode() {
+        let g = GlobalFlags {
+            json: true,
+            ..GlobalFlags::test_default()
+        };
+        g.emit_error_json("something went wrong").unwrap();
+    }
+
+    #[test]
+    fn emit_error_json_does_not_panic_in_quiet_mode() {
+        let g = GlobalFlags {
+            quiet: true,
+            ..GlobalFlags::test_default()
+        };
+        g.emit_error_json("something went wrong").unwrap();
     }
 
     #[test]

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -151,10 +151,7 @@ fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                  TOML, YAML, JSON, Shell.",
                 lang, args.path,
             );
-            if !global.emit_json(&serde_json::json!({"ok": false, "error": msg}))? && !global.quiet
-            {
-                eprintln!("{msg}");
-            }
+            global.emit_error_json(&msg)?;
             return Ok(exit::NO_MATCHES);
         }
         let symbols = symbols::extract_symbols_from_file(&target, Some(lang));
@@ -213,9 +210,7 @@ fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         Ok(exit::SUCCESS)
     } else {
         let msg = format!("no symbols found in {}", args.path);
-        if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))? && !global.quiet {
-            eprintln!("{msg}");
-        }
+        global.emit_error_json(&msg)?;
         Ok(exit::NO_MATCHES)
     }
 }
@@ -365,9 +360,7 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if operations.is_empty() {
         let msg = format!("symbol '{}' not found in {}", args.old_name, args.path);
-        if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))? && !global.quiet {
-            eprintln!("{msg}");
-        }
+        global.emit_error_json(&msg)?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -381,10 +374,7 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         Ok(r) => r,
         Err(e) if exit::is_no_match(&e) => {
             let msg = e.to_string();
-            if !global.emit_json(&serde_json::json!({"ok": false, "error": msg}))? && !global.quiet
-            {
-                eprintln!("{msg}");
-            }
+            global.emit_error_json(&msg)?;
             return Ok(exit::NO_MATCHES);
         }
         Err(e) => return Err(e),
@@ -602,9 +592,7 @@ fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if total_matches == 0 {
         let msg = format!("no matches for pattern in {}", args.path);
-        if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))? && !global.quiet {
-            eprintln!("{msg}");
-        }
+        global.emit_error_json(&msg)?;
         Ok(exit::NO_MATCHES)
     } else {
         Ok(exit::SUCCESS)
@@ -656,9 +644,7 @@ fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if all_refs.is_empty() {
         let msg = format!("no references found for '{}' in {}", args.symbol, args.path);
-        if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))? && !global.quiet {
-            eprintln!("{msg}");
-        }
+        global.emit_error_json(&msg)?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -793,9 +779,7 @@ fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         Ok(exit::SUCCESS)
     } else {
         let msg = format!("no imports found in {}", args.path);
-        if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))? && !global.quiet {
-            eprintln!("{msg}");
-        }
+        global.emit_error_json(&msg)?;
         Ok(exit::NO_MATCHES)
     }
 }
@@ -855,9 +839,7 @@ fn run_map(args: MapArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if entries.is_empty() {
         let msg = format!("no symbols found in {}", args.path);
-        if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))? && !global.quiet {
-            eprintln!("{msg}");
-        }
+        global.emit_error_json(&msg)?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -952,12 +934,7 @@ fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         Ok(code) => Ok(code),
         Err(e) => {
             if exit::is_no_match(&e) {
-                let msg = e.to_string();
-                if !global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?
-                    && !global.quiet
-                {
-                    eprintln!("{msg}");
-                }
+                global.emit_error_json(&e.to_string())?;
                 Ok(exit::NO_MATCHES)
             } else {
                 Err(e)
@@ -1003,13 +980,7 @@ fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let nodes = crate::ast::impact::compute_impact(&args.symbol, &file_pairs, args.depth);
 
     if nodes.is_empty() {
-        if !global.emit_json(&serde_json::json!({
-            "ok": false,
-            "error": format!("no references found for '{}'", args.symbol),
-        }))? && !global.quiet
-        {
-            eprintln!("no references found for '{}'", args.symbol);
-        }
+        global.emit_error_json(&format!("no references found for '{}'", args.symbol))?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -1073,13 +1044,7 @@ fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
 
     if changes.is_empty() {
-        if !global.emit_json(&serde_json::json!({
-            "ok": false,
-            "error": "no structural changes",
-        }))? && !global.quiet
-        {
-            eprintln!("no structural changes");
-        }
+        global.emit_error_json("no structural changes")?;
         return Ok(exit::NO_MATCHES);
     }
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -714,21 +714,11 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             Ok(code) => return Ok(code),
             Err(e) => {
                 if exit::is_no_match(&e) {
-                    let msg = e.to_string();
-                    if !global.emit_json(&serde_json::json!({"ok": false, "error": msg}))?
-                        && !global.quiet
-                    {
-                        eprintln!("{msg}");
-                    }
+                    global.emit_error_json(&e.to_string())?;
                     return Ok(exit::NO_MATCHES);
                 }
                 // TypeError or other engine error → FAILURE
-                let msg = e.to_string();
-                if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))?
-                    && !global.quiet
-                {
-                    eprintln!("{msg}");
-                }
+                global.emit_error_json(&e.to_string())?;
                 return Ok(exit::FAILURE);
             }
         }

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -157,14 +157,7 @@ fn execute_md_op(
         Ok(code) => Ok(code),
         Err(e) => {
             if exit::is_no_match(&e) {
-                let msg = e.to_string();
-                if !global.emit_json(&serde_json::json!({
-                    "ok": false,
-                    "error": &msg,
-                }))? && !global.quiet
-                {
-                    eprintln!("{msg}");
-                }
+                global.emit_error_json(&e.to_string())?;
                 Ok(exit::NO_MATCHES)
             } else {
                 Err(e)
@@ -380,11 +373,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             match find_section(&content, &heading) {
                 None => {
                     let msg = format!("heading {:?} not found in {file}", heading);
-                    if !global.emit_json(&serde_json::json!({"ok": false, "error": &msg}))?
-                        && !global.quiet
-                    {
-                        eprintln!("{msg}");
-                    }
+                    global.emit_error_json(&msg)?;
                     Ok(exit::NO_MATCHES)
                 }
                 Some((body_start, body_end)) => {


### PR DESCRIPTION
## Summary

Add `GlobalFlags::emit_error_json()` that encapsulates the standard error-reporting pattern for NO_MATCHES and similar error paths, replacing 15 inline call sites.

The helper emits `{"ok": false, "error": msg}` in JSON/JSONL mode and falls back to `eprintln!` in text mode (respecting `--quiet`).

## Changes

- **`src/cli/global.rs`**: Add `emit_error_json(&self, msg: &str)` method + 3 unit tests (text mode, JSON mode, quiet mode)
- **`src/cmd/ast.rs`**: Replace 11 inline sites with `global.emit_error_json(&msg)?`
- **`src/cmd/doc.rs`**: Replace 2 inline sites
- **`src/cmd/md.rs`**: Replace 2 inline sites

Net result: **-19 lines** (52 added, 71 removed).

### Intentionally unchanged sites

| File | Reason |
|------|--------|
| `doc.rs` `format_no_match` | Different output pipeline (manual JSON string formatting) |
| `patch.rs` `emit_error` | Parse errors that always print to stderr (no quiet suppression) |
| `undo.rs` | Uses `show_status()` instead of `!quiet` (intentionally stricter) |

Closes #1336