### PR TITLE
fix: return CHANGES_DETECTED exit code in default preview mode

### DIFF
--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -220,7 +220,7 @@ mod tests {
         let global = GlobalFlags::test_default();
 
         let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(code, exit::CHANGES_DETECTED);
 
         // File should NOT be created in default diff-preview mode.
         assert!(!file.exists());

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -76,7 +76,7 @@ mod tests {
         std::fs::write(&file, "content").unwrap();
 
         let code = run(make_args(&file.to_string_lossy()), &GlobalFlags::default()).unwrap();
-        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(code, exit::CHANGES_DETECTED);
         assert!(file.exists(), "dry-run should not delete the file");
     }
 

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -139,11 +139,12 @@ fn execute_via_engine_inner<T: Serialize>(
     }
 
     // Show preview output.
+    let has_changes = result.has_changes;
     let output = make_output(WritePhase::Preview, diff_text);
     if !global.emit_json(&output)? {
         if !diffs.is_empty() {
             print!("{}", render_diffs_colored(&diffs, global.should_color()));
-        } else if result.has_changes && !global.quiet {
+        } else if has_changes && !global.quiet {
             println!("{check_msg}");
         }
     }
@@ -152,9 +153,14 @@ fn execute_via_engine_inner<T: Serialize>(
     if global.should_apply() {
         result.commit()?;
         crate::write::run_format_command(global, &cwd)?;
+        return Ok(exit::SUCCESS);
     }
 
-    Ok(exit::SUCCESS)
+    if has_changes {
+        Ok(exit::CHANGES_DETECTED)
+    } else {
+        Ok(exit::SUCCESS)
+    }
 }
 
 #[cfg(test)]
@@ -324,7 +330,38 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(code, exit::CHANGES_DETECTED);
         assert!(!dir.path().join("preview.txt").exists());
+    }
+
+    #[test]
+    fn execute_via_engine_preview_no_changes() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("existing.txt");
+        fs::write(&file, "hello\n").unwrap();
+
+        let global = GlobalFlags::test_with_cwd(dir.path());
+
+        // FileCreate with same content + force should have no changes
+        // but that depends on engine internals; use Append with empty content
+        let op = Operation::FileAppend {
+            path: "existing.txt".to_string(),
+            content: String::new(),
+        };
+
+        let code = execute_via_engine(
+            op,
+            &global,
+            |_phase, _diff| TestOutput {
+                ok: true,
+                path: "existing.txt".to_string(),
+                applied: None,
+            },
+            "would change existing.txt",
+            "changed existing.txt",
+        )
+        .unwrap();
+
+        assert_eq!(code, exit::SUCCESS);
     }
 }

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -973,7 +973,7 @@ fn test_verbose_md_emits_trace() {
         .arg("--content")
         .arg("New body\n")
         .assert()
-        .success()
+        .code(2)
         .stderr(predicate::str::contains("[patchloom] md:"));
 }
 
@@ -1122,7 +1122,7 @@ fn test_verbose_doc_set_emits_trace() {
         .arg("--cwd")
         .arg(dir.path())
         .assert()
-        .success()
+        .code(2)
         .stderr(
             predicate::str::contains("[patchloom] doc:").and(predicate::str::contains("doc: set")),
         );

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -577,3 +577,25 @@ fn test_create_format_flag_runs_after_apply() {
         "--format command should have run after create --apply"
     );
 }
+
+// Regression: default (preview) mode must return exit code 2 (CHANGES_DETECTED)
+// when the operation would produce changes, not 0 (SUCCESS).
+#[test]
+fn test_create_default_mode_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("new.txt");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("create")
+        .arg(&file)
+        .arg("--content")
+        .arg("hello")
+        .assert()
+        .code(2);
+
+    assert!(
+        !file.exists(),
+        "file should not be created in default (preview) mode"
+    );
+}

