### PR TITLE
ci: add 5 missing fuzz targets to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,6 +422,11 @@ jobs:
           - fuzz_batch_tokenize
           - fuzz_selector_eval
           - fuzz_doc_parse
+          - fuzz_containment_check
+          - fuzz_fallback_resolve
+          - fuzz_ast_parse
+          - fuzz_md_heading
+          - fuzz_replace_regex
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4


### PR DESCRIPTION
The Makefile fuzz target runs 11 fuzz targets but the CI matrix only included 6. Add the 5 missing targets:

- `fuzz_containment_check`
- `fuzz_fallback_resolve`
- `fuzz_ast_parse`
- `fuzz_md_heading`
- `fuzz_replace_regex`

All targets use the same `cargo fuzz run` command and inherit features from `fuzz/Cargo.toml` (`cli`, `ast`, `files`).

Closes #1362