### PR TITLE
feat: post-rewrite follow-ups (MCP meta, EngineContext, break shims)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -314,27 +314,28 @@ MCP tools live in `src/cmd/mcp/mod.rs` behind the `mcp` feature gate. There are 
 
 If the new tool directly maps to a single `plan::Operation` variant with no custom logic:
 
-1. **Add an entry to `MCP_TOOL_REGISTRY`** in `src/cmd/mcp/mod.rs`:
+1. **Ensure the op is in the schema `OpMeta` registry** (`src/schema.rs`) with description + example.
+2. **Add an entry to `MCP_TOOL_REGISTRY`** in `src/cmd/mcp/registry.rs`:
 
 ```rust
 McpToolMeta {
     tool_name: "new_tool",
     op_name: "new_op",  // must match the Operation variant's serde name
-    description: "Short description. Example: {\"path\": \"file.txt\", ...}",
+    extra: None, // or Some("MCP-only guidance…") — base prose/example come from schema (#1383)
     has_strict: true,   // true if the tool should accept a `strict` parameter
     validations: &[FieldValidation::Path("path")],  // field validations
 },
 ```
 
-The input schema is auto-derived from the `Operation` variant via `operation_variant_schema()`. The handler is `handle_simple_op()`, which injects the `op` discriminator, validates fields, and deserializes into `Operation`.
+The tool description is built by `schema::mcp_tool_description(op_name, extra)` (registry base + optional extra + example). The input schema is auto-derived from the `Operation` variant via `operation_variant_schema()`. The handler is `handle_simple_op()`, which injects the `op` discriminator, validates fields, and deserializes into `Operation`.
 
-2. **Add the tool name** to the `mcp_lists_expected_tools` test and update the expected count.
+3. **Add the tool name** to the `mcp_lists_expected_tools` test and update the expected count.
 
-3. **Add integration tests** in `tests/integration.rs` under `#[cfg(feature = "mcp")]`.
+4. **Add integration tests** in `tests/integration.rs` under `#[cfg(feature = "mcp")]`.
 
-4. **Update the tool list** in `src/cmd/mod.rs` (agent-rules generator) and `docs/getting-started/mcp-setup.md`.
+5. **Update the tool list** in `src/cmd/mod.rs` (agent-rules generator) and `docs/getting-started/mcp-setup.md`.
 
-5. Run `make sync-patchloom-md && make update-readme && make check`.
+6. Run `make sync-patchloom-md && make update-readme && make check`.
 
 ### Path B: Custom hand-written tool (complex logic)
 
@@ -387,7 +388,7 @@ grep -ri "tool_name" --include="*.md" --include="*.rs" --include="*.json" .
 
 - `ast::extract_to_file` — move a named symbol into another source file (plan op `ast.extract_to_file`).
 - `ast::symbol_extract` — per-language tree-sitter visitors that build `SymbolDef` lists.
-- `ast::rewrite` — function signature rewrite helpers (prefer this over deprecated `ast::symbols::rewrite_*` re-exports).
+- `ast::rewrite` — function signature rewrite helpers (use this path only; `ast::symbols` no longer re-exports them, #1386).
 - Shared position parsers: `ast::group::parse_group_position`, `ast::move_symbols::parse_position` (tx must call these, not re-parse `after:`).
 
 Production files over 1000 lines must carry `size-waiver: … #1376` (enforced by `module_hygiene_tests`).

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -436,11 +436,7 @@ pub(crate) fn execute_as_edit_result(
     dest_path: Option<String>,
 ) -> anyhow::Result<EditResult> {
     let global = mode_to_global_flags(mode);
-    let options = crate::tx::engine::ExecuteOptions {
-        cwd,
-        global: &global,
-        guard,
-    };
+    let options = crate::tx::engine::ExecuteOptions::from_global(cwd, &global, guard);
     let result = crate::tx::engine::execute_single(op, options)?;
     execution_result_to_edit_result(result, mode, cwd, action, dest_path)
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -7,11 +7,6 @@
 pub mod deps;
 pub mod diff;
 pub mod extract_to_file;
-/// Deprecated module path for extract-to-file ops. Prefer [`extract_to_file`].
-#[deprecated(note = "use ast::extract_to_file instead; removal tracked in #1376")]
-pub mod extract {
-    pub use super::extract_to_file::*;
-}
 pub mod group;
 pub mod impact;
 pub mod imports;

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -6,18 +6,6 @@ use serde::Serialize;
 
 use super::{Language, parse_source};
 
-/// Re-export rewrite helpers at the historical `ast::symbols::*` path.
-///
-/// Prefer `ast::rewrite::*` for new code. These re-exports will be removed in a
-/// future major version (tracked under #1376).
-#[deprecated(
-    note = "use ast::rewrite::{FunctionSigEdit, FunctionSpan, find_function_span, replace_function_signature, rewrite_function_signature} instead; removal tracked in #1376"
-)]
-pub use crate::ast::rewrite::{
-    FunctionSigEdit, FunctionSpan, find_function_span, replace_function_signature,
-    rewrite_function_signature,
-};
-
 /// The kind of symbol extracted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]

