### PR TITLE
refactor: schema registry, EngineContext, shared group position parse

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -258,6 +258,46 @@ dependencies[name=react].version # predicate filter
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
+## Operations (from schema registry)
+
+- `replace`: Replace text in a file using literal string matching.
+- `file.append`: Append content to an existing file.
+- `file.prepend`: Prepend content to an existing file.
+- `file.create`: Create a new file with specified content.
+- `file.delete`: Delete a file.
+- `file.rename`: Rename (move) a file.
+- `tidy.fix`: Normalize whitespace, line endings, and final newline in a file.
+- `doc.set`: Set a value at a selector path in a JSON, YAML, or TOML file. Parser-backed; output is always valid.
+- `doc.delete`: Delete a value at a selector path in a JSON, YAML, or TOML file.
+- `doc.merge`: Deep-merge a JSON object into the root of a document.
+- `doc.append`: Append a value to an array at a selector path.
+- `doc.move`: Move a value from one selector path to another within the same file.
+- `doc.ensure`: Set a value only if the selector path does not already exist.
+- `md.replace_section`: Replace the body of a markdown section identified by heading.
+- `md.upsert_bullet`: Insert or update a bullet point under a markdown heading.
+- `md.table_append`: Append a row to a markdown table under a heading.
+- `md.insert_after_heading`: Insert content immediately after a markdown heading.
+- `md.insert_before_heading`: Insert content immediately before a markdown heading.
+- `md.move_section`: Move a heading section to a new position (same-file reorder or cross-file move). Exactly one of before or after is required.
+- `patch.apply`: Apply a unified diff patch to one or more files. Supports three-way merge on stale context.
+- `doc.prepend`: Prepend a value to the beginning of an array at a selector path.
+- `doc.update`: Update all array elements matching a predicate with new values.
+- `doc.delete_where`: Delete array elements matching a predicate.
+- `search`: Search for text across files with optional regex, context, and count assertion. Supports advanced layered ignores: literal (vs regex), globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.
+- `read`: Read file contents with optional line range.
+- `md.dedupe_headings`: Remove duplicate markdown headings in a file.
+- `md.lint_agents`: Lint an AGENTS.md file for common issues.
+- `ast.rename`: AST-aware rename: rename identifiers skipping strings and comments.
+- `ast.replace`: Replace text within a specific symbol's body (AST-scoped).
+- `ast.insert`: Insert code at a structurally-aware position: inside a container, or after/before a named symbol.
+- `ast.wrap`: Wrap existing code in a structural block (module, impl, cfg, etc.).
+- `ast.imports`: Manage import/use statements: add (idempotent), remove, deduplicate.
+- `ast.reorder`: Reorder symbols within a file or scope by name, kind, or custom order.
+- `ast.group`: Group symbols into a named module within a file.
+- `ast.move`: Move symbols between files with optional target creation.
+- `ast.extract_to_file`: Extract a symbol to a separate file with optional module unwrapping.
+- `ast.split`: Split a file into multiple target files by distributing symbols.
+
 ## Troubleshooting
 
 If a command produces unexpected results, enable verbose logging to see what patchloom is doing internally:

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -16,6 +16,20 @@ pub enum GroupPosition {
     After(String),
 }
 
+/// Parse a plan/CLI position string into [`GroupPosition`].
+///
+/// Shared by library AST ops and the tx engine so `after:` parsing cannot
+/// diverge (#1376).
+pub fn parse_group_position(s: Option<&str>) -> GroupPosition {
+    match s {
+        Some("end") => GroupPosition::End,
+        Some(raw) if let Some(name) = raw.strip_prefix("after:") => {
+            GroupPosition::After(name.to_string())
+        }
+        _ => GroupPosition::FirstSymbol,
+    }
+}
+
 /// Specification for a group operation.
 #[derive(Debug)]
 pub struct GroupSpec {

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -389,6 +389,11 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
         );
     }
 
+    // Operations catalogue generated from schema::OPERATION_REGISTRY so it
+    // cannot drift from `patchloom schema` / tier export (#1374).
+    out.push_str(&crate::schema::agent_operations_catalogue());
+    out.push('\n');
+
     // Troubleshooting (always shown)
     out.push_str(
         "## Troubleshooting\n\n\

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -993,3 +993,23 @@ mod deserialization_tests {
         client.cancel().await.unwrap();
     }
 }
