### PR TITLE
fix: MPI rotation - exit codes, JSON output, backup perms, editorconfig, docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,10 +257,14 @@ mod tests {
 // For write commands:
 Command::<Name>(args) => {
     global.merge_write(&args.write);
+    load_project_config(&mut global);
     <name>::run(args, &global)
 }
 // For read-only commands:
-Command::<Name>(args) => <name>::run(args, &global),
+Command::<Name>(args) => {
+    load_project_config(&mut global);
+    <name>::run(args, &global)
+}
 ```
 
 5. **Choose the correct write path for commands that mutate files:**

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -98,6 +98,14 @@ impl BackupSession {
         std::fs::create_dir_all(&session_dir)
             .with_context(|| format!("failed to create backup dir {}", session_dir.display()))?;
 
+        // Restrict backup directory to owner-only access so that backed-up
+        // files with sensitive content are not world-readable.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&session_dir, std::fs::Permissions::from_mode(0o700));
+        }
+
         // Best-effort prune of old backups; ignore errors.
         let _ = prune_old_backups(project_root);
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -453,6 +453,20 @@ fn format_values(values: &[&serde_json::Value], mode: OutputMode) -> anyhow::Res
 /// Used by read-only doc subcommands (get, keys, len, flatten) to produce
 /// consistent no-match output without repeating the Json/Jsonl/Text match.
 fn format_no_match(error_msg: &str, mode: OutputMode, quiet: bool) -> anyhow::Result<(String, u8)> {
+    format_error(error_msg, mode, quiet, exit::NO_MATCHES)
+}
+
+/// Format an error result for the given output mode and exit code.
+///
+/// In Json/Jsonl mode, wraps the message in a `{"ok": false, "error": ...}`
+/// envelope. In Text mode, prints to stderr (unless quiet). Returns the
+/// supplied exit code.
+fn format_error(
+    error_msg: &str,
+    mode: OutputMode,
+    quiet: bool,
+    code: u8,
+) -> anyhow::Result<(String, u8)> {
     let output = match mode {
         OutputMode::Json => {
             serde_json::to_string_pretty(&serde_json::json!({"ok": false, "error": error_msg}))?
@@ -467,7 +481,7 @@ fn format_no_match(error_msg: &str, mode: OutputMode, quiet: bool) -> anyhow::Re
             String::new()
         }
     };
-    Ok((output, exit::NO_MATCHES))
+    Ok((output, code))
 }
 
 // ---------------------------------------------------------------------------
@@ -531,10 +545,12 @@ fn execute_with_mode_inner(
                     output_mode,
                     quiet,
                 ),
-                crate::ops::doc::query::QueryKeysResult::NotAnObject => Ok((
-                    format!("doc keys: target at '{selector}' is not an object"),
+                crate::ops::doc::query::QueryKeysResult::NotAnObject => format_error(
+                    &format!("doc keys: target at '{selector}' is not an object"),
+                    output_mode,
+                    quiet,
                     exit::FAILURE,
-                )),
+                ),
                 crate::ops::doc::query::QueryKeysResult::Keys(keys) => {
                     let output = match output_mode {
                         OutputMode::Text => keys.join("\n"),
@@ -559,10 +575,12 @@ fn execute_with_mode_inner(
                     output_mode,
                     quiet,
                 ),
-                crate::ops::doc::query::QueryLenResult::NotArrayOrObject => Ok((
-                    format!("doc len: target at '{selector}' is not an array or object"),
+                crate::ops::doc::query::QueryLenResult::NotArrayOrObject => format_error(
+                    &format!("doc len: target at '{selector}' is not an array or object"),
+                    output_mode,
+                    quiet,
                     exit::FAILURE,
-                )),
+                ),
                 crate::ops::doc::query::QueryLenResult::Len(len) => {
                     let output = match output_mode {
                         OutputMode::Text => len.to_string(),

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -738,26 +738,54 @@ mod error_handling {
     fn keys_on_scalar_returns_failure() {
         let dir = TempDir::new().unwrap();
         let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-        let action = DocAction::Keys {
-            file: path,
-            selector: "name".into(),
-        };
-        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        // Text mode: error goes to stderr, output is empty. Verify exit code.
+        let (_output, code) = execute_with_mode(
+            &DocAction::Keys {
+                file: path.clone(),
+                selector: "name".into(),
+            },
+            OutputMode::Text,
+        )
+        .unwrap();
         assert_eq!(code, exit::FAILURE);
-        assert!(output.contains("not an object"));
+        // JSON mode: error is wrapped in a JSON envelope.
+        let (json_output, json_code) = execute_with_mode(
+            &DocAction::Keys {
+                file: path,
+                selector: "name".into(),
+            },
+            OutputMode::Json,
+        )
+        .unwrap();
+        assert_eq!(json_code, exit::FAILURE);
+        assert!(json_output.contains("not an object"));
     }
 
     #[test]
     fn len_on_scalar_returns_failure() {
         let dir = TempDir::new().unwrap();
         let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
-        let action = DocAction::Len {
-            file: path,
-            selector: "name".into(),
-        };
-        let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
+        // Text mode: error goes to stderr, output is empty. Verify exit code.
+        let (_output, code) = execute_with_mode(
+            &DocAction::Len {
+                file: path.clone(),
+                selector: "name".into(),
+            },
+            OutputMode::Text,
+        )
+        .unwrap();
         assert_eq!(code, exit::FAILURE);
-        assert!(output.contains("not an array or object"));
+        // JSON mode: error is wrapped in a JSON envelope.
+        let (json_output, json_code) = execute_with_mode(
+            &DocAction::Len {
+                file: path,
+                selector: "name".into(),
+            },
+            OutputMode::Json,
+        )
+        .unwrap();
+        assert_eq!(json_code, exit::FAILURE);
+        assert!(json_output.contains("not an array or object"));
     }
 
     #[test]

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -371,7 +371,8 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         } else if has_conflicts && !apply_options.allow_conflicts {
             exit::CONFLICTS
         } else {
-            exit::SUCCESS
+            // Preview/check mode: report that changes would be applied.
+            exit::CHANGES_DETECTED
         });
     }
 
@@ -561,8 +562,9 @@ mod tests {
             &global,
         )
         .unwrap();
-        // Should succeed (not error), treating missing file as empty.
-        assert_eq!(code, exit::SUCCESS);
+        // Should report changes detected (not error), treating missing file
+        // as empty for new file creation.
+        assert_eq!(code, exit::CHANGES_DETECTED);
     }
 
     #[test]

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -156,11 +156,7 @@ fn inject_stale_label(msg: &str, label: &str) -> String {
 }
 
 fn emit_error(global: &GlobalFlags, error: &str) -> anyhow::Result<()> {
-    if global.emit_json(&serde_json::json!({"ok": false, "error": error}))? {
-        return Ok(());
-    }
-    eprintln!("{error}");
-    Ok(())
+    global.emit_error_json(error)
 }
 
 fn emit_patch_files_output(

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -365,7 +365,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             files: vec![],
         };
         global.emit_json(&payload)?;
-        if !global.quiet {
+        if !global.quiet && !global.json && !global.jsonl {
             let paths: Vec<&str> = args.paths.iter().map(|s| s.as_str()).collect();
             let path_desc = if paths.is_empty() {
                 ".".to_string()

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -147,45 +147,33 @@ fn check_file(
     issues
 }
 
-/// Resolve the `end_of_line` property from `.editorconfig` for `path`.
-///
-/// Returns `Some(EolMode)` when an `.editorconfig` declares an explicit
-/// `end_of_line` for this file, `None` otherwise.
+/// Resolve both EOL and trailing-whitespace properties from `.editorconfig`
+/// in a single parse pass.
 #[cfg(feature = "cli")]
-fn editorconfig_eol(path: &Path) -> Option<crate::write::EolMode> {
-    let props = ec4rs::properties_of(path).ok()?;
-    let val = props.get::<ec4rs::property::EndOfLine>().ok()?;
-    Some(match val {
-        ec4rs::property::EndOfLine::Lf => crate::write::EolMode::Lf,
-        ec4rs::property::EndOfLine::CrLf => crate::write::EolMode::Crlf,
-        ec4rs::property::EndOfLine::Cr => crate::write::EolMode::Cr,
-    })
+fn editorconfig_check_props(path: &Path) -> (Option<crate::write::EolMode>, bool) {
+    let props = match ec4rs::properties_of(path) {
+        Ok(p) => p,
+        Err(_) => return (None, true),
+    };
+    let eol = props
+        .get::<ec4rs::property::EndOfLine>()
+        .ok()
+        .map(|val| match val {
+            ec4rs::property::EndOfLine::Lf => crate::write::EolMode::Lf,
+            ec4rs::property::EndOfLine::CrLf => crate::write::EolMode::Crlf,
+            ec4rs::property::EndOfLine::Cr => crate::write::EolMode::Cr,
+        });
+    let trim = match props.get::<ec4rs::property::TrimTrailingWs>() {
+        Ok(ec4rs::property::TrimTrailingWs::Value(v)) => v,
+        _ => true,
+    };
+    (eol, trim)
 }
 
-/// Stub for non-CLI builds where EditorConfig support is unavailable.
+/// Stub for non-CLI builds.
 #[cfg(not(feature = "cli"))]
-fn editorconfig_eol(_path: &Path) -> Option<crate::write::EolMode> {
-    None
-}
-
-/// Resolve the `trim_trailing_whitespace` property from `.editorconfig`.
-///
-/// Returns `Some(false)` when editorconfig explicitly sets
-/// `trim_trailing_whitespace = false` for this file, `Some(true)` when it
-/// explicitly sets it to `true`, and `None` when unset.
-#[cfg(feature = "cli")]
-fn editorconfig_trim_ws(path: &Path) -> Option<bool> {
-    let props = ec4rs::properties_of(path).ok()?;
-    match props.get::<ec4rs::property::TrimTrailingWs>() {
-        Ok(ec4rs::property::TrimTrailingWs::Value(v)) => Some(v),
-        _ => None,
-    }
-}
-
-/// Stub for non-CLI builds where EditorConfig support is unavailable.
-#[cfg(not(feature = "cli"))]
-fn editorconfig_trim_ws(_path: &Path) -> Option<bool> {
-    None
+fn editorconfig_check_props(_path: &Path) -> (Option<crate::write::EolMode>, bool) {
+    (None, true)
 }
 
 /// Collect all issues from the given paths, honouring .gitignore and optional
@@ -205,21 +193,13 @@ fn collect_issues(paths: &[String], global: &GlobalFlags) -> anyhow::Result<Vec<
             // Resolve per-file EOL target: explicit --normalize-eol takes
             // precedence; otherwise consult .editorconfig when
             // --respect-editorconfig is set.
-            let file_eol_target =
-                eol_target.or_else(|| respect_ec.then(|| editorconfig_eol(path)).flatten());
-
-            // Resolve per-file trailing-whitespace check: when
-            // --respect-editorconfig is set and editorconfig declares
-            // trim_trailing_whitespace = false for this file type,
-            // suppress trailing-whitespace diagnostics.
-            let check_trailing_ws = if respect_ec {
-                match editorconfig_trim_ws(path) {
-                    Some(false) => false,
-                    Some(true) => true,
-                    None => true, // default: check trailing ws
-                }
+            // Resolve editorconfig properties once per file (avoid
+            // double-parsing .editorconfig when both EOL and trailing-WS
+            // settings are needed).
+            let (file_eol_target, check_trailing_ws) = if respect_ec && eol_target.is_none() {
+                editorconfig_check_props(path)
             } else {
-                true
+                (eol_target, true)
             };
 
             let issues = check_file(path, quiet, file_eol_target, check_trailing_ws);

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -152,7 +152,7 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         "status": "restored",
         "session": timestamp,
         "file_count": restored,
-    }))? && global.show_status()
+    }))? && !global.quiet
     {
         eprintln!("restored {restored} file(s) from session {timestamp}");
     }

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -338,7 +338,7 @@ fn test_patch_merge_check_exits_8_on_conflict() {
 }
 
 #[test]
-fn test_patch_merge_check_allow_conflicts_exits_0() {
+fn test_patch_merge_check_allow_conflicts_exits_2() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
     fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
@@ -348,8 +348,8 @@ fn test_patch_merge_check_allow_conflicts_exits_0() {
         "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
     )
     .unwrap();
-    // With --allow-conflicts, --check should predict that apply would succeed
-    // (conflicts are acceptable), so exit 0 instead of 8.
+    // With --allow-conflicts, --check should report that changes would be
+    // applied (CHANGES_DETECTED = exit 2), not CONFLICTS (exit 8).
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("--cwd")
@@ -360,7 +360,7 @@ fn test_patch_merge_check_allow_conflicts_exits_0() {
         .arg("--check")
         .arg("--allow-conflicts")
         .assert()
-        .code(0);
+        .code(2); // CHANGES_DETECTED
 }
 
 #[test]

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -929,6 +929,29 @@ fn test_search_follows_symlink_within_cwd() {
 }
 
 #[test]
+fn test_search_skips_patchloom_backup_directory() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("real.txt"), "needle in real file\n").unwrap();
+    fs::create_dir_all(dir.path().join(".patchloom/backups/12345")).unwrap();
+    fs::write(
+        dir.path().join(".patchloom/backups/12345/manifest.json"),
+        "needle in backup\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("search")
+        .arg("needle")
+        .arg(dir.path())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("real.txt"))
+        .stdout(predicates::str::contains("manifest.json").not());
+}
+
+#[test]
 fn test_search_jsonl_no_match_emits_valid_jsonl() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("f.txt"), "hello\n").unwrap();


### PR DESCRIPTION
## Summary

Multi-perspective improvement (MPI) rotation fixing 9 issues found across QA, Developer, End User, Security, Performance, Spec/Contract, Backward Compatibility, New Contributor, and Observability perspectives.

## Changes

### Exit code contract fixes
- `patch merge` check/preview mode now returns `CHANGES_DETECTED` (exit 2) instead of `SUCCESS` (exit 0)
- `patch emit_error` now delegates to `emit_error_json`, respecting `--quiet`
- `undo --apply` confirmation uses `!quiet` instead of `show_status()` (visible in pipelines)

### JSON output consistency
- `doc keys` NotAnObject error wrapped in `{"ok": false, "error": ...}` JSON envelope
- `doc len` NotArrayOrObject error uses the same JSON envelope pattern
- `search` no-match hints suppressed in `--json`/`--jsonl` mode

### Security
- Backup session directories set to `0o700` on Unix (owner-only access)

### Performance
- EditorConfig: combined `editorconfig_eol` + `editorconfig_trim_ws` into single `editorconfig_check_props` (one `ec4rs::properties_of` call per file instead of two)

### Documentation
- `AGENTS.md`: dispatch examples now include mandatory `load_project_config()` call

### Deferred
- `WritePolicyOverride` forward-compat tracked in Ref #1353
