### PR TITLE
fix: resolve bugs #1349 and #1350 (exit code and .patchloom exclusion)

### DIFF
--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -135,7 +135,11 @@ fn execute_via_engine_inner<T: Serialize>(
         }
         let output = make_output(WritePhase::Confirmed(applied), diff_text);
         global.emit_json(&output)?;
-        return Ok(exit::SUCCESS);
+        return if applied {
+            Ok(exit::SUCCESS)
+        } else {
+            Ok(exit::CHANGES_DETECTED)
+        };
     }
 
     // Show preview output.
@@ -332,6 +336,40 @@ mod tests {
 
         assert_eq!(code, exit::CHANGES_DETECTED);
         assert!(!dir.path().join("preview.txt").exists());
+    }
+
+    #[test]
+    fn execute_via_engine_confirm_json_decline_returns_changes_detected() {
+        let dir = TempDir::new().unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.confirm = true;
+        global.json = true;
+        // confirm + json in non-TTY -> should_apply() returns false
+
+        let op = Operation::FileCreate {
+            path: "new.txt".to_string(),
+            content: "hello\n".to_string(),
+            force: None,
+        };
+
+        let code = execute_via_engine(
+            op,
+            &global,
+            |phase, _diff| TestOutput {
+                ok: true,
+                path: "new.txt".to_string(),
+                applied: match phase {
+                    WritePhase::Confirmed(a) => Some(a),
+                    _ => None,
+                },
+            },
+            "would create new.txt",
+            "created new.txt",
+        )
+        .unwrap();
+
+        assert_eq!(code, exit::CHANGES_DETECTED);
+        assert!(!dir.path().join("new.txt").exists());
     }
 
     #[test]

--- a/src/cmd/write_dispatch.rs
+++ b/src/cmd/write_dispatch.rs
@@ -81,7 +81,11 @@ pub fn execute_write<T: Serialize>(
         }
         let output = make_output(WritePhase::Confirmed(applied), diff_text);
         global.emit_json(&output)?;
-        return Ok(exit::SUCCESS);
+        return if applied {
+            Ok(exit::SUCCESS)
+        } else {
+            Ok(exit::CHANGES_DETECTED)
+        };
     }
 
     // Show preview output.
@@ -234,6 +238,32 @@ mod tests {
         .unwrap();
 
         assert_eq!(code, exit::CHANGES_DETECTED);
+    }
+
+    #[test]
+    fn confirm_json_decline_returns_changes_detected() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.confirm = true;
+        global.json = true;
+        // confirm + json in non-TTY -> should_apply() returns false
+
+        let mut applied = false;
+        let code = execute_write(
+            &global,
+            dir.path(),
+            make_test_output,
+            Some(&|_color| "diff".to_string()),
+            || {
+                applied = true;
+                Ok(())
+            },
+            test_msgs(),
+        )
+        .unwrap();
+
+        assert_eq!(code, exit::CHANGES_DETECTED);
+        assert!(!applied, "decline must not apply");
     }
 
     #[test]

