### PR TITLE
docs: MCP surface honesty (registry default, justified custom)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,10 +82,9 @@ src/
                        generator, and inline Completions command
   cmd/append.rs        Append content to an existing file
   cmd/batch.rs         Line-oriented batch operations, parses positional args, delegates to tx engine
-  cmd/mcp/mod.rs       MCP server (feature-gated): 21 auto-generated tools via MCP_TOOL_REGISTRY +
-                       33 hand-written #[tool] handlers, dynamic registration via ToolRoute::new_dyn()
-  cmd/mcp/params.rs    Parameter structs for hand-written MCP tool handlers only; simple tools use
-                       Operation variant schemas directly via operation_variant_schema()
+  cmd/mcp/             MCP server (feature-gated): registry (1:1 Operation tools) + hand-written
+                       handlers. Surface policy and custom-tool inventory: mcp/surface.rs
+                       (registry default; custom must be justified). Dynamic ToolRoute registration.
   cmd/search.rs        Literal/regex search across files with context, count, files-with-matches, -i
   cmd/replace.rs       Literal/regex string replacement with diff preview, --nth, -i, atomic write
   cmd/delete.rs        Delete a file (with --apply/--check modes)
@@ -309,11 +308,18 @@ When adding a field to the `Plan` struct in `src/plan/mod.rs`:
 
 ## Adding a new MCP tool
 
-MCP tools live in `src/cmd/mcp/mod.rs` behind the `mcp` feature gate. There are two paths depending on whether the tool maps 1:1 to an existing `Operation` variant.
+MCP tools live under `src/cmd/mcp/` behind the `mcp` feature gate.
+
+### Surface policy (registry default, custom exception)
+
+| Path | When to use | Where |
+|------|-------------|--------|
+| **A. Registry** | 1:1 mapping to a write `plan::Operation`, no multi-file preflight, no multi-op batch, no non-plan read UX | `MCP_TOOL_REGISTRY` in `registry.rs` |
+| **B. Custom** | Multi-file scan, batch/plan, readonly query, AST analyze/mutate, patch conflict UX, server meta | `handlers.rs` / `ast_tools.rs` **and** a row in `surface::CUSTOM_MCP_TOOLS` |
+
+**Do not** move search, batch, `execute_plan`, or AST-read tools into the registry just to reduce the custom count. The metric is “no *unjustified* custom tools,” not “zero custom tools.” Inventory and tests live in [`src/cmd/mcp/surface.rs`](src/cmd/mcp/surface.rs).
 
 ### Path A: Auto-generated tool (1:1 Operation mapping)
-
-If the new tool directly maps to a single `plan::Operation` variant with no custom logic:
 
 1. **Ensure the op is in the schema `OpMeta` registry** (`src/schema.rs`) with description + example.
 2. **Add an entry to `MCP_TOOL_REGISTRY`** in `src/cmd/mcp/registry.rs`:
@@ -328,46 +334,28 @@ McpToolMeta {
 },
 ```
 
-The tool description is built by `schema::mcp_tool_description(op_name, extra)` (registry base + optional extra + example). The input schema is auto-derived from the `Operation` variant via `operation_variant_schema()`. The handler is `handle_simple_op()`, which injects the `op` discriminator, validates fields, and deserializes into `Operation`.
+The tool description is built by `schema::mcp_tool_description(op_name, extra)`. The input schema is auto-derived via `operation_variant_schema()`. The handler is `handle_simple_op()`.
 
-3. **Add the tool name** to the `mcp_lists_expected_tools` test and update the expected count.
-
-4. **Add integration tests** in `tests/integration.rs` under `#[cfg(feature = "mcp")]`.
-
-5. **Update the tool list** in `src/cmd/mod.rs` (agent-rules generator) and `docs/getting-started/mcp-setup.md`.
-
+3. **Update** `mcp_lists_expected_tools` total count and `surface` tests if totals change.
+4. **Add integration tests** under `#[cfg(feature = "mcp")]` as needed.
+5. **Update** agent-rules / `docs/getting-started/mcp-setup.md` tool tables.
 6. Run `make sync-patchloom-md && make update-readme && make check`.
 
