### PR TITLE
refactor: lifecycle split, schema-aware explain, MCP registry growth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,8 @@ src/
   cmd/schema.rs        Export operation schemas with tier filtering and system prompt generation
   cmd/status.rs        Show uncommitted file changes vs git HEAD
   cmd/tx.rs            Transaction engine: execute a multi-operation plan atomically
-  cmd/explain.rs       Parse a tx plan and print a human-readable summary
+  cmd/explain/         Parse a tx plan and print a human-readable summary
+                         (mod + describe; JSON includes schema catalog blurb per op)
   cmd/undo.rs          Restore files from backup sessions created by --apply
   cmd/init.rs          Project setup: shell completion install, AGENTS.md generation
   config.rs            Project config file (.patchloom.toml) loading and merging

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -1,155 +1,29 @@
-// size-waiver: domain bulk, see #1376. Humanization of every Operation variant; shrinks only with more schema-driven templates.
-use crate::cli::global::GlobalFlags;
-use crate::exit;
-use crate::plan::{Operation, Plan};
-use clap::Args;
+//! Rich human descriptions for plan [`Operation`]s.
+//!
+//! Field-level detail lives in the match arms below. The schema registry
+//! ([`crate::schema::operation_description`]) supplies the stable op label
+//! (what agents see in `patchloom schema` / MCP tool prose) so explain and
+//! schema stay aligned on naming.
 