--- a/tests/integration/delete_tests.rs
+++ b/tests/integration/delete_tests.rs
@@ -216,7 +216,7 @@ fn test_delete_default_dry_run_does_not_remove() {
         .arg("delete")
         .arg(file.to_str().unwrap())
         .assert()
-        .success()
+        .code(2)
         .stdout(predicate::str::contains("would delete"));
 
     assert!(file.exists(), "dry-run should not delete the file");
@@ -234,7 +234,7 @@ fn test_delete_quiet_dry_run_suppresses_output() {
         .arg("delete")
         .arg(file.to_str().unwrap())
         .assert()
-        .success()
+        .code(2)
         .stdout(predicate::str::is_empty());
 
     assert!(file.exists(), "quiet dry-run should not delete the file");
@@ -319,4 +319,21 @@ fn test_delete_binary_file_succeeds() {
         .code(0);
 
     assert!(!file.exists(), "binary file should be deleted");
+}
+
+// Regression: default (preview) mode must return exit 2 (CHANGES_DETECTED), not 0.
+#[test]
+fn test_delete_default_mode_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("target.txt");
+    fs::write(&file, "keep me\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["delete"])
+        .arg(file.to_str().unwrap())
+        .assert()
+        .code(2);
+
+    assert!(file.exists(), "file should not be deleted in default mode");
 }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -187,7 +187,11 @@ fn test_doc_set_confirm_eof_does_not_modify_file() {
         "\u{4}",
     );
 
-    assert!(output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "declined confirm should exit 2 (CHANGES_DETECTED)"
+    );
     let content = fs::read_to_string(&file).unwrap();
     let v: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert_eq!(v["version"], serde_json::json!("1.0"));
@@ -2069,6 +2073,53 @@ fn test_doc_get_no_match_quiet_suppresses_stderr() {
         "--quiet should suppress stderr, got: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+// ---------------------------------------------------------------------------
+// Regression: default (preview) mode exit code (#1345)
+// ---------------------------------------------------------------------------
+
+// doc set in default mode must return exit 2 (CHANGES_DETECTED), not 0.
+#[test]
+fn test_doc_set_default_mode_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"version":"1.0"}"#).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("version")
+        .arg("\"2.0\"")
+        .assert()
+        .code(2);
+
+    // File should not be modified
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(content, r#"{"version":"1.0"}"#);
+}
+
+// doc delete in default mode must return exit 2 (CHANGES_DETECTED), not 0.
+#[test]
+fn test_doc_delete_default_mode_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"a":1,"b":2}"#).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("delete")
+        .arg(&file)
+        .arg("a")
+        .assert()
+        .code(2);
+
+    // File should not be modified
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(content.contains("\"a\""));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -122,7 +122,7 @@ fn test_append_cli_diff_shows_unified_diff() {
     patchloom_in(dir.path())
         .args(["append", "log.txt", "--content", "second\n"])
         .assert()
-        .success()
+        .code(2)
         .stdout(predicates::str::contains("+second"));
 }
 
@@ -206,6 +206,43 @@ fn test_prepend_cli_diff_shows_unified_diff() {
     patchloom_in(dir.path())
         .args(["prepend", "log.txt", "--content", "first\n"])
         .assert()
-        .success()
+        .code(2)
         .stdout(predicates::str::contains("+first"));
+}
+
+// Regression: default (preview) mode must return exit 2 (CHANGES_DETECTED), not 0.
+#[test]
+fn test_append_default_mode_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("log.txt");
+    fs::write(&file, "line1\n").unwrap();
+
+    patchloom_in(dir.path())
+        .args(["append", "log.txt", "--content", "line2\n"])
+        .assert()
+        .code(2);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line1\n",
+        "file should not be modified in default mode"
+    );
+}
+
+#[test]
+fn test_prepend_default_mode_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("log.txt");
+    fs::write(&file, "line1\n").unwrap();
+
+    patchloom_in(dir.path())
+        .args(["prepend", "log.txt", "--content", "header\n"])
+        .assert()
+        .code(2);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line1\n",
+        "file should not be modified in default mode"
+    );
 }

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -65,7 +65,11 @@ fn test_md_default_mode_shows_diff() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "default mode with changes should exit 2 (CHANGES_DETECTED)"
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("--- a/"),

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -610,7 +610,7 @@ fn test_rename_default_diff_preview() {
         .arg(&src)
         .arg(&dst)
         .assert()
-        .success()
+        .code(2)
         .stdout(predicate::str::contains("-hello"))
         .stdout(predicate::str::contains("+hello"));
 


### PR DESCRIPTION
## Summary

`execute_via_engine_inner()` unconditionally returned `exit::SUCCESS` (0) in the default/preview path, even when the operation would produce changes. This was inconsistent with `--check` mode (which correctly returned `exit::CHANGES_DETECTED`) and with the `replace` command (which uses `execute_precomputed` and correctly returned exit 2).

## Affected commands

All commands routed through `execute_via_engine`: `doc set`, `doc delete`, `doc merge`, `md replace-section`, `md insert`, `md upsert-bullet`, `md table-append`, `create`, `delete`, `append`, `prepend`, `rename`.

## Root cause

`src/cmd/output.rs:157` in `execute_via_engine_inner()` had an unconditional `Ok(exit::SUCCESS)` as the final return. The fix checks `result.has_changes` and returns `exit::CHANGES_DETECTED` when changes would be made.

## Changes

- Fix the exit code in the default/preview path of `execute_via_engine_inner()`
- Capture `has_changes` before the confirm block (which may consume `result` via `commit()`)
- When confirm is accepted and `commit()` runs, return `SUCCESS`; otherwise return `CHANGES_DETECTED`
- Updated 10 existing tests that incorrectly asserted exit 0 in default mode with changes
- Added 8 new regression tests covering all affected command families

Found by fixrealloop Round 2 runtime testing.

Closes #1345