### PR TITLE
fix: return CHANGES_DETECTED in default mode for tx, batch, and patch commands

### DIFF
--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -438,6 +438,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // Default / --diff mode: show diff preview.
+    let has_changes = result.has_changes;
     let diffs = result.build_diffs();
     if global.json || global.jsonl {
         let files = build_file_results(&diffs, "changed");
@@ -448,7 +449,11 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             format_diff_result_colored(&DiffResult { diffs }, global.should_color())
         );
     }
-    Ok(exit::SUCCESS)
+    if has_changes {
+        Ok(exit::CHANGES_DETECTED)
+    } else {
+        Ok(exit::SUCCESS)
+    }
 }
 
 #[cfg(test)]

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -477,7 +477,11 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return commit_and_finalize(&ctx, &mut result, global, false);
     }
 
-    Ok(exit::SUCCESS)
+    if !result.no_effective_changes {
+        Ok(exit::CHANGES_DETECTED)
+    } else {
+        Ok(exit::SUCCESS)
+    }
 }
 
 #[path = "tx_tests.rs"]

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -59,7 +59,7 @@ fn test_batch_diff_mode_does_not_write() {
         .arg("batch")
         .arg(&ops)
         .assert()
-        .code(0);
+        .code(2);
 
     // File must be unchanged in default (diff) mode.
     let content = fs::read_to_string(dir.path().join("pkg.json")).unwrap();

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -878,7 +878,7 @@ fn test_verbose_tx_emits_trace() {
         .arg("--cwd")
         .arg(dir.path())
         .assert()
-        .success()
+        .code(2)
         .stderr(
             predicate::str::contains("[patchloom] tx:")
                 .and(predicate::str::contains("[patchloom] tx: executing plan")),
@@ -949,7 +949,7 @@ fn test_verbose_batch_emits_trace() {
         .arg("--cwd")
         .arg(dir.path())
         .assert()
-        .success()
+        .code(2)
         .stderr(predicate::str::contains("[patchloom] batch:"));
 }
 
@@ -994,7 +994,7 @@ fn test_verbose_patch_emits_trace() {
         .arg("--cwd")
         .arg(dir.path())
         .assert()
-        .success()
+        .code(2)
         .stderr(predicate::str::contains("[patchloom] patch:"));
 }
 

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -22,7 +22,7 @@ fn test_patch_apply_dry_run_does_not_modify_file() {
         .arg("apply")
         .arg(&patch_file)
         .assert()
-        .code(0);
+        .code(2);
 
     let content = fs::read_to_string(&file).unwrap();
     assert_eq!(

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -230,13 +230,13 @@ fn test_smoke_example_07_yaml_plan() {
     )
     .unwrap();
 
-    // --diff mode: plan should parse successfully.
+    // --diff mode: plan should parse successfully and exit 2 (changes detected).
     patchloom_in(dir.path())
         .arg("tx")
         .arg(example_plan_path("07-yaml-plan.yaml"))
         .arg("--diff")
         .assert()
-        .code(0);
+        .code(2);
 
     // --apply: skip format/validate (prettier/yamllint may not exist).
     // Instead verify the plan parses and operations apply.
@@ -295,7 +295,7 @@ fn test_smoke_example_09_patch_apply() {
         .arg(example_plan_path("09-patch-apply.json"))
         .arg("--diff")
         .assert()
-        .code(0);
+        .code(2);
 }
 
 #[test]
@@ -321,7 +321,7 @@ fn test_smoke_example_10_inspect_and_edit() {
         .arg(example_plan_path("10-inspect-and-edit.json"))
         .arg("--diff")
         .assert()
-        .code(0);
+        .code(2);
 
     // --apply: verify writes landed.
     patchloom_in(dir.path())
@@ -504,7 +504,11 @@ fn test_smoke_quickstart_command_flow() {
         )
         .output()
         .unwrap();
-    assert!(batch_preview.status.success());
+    assert_eq!(
+        batch_preview.status.code(),
+        Some(2),
+        "batch preview should exit 2"
+    );
     let batch_preview_stdout = String::from_utf8_lossy(&batch_preview.stdout);
     assert!(batch_preview_stdout.contains("package.json"));
     assert!(batch_preview_stdout.contains("README.md"));
@@ -592,7 +596,7 @@ fn test_smoke_quickstart_transaction_snippet() {
         .arg(&plan_file)
         .output()
         .unwrap();
-    assert!(diff_output.status.success());
+    assert_eq!(diff_output.status.code(), Some(2), "tx diff should exit 2");
     let diff_stdout = String::from_utf8_lossy(&diff_output.stdout);
     assert!(diff_stdout.contains("package.json"));
     assert!(diff_stdout.contains("README.md"));

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -3320,7 +3320,11 @@ fn test_tx_read_sees_in_plan_state() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "tx with replace should exit 2 in preview mode"
+    );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let reads = json["reads"].as_array().unwrap();
     assert_eq!(reads.len(), 2);
@@ -4093,7 +4097,11 @@ fn test_tx_json_output_on_diff() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "tx default mode with changes should exit 2"
+    );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], true);
     assert_eq!(json["status"], "success");


### PR DESCRIPTION
## Summary

Same class of bug as #1345 (fixed in `execute_via_engine`), but in the `tx` and `patch` code paths which have their own mode branching.

## Root cause

- **tx** (`src/cmd/tx.rs:480`): unconditionally returned `SUCCESS` in default/preview mode even when operations produced changes. The `--check` path correctly returned `CHANGES_DETECTED`.
- **patch** (`src/cmd/patch.rs:451`): same pattern.
- **batch** delegates to `tx::run()`, so the tx fix covers batch too.

## Changes

- Fix exit code in tx default/preview path: return `CHANGES_DETECTED` when `!result.no_effective_changes`
- Fix exit code in patch default/preview path: return `CHANGES_DETECTED` when `has_changes`
- Updated 12 tests that incorrectly asserted exit 0 in default mode with changes

Found by fixrealloop Round 3 runtime testing.