### PR TITLE
fix: feature-gate custom MCP inventory to match list_tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,7 +316,7 @@ MCP tools live under `src/cmd/mcp/` behind the `mcp` feature gate.
 | Path | When to use | Where |
 |------|-------------|--------|
 | **A. Registry** | 1:1 mapping to a write `plan::Operation`, no multi-file preflight, no multi-op batch, no non-plan read UX | `MCP_TOOL_REGISTRY` in `registry.rs` |
-| **B. Custom** | Multi-file scan, batch/plan, readonly query, AST analyze/mutate, patch conflict UX, server meta | `handlers.rs` / `ast_tools.rs` **and** a row in `surface::CUSTOM_MCP_TOOLS` |
+| **B. Custom** | Multi-file scan, batch/plan, readonly query, AST analyze/mutate, patch conflict UX, server meta | `handlers.rs` / `ast_tools.rs` **and** a row in `surface::CUSTOM_MCP_TOOLS_CORE` or `_AST` (feature-gated) |
 
 **Do not** move search, batch, `execute_plan`, or AST-read tools into the registry just to reduce the custom count. The metric is “no *unjustified* custom tools,” not “zero custom tools.” Inventory and tests live in [`src/cmd/mcp/surface.rs`](src/cmd/mcp/surface.rs).
 
@@ -346,7 +346,7 @@ The tool description is built by `schema::mcp_tool_description(op_name, extra)`.
 
 1. **Define a params struct** in `src/cmd/mcp/params.rs` (`Deserialize` + `schemars::JsonSchema`).
 2. **Add a `#[tool]` handler** in `src/cmd/mcp/handlers.rs` (AST: thin stub + `ast_tools`).
