### PR TITLE
refactor: write-path call-site singularity via stage + finalize

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ All subcommands receive a `&GlobalFlags` reference. Read-only flags (`--json`, `
 - Return `Ok(exit::SUCCESS)` for success, `Ok(exit::NO_MATCHES)` for no-match, etc.
 - When returning `NO_MATCHES` with an error message, use `global.emit_error_json(&msg)?` (added in PR #1339). This helper encapsulates the standard pattern: emit `{"ok": false, "error": msg}` in JSON/JSONL mode, fall back to `eprintln!` in text mode (respecting `--quiet`). Before this helper, the inline pattern was `if !global.emit_json(&json!({"ok": false, "error": &msg}))? && !global.quiet { eprintln!("{msg}"); }`.
 - **Never use `global.show_status()` on error diagnostic paths.** `show_status()` requires a TTY (returns `false` when stderr is piped), which silently suppresses error messages in scripts and pipelines. Use `!global.quiet` instead. Reserve `show_status()` for optional progress hints and status messages that are genuinely TTY-only (e.g., "hint: use --apply", file count summaries). See #1340 and #1341 for bugs caused by this confusion.
-- **Preview mode must return `CHANGES_DETECTED` (exit 2), not `SUCCESS` (exit 0).** When a write command runs in default mode (no `--apply`, `--check`, or `--diff`) and the operation would produce changes, the exit code must be `exit::CHANGES_DETECTED`. Returning `exit::SUCCESS` in preview mode is a bug: it makes scripts think no changes exist. **Exit codes are owned by `src/cmd/write_mode.rs`** (`classify_write_mode`, `write_exit_code`, `finalize_execution_result`, `finalize_callback_write`). Staging entry points still differ (`execute_via_engine` / `execute_operations` / `execute_precomputed` / `execute_write` / `execute_single`), but they must not invent their own exit matrix. Contract lock: `tests/integration/write_path_contract_tests.rs` and `docs/plans/write-pipeline.md`. Historical multi-path bugs: #1345-#1348; singularity work: #1373.
+- **Preview mode must return `CHANGES_DETECTED` (exit 2), not `SUCCESS` (exit 0).** When a write command runs in default mode (no `--apply`, `--check`, or `--diff`) and the operation would produce changes, the exit code must be `exit::CHANGES_DETECTED`. Returning `exit::SUCCESS` in preview mode is a bug: it makes scripts think no changes exist. **Write singularity:** stage with `tx::engine::stage(WriteRequest)` (or CLI `cmd::output::run_write` / `stage_for_write`), then finalize with `cmd::write_mode::finalize_execution_result` (or `finalize_callback_write` for binary/case-only renames). Mode and exit codes are owned only by `write_mode.rs`. Do not invent a parallel check/apply/preview matrix in a command. Contract lock: `tests/integration/write_path_contract_tests.rs` and `docs/plans/write-pipeline.md`. Historical multi-path bugs: #1345-#1348; singularity: #1373.
 
 ### Testing
 
@@ -268,17 +268,16 @@ Command::<Name>(args) => {
 }
 ```
 
-5. **Choose the correct staging entry for commands that mutate files** (exit codes always via `write_mode`):
+5. **Write path for commands that mutate files (rewrite singularity):**
 
 | Pattern | When to use | Example commands |
 |---------|-------------|------------------|
-| `execute_via_engine()` | Single-operation writes (most commands); uses `finalize_execution_result` | doc, md, create, delete, append, ast replace |
-| `execute_operations()` | Multi-file writes with pre-filtering; caller uses `write_exit_code` / classify | ast rename, tidy fix |
-| `execute_precomputed()` | Parallel scan + batch commit (optimization); caller uses classify + exit | replace (multi-file regex scan) |
-| `execute_write()` | Binary/case-only via `finalize_callback_write` | rename (binary files, case-only renames) |
-| `execute_single()` | One-off staging; caller must use `write_mode` for mode/exit | md dedupe-headings, patch apply |
+| `run_write` / `run_write_op` | Standard single-op + standard JSON schema | doc, create, delete, append, ast replace |
+| `stage_for_write` + `finalize_execution_result` | Multi-op or custom messages, standard finalize | ast rename, md dedupe-headings |
+| `stage_for_write` + custom renderer | Custom JSON; still use `classify_write_mode` / `write_exit_code` | replace, tidy fix, patch |
+| `execute_write` (`write_dispatch`) | Binary/case-only only (`finalize_callback_write`) | rename (binary / case-only) |
 
-Staging differs; **mode → exit is shared** (`src/cmd/write_mode.rs`). Do not use `atomic_write()` directly in command implementations.
+Engine staging is always `tx::engine::stage(WriteRequest)` (`Operations` or `Precomputed`). Prefer `cmd::output` helpers at the CLI boundary. Do not use `atomic_write()` directly in command implementations.
 
 6. If the command scans multiple files, use `crate::par_process_files()` for adaptive parallelism instead of a sequential loop. The closure must be `Fn + Sync` (no mutable captures). Write-back stays serial.
 

--- a/docs/plans/write-pipeline.md
+++ b/docs/plans/write-pipeline.md
@@ -1,14 +1,13 @@
-# Write pipeline inventory (Phase 1 of #1373 / epic #1372)
+# Write pipeline (rewrite singularity)
 
-**Status:** PR 1.1 inventory+contract (merged #1377). PR 1.2–1.4: `src/cmd/write_mode.rs`
-owns `classify_write_mode` / `write_exit_code` / `finalize_execution_result` /
-`finalize_callback_write`. All CLI write paths route exit codes through it.
+**Status:** Engine stages via `stage(WriteRequest)`; CLI finalizes via
+`write_mode` (`classify_write_mode` / `write_exit_code` /
+`finalize_execution_result` / `finalize_callback_write`). Call-site
+singularity completed after #1388: commands use `run_write` /
+`stage_for_write`, not five parallel mode matrices.
 
-**Goal of Phase 1:** one write pipeline owns mode → exit code, backup, and
-diff policy. Strategies become *inputs*, not five sibling mode matrices.
-
-This document is the call-site inventory for the collapse. Keep it updated
-when adding or removing write entry points.
+**Goal:** one write pipeline owns mode → exit code, backup, and diff policy.
+Strategies are *inputs* (`WriteSource`), not sibling exit owners.
 
 ## Contract (must hold for every path when changes exist)
 
@@ -19,132 +18,60 @@ when adding or removing write entry points.
 | Apply | `--apply` | **0** (`SUCCESS`) | yes |
 | Confirm + JSON decline | `--confirm` + `--json`/`--jsonl`, non-TTY / EOF | **2** | no |
 
-When there are **no** changes, preview and check should exit **0** (path-specific
-edge cases stay in existing tests; this matrix covers the *has changes* case).
+When there are **no** changes, preview and check should exit **0**.
 
 Integration lock: `tests/integration/write_path_contract_tests.rs`.
 
-## Entry points (five production paths)
+## Canonical flow
 
-### 1. `execute_via_engine` / `execute_via_engine_inner`
-
-| Item | Location |
-|------|----------|
-| Definition | `src/cmd/output.rs` |
-| Engine core | calls `tx::engine::execute_single` |
-| Mode/exit owner | **local** in `execute_via_engine_inner` |
-
-**CLI call sites (representative):**
-
-| Command | File | Notes |
-|---------|------|-------|
-| `create` | `src/cmd/create.rs` | representative in contract matrix |
-| `append` | `src/cmd/append.rs` | |
-| `prepend` | `src/cmd/prepend.rs` | thin wrapper over append-style |
-| `delete` | uses **no_preview_diffs** variant below | |
-| `rename` (text, non-case-only) | `src/cmd/rename.rs` | |
-| `doc` writes | `src/cmd/doc.rs` | |
-| `md` most writes | `src/cmd/md.rs` | some subcommands use `execute_single` directly |
-| `ast` some writes | `src/cmd/ast/` (mutate) | also `execute_operations` / `stage` for multi-file |
-
-**Variant:** `execute_via_engine_no_preview_diffs` — same function with
-`preview_diffs: false` (e.g. `delete`). Not a sixth path; same mode/exit owner.
-
-### 2. `execute_operations`
-
-| Item | Location |
-|------|----------|
-| Definition | `src/tx/engine.rs` |
-| Role | Stage multi-`Operation` plans; returns `ExecutionResult` |
-| Mode/exit owner | **caller** (CLI reimplements mode branch after call) |
-
-**CLI call sites:**
-
-| Command | File | Notes |
-|---------|------|-------|
-| `tidy fix` multi-file | `src/cmd/tidy.rs` → `tidy_fix_output` | representative in contract matrix (`tidy fix …`) |
-| `replace` with context anchors | `src/cmd/replace.rs` → `run_context_replace` | secondary |
-| `ast` multi-file rename/etc. | `src/cmd/ast/mutate.rs` | unified via `stage(WriteRequest)` |
-
-### 3. `execute_precomputed`
-
-| Item | Location |
-|------|----------|
-| Definition | `src/tx/engine.rs` |
-| Role | Commit path for already-computed `(path, original, new)` triples |
-| Mode/exit owner | **caller** (`replace_output` in `src/cmd/replace.rs`) |
-
-**CLI call sites:**
-
-| Command | File | Notes |
-|---------|------|-------|
-| `replace` (default multi-file scan) | `src/cmd/replace.rs` | representative in contract matrix |
-
-### 4. `execute_write` (`write_dispatch`)
-
-| Item | Location |
-|------|----------|
-| Definition | `src/cmd/write_dispatch.rs` |
-| Role | Binary / case-only renames that cannot use UTF-8 tx engine |
-| Mode/exit owner | **local** in `execute_write` (parallel to `execute_via_engine_inner`) |
-
-**CLI call sites:**
-
-| Command | File | Notes |
-|---------|------|-------|
-| `rename` binary | `src/cmd/rename.rs` → `run_binary_rename` | representative (null-byte file) |
-| `rename` case-only | same | case-insensitive FS only |
-
-### 5. `execute_single` + **custom CLI mode branch**
-
-| Item | Location |
-|------|----------|
-| Definition | `src/tx/engine.rs` |
-| Role | Single `Operation` → stage; returns `ExecutionResult` |
-| Mode/exit owner | **shared helper** when via `execute_via_engine`; **custom** when CLI reimplements branch |
-
-**Custom mode-branch callers (not using `execute_via_engine`):**
-
-| Command | File | Notes |
-|---------|------|-------|
-| `patch apply` | `src/cmd/patch.rs` | representative in contract matrix |
-| `md` dedupe-headings (and similar) | `src/cmd/md.rs` | own branch after `execute_single` |
-| library API | `src/api/mod.rs` → `execute_as_edit_result` | maps to `EditResult`, not CLI exits |
-
-`execute_via_engine` also calls `execute_single` internally; that does **not**
-count as a separate mode matrix.
-
-## Duplication map (why collapse)
-
-Each of these owns a near-copy of check / apply / confirm+json / preview:
-
-1. `cmd/output.rs` → `execute_via_engine_inner`
-2. `cmd/write_dispatch.rs` → `execute_write`
-3. `cmd/replace.rs` → `replace_output`
-4. `cmd/tidy.rs` → `tidy_fix_output`
-5. `cmd/patch.rs` (inline after `execute_single`)
-6. Plus other custom branches (md specials, ast multi-file output)
-
-Historical proof of divergence: PRs #1345–#1348 fixed the same preview
-exit-0 bug across multiple paths independently.
-
-## Collapse target (PR 1.2–1.4)
-
-```text
-WriteRequest {
-  cwd, mode, policy, guard,
-  source: SingleOp | Ops | Precomputed | BinaryDispatch,
-  render: RenderPolicy { preview_diffs, ... },
-}
-→ WriteReport { has_changes, diffs, exit_code, ... }
+```
+CLI / API boundary
+  → WriteSource::{Operations(Vec<Operation>), Precomputed(Vec<…>)}
+  → stage(WriteRequest { source, options: ExecuteOptions { context, guard } })
+  → WriteReport (ExecutionResult)
+  → finalize_execution_result(...)   // or custom renderer using write_exit_code
+  → optional commit inside finalize when apply/confirm accepts
 ```
 
-One function owns mode → exit. Strategies only supply staged changes / apply
-closures.
+### CLI helpers (`src/cmd/output.rs`)
 
-## Related issues
+| Helper | Role |
+|--------|------|
+| `run_write` / `run_write_op` | stage + finalize (standard schema) |
+| `run_write_op_no_preview_diffs` | same, no unified diffs in preview (delete) |
+| `stage_for_write` | stage only; caller finalizes or custom-renders |
+| `execute_via_engine*` | **compat aliases** of `run_write_op*` |
 
-- Epic: #1372
-- Phase 1: #1373
-- Prior partial unifications: #967, #1004, #1007
-- Exit multi-path: #1345–#1348
+### Engine (`src/tx/engine.rs`)
+
+| API | Role |
+|-----|------|
+| `stage` | **canonical** entry |
+| `execute_single` / `execute_operations` / `execute_precomputed` | source implementations used by `stage` (also fine for tests) |
+| `ExecuteOptions` | `EngineContext` + optional `PathGuard` only (no `GlobalFlags`) |
+
+### Callback path (`src/cmd/write_dispatch.rs`)
+
+Binary / case-only renames cannot use the UTF-8 tx engine. They use
+`execute_write` → `finalize_callback_write` (same exit matrix).
+
+## Commands
+
+| Command | Staging | Finalize |
+|---------|---------|----------|
+| create, append, prepend, delete, doc writes, md most, ast replace | `run_write_op` / via engine alias | `finalize_execution_result` |
+| ast rename | `stage_for_write(Operations)` | `finalize_execution_result` |
+| replace (scan) | `stage_for_write(Precomputed)` | custom `replace_output` + `write_exit_code` |
+| replace (context) | `stage_for_write(Operations)` | same `replace_output` |
+| tidy fix | `stage_for_write(Operations)` | custom `tidy_fix_output` + `write_exit_code` |
+| patch apply | `stage_for_write(Operations)` | custom patch mode branch + `write_exit_code` |
+| md dedupe-headings | `stage_for_write` | `finalize_execution_result` (side-channel headings first) |
+| rename binary/case-only | n/a | `execute_write` / `finalize_callback_write` |
+
+## Adding a write command
+
+1. Prefer building an `Operation` and calling `run_write_op`.
+2. If multi-file scan with precomputed content, use `WriteSource::Precomputed` + `stage_for_write`.
+3. If JSON schema cannot use the phase constructor, custom-render **only** after `stage_for_write`, and still call `classify_write_mode` / `write_exit_code` (or `finalize_execution_result`).
+4. Never call `atomic_write` from a command for normal text writes.
+5. Add/extend a row in `write_path_contract_tests` when introducing a new public write surface.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -437,7 +437,10 @@ pub(crate) fn execute_as_edit_result(
 ) -> anyhow::Result<EditResult> {
     let global = mode_to_global_flags(mode);
     let options = crate::tx::engine::ExecuteOptions::from_global(cwd, &global, guard);
-    let result = crate::tx::engine::execute_single(op, options)?;
+    let result = crate::tx::engine::stage(crate::tx::engine::WriteRequest {
+        source: crate::tx::engine::WriteSource::Operations(vec![op]),
+        options,
+    })?;
     execution_result_to_edit_result(result, mode, cwd, action, dest_path)
 }
 

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -2,10 +2,11 @@
 
 use super::common::{resolve_lang, setup_multi_file};
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::{WritePhase, execute_via_engine};
+use crate::cmd::output::{WritePhase, run_write_op, stage_for_write};
+use crate::cmd::write_mode::{RenderPolicy, WriteMessages, finalize_execution_result};
 use crate::exit;
 use crate::plan::Operation;
-use crate::tx::engine::ExecuteOptions;
+use crate::tx::engine::WriteSource;
 use anyhow::Context;
 use clap::Args;
 use serde::Serialize;
@@ -84,9 +85,8 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
     }
 
     let files_changed = operations.len();
-    let options = ExecuteOptions::from_global(&cwd, global, None);
-    let result = match crate::tx::engine::execute_operations(operations, options) {
-        Ok(r) => r,
+    let (cwd, result) = match stage_for_write(WriteSource::Operations(operations), global) {
+        Ok(v) => v,
         Err(e) if exit::is_no_match(&e) => {
             let msg = e.to_string();
             global.emit_error_json(&msg)?;
@@ -95,45 +95,29 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
         Err(e) => return Err(e),
     };
 
-    if global.check {
-        global.emit_json(&serde_json::json!({
-            "ok": true,
-            "files_changed": files_changed,
-        }))?;
-        return Ok(exit::CHANGES_DETECTED);
+    #[derive(serde::Serialize)]
+    struct RenameOut {
+        ok: bool,
+        files_changed: usize,
     }
 
-    if global.apply {
-        let diffs = result.build_diffs();
-        result.commit()?;
-        crate::write::run_format_command(global, &cwd)?;
-
-        if !global.emit_json(&serde_json::json!({
-            "ok": true,
-            "files_changed": diffs.len(),
-        }))? && !global.quiet
-        {
-            for d in &diffs {
-                eprintln!("{}: renamed", d.path);
-            }
-        }
-        return Ok(exit::SUCCESS);
-    }
-
-    // Default preview mode
-    let diffs = result.build_diffs();
-    if !diffs.is_empty() {
-        let colored = crate::diff::render_diffs_colored(&diffs, global.should_color());
-        print!("{colored}");
-    }
-
-    if global.should_apply() {
-        result.commit()?;
-        crate::write::run_format_command(global, &cwd)?;
-        return Ok(exit::SUCCESS);
-    }
-
-    Ok(exit::CHANGES_DETECTED)
+    let check_msg = format!("would rename in {files_changed} file(s)");
+    let apply_msg = format!("renamed in {files_changed} file(s)");
+    finalize_execution_result(
+        global,
+        &cwd,
+        result,
+        |_phase, _diff| RenameOut {
+            ok: true,
+            files_changed,
+        },
+        WriteMessages {
+            check: &check_msg,
+            apply: &apply_msg,
+            post_confirm: None,
+        },
+        RenderPolicy::default(),
+    )
 }
 
 #[derive(Debug, Args)]
@@ -197,7 +181,7 @@ pub(super) fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Re
     let check_msg = format!("would replace in symbol '{symbol}' in {}", args.path);
     let apply_msg = format!("replaced in symbol '{symbol}' in {}", args.path);
 
-    match execute_via_engine(
+    match run_write_op(
         op,
         global,
         |phase, diff| AstReplaceOutput {

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -284,14 +284,13 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 }
             }
 
-            // Route the write through the engine. Use execute_single directly
-            // to avoid execute_via_engine's JSON emission (which would conflict
-            // with the removed-headings output already emitted above).
+            // Side-channel headings already emitted; do not emit a second JSON
+            // body via finalize_execution_result. Stage + mode/exit only.
             let op = Operation::MdDedupeHeadings { path: file.clone() };
-            let options = crate::tx::engine::ExecuteOptions::from_global(&cwd, global, None);
-            let result = crate::tx::engine::execute_single(op, options)?;
-
-            // Mode → exit ownership: write_mode (see #1373).
+            let (cwd, result) = crate::cmd::output::stage_for_write(
+                crate::tx::engine::WriteSource::Operations(vec![op]),
+                global,
+            )?;
             use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
             let has_changes = result.has_changes;
             match classify_write_mode(global) {

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -1,24 +1,105 @@
 //! Shared output model for CLI write commands.
 //!
-//! Engine-backed single-op writes go through
-//! [`crate::cmd::write_mode::finalize_execution_result`], the single owner of
-//! mode → exit mapping for staged changes (see #1373).
+//! **Canonical engine-backed write path (rewrite singularity):**
+//!
+//! 1. Build a [`crate::tx::engine::WriteRequest`] (`Operations` or `Precomputed`)
+//! 2. Call [`run_write`] (or [`stage`](crate::tx::engine::stage) +
+//!    [`finalize_execution_result`](crate::cmd::write_mode::finalize_execution_result)
+//!    when a command needs a custom JSON schema)
+//!
+//! Mode → exit ownership always lives in [`crate::cmd::write_mode`].
+//! Binary/case-only renames use [`crate::cmd::write_dispatch::execute_write`]
+//! (callback path; same exit matrix via `finalize_callback_write`).
 
 use crate::cli::global::GlobalFlags;
 use crate::cmd::write_mode::{RenderPolicy, WriteMessages, finalize_execution_result};
-use crate::tx::engine::{ExecuteOptions, execute_single};
+use crate::tx::engine::{ExecuteOptions, WriteRequest, WriteSource, stage};
 use serde::Serialize;
 
 pub use crate::cmd::write_mode::WritePhase;
 
+/// Stage a write and finalize under global flags (canonical single-op path).
+///
+/// Prefer this over constructing engine options and calling `stage` yourself
+/// when the command uses the standard phase-based JSON schema.
+pub fn run_write<T: Serialize>(
+    source: WriteSource,
+    global: &GlobalFlags,
+    make_output: impl Fn(WritePhase, Option<String>) -> T,
+    msgs: WriteMessages<'_>,
+    render: RenderPolicy,
+) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    let options = ExecuteOptions::from_global(&cwd, global, None);
+    let result = stage(WriteRequest { source, options })?;
+    finalize_execution_result(global, &cwd, result, make_output, msgs, render)
+}
+
+/// Stage one `Operation` and finalize (most CLI write commands).
+pub fn run_write_op<T: Serialize>(
+    op: crate::plan::Operation,
+    global: &GlobalFlags,
+    make_output: impl Fn(WritePhase, Option<String>) -> T,
+    check_msg: &str,
+    apply_msg: &str,
+) -> anyhow::Result<u8> {
+    run_write(
+        WriteSource::Operations(vec![op]),
+        global,
+        make_output,
+        WriteMessages {
+            check: check_msg,
+            apply: apply_msg,
+            post_confirm: None,
+        },
+        RenderPolicy::default(),
+    )
+}
+
+/// Like [`run_write_op`] but without unified diffs in preview (e.g. `delete`).
+pub fn run_write_op_no_preview_diffs<T: Serialize>(
+    op: crate::plan::Operation,
+    global: &GlobalFlags,
+    make_output: impl Fn(WritePhase, Option<String>) -> T,
+    check_msg: &str,
+    apply_msg: &str,
+) -> anyhow::Result<u8> {
+    run_write(
+        WriteSource::Operations(vec![op]),
+        global,
+        make_output,
+        WriteMessages {
+            check: check_msg,
+            apply: apply_msg,
+            post_confirm: None,
+        },
+        RenderPolicy {
+            preview_diffs: false,
+        },
+    )
+}
+
+/// Stage multi-op or precomputed changes and return the report for a custom
+/// renderer. Callers must use [`finalize_execution_result`] (or the same
+/// `classify_write_mode` / `write_exit_code` contract) for mode/exit.
+pub fn stage_for_write(
+    source: WriteSource,
+    global: &GlobalFlags,
+) -> anyhow::Result<(std::path::PathBuf, crate::tx::engine::WriteReport)> {
+    let cwd = global.resolve_cwd()?;
+    let options = ExecuteOptions::from_global(&cwd, global, None);
+    let report = stage(WriteRequest { source, options })?;
+    Ok((cwd, report))
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility aliases (same behavior; prefer run_write* for new code)
+// ---------------------------------------------------------------------------
+
 /// Execute a single operation through the engine and render output based
 /// on the global flags (check/apply/diff/confirm modes).
 ///
-/// `make_output` builds the command-specific JSON output struct from
-/// a phase indicator and an optional diff string, preserving the exact
-/// JSON schema that each command's integration tests expect.
-///
-/// `check_msg` and `apply_msg` are human-readable messages for text output.
+/// Prefer [`run_write_op`].
 pub fn execute_via_engine<T: Serialize>(
     op: crate::plan::Operation,
     global: &GlobalFlags,
@@ -26,13 +107,12 @@ pub fn execute_via_engine<T: Serialize>(
     check_msg: &str,
     apply_msg: &str,
 ) -> anyhow::Result<u8> {
-    execute_via_engine_inner(op, global, make_output, check_msg, apply_msg, true)
+    run_write_op(op, global, make_output, check_msg, apply_msg)
 }
 
 /// Like `execute_via_engine` but without showing diffs in preview mode.
 ///
-/// Used by commands like `delete` where the old behavior was to show a
-/// human-readable message instead of a diff preview.
+/// Prefer [`run_write_op_no_preview_diffs`].
 pub fn execute_via_engine_no_preview_diffs<T: Serialize>(
     op: crate::plan::Operation,
     global: &GlobalFlags,
@@ -40,33 +120,7 @@ pub fn execute_via_engine_no_preview_diffs<T: Serialize>(
     check_msg: &str,
     apply_msg: &str,
 ) -> anyhow::Result<u8> {
-    execute_via_engine_inner(op, global, make_output, check_msg, apply_msg, false)
-}
-
-fn execute_via_engine_inner<T: Serialize>(
-    op: crate::plan::Operation,
-    global: &GlobalFlags,
-    make_output: impl Fn(WritePhase, Option<String>) -> T,
-    check_msg: &str,
-    apply_msg: &str,
-    preview_diffs: bool,
-) -> anyhow::Result<u8> {
-    let cwd = global.resolve_cwd()?;
-    let options = ExecuteOptions::from_global(&cwd, global, None);
-
-    let result = execute_single(op, options)?;
-    finalize_execution_result(
-        global,
-        &cwd,
-        result,
-        make_output,
-        WriteMessages {
-            check: check_msg,
-            apply: apply_msg,
-            post_confirm: None,
-        },
-        RenderPolicy { preview_diffs },
-    )
+    run_write_op_no_preview_diffs(op, global, make_output, check_msg, apply_msg)
 }
 
 #[cfg(test)]

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -6,7 +6,7 @@ use crate::ops::patch::{
     apply_hunks_with_options, parse_patch,
 };
 use crate::plan::Operation;
-use crate::tx::engine::{ExecuteOptions, execute_single};
+use crate::tx::engine::WriteSource;
 use clap::Args;
 use serde::Serialize;
 
@@ -383,27 +383,27 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         allow_conflicts: apply_options.allow_conflicts,
     };
 
-    let options = ExecuteOptions::from_global(&cwd, global, None);
-    let result = match execute_single(op, options) {
-        Ok(r) => r,
-        Err(e) => {
-            let msg = e.to_string();
-            // Map engine errors to specific exit codes with CLI-style messages.
-            // The engine error from apply_patch_with_loader already includes
-            // "patch apply: <path> -- <detail>", so we add the STALE/MERGE
-            // FAILED label to match the original CLI format.
-            let exit_code = if msg.contains("conflict(s)") {
-                exit::CONFLICTS
-            } else {
-                exit::AMBIGUOUS
-            };
-            // Inject the STALE/MERGE FAILED label between path and error detail.
-            let label = if merge_mode { "MERGE FAILED" } else { "STALE" };
-            let err = inject_stale_label(&msg, label);
-            emit_error(global, &err)?;
-            return Ok(exit_code);
-        }
-    };
+    let (cwd, result) =
+        match crate::cmd::output::stage_for_write(WriteSource::Operations(vec![op]), global) {
+            Ok(v) => v,
+            Err(e) => {
+                let msg = e.to_string();
+                // Map engine errors to specific exit codes with CLI-style messages.
+                // The engine error from apply_patch_with_loader already includes
+                // "patch apply: <path> -- <detail>", so we add the STALE/MERGE
+                // FAILED label to match the original CLI format.
+                let exit_code = if msg.contains("conflict(s)") {
+                    exit::CONFLICTS
+                } else {
+                    exit::AMBIGUOUS
+                };
+                // Inject the STALE/MERGE FAILED label between path and error detail.
+                let label = if merge_mode { "MERGE FAILED" } else { "STALE" };
+                let err = inject_stale_label(&msg, label);
+                emit_error(global, &err)?;
+                return Ok(exit_code);
+            }
+        };
 
     // Mode → exit ownership: write_mode (see #1373).
     use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -4,7 +4,7 @@ use crate::exit;
 use crate::ops::replace::{
     compile_replace_regex, replace_content, replace_whole_lines, replacement_text,
 };
-use crate::tx::engine::{ExecuteOptions, execute_precomputed};
+use crate::tx::engine::WriteSource;
 use clap::Args;
 use serde::Serialize;
 
@@ -332,10 +332,11 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         })
         .collect();
 
-    let options = ExecuteOptions::from_global(&cwd, global, None);
-    let result = execute_precomputed(precomputed, options);
+    let (cwd, result) =
+        crate::cmd::output::stage_for_write(WriteSource::Precomputed(precomputed), global)?;
 
     // Phase 3: Render output based on mode (check/apply/diff/confirm).
+    // Custom JSON schema (match counts); mode/exit via write_mode helpers.
     replace_output(global, result, &files, total_matches, file_count, &cwd)
 }
 
@@ -430,10 +431,9 @@ fn replace_output(
 fn run_context_replace(
     args: ReplaceArgs,
     global: &GlobalFlags,
-    cwd: &std::path::Path,
+    _cwd: &std::path::Path,
 ) -> anyhow::Result<u8> {
     use crate::plan::Operation;
-    use crate::tx::engine::{ExecuteOptions, execute_operations};
 
     // Context-based replace requires explicit file paths (not directory scan).
     if args.paths.is_empty() {
@@ -464,8 +464,7 @@ fn run_context_replace(
         })
         .collect();
 
-    let options = ExecuteOptions::from_global(cwd, global, None);
-    let result = execute_operations(ops, options)?;
+    let (cwd, result) = crate::cmd::output::stage_for_write(WriteSource::Operations(ops), global)?;
 
     if !result.has_changes {
         let empty = ReplaceOutput {
@@ -490,7 +489,7 @@ fn run_context_replace(
         .changes
         .iter()
         .map(|(p, _, _)| ReplaceFileResult {
-            path: crate::files::relative_display(p, cwd)
+            path: crate::files::relative_display(p, &cwd)
                 .to_string_lossy()
                 .into_owned(),
             match_count: 1,
@@ -498,72 +497,8 @@ fn run_context_replace(
         .collect();
     let total_matches = files.len();
     let file_count = total_matches;
-
-    let build_output = |diff: Option<String>| ReplaceOutput {
-        ok: true,
-        match_count: total_matches,
-        file_count,
-        files: files.clone(),
-        diff,
-    };
-
-    // --check mode.
-    if global.check {
-        if global.json {
-            global.emit_json(&build_output(None))?;
-        } else if !global.emit_json_items(&files)? && !global.quiet {
-            println!("{total_matches} file(s) changed");
-        }
-        return Ok(exit::CHANGES_DETECTED);
-    }
-
-    // --apply mode.
-    if global.apply {
-        let diffs = result.build_diffs();
-        result.commit()?;
-        crate::write::run_format_command(global, cwd)?;
-
-        let diff_text = if global.diff {
-            Some(render_diffs_plain(&diffs))
-        } else {
-            None
-        };
-        if global.json {
-            global.emit_json(&build_output(diff_text))?;
-        } else if !global.emit_json_items(&files)? {
-            if global.diff {
-                print!("{}", render_diffs_colored(&diffs, global.should_color()));
-            } else if !global.quiet {
-                println!("replaced in {total_matches} file(s) (context-based)");
-            }
-        }
-        return Ok(exit::SUCCESS);
-    }
-
-    // Default / --diff: preview.
-    let diffs = result.build_diffs();
-    let diff_text = if !diffs.is_empty() {
-        Some(render_diffs_plain(&diffs))
-    } else {
-        None
-    };
-
-    if global.json {
-        global.emit_json(&build_output(diff_text))?;
-    } else if !global.emit_json_items(&files)? && !diffs.is_empty() {
-        print!("{}", render_diffs_colored(&diffs, global.should_color()));
-    }
-    if global.show_status() {
-        eprintln!("{total_matches} file(s) changed");
-    }
-
-    if global.should_apply() {
-        result.commit()?;
-        crate::write::run_format_command(global, cwd)?;
-        return Ok(exit::SUCCESS);
-    }
-
-    Ok(exit::CHANGES_DETECTED)
+    // Same mode/exit owner as default replace path (no hand-rolled matrix).
+    replace_output(global, result, &files, total_matches, file_count, &cwd)
 }
 
 #[path = "replace_tests.rs"]

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -3,7 +3,7 @@ use crate::cli::global::GlobalFlags;
 use crate::diff::{render_diffs_colored, render_diffs_plain};
 use crate::exit;
 use crate::plan::Operation;
-use crate::tx::engine::{ExecuteOptions, ExecutionResult, execute_operations};
+use crate::tx::engine::{ExecutionResult, WriteSource};
 use crate::write::{apply_policy, policy_from_flags};
 use clap::Args;
 use serde::Serialize;
@@ -363,8 +363,8 @@ pub fn run(args: TidyArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 })
                 .collect();
 
-            let options = ExecuteOptions::from_global(&cwd, global, None);
-            let result = execute_operations(ops, options)?;
+            let (cwd, result) =
+                crate::cmd::output::stage_for_write(WriteSource::Operations(ops), global)?;
 
             tidy_fix_output(global, result, &dirty_rel_paths, &cwd)
         }

--- a/src/cmd/write_mode.rs
+++ b/src/cmd/write_mode.rs
@@ -4,9 +4,10 @@
 //! [`classify_write_mode`] and [`write_exit_code`] so preview/check/apply/confirm
 //! cannot diverge by path (see #1345–#1348 and #1373).
 //!
-//! Engine-backed commands should prefer [`finalize_execution_result`] for the
-//! full check/apply/confirm/preview lifecycle. Callback-based paths (binary
-//! rename) use [`finalize_callback_write`].
+//! Engine-backed commands: stage with [`crate::tx::engine::stage`] (or CLI
+//! [`crate::cmd::output::run_write`] / [`crate::cmd::output::stage_for_write`]),
+//! then finalize here. Callback-based paths (binary rename) use
+//! [`finalize_callback_write`].
 
 use crate::cli::global::GlobalFlags;
 use crate::diff::{FileDiff, render_diffs_colored, render_diffs_plain};

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -63,12 +63,19 @@ pub struct WriteRequest<'a> {
 /// Unified staging report (alias of [`ExecutionResult`] for the write model).
 pub type WriteReport = ExecutionResult;
 
-/// Stage changes in memory without committing. Prefer this over calling
-/// `execute_single` / `execute_operations` / `execute_precomputed` separately.
+/// Stage changes in memory without committing.
+///
+/// **Canonical engine entry** for all surfaces (CLI, MCP, library). Source
+/// variants cover multi-op plans and precomputed scan results; mode/exit is
+/// owned by the caller (typically `cmd::write_mode::finalize_execution_result`).
 pub fn stage(request: WriteRequest<'_>) -> anyhow::Result<WriteReport> {
     match request.source {
-        WriteSource::Operations(ops) => execute_plan_inner(ops, request.options),
-        WriteSource::Precomputed(changes) => Ok(stage_precomputed(changes, request.options)),
+        WriteSource::Operations(mut ops) if ops.len() == 1 => {
+            let op = ops.pop().expect("len checked");
+            execute_single(op, request.options)
+        }
+        WriteSource::Operations(ops) => execute_operations(ops, request.options),
+        WriteSource::Precomputed(changes) => Ok(execute_precomputed(changes, request.options)),
     }
 }
 
@@ -139,68 +146,27 @@ impl ExecutionResult {
     }
 }
 
-/// Execute a single `Operation` through the unified engine.
-///
-/// This is the primary entry point for CLI commands that want to delegate
-/// their orchestration to the tx engine. It handles:
-/// - File resolution via cwd
-/// - Write policy application
-/// - Change collection in memory (no disk writes)
-///
-/// The caller decides whether to commit (via `ExecutionResult::commit()`)
-/// based on the apply/check/diff mode.
+/// Stage a single operation (source constructor used by [`stage`]).
 pub fn execute_single(
     op: Operation,
     options: ExecuteOptions<'_>,
 ) -> anyhow::Result<ExecutionResult> {
-    stage(WriteRequest {
-        source: WriteSource::Operations(vec![op]),
-        options,
-    })
+    execute_operations(vec![op], options)
 }
 
-/// Execute multiple operations through the unified engine.
-///
-/// Similar to `execute_single` but for multi-operation batches that need
-/// atomicity (all succeed or none are committed).
-///
-/// Used by CLI commands (`tidy`, `ast rename`) for multi-file batches.
+/// Stage one or more operations (implementation used by [`stage`]).
 pub fn execute_operations(
     operations: Vec<Operation>,
     options: ExecuteOptions<'_>,
 ) -> anyhow::Result<ExecutionResult> {
-    stage(WriteRequest {
-        source: WriteSource::Operations(operations),
-        options,
-    })
+    execute_plan_inner(operations, options)
 }
 
 /// A pre-computed file change: `(relative_path, original_content, new_content)`.
-///
-/// Used by commands that perform their own parallel scan/compute phase and
-/// want to hand off the results to the engine for commit/diff/backup without
-/// re-reading or re-computing.
 pub type PrecomputedChange = (String, String, String);
 
-/// Wrap pre-computed file changes into an `ExecutionResult`.
-///
-/// This bypasses operation execution entirely: the caller has already read
-/// files and computed new content (e.g. via a parallel scan phase). The
-/// engine provides only the commit/diff/backup lifecycle.
-///
-/// Prefer [`stage`] with [`WriteSource::Precomputed`] for new code.
+/// Stage pre-computed changes (implementation used by [`stage`]).
 pub fn execute_precomputed(
-    changes: Vec<PrecomputedChange>,
-    options: ExecuteOptions<'_>,
-) -> ExecutionResult {
-    stage(WriteRequest {
-        source: WriteSource::Precomputed(changes),
-        options,
-    })
-    .expect("precomputed staging is infallible")
-}
-
-fn stage_precomputed(
     changes: Vec<PrecomputedChange>,
     options: ExecuteOptions<'_>,
 ) -> ExecutionResult {


### PR DESCRIPTION
## Summary

Completes the rewrite-quality **write-path call-site singularity** after #1388:

1. **Canonical CLI entry:** `run_write` / `run_write_op` / `stage_for_write` in `cmd/output.rs` (stage + finalize, or stage for custom JSON).
2. **All engine-backed writers stage via `WriteRequest`:** replace (precomputed + context ops), tidy fix, patch apply, ast rename, md dedupe, library `execute_as_edit_result`.
3. **ast rename** no longer invents its own check/apply/preview matrix; it uses `finalize_execution_result`.
4. **Docs** updated so AGENTS and `docs/plans/write-pipeline.md` describe one pipeline (not five sibling owners).

Binary/case-only renames stay on `execute_write` → `finalize_callback_write` (UTF-8 engine cannot apply).

## Verification

- `make check-fast` green (including write_path_contract_tests and md dedupe JSON tests)

## Out of scope

- Splitting `tx/lifecycle` (still size-waived; attempt deferred; domain co-location still justified for atomicity review)
- Growing MCP auto-registry further

Ref #1373
Ref #1388