### PR TITLE
fix: context-replace emits ok:false on no-match and guards stderr

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -479,7 +479,7 @@ fn run_context_replace(
 
     if !result.has_changes {
         let empty = ReplaceOutput {
-            ok: true,
+            ok: args.if_exists,
             match_count: 0,
             file_count: 0,
             files: vec![],
@@ -489,7 +489,7 @@ fn run_context_replace(
         if args.if_exists {
             return Ok(exit::SUCCESS);
         }
-        if !global.quiet {
+        if !global.quiet && !global.json && !global.jsonl {
             eprintln!("no matches for '{}' in context-based replace", args.old);
         }
         return Ok(exit::NO_MATCHES);

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -25,6 +25,30 @@ fn test_replace_json_no_match_emits_valid_json() {
 }
 
 #[test]
+fn test_replace_context_json_no_match_emits_ok_false() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "hello world\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("replace")
+        .arg("nonexistent")
+        .arg("--new")
+        .arg("replacement")
+        .arg("--before-context")
+        .arg("hello")
+        .arg(dir.path().join("f.txt"))
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3), "should exit 3 (no matches)");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["match_count"], 0);
+}
+
+#[test]
 fn test_replace_apply_modifies_file() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");


### PR DESCRIPTION
## Summary

MPI Cycle 8: the Cycle 6 ok:false fix for search/replace missed the context-based replace code path (`--before-context`/`--after-context`).

## Bug

`run_context_replace` unconditionally emitted `ok: true` in JSON output even when returning exit code 3 (`NO_MATCHES`) with `if_exists=false`. This contradicted the JSON envelope contract: agents parsing the JSON would see success despite no operation being performed.

The same path was also missing the `--json`/`--jsonl` guard on its stderr diagnostic, allowing text to leak into structured output.

## Fix

- Set `ok: args.if_exists` instead of `ok: true` in the context-replace no-match path, matching the regular replace path behavior
- Add `!global.json && !global.jsonl` guard on stderr output, matching the Cycle 6 fix for the regular replace path

## Testing

- New integration test `test_replace_context_json_no_match_emits_ok_false` verifies exit code 3 and `ok: false` in JSON output
- All checks pass: `make check-fast` (fmt, clippy, 2096 unit tests, 901 integration tests, 10 PTY tests)