--- a/src/files.rs
+++ b/src/files.rs
@@ -143,9 +143,14 @@ pub(crate) fn collect_file_paths_opts(
             target: &collected,
         };
         Box::new(move |result| {
-            if let Ok(entry) = result
-                && entry.file_type().is_some_and(|ft| ft.is_file())
-            {
+            let Ok(entry) = result else {
+                return WalkState::Continue;
+            };
+            // Skip .patchloom directory (internal backup storage, #1349).
+            if entry.file_name() == ".patchloom" {
+                return WalkState::Skip;
+            }
+            if entry.file_type().is_some_and(|ft| ft.is_file()) {
                 state.batch.push(entry.into_path());
                 if state.batch.len() >= 256 {
                     state
@@ -460,12 +465,16 @@ pub fn collect_file_paths_with_ignores(
     for name in custom_ignore_filenames {
         builder.add_custom_ignore_filename(name);
     }
-    let mut paths: Vec<PathBuf> = builder
-        .build()
-        .filter_map(Result::ok)
-        .filter(|e| e.file_type().is_some_and(|ft| ft.is_file()))
-        .map(|e| e.into_path())
-        .collect();
+    let mut paths: Vec<PathBuf> = Vec::new();
+    for entry in builder.build().filter_map(Result::ok) {
+        // Skip .patchloom directory (internal backup storage, #1349).
+        if entry.file_name() == ".patchloom" {
+            continue;
+        }
+        if entry.file_type().is_some_and(|ft| ft.is_file()) {
+            paths.push(entry.into_path());
+        }
+    }
 
     apply_exclude_globs(&mut paths, exclude_patterns, Some(root))?;
     Ok(paths)
@@ -880,6 +889,57 @@ mod tests {
                 .any(|r| r.starts_with("target") || r.ends_with(".md") || r.ends_with(".rs")),
             "advanced ignores not applied: {:?}",
             rels
+        );
+    }
+
+    #[test]
+    #[cfg(any(feature = "cli", feature = "files"))]
+    fn collect_file_paths_skips_patchloom_directory() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("real.txt"), "hello\n").unwrap();
+        fs::create_dir_all(root.join(".patchloom/backups/12345")).unwrap();
+        fs::write(root.join(".patchloom/backups/12345/manifest.json"), "{}\n").unwrap();
+
+        let paths = collect_file_paths(root, false).unwrap();
+        let rels: Vec<_> = paths
+            .iter()
+            .map(|p| p.strip_prefix(root).unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            rels.contains(&"real.txt".to_string()),
+            "real.txt should be collected: {rels:?}"
+        );
+        assert!(
+            !rels.iter().any(|r| r.contains(".patchloom")),
+            ".patchloom files should be excluded: {rels:?}"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn collect_file_paths_opts_skips_patchloom_directory() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("real.txt"), "hello\n").unwrap();
+        fs::create_dir_all(root.join(".patchloom/backups/12345")).unwrap();
+        fs::write(root.join(".patchloom/backups/12345/manifest.json"), "{}\n").unwrap();
+
+        let global = GlobalFlags::test_with_cwd(root);
+        let paths = collect_file_paths_opts(&[".".to_string()], &global, true, Some(root)).unwrap();
+        let rels: Vec<_> = paths
+            .iter()
+            .map(|p| p.strip_prefix(root).unwrap().to_string_lossy().to_string())
+            .collect();
+        assert!(
+            rels.contains(&"real.txt".to_string()),
+            "real.txt should be collected: {rels:?}"
+        );
+        assert!(
+            !rels.iter().any(|r| r.contains(".patchloom")),
+            ".patchloom files should be excluded even with include_hidden=true: {rels:?}"
         );
     }
 

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -290,7 +290,11 @@ fn test_create_json_confirm_output_reports_applied_false_on_tty_eof() {
         "\u{4}",
     );
 
-    assert!(output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2), // CHANGES_DETECTED
+        "declining --confirm --json should return CHANGES_DETECTED (exit 2)"
+    );
     assert!(
         !file.exists(),
         "file should not be created when confirmation input ends at EOF"

--- a/tests/integration/delete_tests.rs
+++ b/tests/integration/delete_tests.rs
@@ -98,7 +98,11 @@ fn test_delete_json_confirm_output_reports_applied_false_on_tty_eof() {
         "\u{4}",
     );
 
-    assert!(output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2), // CHANGES_DETECTED
+        "declining --confirm --json should return CHANGES_DETECTED (exit 2)"
+    );
     assert!(
         file.exists(),
         "file should remain when confirmation input ends at EOF"

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -486,7 +486,11 @@ fn test_rename_json_confirm_output_reports_applied_false_on_tty_eof() {
         "\u{4}",
     );
 
-    assert!(output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2), // CHANGES_DETECTED
+        "declining --confirm --json should return CHANGES_DETECTED (exit 2)"
+    );
     assert!(
         src.exists(),
         "source should remain when confirmation input ends at EOF"


### PR DESCRIPTION
## Summary

Two bug fixes:

1. **--confirm --json exit code (#1350):** When using `--confirm --json` on a write command and the user declines, the exit code was incorrectly 0 (SUCCESS). Now correctly returns 2 (CHANGES_DETECTED). Fixed in both `execute_via_engine` (output.rs) and `execute_write` (write_dispatch.rs).

2. **.patchloom/ directory exclusion (#1349):** File-walking commands (search, replace, tidy, status) now skip the `.patchloom/` directory by default. This prevents tidy from reporting internal backup manifests as needing fixes, and prevents `--apply` from corrupting backup files.

Both fixes include unit tests and updated integration tests.

Closes #1350
Closes #1349