### PR TITLE
fix: ast read and md dedupe-headings exit code consistency

### DIFF
--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -245,8 +245,14 @@ fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.symbol
     );
     let all_symbols = symbols::extract_symbols(&source, lang);
-    let sym = symbols::find_symbol(&all_symbols, &args.symbol)
-        .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in {}", args.symbol, args.path))?;
+    let sym = match symbols::find_symbol(&all_symbols, &args.symbol) {
+        Some(s) => s,
+        None => {
+            let msg = format!("symbol '{}' not found in {}", args.symbol, args.path);
+            global.emit_error_json(&msg)?;
+            return Ok(exit::NO_MATCHES);
+        }
+    };
 
     let lines: Vec<&str> = source.lines().collect();
     let start = sym

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -310,6 +310,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
 
             // Default / --diff mode: preview diffs.
+            let has_changes = result.has_changes;
             let diffs = result.build_diffs();
             if !diffs.is_empty() && !global.json && !global.jsonl {
                 let dr = crate::diff::DiffResult {
@@ -325,9 +326,14 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             if global.should_apply() {
                 result.commit()?;
                 crate::write::run_format_command(global, &cwd)?;
+                return Ok(exit::SUCCESS);
             }
 
-            Ok(exit::SUCCESS)
+            if has_changes {
+                Ok(exit::CHANGES_DETECTED)
+            } else {
+                Ok(exit::SUCCESS)
+            }
         }
 
         MdAction::LintAgents { file } => {

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -56,6 +56,35 @@ fn test_ast_read_basic() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_read_symbol_not_found_exits_3() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("main.rs");
+    fs::write(&f, "fn target() { let x=1; }\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "read", "main.rs", "nonexistent"])
+        .assert()
+        .code(3)
+        .stderr(predicates::str::contains("not found"));
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_read_symbol_not_found_json() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("main.rs");
+    fs::write(&f, "fn target() { let x=1; }\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "read", "main.rs", "nonexistent", "--json"])
+        .assert()
+        .code(3)
+        .stdout(
+            predicates::str::contains(r#""ok":false"#)
+                .or(predicates::str::contains(r#""ok": false"#)),
+        );
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_validate_ok() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("ok.rs");

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -225,6 +225,26 @@ fn test_md_dedupe_headings_removes_duplicate() {
 }
 
 #[test]
+fn test_md_dedupe_headings_default_mode_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.md");
+    fs::write(&file, "# Title\n\n## Dup\n\nFirst\n\n## Dup\n\nSecond\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("md")
+        .arg("dedupe-headings")
+        .arg(&file)
+        .assert()
+        .code(2);
+
+    // File should not be modified in preview mode
+    let content = fs::read_to_string(&file).unwrap();
+    let count = content.matches("## Dup").count();
+    assert_eq!(count, 2, "preview mode should not modify file");
+}
+
+#[test]
 fn test_md_dedupe_headings_jsonl_output() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.md");


### PR DESCRIPTION
## Summary

Two exit code consistency fixes found by fixrealloop Round 4:

**1. `ast read` symbol-not-found returns exit 1 instead of exit 3**

`ast read` used `anyhow::anyhow!("symbol not found")?` which propagated as exit 1 (FAILURE). Every other ast subcommand (`list`, `rename`, `refs`, `search`, `imports`) correctly returns exit 3 (NO_MATCHES) with `emit_error_json` for not-found conditions.

Fix: replaced anyhow error propagation with `emit_error_json` + `return Ok(exit::NO_MATCHES)`.

**2. `md dedupe-headings` preview mode returns exit 0 instead of exit 2**

Same class of bug as PR #1345 and PR #1346. The dedupe-headings code path bypasses `execute_via_engine` (uses `execute_single` directly) so it was not covered by those fixes. Preview mode unconditionally returned SUCCESS even when duplicate headings were detected.

Fix: capture `has_changes` before the confirm block and return CHANGES_DETECTED when changes exist.

## Tests

- `test_ast_read_symbol_not_found_exits_3`: text mode exits 3
- `test_ast_read_symbol_not_found_json`: JSON mode returns `{"ok": false}`
- `test_md_dedupe_headings_default_mode_exits_2`: preview mode exits 2, file unmodified

`make check-fast` passes.