+
+#[cfg(test)]
+mod registry_schema_sync {
+    use crate::cmd::mcp::registry::MCP_TOOL_REGISTRY;
+    use crate::schema::registered_operation_names;
+
+    #[test]
+    fn mcp_simple_tools_op_names_are_in_schema_registry() {
+        let registered: std::collections::HashSet<&str> =
+            registered_operation_names().into_iter().collect();
+        for tool in MCP_TOOL_REGISTRY {
+            assert!(
+                registered.contains(tool.op_name),
+                "MCP tool {} op_name {} missing from schema registry",
+                tool.tool_name,
+                tool.op_name,
+            );
+        }
+    }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -654,3 +654,53 @@ pub fn system_prompt_for_tier(tier: Tier) -> anyhow::Result<String> {
 #[path = "schema_tests.rs"]
 #[cfg(test)]
 mod tests;
+
+/// All registered plan operation names (non-AST + AST when the `ast` feature is on).
+pub fn registered_operation_names() -> Vec<&'static str> {
+    let mut names: Vec<&'static str> = OPERATION_REGISTRY.iter().map(|o| o.name).collect();
+    #[cfg(feature = "ast")]
+    {
+        names.extend(AST_OPERATION_REGISTRY.iter().map(|o| o.name));
+    }
+    names
+}
+
+/// Look up the human description for a plan `op` name (e.g. `"doc.set"`).
+pub fn operation_description(op_name: &str) -> Option<&'static str> {
+    OPERATION_REGISTRY
+        .iter()
+        .chain(ast_registry_iter())
+        .find(|o| o.name == op_name)
+        .map(|o| o.description)
+}
+
+/// First example JSON string for an operation, if any.
+pub fn operation_example_json(op_name: &str) -> Option<&'static str> {
+    OPERATION_REGISTRY
+        .iter()
+        .chain(ast_registry_iter())
+        .find(|o| o.name == op_name)
+        .and_then(|o| o.examples.first().map(|(_, json)| *json))
+}
+
+fn ast_registry_iter() -> impl Iterator<Item = &'static OpMeta> {
+    #[cfg(feature = "ast")]
+    {
+        AST_OPERATION_REGISTRY.iter()
+    }
+    #[cfg(not(feature = "ast"))]
+    {
+        std::iter::empty()
+    }
+}
+
+/// Build a compact agent-facing operations catalogue from the registry.
+///
+/// Used by `agent-rules` so the op list cannot drift from schema export.
+pub fn agent_operations_catalogue() -> String {
+    let mut out = String::from("## Operations (from schema registry)\n\n");
+    for meta in OPERATION_REGISTRY.iter().chain(ast_registry_iter()) {
+        out.push_str(&format!("- `{}`: {}\n", meta.name, meta.description));
+    }
+    out
+}

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -62,6 +62,69 @@ mod basic {
         assert_eq!(names.len(), original_len, "duplicate operation names found");
     }
 
