### PR TITLE
test: lock write-path exit/mode contract matrix (#1373 PR 1.1)

### DIFF
--- a/docs/plans/write-pipeline.md
+++ b/docs/plans/write-pipeline.md
@@ -1,0 +1,148 @@
+# Write pipeline inventory (Phase 1 of #1373 / epic #1372)
+
+**Status:** inventory + contract matrix (PR 1.1). No behavior change yet.
+
+**Goal of Phase 1:** one write pipeline owns mode → exit code, backup, and
+diff policy. Strategies become *inputs*, not five sibling mode matrices.
+
+This document is the call-site inventory for the collapse. Keep it updated
+when adding or removing write entry points.
+
+## Contract (must hold for every path when changes exist)
+
+| Mode | Flags | Exit | Mutation |
+|------|-------|-----:|----------|
+| Preview (default) | *(none of apply/check)* | **2** (`CHANGES_DETECTED`) | no |
+| Check | `--check` | **2** | no |
+| Apply | `--apply` | **0** (`SUCCESS`) | yes |
+| Confirm + JSON decline | `--confirm` + `--json`/`--jsonl`, non-TTY / EOF | **2** | no |
+
+When there are **no** changes, preview and check should exit **0** (path-specific
+edge cases stay in existing tests; this matrix covers the *has changes* case).
+
+Integration lock: `tests/integration/write_path_contract_tests.rs`.
+
+## Entry points (five production paths)
+
+### 1. `execute_via_engine` / `execute_via_engine_inner`
+
+| Item | Location |
+|------|----------|
+| Definition | `src/cmd/output.rs` |
+| Engine core | calls `tx::engine::execute_single` |
+| Mode/exit owner | **local** in `execute_via_engine_inner` |
+
+**CLI call sites (representative):**
+
+| Command | File | Notes |
+|---------|------|-------|
+| `create` | `src/cmd/create.rs` | representative in contract matrix |
+| `append` | `src/cmd/append.rs` | |
+| `prepend` | `src/cmd/prepend.rs` | thin wrapper over append-style |
+| `delete` | uses **no_preview_diffs** variant below | |
+| `rename` (text, non-case-only) | `src/cmd/rename.rs` | |
+| `doc` writes | `src/cmd/doc.rs` | |
+| `md` most writes | `src/cmd/md.rs` | some subcommands use `execute_single` directly |
+| `ast` some writes | `src/cmd/ast.rs` | also `execute_operations` for multi-file |
+
+**Variant:** `execute_via_engine_no_preview_diffs` — same function with
+`preview_diffs: false` (e.g. `delete`). Not a sixth path; same mode/exit owner.
+
+### 2. `execute_operations`
+
+| Item | Location |
+|------|----------|
+| Definition | `src/tx/engine.rs` |
+| Role | Stage multi-`Operation` plans; returns `ExecutionResult` |
+| Mode/exit owner | **caller** (CLI reimplements mode branch after call) |
+
+**CLI call sites:**
+
+| Command | File | Notes |
+|---------|------|-------|
+| `tidy fix` multi-file | `src/cmd/tidy.rs` → `tidy_fix_output` | representative in contract matrix (`tidy fix …`) |
+| `replace` with context anchors | `src/cmd/replace.rs` → `run_context_replace` | secondary |
+| `ast` multi-file rename/etc. | `src/cmd/ast.rs` | |
+
+### 3. `execute_precomputed`
+
+| Item | Location |
+|------|----------|
+| Definition | `src/tx/engine.rs` |
+| Role | Commit path for already-computed `(path, original, new)` triples |
+| Mode/exit owner | **caller** (`replace_output` in `src/cmd/replace.rs`) |
+
+**CLI call sites:**
+
+| Command | File | Notes |
+|---------|------|-------|
+| `replace` (default multi-file scan) | `src/cmd/replace.rs` | representative in contract matrix |
+
+### 4. `execute_write` (`write_dispatch`)
+
+| Item | Location |
+|------|----------|
+| Definition | `src/cmd/write_dispatch.rs` |
+| Role | Binary / case-only renames that cannot use UTF-8 tx engine |
+| Mode/exit owner | **local** in `execute_write` (parallel to `execute_via_engine_inner`) |
+
+**CLI call sites:**
+
+| Command | File | Notes |
+|---------|------|-------|
+| `rename` binary | `src/cmd/rename.rs` → `run_binary_rename` | representative (null-byte file) |
+| `rename` case-only | same | case-insensitive FS only |
+
+### 5. `execute_single` + **custom CLI mode branch**
+
+| Item | Location |
+|------|----------|
+| Definition | `src/tx/engine.rs` |
+| Role | Single `Operation` → stage; returns `ExecutionResult` |
+| Mode/exit owner | **shared helper** when via `execute_via_engine`; **custom** when CLI reimplements branch |
+
+**Custom mode-branch callers (not using `execute_via_engine`):**
+
+| Command | File | Notes |
+|---------|------|-------|
+| `patch apply` | `src/cmd/patch.rs` | representative in contract matrix |
+| `md` dedupe-headings (and similar) | `src/cmd/md.rs` | own branch after `execute_single` |
+| library API | `src/api/mod.rs` → `execute_as_edit_result` | maps to `EditResult`, not CLI exits |
+
+`execute_via_engine` also calls `execute_single` internally; that does **not**
+count as a separate mode matrix.
+
+## Duplication map (why collapse)
+
+Each of these owns a near-copy of check / apply / confirm+json / preview:
+
+1. `cmd/output.rs` → `execute_via_engine_inner`
+2. `cmd/write_dispatch.rs` → `execute_write`
+3. `cmd/replace.rs` → `replace_output`
+4. `cmd/tidy.rs` → `tidy_fix_output`
+5. `cmd/patch.rs` (inline after `execute_single`)
+6. Plus other custom branches (md specials, ast multi-file output)
+
+Historical proof of divergence: PRs #1345–#1348 fixed the same preview
+exit-0 bug across multiple paths independently.
+
+## Collapse target (PR 1.2–1.4)
+
+```text
+WriteRequest {
+  cwd, mode, policy, guard,
+  source: SingleOp | Ops | Precomputed | BinaryDispatch,
+  render: RenderPolicy { preview_diffs, ... },
+}
+→ WriteReport { has_changes, diffs, exit_code, ... }
+```
+
+One function owns mode → exit. Strategies only supply staged changes / apply
+closures.
+
+## Related issues
+
+- Epic: #1372
+- Phase 1: #1373
+- Prior partial unifications: #967, #1004, #1007
+- Exit multi-path: #1345–#1348

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -705,3 +705,4 @@ mod status_tests;
 mod tidy_tests;
 mod tx_tests;
 mod undo_tests;
+mod write_path_contract_tests;

--- a/tests/integration/write_path_contract_tests.rs
+++ b/tests/integration/write_path_contract_tests.rs
@@ -1,0 +1,285 @@
+//! Write-path contract matrix for Phase 1 of #1373 / epic #1372.
+//!
+//! Locks exit codes and mutation semantics for each of the five production
+//! write entry paths when changes exist:
+//!
+//! | Mode | Exit | Mutates |
+//! |------|-----:|---------|
+//! | preview (default) | 2 | no |
+//! | --check | 2 | no |
+//! | --apply | 0 | yes |
+//! | --confirm --json (non-TTY decline) | 2 | no |
+//!
+//! Inventory: `docs/plans/write-pipeline.md`.
+//!
+//! These tests intentionally use one *representative* CLI command per path.
+//! Broader coverage lives in per-command integration modules; this file is
+//! the regression lock for the multi-path exit-code class (#1345–#1348).
+
+use super::*;
+
+/// Exit code constants (must match `src/exit.rs`).
+const SUCCESS: i32 = 0;
+const CHANGES_DETECTED: i32 = 2;
+
+/// How write flags are applied for a contract scenario.
+#[derive(Clone, Copy, Debug)]
+enum Mode {
+    Preview,
+    Check,
+    Apply,
+    /// `--confirm` with `--json`; non-TTY decline (`should_apply` == false).
+    ConfirmJsonDecline,
+}
+
+impl Mode {
+    fn write_flags(self) -> &'static [&'static str] {
+        match self {
+            Mode::Preview => &[],
+            Mode::Check => &["--check"],
+            Mode::Apply => &["--apply"],
+            Mode::ConfirmJsonDecline => &["--confirm"],
+        }
+    }
+
+    fn wants_json(self) -> bool {
+        matches!(self, Mode::ConfirmJsonDecline)
+    }
+
+    fn expected_exit(self) -> i32 {
+        match self {
+            Mode::Apply => SUCCESS,
+            Mode::Preview | Mode::Check | Mode::ConfirmJsonDecline => CHANGES_DETECTED,
+        }
+    }
+
+    fn expects_mutation(self) -> bool {
+        matches!(self, Mode::Apply)
+    }
+}
+
+/// Shared assertion helper for a write command with pending changes.
+///
+/// `configure` adds the subcommand and its positional/option args (not write
+/// flags, not `--cwd` / `--json`). Write and global flags are applied here so
+/// clap global-order rules stay correct.
+fn assert_write_path_contract(
+    path_label: &str,
+    dir: &TempDir,
+    configure: impl Fn(&mut assert_cmd::Command),
+    mutated: impl Fn() -> bool,
+    reset: impl Fn(),
+) {
+    for mode in [
+        Mode::Preview,
+        Mode::Check,
+        Mode::ConfirmJsonDecline,
+        Mode::Apply, // last: mutates the fixture
+    ] {
+        reset();
+        assert!(
+            !mutated(),
+            "{path_label}/{mode:?}: fixture must start unmutated"
+        );
+
+        let mut cmd = Command::cargo_bin("patchloom").unwrap();
+        cmd.arg("--cwd").arg(dir.path());
+        if mode.wants_json() {
+            cmd.arg("--json");
+        }
+        configure(&mut cmd);
+        for f in mode.write_flags() {
+            cmd.arg(f);
+        }
+
+        cmd.assert().code(mode.expected_exit());
+
+        if mode.expects_mutation() {
+            assert!(
+                mutated(),
+                "{path_label}/{mode:?}: expected mutation after exit {}",
+                mode.expected_exit()
+            );
+        } else {
+            assert!(
+                !mutated(),
+                "{path_label}/{mode:?}: must not mutate (exit {} contract)",
+                mode.expected_exit()
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Path 1: execute_via_engine  (representative: create)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contract_execute_via_engine_create() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("via_engine.txt");
+
+    assert_write_path_contract(
+        "execute_via_engine/create",
+        &dir,
+        |cmd| {
+            cmd.arg("create")
+                .arg("via_engine.txt")
+                .arg("--content")
+                .arg("hello\n");
+        },
+        || file.exists() && fs::read_to_string(&file).unwrap() == "hello\n",
+        || {
+            let _ = fs::remove_file(&file);
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Path 1 variant: execute_via_engine_no_preview_diffs  (representative: delete)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contract_execute_via_engine_no_preview_diffs_delete() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("via_engine_delete.txt");
+
+    assert_write_path_contract(
+        "execute_via_engine_no_preview_diffs/delete",
+        &dir,
+        |cmd| {
+            cmd.arg("delete").arg("via_engine_delete.txt");
+        },
+        || !file.exists(),
+        || {
+            fs::write(&file, "remove me\n").unwrap();
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Path 2: execute_operations  (representative: tidy multi-file fix)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contract_execute_operations_tidy() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("ops_tidy.txt");
+    // Missing final newline → tidy --ensure-final-newline has work to do.
+    let dirty = "line without final newline";
+    let clean = "line without final newline\n";
+
+    assert_write_path_contract(
+        "execute_operations/tidy",
+        &dir,
+        |cmd| {
+            cmd.arg("tidy")
+                .arg("fix")
+                .arg("ops_tidy.txt")
+                .arg("--ensure-final-newline");
+        },
+        || {
+            fs::read_to_string(&file)
+                .map(|s| s == clean)
+                .unwrap_or(false)
+        },
+        || {
+            fs::write(&file, dirty).unwrap();
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Path 3: execute_precomputed  (representative: replace scan)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contract_execute_precomputed_replace() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("precomputed_replace.txt");
+    let before = "hello world\n";
+    let after = "hello patchloom\n";
+
+    assert_write_path_contract(
+        "execute_precomputed/replace",
+        &dir,
+        |cmd| {
+            cmd.arg("replace")
+                .arg("world")
+                .arg("--new")
+                .arg("patchloom")
+                .arg("precomputed_replace.txt");
+        },
+        || {
+            fs::read_to_string(&file)
+                .map(|s| s == after)
+                .unwrap_or(false)
+        },
+        || {
+            fs::write(&file, before).unwrap();
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Path 4: execute_write (write_dispatch)  (representative: binary rename)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contract_execute_write_binary_rename() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("binary_src.bin");
+    let dst = dir.path().join("binary_dst.bin");
+    // NUL byte forces the binary rename path (execute_write), not the tx engine.
+    let payload = b"bin\0ary";
+
+    assert_write_path_contract(
+        "execute_write/binary_rename",
+        &dir,
+        |cmd| {
+            cmd.arg("rename")
+                .arg("binary_src.bin")
+                .arg("binary_dst.bin");
+        },
+        || dst.exists() && !src.exists() && fs::read(&dst).unwrap() == payload,
+        || {
+            let _ = fs::remove_file(&dst);
+            fs::write(&src, payload).unwrap();
+        },
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Path 5: execute_single + custom CLI mode branch  (representative: patch apply)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn contract_execute_single_custom_mode_patch() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("patched.txt");
+    let patch = dir.path().join("change.patch");
+    let before = "line1\nold line\nline3\n";
+    let after = "line1\nnew line\nline3\n";
+    let patch_body = "--- a/patched.txt\n+++ b/patched.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n";
+
+    // Use absolute patch path: some patch loaders resolve the patch file
+    // against process CWD rather than --cwd (lock current behavior for the
+    // exit/mutation contract, not path resolution).
+    let patch_path = patch.clone();
+    assert_write_path_contract(
+        "execute_single_custom/patch",
+        &dir,
+        |cmd| {
+            cmd.arg("patch").arg("apply").arg(patch_path.as_os_str());
+        },
+        || {
+            fs::read_to_string(&file)
+                .map(|s| s == after)
+                .unwrap_or(false)
+        },
+        || {
+            fs::write(&file, before).unwrap();
+            fs::write(&patch, patch_body).unwrap();
+        },
+    );
+}


### PR DESCRIPTION
## Summary

Phase 1 PR 1.1 of the structural rewrite program ([#1373](https://github.com/patchloom/patchloom/issues/1373) / epic [#1372](https://github.com/patchloom/patchloom/issues/1372)).

- Inventory of the five write entry paths in [`docs/plans/write-pipeline.md`](docs/plans/write-pipeline.md)
- Integration contract matrix: preview / `--check` / `--apply` / `--confirm --json` decline (non-TTY) for one representative command **per path**
- **No behavior change** (locks the multi-path exit-code class from #1345–#1348 before collapse)

### Paths covered

| Path | Representative |
|------|----------------|
| `execute_via_engine` | `create` |
| `execute_via_engine_no_preview_diffs` | `delete` |
| `execute_operations` | `tidy fix` |
| `execute_precomputed` | `replace` |
| `execute_write` | binary `rename` |
| `execute_single` + custom mode branch | `patch apply` |

## Next (not in this PR)

- PR 1.2 shared mode/exit resolver
- PR 1.3 collapse entry points
- PR 1.4 delete forks + AGENTS.md rewrite

## Test plan

- [x] `cargo test --test integration write_path_contract --all-features`
- [x] `make check`

Refs #1373