### PR TITLE
test: assert ok field in explain and schema integration tests

### DIFF
--- a/tests/integration/explain_tests.rs
+++ b/tests/integration/explain_tests.rs
@@ -49,6 +49,7 @@ fn test_explain_json_output() {
     assert!(output.status.success());
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
     assert_eq!(json["operation_count"], 1);
     assert_eq!(json["strict"], true);
     assert!(json["has_write_policy"].is_boolean());

--- a/tests/integration/schema_tests.rs
+++ b/tests/integration/schema_tests.rs
@@ -11,7 +11,8 @@ fn test_schema_json_output() {
     let stdout = String::from_utf8(output.get_output().stdout.clone()).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
 
-    // Envelope must contain version, operations, and plan_envelope.
+    // Envelope must contain ok, version, operations, and plan_envelope.
+    assert_eq!(parsed["ok"], true);
     let version = parsed
         .get("version")
         .and_then(|v| v.as_str())


### PR DESCRIPTION
## Summary

MPI Cycle 9: adds missing test assertions for the `ok` field in explain and schema JSON output.

## Changes

The `ok: true` field was added to `explain` and `schema` JSON output in Cycle 6 (PR #1360), but the integration tests were not updated to assert this field. If the field were accidentally removed or changed, no test would catch it.

- `tests/integration/explain_tests.rs`: add `assert_eq!(json["ok"], true)`
- `tests/integration/schema_tests.rs`: add `assert_eq!(parsed["ok"], true)`

## Testing

`make check-fast` passes (fmt, clippy, 2096 unit tests, 901 integration tests, 10 PTY tests).