### PR TITLE
docs: update error handling guidance for emit_error_json and show_status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,7 +174,8 @@ All subcommands receive a `&GlobalFlags` reference. Read-only flags (`--json`, `
 - Use `anyhow::Result` for propagating errors.
 - Return exit codes directly using constants from `src/exit.rs` (e.g. `exit::NO_MATCHES`, `exit::CHANGES_DETECTED`).
 - Return `Ok(exit::SUCCESS)` for success, `Ok(exit::NO_MATCHES)` for no-match, etc.
-- When returning `NO_MATCHES` with an error message, always use the standard pattern: `if !global.emit_json(&json!({"ok": false, "error": &msg}))? && !global.quiet { eprintln!("{msg}"); }`. Both conditions are required: `emit_json` returns true when JSON was emitted (skip text), and `!global.quiet` suppresses stderr in quiet mode. Omitting `!global.quiet` is a recurring bug.
+- When returning `NO_MATCHES` with an error message, use `global.emit_error_json(&msg)?` (added in PR #1339). This helper encapsulates the standard pattern: emit `{"ok": false, "error": msg}` in JSON/JSONL mode, fall back to `eprintln!` in text mode (respecting `--quiet`). Before this helper, the inline pattern was `if !global.emit_json(&json!({"ok": false, "error": &msg}))? && !global.quiet { eprintln!("{msg}"); }`.
+- **Never use `global.show_status()` on error diagnostic paths.** `show_status()` requires a TTY (returns `false` when stderr is piped), which silently suppresses error messages in scripts and pipelines. Use `!global.quiet` instead. Reserve `show_status()` for optional progress hints and status messages that are genuinely TTY-only (e.g., "hint: use --apply", file count summaries). See #1340 and #1341 for bugs caused by this confusion.
 
 ### Testing
 


### PR DESCRIPTION
Document the new `emit_error_json()` helper (PR #1339) and add a warning against using `show_status()` on error diagnostic paths.

Refs #1340, #1341