### PR TITLE
refactor: finalize_report hooks end command-local write mode matrices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,11 +273,11 @@ Command::<Name>(args) => {
 | Pattern | When to use | Example commands |
 |---------|-------------|------------------|
 | `run_write` / `run_write_op` | Standard single-op + standard JSON schema | doc, create, delete, append, ast replace |
-| `stage_for_write` + `finalize_execution_result` | Multi-op or custom messages, standard finalize | ast rename, md dedupe-headings |
-| `stage_for_write` + custom renderer | Custom JSON; still use `classify_write_mode` / `write_exit_code` | replace, tidy fix, patch |
+| `stage_for_write` + `finalize_execution_result` | Multi-op / standard phase schema | ast rename |
+| `stage_for_write` + `finalize_report` | Custom JSON/text **hooks only** (never re-match modes) | replace, tidy fix, patch, md dedupe |
 | `execute_write` (`write_dispatch`) | Binary/case-only only (`finalize_callback_write`) | rename (binary / case-only) |
 
-Engine staging is always `tx::engine::stage(WriteRequest)` (`Operations` or `Precomputed`). Prefer `cmd::output` helpers at the CLI boundary. Do not use `atomic_write()` directly in command implementations.
+Engine staging is always `tx::engine::stage(WriteRequest)` (`Operations` or `Precomputed`). Prefer `cmd::output` helpers at the CLI boundary. **`match classify_write_mode` is only allowed in `write_mode.rs`.** Do not use `atomic_write()` directly in command implementations.
 
 6. If the command scans multiple files, use `crate::par_process_files()` for adaptive parallelism instead of a sequential loop. The closure must be `Fn + Sync` (no mutable captures). Write-back stays serial.
 

--- a/docs/plans/write-pipeline.md
+++ b/docs/plans/write-pipeline.md
@@ -29,9 +29,12 @@ CLI / API boundary
   → WriteSource::{Operations(Vec<Operation>), Precomputed(Vec<…>)}
   → stage(WriteRequest { source, options: ExecuteOptions { context, guard } })
   → WriteReport (ExecutionResult)
-  → finalize_execution_result(...)   // or custom renderer using write_exit_code
-  → optional commit inside finalize when apply/confirm accepts
+  → finalize_execution_result(...)   // standard phase JSON schema
+    OR finalize_report(hooks...)     // custom emit only; no mode match in commands
+  → commit/format inside finalize when apply/confirm accepts
 ```
+
+**Rule:** `match classify_write_mode` must only appear in `src/cmd/write_mode.rs`.
 
 ### CLI helpers (`src/cmd/output.rs`)
 
@@ -61,11 +64,10 @@ Binary / case-only renames cannot use the UTF-8 tx engine. They use
 |---------|---------|----------|
 | create, append, prepend, delete, doc writes, md most, ast replace | `run_write_op` / via engine alias | `finalize_execution_result` |
 | ast rename | `stage_for_write(Operations)` | `finalize_execution_result` |
-| replace (scan) | `stage_for_write(Precomputed)` | custom `replace_output` + `write_exit_code` |
-| replace (context) | `stage_for_write(Operations)` | same `replace_output` |
-| tidy fix | `stage_for_write(Operations)` | custom `tidy_fix_output` + `write_exit_code` |
-| patch apply | `stage_for_write(Operations)` | custom patch mode branch + `write_exit_code` |
-| md dedupe-headings | `stage_for_write` | `finalize_execution_result` (side-channel headings first) |
+| replace (scan + context) | `stage_for_write` | `finalize_report` via `replace_output` hooks |
+| tidy fix | `stage_for_write(Operations)` | `finalize_report` via `tidy_fix_output` hooks |
+| patch apply | `stage_for_write(Operations)` | `finalize_report` hooks |
+| md dedupe-headings | `stage_for_write` | `finalize_report` (side-channel headings first; no 2nd JSON body) |
 | rename binary/case-only | n/a | `execute_write` / `finalize_callback_write` |
 
 ## Adding a write command

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -284,41 +284,35 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 }
             }
 
-            // Side-channel headings already emitted; do not emit a second JSON
-            // body via finalize_execution_result. Stage + mode/exit only.
+            // Side-channel headings already emitted; no second JSON schema body.
             let op = Operation::MdDedupeHeadings { path: file.clone() };
             let (cwd, result) = crate::cmd::output::stage_for_write(
                 crate::tx::engine::WriteSource::Operations(vec![op]),
                 global,
             )?;
-            use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
-            let has_changes = result.has_changes;
-            match classify_write_mode(global) {
-                WriteMode::Check => Ok(write_exit_code(has_changes, false)),
-                WriteMode::Apply => {
-                    result.commit()?;
-                    crate::write::run_format_command(global, &cwd)?;
-                    Ok(write_exit_code(has_changes, true))
-                }
-                WriteMode::ConfirmJson | WriteMode::Preview => {
-                    let diffs = result.build_diffs();
-                    if !diffs.is_empty() && !global.json && !global.jsonl {
+            use crate::cmd::write_mode::finalize_report;
+            finalize_report(
+                global,
+                &cwd,
+                result,
+                true,
+                |_g, _has, _diffs| Ok(()),
+                |_g, _has, _diffs, _plain| Ok(()),
+                |g, _has, diffs, _plain| {
+                    if !diffs.is_empty() && !g.json && !g.jsonl {
                         let dr = crate::diff::DiffResult {
-                            diffs: diffs.clone(),
+                            diffs: diffs.to_vec(),
                         };
                         print!(
                             "{}",
-                            crate::diff::format_diff_result_colored(&dr, global.should_color())
+                            crate::diff::format_diff_result_colored(&dr, g.should_color())
                         );
                     }
-                    let applied = global.should_apply();
-                    if applied {
-                        result.commit()?;
-                        crate::write::run_format_command(global, &cwd)?;
-                    }
-                    Ok(write_exit_code(has_changes, applied))
-                }
-            }
+                    Ok(())
+                },
+                |_| {},
+                |_| {},
+            )
         }
 
         MdAction::LintAgents { file } => {

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -405,53 +405,49 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         };
 
-    // Mode → exit ownership: write_mode (see #1373).
-    use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
+    use crate::cmd::write_mode::finalize_report;
 
-    let has_changes = result.has_changes;
-    match classify_write_mode(global) {
-        WriteMode::Check => {
-            let diffs = result.build_diffs();
-            let files = build_file_results(&diffs, "changed");
+    finalize_report(
+        global,
+        &cwd,
+        result,
+        true,
+        |g, _has, diffs| {
+            let files = build_file_results(diffs, "changed");
             let changed = files.len();
             if changed > 0 {
-                emit_patch_files_output(global, true, &files)?;
-                if !(global.json || global.jsonl || global.quiet) {
+                emit_patch_files_output(g, true, &files)?;
+                if !(g.json || g.jsonl || g.quiet) {
                     println!("{changed} file(s) would change");
                 }
             }
-            Ok(write_exit_code(has_changes, false))
-        }
-        WriteMode::Apply => {
-            let diffs = result.build_diffs();
-            let files = build_file_results(&diffs, "applied");
-            result.commit()?;
-            crate::write::run_format_command(global, &cwd)?;
-            emit_patch_files_output(global, true, &files)?;
-            Ok(write_exit_code(has_changes, true))
-        }
-        WriteMode::ConfirmJson | WriteMode::Preview => {
-            let diffs = result.build_diffs();
-            if global.json || global.jsonl {
-                let files = build_file_results(&diffs, "changed");
-                emit_patch_files_output(global, true, &files)?;
+            Ok(())
+        },
+        |g, _has, diffs, _plain| {
+            let files = build_file_results(diffs, "applied");
+            emit_patch_files_output(g, true, &files)?;
+            Ok(())
+        },
+        |g, _has, diffs, _plain| {
+            if g.json || g.jsonl {
+                let files = build_file_results(diffs, "changed");
+                emit_patch_files_output(g, true, &files)?;
             } else {
                 print!(
                     "{}",
-                    format_diff_result_colored(&DiffResult { diffs }, global.should_color())
+                    format_diff_result_colored(
+                        &DiffResult {
+                            diffs: diffs.to_vec()
+                        },
+                        g.should_color()
+                    )
                 );
             }
-            // Interactive confirm (and confirm+json via should_apply on non-TTY).
-            let applied = global.should_apply();
-            if applied {
-                // Rebuild diffs already consumed above only for commit path:
-                // commit does not need the FileDiff list.
-                result.commit()?;
-                crate::write::run_format_command(global, &cwd)?;
-            }
-            Ok(write_exit_code(has_changes, applied))
-        }
-    }
+            Ok(())
+        },
+        |_| {},
+        |_| {},
+    )
 }
 
 #[cfg(test)]

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -1,5 +1,5 @@
 use crate::cli::global::GlobalFlags;
-use crate::diff::{render_diffs_colored, render_diffs_plain};
+use crate::diff::render_diffs_colored;
 use crate::exit;
 use crate::ops::replace::{
     compile_replace_regex, replace_content, replace_whole_lines, replacement_text,
@@ -342,7 +342,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
 /// Handle output rendering and commit/check/preview for replace via the engine.
 ///
-/// Exit codes are owned by [`crate::cmd::write_mode::write_exit_code`].
+/// Mode/exit owned by [`crate::cmd::write_mode::finalize_report`].
 fn replace_output(
     global: &GlobalFlags,
     result: crate::tx::engine::ExecutionResult,
@@ -351,7 +351,7 @@ fn replace_output(
     file_count: usize,
     cwd: &std::path::Path,
 ) -> anyhow::Result<u8> {
-    use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
+    use crate::cmd::write_mode::finalize_report;
 
     let build_output = |diff: Option<String>| ReplaceOutput {
         ok: true,
@@ -360,70 +360,57 @@ fn replace_output(
         files: files.to_vec(),
         diff,
     };
-    // Precomputed path only reaches here when matches exist.
-    let has_changes = result.has_changes;
 
-    match classify_write_mode(global) {
-        WriteMode::Check => {
-            if global.json {
-                global.emit_json(&build_output(None))?;
-            } else if !global.emit_json_items(files)? && !global.quiet {
+    finalize_report(
+        global,
+        cwd,
+        result,
+        true,
+        |g, _has, _diffs| {
+            if g.json {
+                g.emit_json(&build_output(None))?;
+            } else if !g.emit_json_items(files)? && !g.quiet {
                 println!("{total_matches} match(es) in {file_count} file(s)");
                 for f in files {
                     println!("  {}: {} match(es)", f.path, f.match_count);
                 }
             }
-            Ok(write_exit_code(has_changes, false))
-        }
-        WriteMode::Apply => {
-            let diffs = result.build_diffs();
-            result.commit()?;
-            crate::write::run_format_command(global, cwd)?;
-            let diff_text = if global.diff {
-                Some(render_diffs_plain(&diffs))
-            } else {
-                None
-            };
-            if global.json {
-                global.emit_json(&build_output(diff_text))?;
-            } else if !global.emit_json_items(files)? {
-                if global.diff {
-                    print!("{}", render_diffs_colored(&diffs, global.should_color()));
-                } else if !global.quiet {
+            Ok(())
+        },
+        |g, _has, diffs, diff_text| {
+            if g.json {
+                g.emit_json(&build_output(diff_text))?;
+            } else if !g.emit_json_items(files)? {
+                if g.diff {
+                    print!("{}", render_diffs_colored(diffs, g.should_color()));
+                } else if !g.quiet {
                     println!("replaced {total_matches} match(es) in {file_count} file(s)");
                     for f in files {
                         println!("  {}: {} match(es)", f.path, f.match_count);
                     }
                 }
             }
-            Ok(write_exit_code(has_changes, true))
-        }
-        WriteMode::ConfirmJson | WriteMode::Preview => {
-            let diffs = result.build_diffs();
-            let diff_text = if !diffs.is_empty() {
-                Some(render_diffs_plain(&diffs))
-            } else {
-                None
-            };
-            if global.json {
-                global.emit_json(&build_output(diff_text))?;
-            } else if !global.emit_json_items(files)? && !diffs.is_empty() {
-                print!("{}", render_diffs_colored(&diffs, global.should_color()));
+            Ok(())
+        },
+        |g, _has, diffs, diff_text| {
+            if g.json {
+                g.emit_json(&build_output(diff_text))?;
+            } else if !g.emit_json_items(files)? && !diffs.is_empty() {
+                print!("{}", render_diffs_colored(diffs, g.should_color()));
             }
-            if global.show_status() {
+            Ok(())
+        },
+        |g| {
+            if g.show_status() {
                 eprintln!("{file_count} file(s) changed, {total_matches} replacement(s)");
             }
-            let applied = global.should_apply();
-            if applied {
-                result.commit()?;
-                crate::write::run_format_command(global, cwd)?;
-                if global.show_status() {
-                    eprintln!("replaced {total_matches} match(es) in {file_count} file(s)");
-                }
+        },
+        |g| {
+            if g.show_status() {
+                eprintln!("replaced {total_matches} match(es) in {file_count} file(s)");
             }
-            Ok(write_exit_code(has_changes, applied))
-        }
-    }
+        },
+    )
 }
 
 /// Context-based replace: routes through the tx engine where

--- a/src/cmd/tidy.rs
+++ b/src/cmd/tidy.rs
@@ -1,6 +1,6 @@
 // size-waiver: domain bulk, see #1376. Tidy check+fix CLI surface with multi-file engine handoff.
 use crate::cli::global::GlobalFlags;
-use crate::diff::{render_diffs_colored, render_diffs_plain};
+use crate::diff::render_diffs_colored;
 use crate::exit;
 use crate::plan::Operation;
 use crate::tx::engine::{ExecutionResult, WriteSource};
@@ -383,66 +383,53 @@ fn eol_mode_to_str(mode: crate::cli::global::EolMode) -> &'static str {
 
 /// Handle output rendering and commit/check/preview for tidy fix via the engine.
 ///
-/// Exit codes are owned by [`crate::cmd::write_mode::write_exit_code`].
+/// Mode/exit owned by [`crate::cmd::write_mode::finalize_report`].
 fn tidy_fix_output(
     global: &GlobalFlags,
     result: ExecutionResult,
     dirty_rel_paths: &[String],
     cwd: &Path,
 ) -> anyhow::Result<u8> {
-    use crate::cmd::write_mode::{WriteMode, classify_write_mode, write_exit_code};
+    use crate::cmd::write_mode::finalize_report;
 
     let fix_files: Vec<TidyFixFileResult> = dirty_rel_paths
         .iter()
         .map(|p| TidyFixFileResult { path: p.clone() })
         .collect();
-    // Fix path only stages when dirty files exist.
-    let has_changes = result.has_changes;
+    let n_files = dirty_rel_paths.len();
 
-    match classify_write_mode(global) {
-        WriteMode::Check => {
-            emit_tidy_fix_output(global, &fix_files, None)?;
-            if !global.quiet && !global.json && !global.jsonl {
+    finalize_report(
+        global,
+        cwd,
+        result,
+        true,
+        |g, _has, _diffs| {
+            emit_tidy_fix_output(g, &fix_files, None)?;
+            if !g.quiet && !g.json && !g.jsonl {
                 for p in dirty_rel_paths {
                     println!("{p}");
                 }
             }
-            Ok(write_exit_code(has_changes, false))
-        }
-        WriteMode::Apply => {
-            let diffs = result.build_diffs();
-            result.commit()?;
-            crate::write::run_format_command(global, cwd)?;
-            let diff_text = if global.diff {
-                Some(render_diffs_plain(&diffs))
-            } else {
-                None
-            };
-            emit_tidy_fix_output(global, &fix_files, diff_text)?;
-            Ok(write_exit_code(has_changes, true))
-        }
-        WriteMode::ConfirmJson | WriteMode::Preview => {
-            let diffs = result.build_diffs();
-            let diff_text = if !diffs.is_empty() {
-                Some(render_diffs_plain(&diffs))
-            } else {
-                None
-            };
-            emit_tidy_fix_output(global, &fix_files, diff_text)?;
-            if !global.json && !global.jsonl && !global.quiet && !diffs.is_empty() {
-                print!("{}", render_diffs_colored(&diffs, global.should_color()));
+            Ok(())
+        },
+        |g, _has, _diffs, diff_text| {
+            emit_tidy_fix_output(g, &fix_files, diff_text)?;
+            Ok(())
+        },
+        |g, _has, diffs, diff_text| {
+            emit_tidy_fix_output(g, &fix_files, diff_text)?;
+            if !g.json && !g.jsonl && !g.quiet && !diffs.is_empty() {
+                print!("{}", render_diffs_colored(diffs, g.should_color()));
             }
-            if global.show_status() {
-                eprintln!("{} file(s) changed", dirty_rel_paths.len());
+            Ok(())
+        },
+        |g| {
+            if g.show_status() {
+                eprintln!("{n_files} file(s) changed");
             }
-            let applied = global.should_apply();
-            if applied {
-                result.commit()?;
-                crate::write::run_format_command(global, cwd)?;
-            }
-            Ok(write_exit_code(has_changes, applied))
-        }
-    }
+        },
+        |_| {},
+    )
 }
 
 /// Emit structured JSON/JSONL output for tidy fix.

--- a/src/cmd/write_mode.rs
+++ b/src/cmd/write_mode.rs
@@ -1,13 +1,16 @@
 //! Single owner of write **mode classification** and **exit codes**.
 //!
 //! Every CLI write path (engine-backed and binary/case-only callbacks) must use
-//! [`classify_write_mode`] and [`write_exit_code`] so preview/check/apply/confirm
-//! cannot diverge by path (see #1345–#1348 and #1373).
+//! the finalize helpers so preview/check/apply/confirm cannot diverge by path
+//! (see #1345–#1348 and #1373).
 //!
-//! Engine-backed commands: stage with [`crate::tx::engine::stage`] (or CLI
-//! [`crate::cmd::output::run_write`] / [`crate::cmd::output::stage_for_write`]),
-//! then finalize here. Callback-based paths (binary rename) use
-//! [`finalize_callback_write`].
+//! **Commands must not `match classify_write_mode` themselves.**
+//!
+//! - Standard phase JSON → [`finalize_execution_result`]
+//! - Custom JSON/text (replace, tidy, patch, md) → [`finalize_report`]
+//! - Binary/case-only rename → [`finalize_callback_write`]
+//!
+//! Stage with [`crate::tx::engine::stage`] or CLI `run_write` / `stage_for_write`.
 
 use crate::cli::global::GlobalFlags;
 use crate::diff::{FileDiff, render_diffs_colored, render_diffs_plain};
@@ -47,6 +50,8 @@ pub enum WriteMode {
 /// Classify write mode from global flags.
 ///
 /// Priority: check > apply > confirm+json > preview.
+///
+/// Do not match on this in command modules; use a finalize helper instead.
 #[must_use]
 pub fn classify_write_mode(global: &GlobalFlags) -> WriteMode {
     if global.check {
@@ -104,12 +109,68 @@ impl Default for RenderPolicy {
     }
 }
 
-/// Finalize a staged [`ExecutionResult`] under global write flags.
+/// Canonical mode → commit → format → exit for custom-rendered staged writes.
 ///
-/// This is the **canonical** mode → commit → exit owner for engine-backed
-/// single and multi-op writes (`execute_via_engine`, and callers that stage
-/// via `execute_single` / `execute_operations` / `execute_precomputed` and
-/// then hand off here).
+/// Callers only supply **emit** behavior. Order for preview/confirm-json:
+/// `on_preview` → optional status → `should_apply` → optional commit → optional
+/// post-apply status. That matches replace/tidy/patch/md custom output.
+///
+/// `on_check` receives built diffs (for commands that list changed files in
+/// check mode). Prefer [`finalize_execution_result`] for standard
+/// `make_output(WritePhase, diff)` schemas (ConfirmJson emits *after* apply).
+#[allow(clippy::too_many_arguments)]
+pub fn finalize_report(
+    global: &GlobalFlags,
+    cwd: &Path,
+    result: ExecutionResult,
+    preview_diffs: bool,
+    mut on_check: impl FnMut(&GlobalFlags, bool, &[FileDiff]) -> anyhow::Result<()>,
+    mut on_apply: impl FnMut(&GlobalFlags, bool, &[FileDiff], Option<String>) -> anyhow::Result<()>,
+    mut on_preview: impl FnMut(&GlobalFlags, bool, &[FileDiff], Option<String>) -> anyhow::Result<()>,
+    mut after_preview_emit: impl FnMut(&GlobalFlags),
+    mut after_preview_apply: impl FnMut(&GlobalFlags),
+) -> anyhow::Result<u8> {
+    let has_changes = result.has_changes;
+    match classify_write_mode(global) {
+        WriteMode::Check => {
+            let diffs = result.build_diffs();
+            on_check(global, has_changes, &diffs)?;
+            Ok(write_exit_code(has_changes, false))
+        }
+        WriteMode::Apply => {
+            let diffs = result.build_diffs();
+            result.commit()?;
+            crate::write::run_format_command(global, cwd)?;
+            let diff_text = if global.diff {
+                Some(render_diffs_plain(&diffs))
+            } else {
+                None
+            };
+            on_apply(global, has_changes, &diffs, diff_text)?;
+            Ok(write_exit_code(has_changes, true))
+        }
+        WriteMode::ConfirmJson | WriteMode::Preview => {
+            let diffs = if preview_diffs {
+                result.build_diffs()
+            } else {
+                Vec::new()
+            };
+            let diff_text = plain_diff_opt(&diffs);
+            on_preview(global, has_changes, &diffs, diff_text)?;
+            after_preview_emit(global);
+            let applied = global.should_apply();
+            if applied {
+                result.commit()?;
+                crate::write::run_format_command(global, cwd)?;
+                after_preview_apply(global);
+            }
+            Ok(write_exit_code(has_changes, applied))
+        }
+    }
+}
+
+/// Finalize a staged [`ExecutionResult`] under global write flags with a
+/// standard phase-based JSON schema (`make_output(phase, diff)`).
 pub fn finalize_execution_result<T: Serialize>(
     global: &GlobalFlags,
     cwd: &Path,
@@ -316,5 +377,47 @@ mod tests {
         assert_eq!(write_exit_code(false, true), exit::SUCCESS);
         assert_eq!(write_exit_code(true, false), exit::CHANGES_DETECTED);
         assert_eq!(write_exit_code(false, false), exit::SUCCESS);
+    }
+
+    #[test]
+    fn finalize_report_check_does_not_commit() {
+        use crate::plan::Operation;
+        use crate::tx::engine::{ExecuteOptions, WriteRequest, WriteSource, stage};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.check = true;
+        let options = ExecuteOptions::from_global(dir.path(), &global, None);
+        let report = stage(WriteRequest {
+            source: WriteSource::Operations(vec![Operation::FileCreate {
+                path: "f.txt".to_string(),
+                content: "x\n".to_string(),
+                force: None,
+            }]),
+            options,
+        })
+        .unwrap();
+
+        let checks = AtomicUsize::new(0);
+        let code = finalize_report(
+            &global,
+            dir.path(),
+            report,
+            true,
+            |_g, has, _d| {
+                assert!(has);
+                checks.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            |_g, _, _, _| panic!("apply must not run"),
+            |_g, _, _, _| panic!("preview must not run"),
+            |_| {},
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+        assert_eq!(checks.load(Ordering::SeqCst), 1);
+        assert!(!dir.path().join("f.txt").exists());
     }
 }


### PR DESCRIPTION
## Summary

Completes write-path **finalize** singularity (follow-up to #1389):

- New [`finalize_report`](src/cmd/write_mode.rs): mode → commit → format → exit with pluggable emit hooks
- **replace**, **tidy fix**, **patch apply**, **md dedupe** no longer `match classify_write_mode`
- `rg 'match classify_write_mode' src` only hits `write_mode.rs`
- AGENTS + write-pipeline docs enforce the rule
- Unit test: `finalize_report_check_does_not_commit`

Standard schema commands still use `finalize_execution_result` (ConfirmJson emit-after-apply order preserved there).

## Verification

- `make check-fast` green (including write_path_contract_tests)

Ref #1373
Ref #1389