-### Path B: Custom hand-written tool (complex logic)
+### Path B: Custom hand-written tool
 
-If the tool needs custom validation, multi-operation plans, or read-only CLI delegation:
+1. **Define a params struct** in `src/cmd/mcp/params.rs` (`Deserialize` + `schemars::JsonSchema`).
+2. **Add a `#[tool]` handler** in `src/cmd/mcp/handlers.rs` (AST: thin stub + `ast_tools`).
+3. **Add a row to `CUSTOM_MCP_TOOLS`** in `src/cmd/mcp/surface.rs` with a one-line `why` (required).
+4. Follow Path A steps 3–6 for counts, tests, and docs.
 
-1. **Define a params struct** in `src/cmd/mcp/params.rs` with `Deserialize` and `schemars::JsonSchema`.
-
-2. **Add a handler method** in the `#[tool_router] impl PatchloomService` block in `src/cmd/mcp/mod.rs`:
-
-```rust
-#[tool(description = "Short description of what the tool does.")]
-async fn new_tool(
-    &self,
-    Parameters(p): Parameters<NewToolParams>,
-) -> Result<CallToolResult, McpError> {
-    self.check_path(&p.path)?;
-    // For write tools: build an Operation and call execute_plan()
-    // For read-only tools: call run_readonly_command()
-}
-```
-
-3. Follow steps 2-5 from Path A above.
-
-**PR body requirement (see #819):** When opening the PR for this MCP tool work, ensure the body contains `Closes #NNN` (or `Fixes`) lines for every targeted issue. Follow-up changes after base merges commonly miss this; edit the PR body explicitly.
+**PR body requirement (see #819):** include `Closes #NNN` / `Fixes #NNN` in the PR body for every resolved issue.
 
 ## Removing an MCP tool
 
-1. **For auto-generated tools:** Remove the `McpToolMeta` entry from `MCP_TOOL_REGISTRY` in `src/cmd/mcp/mod.rs`.
-   **For custom tools:** Remove the handler method from `src/cmd/mcp/mod.rs` and the params struct from `src/cmd/mcp/params.rs`.
+1. **For auto-generated tools:** Remove the `McpToolMeta` entry from `MCP_TOOL_REGISTRY` in `src/cmd/mcp/registry.rs`.
+   **For custom tools:** Remove the handler from `handlers.rs` / `ast_tools.rs`, the params struct from `params.rs`, and the row from `surface::CUSTOM_MCP_TOOLS`.
 
-2. **Remove the tool name** from the `mcp_lists_expected_tools` test and update the expected count.
+2. **Remove the tool name** from the `mcp_lists_expected_tools` test and update the expected total (and surface tests).
 
 3. **Remove integration tests** for the tool from `tests/integration.rs`.
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -75,6 +75,17 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 
 ## Available tools
 
+Patchloom exposes **two registration paths** for MCP tools (see
+`src/cmd/mcp/surface.rs` for the inventory and policy):
+
+| Path | Rule | Examples |
+|------|------|----------|
+| **Registry** (default) | 1:1 with a plan write `Operation`; schema from the variant | `doc_set`, `create_file`, `fix_whitespace`, most `md_*` writers |
+| **Custom** (justified exception) | Multi-file scan, multi-op/batch/plan, readonly query, AST analyze, patch/meta | `search_files`, `replace_text`, `batch_*`, `execute_plan`, `doc_get` / `doc_query`, all `ast_*` |
+
+Prefer the registry for new simple write tools. Do not force custom tools into
+the registry when that would lose multi-file, batch, or read UX.
+
 | Tool | Description |
 |------|-------------|
 | `doc_set` | Set a value by selector path in a JSON, YAML, or TOML file |
@@ -129,7 +140,7 @@ Any MCP client that supports stdio transport can connect by spawning `patchloom 
 | `ast_reorder` | Reorder symbols by strategy: alphabetical, reverse, kind-first, or custom order. |
 | `ast_group` | Move symbols into a new or existing module block within the same file. |
 | `ast_move` | Move symbols between files with configurable insertion position. |
-| `ast_extract` | Extract a symbol to a new file, optionally unwrapping module blocks. |
+| `ast_extract_to_file` | Extract a symbol to a new file, optionally unwrapping module blocks. |
 | `ast_split` | Split a file by distributing symbols across multiple target files. |
 
 ## How MCP mode differs from CLI mode

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -3,6 +3,10 @@
 //! Contains the `#[tool_router] impl PatchloomService` block with all
 //! `#[tool(...)]` handler methods that require custom logic beyond the
 //! auto-generated `MCP_TOOL_REGISTRY` dispatch.
+//!
+//! **Every tool in this module must appear in
+//! [`super::surface::CUSTOM_MCP_TOOLS`] with a reason.** Prefer the registry
+//! for new 1:1 `Operation` writes. See `surface` module docs for the policy.
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -9,10 +9,19 @@
 //!
 //! - [`validation`] - Resource limits and input validation helpers.
 //! - [`registry`]   - Auto-generated tool registry (1:1 Operation mappings).
-//! - [`handlers`]   - Hand-written `#[tool]` handler implementations.
+//! - [`surface`]    - Registry vs custom tool inventory (MCP surface honesty).
+//! - [`handlers`]   - Hand-written `#[tool]` handlers (must be listed in `surface`).
 //! - [`transport`]  - `ServerHandler` impl and server startup (stdio/HTTP).
 //! - [`params`]     - Parameter structs for hand-written MCP tools.
 //! - [`ast_tools`]  - AST MCP handler implementations (feature-gated).
+//!
+//! ## Surface policy
+//!
+//! **Registry is the default** for 1:1 write `Operation` tools. **Custom
+//! handlers are the exception** and must be justified in
+//! [`surface::CUSTOM_MCP_TOOLS`]. Do not migrate multi-file search/replace,
+//! batch tools, full plans, or AST analyze tools into the registry just to
+//! shrink the custom count.
 
 use rmcp::handler::server::router::tool::{ToolRoute, ToolRouter};
 use rmcp::handler::server::tool::ToolCallContext;
@@ -31,6 +40,7 @@ use crate::plan::{Operation, Plan};
 mod handlers;
 mod params;
 mod registry;
+mod surface;
 mod transport;
 mod validation;
 

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -1,4 +1,8 @@
 //! Auto-generated MCP tool registry mapping Operation variants to MCP tools.
+//!
+//! This is the **default** path for new write tools that map 1:1 to a plan
+//! [`crate::plan::Operation`]. Tools that cannot use this path are listed in
+//! [`super::surface::CUSTOM_MCP_TOOLS`] (MCP surface honesty).
 
 use rmcp::model::{CallToolResult, ErrorData as McpError};
 

--- a/src/cmd/mcp/surface.rs
+++ b/src/cmd/mcp/surface.rs
@@ -1,0 +1,282 @@
+//! MCP tool surface map: registry default vs justified custom tools.
+//!
+//! # Policy (MCP surface honesty)
+//!
+//! - **Default:** add tools via [`super::registry::MCP_TOOL_REGISTRY`] when the
+//!   tool is a 1:1 mapping to a plan [`crate::plan::Operation`] with no special
+//!   multi-file preflight, multi-op batching, or non-plan read UX.
+//! - **Custom (hand-written `#[tool]`):** only when the tool is *not* a simple
+//!   Operation write. Every custom tool must appear in
+//!   [`CUSTOM_MCP_TOOLS`] with a one-line reason.
+//! - **Metric:** "no unjustified custom tools," not "fewer custom tools."
+//!   Forcing search/batch/AST-read into the registry would fight agent UX.
+//!
+//! Counts (with default features, including `ast`):
+//! registry + custom = total tools exposed by `list_tools`.
+//!
+//! Inventory is consumed by unit tests and documentation; it is intentionally
+//! not wired into every production call path.
+
+// Inventory for tests/docs; not every item is referenced outside `#[cfg(test)]`.
+#![allow(dead_code)]
+
+/// Why a tool is hand-written instead of registry-generated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CustomMcpTool {
+    pub name: &'static str,
+    /// One-line justification (stable; tested for presence, not exact wording drift).
+    pub why: &'static str,
+    pub kind: CustomKind,
+}
+
+/// Coarse category for custom tools (documentation + tests).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CustomKind {
+    /// Read-only structured doc queries (not write Operations).
+    DocReadonly,
+    /// Multi-file / parallel / CLI-shaped search or replace.
+    MultiFileOrScan,
+    /// Multi-op batch or full plan execution.
+    MultiOp,
+    /// Markdown helpers that need custom output or non-registry shapes.
+    MdCustom,
+    /// Patch apply with conflict/stale UX.
+    Patch,
+    /// AST analyze/mutate via tree-sitter (mostly non-plan or custom resolve).
+    Ast,
+    /// Server metadata / workspace discovery.
+    Meta,
+}
+
+/// Authoritative list of hand-written MCP tools and why they are not registry tools.
+///
+/// When adding a custom `#[tool]` handler, add a row here in the same PR.
+/// When moving a tool to the registry, remove its row here.
+pub(super) const CUSTOM_MCP_TOOLS: &[CustomMcpTool] = &[
+    // --- Doc readonly ---
+    CustomMcpTool {
+        name: "doc_get",
+        why: "readonly doc get; not a write Operation",
+        kind: CustomKind::DocReadonly,
+    },
+    CustomMcpTool {
+        name: "doc_query",
+        why: "readonly multi-action query (has/keys/len/select/flatten)",
+        kind: CustomKind::DocReadonly,
+    },
+    CustomMcpTool {
+        name: "doc_diff",
+        why: "readonly structured file compare",
+        kind: CustomKind::DocReadonly,
+    },
+    // --- Multi-file / scan ---
+    CustomMcpTool {
+        name: "search_files",
+        why: "multi-path search with layered ignores and report modes",
+        kind: CustomKind::MultiFileOrScan,
+    },
+    CustomMcpTool {
+        name: "replace_text",
+        why: "parallel multi-file scan + precomputed engine handoff",
+        kind: CustomKind::MultiFileOrScan,
+    },
+    // --- Multi-op ---
+    CustomMcpTool {
+        name: "batch_replace",
+        why: "builds multi-file replace batch, not one Operation",
+        kind: CustomKind::MultiOp,
+    },
+    CustomMcpTool {
+        name: "batch_tidy",
+        why: "builds multi-file tidy batch, not one Operation",
+        kind: CustomKind::MultiOp,
+    },
+    CustomMcpTool {
+        name: "execute_plan",
+        why: "full transaction plan (inline or path), not one Operation",
+        kind: CustomKind::MultiOp,
+    },
+    // --- Md custom ---
+    CustomMcpTool {
+        name: "md_move_section",
+        why: "cross-file section move + custom result shape",
+        kind: CustomKind::MdCustom,
+    },
+    CustomMcpTool {
+        name: "md_lint",
+        why: "readonly AGENTS.md lint; not a write Operation",
+        kind: CustomKind::MdCustom,
+    },
+    // --- Patch ---
+    CustomMcpTool {
+        name: "apply_patch",
+        why: "unified-diff apply with stale/conflict exit mapping",
+        kind: CustomKind::Patch,
+    },
+    // --- Meta ---
+    CustomMcpTool {
+        name: "git_status",
+        why: "readonly git status vs HEAD",
+        kind: CustomKind::Meta,
+    },
+    CustomMcpTool {
+        name: "server_info",
+        why: "server/workspace metadata for agents",
+        kind: CustomKind::Meta,
+    },
+    // --- AST (feature-gated at registration; always listed here) ---
+    CustomMcpTool {
+        name: "ast_list",
+        why: "AST symbol listing (analyze, not plan write)",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_read",
+        why: "AST symbol body read",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_rename",
+        why: "AST multi-file rename with scan/filter then stage",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_validate",
+        why: "AST syntax validation report",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_search",
+        why: "structural AST search",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_refs",
+        why: "cross-file symbol references",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_deps",
+        why: "import/dependency extraction",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_map",
+        why: "repo map / PageRank over symbols",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_diff",
+        why: "structural symbol diff across git refs",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_impact",
+        why: "transitive impact analysis",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_replace",
+        why: "symbol-scoped replace with custom resolve/output",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_insert",
+        why: "AST insert with position/container resolve",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_wrap",
+        why: "AST wrap with container resolve",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_imports",
+        why: "import list/add/remove/dedupe actions",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_reorder",
+        why: "symbol reorder strategies",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_group",
+        why: "group symbols into module blocks",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_move",
+        why: "move symbols across files",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_extract_to_file",
+        why: "extract symbol to new file",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
+        name: "ast_split",
+        why: "split file across targets by symbols",
+        kind: CustomKind::Ast,
+    },
+];
+
+/// Names of custom tools (for set algebra in tests).
+pub(super) fn custom_tool_names() -> impl Iterator<Item = &'static str> {
+    CUSTOM_MCP_TOOLS.iter().map(|t| t.name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::registry::MCP_TOOL_REGISTRY;
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn custom_tool_names_are_unique() {
+        let mut seen = BTreeSet::new();
+        for t in CUSTOM_MCP_TOOLS {
+            assert!(
+                seen.insert(t.name),
+                "duplicate custom tool name: {}",
+                t.name
+            );
+            assert!(!t.why.is_empty(), "{} missing why", t.name);
+        }
+    }
+
+    #[test]
+    fn registry_and_custom_are_disjoint() {
+        let registry: BTreeSet<_> = MCP_TOOL_REGISTRY.iter().map(|t| t.tool_name).collect();
+        let custom: BTreeSet<_> = custom_tool_names().collect();
+        let overlap: Vec<_> = registry.intersection(&custom).copied().collect();
+        assert!(
+            overlap.is_empty(),
+            "tool(s) listed as both registry and custom: {overlap:?}"
+        );
+    }
+
+    #[test]
+    fn registry_plus_custom_count_matches_list_tools_expectation() {
+        // With default features, ast tools are registered (see mcp_lists_expected_tools).
+        let registry_n = MCP_TOOL_REGISTRY.len();
+        let custom_n = CUSTOM_MCP_TOOLS.len();
+        assert_eq!(
+            registry_n + custom_n,
+            54,
+            "registry ({registry_n}) + custom ({custom_n}) must equal total MCP tools (54)"
+        );
+    }
+
+    #[test]
+    fn fix_whitespace_is_registry_not_custom() {
+        // Regression: fix_whitespace was promoted to registry (#1391 honesty target).
+        assert!(
+            MCP_TOOL_REGISTRY
+                .iter()
+                .any(|t| t.tool_name == "fix_whitespace")
+        );
+        assert!(!custom_tool_names().any(|n| n == "fix_whitespace"));
+    }
+}


### PR DESCRIPTION
## Summary

MCP surface honesty pass: make the dual registration path **intentional and enforced**, not an accidental evolution.

### Policy
- **Default:** `MCP_TOOL_REGISTRY` for 1:1 write `Operation` tools
- **Exception:** hand-written `#[tool]` only when multi-file, multi-op, readonly, AST, patch/meta UX requires it
- **Metric:** no *unjustified* custom tools (not “zero custom tools”)

### Code
- New [`src/cmd/mcp/surface.rs`](src/cmd/mcp/surface.rs): `CUSTOM_MCP_TOOLS` inventory with `why` + `CustomKind`
- Unit tests: unique names, disjoint from registry, registry+custom = 54, `fix_whitespace` stays registry

### Docs
- AGENTS: surface policy table; Path A/B updated; remove/add steps mention `surface.rs`
- `docs/getting-started/mcp-setup.md`: registry vs custom table; `ast_extract_to_file` name fix
- Module docs on `mcp/mod.rs`, `registry.rs`, `handlers.rs`

## Verification

- `make check-fast` green
- `cargo test --lib mcp::surface --all-features`

No tool behavior changes.