### PR TITLE
fix: emit stderr for silent no-match errors in doc and undo commands

### DIFF
--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -452,7 +452,7 @@ fn format_values(values: &[&serde_json::Value], mode: OutputMode) -> anyhow::Res
 ///
 /// Used by read-only doc subcommands (get, keys, len, flatten) to produce
 /// consistent no-match output without repeating the Json/Jsonl/Text match.
-fn format_no_match(error_msg: &str, mode: OutputMode) -> anyhow::Result<(String, u8)> {
+fn format_no_match(error_msg: &str, mode: OutputMode, quiet: bool) -> anyhow::Result<(String, u8)> {
     let output = match mode {
         OutputMode::Json => {
             serde_json::to_string_pretty(&serde_json::json!({"ok": false, "error": error_msg}))?
@@ -460,7 +460,12 @@ fn format_no_match(error_msg: &str, mode: OutputMode) -> anyhow::Result<(String,
         OutputMode::Jsonl => {
             serde_json::to_string(&serde_json::json!({"ok": false, "error": error_msg}))?
         }
-        OutputMode::Text => String::new(),
+        OutputMode::Text => {
+            if !quiet {
+                eprintln!("{error_msg}");
+            }
+            String::new()
+        }
     };
     Ok((output, exit::NO_MATCHES))
 }
@@ -473,14 +478,24 @@ pub(crate) fn execute_with_mode(
     action: &DocAction,
     output_mode: OutputMode,
 ) -> anyhow::Result<(String, u8)> {
+    execute_with_mode_inner(action, output_mode, false)
+}
+
+fn execute_with_mode_inner(
+    action: &DocAction,
+    output_mode: OutputMode,
+    quiet: bool,
+) -> anyhow::Result<(String, u8)> {
     match action {
         DocAction::Get { file, selector } | DocAction::Select { file, selector } => {
             crate::verbose!("doc: get/select file={}, selector={:?}", file, selector);
             let root = load_file(file)?;
             match crate::ops::doc::query::query_get(&root, selector)? {
-                crate::ops::doc::query::QueryResult::NoMatch => {
-                    format_no_match(&format!("no match for selector: {selector}"), output_mode)
-                }
+                crate::ops::doc::query::QueryResult::NoMatch => format_no_match(
+                    &format!("no match for selector: {selector}"),
+                    output_mode,
+                    quiet,
+                ),
                 crate::ops::doc::query::QueryResult::Values(vals) => {
                     let refs: Vec<&serde_json::Value> = vals.iter().collect();
                     Ok((format_values(&refs, output_mode)?, exit::SUCCESS))
@@ -511,9 +526,11 @@ pub(crate) fn execute_with_mode(
             crate::verbose!("doc: keys file={}, selector={:?}", file, selector);
             let root = load_file(file)?;
             match crate::ops::doc::query::query_keys(&root, selector)? {
-                crate::ops::doc::query::QueryKeysResult::NoMatch => {
-                    format_no_match(&format!("no match for selector: {selector}"), output_mode)
-                }
+                crate::ops::doc::query::QueryKeysResult::NoMatch => format_no_match(
+                    &format!("no match for selector: {selector}"),
+                    output_mode,
+                    quiet,
+                ),
                 crate::ops::doc::query::QueryKeysResult::NotAnObject => Ok((
                     format!("doc keys: target at '{selector}' is not an object"),
                     exit::FAILURE,
@@ -537,9 +554,11 @@ pub(crate) fn execute_with_mode(
             crate::verbose!("doc: len file={}, selector={:?}", file, selector);
             let root = load_file(file)?;
             match crate::ops::doc::query::query_len(&root, selector)? {
-                crate::ops::doc::query::QueryLenResult::NoMatch => {
-                    format_no_match(&format!("no match for selector: {selector}"), output_mode)
-                }
+                crate::ops::doc::query::QueryLenResult::NoMatch => format_no_match(
+                    &format!("no match for selector: {selector}"),
+                    output_mode,
+                    quiet,
+                ),
                 crate::ops::doc::query::QueryLenResult::NotArrayOrObject => Ok((
                     format!("doc len: target at '{selector}' is not an array or object"),
                     exit::FAILURE,
@@ -562,7 +581,11 @@ pub(crate) fn execute_with_mode(
             let mut path_buf = String::new();
             flatten_value(&root, &mut path_buf, &mut entries);
             if entries.is_empty() {
-                return format_no_match("document has no leaf values to flatten", output_mode);
+                return format_no_match(
+                    "document has no leaf values to flatten",
+                    output_mode,
+                    quiet,
+                );
             }
             match output_mode {
                 OutputMode::Json => {
@@ -736,7 +759,7 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         OutputMode::Text
     };
 
-    let (output, code) = execute_with_mode(&args.action, output_mode)?;
+    let (output, code) = execute_with_mode_inner(&args.action, output_mode, global.quiet)?;
     if !output.is_empty() && (global.json || global.jsonl || !global.quiet) {
         println!("{output}");
     }

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -851,7 +851,7 @@ mod format_no_match_tests {
 
     #[test]
     fn json_mode_returns_structured_error() {
-        let (output, code) = format_no_match("selector missed", OutputMode::Json).unwrap();
+        let (output, code) = format_no_match("selector missed", OutputMode::Json, false).unwrap();
         assert_eq!(code, crate::exit::NO_MATCHES);
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
         assert_eq!(parsed["ok"], false);
@@ -860,7 +860,7 @@ mod format_no_match_tests {
 
     #[test]
     fn jsonl_mode_returns_compact_error() {
-        let (output, code) = format_no_match("selector missed", OutputMode::Jsonl).unwrap();
+        let (output, code) = format_no_match("selector missed", OutputMode::Jsonl, false).unwrap();
         assert_eq!(code, crate::exit::NO_MATCHES);
         // JSONL output should be a single compact line (no internal newlines).
         assert!(!output.contains('\n'));
@@ -869,8 +869,18 @@ mod format_no_match_tests {
     }
 
     #[test]
-    fn text_mode_returns_empty_string() {
-        let (output, code) = format_no_match("selector missed", OutputMode::Text).unwrap();
+    fn text_mode_returns_empty_string_and_emits_stderr() {
+        // In text mode, format_no_match emits to stderr and returns empty
+        // stdout. We can't capture stderr in a unit test, but we verify
+        // the return value is correct.
+        let (output, code) = format_no_match("selector missed", OutputMode::Text, false).unwrap();
+        assert_eq!(code, crate::exit::NO_MATCHES);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn text_mode_quiet_suppresses_stderr() {
+        let (output, code) = format_no_match("selector missed", OutputMode::Text, true).unwrap();
         assert_eq!(code, crate::exit::NO_MATCHES);
         assert!(output.is_empty());
     }

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -52,7 +52,7 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let sessions = backup::list_sessions(&cwd)?;
         if sessions.is_empty() {
             let empty: Vec<()> = vec![];
-            if !global.emit_json(&empty)? && global.show_status() {
+            if !global.emit_json(&empty)? && !global.quiet {
                 eprintln!("no backup sessions found");
             }
             return Ok(exit::NO_MATCHES);
@@ -86,7 +86,7 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             if !global.emit_json(&serde_json::json!({
                 "ok": false,
                 "error": "no backup sessions found",
-            }))? && global.show_status()
+            }))? && !global.quiet
             {
                 eprintln!("no backup sessions found");
             }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1975,5 +1975,102 @@ fn test_doc_update_apply_no_match_emits_stderr_in_text_mode() {
 }
 
 // ---------------------------------------------------------------------------
+// Text-mode no-match stderr output (#1340)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_doc_get_no_match_text_mode_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"a": 1}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("get")
+        .arg(&file)
+        .arg("nonexistent")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no match"),
+        "text mode should emit error to stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_doc_keys_no_match_text_mode_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"a": 1}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("keys")
+        .arg(&file)
+        .arg("nonexistent")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no match"),
+        "text mode should emit error to stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_doc_len_no_match_text_mode_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"a": 1}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("len")
+        .arg(&file)
+        .arg("nonexistent")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no match"),
+        "text mode should emit error to stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_doc_get_no_match_quiet_suppresses_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"a": 1}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--quiet")
+        .arg("doc")
+        .arg("get")
+        .arg(&file)
+        .arg("nonexistent")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(
+        output.stderr.is_empty(),
+        "--quiet should suppress stderr, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Symlink integration tests (#231 coverage)
 // ---------------------------------------------------------------------------

--- a/tests/integration/undo_tests.rs
+++ b/tests/integration/undo_tests.rs
@@ -342,6 +342,69 @@ fn test_undo_list_json_empty_emits_array() {
     assert_eq!(parsed.as_array().unwrap().len(), 0);
 }
 
+// ---------------------------------------------------------------------------
+// Non-TTY error output (#1341)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_undo_list_no_sessions_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+
+    // Integration tests run with piped stderr (non-TTY). Before the fix,
+    // show_status() suppressed the error message in non-TTY contexts.
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["undo", "--list", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no backup sessions found"),
+        "text mode should emit error to stderr in non-TTY, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_undo_no_sessions_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["undo", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no backup sessions found"),
+        "text mode should emit error to stderr in non-TTY, got: {stderr}"
+    );
+}
+
+#[test]
+fn test_undo_list_no_sessions_quiet_suppresses_stderr() {
+    let dir = TempDir::new().unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--quiet", "undo", "--list", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    assert!(
+        output.stderr.is_empty(),
+        "--quiet should suppress stderr, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 #[test]
 fn test_undo_invalid_session_apply_exits_1() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fix two bugs where error diagnostics were silently suppressed when stderr is not a TTY (e.g., in scripts and pipelines).

**`doc` subcommands (#1340):** `format_no_match()` returned an empty string in Text mode without emitting to stderr. Scripts piping `patchloom doc get` with a missing selector saw exit code 3 but no error message.

**`undo` command (#1341):** Two error paths used `show_status()` (which requires a TTY) instead of `!global.quiet` to guard stderr output. "No backup sessions" and "session not found" errors were invisible in pipelines.

## Changes

- **`src/cmd/doc.rs`:** Add `quiet` parameter to `format_no_match()`; emit error to stderr in Text mode (unless quiet). Add `execute_with_mode_inner()` wrapper to thread `quiet` from `GlobalFlags` without changing the public `execute_with_mode()` API (used by MCP).
- **`src/cmd/undo.rs`:** Replace `show_status()` with `!global.quiet` on two error diagnostic paths (lines 55, 89). Status/hint messages on lines 137, 155 correctly remain `show_status()`.
- **Unit tests:** Update `format_no_match` tests for new `quiet` parameter; add `text_mode_quiet_suppresses_stderr` test.
- **Integration tests:** 4 new doc tests (stderr emission for get/keys/len, quiet suppression) and 3 new undo tests (stderr emission for list/restore, quiet suppression).

Closes #1340
Closes #1341