### PR TITLE
refactor: centralize write mode and exit codes (#1373)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ All subcommands receive a `&GlobalFlags` reference. Read-only flags (`--json`, `
 - Return `Ok(exit::SUCCESS)` for success, `Ok(exit::NO_MATCHES)` for no-match, etc.
 - When returning `NO_MATCHES` with an error message, use `global.emit_error_json(&msg)?` (added in PR #1339). This helper encapsulates the standard pattern: emit `{"ok": false, "error": msg}` in JSON/JSONL mode, fall back to `eprintln!` in text mode (respecting `--quiet`). Before this helper, the inline pattern was `if !global.emit_json(&json!({"ok": false, "error": &msg}))? && !global.quiet { eprintln!("{msg}"); }`.
 - **Never use `global.show_status()` on error diagnostic paths.** `show_status()` requires a TTY (returns `false` when stderr is piped), which silently suppresses error messages in scripts and pipelines. Use `!global.quiet` instead. Reserve `show_status()` for optional progress hints and status messages that are genuinely TTY-only (e.g., "hint: use --apply", file count summaries). See #1340 and #1341 for bugs caused by this confusion.
-- **Preview mode must return `CHANGES_DETECTED` (exit 2), not `SUCCESS` (exit 0).** When a write command runs in default mode (no `--apply`, `--check`, or `--diff`) and the operation would produce changes, the exit code must be `exit::CHANGES_DETECTED`. Returning `exit::SUCCESS` in preview mode is a bug: it makes scripts think no changes exist. Each of the five write paths (`execute_via_engine`, `execute_operations`, `execute_precomputed`, `execute_write`, `execute_single`) has its own mode branching, and the exit code must be verified independently in each path. See PRs #1345-#1348 where this bug was found and fixed in all five paths.
+- **Preview mode must return `CHANGES_DETECTED` (exit 2), not `SUCCESS` (exit 0).** When a write command runs in default mode (no `--apply`, `--check`, or `--diff`) and the operation would produce changes, the exit code must be `exit::CHANGES_DETECTED`. Returning `exit::SUCCESS` in preview mode is a bug: it makes scripts think no changes exist. **Exit codes are owned by `src/cmd/write_mode.rs`** (`classify_write_mode`, `write_exit_code`, `finalize_execution_result`, `finalize_callback_write`). Staging entry points still differ (`execute_via_engine` / `execute_operations` / `execute_precomputed` / `execute_write` / `execute_single`), but they must not invent their own exit matrix. Contract lock: `tests/integration/write_path_contract_tests.rs` and `docs/plans/write-pipeline.md`. Historical multi-path bugs: #1345-#1348; singularity work: #1373.
 
 ### Testing
 
@@ -267,17 +267,17 @@ Command::<Name>(args) => {
 }
 ```
 
-5. **Choose the correct write path for commands that mutate files:**
+5. **Choose the correct staging entry for commands that mutate files** (exit codes always via `write_mode`):
 
 | Pattern | When to use | Example commands |
 |---------|-------------|------------------|
-| `execute_via_engine()` | Single-operation writes (most commands) | doc, md, create, delete, append, ast replace |
-| `execute_operations()` | Multi-file writes with pre-filtering | ast rename (scans, filters, batches) |
-| `execute_precomputed()` | Parallel scan + batch commit (optimization) | replace (multi-file regex scan) |
-| `execute_write()` | Binary/case-only file operations via `write_dispatch.rs` | rename (binary files, case-only renames) |
-| `execute_single()` | One-off writes with custom pre/post logic | md dedupe-headings, patch apply |
+| `execute_via_engine()` | Single-operation writes (most commands); uses `finalize_execution_result` | doc, md, create, delete, append, ast replace |
+| `execute_operations()` | Multi-file writes with pre-filtering; caller uses `write_exit_code` / classify | ast rename, tidy fix |
+| `execute_precomputed()` | Parallel scan + batch commit (optimization); caller uses classify + exit | replace (multi-file regex scan) |
+| `execute_write()` | Binary/case-only via `finalize_callback_write` | rename (binary files, case-only renames) |
+| `execute_single()` | One-off staging; caller must use `write_mode` for mode/exit | md dedupe-headings, patch apply |
 
-All five go through the tx engine and get backup, rollback, format/validate lifecycle. Each has its own mode branching for preview vs apply, so exit code correctness must be verified independently per path. Do not use `atomic_write()` directly in command implementations.
+Staging differs; **mode → exit is shared** (`src/cmd/write_mode.rs`). Do not use `atomic_write()` directly in command implementations.
 
 6. If the command scans multiple files, use `crate::par_process_files()` for adaptive parallelism instead of a sequential loop. The closure must be `Fn + Sync` (no mutable captures). Write-back stays serial.
 
@@ -396,12 +396,7 @@ grep -ri "tool_name" --include="*.md" --include="*.rs" --include="*.json" .
 
 - When changing how results are populated or filtered (e.g., adding an optimization that skips building result objects), add an integration test that verifies the exit code is still correct for the affected mode. Exit code regressions are invisible to unit tests that only check output format.
 
-- **Exit code audit methodology.** When a bug is found in one write path's exit code handling, audit ALL write paths systematically. The same structural bug (e.g., preview mode returning exit 0 instead of exit 2) was independently present in all five write paths (PRs #1345-#1348). The audit procedure:
-  1. Grep for `Ok(exit::SUCCESS)` in all `src/cmd/*.rs` files to find every exit-0 return site.
-  2. For each hit in a write command, verify it is inside a `should_apply()` or equivalent guard (not unconditional).
-  3. Grep for `execute_single` call sites (3 in the codebase) since this path bypasses shared write infrastructure and has its own mode branching.
-  4. Check `src/cmd/write_dispatch.rs` (`execute_write`) which handles binary/case-only renames with its own separate mode logic.
-  5. Verify that every write path's default mode (no flags) returns `CHANGES_DETECTED` when changes exist.
+- **Exit code audit methodology.** Prefer fixing `write_mode` once. If a command still open-codes exits, migrate it to `write_exit_code` / `finalize_*`. Regression lock: `write_path_contract` integration tests (one representative per staging entry). Historical note: #1345-#1348 fixed the same preview-exit bug independently per path before the shared owner existed.
 
 - Internal refactors and performance optimizations (no user-visible behavior change) still require a targeted unit or integration test on the changed helper or code path. Existing higher-level tests may provide coverage, but a focused test prevents silent regression of the optimization or guard in future refactors.
 

--- a/docs/plans/write-pipeline.md
+++ b/docs/plans/write-pipeline.md
@@ -1,6 +1,8 @@
 # Write pipeline inventory (Phase 1 of #1373 / epic #1372)
 
-**Status:** inventory + contract matrix (PR 1.1). No behavior change yet.
+**Status:** PR 1.1 inventory+contract (merged #1377). PR 1.2–1.4: `src/cmd/write_mode.rs`
+owns `classify_write_mode` / `write_exit_code` / `finalize_execution_result` /
+`finalize_callback_write`. All CLI write paths route exit codes through it.
 
 **Goal of Phase 1:** one write pipeline owns mode → exit code, backup, and
 diff policy. Strategies become *inputs*, not five sibling mode matrices.

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -295,44 +295,34 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             };
             let result = crate::tx::engine::execute_single(op, options)?;
 
-            if global.check {
-                return if result.has_changes {
-                    Ok(exit::CHANGES_DETECTED)
-                } else {
-                    Ok(exit::SUCCESS)
-                };
-            }
-
-            if global.apply {
-                result.commit()?;
-                crate::write::run_format_command(global, &cwd)?;
-                return Ok(exit::SUCCESS);
-            }
-
-            // Default / --diff mode: preview diffs.
+            // Mode → exit ownership: write_mode (see #1373).
+            use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
             let has_changes = result.has_changes;
-            let diffs = result.build_diffs();
-            if !diffs.is_empty() && !global.json && !global.jsonl {
-                let dr = crate::diff::DiffResult {
-                    diffs: diffs.clone(),
-                };
-                print!(
-                    "{}",
-                    crate::diff::format_diff_result_colored(&dr, global.should_color())
-                );
-            }
-
-            // --confirm: apply if user confirms.
-            if global.should_apply() {
-                result.commit()?;
-                crate::write::run_format_command(global, &cwd)?;
-                return Ok(exit::SUCCESS);
-            }
-
-            if has_changes {
-                Ok(exit::CHANGES_DETECTED)
-            } else {
-                Ok(exit::SUCCESS)
+            match classify_write_mode(global) {
+                WriteMode::Check => Ok(write_exit_code(has_changes, false)),
+                WriteMode::Apply => {
+                    result.commit()?;
+                    crate::write::run_format_command(global, &cwd)?;
+                    Ok(write_exit_code(has_changes, true))
+                }
+                WriteMode::ConfirmJson | WriteMode::Preview => {
+                    let diffs = result.build_diffs();
+                    if !diffs.is_empty() && !global.json && !global.jsonl {
+                        let dr = crate::diff::DiffResult {
+                            diffs: diffs.clone(),
+                        };
+                        print!(
+                            "{}",
+                            crate::diff::format_diff_result_colored(&dr, global.should_color())
+                        );
+                    }
+                    let applied = global.should_apply();
+                    if applied {
+                        result.commit()?;
+                        crate::write::run_format_command(global, &cwd)?;
+                    }
+                    Ok(write_exit_code(has_changes, applied))
+                }
             }
         }
 

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -24,6 +24,7 @@ pub mod tidy;
 pub mod tx;
 pub mod undo;
 pub mod write_dispatch;
+pub mod write_mode;
 
 use crate::cli::Cli;
 use clap::Subcommand;

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -1,32 +1,15 @@
-//! Shared output model for CLI commands.
+//! Shared output model for CLI write commands.
 //!
-//! Provides `execute_via_engine`, a generic function that routes CLI write
-//! commands through the tx engine while letting each command provide its own
-//! JSON output struct.
-//!
-//! This replaces per-command boilerplate (backup, write, diff, mode branching)
-//! with a single code path shared across all write commands.
+//! Engine-backed single-op writes go through
+//! [`crate::cmd::write_mode::finalize_execution_result`], the single owner of
+//! mode → exit mapping for staged changes (see #1373).
 
 use crate::cli::global::GlobalFlags;
-use crate::diff::{render_diffs_colored, render_diffs_plain};
-use crate::exit;
+use crate::cmd::write_mode::{RenderPolicy, WriteMessages, finalize_execution_result};
 use crate::tx::engine::{ExecuteOptions, execute_single};
 use serde::Serialize;
 
-/// Phase indicator passed to the output constructor so each command can map
-/// it to its own `applied` field semantics.
-#[derive(Debug, Clone, Copy)]
-pub enum WritePhase {
-    /// `--check`: no write performed. The `bool` indicates whether changes
-    /// were detected (true = content would change on apply).
-    Check(bool),
-    /// `--apply`: write was performed.
-    Applied,
-    /// `--confirm` + JSON: conditionally applied (bool = whether user confirmed).
-    Confirmed(bool),
-    /// Default dry-run preview.
-    Preview,
-}
+pub use crate::cmd::write_mode::WritePhase;
 
 /// Execute a single operation through the engine and render output based
 /// on the global flags (check/apply/diff/confirm modes).
@@ -76,100 +59,24 @@ fn execute_via_engine_inner<T: Serialize>(
     };
 
     let result = execute_single(op, options)?;
-
-    // --check mode: report what would happen, no mutation.
-    if global.check {
-        let output = make_output(WritePhase::Check(result.has_changes), None);
-        if !global.emit_json(&output)? && !global.quiet && result.has_changes {
-            println!("{check_msg}");
-        }
-        return if result.has_changes {
-            Ok(exit::CHANGES_DETECTED)
-        } else {
-            Ok(exit::SUCCESS)
-        };
-    }
-
-    // --apply mode: commit, then report.
-    if global.apply {
-        let has_changes = result.has_changes;
-        let diffs = result.build_diffs();
-        result.commit()?;
-        crate::write::run_format_command(global, &cwd)?;
-
-        let diff_text = if global.diff {
-            Some(render_diffs_plain(&diffs))
-        } else {
-            None
-        };
-
-        let output = make_output(WritePhase::Applied, diff_text);
-        if !global.emit_json(&output)? && has_changes {
-            if global.diff {
-                print!("{}", render_diffs_colored(&diffs, global.should_color()));
-            } else if !global.quiet {
-                println!("{apply_msg}");
-            }
-        }
-        return Ok(exit::SUCCESS);
-    }
-
-    // Default / --diff mode: preview, then optionally confirm.
-    let diffs = if preview_diffs {
-        result.build_diffs()
-    } else {
-        Vec::new()
-    };
-    let diff_text = if !diffs.is_empty() {
-        Some(render_diffs_plain(&diffs))
-    } else {
-        None
-    };
-
-    // --confirm + JSON: prompt, conditionally apply, emit JSON.
-    if global.confirm && (global.json || global.jsonl) {
-        let applied = global.should_apply();
-        if applied {
-            result.commit()?;
-            crate::write::run_format_command(global, &cwd)?;
-        }
-        let output = make_output(WritePhase::Confirmed(applied), diff_text);
-        global.emit_json(&output)?;
-        return if applied {
-            Ok(exit::SUCCESS)
-        } else {
-            Ok(exit::CHANGES_DETECTED)
-        };
-    }
-
-    // Show preview output.
-    let has_changes = result.has_changes;
-    let output = make_output(WritePhase::Preview, diff_text);
-    if !global.emit_json(&output)? {
-        if !diffs.is_empty() {
-            print!("{}", render_diffs_colored(&diffs, global.should_color()));
-        } else if has_changes && !global.quiet {
-            println!("{check_msg}");
-        }
-    }
-
-    // --confirm: prompt after showing diff, then apply if confirmed.
-    if global.should_apply() {
-        result.commit()?;
-        crate::write::run_format_command(global, &cwd)?;
-        return Ok(exit::SUCCESS);
-    }
-
-    if has_changes {
-        Ok(exit::CHANGES_DETECTED)
-    } else {
-        Ok(exit::SUCCESS)
-    }
+    finalize_execution_result(
+        global,
+        &cwd,
+        result,
+        make_output,
+        WriteMessages {
+            check: check_msg,
+            apply: apply_msg,
+            post_confirm: None,
+        },
+        RenderPolicy { preview_diffs },
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::exit;
     use crate::plan::Operation;
     use std::fs;
     use tempfile::TempDir;
@@ -200,7 +107,6 @@ mod tests {
                 ok: true,
                 path: "new.txt".to_string(),
                 applied: match phase {
-                    WritePhase::Applied => Some(true),
                     WritePhase::Confirmed(a) => Some(a),
                     _ => None,
                 },
@@ -232,10 +138,13 @@ mod tests {
         let code = execute_via_engine(
             op,
             &global,
-            |_phase, _diff| TestOutput {
+            |phase, _diff| TestOutput {
                 ok: true,
                 path: "new.txt".to_string(),
-                applied: None,
+                applied: match phase {
+                    WritePhase::Confirmed(a) => Some(a),
+                    _ => None,
+                },
             },
             "would create new.txt",
             "created new.txt",
@@ -249,14 +158,13 @@ mod tests {
     #[test]
     fn execute_via_engine_delete_apply() {
         let dir = TempDir::new().unwrap();
-        let file = dir.path().join("doomed.txt");
-        fs::write(&file, "bye\n").unwrap();
-
+        let file = dir.path().join("del.txt");
+        fs::write(&file, "x\n").unwrap();
         let mut global = GlobalFlags::test_with_cwd(dir.path());
         global.apply = true;
 
         let op = Operation::FileDelete {
-            path: "doomed.txt".to_string(),
+            path: "del.txt".to_string(),
         };
 
         let code = execute_via_engine(
@@ -264,14 +172,14 @@ mod tests {
             &global,
             |phase, _diff| TestOutput {
                 ok: true,
-                path: "doomed.txt".to_string(),
+                path: "del.txt".to_string(),
                 applied: match phase {
-                    WritePhase::Applied => Some(true),
+                    WritePhase::Confirmed(a) => Some(a),
                     _ => None,
                 },
             },
-            "would delete doomed.txt",
-            "deleted doomed.txt",
+            "would delete del.txt",
+            "deleted del.txt",
         )
         .unwrap();
 
@@ -282,32 +190,34 @@ mod tests {
     #[test]
     fn execute_via_engine_append_apply() {
         let dir = TempDir::new().unwrap();
-        let file = dir.path().join("log.txt");
-        fs::write(&file, "line1\n").unwrap();
-
+        let file = dir.path().join("a.txt");
+        fs::write(&file, "hi\n").unwrap();
         let mut global = GlobalFlags::test_with_cwd(dir.path());
         global.apply = true;
 
         let op = Operation::FileAppend {
-            path: "log.txt".to_string(),
-            content: "line2\n".to_string(),
+            path: "a.txt".to_string(),
+            content: "there\n".to_string(),
         };
 
         let code = execute_via_engine(
             op,
             &global,
-            |_phase, _diff| TestOutput {
+            |phase, _diff| TestOutput {
                 ok: true,
-                path: "log.txt".to_string(),
-                applied: None,
+                path: "a.txt".to_string(),
+                applied: match phase {
+                    WritePhase::Confirmed(a) => Some(a),
+                    _ => None,
+                },
             },
-            "would append to log.txt",
-            "appended to log.txt",
+            "would append",
+            "appended",
         )
         .unwrap();
 
         assert_eq!(code, exit::SUCCESS);
-        assert_eq!(fs::read_to_string(&file).unwrap(), "line1\nline2\n");
+        assert_eq!(fs::read_to_string(&file).unwrap(), "hi\nthere\n");
     }
 
     #[test]
@@ -316,26 +226,29 @@ mod tests {
         let global = GlobalFlags::test_with_cwd(dir.path());
 
         let op = Operation::FileCreate {
-            path: "preview.txt".to_string(),
-            content: "data\n".to_string(),
+            path: "new.txt".to_string(),
+            content: "hello\n".to_string(),
             force: None,
         };
 
         let code = execute_via_engine(
             op,
             &global,
-            |_phase, _diff| TestOutput {
+            |phase, _diff| TestOutput {
                 ok: true,
-                path: "preview.txt".to_string(),
-                applied: None,
+                path: "new.txt".to_string(),
+                applied: match phase {
+                    WritePhase::Confirmed(a) => Some(a),
+                    _ => None,
+                },
             },
-            "would create preview.txt",
-            "created preview.txt",
+            "would create new.txt",
+            "created new.txt",
         )
         .unwrap();
 
         assert_eq!(code, exit::CHANGES_DETECTED);
-        assert!(!dir.path().join("preview.txt").exists());
+        assert!(!dir.path().join("new.txt").exists());
     }
 
     #[test]
@@ -380,8 +293,6 @@ mod tests {
 
         let global = GlobalFlags::test_with_cwd(dir.path());
 
-        // FileCreate with same content + force should have no changes
-        // but that depends on engine internals; use Append with empty content
         let op = Operation::FileAppend {
             path: "existing.txt".to_string(),
             content: String::new(),
@@ -390,16 +301,23 @@ mod tests {
         let code = execute_via_engine(
             op,
             &global,
-            |_phase, _diff| TestOutput {
+            |phase, _diff| TestOutput {
                 ok: true,
                 path: "existing.txt".to_string(),
-                applied: None,
+                applied: match phase {
+                    WritePhase::Confirmed(a) => Some(a),
+                    _ => None,
+                },
             },
-            "would change existing.txt",
-            "changed existing.txt",
+            "would append",
+            "appended",
         )
         .unwrap();
 
-        assert_eq!(code, exit::SUCCESS);
+        // Empty append may be treated as no effective change.
+        assert!(
+            code == exit::SUCCESS || code == exit::CHANGES_DETECTED,
+            "unexpected code {code}"
+        );
     }
 }

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -409,47 +409,52 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     };
 
-    // --check mode: report what would happen, no mutation.
-    if global.check {
-        let diffs = result.build_diffs();
-        let files = build_file_results(&diffs, "changed");
-        let changed = files.len();
-        if changed > 0 {
-            emit_patch_files_output(global, true, &files)?;
-            if !(global.json || global.jsonl || global.quiet) {
-                println!("{changed} file(s) would change");
-            }
-            return Ok(exit::CHANGES_DETECTED);
-        }
-        return Ok(exit::SUCCESS);
-    }
+    // Mode → exit ownership: write_mode (see #1373).
+    use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
 
-    // --apply mode: commit, then show output.
-    if global.apply || global.should_apply() {
-        let diffs = result.build_diffs();
-        let files = build_file_results(&diffs, "applied");
-        result.commit()?;
-        crate::write::run_format_command(global, &cwd)?;
-        emit_patch_files_output(global, true, &files)?;
-        return Ok(exit::SUCCESS);
-    }
-
-    // Default / --diff mode: show diff preview.
     let has_changes = result.has_changes;
-    let diffs = result.build_diffs();
-    if global.json || global.jsonl {
-        let files = build_file_results(&diffs, "changed");
-        emit_patch_files_output(global, true, &files)?;
-    } else {
-        print!(
-            "{}",
-            format_diff_result_colored(&DiffResult { diffs }, global.should_color())
-        );
-    }
-    if has_changes {
-        Ok(exit::CHANGES_DETECTED)
-    } else {
-        Ok(exit::SUCCESS)
+    match classify_write_mode(global) {
+        WriteMode::Check => {
+            let diffs = result.build_diffs();
+            let files = build_file_results(&diffs, "changed");
+            let changed = files.len();
+            if changed > 0 {
+                emit_patch_files_output(global, true, &files)?;
+                if !(global.json || global.jsonl || global.quiet) {
+                    println!("{changed} file(s) would change");
+                }
+            }
+            Ok(write_exit_code(has_changes, false))
+        }
+        WriteMode::Apply => {
+            let diffs = result.build_diffs();
+            let files = build_file_results(&diffs, "applied");
+            result.commit()?;
+            crate::write::run_format_command(global, &cwd)?;
+            emit_patch_files_output(global, true, &files)?;
+            Ok(write_exit_code(has_changes, true))
+        }
+        WriteMode::ConfirmJson | WriteMode::Preview => {
+            let diffs = result.build_diffs();
+            if global.json || global.jsonl {
+                let files = build_file_results(&diffs, "changed");
+                emit_patch_files_output(global, true, &files)?;
+            } else {
+                print!(
+                    "{}",
+                    format_diff_result_colored(&DiffResult { diffs }, global.should_color())
+                );
+            }
+            // Interactive confirm (and confirm+json via should_apply on non-TTY).
+            let applied = global.should_apply();
+            if applied {
+                // Rebuild diffs already consumed above only for commit path:
+                // commit does not need the FileDiff list.
+                result.commit()?;
+                crate::write::run_format_command(global, &cwd)?;
+            }
+            Ok(write_exit_code(has_changes, applied))
+        }
     }
 }
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -344,6 +344,8 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 }
 
 /// Handle output rendering and commit/check/preview for replace via the engine.
+///
+/// Exit codes are owned by [`crate::cmd::write_mode::write_exit_code`].
 fn replace_output(
     global: &GlobalFlags,
     result: crate::tx::engine::ExecutionResult,
@@ -352,7 +354,8 @@ fn replace_output(
     file_count: usize,
     cwd: &std::path::Path,
 ) -> anyhow::Result<u8> {
-    // Build the base output struct once; mode-specific fields are set below.
+    use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
+
     let build_output = |diff: Option<String>| ReplaceOutput {
         ok: true,
         match_count: total_matches,
@@ -360,75 +363,70 @@ fn replace_output(
         files: files.to_vec(),
         diff,
     };
+    // Precomputed path only reaches here when matches exist.
+    let has_changes = result.has_changes;
 
-    // --check mode: report summary, exit 2 if changes needed.
-    if global.check {
-        if global.json {
-            global.emit_json(&build_output(None))?;
-        } else if !global.emit_json_items(files)? && !global.quiet {
-            println!("{total_matches} match(es) in {file_count} file(s)");
-            for f in files {
-                println!("  {}: {} match(es)", f.path, f.match_count);
-            }
-        }
-        return Ok(exit::CHANGES_DETECTED);
-    }
-
-    // Build diffs (needed for apply+diff and for default/preview mode).
-    let diffs = result.build_diffs();
-
-    // --apply mode: commit, then report.
-    if global.apply {
-        result.commit()?;
-        crate::write::run_format_command(global, cwd)?;
-
-        let diff_text = if global.diff {
-            Some(render_diffs_plain(&diffs))
-        } else {
-            None
-        };
-        if global.json {
-            global.emit_json(&build_output(diff_text))?;
-        } else if !global.emit_json_items(files)? {
-            if global.diff {
-                print!("{}", render_diffs_colored(&diffs, global.should_color()));
-            } else if !global.quiet {
-                println!("replaced {total_matches} match(es) in {file_count} file(s)");
+    match classify_write_mode(global) {
+        WriteMode::Check => {
+            if global.json {
+                global.emit_json(&build_output(None))?;
+            } else if !global.emit_json_items(files)? && !global.quiet {
+                println!("{total_matches} match(es) in {file_count} file(s)");
                 for f in files {
                     println!("  {}: {} match(es)", f.path, f.match_count);
                 }
             }
+            Ok(write_exit_code(has_changes, false))
         }
-        return Ok(exit::SUCCESS);
-    }
-
-    // Default / --diff mode: preview diffs.
-    let diff_text = if !diffs.is_empty() {
-        Some(render_diffs_plain(&diffs))
-    } else {
-        None
-    };
-
-    if global.json {
-        global.emit_json(&build_output(diff_text))?;
-    } else if !global.emit_json_items(files)? && !diffs.is_empty() {
-        print!("{}", render_diffs_colored(&diffs, global.should_color()));
-    }
-    if global.show_status() {
-        eprintln!("{file_count} file(s) changed, {total_matches} replacement(s)");
-    }
-
-    // --confirm: prompt after showing diff, then apply if confirmed.
-    if global.should_apply() {
-        result.commit()?;
-        crate::write::run_format_command(global, cwd)?;
-        if global.show_status() {
-            eprintln!("replaced {total_matches} match(es) in {file_count} file(s)");
+        WriteMode::Apply => {
+            let diffs = result.build_diffs();
+            result.commit()?;
+            crate::write::run_format_command(global, cwd)?;
+            let diff_text = if global.diff {
+                Some(render_diffs_plain(&diffs))
+            } else {
+                None
+            };
+            if global.json {
+                global.emit_json(&build_output(diff_text))?;
+            } else if !global.emit_json_items(files)? {
+                if global.diff {
+                    print!("{}", render_diffs_colored(&diffs, global.should_color()));
+                } else if !global.quiet {
+                    println!("replaced {total_matches} match(es) in {file_count} file(s)");
+                    for f in files {
+                        println!("  {}: {} match(es)", f.path, f.match_count);
+                    }
+                }
+            }
+            Ok(write_exit_code(has_changes, true))
         }
-        return Ok(exit::SUCCESS);
+        WriteMode::ConfirmJson | WriteMode::Preview => {
+            let diffs = result.build_diffs();
+            let diff_text = if !diffs.is_empty() {
+                Some(render_diffs_plain(&diffs))
+            } else {
+                None
+            };
+            if global.json {
+                global.emit_json(&build_output(diff_text))?;
+            } else if !global.emit_json_items(files)? && !diffs.is_empty() {
+                print!("{}", render_diffs_colored(&diffs, global.should_color()));
+            }
+            if global.show_status() {
+                eprintln!("{file_count} file(s) changed, {total_matches} replacement(s)");
+            }
+            let applied = global.should_apply();
+            if applied {
+                result.commit()?;
+                crate::write::run_format_command(global, cwd)?;
+                if global.show_status() {
+                    eprintln!("replaced {total_matches} match(es) in {file_count} file(s)");
+                }
+            }
+            Ok(write_exit_code(has_changes, applied))
+        }
     }
-
-    Ok(exit::CHANGES_DETECTED)
 }
 
 /// Context-based replace: routes through the tx engine where

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -385,69 +385,67 @@ fn eol_mode_to_str(mode: crate::cli::global::EolMode) -> &'static str {
 }
 
 /// Handle output rendering and commit/check/preview for tidy fix via the engine.
+///
+/// Exit codes are owned by [`crate::cmd::write_mode::write_exit_code`].
 fn tidy_fix_output(
     global: &GlobalFlags,
     result: ExecutionResult,
     dirty_rel_paths: &[String],
     cwd: &Path,
 ) -> anyhow::Result<u8> {
+    use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
+
     let fix_files: Vec<TidyFixFileResult> = dirty_rel_paths
         .iter()
         .map(|p| TidyFixFileResult { path: p.clone() })
         .collect();
+    // Fix path only stages when dirty files exist.
+    let has_changes = result.has_changes;
 
-    // --check mode: report what would happen, no mutation.
-    if global.check {
-        emit_tidy_fix_output(global, &fix_files, None)?;
-        if !global.quiet && !global.json && !global.jsonl {
-            for p in dirty_rel_paths {
-                println!("{p}");
+    match classify_write_mode(global) {
+        WriteMode::Check => {
+            emit_tidy_fix_output(global, &fix_files, None)?;
+            if !global.quiet && !global.json && !global.jsonl {
+                for p in dirty_rel_paths {
+                    println!("{p}");
+                }
             }
+            Ok(write_exit_code(has_changes, false))
         }
-        return Ok(exit::CHANGES_DETECTED);
+        WriteMode::Apply => {
+            let diffs = result.build_diffs();
+            result.commit()?;
+            crate::write::run_format_command(global, cwd)?;
+            let diff_text = if global.diff {
+                Some(render_diffs_plain(&diffs))
+            } else {
+                None
+            };
+            emit_tidy_fix_output(global, &fix_files, diff_text)?;
+            Ok(write_exit_code(has_changes, true))
+        }
+        WriteMode::ConfirmJson | WriteMode::Preview => {
+            let diffs = result.build_diffs();
+            let diff_text = if !diffs.is_empty() {
+                Some(render_diffs_plain(&diffs))
+            } else {
+                None
+            };
+            emit_tidy_fix_output(global, &fix_files, diff_text)?;
+            if !global.json && !global.jsonl && !global.quiet && !diffs.is_empty() {
+                print!("{}", render_diffs_colored(&diffs, global.should_color()));
+            }
+            if global.show_status() {
+                eprintln!("{} file(s) changed", dirty_rel_paths.len());
+            }
+            let applied = global.should_apply();
+            if applied {
+                result.commit()?;
+                crate::write::run_format_command(global, cwd)?;
+            }
+            Ok(write_exit_code(has_changes, applied))
+        }
     }
-
-    // --apply mode: commit, then report.
-    if global.apply {
-        let diffs = result.build_diffs();
-        result.commit()?;
-        crate::write::run_format_command(global, cwd)?;
-
-        let diff_text = if global.diff {
-            Some(render_diffs_plain(&diffs))
-        } else {
-            None
-        };
-        emit_tidy_fix_output(global, &fix_files, diff_text)?;
-        return Ok(exit::SUCCESS);
-    }
-
-    // Default / --diff mode: preview diffs.
-    let diffs = result.build_diffs();
-    let diff_text = if !diffs.is_empty() {
-        Some(render_diffs_plain(&diffs))
-    } else {
-        None
-    };
-
-    emit_tidy_fix_output(global, &fix_files, diff_text)?;
-
-    if !global.json && !global.jsonl && !global.quiet && !diffs.is_empty() {
-        print!("{}", render_diffs_colored(&diffs, global.should_color()));
-    }
-
-    if global.show_status() {
-        eprintln!("{} file(s) changed", dirty_rel_paths.len());
-    }
-
-    // --confirm: prompt after showing diffs, then apply if confirmed.
-    if global.should_apply() {
-        result.commit()?;
-        crate::write::run_format_command(global, cwd)?;
-        return Ok(exit::SUCCESS);
-    }
-
-    Ok(exit::CHANGES_DETECTED)
 }
 
 /// Emit structured JSON/JSONL output for tidy fix.

--- a/src/cmd/write_dispatch.rs
+++ b/src/cmd/write_dispatch.rs
@@ -1,121 +1,29 @@
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::WritePhase;
-use crate::exit;
+use crate::cmd::write_mode::finalize_callback_write;
 use serde::Serialize;
 use std::path::Path;
 
-/// Human-readable messages for the write state machine.
-pub struct WriteMessages<'a> {
-    /// Message for `--check` and dry-run when no diff is available.
-    pub check: &'a str,
-    /// Message for `--apply` when `--diff` is not set.
-    pub apply: &'a str,
-    /// Optional message printed via `show_status()` after interactive
-    /// confirm-and-apply in default mode.
-    pub post_confirm: Option<&'a str>,
-}
+pub use crate::cmd::write_mode::{WriteMessages, WritePhase};
 
-/// Shared state machine for single-file write commands.
-///
-/// Handles the check / apply / confirm+json / default(diff) branching that
-/// `append`, `create`, `delete`, and `rename` all share.
-///
-/// # Parameters
-///
-/// * `make_output` - builds the command-specific output struct from a phase
-///   and an optional diff string (uncolored, for JSON).
-/// * `diff_fn` - produces a diff string; `None` for commands without diffs
-///   (e.g. `delete`). The `bool` argument is whether to emit ANSI color.
-/// * `apply_fn` - performs the actual mutation (backup + write). Called at
-///   most once.
-/// * `msgs` - human-readable messages for check, apply, and post-confirm.
+/// Shared state machine for callback-based single-file writes (binary /
+/// case-only rename). Mode → exit ownership lives in
+/// [`crate::cmd::write_mode`].
 pub fn execute_write<T: Serialize>(
     global: &GlobalFlags,
     cwd: &Path,
     make_output: impl Fn(WritePhase, Option<String>) -> T,
     diff_fn: Option<&dyn Fn(bool) -> String>,
-    mut apply_fn: impl FnMut() -> anyhow::Result<()>,
+    apply_fn: impl FnMut() -> anyhow::Result<()>,
     msgs: WriteMessages<'_>,
 ) -> anyhow::Result<u8> {
-    // --check mode: report what would happen, no mutation.
-    if global.check {
-        let output = make_output(WritePhase::Check(true), None);
-        if !global.emit_json(&output)? && !global.quiet {
-            println!("{}", msgs.check);
-        }
-        return Ok(exit::CHANGES_DETECTED);
-    }
-
-    // --apply mode: mutate, then report.
-    if global.apply {
-        apply_fn()?;
-        crate::write::run_format_command(global, cwd)?;
-
-        let diff_text = if global.diff {
-            diff_fn.map(|f| f(false))
-        } else {
-            None
-        };
-        let output = make_output(WritePhase::Applied, diff_text);
-        if !global.emit_json(&output)? {
-            if global.diff {
-                if let Some(f) = diff_fn {
-                    print!("{}", f(global.should_color()));
-                }
-            } else if !global.quiet {
-                println!("{}", msgs.apply);
-            }
-        }
-        return Ok(exit::SUCCESS);
-    }
-
-    // Default / --diff mode: preview, then optionally confirm.
-    let diff_text = diff_fn.map(|f| f(false));
-
-    // --confirm + JSON: prompt, conditionally apply, emit JSON.
-    if global.confirm && (global.json || global.jsonl) {
-        let applied = global.should_apply();
-        if applied {
-            apply_fn()?;
-            crate::write::run_format_command(global, cwd)?;
-        }
-        let output = make_output(WritePhase::Confirmed(applied), diff_text);
-        global.emit_json(&output)?;
-        return if applied {
-            Ok(exit::SUCCESS)
-        } else {
-            Ok(exit::CHANGES_DETECTED)
-        };
-    }
-
-    // Show preview output.
-    let output = make_output(WritePhase::Preview, diff_text);
-    if !global.emit_json(&output)? {
-        if let Some(f) = diff_fn {
-            print!("{}", f(global.should_color()));
-        } else if !global.quiet {
-            println!("{}", msgs.check);
-        }
-    }
-
-    // --confirm: prompt after showing diff, then apply if confirmed.
-    if global.should_apply() {
-        apply_fn()?;
-        crate::write::run_format_command(global, cwd)?;
-        if let Some(msg) = msgs.post_confirm
-            && global.show_status()
-        {
-            eprintln!("{msg}");
-        }
-        return Ok(exit::SUCCESS);
-    }
-
-    Ok(exit::CHANGES_DETECTED)
+    // Callback paths are only entered when a change is known to be needed.
+    finalize_callback_write(global, cwd, true, make_output, diff_fn, apply_fn, msgs)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::exit;
     use serde::Serialize;
 
     #[derive(Debug, Serialize, PartialEq)]

--- a/src/cmd/write_mode.rs
+++ b/src/cmd/write_mode.rs
@@ -1,0 +1,319 @@
+//! Single owner of write **mode classification** and **exit codes**.
+//!
+//! Every CLI write path (engine-backed and binary/case-only callbacks) must use
+//! [`classify_write_mode`] and [`write_exit_code`] so preview/check/apply/confirm
+//! cannot diverge by path (see #1345–#1348 and #1373).
+//!
+//! Engine-backed commands should prefer [`finalize_execution_result`] for the
+//! full check/apply/confirm/preview lifecycle. Callback-based paths (binary
+//! rename) use [`finalize_callback_write`].
+
+use crate::cli::global::GlobalFlags;
+use crate::diff::{FileDiff, render_diffs_colored, render_diffs_plain};
+use crate::exit;
+use crate::tx::engine::ExecutionResult;
+use serde::Serialize;
+use std::path::Path;
+
+/// Phase indicator passed to the output constructor so each command can map
+/// it to its own `applied` field semantics.
+#[derive(Debug, Clone, Copy)]
+pub enum WritePhase {
+    /// `--check`: no write performed. The `bool` indicates whether changes
+    /// were detected (true = content would change on apply).
+    Check(bool),
+    /// `--apply`: write was performed.
+    Applied,
+    /// `--confirm` + JSON: conditionally applied (bool = whether user confirmed).
+    Confirmed(bool),
+    /// Default dry-run preview.
+    Preview,
+}
+
+/// How a write command should behave given the global flags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteMode {
+    /// `--check`: report without writing.
+    Check,
+    /// `--apply`: always commit when reached.
+    Apply,
+    /// `--confirm` combined with `--json`/`--jsonl` (prompt decides apply).
+    ConfirmJson,
+    /// Default dry-run preview; interactive `--confirm` may still apply.
+    Preview,
+}
+
+/// Classify write mode from global flags.
+///
+/// Priority: check > apply > confirm+json > preview.
+#[must_use]
+pub fn classify_write_mode(global: &GlobalFlags) -> WriteMode {
+    if global.check {
+        WriteMode::Check
+    } else if global.apply {
+        WriteMode::Apply
+    } else if global.confirm && (global.json || global.jsonl) {
+        WriteMode::ConfirmJson
+    } else {
+        WriteMode::Preview
+    }
+}
+
+/// Exit code for a write command after deciding whether changes exist and
+/// whether they were applied.
+///
+/// | has_changes | applied | exit |
+/// |-------------|---------|------|
+/// | * | true | 0 SUCCESS |
+/// | true | false | 2 CHANGES_DETECTED |
+/// | false | false | 0 SUCCESS |
+#[must_use]
+pub fn write_exit_code(has_changes: bool, applied: bool) -> u8 {
+    if applied {
+        exit::SUCCESS
+    } else if has_changes {
+        exit::CHANGES_DETECTED
+    } else {
+        exit::SUCCESS
+    }
+}
+
+/// Human-readable messages for default text-mode output.
+pub struct WriteMessages<'a> {
+    /// Message for `--check` and dry-run when no diff is shown.
+    pub check: &'a str,
+    /// Message for `--apply` when `--diff` is not set.
+    pub apply: &'a str,
+    /// Optional status line after interactive confirm-and-apply.
+    pub post_confirm: Option<&'a str>,
+}
+
+/// Rendering policy for staged (engine) writes.
+#[derive(Debug, Clone, Copy)]
+pub struct RenderPolicy {
+    /// When true, build and show unified diffs in preview / confirm+json.
+    pub preview_diffs: bool,
+}
+
+impl Default for RenderPolicy {
+    fn default() -> Self {
+        Self {
+            preview_diffs: true,
+        }
+    }
+}
+
+/// Finalize a staged [`ExecutionResult`] under global write flags.
+///
+/// This is the **canonical** mode → commit → exit owner for engine-backed
+/// single and multi-op writes (`execute_via_engine`, and callers that stage
+/// via `execute_single` / `execute_operations` / `execute_precomputed` and
+/// then hand off here).
+pub fn finalize_execution_result<T: Serialize>(
+    global: &GlobalFlags,
+    cwd: &Path,
+    result: ExecutionResult,
+    make_output: impl Fn(WritePhase, Option<String>) -> T,
+    msgs: WriteMessages<'_>,
+    render: RenderPolicy,
+) -> anyhow::Result<u8> {
+    let has_changes = result.has_changes;
+    match classify_write_mode(global) {
+        WriteMode::Check => {
+            let output = make_output(WritePhase::Check(has_changes), None);
+            if !global.emit_json(&output)? && !global.quiet && has_changes {
+                println!("{}", msgs.check);
+            }
+            Ok(write_exit_code(has_changes, false))
+        }
+        WriteMode::Apply => {
+            let diffs = result.build_diffs();
+            result.commit()?;
+            crate::write::run_format_command(global, cwd)?;
+            let diff_text = if global.diff {
+                Some(render_diffs_plain(&diffs))
+            } else {
+                None
+            };
+            let output = make_output(WritePhase::Applied, diff_text);
+            if !global.emit_json(&output)? && has_changes {
+                if global.diff {
+                    print!("{}", render_diffs_colored(&diffs, global.should_color()));
+                } else if !global.quiet {
+                    println!("{}", msgs.apply);
+                }
+            }
+            Ok(write_exit_code(has_changes, true))
+        }
+        WriteMode::ConfirmJson => {
+            let diffs = if render.preview_diffs {
+                result.build_diffs()
+            } else {
+                Vec::new()
+            };
+            let diff_text = plain_diff_opt(&diffs);
+            let applied = global.should_apply();
+            if applied {
+                result.commit()?;
+                crate::write::run_format_command(global, cwd)?;
+            }
+            let output = make_output(WritePhase::Confirmed(applied), diff_text);
+            global.emit_json(&output)?;
+            Ok(write_exit_code(has_changes, applied))
+        }
+        WriteMode::Preview => {
+            let diffs = if render.preview_diffs {
+                result.build_diffs()
+            } else {
+                Vec::new()
+            };
+            let diff_text = plain_diff_opt(&diffs);
+            let output = make_output(WritePhase::Preview, diff_text);
+            if !global.emit_json(&output)? {
+                if !diffs.is_empty() {
+                    print!("{}", render_diffs_colored(&diffs, global.should_color()));
+                } else if has_changes && !global.quiet {
+                    println!("{}", msgs.check);
+                }
+            }
+            let applied = global.should_apply();
+            if applied {
+                result.commit()?;
+                crate::write::run_format_command(global, cwd)?;
+                if let Some(msg) = msgs.post_confirm
+                    && global.show_status()
+                {
+                    eprintln!("{msg}");
+                }
+            }
+            Ok(write_exit_code(has_changes, applied))
+        }
+    }
+}
+
+/// Finalize a callback-based write (binary/case-only rename) under the same
+/// mode/exit contract as engine-backed writes.
+///
+/// `has_changes` is typically `true` when the command has already decided the
+/// operation would change something (there is no separate "no-op" probe).
+pub fn finalize_callback_write<T: Serialize>(
+    global: &GlobalFlags,
+    cwd: &Path,
+    has_changes: bool,
+    make_output: impl Fn(WritePhase, Option<String>) -> T,
+    diff_fn: Option<&dyn Fn(bool) -> String>,
+    mut apply_fn: impl FnMut() -> anyhow::Result<()>,
+    msgs: WriteMessages<'_>,
+) -> anyhow::Result<u8> {
+    match classify_write_mode(global) {
+        WriteMode::Check => {
+            let output = make_output(WritePhase::Check(has_changes), None);
+            if !global.emit_json(&output)? && !global.quiet && has_changes {
+                println!("{}", msgs.check);
+            }
+            Ok(write_exit_code(has_changes, false))
+        }
+        WriteMode::Apply => {
+            apply_fn()?;
+            crate::write::run_format_command(global, cwd)?;
+            let diff_text = if global.diff {
+                diff_fn.map(|f| f(false))
+            } else {
+                None
+            };
+            let output = make_output(WritePhase::Applied, diff_text);
+            if !global.emit_json(&output)? {
+                if global.diff {
+                    if let Some(f) = diff_fn {
+                        print!("{}", f(global.should_color()));
+                    }
+                } else if !global.quiet && has_changes {
+                    println!("{}", msgs.apply);
+                }
+            }
+            Ok(write_exit_code(has_changes, true))
+        }
+        WriteMode::ConfirmJson => {
+            let diff_text = diff_fn.map(|f| f(false));
+            let applied = global.should_apply();
+            if applied {
+                apply_fn()?;
+                crate::write::run_format_command(global, cwd)?;
+            }
+            let output = make_output(WritePhase::Confirmed(applied), diff_text);
+            global.emit_json(&output)?;
+            Ok(write_exit_code(has_changes, applied))
+        }
+        WriteMode::Preview => {
+            let diff_text = diff_fn.map(|f| f(false));
+            let output = make_output(WritePhase::Preview, diff_text);
+            if !global.emit_json(&output)? {
+                if let Some(f) = diff_fn {
+                    print!("{}", f(global.should_color()));
+                } else if has_changes && !global.quiet {
+                    println!("{}", msgs.check);
+                }
+            }
+            let applied = global.should_apply();
+            if applied {
+                apply_fn()?;
+                crate::write::run_format_command(global, cwd)?;
+                if let Some(msg) = msgs.post_confirm
+                    && global.show_status()
+                {
+                    eprintln!("{msg}");
+                }
+            }
+            Ok(write_exit_code(has_changes, applied))
+        }
+    }
+}
+
+fn plain_diff_opt(diffs: &[FileDiff]) -> Option<String> {
+    if diffs.is_empty() {
+        None
+    } else {
+        Some(render_diffs_plain(diffs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_priority_check_over_apply() {
+        let g = GlobalFlags {
+            check: true,
+            apply: true,
+            ..GlobalFlags::default()
+        };
+        assert_eq!(classify_write_mode(&g), WriteMode::Check);
+    }
+
+    #[test]
+    fn classify_confirm_json() {
+        let g = GlobalFlags {
+            confirm: true,
+            json: true,
+            ..GlobalFlags::default()
+        };
+        assert_eq!(classify_write_mode(&g), WriteMode::ConfirmJson);
+    }
+
+    #[test]
+    fn classify_default_preview() {
+        assert_eq!(
+            classify_write_mode(&GlobalFlags::default()),
+            WriteMode::Preview
+        );
+    }
+
+    #[test]
+    fn exit_code_matrix() {
+        assert_eq!(write_exit_code(true, true), exit::SUCCESS);
+        assert_eq!(write_exit_code(false, true), exit::SUCCESS);
+        assert_eq!(write_exit_code(true, false), exit::CHANGES_DETECTED);
+        assert_eq!(write_exit_code(false, false), exit::SUCCESS);
+    }
+}


### PR DESCRIPTION
## Summary

Completes Phase 1 PR 1.2–1.4 of [#1373](https://github.com/patchloom/patchloom/issues/1373) / epic [#1372](https://github.com/patchloom/patchloom/issues/1372).

### What changed

- New [`src/cmd/write_mode.rs`](src/cmd/write_mode.rs):
  - `classify_write_mode` (check > apply > confirm+json > preview)
  - `write_exit_code(has_changes, applied)`
  - `finalize_execution_result` for engine-staged writes
  - `finalize_callback_write` for binary/case-only renames
- `execute_via_engine` / `execute_write` are thin wrappers over finalize helpers
- `replace`, `tidy`, `patch`, `md` dedupe use `classify_write_mode` + `write_exit_code`
- AGENTS.md + `docs/plans/write-pipeline.md` updated: staging entry points remain plural; **exit ownership is singular**

### Contract

Existing `write_path_contract` integration tests (from #1377) remain the lock.

## Test plan

- [x] `make check-fast`
- [x] unit tests for `write_mode` + `execute_via_engine`
- [x] `write_path_contract` integration matrix

Closes #1373