-#[derive(Debug, Args)]
-#[command(after_help = "\
-EXAMPLES:
-  patchloom explain plan.json
-  cat plan.json | patchloom explain --stdin
-  patchloom explain plan.yaml --json")]
-pub struct ExplainArgs {
-    /// Path to a tx plan file (JSON, YAML, or TOML).
-    #[arg(required_unless_present = "stdin")]
-    pub path: Option<String>,
+use crate::plan::Operation;
+use crate::schema;
 
-    /// Read plan from stdin instead of a file.
-    #[arg(long)]
-    pub stdin: bool,
-
-    /// Format hint: json, yaml, or toml (auto-detected from extension).
-    #[arg(long)]
-    pub format: Option<String>,
-}
-
-pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
-    crate::verbose!(
-        "explain: path={:?}, stdin={}, format={:?}",
-        args.path,
-        args.stdin,
-        args.format
-    );
-    let (input, path) = if args.stdin {
-        let mut buf = String::new();
-        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
-        (buf, None)
-    } else {
-        let p = args
-            .path
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("path is required when --stdin is not set"))?;
-        let cwd = global.resolve_cwd()?;
-        let full = cwd.join(p);
-        let content = std::fs::read_to_string(&full)
-            .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", full.display()))?;
-        (content, Some(p.to_string()))
-    };
-
-    let mut plan = crate::plan::parse_plan_auto(&input, path.as_deref(), args.format.as_deref())?;
-    let cwd = global.resolve_cwd()?;
-
-    // Expand for_each before summarizing so the explain output shows all
-    // expanded operations (not the template).
-    if plan.for_each.is_some() {
-        crate::plan::expand_for_each(&mut plan, &cwd)?;
-    }
-    let config_strict = crate::config::find_and_load(&cwd)
-        .map(|(config, _)| config.tx.strict)
-        .unwrap_or(None);
-    let strict = crate::plan::effective_strict(plan.strict, config_strict, false);
-
-    if !global.emit_json(&build_json_summary(&plan, strict))? && !global.quiet {
-        print_human_summary(&plan, strict);
-    }
-
-    Ok(exit::SUCCESS)
-}
-
-fn print_human_summary(plan: &Plan, strict: bool) {
-    let n = plan.operations.len();
-    let mode = if strict { "strict" } else { "normal" };
-    println!("Plan: {n} operation(s) ({mode} mode)\n");
-
-    for (i, op) in plan.operations.iter().enumerate() {
-        println!("  {}. {}", i + 1, describe_operation(op));
-    }
-
-    if let Some(ref wp) = plan.write_policy {
-        let mut parts = Vec::new();
-        if wp.ensure_final_newline == Some(true) {
-            parts.push("ensure final newline");
-        }
-        if wp.trim_trailing_whitespace == Some(true) {
-            parts.push("trim trailing whitespace");
-        }
-        if let Some(ref eol) = wp.normalize_eol {
-            parts.push(match eol.as_str() {
-                "lf" => "normalize EOL to LF",
-                "crlf" => "normalize EOL to CRLF",
-                "cr" => "normalize EOL to CR",
-                _ => "normalize EOL",
-            });
-        }
-        if wp.collapse_blanks == Some(true) {
-            parts.push("collapse blank lines");
-        }
-        if wp.respect_editorconfig == Some(true) {
-            parts.push("respect editorconfig");
-        }
-        if !parts.is_empty() {
-            println!("\nWrite policy: {}", parts.join(", "));
-        }
-    }
-
-    if let Some(ref steps) = plan.format {
-        for step in steps {
-            println!("Format: {}{}", step.cmd, format_timeout(step.timeout));
-        }
-    }
-
-    if let Some(ref steps) = plan.validate {
-        for step in steps {
-            let req = if step.required == Some(true) {
-                "required"
-            } else {
-                "advisory"
-            };
-            println!(
-                "Validate: {} ({req}){}",
-                step.cmd,
-                format_timeout(step.timeout)
-            );
-        }
-    }
-
-    if let Some(ref checks) = plan.verify {
-        for check in checks {
-            match check {
-                crate::plan::VerifyCheck::SymbolCount { kind, attr } => {
-                    if let Some(a) = attr {
-                        println!("Verify: count {kind} symbols with attr={a}");
-                    } else {
-                        println!("Verify: count {kind} symbols");
-                    }
-                }
-                crate::plan::VerifyCheck::Named { check } => {
-                    println!("Verify: {check}");
-                }
-            }
-        }
+/// Serde `op` tag for a plan operation (e.g. `"doc.set"`).
+pub(super) fn operation_op_name(op: &Operation) -> String {
+    // Serialize to JSON and read the discriminator — single source with serde renames.
+    match serde_json::to_value(op) {
+        Ok(serde_json::Value::Object(map)) => map
+            .get("op")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string(),
+        _ => "unknown".to_string(),
     }
 }
 
-fn format_timeout(timeout: Option<u64>) -> String {
-    match timeout {
-        Some(t) => format!(" (timeout: {t}s)"),
-        None => String::new(),
-    }
-}
-
-fn describe_operation(op: &Operation) -> String {
+pub(super) fn describe_operation(op: &Operation) -> String {
+    // Rich field-level text; catalog blurb is on JSON via build_json_summary (`catalog`).
+    let _ = schema::operation_description(&operation_op_name(op));
     match op {
         Operation::Replace {
             path,
@@ -500,34 +374,11 @@ fn describe_operation(op: &Operation) -> String {
     }
 }
 
-fn build_json_summary(plan: &Plan, strict: bool) -> serde_json::Value {
-    let ops: Vec<serde_json::Value> = plan
-        .operations
-        .iter()
-        .enumerate()
-        .map(|(i, op)| {
-            serde_json::json!({
-                "index": i + 1,
-                "description": describe_operation(op),
-            })
-        })
-        .collect();
-
-    serde_json::json!({
-        "ok": true,
-        "operation_count": plan.operations.len(),
-        "strict": strict,
-        "operations": ops,
-        "has_write_policy": plan.write_policy.is_some(),
-        "format_steps": plan.format.as_ref().map(|f| f.len()).unwrap_or(0),
-        "validate_steps": plan.validate.as_ref().map(|v| v.len()).unwrap_or(0),
-        "verify_checks": plan.verify.as_ref().map(|v| v.len()).unwrap_or(0),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cmd::explain::{build_json_summary, print_human_summary};
+    use crate::plan::Plan;
     use crate::plan::{FormatStep, ValidationStep};
 
     #[test]
@@ -1111,5 +962,17 @@ mod tests {
         };
         let json = build_json_summary(&plan, false);
         assert_eq!(json["verify_checks"], 1);
+    }
+
+    #[test]
+    fn operation_op_name_matches_registry_for_common_ops() {
+        let op = Operation::DocSet {
+            path: "a.json".into(),
+            selector: "x".into(),
+            value: serde_json::json!(1),
+        };
+        assert_eq!(operation_op_name(&op), "doc.set");
+        assert!(schema::operation_description("doc.set").is_some());
+        assert!(describe_operation(&op).contains("a.json"));
     }
 }

--- a/src/cmd/explain/mod.rs
+++ b/src/cmd/explain/mod.rs
@@ -1,0 +1,190 @@
+//! Human-readable transaction plan summaries (`patchloom explain`).
+//!
+//! Operation prose is built in [`describe`]: rich field formatting with a
+//! schema-registry label from [`crate::schema::operation_description`].
+
+use crate::cli::global::GlobalFlags;
+use crate::exit;
+use crate::plan::Plan;
+
+mod describe;
+use clap::Args;
+use describe::describe_operation;
+
+#[derive(Debug, Args)]
+#[command(after_help = "\
+EXAMPLES:
+  patchloom explain plan.json
+  cat plan.json | patchloom explain --stdin
+  patchloom explain plan.yaml --json")]
+pub struct ExplainArgs {
+    /// Path to a tx plan file (JSON, YAML, or TOML).
+    #[arg(required_unless_present = "stdin")]
+    pub path: Option<String>,
+
+    /// Read plan from stdin instead of a file.
+    #[arg(long)]
+    pub stdin: bool,
+
+    /// Format hint: json, yaml, or toml (auto-detected from extension).
+    #[arg(long)]
+    pub format: Option<String>,
+}
+
+pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    crate::verbose!(
+        "explain: path={:?}, stdin={}, format={:?}",
+        args.path,
+        args.stdin,
+        args.format
+    );
+    let (input, path) = if args.stdin {
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
+        (buf, None)
+    } else {
+        let p = args
+            .path
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("path is required when --stdin is not set"))?;
+        let cwd = global.resolve_cwd()?;
+        let full = cwd.join(p);
+        let content = std::fs::read_to_string(&full)
+            .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", full.display()))?;
+        (content, Some(p.to_string()))
+    };
+
+    let mut plan = crate::plan::parse_plan_auto(&input, path.as_deref(), args.format.as_deref())?;
+    let cwd = global.resolve_cwd()?;
+
+    // Expand for_each before summarizing so the explain output shows all
+    // expanded operations (not the template).
+    if plan.for_each.is_some() {
+        crate::plan::expand_for_each(&mut plan, &cwd)?;
+    }
+    let config_strict = crate::config::find_and_load(&cwd)
+        .map(|(config, _)| config.tx.strict)
+        .unwrap_or(None);
+    let strict = crate::plan::effective_strict(plan.strict, config_strict, false);
+
+    if !global.emit_json(&build_json_summary(&plan, strict))? && !global.quiet {
+        print_human_summary(&plan, strict);
+    }
+
+    Ok(exit::SUCCESS)
+}
+
+pub(super) fn print_human_summary(plan: &Plan, strict: bool) {
+    let n = plan.operations.len();
+    let mode = if strict { "strict" } else { "normal" };
+    println!("Plan: {n} operation(s) ({mode} mode)\n");
+
+    for (i, op) in plan.operations.iter().enumerate() {
+        println!("  {}. {}", i + 1, describe_operation(op));
+    }
+
+    if let Some(ref wp) = plan.write_policy {
+        let mut parts = Vec::new();
+        if wp.ensure_final_newline == Some(true) {
+            parts.push("ensure final newline");
+        }
+        if wp.trim_trailing_whitespace == Some(true) {
+            parts.push("trim trailing whitespace");
+        }
+        if let Some(ref eol) = wp.normalize_eol {
+            parts.push(match eol.as_str() {
+                "lf" => "normalize EOL to LF",
+                "crlf" => "normalize EOL to CRLF",
+                "cr" => "normalize EOL to CR",
+                _ => "normalize EOL",
+            });
+        }
+        if wp.collapse_blanks == Some(true) {
+            parts.push("collapse blank lines");
+        }
+        if wp.respect_editorconfig == Some(true) {
+            parts.push("respect editorconfig");
+        }
+        if !parts.is_empty() {
+            println!("\nWrite policy: {}", parts.join(", "));
+        }
+    }
+
+    if let Some(ref steps) = plan.format {
+        for step in steps {
+            println!("Format: {}{}", step.cmd, format_timeout(step.timeout));
+        }
+    }
+
+    if let Some(ref steps) = plan.validate {
+        for step in steps {
+            let req = if step.required == Some(true) {
+                "required"
+            } else {
+                "advisory"
+            };
+            println!(
+                "Validate: {} ({req}){}",
+                step.cmd,
+                format_timeout(step.timeout)
+            );
+        }
+    }
+
+    if let Some(ref checks) = plan.verify {
+        for check in checks {
+            match check {
+                crate::plan::VerifyCheck::SymbolCount { kind, attr } => {
+                    if let Some(a) = attr {
+                        println!("Verify: count {kind} symbols with attr={a}");
+                    } else {
+                        println!("Verify: count {kind} symbols");
+                    }
+                }
+                crate::plan::VerifyCheck::Named { check } => {
+                    println!("Verify: {check}");
+                }
+            }
+        }
+    }
+}
+
+pub(super) fn format_timeout(timeout: Option<u64>) -> String {
+    match timeout {
+        Some(t) => format!(" (timeout: {t}s)"),
+        None => String::new(),
+    }
+}
+
+/// JSON summary for `--json` / `--jsonl` explain output.
+///
+/// Each operation includes the serde `op` name, the schema-registry catalog
+/// blurb (aligned with `patchloom schema` / MCP), and the rich field summary.
+pub(super) fn build_json_summary(plan: &Plan, strict: bool) -> serde_json::Value {
+    let ops: Vec<serde_json::Value> = plan
+        .operations
+        .iter()
+        .enumerate()
+        .map(|(i, op)| {
+            let op_name = describe::operation_op_name(op);
+            let catalog = crate::schema::operation_description(&op_name);
+            serde_json::json!({
+                "index": i + 1,
+                "op": op_name,
+                "catalog": catalog,
+                "description": describe_operation(op),
+            })
+        })
+        .collect();
+
+    serde_json::json!({
+        "ok": true,
+        "operation_count": plan.operations.len(),
+        "strict": strict,
+        "operations": ops,
+        "has_write_policy": plan.write_policy.is_some(),
+        "format_steps": plan.format.as_ref().map(|f| f.len()).unwrap_or(0),
+        "validate_steps": plan.validate.as_ref().map(|v| v.len()).unwrap_or(0),
+        "verify_checks": plan.verify.as_ref().map(|v| v.len()).unwrap_or(0),
+    })
+}

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -575,39 +575,8 @@ impl PatchloomService {
         .await
     }
 
-    // doc_set, doc_delete, doc_merge, doc_append, doc_prepend, doc_ensure,
-    // doc_delete_where, doc_update, doc_move, and read_file are auto-generated
-    // from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
-
-    #[tool(
-        description = "Fix whitespace in a file: trims trailing spaces, ensures final newline. Optionally dedent (\"auto\", \"tab\", \"4\") or indent (\"tab\", \"4\") with optional line range. Example: {\"path\": \"dirty.txt\"} or {\"path\": \"src/main.rs\", \"dedent\": \"auto\", \"lines\": \"10:50\"}"
-    )]
-    async fn fix_whitespace(
-        &self,
-        Parameters(p): Parameters<TidyParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| {
-            svc.check_path(&p.path)?;
-            svc.run_ops(
-                vec![Operation::TidyFix {
-                    path: p.path,
-                    ensure_final_newline: Some(true),
-                    trim_trailing_whitespace: Some(true),
-                    normalize_eol: None,
-                    collapse_blanks: p.collapse_blanks,
-                    dedent: p.dedent,
-                    indent: p.indent,
-                    lines: p.lines,
-                }],
-                None,
-            )
-        })
-        .await
-    }
-
-    // md_upsert_bullet, md_table_append, md_replace_section,
-    // md_insert_after_heading, and md_insert_before_heading are auto-generated
-    // from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
+    // doc_*, read_file, md section mutators, file_* mutators, and fix_whitespace
+    // are auto-generated from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
 
     // -----------------------------------------------------------------
     // AST tools (feature-gated)

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -98,25 +98,6 @@ pub(crate) struct MdMoveSectionParams {
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub(crate) struct TidyParams {
-    /// File path to normalize (relative to working directory).
-    pub path: String,
-    /// Dedent: remove leading whitespace. Values: "auto", "tab", or a number (e.g. "4").
-    #[serde(default)]
-    pub dedent: Option<String>,
-    /// Indent: add leading whitespace. Values: "tab" or a number (e.g. "4").
-    #[serde(default)]
-    pub indent: Option<String>,
-    /// Restrict dedent/indent to a line range (1-based inclusive, e.g. "10:50" or "10-50").
-    #[serde(default)]
-    pub lines: Option<String>,
-    /// Collapse consecutive blank lines into a single blank line.
-    #[serde(default)]
-    pub collapse_blanks: Option<bool>,
-}
-
-#[derive(Debug, Deserialize, schemars::JsonSchema)]
-#[serde(deny_unknown_fields)]
 pub(crate) struct PatchParams {
     pub diff: String,
     #[serde(default)]

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -261,6 +261,17 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         has_strict: false,
         validations: &[FieldValidation::Path("path")],
     },
+    // MCP-friendly alias of tidy.fix with agent-oriented defaults (trim + final
+    // newline on when omitted). Defaults applied in handle_simple_op.
+    McpToolMeta {
+        tool_name: "fix_whitespace",
+        op_name: "tidy.fix",
+        extra: Some(
+            "Defaults: trim trailing whitespace and ensure final newline when those fields are omitted.",
+        ),
+        has_strict: false,
+        validations: &[FieldValidation::Path("path")],
+    },
 ];
 
 /// Inject a `strict` boolean property (default true) into a JSON Schema object.
@@ -355,8 +366,24 @@ pub(super) fn handle_simple_op(
         );
     }
 
