### PR TITLE
fix: feature-gate verify HashMap and VerifyResult for non-ast builds

### DIFF
--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -7,7 +7,9 @@
 #[cfg(feature = "ast")]
 use crate::ast::{Language, symbols};
 use crate::plan::VerifyCheck;
-use std::collections::{HashMap, HashSet};
+#[cfg(feature = "ast")]
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 /// Snapshot of symbol counts per file, keyed by file path.
@@ -296,6 +298,7 @@ fn capitalize(s: &str) -> String {
 }
 
 /// Result of a verification comparison.
+#[cfg(feature = "ast")]
 #[derive(Debug)]
 pub(crate) struct VerifyResult {
     pub(crate) passed: bool,


### PR DESCRIPTION
## Summary

- `HashMap` and `VerifyResult` in `src/tx/verify.rs` are only used by AST-backed verification paths
- Gate them with `#[cfg(feature = "ast")]` so `make test-mcp-no-ast` is warning-free

## Test plan

- [x] `cargo test --lib --no-default-features --features "mcp,cli,files"` (no warnings)
- [x] `cargo test --lib --all-features verify::`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`