### PR TITLE
fix: drop indent spaces from feature-gated MCP instruction lines

### DIFF
--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -217,14 +217,25 @@ mod basic {
             "instructions must mention Text ops category"
         );
         #[cfg(feature = "ast")]
-        assert!(
-            instructions.contains("AST ops"),
-            "instructions must mention AST ops category when ast is enabled"
-        );
+        {
+            assert!(
+                instructions.contains("AST ops"),
+                "instructions must mention AST ops category when ast is enabled"
+            );
+            // No accidental indent from push_str bodies (cycle 5 honesty).
+            assert!(
+                instructions.contains("\n- AST ops"),
+                "AST category line must not have leading indent spaces"
+            );
+        }
         #[cfg(not(feature = "ast"))]
         assert!(
             !instructions.contains("AST ops"),
             "instructions must not advertise AST ops without the ast feature"
+        );
+        assert!(
+            instructions.contains("\n- Plan ops"),
+            "Plan category line must not have leading indent spaces"
         );
         assert!(
             instructions.contains("File ops"),

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -31,15 +31,17 @@ fn server_instructions() -> String {
          - File ops: create_file, read_file, delete_file, move_file, append_file, \
          prepend_file, fix_whitespace, batch_tidy, git_status\n",
     );
+    // Continuation lines after `\` discard leading whitespace. Start each
+    // push_str body on the category marker so we do not inject indent spaces.
     #[cfg(feature = "ast")]
     s.push_str(
-        "         - AST ops (code-aware, 20 languages): ast_list, ast_read, ast_rename, \
+        "- AST ops (code-aware, 20 languages): ast_list, ast_read, ast_rename, \
          ast_replace, ast_search, ast_refs, ast_impact, ast_deps, ast_diff, ast_imports, \
          ast_insert, ast_wrap, ast_move, ast_reorder, ast_group, ast_extract_to_file, \
          ast_split, ast_map, ast_validate\n",
     );
     s.push_str(
-        "         - Plan ops: execute_plan\n\
+        "- Plan ops: execute_plan\n\
          - Server: server_info\n\n\
          Use doc_* tools for parser-backed JSON/YAML/TOML mutations by selector path \
          (e.g. doc_set for setting values, doc_merge for merging objects). Use replace_text \


### PR DESCRIPTION
## Summary

- `server_instructions()` used `push_str("         - AST ops...")` which embedded source indent spaces into the agent-facing text
- Start feature-gated segments on the category marker; assert `\n- AST ops` / `\n- Plan ops` in tests

## Test plan

- [x] `cargo test --lib --all-features mcp_instructions`
- [x] `cargo test --lib --no-default-features --features "mcp,cli,files" mcp_instructions`