### PR TITLE
test: lock MCP surface set equality and finalize_report modes

### DIFF
--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -121,12 +121,30 @@ mod basic {
             "missing ast_extract_to_file tool"
         );
         assert!(names.contains(&"ast_split"), "missing ast_split tool");
-        // 21 auto-generated (registry) + 33 hand-written (#[tool]) = 54
         assert!(
             names.contains(&"md_dedupe_headings"),
             "missing md_dedupe_headings tool"
         );
-        assert_eq!(names.len(), 54, "expected 54 tools, got {}", names.len());
+        // Surface honesty: live list_tools must equal registry ∪ CUSTOM_MCP_TOOLS.
+        // (Counts: registry 22 + custom 32 = 54 with default features / ast.)
+        {
+            use super::super::registry::MCP_TOOL_REGISTRY;
+            use super::super::surface::{CUSTOM_MCP_TOOLS, custom_tool_names};
+            use std::collections::BTreeSet;
+
+            let live: BTreeSet<&str> = names.iter().copied().collect();
+            let mut expected: BTreeSet<&str> =
+                MCP_TOOL_REGISTRY.iter().map(|t| t.tool_name).collect();
+            expected.extend(custom_tool_names());
+            assert_eq!(
+                live,
+                expected,
+                "list_tools drifted from surface inventory.\nonly live: {:?}\nonly inventory: {:?}",
+                live.difference(&expected).collect::<Vec<_>>(),
+                expected.difference(&live).collect::<Vec<_>>(),
+            );
+            assert_eq!(CUSTOM_MCP_TOOLS.len() + MCP_TOOL_REGISTRY.len(), live.len());
+        }
         client.cancel().await.unwrap();
     }
 

--- a/src/cmd/write_mode.rs
+++ b/src/cmd/write_mode.rs
@@ -420,4 +420,87 @@ mod tests {
         assert_eq!(checks.load(Ordering::SeqCst), 1);
         assert!(!dir.path().join("f.txt").exists());
     }
+
+    #[test]
+    fn finalize_report_apply_commits_and_runs_apply_hook() {
+        use crate::plan::Operation;
+        use crate::tx::engine::{ExecuteOptions, WriteRequest, WriteSource, stage};
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let options = ExecuteOptions::from_global(dir.path(), &global, None);
+        let report = stage(WriteRequest {
+            source: WriteSource::Operations(vec![Operation::FileCreate {
+                path: "applied.txt".to_string(),
+                content: "ok\n".to_string(),
+                force: None,
+            }]),
+            options,
+        })
+        .unwrap();
+
+        let applied_hook = AtomicBool::new(false);
+        let code = finalize_report(
+            &global,
+            dir.path(),
+            report,
+            true,
+            |_g, _, _| panic!("check must not run"),
+            |_g, has, diffs, _plain| {
+                assert!(has);
+                assert!(!diffs.is_empty());
+                applied_hook.store(true, Ordering::SeqCst);
+                Ok(())
+            },
+            |_g, _, _, _| panic!("preview must not run"),
+            |_| {},
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(applied_hook.load(Ordering::SeqCst));
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("applied.txt")).unwrap(),
+            "ok\n"
+        );
+    }
+
+    #[test]
+    fn finalize_report_preview_does_not_commit_without_apply() {
+        use crate::plan::Operation;
+        use crate::tx::engine::{ExecuteOptions, WriteRequest, WriteSource, stage};
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let options = ExecuteOptions::from_global(dir.path(), &global, None);
+        let report = stage(WriteRequest {
+            source: WriteSource::Operations(vec![Operation::FileCreate {
+                path: "preview.txt".to_string(),
+                content: "p\n".to_string(),
+                force: None,
+            }]),
+            options,
+        })
+        .unwrap();
+
+        let code = finalize_report(
+            &global,
+            dir.path(),
+            report,
+            true,
+            |_g, _, _| panic!("check must not run"),
+            |_g, _, _, _| panic!("apply must not run"),
+            |_g, has, _d, _p| {
+                assert!(has);
+                Ok(())
+            },
+            |_| {},
+            |_| {},
+        )
+        .unwrap();
+        assert_eq!(code, exit::CHANGES_DETECTED);
+        assert!(!dir.path().join("preview.txt").exists());
+    }
 }


### PR DESCRIPTION
## Summary

MPI cycle 1 (QA / Spec / write-path contract) on a post-rewrite main:

1. **MCP surface honesty enforcement:** `mcp_lists_expected_tools` now asserts the live tool set equals `MCP_TOOL_REGISTRY ∪ CUSTOM_MCP_TOOLS` (set equality, not only `len == 54`). Catches tools registered in handlers but missing from the inventory (or the reverse).
2. **finalize_report mode tests:** apply commits and invokes the apply hook; default preview does not commit and returns `CHANGES_DETECTED`.

## Verification

- `make check-fast` green
- `cargo test --lib finalize_report --all-features`
- `cargo test --lib mcp_lists_expected --all-features`

## Gate notes

- Release PR **#1313** (patchloom 0.10.0) left open; not merged (needs explicit approval).
- Open issues remain dist-only / external (#632-634, #960-963).