### PR TITLE
fix: add test-library-hygiene to make check and fix stale doc reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make pty-test` | Run PTY-based interactive terminal tests (`cargo test --test pty --all-features -- --test-threads=1`) |
 | `make test-library-hygiene` | Enforce Bline library set: clippy + tests under `--no-default-features --features "ast,files"` (catches dead_code, hygiene for #800 #802) |
 | `make clippy` | Run `cargo clippy --all-targets --all-features -- -D warnings` |
-| `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme |
+| `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme |
 | `make check-fast` | Fast check: fmt-check, clippy, test, test-no-default, test-ast-only, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene (skips doc verification; enforces library hygiene) |
 | `make update-readme` | Update README.md rounded test count (only changes when hundreds digit changes) |
 | `make check-readme` | Verify README.md rounded test count is accurate (part of `check`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ See the "Adding a new MCP tool" section in [AGENTS.md](./AGENTS.md).
 | `make fmt-check` | Run `make fmt` to auto-format, then re-run `make check`. |
 | `make clippy` | Address the specific warning shown in the output. Clippy treats all warnings as errors (`-D warnings`). |
 | `make check-patchloom-md` | The agent-rules output changed. Run `make sync-patchloom-md` to regenerate `PATCHLOOM.md`. |
-| `make check-readme` | Test counts drifted. Run `make update-readme` to refresh `README.md` and `CHANGELOG.md`. |
+| `make check-readme` | Test counts drifted. Run `make update-readme` to refresh `README.md`. |
 
 ## License
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ pty-test: ## Run PTY-based interactive terminal tests (serial)
 clippy: ## Run clippy linter
 	cargo clippy --all-targets --all-features -- -D warnings
 
-check: fmt-check clippy test test-no-default test-ast-only integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme ## Run all checks (full CI gate)
+check: fmt-check clippy test test-no-default test-ast-only test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme ## Run all checks (full CI gate)
 
 check-fast: fmt-check clippy test test-no-default test-ast-only test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene ## Fast check (skips doc verification; includes release notes verify)
 


### PR DESCRIPTION
## Summary

MPI Cycle 7: two findings from 14-perspective rotation (12 perspectives returned no-op).

## Changes

### Makefile: add `test-library-hygiene` to `check` target
The `test-library-hygiene` target (clippy + tests under `--no-default-features --features "ast,files"`) was part of `check-fast` but missing from `check`. Since CI runs `make check`, library hygiene regressions (dead_code under the Bline feature set, per #800/#802) were invisible in CI.

### CONTRIBUTING.md: remove stale CHANGELOG.md reference
The troubleshooting table for `make check-readme` said to run `make update-readme` to refresh "README.md and CHANGELOG.md". The `update-readme` target only touches README.md; the CHANGELOG.md reference was stale copy.

### AGENTS.md: sync `make check` description
Updated the dev commands table to include `test-library-hygiene` in the `make check` entry.

## Testing

All changes verified by `make check-fast` (fmt, clippy, 2096 unit tests, 900 integration tests, 10 PTY tests).