### PR TITLE
fix: close PathGuard containment gaps in PatchApply and glob-replace

### DIFF
--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -70,9 +70,11 @@ fn validate_operation_paths(
     for op in operations {
         for path in op.declared_paths() {
             guard
-                .check_path(path)
+                .check_path(&path)
                 .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
         }
+        // Note: PatchApply paths are now covered by declared_paths() which
+        // parses the diff. The block below is retained as defense-in-depth.
         if let Operation::PatchApply { diff, .. } = op {
             let patch_files = crate::ops::patch::parse_patch(diff).map_err(|e| {
                 McpError::invalid_params(
@@ -255,7 +257,7 @@ impl PatchloomService {
     /// Validate paths for a single operation (including embedded paths for PatchApply).
     fn validate_op_paths(&self, op: &Operation) -> Result<(), McpError> {
         for declared in op.declared_paths() {
-            self.check_path(declared)?;
+            self.check_path(&declared)?;
         }
         if let Operation::PatchApply { diff, .. } = op {
             let patch_files = crate::ops::patch::parse_patch(diff).map_err(|e| {

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -353,7 +353,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // 4. Execute all operations, collecting changes in memory (no writes).
     let mut result =
-        match crate::tx::execute_and_collect(&plan, &cwd, global, global.quiet, structured) {
+        match crate::tx::execute_and_collect(&plan, &cwd, global, global.quiet, structured, None) {
             Ok(r) => r,
             Err(e) => {
                 let msg = e.to_string();

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -684,7 +684,7 @@ impl Operation {
 
     /// Returns the file paths declared by this operation for containment
     /// validation. See [`declared_paths`] for details.
-    pub fn declared_paths(&self) -> Vec<&str> {
+    pub fn declared_paths(&self) -> Vec<String> {
         declared_paths(self)
     }
 }
@@ -796,31 +796,40 @@ pub(crate) fn op_to_doc_mutation(op: &Operation) -> Option<(&str, crate::ops::do
 /// - `Replace`: includes `path` (if present) and `glob` pattern (if present).
 /// - Cross-file ops (`FileRename`, `MdMoveSection`): includes both source
 ///   and destination file paths.
-/// - `PatchApply`: returns empty; embedded paths are validated by the
-///   caller (MCP always parses the diff and checks before execute).
+/// - `PatchApply`: parses the embedded diff via `parse_patch()` and returns
+///   the file paths from `---`/`+++` headers. This ensures the upfront
+///   PathGuard check in `execute_plan` catches out-of-boundary patches
+///   (#1363). Returns empty on parse failure (error deferred to apply time).
 /// - All other ops: their primary `path` (or equivalent).
 /// - AST variants are included only when the `ast` feature is enabled.
-pub(crate) fn declared_paths(op: &Operation) -> Vec<&str> {
+pub(crate) fn declared_paths(op: &Operation) -> Vec<String> {
     match op {
         Operation::Replace { path, glob, .. } => {
             let mut p = Vec::new();
             if let Some(s) = path {
-                p.push(s.as_str());
+                p.push(s.clone());
             }
             if let Some(s) = glob {
-                p.push(s.as_str());
+                p.push(s.clone());
             }
             p
         }
-        Operation::FileRename { from, to, .. } => vec![from.as_str(), to.as_str()],
+        Operation::FileRename { from, to, .. } => vec![from.clone(), to.clone()],
         Operation::MdMoveSection { path, to, .. } => {
-            let mut p = vec![path.as_str()];
+            let mut p = vec![path.clone()];
             if let Some(t) = to {
-                p.push(t.as_str());
+                p.push(t.clone());
             }
             p
         }
-        Operation::PatchApply { .. } => vec![],
+        Operation::PatchApply { diff, .. } => {
+            // Parse the diff to extract file paths from ---/+++ headers.
+            // If parsing fails, return empty (the error will surface at apply time).
+            match crate::ops::patch::parse_patch(diff) {
+                Ok(files) => files.into_iter().map(|pf| pf.path).collect(),
+                Err(_) => vec![],
+            }
+        }
         // Single-path operations (file, doc, md, read, search, tidy, lint, etc.)
         Operation::DocSet { path, .. }
         | Operation::DocDelete { path, .. }
@@ -844,7 +853,7 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<&str> {
         | Operation::FileDelete { path, .. }
         | Operation::Read { path, .. }
         | Operation::Search { path, .. }
-        | Operation::MdLintAgents { path, .. } => vec![path.as_str()],
+        | Operation::MdLintAgents { path, .. } => vec![path.clone()],
         #[cfg(feature = "ast")]
         Operation::AstRename { path, .. }
         | Operation::AstReplace { path, .. }
@@ -853,21 +862,21 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<&str> {
         | Operation::AstImports { path, .. }
         | Operation::AstReorder { path, .. }
         | Operation::AstGroup { path, .. } => {
-            vec![path.as_str()]
+            vec![path.clone()]
         }
         #[cfg(feature = "ast")]
-        Operation::AstMove { path, target, .. } => vec![path.as_str(), target.as_str()],
+        Operation::AstMove { path, target, .. } => vec![path.clone(), target.clone()],
         #[cfg(feature = "ast")]
         Operation::AstExtractToFile { source, target, .. } => {
-            vec![source.as_str(), target.as_str()]
+            vec![source.clone(), target.clone()]
         }
         #[cfg(feature = "ast")]
         Operation::AstSplit {
             source, targets, ..
         } => {
-            let mut p = vec![source.as_str()];
+            let mut p = vec![source.clone()];
             for t in targets {
-                p.push(t.path.as_str());
+                p.push(t.path.clone());
             }
             p
         }
@@ -1613,7 +1622,7 @@ mod tests {
         let json = r#"{"version": 1,"operations":[{"op":"replace","path":"src/main.rs","glob":"**/*.rs","old":"old","new":"new"}]}"#;
         let plan = parse_plan(json).unwrap();
         let ps = declared_paths(&plan.operations[0]);
-        assert!(ps.contains(&"src/main.rs") && ps.contains(&"**/*.rs"));
+        assert!(ps.contains(&"src/main.rs".to_string()) && ps.contains(&"**/*.rs".to_string()));
 
         // FileRename (cross-file paths)
         let json = r#"{"version": 1,"operations":[{"op":"file.rename","from":"old.txt","to":"new.txt","force":false}]}"#;
@@ -1632,10 +1641,16 @@ mod tests {
         let json = r#"{"version": 1,"operations":[{"op":"md.move_section","path":"src.md","heading":"H","to":"dst.md"}]}"#;
         let plan = parse_plan(json).unwrap();
         let ps = declared_paths(&plan.operations[0]);
-        assert!(ps.contains(&"src.md") && ps.contains(&"dst.md"));
+        assert!(ps.contains(&"src.md".to_string()) && ps.contains(&"dst.md".to_string()));
 
-        // PatchApply: declared empty (diff paths handled by caller in MCP)
+        // PatchApply: now parses diff and returns file paths
         let json = r#"{"version": 1,"operations":[{"op":"patch.apply","diff":"--- a/x\n+++ b/x\n@@ -1 +1 @@\n- old\n+ new\n"}]}"#;
+        let plan = parse_plan(json).unwrap();
+        assert_eq!(declared_paths(&plan.operations[0]), vec!["x"]);
+
+        // PatchApply with invalid diff: returns empty (error deferred to apply time)
+        let json =
+            r#"{"version": 1,"operations":[{"op":"patch.apply","diff":"not a valid diff"}]}"#;
         let plan = parse_plan(json).unwrap();
         assert!(declared_paths(&plan.operations[0]).is_empty());
 

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -209,7 +209,7 @@ fn execute_plan_inner(
     if let Some(g) = options.guard {
         for op in &operations {
             for p in op.declared_paths() {
-                g.check_path(p)
+                g.check_path(&p)
                     .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
             }
         }
@@ -228,7 +228,8 @@ fn execute_plan_inner(
     };
 
     let cwd = options.cwd.to_path_buf();
-    let result = super::execute_and_collect(&plan, &cwd, options.global, true, true)?;
+    let result =
+        super::execute_and_collect(&plan, &cwd, options.global, true, true, options.guard)?;
 
     let has_changes = !result.no_effective_changes;
 

--- a/src/tx/execute.rs
+++ b/src/tx/execute.rs
@@ -271,6 +271,11 @@ pub(crate) struct TxState<'a> {
     pub(crate) cwd: &'a Path,
     pub(crate) quiet: bool,
     pub(crate) structured: bool,
+    /// Optional PathGuard for defense-in-depth containment checks on
+    /// dynamically-expanded paths (e.g. glob-matched files in replace). The
+    /// upfront declared_paths check covers static paths; this catches paths
+    /// discovered at runtime (#1361).
+    pub(crate) guard: Option<&'a crate::containment::PathGuard>,
 }
 
 /// Test fixture that owns all the storage behind a `TxState`, avoiding
@@ -316,6 +321,7 @@ impl TxStateFixture {
             cwd,
             quiet: true,
             structured: false,
+            guard: None,
         }
     }
 }
@@ -1406,6 +1412,7 @@ pub(crate) fn execute_and_collect(
     global: &GlobalFlags,
     quiet: bool,
     structured: bool,
+    guard: Option<&crate::containment::PathGuard>,
 ) -> anyhow::Result<TxExecResult> {
     let mut pending: HashMap<PathBuf, (String, String)> = HashMap::new();
     let mut deletions: HashSet<PathBuf> = HashSet::new();
@@ -1456,6 +1463,7 @@ pub(crate) fn execute_and_collect(
             cwd,
             quiet,
             structured,
+            guard,
         };
         match execute_operation(op, &mut tx) {
             Ok(count) => {
@@ -1922,7 +1930,7 @@ mod tests {
             ensure_final_newline: true,
             ..GlobalFlags::default()
         };
-        let result = execute_and_collect(&plan, dir.path(), &global, true, false).unwrap();
+        let result = execute_and_collect(&plan, dir.path(), &global, true, false, None).unwrap();
 
         // The file should NOT appear in changes since it was only read.
         assert!(

--- a/src/tx/lifecycle.rs
+++ b/src/tx/lifecycle.rs
@@ -540,7 +540,7 @@ pub fn execute_plan_direct(
         // patterns, patch embedded paths) are best-effort or handled by loaders.
         for op in &plan.operations {
             for p in op.declared_paths() {
-                g.check_path(p)
+                g.check_path(&p)
                     .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
             }
         }
@@ -566,7 +566,7 @@ pub fn execute_plan_direct(
     };
 
     // Execute operations and collect changes in memory.
-    let mut result = match execute_and_collect(&plan, &effective_cwd, &global, true, true) {
+    let mut result = match execute_and_collect(&plan, &effective_cwd, &global, true, true, guard) {
         Ok(r) => r,
         Err(e) => {
             return Ok(build_error_output("operation_failed", &e.to_string(), None));

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -13,7 +13,10 @@ use std::path::Path;
 pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
     crate::verbose!(
         "replace_op: target={}, old_len={}, regex={}",
-        op.declared_paths().first().unwrap_or(&"<glob>"),
+        op.declared_paths()
+            .first()
+            .map(|s| s.as_str())
+            .unwrap_or("<glob>"),
         if let Operation::Replace { old, .. } = op {
             old.len()
         } else {
@@ -237,6 +240,16 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             }
             if seen_paths.insert(pending_path.clone()) {
                 candidate_paths.push(pending_path.clone());
+            }
+        }
+
+        // Defense-in-depth: validate glob-expanded paths against PathGuard.
+        // WalkBuilder doesn't follow symlinks by default, but this catches edge
+        // cases where a path might escape the containment boundary (#1361).
+        if let Some(guard) = tx.guard {
+            for path in &candidate_paths {
+                let rel = path.strip_prefix(tx.cwd).unwrap_or(path).to_string_lossy();
+                guard.check_path(&rel)?;
             }
         }
 

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -70,7 +70,7 @@ pub(crate) fn affected_file_paths(plan: &crate::plan::Plan, cwd: &Path) -> Vec<P
     let mut paths = HashSet::new();
     for op in &plan.operations {
         for p in op.declared_paths() {
-            let full = cwd.join(p);
+            let full = cwd.join(&p);
             if full.is_file() {
                 paths.insert(full);
             } else if full.is_dir() {
@@ -84,11 +84,11 @@ pub(crate) fn affected_file_paths(plan: &crate::plan::Plan, cwd: &Path) -> Vec<P
                         paths.insert(f);
                     }
                 }
-            } else if is_glob_pattern(p) {
+            } else if is_glob_pattern(&p) {
                 // Expand glob patterns against cwd so verification
                 // covers files targeted by glob-based operations.
                 #[cfg(feature = "files")]
-                if let Ok(glob) = globset::Glob::new(p) {
+                if let Ok(glob) = globset::Glob::new(&p) {
                     let matcher = glob.compile_matcher();
                     walk_and_match(cwd, cwd, &matcher, &mut paths);
                 }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -420,6 +420,103 @@ fn test_tx_guard_rejects_escaping_declared_path() {
     );
 }
 
+/// PatchApply declared_paths now parses the embedded diff and returns file
+/// paths, so the upfront PathGuard check catches out-of-boundary patches (#1363).
+#[test]
+fn test_tx_guard_rejects_patch_apply_escaping_path() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ok.txt"), "hello\n").unwrap();
+    let guard = patchloom::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        patchloom::containment::AbsolutePathPolicy::Reject,
+    )
+    .unwrap();
+
+    // Diff targeting a path that escapes the workspace via ../
+    let plan: patchloom::plan::Plan = serde_json::from_value(serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "patch.apply",
+                "diff": "--- a/../escape.txt\n+++ b/../escape.txt\n@@ -1 +1 @@\n-old\n+new\n"
+            }
+        ]
+    }))
+    .unwrap();
+
+    let res = patchloom::cmd::tx::execute_plan_direct(plan, dir.path(), Some(&guard));
+    let msg = res
+        .expect_err("guard should reject patch targeting escaped path")
+        .to_string();
+    assert!(
+        msg.contains("path rejected by workspace guard") || msg.contains("Escaped"),
+        "unexpected error: {msg}"
+    );
+}
+
+/// PatchApply with paths inside the workspace should work normally with a guard.
+#[test]
+fn test_tx_guard_allows_patch_apply_within_boundary() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("file.txt"), "old\n").unwrap();
+    let guard = patchloom::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        patchloom::containment::AbsolutePathPolicy::Reject,
+    )
+    .unwrap();
+
+    let plan: patchloom::plan::Plan = serde_json::from_value(serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "patch.apply",
+                "diff": "--- a/file.txt\n+++ b/file.txt\n@@ -1 +1 @@\n-old\n+new\n"
+            }
+        ]
+    }))
+    .unwrap();
+
+    let result = patchloom::cmd::tx::execute_plan_direct(plan, dir.path(), Some(&guard));
+    assert!(
+        result.is_ok(),
+        "patch within boundary should succeed: {result:?}"
+    );
+}
+
+/// Glob-replace with a PathGuard validates expanded paths at runtime (#1361).
+/// Verifies the guard is correctly threaded through execute_and_collect → TxState
+/// and that glob-expanded files inside the boundary are processed normally.
+#[test]
+fn test_tx_guard_allows_glob_replace_within_boundary() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "old_value\n").unwrap();
+    fs::write(dir.path().join("b.txt"), "old_value\n").unwrap();
+    let guard = patchloom::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        patchloom::containment::AbsolutePathPolicy::Reject,
+    )
+    .unwrap();
+
+    let plan: patchloom::plan::Plan = serde_json::from_value(serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "replace",
+                "glob": "*.txt",
+                "old": "old_value",
+                "new": "new_value"
+            }
+        ]
+    }))
+    .unwrap();
+
+    let result = patchloom::cmd::tx::execute_plan_direct(plan, dir.path(), Some(&guard));
+    assert!(
+        result.is_ok(),
+        "glob replace within boundary should succeed: {result:?}"
+    );
+}
+
 #[test]
 fn test_tx_success_applies_all() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Close two PathGuard containment bypass gaps found during MPI cycles.

### PatchApply bypass (#1363)

`Operation::PatchApply` returned `vec![]` from `declared_paths()`, so the upfront PathGuard check in `execute_plan_direct`/`execute_plan_inner` was a no-op. A library consumer calling `execute_plan()` with a crafted diff could write outside the containment boundary.

**Fix:** `declared_paths()` now parses the embedded diff via `parse_patch()` and returns file paths from `---`/`+++` headers. The existing upfront guard check catches out-of-boundary patches before execution.

### Glob-replace symlink gap (#1361)

Glob-expanded paths from `WalkBuilder` were never individually checked against PathGuard. While `WalkBuilder` does not follow symlinks by default, defense-in-depth requires explicit validation.

**Fix:** The PathGuard is now threaded through `execute_and_collect` into `TxState`, and `replace_op.rs` validates each glob-expanded candidate path against it.

### Implementation details

- `declared_paths()` return type changed from `Vec<&str>` to `Vec<String>` to support returning owned paths parsed from diffs. All callers updated.
- MCP handler's special-case PatchApply path validation retained as defense-in-depth.
- 4 new integration tests cover guard rejection and acceptance for both PatchApply and glob-replace.

Closes #1363
Closes #1361