### PR TITLE
fix: correct JSON ok field semantics and assertion quality

### DIFF
--- a/src/cmd/explain.rs
+++ b/src/cmd/explain.rs
@@ -513,6 +513,7 @@ fn build_json_summary(plan: &Plan, strict: bool) -> serde_json::Value {
         .collect();
 
     serde_json::json!({
+        "ok": true,
         "operation_count": plan.operations.len(),
         "strict": strict,
         "operations": ops,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -290,14 +290,14 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::SUCCESS);
         }
         let output = ReplaceOutput {
-            ok: true,
+            ok: false,
             match_count: 0,
             file_count: 0,
             files: vec![],
             diff: None,
         };
         global.emit_json(&output)?;
-        if !global.quiet {
+        if !global.quiet && !global.json && !global.jsonl {
             let path_desc = if args.paths.is_empty() {
                 ".".to_string()
             } else {

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -71,6 +71,7 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     .collect::<serde_json::Result<Vec<_>>>()?
             };
             let envelope = serde_json::json!({
+                "ok": true,
                 "version": schema::INTENT_FORMAT_VERSION,
                 "operations": ops_json,
                 "plan_envelope": {

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -358,7 +358,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
     if !has_matches {
         let payload = SearchOutput {
-            ok: true,
+            ok: false,
             match_count: 0,
             file_count: 0,
             matches: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,9 @@ mod tests {
         assert!(tiny.build().is_err(), "1-byte limit should reject any NFA");
 
         // Our builder should compile normal patterns just fine.
-        assert!(bounded_regex_builder(r"\d+").build().is_ok());
+        bounded_regex_builder(r"\d+")
+            .build()
+            .expect("simple pattern should compile");
 
         // Verify the builder actually sets size_limit (not just dfa_size_limit)
         // by building a moderately large pattern that fits 10 MiB.
@@ -301,6 +303,8 @@ mod tests {
             .map(|i| format!("word_{i}"))
             .collect::<Vec<_>>()
             .join("|");
-        assert!(bounded_regex_builder(&medium).build().is_ok());
+        bounded_regex_builder(&medium)
+            .build()
+            .expect("1K-alternation pattern should compile within 10 MiB limit");
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -970,7 +970,10 @@ fn substitute_single_pass(template: &str, vars: &[(&str, String)]) -> String {
             // Advance by one full UTF-8 character, not one byte.
             // `bytes[i] as char` would interpret each byte of a multi-byte
             // sequence as a Latin-1 code point, corrupting non-ASCII text.
-            let ch = template[i..].chars().next().unwrap();
+            let ch = template[i..]
+                .chars()
+                .next()
+                .expect("i < len guarantees non-empty slice");
             result.push(ch);
             i += ch.len_utf8();
         }

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -18,7 +18,7 @@ fn test_replace_json_no_match_emits_valid_json() {
     assert_eq!(output.status.code(), Some(3), "should exit 3 (no matches)");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["ok"], false);
     assert_eq!(parsed["match_count"], 0);
     assert_eq!(parsed["file_count"], 0);
     assert!(parsed["files"].as_array().unwrap().is_empty());

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -184,7 +184,7 @@ fn test_search_json_no_match_emits_valid_json() {
     assert_eq!(output.status.code(), Some(3), "should exit 3 (no matches)");
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
-    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["ok"], false);
     assert_eq!(parsed["match_count"], 0);
     assert_eq!(parsed["file_count"], 0);
     assert!(parsed["matches"].as_array().unwrap().is_empty());
@@ -971,7 +971,7 @@ fn test_search_jsonl_no_match_emits_valid_jsonl() {
         "--jsonl no-match should emit a JSON line, got empty stdout"
     );
     let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
-    assert_eq!(parsed["ok"], true);
+    assert_eq!(parsed["ok"], false);
     assert_eq!(parsed["match_count"], 0);
     assert_eq!(parsed["file_count"], 0);
     assert!(parsed["matches"].as_array().unwrap().is_empty());


### PR DESCRIPTION
## Summary

MPI Cycle 6: fixes JSON contract violations and assertion quality issues found during multi-perspective review.

## Changes

### JSON ok field semantics
- **search/replace**: emit `ok: false` (not `ok: true`) when returning `NO_MATCHES` exit code. An `ok: true` payload with exit 3 misleads callers that check the JSON envelope.
- **explain**: add `ok: true` to JSON summary output for envelope consistency with all other commands.
- **schema**: add `ok: true` to JSON envelope for envelope consistency.

### Output guard
- **replace**: guard stderr diagnostic behind `--json`/`--jsonl` check to prevent text leaking into structured output streams.

### Assertion quality
- **lib.rs**: replace bare `assert!(result.is_ok())` with `.expect()` for clearer panic messages on test failure.
- **plan.rs**: replace bare `unwrap()` with `expect()` on infallible slice operation for better diagnostics.

## Testing

All changes verified by `make check-fast` (fmt, clippy, 2096 unit tests, 900 integration tests, 10 PTY tests).