### PR TITLE
docs: complete write path table and add exit code audit methodology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ All subcommands receive a `&GlobalFlags` reference. Read-only flags (`--json`, `
 - Return `Ok(exit::SUCCESS)` for success, `Ok(exit::NO_MATCHES)` for no-match, etc.
 - When returning `NO_MATCHES` with an error message, use `global.emit_error_json(&msg)?` (added in PR #1339). This helper encapsulates the standard pattern: emit `{"ok": false, "error": msg}` in JSON/JSONL mode, fall back to `eprintln!` in text mode (respecting `--quiet`). Before this helper, the inline pattern was `if !global.emit_json(&json!({"ok": false, "error": &msg}))? && !global.quiet { eprintln!("{msg}"); }`.
 - **Never use `global.show_status()` on error diagnostic paths.** `show_status()` requires a TTY (returns `false` when stderr is piped), which silently suppresses error messages in scripts and pipelines. Use `!global.quiet` instead. Reserve `show_status()` for optional progress hints and status messages that are genuinely TTY-only (e.g., "hint: use --apply", file count summaries). See #1340 and #1341 for bugs caused by this confusion.
+- **Preview mode must return `CHANGES_DETECTED` (exit 2), not `SUCCESS` (exit 0).** When a write command runs in default mode (no `--apply`, `--check`, or `--diff`) and the operation would produce changes, the exit code must be `exit::CHANGES_DETECTED`. Returning `exit::SUCCESS` in preview mode is a bug: it makes scripts think no changes exist. Each of the five write paths (`execute_via_engine`, `execute_operations`, `execute_precomputed`, `execute_write`, `execute_single`) has its own mode branching, and the exit code must be verified independently in each path. See PRs #1345-#1348 where this bug was found and fixed in all five paths.
 
 ### Testing
 
@@ -269,8 +270,10 @@ Command::<Name>(args) => <name>::run(args, &global),
 | `execute_via_engine()` | Single-operation writes (most commands) | doc, md, create, delete, append, ast replace |
 | `execute_operations()` | Multi-file writes with pre-filtering | ast rename (scans, filters, batches) |
 | `execute_precomputed()` | Parallel scan + batch commit (optimization) | replace (multi-file regex scan) |
+| `execute_write()` | Binary/case-only file operations via `write_dispatch.rs` | rename (binary files, case-only renames) |
+| `execute_single()` | One-off writes with custom pre/post logic | md dedupe-headings, patch apply |
 
-All three go through the tx engine and get backup, rollback, format/validate lifecycle. Do not use `atomic_write()` directly in command implementations.
+All five go through the tx engine and get backup, rollback, format/validate lifecycle. Each has its own mode branching for preview vs apply, so exit code correctness must be verified independently per path. Do not use `atomic_write()` directly in command implementations.
 
 6. If the command scans multiple files, use `crate::par_process_files()` for adaptive parallelism instead of a sequential loop. The closure must be `Fn + Sync` (no mutable captures). Write-back stays serial.
 
@@ -388,6 +391,13 @@ grep -ri "tool_name" --include="*.md" --include="*.rs" --include="*.json" .
 - Use `anyhow::Context` to add context to errors rather than custom `.map_err()` chains.
 
 - When changing how results are populated or filtered (e.g., adding an optimization that skips building result objects), add an integration test that verifies the exit code is still correct for the affected mode. Exit code regressions are invisible to unit tests that only check output format.
+
+- **Exit code audit methodology.** When a bug is found in one write path's exit code handling, audit ALL write paths systematically. The same structural bug (e.g., preview mode returning exit 0 instead of exit 2) was independently present in all five write paths (PRs #1345-#1348). The audit procedure:
+  1. Grep for `Ok(exit::SUCCESS)` in all `src/cmd/*.rs` files to find every exit-0 return site.
+  2. For each hit in a write command, verify it is inside a `should_apply()` or equivalent guard (not unconditional).
+  3. Grep for `execute_single` call sites (3 in the codebase) since this path bypasses shared write infrastructure and has its own mode branching.
+  4. Check `src/cmd/write_dispatch.rs` (`execute_write`) which handles binary/case-only renames with its own separate mode logic.
+  5. Verify that every write path's default mode (no flags) returns `CHANGES_DETECTED` when changes exist.
 
 - Internal refactors and performance optimizations (no user-visible behavior change) still require a targeted unit or integration test on the changed helper or code path. Existing higher-level tests may provide coverage, but a focused test prevents silent regression of the optimization or guard in future refactors.
 


### PR DESCRIPTION
## Summary

Captures lessons from the fixrealloop exit code audit session (PRs #1345-#1348).

### Changes

1. **Write path table** (Adding a new command section): Added `execute_write()` and `execute_single()` to the table. Previously listed 3 paths; there are actually 5. The two missing entries directly caused the same exit code bug to hide in those paths.

2. **Preview mode exit code contract** (Error handling section): Documents that preview mode MUST return `CHANGES_DETECTED` (exit 2) when changes exist. Each of the five write paths has its own mode branching, so exit code correctness must be verified independently per path.

3. **Exit code audit methodology** (Coding conventions section): Step-by-step procedure for auditing all write paths when an exit code bug is found in one path.

### Context

The fixrealloop session found the same structural bug in all five write paths: preview mode unconditionally returned `exit::SUCCESS` (0) instead of `exit::CHANGES_DETECTED` (2). The AGENTS.md table only listed 3 write paths, so auditing "all paths" still missed the other 2. This update prevents that gap.

Refs #1345, #1346, #1347, #1348, #1349, #1350