### PR TITLE
ci: add test-mcp-no-ast to make check for feature honesty

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,10 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make integration-test` | Run integration tests (`cargo test --test integration --all-features`) |
 | `make pty-test` | Run PTY-based interactive terminal tests (`cargo test --test pty --all-features -- --test-threads=1`) |
 | `make test-library-hygiene` | Enforce Bline library set: clippy + tests under `--no-default-features --features "ast,files"` (catches dead_code, hygiene for #800 #802) |
+| `make test-mcp-no-ast` | Lib tests with `mcp,cli,files` and no `ast` (MCP inventory/router/instructions honesty) |
 | `make clippy` | Run `cargo clippy --all-targets --all-features -- -D warnings` |
-| `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme |
-| `make check-fast` | Fast check: fmt-check, clippy, test, test-no-default, test-ast-only, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene (skips doc verification; enforces library hygiene) |
+| `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, test-mcp-no-ast, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme |
+| `make check-fast` | Fast check: fmt-check, clippy, test, test-no-default, test-ast-only, test-mcp-no-ast, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene (skips doc verification; enforces library hygiene) |
 | `make update-readme` | Update README.md rounded test count (only changes when hundreds digit changes) |
 | `make check-readme` | Verify README.md rounded test count is accurate (part of `check`) |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd patchloom
 make check
 ```
 
-`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks. While iterating locally, `make check-fast` skips the doc freshness checks but adds library hygiene enforcement.
+`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks. While iterating locally, `make check-fast` skips the doc freshness checks but adds library hygiene enforcement.
 
 ## Development workflow
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit-test-hygiene audit bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz git-clean clean
+.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit-test-hygiene audit bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -23,6 +23,9 @@ test-no-default: ## Run lib tests with no default features (pure lib use, exerci
 test-ast-only: ## Run lib tests with only the ast feature (no cli, no mcp)
 	cargo test --lib --no-default-features --features ast
 
+test-mcp-no-ast: ## MCP without ast (inventory, tool_router merge, instructions honesty; #1395 #1396)
+	cargo test --lib --no-default-features --features "mcp,cli,files"
+
 test-library-hygiene: ## Run clippy + lib tests under exact Bline pure-library set (ast+files) to enforce no dead_code and hygiene (addresses #800 #802)
 	cargo clippy --no-default-features --features "ast,files" -- -D warnings
 	cargo test --no-default-features --features "ast,files" --lib
@@ -36,9 +39,9 @@ pty-test: ## Run PTY-based interactive terminal tests (serial)
 clippy: ## Run clippy linter
 	cargo clippy --all-targets --all-features -- -D warnings
 
-check: fmt-check clippy test test-no-default test-ast-only test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme ## Run all checks (full CI gate)
+check: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme ## Run all checks (full CI gate)
 
-check-fast: fmt-check clippy test test-no-default test-ast-only test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene ## Fast check (skips doc verification; includes release notes verify)
+check-fast: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene ## Fast check (skips doc verification; includes release notes verify)
 
 audit-test-hygiene: ## Audit test names/comments for staleness and weak assertions after refactors (addresses post-refactor tech debt)
 	@echo "=== Suspicious test names (same file, core, outdated concepts) ==="

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -522,6 +522,7 @@ mod doc_completeness {
     }
 
     #[test]
+    #[cfg(feature = "ast")]
     fn doc_comment_lists_ast_rename_and_replace() {
         // #1178: AST operations must be documented in the batch help text.
         let result = parse_line(r#"ast.rename test.rs old_fn new_fn"#, 1);


### PR DESCRIPTION
## Summary

- Add `make test-mcp-no-ast` (`cargo test --lib --no-default-features --features "mcp,cli,files"`)
- Wire it into `make check` and `make check-fast` so CI keeps MCP-without-ast honest after #1395/#1396
- `#[cfg(feature = "ast")]` on the batch help AST completeness test (fails without ast)
- Document the target in AGENTS.md and CONTRIBUTING.md (gate drift)

## Test plan

- [x] `make test-mcp-no-ast` (1787 passed)
- [x] `make check-fast`