### PR TITLE
fix: emit stderr for silent no-match/ambiguous errors in replace and search commands

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -264,7 +264,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     diff: None,
                 };
                 global.emit_json(&output)?;
-                if global.show_status() {
+                if !global.quiet {
                     eprintln!(
                         "ambiguous match: pattern {:?} matches {} times in {}; use --nth or add context to disambiguate",
                         crate::fallback::truncate_str(&args.old, 60),
@@ -297,7 +297,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             diff: None,
         };
         global.emit_json(&output)?;
-        if global.show_status() {
+        if !global.quiet {
             let path_desc = if args.paths.is_empty() {
                 ".".to_string()
             } else {
@@ -489,7 +489,7 @@ fn run_context_replace(
         if args.if_exists {
             return Ok(exit::SUCCESS);
         }
-        if global.show_status() {
+        if !global.quiet {
             eprintln!("no matches for '{}' in context-based replace", args.old);
         }
         return Ok(exit::NO_MATCHES);

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -365,7 +365,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             files: vec![],
         };
         global.emit_json(&payload)?;
-        if global.show_status() {
+        if !global.quiet {
             let paths: Vec<&str> = args.paths.iter().map(|s| s.as_str()).collect();
             let path_desc = if paths.is_empty() {
                 ".".to_string()

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -379,6 +379,132 @@ fn test_replace_no_match_without_if_exists_exits_3() {
 }
 
 #[test]
+fn test_replace_no_match_text_mode_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "some content\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("nonexistent_xyz")
+        .arg("--new")
+        .arg("new")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no matches"),
+        "stderr should contain 'no matches' but was: {stderr}"
+    );
+}
+
+#[test]
+fn test_replace_no_match_quiet_suppresses_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "some content\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--quiet")
+        .arg("replace")
+        .arg("nonexistent_xyz")
+        .arg("--new")
+        .arg("new")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("no matches"),
+        "stderr should be suppressed with --quiet but was: {stderr}"
+    );
+}
+
+#[test]
+fn test_replace_ambiguous_match_text_mode_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "aaa bbb aaa\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("aaa")
+        .arg("--new")
+        .arg("ccc")
+        .arg("--unique")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(5)); // AMBIGUOUS
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ambiguous match"),
+        "stderr should contain 'ambiguous match' but was: {stderr}"
+    );
+}
+
+#[test]
+fn test_replace_ambiguous_match_quiet_suppresses_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "aaa bbb aaa\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--quiet")
+        .arg("replace")
+        .arg("aaa")
+        .arg("--new")
+        .arg("ccc")
+        .arg("--unique")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(5)); // AMBIGUOUS
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("ambiguous match"),
+        "stderr should be suppressed with --quiet but was: {stderr}"
+    );
+}
+
+#[test]
+fn test_replace_context_no_match_text_mode_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line one\nline two\nline three\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("nonexistent_xyz")
+        .arg("--new")
+        .arg("replaced")
+        .arg("--before-context")
+        .arg("line one")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no matches"),
+        "stderr should contain 'no matches' but was: {stderr}"
+    );
+}
+
+#[test]
 fn test_replace_normalize_eol_lf() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("crlf.txt");

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -30,6 +30,47 @@ fn test_search_no_matches_exit_3() {
 }
 
 #[test]
+fn test_search_no_match_text_mode_emits_stderr() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("test.txt"), "some content\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("search")
+        .arg("nonexistent_xyz")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no matches"),
+        "stderr should contain 'no matches' but was: {stderr}"
+    );
+}
+
+#[test]
+fn test_search_no_match_quiet_suppresses_stderr() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("test.txt"), "some content\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--quiet")
+        .arg("search")
+        .arg("nonexistent_xyz")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("no matches"),
+        "stderr should be suppressed with --quiet but was: {stderr}"
+    );
+}
+
+#[test]
 fn test_search_jsonl_output_has_path_field() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("hello.txt"), "hello world\n").unwrap();


### PR DESCRIPTION
## Summary

Same bug class as #1340/#1341: `show_status()` requires a TTY, silently suppressing error diagnostics when stderr is piped. Changed to `!global.quiet` on 4 error diagnostic paths in replace and search commands.

## Changes

- **`src/cmd/replace.rs`:** Fix 3 paths: no-match in standard mode (exit 3), no-match in context-based mode (exit 3), ambiguous match with `--unique` (exit 5).
- **`src/cmd/search.rs`:** Fix 1 path: no-match (exit 3).
- **Integration tests:** 7 new tests verifying stderr emission and `--quiet` suppression for all 4 fixed paths.