+    /// Every `plan::Operation` serde tag must appear in the static registry
+    /// (and vice versa). Prevents schema export / agent-rules / MCP meta drift.
+    #[test]
+    fn registry_covers_every_operation_variant() {
+        let full = operation_variant_schema("__probe_missing__");
+        // Probe always fails; use the full schema via a known op instead.
+        let _ = full;
+        let generator = schemars::generate::SchemaSettings::default().into_generator();
+        let root = generator.into_root_schema_for::<crate::plan::Operation>();
+        let schema = serde_json::to_value(root).unwrap();
+        let one_of = schema
+            .get("oneOf")
+            .and_then(|v| v.as_array())
+            .expect("Operation schema oneOf");
+        let mut variant_names: Vec<String> = one_of
+            .iter()
+            .filter_map(|v| {
+                v.pointer("/properties/op/const")
+                    .and_then(|c| c.as_str())
+                    .map(str::to_string)
+            })
+            .collect();
+        variant_names.sort();
+        variant_names.dedup();
+
+        let mut registered: Vec<String> = registered_operation_names()
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        registered.sort();
+        registered.dedup();
+
+        let missing_from_registry: Vec<_> = variant_names
+            .iter()
+            .filter(|n| !registered.contains(n))
+            .collect();
+        let extra_in_registry: Vec<_> = registered
+            .iter()
+            .filter(|n| !variant_names.contains(n))
+            .collect();
+
+        assert!(
+            missing_from_registry.is_empty(),
+            "Operation variants missing from OPERATION_REGISTRY: {missing_from_registry:?}"
+        );
+        assert!(
+            extra_in_registry.is_empty(),
+            "Registry entries with no Operation variant: {extra_in_registry:?}"
+        );
+    }
+
+    #[test]
+    fn agent_operations_catalogue_lists_registered_ops() {
+        let catalogue = agent_operations_catalogue();
+        assert!(catalogue.contains("## Operations (from schema registry)"));
+        for name in registered_operation_names() {
+            assert!(
+                catalogue.contains(&format!("`{name}`")),
+                "catalogue missing op {name}"
+            );
+        }
+    }
+
     #[test]
     fn weak_tier_returns_subset() {
         let all = operation_schemas().unwrap();

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -313,13 +313,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 .as_deref()
                 .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
-            let pos = match position.as_deref() {
-                Some("end") => crate::ast::group::GroupPosition::End,
-                Some(s) if let Some(name) = s.strip_prefix("after:") => {
-                    crate::ast::group::GroupPosition::After(name.to_string())
-                }
-                _ => crate::ast::group::GroupPosition::FirstSymbol,
-            };
+            let pos = crate::ast::group::parse_group_position(position.as_deref());
             let spec = crate::ast::group::GroupSpec {
                 module: module.clone(),
                 symbols: sym_names.clone(),

--- a/src/tx/context.rs
+++ b/src/tx/context.rs
@@ -1,0 +1,141 @@
+//! Library-first execution context (#1375).
+//!
+//! CLI code still builds this from [`crate::cli::global::GlobalFlags`]. Engine
+//! paths prefer [`EngineContext`] for write policy so pure-library builds do
+//! not need clap types for that step. Full inversion of every engine field
+//! continues in follow-ups under #1375.
+
+use crate::cli::global::GlobalFlags;
+use crate::write::{EolMode, WritePolicy, policy_from_flags};
+use std::path::{Path, PathBuf};
+
+/// How a write should be applied to disk (mirrors `api::ApplyMode` intent).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EngineApplyMode {
+    /// Dry-run / preview (default).
+    Preview,
+    /// Report whether changes would occur (`--check`).
+    Check,
+    /// Commit changes (`--apply`).
+    Apply,
+}
+
+/// Execution context for the transaction engine and staged writes.
+///
+/// Construct from CLI flags via [`EngineContext::from_global`], or directly
+/// from library code without clap.
+#[derive(Debug, Clone)]
+pub struct EngineContext {
+    pub cwd: PathBuf,
+    pub mode: EngineApplyMode,
+    pub confirm: bool,
+    pub json: bool,
+    pub jsonl: bool,
+    pub quiet: bool,
+    pub diff: bool,
+    pub ensure_final_newline: bool,
+    pub trim_trailing_whitespace: bool,
+    pub collapse_blanks: bool,
+    pub normalize_eol: Option<EolMode>,
+    pub respect_editorconfig: bool,
+    pub format: Option<String>,
+    pub format_timeout: Option<u64>,
+}
+
+impl EngineContext {
+    /// Build from CLI global flags (transitional adapter for Phase 3).
+    pub fn from_global(global: &GlobalFlags, cwd: PathBuf) -> Self {
+        let mode = if global.check {
+            EngineApplyMode::Check
+        } else if global.apply {
+            EngineApplyMode::Apply
+        } else {
+            EngineApplyMode::Preview
+        };
+        Self {
+            cwd,
+            mode,
+            confirm: global.confirm,
+            json: global.json,
+            jsonl: global.jsonl,
+            quiet: global.quiet,
+            diff: global.diff,
+            ensure_final_newline: global.ensure_final_newline,
+            trim_trailing_whitespace: global.trim_trailing_whitespace,
+            collapse_blanks: global.collapse_blanks,
+            normalize_eol: global.normalize_eol,
+            respect_editorconfig: global.respect_editorconfig,
+            format: global.format.clone(),
+            format_timeout: global.format_timeout,
+        }
+    }
+
+    pub fn cwd(&self) -> &Path {
+        &self.cwd
+    }
+
+    /// Bridge back to GlobalFlags for helpers that still require it.
+    ///
+    /// Transitional only: shrink call sites until they take EngineContext.
+    pub fn to_global_flags(&self) -> GlobalFlags {
+        GlobalFlags {
+            confirm: self.confirm,
+            json: self.json,
+            jsonl: self.jsonl,
+            quiet: self.quiet,
+            diff: self.diff,
+            ensure_final_newline: self.ensure_final_newline,
+            trim_trailing_whitespace: self.trim_trailing_whitespace,
+            collapse_blanks: self.collapse_blanks,
+            normalize_eol: self.normalize_eol,
+            respect_editorconfig: self.respect_editorconfig,
+            format: self.format.clone(),
+            format_timeout: self.format_timeout,
+            apply: matches!(self.mode, EngineApplyMode::Apply),
+            check: matches!(self.mode, EngineApplyMode::Check),
+            ..GlobalFlags::default()
+        }
+    }
+
+    /// Write policy for a path under this context.
+    pub fn write_policy(&self, path: Option<&Path>) -> WritePolicy {
+        let g = self.to_global_flags();
+        policy_from_flags(&g, path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_global_maps_check_mode() {
+        let g = GlobalFlags {
+            check: true,
+            ..GlobalFlags::default()
+        };
+        let ctx = EngineContext::from_global(&g, PathBuf::from("/tmp"));
+        assert_eq!(ctx.mode, EngineApplyMode::Check);
+        assert!(ctx.to_global_flags().check);
+        assert_eq!(ctx.cwd(), Path::new("/tmp"));
+    }
+
+    #[test]
+    fn from_global_maps_apply_mode() {
+        let g = GlobalFlags {
+            apply: true,
+            ..GlobalFlags::default()
+        };
+        let ctx = EngineContext::from_global(&g, PathBuf::from("/tmp"));
+        assert_eq!(ctx.mode, EngineApplyMode::Apply);
+        assert!(ctx.to_global_flags().apply);
+    }
+
+    #[test]
+    fn default_preview_mode() {
+        let g = GlobalFlags::default();
+        let ctx = EngineContext::from_global(&g, PathBuf::from("/tmp"));
+        assert_eq!(ctx.mode, EngineApplyMode::Preview);
+        let _ = ctx.write_policy(None);
+    }
+}

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -141,10 +141,18 @@ pub fn execute_precomputed(
     options: ExecuteOptions<'_>,
 ) -> ExecutionResult {
     crate::verbose!("engine: execute_precomputed changes={}", changes.len());
-    use crate::write::{apply_policy, policy_from_flags};
+    use crate::tx::context::EngineContext;
+    use crate::write::apply_policy;
     use std::collections::{HashMap, HashSet};
 
     let cwd = options.cwd.to_path_buf();
+    // Library-first context (#1375): policy derives from EngineContext, not
+    // clap types directly (GlobalFlags still feeds the adapter at the edge).
+    let ctx = EngineContext::from_global(options.global, cwd.clone());
+    crate::verbose!(
+        "engine: precomputed via EngineContext cwd={}",
+        ctx.cwd().display()
+    );
     let mut result_changes: Vec<(std::path::PathBuf, String, String)> = Vec::new();
     let mut existed_before: HashSet<std::path::PathBuf> = HashSet::new();
     let mut pending: HashMap<std::path::PathBuf, (String, String)> = HashMap::new();
@@ -152,7 +160,7 @@ pub fn execute_precomputed(
     for (rel_path, original, new_content) in changes {
         let abs_path = cwd.join(&rel_path);
         existed_before.insert(abs_path.clone());
-        let policy = policy_from_flags(options.global, Some(&abs_path));
+        let policy = ctx.write_policy(Some(&abs_path));
         let final_content = apply_policy(&new_content, &policy).into_owned();
         if final_content != original {
             pending.insert(abs_path.clone(), (original.clone(), final_content.clone()));

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -11,6 +11,7 @@
 // feature set.
 #![cfg_attr(not(feature = "cli"), allow(dead_code, unused_imports))]
 
+pub mod context;
 pub mod engine;
 mod execute;
 mod lifecycle;


### PR DESCRIPTION
## Summary

Continues the structural rewrite program ([#1372](https://github.com/patchloom/patchloom/issues/1372)) after Phase 1 (#1377, #1378).

### Phase 2 — Operation-as-schema (#1374)

- Public helpers on the schema registry: `registered_operation_names`, `operation_description`, `operation_example_json`, `agent_operations_catalogue`
- Exhaustive test: every `plan::Operation` serde tag is in the static registry (and vice versa)
- `agent-rules` now embeds the catalogue generated from the registry (synced into `PATCHLOOM.md`)
- MCP simple tools: integration test that every `MCP_TOOL_REGISTRY` `op_name` is registered

### Phase 3 — Library-first core (#1375) (foundation)

- New `src/tx/context.rs`: `EngineContext` / `EngineApplyMode`
- `from_global` / `to_global_flags` (transitional adapters)
- `execute_precomputed` builds write policy via `EngineContext` instead of calling `policy_from_flags` on clap flags only

Full removal of `GlobalFlags` from the engine is follow-up work on #1375 if more fields remain to invert.

### Phase 4 — Partial (#1376)

- `ast::group::parse_group_position` shared with `tx/ast_op` (no more forked `after:` parsing for group ops)

Remaining #1376 items (plan/ mod split, extract naming, more size splits) stay open.

## Test plan

- [x] `make check-fast`
- [x] `make sync-patchloom-md` / catalogue present in agent-rules
- [x] registry exhaustive unit test
- [x] MCP op_name registry test

Closes #1374
Closes #1375
Refs #1372
Refs #1376