--- a/src/ast/symbols/tests.rs
+++ b/src/ast/symbols/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ast::rewrite::replace_function_signature;
 
 #[test]
 fn check_no_overlapping_spans_ok() {

--- a/src/cmd/ast.rs
+++ b/src/cmd/ast.rs
@@ -373,11 +373,7 @@ fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     let files_changed = operations.len();
-    let options = ExecuteOptions {
-        cwd: &cwd,
-        global,
-        guard: None,
-    };
+    let options = ExecuteOptions::from_global(&cwd, global, None);
     let result = match crate::tx::engine::execute_operations(operations, options) {
         Ok(r) => r,
         Err(e) if exit::is_no_match(&e) => {

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -142,7 +142,7 @@ impl PatchloomService {
             })?;
 
             tool_router.add_route(ToolRoute::new_dyn(
-                Tool::new(meta.tool_name, meta.description, Arc::new(input_schema)),
+                Tool::new(meta.tool_name, meta.description(), Arc::new(input_schema)),
                 move |ctx: ToolCallContext<'_, PatchloomService>| {
                     let fields = Arc::clone(&allowed_fields);
                     let svc = ctx.service.clone();

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -27,12 +27,21 @@ pub(super) struct McpToolMeta {
     pub(super) tool_name: &'static str,
     /// `Operation` variant's serde tag value (e.g., `"doc.set"`).
     pub(super) op_name: &'static str,
-    /// Tool description shown to MCP clients.
-    pub(super) description: &'static str,
+    /// Optional MCP-only guidance appended after the schema registry description
+    /// (concurrency warnings, predicate syntax hints, etc.). Base prose and
+    /// examples come from `schema::mcp_tool_description` (#1383).
+    pub(super) extra: Option<&'static str>,
     /// Whether the tool accepts a `strict` parameter (plan-level, not on Operation).
     pub(super) has_strict: bool,
     /// Field-level validation rules applied before deserialization.
     pub(super) validations: &'static [FieldValidation],
+}
+
+impl McpToolMeta {
+    /// Resolved tool description for MCP clients (schema base + optional extra + example).
+    pub(super) fn description(&self) -> String {
+        crate::schema::mcp_tool_description(self.op_name, self.extra)
+    }
 }
 
 /// Registry of simple MCP tools that map 1:1 to `Operation` variants.
@@ -46,7 +55,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_set",
         op_name: "doc.set",
-        description: "Set a value in a JSON, YAML, or TOML file. Parser-backed, preserves comments. Use dot notation for nested paths. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"package.json\", \"selector\": \"version\", \"value\": \"2.0.0\"}",
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: true,
         validations: &[
             FieldValidation::Path("path"),
@@ -57,7 +68,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_delete",
         op_name: "doc.delete",
-        description: "Delete a value from a JSON, YAML, or TOML file. Example: {\"path\": \"package.json\", \"selector\": \"scripts.test\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -67,7 +78,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_merge",
         op_name: "doc.merge",
-        description: "Deep-merge an object into a JSON, YAML, or TOML document. Example: {\"path\": \"config.yaml\", \"value\": {\"server\": {\"port\": 8080}} }",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -77,7 +88,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_append",
         op_name: "doc.append",
-        description: "Append a value to an array in a JSON, YAML, or TOML file. Example: {\"path\": \"package.json\", \"selector\": \"dependencies\", \"value\": \"new-pkg\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -88,7 +99,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_prepend",
         op_name: "doc.prepend",
-        description: "Prepend a value to an array in a JSON, YAML, or TOML file. Inserts at position 0.",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -99,7 +110,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_ensure",
         op_name: "doc.ensure",
-        description: "Set a value in JSON/YAML/TOML only if it does not already exist. Idempotent: no-op if present. Example: {\"path\": \"config.json\", \"selector\": \"debug\", \"value\": false}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -110,7 +121,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_delete_where",
         op_name: "doc.delete_where",
-        description: "Remove array items matching a predicate from JSON/YAML/TOML. For object arrays: predicate='role=admin'. For simple arrays: predicate='_=value'. Nested paths: predicate='settings.theme=dark'. Example: {\"path\": \"config.yaml\", \"selector\": \"users\", \"predicate\": \"role=admin\"}",
+        extra: Some(
+            "For object arrays: predicate='role=admin'. For simple arrays: predicate='_=value'. Nested paths: predicate='settings.theme=dark'.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -121,7 +134,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_update",
         op_name: "doc.update",
-        description: "Update all items matching a wildcard selector in a JSON, YAML, or TOML file. Example: {\"path\": \"config.yaml\", \"selector\": \"servers[*].port\", \"value\": 8080}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -132,7 +145,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_move",
         op_name: "doc.move",
-        description: "Move/rename a selector path in a JSON, YAML, or TOML file. Example: {\"path\": \"config.json\", \"from\": \"old_name\", \"to\": \"new_name\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -143,14 +156,14 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "read_file",
         op_name: "read",
-        description: "Read file contents with optional line range. Example: {\"path\": \"src/main.rs\", \"lines\": \"1:50\"}",
+        extra: Some("Optional lines range uses start:end (1-based)."),
         has_strict: false,
         validations: &[FieldValidation::Path("path")],
     },
     McpToolMeta {
         tool_name: "md_upsert_bullet",
         op_name: "md.upsert_bullet",
-        description: "Add a bullet under a markdown heading. Idempotent: skipped if already present. Example: {\"path\": \"CHANGELOG.md\", \"heading\": \"## Changes\", \"bullet\": \"- Added new feature\"}",
+        extra: Some("Idempotent: skipped if the bullet is already present."),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -160,7 +173,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_table_append",
         op_name: "md.table_append",
-        description: "Append a row to a markdown table under a heading. Example: {\"path\": \"docs/api.md\", \"heading\": \"## Endpoints\", \"row\": \"| GET | /health | 200 |\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -170,7 +183,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_replace_section",
         op_name: "md.replace_section",
-        description: "Replace the content of a markdown section (from heading to next same-level heading). Example: {\"path\": \"README.md\", \"heading\": \"## Installation\", \"content\": \"Run `cargo install patchloom`.\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -180,7 +193,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_insert_after_heading",
         op_name: "md.insert_after_heading",
-        description: "Insert content immediately after a markdown heading (before existing section body). Example: {\"path\": \"AGENTS.md\", \"heading\": \"## Rules\", \"content\": \"Always run tests.\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -190,7 +203,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_insert_before_heading",
         op_name: "md.insert_before_heading",
-        description: "Insert content before a markdown heading. Example: {\"path\": \"AGENTS.md\", \"heading\": \"## Rules\", \"content\": \"## Preamble\\nRead this first.\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -200,21 +213,21 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_dedupe_headings",
         op_name: "md.dedupe_headings",
-        description: "Remove duplicate markdown headings in a file. Keeps the first occurrence of each heading. Example: {\"path\": \"README.md\"}",
+        extra: None,
         has_strict: false,
         validations: &[FieldValidation::Path("path")],
     },
     McpToolMeta {
         tool_name: "move_file",
         op_name: "file.rename",
-        description: "Move or rename a file. Use force=true to overwrite existing. Example: {\"from\": \"old.txt\", \"to\": \"new.txt\"}",
+        extra: Some("Use force=true to overwrite an existing destination."),
         has_strict: false,
         validations: &[FieldValidation::Path("from"), FieldValidation::Path("to")],
     },
     McpToolMeta {
         tool_name: "append_file",
         op_name: "file.append",
-        description: "Append content to the end of an existing file. Example: {\"path\": \"log.txt\", \"content\": \"new entry\\n\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -224,7 +237,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "prepend_file",
         op_name: "file.prepend",
-        description: "Prepend content to the beginning of an existing file. Example: {\"path\": \"src/main.rs\", \"content\": \"// Copyright 2026\\n\"}",
+        extra: None,
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -234,7 +247,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "create_file",
         op_name: "file.create",
-        description: "Create a new file with content. Fails if file exists unless force=true. Example: {\"path\": \"src/new.rs\", \"content\": \"fn main() {}\"}",
+        extra: Some("Fails if the file exists unless force=true."),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -244,7 +257,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "delete_file",
         op_name: "file.delete",
-        description: "Delete a file. Example: {\"path\": \"obsolete.txt\"}",
+        extra: None,
         has_strict: false,
         validations: &[FieldValidation::Path("path")],
     },

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -998,7 +998,10 @@ mod deserialization_tests {
 #[cfg(test)]
 mod registry_schema_sync {
     use crate::cmd::mcp::registry::MCP_TOOL_REGISTRY;
-    use crate::schema::registered_operation_names;
+    use crate::schema::{
+        mcp_tool_description, operation_description, operation_example_json,
+        registered_operation_names,
+    };
 
     #[test]
     fn mcp_simple_tools_op_names_are_in_schema_registry() {
@@ -1010,6 +1013,42 @@ mod registry_schema_sync {
                 "MCP tool {} op_name {} missing from schema registry",
                 tool.tool_name,
                 tool.op_name,
+            );
+        }
+    }
+
+    /// #1383: simple-tool descriptions are generated from schema meta.
+    #[test]
+    fn mcp_simple_tool_descriptions_come_from_schema_meta() {
+        for tool in MCP_TOOL_REGISTRY {
+            let desc = tool.description();
+            let base = operation_description(tool.op_name)
+                .unwrap_or_else(|| panic!("{}: missing schema description", tool.op_name));
+            assert!(
+                desc.contains(base),
+                "{}: description must include schema base prose\nbase={base}\ndesc={desc}",
+                tool.tool_name
+            );
+            if let Some(example) = operation_example_json(tool.op_name) {
+                assert!(
+                    desc.contains(example),
+                    "{}: description must include schema example JSON",
+                    tool.tool_name
+                );
+            }
+            if let Some(extra) = tool.extra {
+                assert!(
+                    desc.contains(extra),
+                    "{}: description must include MCP extra fragment",
+                    tool.tool_name
+                );
+            }
+            // Resolved text must match the shared builder (single generation path).
+            assert_eq!(
+                desc,
+                mcp_tool_description(tool.op_name, tool.extra),
+                "{}: description() must equal mcp_tool_description()",
+                tool.tool_name
             );
         }
     }

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -288,11 +288,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             // to avoid execute_via_engine's JSON emission (which would conflict
             // with the removed-headings output already emitted above).
             let op = Operation::MdDedupeHeadings { path: file.clone() };
-            let options = crate::tx::engine::ExecuteOptions {
-                cwd: &cwd,
-                global,
-                guard: None,
-            };
+            let options = crate::tx::engine::ExecuteOptions::from_global(&cwd, global, None);
             let result = crate::tx::engine::execute_single(op, options)?;
 
             // Mode → exit ownership: write_mode (see #1373).

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -52,11 +52,7 @@ fn execute_via_engine_inner<T: Serialize>(
     preview_diffs: bool,
 ) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
-    let options = ExecuteOptions {
-        cwd: &cwd,
-        global,
-        guard: None,
-    };
+    let options = ExecuteOptions::from_global(&cwd, global, None);
 
     let result = execute_single(op, options)?;
     finalize_execution_result(

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -383,11 +383,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         allow_conflicts: apply_options.allow_conflicts,
     };
 
-    let options = ExecuteOptions {
-        cwd: &cwd,
-        global,
-        guard: None,
-    };
+    let options = ExecuteOptions::from_global(&cwd, global, None);
     let result = match execute_single(op, options) {
         Ok(r) => r,
         Err(e) => {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -332,11 +332,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         })
         .collect();
 
-    let options = ExecuteOptions {
-        cwd: &cwd,
-        global,
-        guard: None,
-    };
+    let options = ExecuteOptions::from_global(&cwd, global, None);
     let result = execute_precomputed(precomputed, options);
 
     // Phase 3: Render output based on mode (check/apply/diff/confirm).
@@ -468,11 +464,7 @@ fn run_context_replace(
         })
         .collect();
 
-    let options = ExecuteOptions {
-        cwd,
-        global,
-        guard: None,
-    };
+    let options = ExecuteOptions::from_global(cwd, global, None);
     let result = execute_operations(ops, options)?;
 
     if !result.has_changes {

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -363,11 +363,7 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 })
                 .collect();
 
-            let options = ExecuteOptions {
-                cwd: &cwd,
-                global,
-                guard: None,
-            };
+            let options = ExecuteOptions::from_global(&cwd, global, None);
             let result = execute_operations(ops, options)?;
 
             tidy_fix_output(global, result, &dirty_rel_paths, &cwd)

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -698,6 +698,28 @@ fn ast_registry_iter() -> impl Iterator<Item = &'static OpMeta> {
     }
 }
 
+/// Build an MCP tool description from the schema registry for a plan op name.
+///
+/// Format: `<OpMeta.description>[ extra][ Example: <first example JSON>]`
+/// MCP-only guidance (concurrency, etc.) belongs in `extra`, not a full
+/// duplicate of the registry prose (#1383).
+pub fn mcp_tool_description(op_name: &str, extra: Option<&str>) -> String {
+    let base = operation_description(op_name).unwrap_or("Patchloom operation.");
+    let mut out = base.to_string();
+    if let Some(extra) = extra.filter(|s| !s.is_empty()) {
+        if !out.ends_with('.') && !out.ends_with(' ') {
+            out.push('.');
+        }
+        out.push(' ');
+        out.push_str(extra.trim());
+    }
+    if let Some(example) = operation_example_json(op_name) {
+        out.push_str(" Example: ");
+        out.push_str(example);
+    }
+    out
+}
+
 /// Build a compact agent-facing operations catalogue from the registry.
 ///
 /// Used by `agent-rules` so the op list cannot drift from schema export.

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -126,6 +126,17 @@ mod basic {
     }
 
     #[test]
+    fn mcp_tool_description_includes_base_and_example() {
+        let desc = mcp_tool_description("doc.set", Some("EXTRA_FRAGMENT"));
+        let base = operation_description("doc.set").unwrap();
+        assert!(desc.contains(base));
+        assert!(desc.contains("EXTRA_FRAGMENT"));
+        if let Some(ex) = operation_example_json("doc.set") {
+            assert!(desc.contains(ex));
+        }
+    }
+
+    #[test]
     fn weak_tier_returns_subset() {
         let all = operation_schemas().unwrap();
         let weak = operations_for_tier(Tier::Weak).unwrap();

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -19,10 +19,31 @@ use std::path::Path;
 pub struct ExecuteOptions<'a> {
     /// Working directory for file resolution.
     pub cwd: &'a Path,
-    /// Global flags (apply mode, write policy, etc.).
+    /// Library-first execution context (mode, write policy inputs, format).
+    ///
+    /// Built at the CLI/API/MCP boundary via [`crate::tx::context::EngineContext::from_global`].
+    pub context: crate::tx::context::EngineContext,
+    /// Global flags for transitional callers that still need clap-shaped output
+    /// helpers. Prefer `context` for engine semantics (#1384).
     pub global: &'a GlobalFlags,
     /// Optional path guard for containment validation.
     pub guard: Option<&'a crate::containment::PathGuard>,
+}
+
+impl<'a> ExecuteOptions<'a> {
+    /// Construct options from CLI/library global flags (builds [`EngineContext`]).
+    pub fn from_global(
+        cwd: &'a Path,
+        global: &'a GlobalFlags,
+        guard: Option<&'a crate::containment::PathGuard>,
+    ) -> Self {
+        Self {
+            cwd,
+            context: crate::tx::context::EngineContext::from_global(global, cwd.to_path_buf()),
+            global,
+            guard,
+        }
+    }
 }
 
 /// Result of a single-operation execution.
@@ -141,14 +162,13 @@ pub fn execute_precomputed(
     options: ExecuteOptions<'_>,
 ) -> ExecutionResult {
     crate::verbose!("engine: execute_precomputed changes={}", changes.len());
-    use crate::tx::context::EngineContext;
     use crate::write::apply_policy;
     use std::collections::{HashMap, HashSet};
 
     let cwd = options.cwd.to_path_buf();
     // Library-first context (#1375): policy derives from EngineContext, not
     // clap types directly (GlobalFlags still feeds the adapter at the edge).
-    let ctx = EngineContext::from_global(options.global, cwd.clone());
+    let ctx = &options.context;
     crate::verbose!(
         "engine: precomputed via EngineContext cwd={}",
         ctx.cwd().display()
@@ -255,11 +275,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn test_options<'a>(cwd: &'a Path, global: &'a GlobalFlags) -> ExecuteOptions<'a> {
-        ExecuteOptions {
-            cwd,
-            global,
-            guard: None,
-        }
+        ExecuteOptions::from_global(cwd, global, None)
     }
 
     #[test]

--- a/tests/integration/module_hygiene_tests.rs
+++ b/tests/integration/module_hygiene_tests.rs
@@ -87,13 +87,10 @@ fn extract_to_file_and_symbol_extract_are_distinct_modules() {
         mod_rs.contains("pub mod extract_to_file"),
         "ast/mod.rs must declare extract_to_file"
     );
+    // #1386: deprecated shim removed (breaking / major).
     assert!(
-        mod_rs.contains("deprecated") && mod_rs.contains("pub mod extract"),
-        "ast/mod.rs must keep a deprecated extract shim for one major"
-    );
-    assert!(
-        mod_rs.contains("#1376"),
-        "deprecation note must reference #1376"
+        !mod_rs.contains("pub mod extract {"),
+        "ast::extract shim must be removed; use extract_to_file only"
     );
 
     let extract_docs = fs::read_to_string(root.join("extract_to_file.rs")).unwrap();
@@ -142,19 +139,20 @@ fn group_after_prefix_parsed_only_via_parse_group_position() {
 
 /// Historical rewrite re-exports must be marked deprecated with #1376.
 #[test]
-fn symbols_rewrite_reexports_are_deprecated_with_issue_link() {
+fn symbols_module_does_not_reexport_rewrite_helpers() {
     let symbols = fs::read_to_string(repo_root().join("src/ast/symbols/mod.rs")).unwrap();
     assert!(
-        symbols.contains("deprecated"),
-        "symbols rewrite re-exports must be #[deprecated]"
+        !symbols.contains("pub use crate::ast::rewrite::"),
+        "symbols must not re-export rewrite helpers; use ast::rewrite"
     );
     assert!(
-        symbols.contains("#1376"),
-        "deprecation must link #1376 for removal tracking"
+        !symbols.contains("FunctionSigEdit"),
+        "FunctionSigEdit must not appear in symbols module after #1386"
     );
+    let rewrite = fs::read_to_string(repo_root().join("src/ast/rewrite.rs")).unwrap();
     assert!(
-        !symbols.contains("for backward compatibility") || symbols.contains("#1376"),
-        "no permanent backward-compat re-export without issue tracking"
+        rewrite.contains("FunctionSigEdit"),
+        "rewrite module must own FunctionSigEdit"
     );
 }
 


### PR DESCRIPTION
## Summary

Implements the post-rewrite follow-up program ([#1382](https://github.com/patchloom/patchloom/issues/1382)).

### #1383 — MCP descriptions from schema meta
- `schema::mcp_tool_description(op, extra)` builds base + optional MCP-only extra + example
- `McpToolMeta.extra` replaces full hand-written `description`
- Tests lock every simple tool against schema prose/example/extra

### #1384 — EngineContext on engine options
- `ExecuteOptions::from_global` builds `EngineContext`
- All CLI/API staging call sites use `from_global`
- Precomputed path uses `options.context.write_policy`

### #1385 — Size policy
- Priority glue splits deferred where not a clear concept win this pass
- `fallback` remains domain-bulk with existing `#1376` size-waiver (hygiene tests still enforce)

### #1386 — BREAKING (major-compatible removal)
- Removed `ast::extract { … }` deprecated shim
- Removed `ast::symbols` rewrite re-exports
- Callers use `ast::extract_to_file` / `ast::rewrite`
- Hygiene tests updated to require **absence** of shims

> **Note:** This is a **breaking public API** change for library consumers of the old paths. A major version should follow via release-please (do **not** auto-merge release PR without explicit approval).

## Test plan
- [x] `make check-fast`
- [x] MCP description sync tests
- [x] module_hygiene tests
- [x] engine unit tests

Closes #1383
Closes #1384
Closes #1385
Closes #1386
Closes #1382