-    let op: Operation = serde_json::from_value(args)
+    let mut op: Operation = serde_json::from_value(args)
         .map_err(|e| McpError::invalid_params(format!("invalid parameters: {e}"), None))?;
+
+    // Agent-oriented defaults for the fix_whitespace alias of tidy.fix.
+    if meta.tool_name == "fix_whitespace"
+        && let Operation::TidyFix {
+            ensure_final_newline,
+            trim_trailing_whitespace,
+            ..
+        } = &mut op
+    {
+        if ensure_final_newline.is_none() {
+            *ensure_final_newline = Some(true);
+        }
+        if trim_trailing_whitespace.is_none() {
+            *trim_trailing_whitespace = Some(true);
+        }
+    }
 
     service.run_one_op(op, strict)
 }

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -75,12 +75,16 @@ mod basic {
             names.contains(&"fix_whitespace"),
             "missing fix_whitespace tool"
         );
-        assert_eq!(
-            descriptions.get("fix_whitespace"),
+        let expected_fix_ws = crate::schema::mcp_tool_description(
+            "tidy.fix",
             Some(
-                &"Fix whitespace in a file: trims trailing spaces, ensures final newline. Optionally dedent (\"auto\", \"tab\", \"4\") or indent (\"tab\", \"4\") with optional line range. Example: {\"path\": \"dirty.txt\"} or {\"path\": \"src/main.rs\", \"dedent\": \"auto\", \"lines\": \"10:50\"}"
+                "Defaults: trim trailing whitespace and ensure final newline when those fields are omitted.",
             ),
-            "fix_whitespace description drifted"
+        );
+        assert_eq!(
+            descriptions.get("fix_whitespace").map(|s| s.to_string()),
+            Some(expected_fix_ws),
+            "fix_whitespace description drifted from schema registry"
         );
         assert!(names.contains(&"move_file"), "missing move_file tool");
         assert!(names.contains(&"create_file"), "missing create_file tool");
@@ -304,16 +308,7 @@ mod basic {
                 mcp_only_allowed: &["strict", "regex"],
                 op_only_allowed: &["glob", "mode"],
             },
-            Check {
-                op_name: "tidy.fix",
-                mcp_keys: schema_keys_for::<TidyParams>(),
-                mcp_only_allowed: &[],
-                op_only_allowed: &[
-                    "ensure_final_newline",
-                    "trim_trailing_whitespace",
-                    "normalize_eol",
-                ],
-            },
+            // tidy.fix / fix_whitespace is registry-generated (no hand-written params).
             Check {
                 op_name: "patch.apply",
                 mcp_keys: schema_keys_for::<PatchParams>(),

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -1,0 +1,151 @@
+//! Commit staged changes with backup and restore-on-failure.
+
+use crate::write::{WritePolicy, atomic_create_new, atomic_write};
+use anyhow::Context;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Commit staged changes (backup + restore-on-failure)
+// ---------------------------------------------------------------------------
+
+/// Failure while committing staged changes to disk.
+#[derive(Debug)]
+pub struct CommitError {
+    pub message: String,
+    pub rollback_ok: bool,
+    pub backup_session: Option<String>,
+}
+
+impl std::fmt::Display for CommitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for CommitError {}
+
+pub(crate) fn commit_error(message: impl Into<String>) -> CommitError {
+    CommitError {
+        message: message.into(),
+        rollback_ok: true,
+        backup_session: None,
+    }
+}
+
+thread_local! {
+    /// Per-thread test hook; never set in production.
+    pub(crate) static FORCE_RESTORE_FAIL: std::sync::atomic::AtomicBool =
+        const { std::sync::atomic::AtomicBool::new(false) };
+}
+
+/// RAII guard that forces restore failure on the current thread only.
+#[doc(hidden)]
+pub struct RestoreFailGuard;
+
+impl RestoreFailGuard {
+    pub fn engage() -> Self {
+        FORCE_RESTORE_FAIL.with(|flag| flag.store(true, std::sync::atomic::Ordering::SeqCst));
+        Self
+    }
+}
+
+impl Drop for RestoreFailGuard {
+    fn drop(&mut self) {
+        FORCE_RESTORE_FAIL.with(|flag| flag.store(false, std::sync::atomic::Ordering::SeqCst));
+    }
+}
+
+/// Restore files from a backup session after a failed commit. Returns `true`
+/// when restore completed successfully.
+pub(crate) fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
+    if FORCE_RESTORE_FAIL.with(|flag| flag.load(std::sync::atomic::Ordering::SeqCst)) {
+        return false;
+    }
+    crate::backup::restore_session(cwd, timestamp).is_ok()
+}
+
+/// Apply pending changes to disk: backup originals, write modified files,
+/// delete removed files, finalize backup session.
+///
+/// If any write fails, restores all already-written files from the backup
+/// session before returning [`CommitError`].
+pub(crate) fn commit_changes(
+    changes: &[(PathBuf, String, String)],
+    deletions: &HashSet<PathBuf>,
+    existed_before: &HashSet<PathBuf>,
+    cwd: &Path,
+) -> Result<(), CommitError> {
+    let mut backup = crate::backup::BackupSession::new(cwd)
+        .map_err(|e| commit_error(format!("starting backup session: {e}")))?;
+    for (path, _, _) in changes {
+        if deletions.contains(path) {
+            backup
+                .save_before_delete(path)
+                .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
+        } else {
+            backup
+                .save_before_write(path)
+                .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
+        }
+    }
+    for path in deletions {
+        // Skip files already backed up in the changes loop above (#1111).
+        if changes.iter().any(|(p, _, _)| p == path) {
+            continue;
+        }
+        backup
+            .save_before_delete(path)
+            .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
+    }
+
+    // Finalize before writes so undo can recover from a mid-commit failure.
+    let backup_session = backup
+        .finalize()
+        .map_err(|e| commit_error(format!("finalizing backup session: {e}")))?;
+
+    let noop_policy = WritePolicy::default();
+    let write_result = (|| -> anyhow::Result<()> {
+        for (path, _, new_content) in changes {
+            if deletions.contains(path) {
+                std::fs::remove_file(path)
+                    .with_context(|| format!("deleting {}", path.display()))?;
+            } else {
+                if let Some(parent) = path.parent()
+                    && !parent.as_os_str().is_empty()
+                    && !parent.exists()
+                {
+                    std::fs::create_dir_all(parent)
+                        .with_context(|| format!("creating directory {}", parent.display()))?;
+                }
+                if !existed_before.contains(path) {
+                    atomic_create_new(path, new_content, &noop_policy)?;
+                } else {
+                    atomic_write(path, new_content, &noop_policy)?;
+                }
+            }
+        }
+        for path in deletions {
+            if path.exists() {
+                std::fs::remove_file(path)
+                    .with_context(|| format!("deleting {}", path.display()))?;
+            }
+        }
+        Ok(())
+    })();
+
+    if let Err(e) = write_result {
+        let rollback_ok = if let Some(ref ts) = backup_session {
+            restore_after_failed_commit(cwd, ts)
+        } else {
+            true
+        };
+        return Err(CommitError {
+            message: e.to_string(),
+            rollback_ok,
+            backup_session,
+        });
+    }
+
+    Ok(())
+}

--- a/src/tx/lifecycle/mod.rs
+++ b/src/tx/lifecycle/mod.rs
@@ -1,0 +1,21 @@
+//! Transaction lifecycle: format/validate steps, commit/rollback, plan execution.
+//!
+//! Split for module hygiene (former monofile size-waiver retired). Commit and
+//! rollback stay co-located under [`commit`]; plan execution under [`plan_exec`].
+
+// Re-exports are consumed via `crate::tx::lifecycle::*` and `crate::tx` facades.
+#![allow(unused_imports)]
+
+mod commit;
+mod plan_exec;
+mod steps;
+
+pub use commit::{CommitError, RestoreFailGuard};
+pub use plan_exec::execute_plan_direct;
+
+pub(crate) use commit::{commit_changes, restore_after_failed_commit};
+pub(crate) use plan_exec::validate_and_prepare_plan;
+pub(crate) use steps::{
+    resolve_plan_cwd, restore_collateral_files, rollback_strict, run_format_steps, run_lifecycle,
+    run_validate_steps, snapshot_non_tx_files,
+};

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -1,457 +1,18 @@
-// size-waiver: domain bulk, see #1376. Commit/rollback/plan-prepare lifecycle co-located for atomicity reviewability.
-use super::execute::execute_and_collect;
-use super::output::{
-    TxOutput, build_error_output, build_full_tx_output, describe_exit_status,
-    describe_lifecycle_cwd,
+//! Plan validation/preparation and direct in-process plan execution.
+
+use super::commit::commit_changes;
+use super::steps::{
+    resolve_plan_cwd, restore_collateral_files, rollback_strict, run_lifecycle,
+    snapshot_non_tx_files,
 };
-use super::validate::validate_plan_operations;
 use crate::cli::global::GlobalFlags;
-use crate::exec;
 use crate::plan::{self, Plan};
-use crate::write::{WritePolicy, atomic_create_new, atomic_write};
-use anyhow::Context;
-#[cfg(any(feature = "cli", feature = "files"))]
-use ignore::WalkBuilder;
+use crate::tx::execute::execute_and_collect;
+use crate::tx::output::{TxOutput, build_error_output, build_full_tx_output};
+use crate::tx::validate::validate_plan_operations;
+use crate::tx::verify;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
-
-const DEFAULT_LIFECYCLE_TIMEOUT_SECS: u64 = 60;
-
-// ---------------------------------------------------------------------------
-// Lifecycle helpers (extracted from run() for testability)
-// ---------------------------------------------------------------------------
-
-pub(crate) struct LifecycleError {
-    pub(crate) message: String,
-    pub(crate) kind: &'static str,
-}
-
-/// Format a lifecycle step failure message, appending stderr output if available.
-fn lifecycle_failure_msg(header: &str, stderr: &str) -> String {
-    let trimmed = stderr.trim();
-    if trimmed.is_empty() {
-        header.to_string()
-    } else {
-        format!("{header}: {trimmed}")
-    }
-}
-
-/// Shared runner for format and validation lifecycle steps.
-///
-/// `label` is used in error messages (e.g. "format step" or "required validation").
-/// `error_label` is the shorter variant for the error branch (e.g. "format step" or "validation").
-/// `kind` is the `LifecycleError::kind` string.
-/// `fail_on_error` controls whether non-required failures are fatal.
-fn run_lifecycle_steps(
-    steps: impl Iterator<Item = (String, Option<u64>, bool)>,
-    base_cwd: &Path,
-    cwd: &Path,
-    label: &str,
-    error_label: &str,
-    kind: &'static str,
-) -> Result<(), LifecycleError> {
-    let lifecycle_cwd = describe_lifecycle_cwd(base_cwd, cwd);
-    for (index, (cmd, timeout, required)) in steps.enumerate() {
-        crate::verbose!(
-            "tx: running {} step {}: {:?} (timeout={}s, required={})",
-            label,
-            index + 1,
-            cmd,
-            timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS),
-            required
-        );
-        let timeout_secs = timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
-        let result = exec::run_with_timeout(&cmd, timeout_secs, cwd);
-        match result {
-            Ok(exec::ShellResult {
-                status,
-                stderr_head,
-            }) if !status.success() => {
-                let step_label = if required { label } else { error_label };
-                let header = format!(
-                    "{step_label} failed (step {}, {}, cwd: {})",
-                    index + 1,
-                    describe_exit_status(status),
-                    lifecycle_cwd
-                );
-                let msg = lifecycle_failure_msg(&header, &stderr_head);
-                eprintln!("tx: {msg}");
-                if required {
-                    return Err(LifecycleError { message: msg, kind });
-                }
-            }
-            Err(e) => {
-                let msg = format!(
-                    "{error_label} error (step {}, cwd: {}): {e}",
-                    index + 1,
-                    lifecycle_cwd
-                );
-                eprintln!("tx: {msg}");
-                if required {
-                    return Err(LifecycleError { message: msg, kind });
-                }
-            }
-            _ => {}
-        }
-    }
-    Ok(())
-}
-
-pub(crate) fn run_format_steps(
-    steps: &[plan::FormatStep],
-    base_cwd: &Path,
-    cwd: &Path,
-) -> Result<(), LifecycleError> {
-    run_lifecycle_steps(
-        steps.iter().map(|s| (s.cmd.clone(), s.timeout, true)),
-        base_cwd,
-        cwd,
-        "format step",
-        "format step",
-        "format_failed",
-    )
-}
-
-pub(crate) fn run_validate_steps(
-    steps: &[plan::ValidationStep],
-    base_cwd: &Path,
-    cwd: &Path,
-) -> Result<(), LifecycleError> {
-    run_lifecycle_steps(
-        steps
-            .iter()
-            .map(|s| (s.cmd.clone(), s.timeout, s.required.unwrap_or(false))),
-        base_cwd,
-        cwd,
-        "required validation",
-        "validation",
-        "validation_failed",
-    )
-}
-
-/// Maximum file size (in bytes) to include in the collateral snapshot.
-/// Files above this threshold are extremely unlikely to be reformatted by
-/// standard formatters and snapshotting them wastes memory.
-const COLLATERAL_SNAPSHOT_MAX_SIZE: u64 = 1_048_576; // 1 MiB
-
-/// Snapshot the content of non-binary text files under `cwd` that are NOT
-/// already tracked by the transaction. This captures the pre-format state of
-/// files that a format step (e.g. `cargo fmt`) might modify as a side effect.
-///
-/// Only called when `strict` mode is active and the plan has format or
-/// validate steps, so the cost is opt-in.
-#[cfg(any(feature = "cli", feature = "files"))]
-pub(crate) fn snapshot_non_tx_files(
-    cwd: &Path,
-    tx_paths: &HashSet<PathBuf>,
-) -> HashMap<PathBuf, String> {
-    let mut snapshot = HashMap::new();
-    crate::verbose!(
-        "tx: collateral snapshot: walking {} (tx_paths: {})",
-        cwd.display(),
-        tx_paths.len()
-    );
-    let walker = WalkBuilder::new(cwd).hidden(false).build();
-    for entry in walker.flatten() {
-        let path = entry.path().to_path_buf();
-        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
-            continue;
-        }
-        if tx_paths.contains(&path) {
-            crate::verbose!(
-                "tx: collateral snapshot: skipping tx file {}",
-                path.display()
-            );
-            continue;
-        }
-        // Skip files above the size threshold.
-        if let Ok(meta) = std::fs::metadata(&path)
-            && meta.len() > COLLATERAL_SNAPSHOT_MAX_SIZE
-        {
-            crate::verbose!(
-                "tx: collateral snapshot: skipping large file {} ({} bytes)",
-                path.display(),
-                meta.len()
-            );
-            continue;
-        }
-        // Read bytes and skip binary files.
-        let bytes = match std::fs::read(&path) {
-            Ok(b) => b,
-            Err(_) => continue,
-        };
-        if crate::files::is_binary(&bytes) {
-            continue;
-        }
-        if let Ok(content) = String::from_utf8(bytes) {
-            crate::verbose!(
-                "tx: collateral snapshot: captured {} ({} bytes)",
-                path.display(),
-                content.len()
-            );
-            snapshot.insert(path, content);
-        }
-    }
-    crate::verbose!("tx: collateral snapshot: {} files captured", snapshot.len());
-    snapshot
-}
-
-/// Restore any files that were modified by format/validate steps but were
-/// not part of the transaction. Compares current content against the
-/// snapshot and writes back the original content for any files that changed.
-#[cfg(any(feature = "cli", feature = "files"))]
-pub(crate) fn restore_collateral_files(snapshot: &HashMap<PathBuf, String>) {
-    let noop_policy = WritePolicy::default();
-    let mut restored = 0usize;
-    for (path, original) in snapshot {
-        let current = match std::fs::read_to_string(path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        if current != *original {
-            crate::verbose!(
-                "tx: collateral restore: reverting {} (changed by formatter)",
-                path.display()
-            );
-            if let Err(e) = atomic_write(path, original, &noop_policy) {
-                eprintln!(
-                    "tx: rollback: failed to restore collateral file {}: {e}",
-                    path.display()
-                );
-            } else {
-                restored += 1;
-            }
-        }
-    }
-    if restored > 0 {
-        crate::verbose!("tx: collateral restore: reverted {} file(s)", restored);
-    }
-}
-
-pub(crate) fn rollback_strict(
-    changes: &[(PathBuf, String, String)],
-    pending: &HashMap<PathBuf, (String, String)>,
-    deletions: &HashSet<PathBuf>,
-    existed_before: &HashSet<PathBuf>,
-) {
-    let noop_policy = WritePolicy::default();
-    for (path, original, _) in changes {
-        if !existed_before.contains(path) {
-            // File was created during this tx. Whether it was also deleted
-            // does not matter: it should not exist after rollback.
-            if let Err(e) = std::fs::remove_file(path) {
-                eprintln!(
-                    "tx: rollback: failed to remove created file {}: {e}",
-                    path.display()
-                );
-            }
-        } else if !deletions.contains(path) {
-            // File existed before and was modified (not deleted): restore.
-            if let Err(e) = atomic_write(path, original, &noop_policy) {
-                eprintln!("tx: rollback: failed to restore {}: {e}", path.display());
-            }
-        }
-        // If existed_before AND in deletions: handled by the deletions loop below.
-    }
-    for path in deletions {
-        if let Some((orig, _)) = pending.get(path)
-            && existed_before.contains(path)
-        {
-            // Ensure parent directory exists before restoring; the directory
-            // may have been removed if the deletion was the last file in it.
-            if let Some(parent) = path.parent()
-                && !parent.as_os_str().is_empty()
-                && !parent.exists()
-                && let Err(e) = std::fs::create_dir_all(parent)
-            {
-                eprintln!(
-                    "tx: rollback: failed to create dir {}: {e}",
-                    parent.display()
-                );
-                continue;
-            }
-            if let Err(e) = atomic_write(path, orig, &noop_policy) {
-                eprintln!(
-                    "tx: rollback: failed to restore deleted {}: {e}",
-                    path.display()
-                );
-            }
-        }
-    }
-}
-
-/// Run format and validation lifecycle steps. Returns `None` on success.
-pub(crate) fn run_lifecycle(plan: &Plan, base_cwd: &Path, cwd: &Path) -> Option<LifecycleError> {
-    plan.format
-        .as_deref()
-        .map(|steps| run_format_steps(steps, base_cwd, cwd))
-        .unwrap_or(Ok(()))
-        .err()
-        .or_else(|| {
-            plan.validate
-                .as_deref()
-                .and_then(|steps| run_validate_steps(steps, base_cwd, cwd).err())
-        })
-}
-
-pub(crate) fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathBuf {
-    match plan_cwd {
-        Some(plan_cwd) => {
-            let path = Path::new(plan_cwd);
-            if path.is_absolute() {
-                path.to_path_buf()
-            } else {
-                base_cwd.join(path)
-            }
-        }
-        None => base_cwd.to_path_buf(),
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Direct execution (MCP / in-process callers)
-// ---------------------------------------------------------------------------
-
-/// Failure while committing staged changes to disk.
-#[derive(Debug)]
-pub struct CommitError {
-    pub message: String,
-    pub rollback_ok: bool,
-    pub backup_session: Option<String>,
-}
-
-impl std::fmt::Display for CommitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for CommitError {}
-
-fn commit_error(message: impl Into<String>) -> CommitError {
-    CommitError {
-        message: message.into(),
-        rollback_ok: true,
-        backup_session: None,
-    }
-}
-
-thread_local! {
-    /// Per-thread test hook; never set in production.
-    static FORCE_RESTORE_FAIL: std::sync::atomic::AtomicBool =
-        const { std::sync::atomic::AtomicBool::new(false) };
-}
-
-/// RAII guard that forces restore failure on the current thread only.
-#[doc(hidden)]
-pub struct RestoreFailGuard;
-
-impl RestoreFailGuard {
-    pub fn engage() -> Self {
-        FORCE_RESTORE_FAIL.with(|flag| flag.store(true, std::sync::atomic::Ordering::SeqCst));
-        Self
-    }
-}
-
-impl Drop for RestoreFailGuard {
-    fn drop(&mut self) {
-        FORCE_RESTORE_FAIL.with(|flag| flag.store(false, std::sync::atomic::Ordering::SeqCst));
-    }
-}
-
-/// Restore files from a backup session after a failed commit. Returns `true`
-/// when restore completed successfully.
-pub(crate) fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
-    if FORCE_RESTORE_FAIL.with(|flag| flag.load(std::sync::atomic::Ordering::SeqCst)) {
-        return false;
-    }
-    crate::backup::restore_session(cwd, timestamp).is_ok()
-}
-
-/// Apply pending changes to disk: backup originals, write modified files,
-/// delete removed files, finalize backup session.
-///
-/// If any write fails, restores all already-written files from the backup
-/// session before returning [`CommitError`].
-pub(crate) fn commit_changes(
-    changes: &[(PathBuf, String, String)],
-    deletions: &HashSet<PathBuf>,
-    existed_before: &HashSet<PathBuf>,
-    cwd: &Path,
-) -> Result<(), CommitError> {
-    let mut backup = crate::backup::BackupSession::new(cwd)
-        .map_err(|e| commit_error(format!("starting backup session: {e}")))?;
-    for (path, _, _) in changes {
-        if deletions.contains(path) {
-            backup
-                .save_before_delete(path)
-                .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
-        } else {
-            backup
-                .save_before_write(path)
-                .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
-        }
-    }
-    for path in deletions {
-        // Skip files already backed up in the changes loop above (#1111).
-        if changes.iter().any(|(p, _, _)| p == path) {
-            continue;
-        }
-        backup
-            .save_before_delete(path)
-            .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
-    }
-
-    // Finalize before writes so undo can recover from a mid-commit failure.
-    let backup_session = backup
-        .finalize()
-        .map_err(|e| commit_error(format!("finalizing backup session: {e}")))?;
-
-    let noop_policy = WritePolicy::default();
-    let write_result = (|| -> anyhow::Result<()> {
-        for (path, _, new_content) in changes {
-            if deletions.contains(path) {
-                std::fs::remove_file(path)
-                    .with_context(|| format!("deleting {}", path.display()))?;
-            } else {
-                if let Some(parent) = path.parent()
-                    && !parent.as_os_str().is_empty()
-                    && !parent.exists()
-                {
-                    std::fs::create_dir_all(parent)
-                        .with_context(|| format!("creating directory {}", parent.display()))?;
-                }
-                if !existed_before.contains(path) {
-                    atomic_create_new(path, new_content, &noop_policy)?;
-                } else {
-                    atomic_write(path, new_content, &noop_policy)?;
-                }
-            }
-        }
-        for path in deletions {
-            if path.exists() {
-                std::fs::remove_file(path)
-                    .with_context(|| format!("deleting {}", path.display()))?;
-            }
-        }
-        Ok(())
-    })();
-
-    if let Err(e) = write_result {
-        let rollback_ok = if let Some(ref ts) = backup_session {
-            restore_after_failed_commit(cwd, ts)
-        } else {
-            true
-        };
-        return Err(CommitError {
-            message: e.to_string(),
-            rollback_ok,
-            backup_session,
-        });
-    }
-
-    Ok(())
-}
 
 fn config_tx_strict(cwd: &Path) -> Option<bool> {
     crate::config::find_and_load(cwd)
@@ -551,11 +112,11 @@ pub fn execute_plan_direct(
     #[cfg(feature = "ast")]
     let verify_before = if let Some(ref checks) = plan.verify {
         if !checks.is_empty() {
-            let affected = super::verify::affected_file_paths(&plan, &effective_cwd);
+            let affected = verify::affected_file_paths(&plan, &effective_cwd);
             checks
                 .iter()
                 .map(|check| {
-                    let snap = super::verify::snapshot_symbols(&affected, check);
+                    let snap = verify::snapshot_symbols(&affected, check);
                     (check.clone(), snap)
                 })
                 .collect::<Vec<_>>()
@@ -592,14 +153,13 @@ pub fn execute_plan_direct(
     // Post-execution verification against pending content.
     #[cfg(feature = "ast")]
     if !verify_before.is_empty() {
-        let affected = super::verify::affected_file_paths(&plan, &effective_cwd);
+        let affected = verify::affected_file_paths(&plan, &effective_cwd);
         let mut messages = Vec::new();
         let mut any_failed = false;
         for (check, before_snap) in &verify_before {
             let after_snap =
-                super::verify::snapshot_symbols_from_pending(&affected, &result.pending, check);
-            let vr =
-                super::verify::compare_snapshots(before_snap, &after_snap, check, &effective_cwd);
+                verify::snapshot_symbols_from_pending(&affected, &result.pending, check);
+            let vr = verify::compare_snapshots(before_snap, &after_snap, check, &effective_cwd);
             messages.push(vr.message.clone());
             if !vr.passed {
                 any_failed = true;
@@ -661,6 +221,13 @@ pub fn execute_plan_direct(
 
 #[cfg(test)]
 mod tests {
+    use super::super::commit::{
+        CommitError, FORCE_RESTORE_FAIL, RestoreFailGuard, commit_changes, commit_error,
+    };
+    use super::super::steps::{
+        COLLATERAL_SNAPSHOT_MAX_SIZE, LifecycleError, lifecycle_failure_msg, resolve_plan_cwd,
+        restore_collateral_files, rollback_strict, run_lifecycle, snapshot_non_tx_files,
+    };
     use super::*;
 
     // ---- lifecycle_failure_msg ----

--- a/src/tx/lifecycle/steps.rs
+++ b/src/tx/lifecycle/steps.rs
@@ -1,0 +1,302 @@
+//! Format/validate lifecycle steps, collateral snapshot, and strict rollback.
+
+use crate::exec;
+use crate::plan::{self, Plan};
+use crate::tx::output::{describe_exit_status, describe_lifecycle_cwd};
+use crate::write::{WritePolicy, atomic_write};
+#[cfg(any(feature = "cli", feature = "files"))]
+use ignore::WalkBuilder;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+const DEFAULT_LIFECYCLE_TIMEOUT_SECS: u64 = 60;
+
+// Lifecycle helpers (extracted from run() for testability)
+// ---------------------------------------------------------------------------
+
+pub(crate) struct LifecycleError {
+    pub message: String,
+    pub kind: &'static str,
+}
+
+/// Format a lifecycle step failure message, appending stderr output if available.
+pub(crate) fn lifecycle_failure_msg(header: &str, stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() {
+        header.to_string()
+    } else {
+        format!("{header}: {trimmed}")
+    }
+}
+
+/// Shared runner for format and validation lifecycle steps.
+///
+/// `label` is used in error messages (e.g. "format step" or "required validation").
+/// `error_label` is the shorter variant for the error branch (e.g. "format step" or "validation").
+/// `kind` is the `LifecycleError::kind` string.
+/// `fail_on_error` controls whether non-required failures are fatal.
+fn run_lifecycle_steps(
+    steps: impl Iterator<Item = (String, Option<u64>, bool)>,
+    base_cwd: &Path,
+    cwd: &Path,
+    label: &str,
+    error_label: &str,
+    kind: &'static str,
+) -> Result<(), LifecycleError> {
+    let lifecycle_cwd = describe_lifecycle_cwd(base_cwd, cwd);
+    for (index, (cmd, timeout, required)) in steps.enumerate() {
+        crate::verbose!(
+            "tx: running {} step {}: {:?} (timeout={}s, required={})",
+            label,
+            index + 1,
+            cmd,
+            timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS),
+            required
+        );
+        let timeout_secs = timeout.unwrap_or(DEFAULT_LIFECYCLE_TIMEOUT_SECS);
+        let result = exec::run_with_timeout(&cmd, timeout_secs, cwd);
+        match result {
+            Ok(exec::ShellResult {
+                status,
+                stderr_head,
+            }) if !status.success() => {
+                let step_label = if required { label } else { error_label };
+                let header = format!(
+                    "{step_label} failed (step {}, {}, cwd: {})",
+                    index + 1,
+                    describe_exit_status(status),
+                    lifecycle_cwd
+                );
+                let msg = lifecycle_failure_msg(&header, &stderr_head);
+                eprintln!("tx: {msg}");
+                if required {
+                    return Err(LifecycleError { message: msg, kind });
+                }
+            }
+            Err(e) => {
+                let msg = format!(
+                    "{error_label} error (step {}, cwd: {}): {e}",
+                    index + 1,
+                    lifecycle_cwd
+                );
+                eprintln!("tx: {msg}");
+                if required {
+                    return Err(LifecycleError { message: msg, kind });
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn run_format_steps(
+    steps: &[plan::FormatStep],
+    base_cwd: &Path,
+    cwd: &Path,
+) -> Result<(), LifecycleError> {
+    run_lifecycle_steps(
+        steps.iter().map(|s| (s.cmd.clone(), s.timeout, true)),
+        base_cwd,
+        cwd,
+        "format step",
+        "format step",
+        "format_failed",
+    )
+}
+
+pub(crate) fn run_validate_steps(
+    steps: &[plan::ValidationStep],
+    base_cwd: &Path,
+    cwd: &Path,
+) -> Result<(), LifecycleError> {
+    run_lifecycle_steps(
+        steps
+            .iter()
+            .map(|s| (s.cmd.clone(), s.timeout, s.required.unwrap_or(false))),
+        base_cwd,
+        cwd,
+        "required validation",
+        "validation",
+        "validation_failed",
+    )
+}
+
+/// Maximum file size (in bytes) to include in the collateral snapshot.
+/// Files above this threshold are extremely unlikely to be reformatted by
+/// standard formatters and snapshotting them wastes memory.
+pub(crate) const COLLATERAL_SNAPSHOT_MAX_SIZE: u64 = 1_048_576; // 1 MiB
+
+/// Snapshot the content of non-binary text files under `cwd` that are NOT
+/// already tracked by the transaction. This captures the pre-format state of
+/// files that a format step (e.g. `cargo fmt`) might modify as a side effect.
+///
+/// Only called when `strict` mode is active and the plan has format or
+/// validate steps, so the cost is opt-in.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub(crate) fn snapshot_non_tx_files(
+    cwd: &Path,
+    tx_paths: &HashSet<PathBuf>,
+) -> HashMap<PathBuf, String> {
+    let mut snapshot = HashMap::new();
+    crate::verbose!(
+        "tx: collateral snapshot: walking {} (tx_paths: {})",
+        cwd.display(),
+        tx_paths.len()
+    );
+    let walker = WalkBuilder::new(cwd).hidden(false).build();
+    for entry in walker.flatten() {
+        let path = entry.path().to_path_buf();
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+        if tx_paths.contains(&path) {
+            crate::verbose!(
+                "tx: collateral snapshot: skipping tx file {}",
+                path.display()
+            );
+            continue;
+        }
+        // Skip files above the size threshold.
+        if let Ok(meta) = std::fs::metadata(&path)
+            && meta.len() > COLLATERAL_SNAPSHOT_MAX_SIZE
+        {
+            crate::verbose!(
+                "tx: collateral snapshot: skipping large file {} ({} bytes)",
+                path.display(),
+                meta.len()
+            );
+            continue;
+        }
+        // Read bytes and skip binary files.
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        if crate::files::is_binary(&bytes) {
+            continue;
+        }
+        if let Ok(content) = String::from_utf8(bytes) {
+            crate::verbose!(
+                "tx: collateral snapshot: captured {} ({} bytes)",
+                path.display(),
+                content.len()
+            );
+            snapshot.insert(path, content);
+        }
+    }
+    crate::verbose!("tx: collateral snapshot: {} files captured", snapshot.len());
+    snapshot
+}
+
+/// Restore any files that were modified by format/validate steps but were
+/// not part of the transaction. Compares current content against the
+/// snapshot and writes back the original content for any files that changed.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub(crate) fn restore_collateral_files(snapshot: &HashMap<PathBuf, String>) {
+    let noop_policy = WritePolicy::default();
+    let mut restored = 0usize;
+    for (path, original) in snapshot {
+        let current = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if current != *original {
+            crate::verbose!(
+                "tx: collateral restore: reverting {} (changed by formatter)",
+                path.display()
+            );
+            if let Err(e) = atomic_write(path, original, &noop_policy) {
+                eprintln!(
+                    "tx: rollback: failed to restore collateral file {}: {e}",
+                    path.display()
+                );
+            } else {
+                restored += 1;
+            }
+        }
+    }
+    if restored > 0 {
+        crate::verbose!("tx: collateral restore: reverted {} file(s)", restored);
+    }
+}
+
+pub(crate) fn rollback_strict(
+    changes: &[(PathBuf, String, String)],
+    pending: &HashMap<PathBuf, (String, String)>,
+    deletions: &HashSet<PathBuf>,
+    existed_before: &HashSet<PathBuf>,
+) {
+    let noop_policy = WritePolicy::default();
+    for (path, original, _) in changes {
+        if !existed_before.contains(path) {
+            // File was created during this tx. Whether it was also deleted
+            // does not matter: it should not exist after rollback.
+            if let Err(e) = std::fs::remove_file(path) {
+                eprintln!(
+                    "tx: rollback: failed to remove created file {}: {e}",
+                    path.display()
+                );
+            }
+        } else if !deletions.contains(path) {
+            // File existed before and was modified (not deleted): restore.
+            if let Err(e) = atomic_write(path, original, &noop_policy) {
+                eprintln!("tx: rollback: failed to restore {}: {e}", path.display());
+            }
+        }
+        // If existed_before AND in deletions: handled by the deletions loop below.
+    }
+    for path in deletions {
+        if let Some((orig, _)) = pending.get(path)
+            && existed_before.contains(path)
+        {
+            // Ensure parent directory exists before restoring; the directory
+            // may have been removed if the deletion was the last file in it.
+            if let Some(parent) = path.parent()
+                && !parent.as_os_str().is_empty()
+                && !parent.exists()
+                && let Err(e) = std::fs::create_dir_all(parent)
+            {
+                eprintln!(
+                    "tx: rollback: failed to create dir {}: {e}",
+                    parent.display()
+                );
+                continue;
+            }
+            if let Err(e) = atomic_write(path, orig, &noop_policy) {
+                eprintln!(
+                    "tx: rollback: failed to restore deleted {}: {e}",
+                    path.display()
+                );
+            }
+        }
+    }
+}
+
+/// Run format and validation lifecycle steps. Returns `None` on success.
+pub(crate) fn run_lifecycle(plan: &Plan, base_cwd: &Path, cwd: &Path) -> Option<LifecycleError> {
+    plan.format
+        .as_deref()
+        .map(|steps| run_format_steps(steps, base_cwd, cwd))
+        .unwrap_or(Ok(()))
+        .err()
+        .or_else(|| {
+            plan.validate
+                .as_deref()
+                .and_then(|steps| run_validate_steps(steps, base_cwd, cwd).err())
+        })
+}
+
+pub(crate) fn resolve_plan_cwd(base_cwd: &Path, plan_cwd: Option<&str>) -> PathBuf {
+    match plan_cwd {
+        Some(plan_cwd) => {
+            let path = Path::new(plan_cwd);
+            if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                base_cwd.join(path)
+            }
+        }
+        None => base_cwd.to_path_buf(),
+    }
+}


### PR DESCRIPTION
## Summary

Finishes the remaining rewrite-quality architecture steps after #1388–#1390:

### 1. `tx/lifecycle` module tree
- `steps.rs` — format/validate, collateral snapshot, strict rollback
- `commit.rs` — backup commit / restore-fail guard
- `plan_exec.rs` — validate/prepare + `execute_plan_direct`
- Former monofile size-waiver removed (all parts under budget)

### 2. Schema-aware `explain`
- Split into `cmd/explain/{mod,describe}.rs`
- JSON output per op: `op` (serde tag), `catalog` (from `schema::operation_description`), `description` (rich fields)
- Keeps detailed human one-liners; aligns explain with schema/MCP naming

### 3. MCP registry growth
- `fix_whitespace` is now registry-generated from `tidy.fix`
- Agent defaults (trim + final newline) applied in `handle_simple_op` when fields omitted
- Removed hand-written `TidyParams` handler

## Verification

- `make check-fast` green

Ref #1376
Ref #1383