### PR TITLE
fix: write_dispatch preview mode returns exit 0 instead of exit 2

### DIFF
--- a/src/cmd/write_dispatch.rs
+++ b/src/cmd/write_dispatch.rs
@@ -103,9 +103,10 @@ pub fn execute_write<T: Serialize>(
         {
             eprintln!("{msg}");
         }
+        return Ok(exit::SUCCESS);
     }
 
-    Ok(exit::SUCCESS)
+    Ok(exit::CHANGES_DETECTED)
 }
 
 #[cfg(test)]
@@ -191,7 +192,7 @@ mod tests {
     }
 
     #[test]
-    fn default_mode_returns_success_without_apply() {
+    fn default_mode_returns_changes_detected_without_apply() {
         let dir = tempfile::TempDir::new().unwrap();
         let global = GlobalFlags::test_with_cwd(dir.path());
 
@@ -209,7 +210,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(code, exit::CHANGES_DETECTED);
         assert!(!applied, "default mode must not apply");
     }
 
@@ -232,7 +233,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(code, exit::CHANGES_DETECTED);
     }
 
     #[test]

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -535,14 +535,15 @@ fn test_rename_binary_file_diff_mode() {
     let src = dir.path().join("binary.bin");
     fs::write(&src, b"\x00\x01\x02\xff").unwrap();
 
-    // Default mode (--diff) should not crash on binary files.
+    // Default mode (--diff) should not crash on binary files and should
+    // return exit 2 (CHANGES_DETECTED) since a rename would happen.
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("rename")
         .arg(&src)
         .arg(dir.path().join("moved.bin"))
         .assert()
-        .code(0);
+        .code(2);
 
     // Source should still exist (no --apply).
     assert!(src.exists());


### PR DESCRIPTION
## Summary

Last instance of the preview exit code bug class (PRs #1345, #1346, #1347).

`execute_write()` in `write_dispatch.rs` unconditionally returned exit 0 (SUCCESS) in default/preview mode. This path is used by binary file renames and case-only renames, which bypass the tx engine and go through `write_dispatch` directly.

Found via full code audit of all 53 `Ok(exit::SUCCESS)` instances across every command file.

## Fix

Return `CHANGES_DETECTED` from the preview fallthrough, add early `return Ok(exit::SUCCESS)` after confirm-and-apply.

## Tests

- Updated `default_mode_returns_changes_detected_without_apply` unit test
- Updated `no_diff_fn_uses_human_check_in_preview` unit test
- Updated `test_rename_binary_file_diff_mode` integration test (`.code(0)` to `.code(2)`)

`make check-fast` passes.