-3. **Add a row to `CUSTOM_MCP_TOOLS`** in `src/cmd/mcp/surface.rs` with a one-line `why` (required).
+3. **Add a row** to `CUSTOM_MCP_TOOLS_CORE` or `CUSTOM_MCP_TOOLS_AST` in `src/cmd/mcp/surface.rs` with a one-line `why` (required; AST-gated tools go in `_AST`).
 4. Follow Path A steps 3–6 for counts, tests, and docs.
 
 **PR body requirement (see #819):** include `Closes #NNN` / `Fixes #NNN` in the PR body for every resolved issue.
@@ -354,7 +354,7 @@ The tool description is built by `schema::mcp_tool_description(op_name, extra)`.
 ## Removing an MCP tool
 
 1. **For auto-generated tools:** Remove the `McpToolMeta` entry from `MCP_TOOL_REGISTRY` in `src/cmd/mcp/registry.rs`.
-   **For custom tools:** Remove the handler from `handlers.rs` / `ast_tools.rs`, the params struct from `params.rs`, and the row from `surface::CUSTOM_MCP_TOOLS`.
+   **For custom tools:** Remove the handler from `handlers.rs` / `ast_tools.rs`, the params struct from `params.rs`, and the row from `surface::CUSTOM_MCP_TOOLS_CORE` or `_AST`.
 
 2. **Remove the tool name** from the `mcp_lists_expected_tools` test and update the expected total (and surface tests).
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -86,6 +86,11 @@ Patchloom exposes **two registration paths** for MCP tools (see
 Prefer the registry for new simple write tools. Do not force custom tools into
 the registry when that would lose multi-file, batch, or read UX.
 
+Custom tools are inventoried in `CUSTOM_MCP_TOOLS_CORE` (always registered)
+and `CUSTOM_MCP_TOOLS_AST` (only when the `ast` feature is enabled). Default
+builds expose **54** tools (registry + custom). Builds without `ast` omit the
+AST tools so `list_tools` stays honest about what is callable.
+
 | Tool | Description |
 |------|-------------|
 | `doc_set` | Set a value by selector path in a JSON, YAML, or TOML file |

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -30,7 +30,16 @@ use super::{
 /// This wraps the `#[tool_router]`-generated private `tool_router()` method
 /// so it can be called from the parent module (`PatchloomService::new`).
 pub(super) fn new_tool_router() -> ToolRouter<PatchloomService> {
-    PatchloomService::tool_router()
+    #[cfg(feature = "ast")]
+    {
+        let mut router = PatchloomService::tool_router();
+        router.merge(PatchloomService::ast_tool_router());
+        router
+    }
+    #[cfg(not(feature = "ast"))]
+    {
+        PatchloomService::tool_router()
+    }
 }
 
 #[tool_router]
@@ -582,238 +591,6 @@ impl PatchloomService {
     // doc_*, read_file, md section mutators, file_* mutators, and fix_whitespace
     // are auto-generated from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
 
-    // -----------------------------------------------------------------
-    // AST tools (feature-gated)
-    // -----------------------------------------------------------------
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "List symbol definitions (functions, classes, structs, enums, methods, etc.) in a file or directory. Supports 20 languages. Example: {\"path\": \"src/\"} or {\"path\": \"main.py\", \"kind\": \"function,class\"}"
-    )]
-    async fn ast_list(
-        &self,
-        Parameters(p): Parameters<AstListParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_list(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Read a specific symbol's source code by name from a file. Uses AST parsing to find the exact definition. Example: {\"path\": \"src/main.rs\", \"symbol\": \"run\"}"
-    )]
-    async fn ast_read(
-        &self,
-        Parameters(p): Parameters<AstReadParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_read(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Rename identifiers across files using AST-aware renaming (skips strings and comments). Example: {\"old_name\": \"process_data\", \"new_name\": \"transform_data\", \"path\": \"src/\"}"
-    )]
-    async fn ast_rename(
-        &self,
-        Parameters(p): Parameters<AstRenameParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_rename(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Validate syntax of source files. Returns parse errors with line numbers. Supports 20 languages. Example: {\"path\": \"src/main.rs\"}"
-    )]
-    async fn ast_validate(
-        &self,
-        Parameters(p): Parameters<AstValidateParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_validate(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Structural search using AST queries. Use S-expression syntax or set pattern=true for code patterns with meta-variables ($VAR, $$$MULTI). Example: {\"query\": \"(function_item name: (identifier) @name)\", \"path\": \"src/\"}"
-    )]
-    async fn ast_search(
-        &self,
-        Parameters(p): Parameters<AstSearchParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_search(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Find all references to a symbol across files using AST analysis. Distinguishes definitions from references. Example: {\"symbol\": \"process_data\", \"path\": \"src/\"}"
-    )]
-    async fn ast_refs(
-        &self,
-        Parameters(p): Parameters<AstRefsParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_refs(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Extract import/dependency statements from source files. Supports Rust, Python, JS/TS, Go, Java, C/C++, Ruby, PHP. Use reverse=true to find what imports a file. Example: {\"path\": \"src/main.rs\"}"
-    )]
-    async fn ast_deps(
-        &self,
-        Parameters(p): Parameters<AstDepsParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_deps(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Generate a ranked repository map using PageRank over the symbol reference graph. Shows the most important symbols with token-budget-aware output. Example: {\"path\": \"src/\", \"max_tokens\": 2048}"
-    )]
-    async fn ast_map(
-        &self,
-        Parameters(p): Parameters<AstMapParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_map(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Structural diff between two versions of a file. Shows added, removed, and modified symbols (not line-level diff). Compares against git refs. Example: {\"path\": \"src/lib.rs\", \"from\": \"HEAD~1\"}"
-    )]
-    async fn ast_diff(
-        &self,
-        Parameters(p): Parameters<AstDiffParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_diff(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Transitive impact analysis: what symbols are affected by changing a given symbol. Traces the reference graph to find all direct and indirect dependents. Example: {\"symbol\": \"parse_config\", \"path\": \"src/\", \"depth\": 3}"
-    )]
-    async fn ast_impact(
-        &self,
-        Parameters(p): Parameters<AstImpactParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_impact(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Replace text only within a specific symbol's body using AST scoping. Precise: only changes code inside the named symbol, leaving everything else untouched. Example: {\"path\": \"src/lib.rs\", \"symbol\": \"parse_config\", \"old\": \"unwrap()\", \"new\": \"expect(\\\"parse failed\\\")\"}"
-    )]
-    async fn ast_replace(
-        &self,
-        Parameters(p): Parameters<AstReplaceParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_replace(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Insert code at a structurally-aware position: inside a module/impl/struct (at start or end), or after/before a named symbol. Indentation is auto-detected. Example: {\"path\": \"src/lib.rs\", \"content\": \"fn new_fn() {}\", \"after\": \"existing_fn\"}"
-    )]
-    async fn ast_insert(
-        &self,
-        Parameters(p): Parameters<AstInsertParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_insert(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Wrap existing code in a structural block (module, impl, cfg, etc.). Specify symbols by name or a line range. Example: {\"path\": \"src/lib.rs\", \"symbols\": [\"helper_fn\", \"HelperStruct\"], \"wrapper\": \"mod helpers\"}"
-    )]
-    async fn ast_wrap(
-        &self,
-        Parameters(p): Parameters<AstWrapParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_wrap(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Manage import/use statements: add (idempotent), remove, deduplicate. With no mutation args, lists existing imports. Example: {\"path\": \"src/main.rs\", \"add\": [\"use std::collections::HashMap;\"]}"
-    )]
-    async fn ast_imports(
-        &self,
-        Parameters(p): Parameters<AstImportsParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_imports(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Reorder symbols within a file or scope by name, kind, or custom order. Example: {\"path\": \"src/lib.rs\", \"order\": \"alphabetical\"} or {\"path\": \"src/lib.rs\", \"order\": [\"Struct\", \"impl Struct\", \"helper\"], \"inside\": \"mod tests\"}"
-    )]
-    async fn ast_reorder(
-        &self,
-        Parameters(p): Parameters<AstReorderParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_reorder(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Group symbols into a named module within a file. Creates the module if it doesn't exist, or appends to it. Example: {\"path\": \"src/tests.rs\", \"module\": \"line_endings\", \"symbols\": [\"test_crlf\", \"test_lf\"], \"preamble\": \"use super::*;\"}"
-    )]
-    async fn ast_group(
-        &self,
-        Parameters(p): Parameters<AstGroupParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_group(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Move symbols between files. Removes from source, inserts into target (creating it if needed). Example: {\"path\": \"src/big.rs\", \"target\": \"src/helpers.rs\", \"symbols\": [\"helper_fn\"], \"target_prepend\": \"use super::*;\"}"
-    )]
-    async fn ast_move(
-        &self,
-        Parameters(p): Parameters<AstMoveParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_move(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Extract a symbol (module, function, struct) to a separate file. For modules with unwrap=true, content is un-indented. Example: {\"source\": \"src/lib.rs\", \"symbol\": \"tests\", \"target\": \"src/lib_tests.rs\", \"replacement\": \"mod tests;\", \"prepend\": \"use super::*;\"}"
-    )]
-    async fn ast_extract_to_file(
-        &self,
-        Parameters(p): Parameters<AstExtractToFileParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_extract_to_file(svc, p))
-            .await
-    }
-
-    #[cfg(feature = "ast")]
-    #[tool(
-        description = "Split a file into multiple target files by distributing symbols. Atomic: all targets succeed or all roll back. Example: {\"source\": \"src/big.rs\", \"targets\": [{\"path\": \"src/types.rs\", \"symbols\": [\"Config\", \"Mode\"], \"prepend\": \"use super::*;\"}], \"keep_in_source\": [\"main\"], \"source_suffix\": \"mod types;\"}"
-    )]
-    async fn ast_split(
-        &self,
-        Parameters(p): Parameters<AstSplitParams>,
-    ) -> Result<CallToolResult, McpError> {
-        self.blocking(move |svc| ast_tools::handle_ast_split(svc, p))
-            .await
-    }
-
     #[tool(
         description = "Show uncommitted file changes vs git HEAD. Returns lists of modified, created, and deleted files. No parameters required."
     )]
@@ -848,4 +625,224 @@ impl PatchloomService {
 
     // move_file, append_file, create_file, and delete_file are auto-generated
     // from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
+}
+
+// AST tools: separate tool_router so mcp builds without `ast` (closes #1396).
+// The rmcp `#[tool_router]` macro does not honor `#[cfg]` on individual
+// methods, so feature-gating must be at the impl / router-merge level.
+#[cfg(feature = "ast")]
+#[tool_router(router = ast_tool_router)]
+impl PatchloomService {
+    // -----------------------------------------------------------------
+    // AST tools (feature-gated)
+    // -----------------------------------------------------------------
+
+    #[tool(
+        description = "List symbol definitions (functions, classes, structs, enums, methods, etc.) in a file or directory. Supports 20 languages. Example: {\"path\": \"src/\"} or {\"path\": \"main.py\", \"kind\": \"function,class\"}"
+    )]
+    async fn ast_list(
+        &self,
+        Parameters(p): Parameters<AstListParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_list(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Read a specific symbol's source code by name from a file. Uses AST parsing to find the exact definition. Example: {\"path\": \"src/main.rs\", \"symbol\": \"run\"}"
+    )]
+    async fn ast_read(
+        &self,
+        Parameters(p): Parameters<AstReadParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_read(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Rename identifiers across files using AST-aware renaming (skips strings and comments). Example: {\"old_name\": \"process_data\", \"new_name\": \"transform_data\", \"path\": \"src/\"}"
+    )]
+    async fn ast_rename(
+        &self,
+        Parameters(p): Parameters<AstRenameParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_rename(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Validate syntax of source files. Returns parse errors with line numbers. Supports 20 languages. Example: {\"path\": \"src/main.rs\"}"
+    )]
+    async fn ast_validate(
+        &self,
+        Parameters(p): Parameters<AstValidateParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_validate(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Structural search using AST queries. Use S-expression syntax or set pattern=true for code patterns with meta-variables ($VAR, $$$MULTI). Example: {\"query\": \"(function_item name: (identifier) @name)\", \"path\": \"src/\"}"
+    )]
+    async fn ast_search(
+        &self,
+        Parameters(p): Parameters<AstSearchParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_search(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Find all references to a symbol across files using AST analysis. Distinguishes definitions from references. Example: {\"symbol\": \"process_data\", \"path\": \"src/\"}"
+    )]
+    async fn ast_refs(
+        &self,
+        Parameters(p): Parameters<AstRefsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_refs(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Extract import/dependency statements from source files. Supports Rust, Python, JS/TS, Go, Java, C/C++, Ruby, PHP. Use reverse=true to find what imports a file. Example: {\"path\": \"src/main.rs\"}"
+    )]
+    async fn ast_deps(
+        &self,
+        Parameters(p): Parameters<AstDepsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_deps(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Generate a ranked repository map using PageRank over the symbol reference graph. Shows the most important symbols with token-budget-aware output. Example: {\"path\": \"src/\", \"max_tokens\": 2048}"
+    )]
+    async fn ast_map(
+        &self,
+        Parameters(p): Parameters<AstMapParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_map(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Structural diff between two versions of a file. Shows added, removed, and modified symbols (not line-level diff). Compares against git refs. Example: {\"path\": \"src/lib.rs\", \"from\": \"HEAD~1\"}"
+    )]
+    async fn ast_diff(
+        &self,
+        Parameters(p): Parameters<AstDiffParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_diff(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Transitive impact analysis: what symbols are affected by changing a given symbol. Traces the reference graph to find all direct and indirect dependents. Example: {\"symbol\": \"parse_config\", \"path\": \"src/\", \"depth\": 3}"
+    )]
+    async fn ast_impact(
+        &self,
+        Parameters(p): Parameters<AstImpactParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_impact(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Replace text only within a specific symbol's body using AST scoping. Precise: only changes code inside the named symbol, leaving everything else untouched. Example: {\"path\": \"src/lib.rs\", \"symbol\": \"parse_config\", \"old\": \"unwrap()\", \"new\": \"expect(\\\"parse failed\\\")\"}"
+    )]
+    async fn ast_replace(
+        &self,
+        Parameters(p): Parameters<AstReplaceParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_replace(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Insert code at a structurally-aware position: inside a module/impl/struct (at start or end), or after/before a named symbol. Indentation is auto-detected. Example: {\"path\": \"src/lib.rs\", \"content\": \"fn new_fn() {}\", \"after\": \"existing_fn\"}"
+    )]
+    async fn ast_insert(
+        &self,
+        Parameters(p): Parameters<AstInsertParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_insert(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Wrap existing code in a structural block (module, impl, cfg, etc.). Specify symbols by name or a line range. Example: {\"path\": \"src/lib.rs\", \"symbols\": [\"helper_fn\", \"HelperStruct\"], \"wrapper\": \"mod helpers\"}"
+    )]
+    async fn ast_wrap(
+        &self,
+        Parameters(p): Parameters<AstWrapParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_wrap(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Manage import/use statements: add (idempotent), remove, deduplicate. With no mutation args, lists existing imports. Example: {\"path\": \"src/main.rs\", \"add\": [\"use std::collections::HashMap;\"]}"
+    )]
+    async fn ast_imports(
+        &self,
+        Parameters(p): Parameters<AstImportsParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_imports(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Reorder symbols within a file or scope by name, kind, or custom order. Example: {\"path\": \"src/lib.rs\", \"order\": \"alphabetical\"} or {\"path\": \"src/lib.rs\", \"order\": [\"Struct\", \"impl Struct\", \"helper\"], \"inside\": \"mod tests\"}"
+    )]
+    async fn ast_reorder(
+        &self,
+        Parameters(p): Parameters<AstReorderParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_reorder(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Group symbols into a named module within a file. Creates the module if it doesn't exist, or appends to it. Example: {\"path\": \"src/tests.rs\", \"module\": \"line_endings\", \"symbols\": [\"test_crlf\", \"test_lf\"], \"preamble\": \"use super::*;\"}"
+    )]
+    async fn ast_group(
+        &self,
+        Parameters(p): Parameters<AstGroupParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_group(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Move symbols between files. Removes from source, inserts into target (creating it if needed). Example: {\"path\": \"src/big.rs\", \"target\": \"src/helpers.rs\", \"symbols\": [\"helper_fn\"], \"target_prepend\": \"use super::*;\"}"
+    )]
+    async fn ast_move(
+        &self,
+        Parameters(p): Parameters<AstMoveParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_move(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Extract a symbol (module, function, struct) to a separate file. For modules with unwrap=true, content is un-indented. Example: {\"source\": \"src/lib.rs\", \"symbol\": \"tests\", \"target\": \"src/lib_tests.rs\", \"replacement\": \"mod tests;\", \"prepend\": \"use super::*;\"}"
+    )]
+    async fn ast_extract_to_file(
+        &self,
+        Parameters(p): Parameters<AstExtractToFileParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_extract_to_file(svc, p))
+            .await
+    }
+
+    #[tool(
+        description = "Split a file into multiple target files by distributing symbols. Atomic: all targets succeed or all roll back. Example: {\"source\": \"src/big.rs\", \"targets\": [{\"path\": \"src/types.rs\", \"symbols\": [\"Config\", \"Mode\"], \"prepend\": \"use super::*;\"}], \"keep_in_source\": [\"main\"], \"source_suffix\": \"mod types;\"}"
+    )]
+    async fn ast_split(
+        &self,
+        Parameters(p): Parameters<AstSplitParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_split(svc, p))
+            .await
+    }
 }

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -5,7 +5,7 @@
 //! auto-generated `MCP_TOOL_REGISTRY` dispatch.
 //!
 //! **Every tool in this module must appear in
-//! [`super::surface::CUSTOM_MCP_TOOLS`] with a reason.** Prefer the registry
+//! [`super::surface::custom_mcp_tools`] inventory with a reason.** Prefer the registry
 //! for new 1:1 `Operation` writes. See `surface` module docs for the policy.
 
 use rmcp::handler::server::router::tool::ToolRouter;

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! **Registry is the default** for 1:1 write `Operation` tools. **Custom
 //! handlers are the exception** and must be justified in
-//! [`surface::CUSTOM_MCP_TOOLS`]. Do not migrate multi-file search/replace,
+//! [`surface::custom_mcp_tools`]. Do not migrate multi-file search/replace,
 //! batch tools, full plans, or AST analyze tools into the registry just to
 //! shrink the custom count.
 

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -2,7 +2,7 @@
 //!
 //! This is the **default** path for new write tools that map 1:1 to a plan
 //! [`crate::plan::Operation`]. Tools that cannot use this path are listed in
-//! [`super::surface::CUSTOM_MCP_TOOLS`] (MCP surface honesty).
+//! [`super::surface::custom_mcp_tools`] (MCP surface honesty).
 
 use rmcp::model::{CallToolResult, ErrorData as McpError};
 

--- a/src/cmd/mcp/surface.rs
+++ b/src/cmd/mcp/surface.rs
@@ -6,13 +6,16 @@
 //!   tool is a 1:1 mapping to a plan [`crate::plan::Operation`] with no special
 //!   multi-file preflight, multi-op batching, or non-plan read UX.
 //! - **Custom (hand-written `#[tool]`):** only when the tool is *not* a simple
-//!   Operation write. Every custom tool must appear in
-//!   [`CUSTOM_MCP_TOOLS`] with a one-line reason.
+//!   Operation write. Every custom tool must appear in the feature-aware
+//!   inventory ([`CUSTOM_MCP_TOOLS_CORE`] + optional [`CUSTOM_MCP_TOOLS_AST`])
+//!   with a one-line reason. Use [`custom_mcp_tools`] / [`custom_tool_names`]
+//!   for the active feature set.
 //! - **Metric:** "no unjustified custom tools," not "fewer custom tools."
 //!   Forcing search/batch/AST-read into the registry would fight agent UX.
 //!
 //! Counts (with default features, including `ast`):
 //! registry + custom = total tools exposed by `list_tools`.
+//! Without `ast`, AST rows are omitted so inventory matches registration.
 //!
 //! Inventory is consumed by unit tests and documentation; it is intentionally
 //! not wired into every production call path.
@@ -48,11 +51,11 @@ pub(super) enum CustomKind {
     Meta,
 }
 
-/// Authoritative list of hand-written MCP tools and why they are not registry tools.
+/// Hand-written tools that are always registered (no `ast` feature required).
 ///
-/// When adding a custom `#[tool]` handler, add a row here in the same PR.
-/// When moving a tool to the registry, remove its row here.
-pub(super) const CUSTOM_MCP_TOOLS: &[CustomMcpTool] = &[
+/// When adding a custom `#[tool]` handler that is not AST-gated, add a row here
+/// in the same PR. When moving a tool to the registry, remove its row.
+pub(super) const CUSTOM_MCP_TOOLS_CORE: &[CustomMcpTool] = &[
     // --- Doc readonly ---
     CustomMcpTool {
         name: "doc_get",
@@ -124,7 +127,11 @@ pub(super) const CUSTOM_MCP_TOOLS: &[CustomMcpTool] = &[
         why: "server/workspace metadata for agents",
         kind: CustomKind::Meta,
     },
-    // --- AST (feature-gated at registration; always listed here) ---
+];
+
+/// AST custom tools; only registered when the `ast` feature is enabled.
+#[cfg(feature = "ast")]
+pub(super) const CUSTOM_MCP_TOOLS_AST: &[CustomMcpTool] = &[
     CustomMcpTool {
         name: "ast_list",
         why: "AST symbol listing (analyze, not plan write)",
@@ -222,9 +229,19 @@ pub(super) const CUSTOM_MCP_TOOLS: &[CustomMcpTool] = &[
     },
 ];
 
-/// Names of custom tools (for set algebra in tests).
+#[cfg(not(feature = "ast"))]
+pub(super) const CUSTOM_MCP_TOOLS_AST: &[CustomMcpTool] = &[];
+
+/// All custom tools for the current feature set (core + optional AST).
+pub(super) fn custom_mcp_tools() -> impl Iterator<Item = &'static CustomMcpTool> {
+    CUSTOM_MCP_TOOLS_CORE
+        .iter()
+        .chain(CUSTOM_MCP_TOOLS_AST.iter())
+}
+
+/// Names of custom tools for the current feature set (set algebra in tests).
 pub(super) fn custom_tool_names() -> impl Iterator<Item = &'static str> {
-    CUSTOM_MCP_TOOLS.iter().map(|t| t.name)
+    custom_mcp_tools().map(|t| t.name)
 }
 
 #[cfg(test)]
@@ -236,7 +253,7 @@ mod tests {
     #[test]
     fn custom_tool_names_are_unique() {
         let mut seen = BTreeSet::new();
-        for t in CUSTOM_MCP_TOOLS {
+        for t in custom_mcp_tools() {
             assert!(
                 seen.insert(t.name),
                 "duplicate custom tool name: {}",
@@ -259,14 +276,20 @@ mod tests {
 
     #[test]
     fn registry_plus_custom_count_matches_list_tools_expectation() {
-        // With default features, ast tools are registered (see mcp_lists_expected_tools).
+        // Core tools always; AST tools only with `ast` (matches list_tools registration).
         let registry_n = MCP_TOOL_REGISTRY.len();
-        let custom_n = CUSTOM_MCP_TOOLS.len();
+        let custom_n = custom_mcp_tools().count();
+        let expected_total = if cfg!(feature = "ast") { 54 } else { 35 };
         assert_eq!(
             registry_n + custom_n,
-            54,
-            "registry ({registry_n}) + custom ({custom_n}) must equal total MCP tools (54)"
+            expected_total,
+            "registry ({registry_n}) + custom ({custom_n}) must equal total MCP tools ({expected_total})"
         );
+        assert_eq!(CUSTOM_MCP_TOOLS_CORE.len(), 13, "core custom tool count");
+        #[cfg(feature = "ast")]
+        assert_eq!(CUSTOM_MCP_TOOLS_AST.len(), 19, "ast custom tool count");
+        #[cfg(not(feature = "ast"))]
+        assert!(CUSTOM_MCP_TOOLS_AST.is_empty());
     }
 
     #[test]
@@ -278,5 +301,16 @@ mod tests {
                 .any(|t| t.tool_name == "fix_whitespace")
         );
         assert!(!custom_tool_names().any(|n| n == "fix_whitespace"));
+    }
+
+    #[test]
+    fn ast_custom_tools_are_feature_gated_in_inventory() {
+        let names: BTreeSet<_> = custom_tool_names().collect();
+        if cfg!(feature = "ast") {
+            assert!(names.contains("ast_list"));
+            assert!(names.contains("ast_split"));
+        } else {
+            assert!(!names.iter().any(|n| n.starts_with("ast_")));
+        }
     }
 }

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -110,17 +110,27 @@ mod basic {
         );
         assert!(names.contains(&"append_file"), "missing append_file tool");
         assert!(names.contains(&"prepend_file"), "missing prepend_file tool");
-        assert!(names.contains(&"ast_insert"), "missing ast_insert tool");
-        assert!(names.contains(&"ast_wrap"), "missing ast_wrap tool");
-        assert!(names.contains(&"ast_imports"), "missing ast_imports tool");
-        assert!(names.contains(&"ast_reorder"), "missing ast_reorder tool");
-        assert!(names.contains(&"ast_group"), "missing ast_group tool");
-        assert!(names.contains(&"ast_move"), "missing ast_move tool");
-        assert!(
-            names.contains(&"ast_extract_to_file"),
-            "missing ast_extract_to_file tool"
-        );
-        assert!(names.contains(&"ast_split"), "missing ast_split tool");
+        #[cfg(feature = "ast")]
+        {
+            assert!(names.contains(&"ast_insert"), "missing ast_insert tool");
+            assert!(names.contains(&"ast_wrap"), "missing ast_wrap tool");
+            assert!(names.contains(&"ast_imports"), "missing ast_imports tool");
+            assert!(names.contains(&"ast_reorder"), "missing ast_reorder tool");
+            assert!(names.contains(&"ast_group"), "missing ast_group tool");
+            assert!(names.contains(&"ast_move"), "missing ast_move tool");
+            assert!(
+                names.contains(&"ast_extract_to_file"),
+                "missing ast_extract_to_file tool"
+            );
+            assert!(names.contains(&"ast_split"), "missing ast_split tool");
+        }
+        #[cfg(not(feature = "ast"))]
+        {
+            assert!(
+                !names.iter().any(|n| n.starts_with("ast_")),
+                "ast tools must not appear without the ast feature: {names:?}"
+            );
+        }
         assert!(
             names.contains(&"md_dedupe_headings"),
             "missing md_dedupe_headings tool"

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -125,11 +125,11 @@ mod basic {
             names.contains(&"md_dedupe_headings"),
             "missing md_dedupe_headings tool"
         );
-        // Surface honesty: live list_tools must equal registry ∪ CUSTOM_MCP_TOOLS.
-        // (Counts: registry 22 + custom 32 = 54 with default features / ast.)
+        // Surface honesty: live list_tools must equal registry ∪ custom inventory
+        // for the active feature set (AST tools only when `ast` is enabled).
         {
             use super::super::registry::MCP_TOOL_REGISTRY;
-            use super::super::surface::{CUSTOM_MCP_TOOLS, custom_tool_names};
+            use super::super::surface::{custom_mcp_tools, custom_tool_names};
             use std::collections::BTreeSet;
 
             let live: BTreeSet<&str> = names.iter().copied().collect();
@@ -143,7 +143,10 @@ mod basic {
                 live.difference(&expected).collect::<Vec<_>>(),
                 expected.difference(&live).collect::<Vec<_>>(),
             );
-            assert_eq!(CUSTOM_MCP_TOOLS.len() + MCP_TOOL_REGISTRY.len(), live.len());
+            assert_eq!(
+                custom_mcp_tools().count() + MCP_TOOL_REGISTRY.len(),
+                live.len()
+            );
         }
         client.cancel().await.unwrap();
     }

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -216,9 +216,15 @@ mod basic {
             instructions.contains("Text ops"),
             "instructions must mention Text ops category"
         );
+        #[cfg(feature = "ast")]
         assert!(
             instructions.contains("AST ops"),
-            "instructions must mention AST ops category"
+            "instructions must mention AST ops category when ast is enabled"
+        );
+        #[cfg(not(feature = "ast"))]
+        assert!(
+            !instructions.contains("AST ops"),
+            "instructions must not advertise AST ops without the ast feature"
         );
         assert!(
             instructions.contains("File ops"),

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -12,35 +12,46 @@ use crate::cli::global::GlobalFlags;
 
 use super::PatchloomService;
 
+/// Server instructions for agents; AST category omitted when `ast` is disabled.
+fn server_instructions() -> String {
+    let mut s = String::from(
+        "Use these tools for ALL file operations. Prefer 'execute_plan' (or tx plans) \
+         for any multi-op or multi-file work to ensure atomicity and avoid races from \
+         parallel calls on the same paths. Use batch_replace/batch_tidy only for uniform \
+         ops across files. Per-call success does not guarantee combined success if you \
+         issue conflicting parallel writes.\n\n\
+         Tool categories:\n\
+         - Document ops (JSON/YAML/TOML by selector path): doc_set, doc_get, doc_delete, \
+         doc_merge, doc_query, doc_update, doc_ensure, doc_move, doc_append, doc_prepend, \
+         doc_delete_where, doc_diff\n\
+         - Markdown ops (by heading): md_replace_section, md_upsert_bullet, \
+         md_table_append, md_insert_after_heading, md_insert_before_heading, \
+         md_move_section, md_dedupe_headings, md_lint\n\
+         - Text ops: replace_text, batch_replace, search_files, apply_patch\n\
+         - File ops: create_file, read_file, delete_file, move_file, append_file, \
+         prepend_file, fix_whitespace, batch_tidy, git_status\n",
+    );
+    #[cfg(feature = "ast")]
+    s.push_str(
+        "         - AST ops (code-aware, 20 languages): ast_list, ast_read, ast_rename, \
+         ast_replace, ast_search, ast_refs, ast_impact, ast_deps, ast_diff, ast_imports, \
+         ast_insert, ast_wrap, ast_move, ast_reorder, ast_group, ast_extract_to_file, \
+         ast_split, ast_map, ast_validate\n",
+    );
+    s.push_str(
+        "         - Plan ops: execute_plan\n\
+         - Server: server_info\n\n\
+         Use doc_* tools for parser-backed JSON/YAML/TOML mutations by selector path \
+         (e.g. doc_set for setting values, doc_merge for merging objects). Use replace_text \
+         only for literal or regex text replacement where structure does not matter.",
+    );
+    s
+}
+
 impl ServerHandler for PatchloomService {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_instructions(
-                "Use these tools for ALL file operations. Prefer 'execute_plan' (or tx plans) \
-                for any multi-op or multi-file work to ensure atomicity and avoid races from \
-                parallel calls on the same paths. Use batch_replace/batch_tidy only for uniform \
-                ops across files. Per-call success does not guarantee combined success if you \
-                issue conflicting parallel writes.\n\n\
-                Tool categories:\n\
-                - Document ops (JSON/YAML/TOML by selector path): doc_set, doc_get, doc_delete, \
-                doc_merge, doc_query, doc_update, doc_ensure, doc_move, doc_append, doc_prepend, \
-                doc_delete_where, doc_diff\n\
-                - Markdown ops (by heading): md_replace_section, md_upsert_bullet, \
-                md_table_append, md_insert_after_heading, md_insert_before_heading, \
-                md_move_section, md_dedupe_headings, md_lint\n\
-                - Text ops: replace_text, batch_replace, search_files, apply_patch\n\
-                - File ops: create_file, read_file, delete_file, move_file, append_file, \
-                prepend_file, fix_whitespace, batch_tidy, git_status\n\
-                - AST ops (code-aware, 20 languages): ast_list, ast_read, ast_rename, \
-                ast_replace, ast_search, ast_refs, ast_impact, ast_deps, ast_diff, ast_imports, \
-                ast_insert, ast_wrap, ast_move, ast_reorder, ast_group, ast_extract_to_file, \
-                ast_split, ast_map, ast_validate\n\
-                - Plan ops: execute_plan\n\
-                - Server: server_info\n\n\
-                Use doc_* tools for parser-backed JSON/YAML/TOML mutations by selector path \
-                (e.g. doc_set for setting values, doc_merge for merging objects). Use replace_text \
-                only for literal or regex text replacement where structure does not matter.",
-            );
+            .with_instructions(server_instructions());
         info.server_info.name = "patchloom".into();
         info.server_info.version = env!("CARGO_PKG_VERSION").into();
         info


### PR DESCRIPTION
## Summary

- Split hand-written MCP inventory into `CUSTOM_MCP_TOOLS_CORE` + feature-gated `CUSTOM_MCP_TOOLS_AST` so inventory matches what `list_tools` registers
- Register AST tools via a separate `#[tool_router(router = ast_tool_router)]` impl and merge only when `ast` is enabled (rmcp does not honor `#[cfg]` on individual methods)
- Lock `mcp_lists_expected_tools` to set equality against the feature-aware inventory; gate AST name asserts
- Document CORE vs AST inventory in mcp-setup and AGENTS.md

Closes #1396

## Test plan

- [x] `make check-fast`
- [x] `cargo test --lib --all-features mcp_lists_expected_tools`
- [x] `cargo test --lib --no-default-features --features "mcp,cli,files" mcp_lists_expected_tools`
- [x] `cargo test --lib --no-default-features --features "mcp,cli,files" surface`