### PR TITLE
fix: split WritePolicyOverride into config vs plan types

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-2900%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3000%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -429,7 +429,7 @@ flowchart LR
 
 ## Status
 
-2900+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3000+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,13 +6,45 @@
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
-use crate::write::WritePolicyOverride;
+// Note: crate::write::WritePolicyOverride is used for plan serialization (forward-compatible).
+// WritePolicyConfig (below) is used for .patchloom.toml parsing (typo-catching).
+
+/// Config-specific write policy with strict field validation.
+///
+/// This type is used exclusively by `.patchloom.toml` parsing. It has
+/// `deny_unknown_fields` to catch typos like `ensur_final_newline`.
+///
+/// For plan serialization (tx plans, MCP), use [`WritePolicyOverride`] which
+/// omits `deny_unknown_fields` for forward compatibility.
+///
+/// [`WritePolicyOverride`]: crate::write::WritePolicyOverride
+#[derive(Debug, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct WritePolicyConfig {
+    pub ensure_final_newline: Option<bool>,
+    pub normalize_eol: Option<String>,
+    pub trim_trailing_whitespace: Option<bool>,
+    pub collapse_blanks: Option<bool>,
+    pub respect_editorconfig: Option<bool>,
+}
+
+impl From<WritePolicyConfig> for crate::write::WritePolicyOverride {
+    fn from(c: WritePolicyConfig) -> Self {
+        Self {
+            ensure_final_newline: c.ensure_final_newline,
+            normalize_eol: c.normalize_eol,
+            trim_trailing_whitespace: c.trim_trailing_whitespace,
+            collapse_blanks: c.collapse_blanks,
+            respect_editorconfig: c.respect_editorconfig,
+        }
+    }
+}
 
 /// Project-level configuration loaded from `.patchloom.toml`.
 #[derive(Debug, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ProjectConfig {
-    pub write_policy: WritePolicyOverride,
+    pub write_policy: WritePolicyConfig,
     pub exclude: Exclude,
     pub output: Output,
     pub tx: TxConfig,
@@ -341,7 +373,7 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_sets_defaults() {
         let config = ProjectConfig {
-            write_policy: WritePolicyOverride {
+            write_policy: WritePolicyConfig {
                 ensure_final_newline: Some(true),
                 normalize_eol: Some("lf".into()),
                 trim_trailing_whitespace: Some(true),
@@ -384,9 +416,9 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_cli_flags_win() {
         let config = ProjectConfig {
-            write_policy: WritePolicyOverride {
+            write_policy: WritePolicyConfig {
                 ensure_final_newline: Some(true),
-                ..WritePolicyOverride::default()
+                ..WritePolicyConfig::default()
             },
             exclude: Exclude {
                 globs: vec!["config_glob".into()],
@@ -441,9 +473,9 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_unknown_eol_value_ignored() {
         let config = ProjectConfig {
-            write_policy: WritePolicyOverride {
+            write_policy: WritePolicyConfig {
                 normalize_eol: Some("CRLF".into()), // uppercase: not recognized
-                ..WritePolicyOverride::default()
+                ..WritePolicyConfig::default()
             },
             ..ProjectConfig::default()
         };
@@ -462,9 +494,9 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_crlf_eol() {
         let config = ProjectConfig {
-            write_policy: WritePolicyOverride {
+            write_policy: WritePolicyConfig {
                 normalize_eol: Some("crlf".into()),
-                ..WritePolicyOverride::default()
+                ..WritePolicyConfig::default()
             },
             ..ProjectConfig::default()
         };
@@ -545,9 +577,9 @@ color = "always"
     #[cfg(feature = "cli")]
     fn apply_config_respect_editorconfig_from_config() {
         let config = ProjectConfig {
-            write_policy: WritePolicyOverride {
+            write_policy: WritePolicyConfig {
                 respect_editorconfig: Some(true),
-                ..WritePolicyOverride::default()
+                ..WritePolicyConfig::default()
             },
             ..ProjectConfig::default()
         };
@@ -773,9 +805,9 @@ rs = "rustfmt"
     #[cfg(feature = "cli")]
     fn apply_config_keep_eol_is_noop() {
         let config = ProjectConfig {
-            write_policy: WritePolicyOverride {
+            write_policy: WritePolicyConfig {
                 normalize_eol: Some("keep".into()),
-                ..WritePolicyOverride::default()
+                ..WritePolicyConfig::default()
             },
             ..ProjectConfig::default()
         };
@@ -793,9 +825,9 @@ rs = "rustfmt"
     #[cfg(feature = "cli")]
     fn apply_config_cr_eol() {
         let config = ProjectConfig {
-            write_policy: WritePolicyOverride {
+            write_policy: WritePolicyConfig {
                 normalize_eol: Some("cr".into()),
-                ..WritePolicyOverride::default()
+                ..WritePolicyConfig::default()
             },
             ..ProjectConfig::default()
         };
@@ -827,5 +859,35 @@ rs = "rustfmt"
         apply_config(&mut global, &config);
         // defaults.format takes priority over format.command
         assert_eq!(global.format.as_deref(), Some("cargo fmt --all"));
+    }
+
+    /// WritePolicyConfig (config type) must reject unknown fields to catch typos.
+    /// This is the counterpart to the forward-compat test in write_tests.rs.
+    #[test]
+    fn write_policy_config_rejects_unknown_fields() {
+        let toml = r#"ensur_final_newline = true"#; // typo: missing 'e'
+        let result = toml_edit::de::from_str::<WritePolicyConfig>(toml);
+        assert!(
+            result.is_err(),
+            "WritePolicyConfig should reject unknown fields to catch typos"
+        );
+    }
+
+    /// WritePolicyConfig converts to WritePolicyOverride via From.
+    #[test]
+    fn write_policy_config_converts_to_override() {
+        let config = WritePolicyConfig {
+            ensure_final_newline: Some(true),
+            normalize_eol: Some("lf".into()),
+            trim_trailing_whitespace: Some(true),
+            collapse_blanks: None,
+            respect_editorconfig: Some(false),
+        };
+        let ov: crate::write::WritePolicyOverride = config.into();
+        assert_eq!(ov.ensure_final_newline, Some(true));
+        assert_eq!(ov.normalize_eol.as_deref(), Some("lf"));
+        assert_eq!(ov.trim_trailing_whitespace, Some(true));
+        assert!(ov.collapse_blanks.is_none());
+        assert_eq!(ov.respect_editorconfig, Some(false));
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -101,7 +101,7 @@ impl Default for WritePolicy {
 /// Used by `.patchloom.toml` config, tx plan `write_policy`, and any context
 /// that needs to partially override write transformations.
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
-#[serde(default, deny_unknown_fields)]
+#[serde(default)]
 pub struct WritePolicyOverride {
     pub ensure_final_newline: Option<bool>,
     pub normalize_eol: Option<String>,

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -1169,4 +1169,42 @@ mod format_preservation {
         let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
         assert_eq!(mode, 0o644, "expected 0o644, got 0o{mode:o}");
     }
+
+    /// WritePolicyOverride (plan serialization type) must accept unknown fields
+    /// for forward compatibility. Plans from newer patchloom versions may include
+    /// fields that older versions don't recognize. (#1353)
+    #[test]
+    fn write_policy_override_accepts_unknown_fields() {
+        let json = r#"{
+            "ensure_final_newline": true,
+            "future_field_from_v2": "some_value",
+            "another_future_bool": true
+        }"#;
+        let result: Result<WritePolicyOverride, _> = serde_json::from_str(json);
+        assert!(
+            result.is_ok(),
+            "WritePolicyOverride should accept unknown fields for forward compat: {:?}",
+            result.err()
+        );
+        let ov = result.unwrap();
+        assert_eq!(ov.ensure_final_newline, Some(true));
+    }
+
+    /// WritePolicyOverride in a plan context must ignore unknown fields,
+    /// allowing plans from newer patchloom versions to be parsed by older ones.
+    #[test]
+    fn plan_write_policy_forward_compat() {
+        let json = r#"{
+            "version": 1,
+            "write_policy": {
+                "ensure_final_newline": true,
+                "some_future_feature": "value"
+            },
+            "operations": []
+        }"#;
+        let plan: crate::plan::Plan = serde_json::from_str(json)
+            .expect("plan with unknown write_policy fields should parse successfully");
+        let wp = plan.write_policy.unwrap();
+        assert_eq!(wp.ensure_final_newline, Some(true));
+    }
 }


### PR DESCRIPTION
## Problem

`WritePolicyOverride` served two roles with conflicting requirements:

1. **Config parsing** (`.patchloom.toml`): needs `deny_unknown_fields` to catch typos like `ensur_final_newline`
2. **Plan serialization** (tx plans, MCP): needs forward compatibility so plans from newer patchloom versions can be parsed by older ones without "unknown field" errors

## Solution

Split into two types:

| Type | Location | `deny_unknown_fields` | Purpose |
|------|----------|----------------------|---------|
| `WritePolicyConfig` | `config.rs` | Yes | `.patchloom.toml` parsing (typo catching) |
| `WritePolicyOverride` | `write.rs` | No | Plan serialization, MCP (forward compat) |

`WritePolicyConfig` implements `From<WritePolicyConfig> for WritePolicyOverride` for conversion when needed.

## Tests added

- `write_policy_override_accepts_unknown_fields`: verifies `WritePolicyOverride` ignores unknown fields
- `plan_write_policy_forward_compat`: verifies a full plan with unknown write_policy fields parses successfully
- `write_policy_config_rejects_unknown_fields`: verifies `WritePolicyConfig` catches typos
- `write_policy_config_converts_to_override`: verifies the `From` conversion preserves all fields

Existing test `find_and_load_rejects_unknown_keys` continues to pass (config path still uses `deny_unknown_fields`).

Closes #1353