### PR TITLE
refactor: group finalize_report emit hooks into FinalizeCallbacks

### DIFF
--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -290,28 +290,38 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 crate::tx::engine::WriteSource::Operations(vec![op]),
                 global,
             )?;
-            use crate::cmd::write_mode::finalize_report;
+            use crate::cmd::write_mode::{FinalizeCallbacks, finalize_report};
             finalize_report(
                 global,
                 &cwd,
                 result,
                 true,
-                |_g, _has, _diffs| Ok(()),
-                |_g, _has, _diffs, _plain| Ok(()),
-                |g, _has, diffs, _plain| {
-                    if !diffs.is_empty() && !g.json && !g.jsonl {
-                        let dr = crate::diff::DiffResult {
-                            diffs: diffs.to_vec(),
-                        };
-                        print!(
-                            "{}",
-                            crate::diff::format_diff_result_colored(&dr, g.should_color())
-                        );
-                    }
-                    Ok(())
+                FinalizeCallbacks {
+                    on_check: |_g: &GlobalFlags, _has: bool, _diffs: &[crate::diff::FileDiff]| {
+                        Ok(())
+                    },
+                    on_apply: |_g: &GlobalFlags,
+                               _has: bool,
+                               _diffs: &[crate::diff::FileDiff],
+                               _plain: Option<String>| Ok(()),
+                    on_preview: |g: &GlobalFlags,
+                                 _has: bool,
+                                 diffs: &[crate::diff::FileDiff],
+                                 _plain: Option<String>| {
+                        if !diffs.is_empty() && !g.json && !g.jsonl {
+                            let dr = crate::diff::DiffResult {
+                                diffs: diffs.to_vec(),
+                            };
+                            print!(
+                                "{}",
+                                crate::diff::format_diff_result_colored(&dr, g.should_color())
+                            );
+                        }
+                        Ok(())
+                    },
+                    after_preview_emit: |_: &GlobalFlags| {},
+                    after_preview_apply: |_: &GlobalFlags| {},
                 },
-                |_| {},
-                |_| {},
             )
         }
 

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -405,48 +405,56 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         };
 
-    use crate::cmd::write_mode::finalize_report;
+    use crate::cmd::write_mode::{FinalizeCallbacks, finalize_report};
 
     finalize_report(
         global,
         &cwd,
         result,
         true,
-        |g, _has, diffs| {
-            let files = build_file_results(diffs, "changed");
-            let changed = files.len();
-            if changed > 0 {
-                emit_patch_files_output(g, true, &files)?;
-                if !(g.json || g.jsonl || g.quiet) {
-                    println!("{changed} file(s) would change");
-                }
-            }
-            Ok(())
-        },
-        |g, _has, diffs, _plain| {
-            let files = build_file_results(diffs, "applied");
-            emit_patch_files_output(g, true, &files)?;
-            Ok(())
-        },
-        |g, _has, diffs, _plain| {
-            if g.json || g.jsonl {
+        FinalizeCallbacks {
+            on_check: |g: &GlobalFlags, _has: bool, diffs: &[crate::diff::FileDiff]| {
                 let files = build_file_results(diffs, "changed");
+                let changed = files.len();
+                if changed > 0 {
+                    emit_patch_files_output(g, true, &files)?;
+                    if !(g.json || g.jsonl || g.quiet) {
+                        println!("{changed} file(s) would change");
+                    }
+                }
+                Ok(())
+            },
+            on_apply: |g: &GlobalFlags,
+                       _has: bool,
+                       diffs: &[crate::diff::FileDiff],
+                       _plain: Option<String>| {
+                let files = build_file_results(diffs, "applied");
                 emit_patch_files_output(g, true, &files)?;
-            } else {
-                print!(
-                    "{}",
-                    format_diff_result_colored(
-                        &DiffResult {
-                            diffs: diffs.to_vec()
-                        },
-                        g.should_color()
-                    )
-                );
-            }
-            Ok(())
+                Ok(())
+            },
+            on_preview: |g: &GlobalFlags,
+                         _has: bool,
+                         diffs: &[crate::diff::FileDiff],
+                         _plain: Option<String>| {
+                if g.json || g.jsonl {
+                    let files = build_file_results(diffs, "changed");
+                    emit_patch_files_output(g, true, &files)?;
+                } else {
+                    print!(
+                        "{}",
+                        format_diff_result_colored(
+                            &DiffResult {
+                                diffs: diffs.to_vec()
+                            },
+                            g.should_color()
+                        )
+                    );
+                }
+                Ok(())
+            },
+            after_preview_emit: |_: &GlobalFlags| {},
+            after_preview_apply: |_: &GlobalFlags| {},
         },
-        |_| {},
-        |_| {},
     )
 }
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -351,7 +351,7 @@ fn replace_output(
     file_count: usize,
     cwd: &std::path::Path,
 ) -> anyhow::Result<u8> {
-    use crate::cmd::write_mode::finalize_report;
+    use crate::cmd::write_mode::{FinalizeCallbacks, finalize_report};
 
     let build_output = |diff: Option<String>| ReplaceOutput {
         ok: true,
@@ -366,49 +366,57 @@ fn replace_output(
         cwd,
         result,
         true,
-        |g, _has, _diffs| {
-            if g.json {
-                g.emit_json(&build_output(None))?;
-            } else if !g.emit_json_items(files)? && !g.quiet {
-                println!("{total_matches} match(es) in {file_count} file(s)");
-                for f in files {
-                    println!("  {}: {} match(es)", f.path, f.match_count);
-                }
-            }
-            Ok(())
-        },
-        |g, _has, diffs, diff_text| {
-            if g.json {
-                g.emit_json(&build_output(diff_text))?;
-            } else if !g.emit_json_items(files)? {
-                if g.diff {
-                    print!("{}", render_diffs_colored(diffs, g.should_color()));
-                } else if !g.quiet {
-                    println!("replaced {total_matches} match(es) in {file_count} file(s)");
+        FinalizeCallbacks {
+            on_check: |g: &GlobalFlags, _has: bool, _diffs: &[crate::diff::FileDiff]| {
+                if g.json {
+                    g.emit_json(&build_output(None))?;
+                } else if !g.emit_json_items(files)? && !g.quiet {
+                    println!("{total_matches} match(es) in {file_count} file(s)");
                     for f in files {
                         println!("  {}: {} match(es)", f.path, f.match_count);
                     }
                 }
-            }
-            Ok(())
-        },
-        |g, _has, diffs, diff_text| {
-            if g.json {
-                g.emit_json(&build_output(diff_text))?;
-            } else if !g.emit_json_items(files)? && !diffs.is_empty() {
-                print!("{}", render_diffs_colored(diffs, g.should_color()));
-            }
-            Ok(())
-        },
-        |g| {
-            if g.show_status() {
-                eprintln!("{file_count} file(s) changed, {total_matches} replacement(s)");
-            }
-        },
-        |g| {
-            if g.show_status() {
-                eprintln!("replaced {total_matches} match(es) in {file_count} file(s)");
-            }
+                Ok(())
+            },
+            on_apply: |g: &GlobalFlags,
+                       _has: bool,
+                       diffs: &[crate::diff::FileDiff],
+                       diff_text: Option<String>| {
+                if g.json {
+                    g.emit_json(&build_output(diff_text))?;
+                } else if !g.emit_json_items(files)? {
+                    if g.diff {
+                        print!("{}", render_diffs_colored(diffs, g.should_color()));
+                    } else if !g.quiet {
+                        println!("replaced {total_matches} match(es) in {file_count} file(s)");
+                        for f in files {
+                            println!("  {}: {} match(es)", f.path, f.match_count);
+                        }
+                    }
+                }
+                Ok(())
+            },
+            on_preview: |g: &GlobalFlags,
+                         _has: bool,
+                         diffs: &[crate::diff::FileDiff],
+                         diff_text: Option<String>| {
+                if g.json {
+                    g.emit_json(&build_output(diff_text))?;
+                } else if !g.emit_json_items(files)? && !diffs.is_empty() {
+                    print!("{}", render_diffs_colored(diffs, g.should_color()));
+                }
+                Ok(())
+            },
+            after_preview_emit: |g: &GlobalFlags| {
+                if g.show_status() {
+                    eprintln!("{file_count} file(s) changed, {total_matches} replacement(s)");
+                }
+            },
+            after_preview_apply: |g: &GlobalFlags| {
+                if g.show_status() {
+                    eprintln!("replaced {total_matches} match(es) in {file_count} file(s)");
+                }
+            },
         },
     )
 }

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -44,7 +44,7 @@ pub(super) fn tidy_fix_output(
     dirty_rel_paths: &[String],
     cwd: &Path,
 ) -> anyhow::Result<u8> {
-    use crate::cmd::write_mode::finalize_report;
+    use crate::cmd::write_mode::{FinalizeCallbacks, finalize_report};
 
     let fix_files: Vec<TidyFixFileResult> = dirty_rel_paths
         .iter()
@@ -57,32 +57,40 @@ pub(super) fn tidy_fix_output(
         cwd,
         result,
         true,
-        |g, _has, _diffs| {
-            emit_tidy_fix_output(g, &fix_files, None)?;
-            if !g.quiet && !g.json && !g.jsonl {
-                for p in dirty_rel_paths {
-                    println!("{p}");
+        FinalizeCallbacks {
+            on_check: |g: &GlobalFlags, _has: bool, _diffs: &[crate::diff::FileDiff]| {
+                emit_tidy_fix_output(g, &fix_files, None)?;
+                if !g.quiet && !g.json && !g.jsonl {
+                    for p in dirty_rel_paths {
+                        println!("{p}");
+                    }
                 }
-            }
-            Ok(())
+                Ok(())
+            },
+            on_apply: |g: &GlobalFlags,
+                       _has: bool,
+                       _diffs: &[crate::diff::FileDiff],
+                       diff_text: Option<String>| {
+                emit_tidy_fix_output(g, &fix_files, diff_text)?;
+                Ok(())
+            },
+            on_preview: |g: &GlobalFlags,
+                         _has: bool,
+                         diffs: &[crate::diff::FileDiff],
+                         diff_text: Option<String>| {
+                emit_tidy_fix_output(g, &fix_files, diff_text)?;
+                if !g.json && !g.jsonl && !g.quiet && !diffs.is_empty() {
+                    print!("{}", render_diffs_colored(diffs, g.should_color()));
+                }
+                Ok(())
+            },
+            after_preview_emit: |g: &GlobalFlags| {
+                if g.show_status() {
+                    eprintln!("{n_files} file(s) changed");
+                }
+            },
+            after_preview_apply: |_: &GlobalFlags| {},
         },
-        |g, _has, _diffs, diff_text| {
-            emit_tidy_fix_output(g, &fix_files, diff_text)?;
-            Ok(())
-        },
-        |g, _has, diffs, diff_text| {
-            emit_tidy_fix_output(g, &fix_files, diff_text)?;
-            if !g.json && !g.jsonl && !g.quiet && !diffs.is_empty() {
-                print!("{}", render_diffs_colored(diffs, g.should_color()));
-            }
-            Ok(())
-        },
-        |g| {
-            if g.show_status() {
-                eprintln!("{n_files} file(s) changed");
-            }
-        },
-        |_| {},
     )
 }
 

--- a/src/cmd/write_mode.rs
+++ b/src/cmd/write_mode.rs
@@ -109,6 +109,16 @@ impl Default for RenderPolicy {
     }
 }
 
+/// Emit hooks for [`finalize_report`] (grouped so the entrypoint stays under
+/// clippy's argument limit without a suppression).
+pub struct FinalizeCallbacks<OnCheck, OnApply, OnPreview, AfterEmit, AfterApply> {
+    pub on_check: OnCheck,
+    pub on_apply: OnApply,
+    pub on_preview: OnPreview,
+    pub after_preview_emit: AfterEmit,
+    pub after_preview_apply: AfterApply,
+}
+
 /// Canonical mode → commit → format → exit for custom-rendered staged writes.
 ///
 /// Callers only supply **emit** behavior. Order for preview/confirm-json:
@@ -118,23 +128,25 @@ impl Default for RenderPolicy {
 /// `on_check` receives built diffs (for commands that list changed files in
 /// check mode). Prefer [`finalize_execution_result`] for standard
 /// `make_output(WritePhase, diff)` schemas (ConfirmJson emits *after* apply).
-#[allow(clippy::too_many_arguments)]
-pub fn finalize_report(
+pub fn finalize_report<OnCheck, OnApply, OnPreview, AfterEmit, AfterApply>(
     global: &GlobalFlags,
     cwd: &Path,
     result: ExecutionResult,
     preview_diffs: bool,
-    mut on_check: impl FnMut(&GlobalFlags, bool, &[FileDiff]) -> anyhow::Result<()>,
-    mut on_apply: impl FnMut(&GlobalFlags, bool, &[FileDiff], Option<String>) -> anyhow::Result<()>,
-    mut on_preview: impl FnMut(&GlobalFlags, bool, &[FileDiff], Option<String>) -> anyhow::Result<()>,
-    mut after_preview_emit: impl FnMut(&GlobalFlags),
-    mut after_preview_apply: impl FnMut(&GlobalFlags),
-) -> anyhow::Result<u8> {
+    mut cb: FinalizeCallbacks<OnCheck, OnApply, OnPreview, AfterEmit, AfterApply>,
+) -> anyhow::Result<u8>
+where
+    OnCheck: FnMut(&GlobalFlags, bool, &[FileDiff]) -> anyhow::Result<()>,
+    OnApply: FnMut(&GlobalFlags, bool, &[FileDiff], Option<String>) -> anyhow::Result<()>,
+    OnPreview: FnMut(&GlobalFlags, bool, &[FileDiff], Option<String>) -> anyhow::Result<()>,
+    AfterEmit: FnMut(&GlobalFlags),
+    AfterApply: FnMut(&GlobalFlags),
+{
     let has_changes = result.has_changes;
     match classify_write_mode(global) {
         WriteMode::Check => {
             let diffs = result.build_diffs();
-            on_check(global, has_changes, &diffs)?;
+            (cb.on_check)(global, has_changes, &diffs)?;
             Ok(write_exit_code(has_changes, false))
         }
         WriteMode::Apply => {
@@ -146,7 +158,7 @@ pub fn finalize_report(
             } else {
                 None
             };
-            on_apply(global, has_changes, &diffs, diff_text)?;
+            (cb.on_apply)(global, has_changes, &diffs, diff_text)?;
             Ok(write_exit_code(has_changes, true))
         }
         WriteMode::ConfirmJson | WriteMode::Preview => {
@@ -156,13 +168,13 @@ pub fn finalize_report(
                 Vec::new()
             };
             let diff_text = plain_diff_opt(&diffs);
-            on_preview(global, has_changes, &diffs, diff_text)?;
-            after_preview_emit(global);
+            (cb.on_preview)(global, has_changes, &diffs, diff_text)?;
+            (cb.after_preview_emit)(global);
             let applied = global.should_apply();
             if applied {
                 result.commit()?;
                 crate::write::run_format_command(global, cwd)?;
-                after_preview_apply(global);
+                (cb.after_preview_apply)(global);
             }
             Ok(write_exit_code(has_changes, applied))
         }
@@ -405,15 +417,21 @@ mod tests {
             dir.path(),
             report,
             true,
-            |_g, has, _d| {
-                assert!(has);
-                checks.fetch_add(1, Ordering::SeqCst);
-                Ok(())
+            FinalizeCallbacks {
+                on_check: |_g: &GlobalFlags, has: bool, _d: &[FileDiff]| {
+                    assert!(has);
+                    checks.fetch_add(1, Ordering::SeqCst);
+                    Ok(())
+                },
+                on_apply: |_g: &GlobalFlags, _: bool, _: &[FileDiff], _: Option<String>| {
+                    panic!("apply must not run")
+                },
+                on_preview: |_g: &GlobalFlags, _: bool, _: &[FileDiff], _: Option<String>| {
+                    panic!("preview must not run")
+                },
+                after_preview_emit: |_: &GlobalFlags| {},
+                after_preview_apply: |_: &GlobalFlags| {},
             },
-            |_g, _, _, _| panic!("apply must not run"),
-            |_g, _, _, _| panic!("preview must not run"),
-            |_| {},
-            |_| {},
         )
         .unwrap();
         assert_eq!(code, exit::CHANGES_DETECTED);
@@ -447,16 +465,23 @@ mod tests {
             dir.path(),
             report,
             true,
-            |_g, _, _| panic!("check must not run"),
-            |_g, has, diffs, _plain| {
-                assert!(has);
-                assert!(!diffs.is_empty());
-                applied_hook.store(true, Ordering::SeqCst);
-                Ok(())
+            FinalizeCallbacks {
+                on_check: |_g: &GlobalFlags, _: bool, _: &[FileDiff]| panic!("check must not run"),
+                on_apply: |_g: &GlobalFlags,
+                           has: bool,
+                           diffs: &[FileDiff],
+                           _plain: Option<String>| {
+                    assert!(has);
+                    assert!(!diffs.is_empty());
+                    applied_hook.store(true, Ordering::SeqCst);
+                    Ok(())
+                },
+                on_preview: |_g: &GlobalFlags, _: bool, _: &[FileDiff], _: Option<String>| {
+                    panic!("preview must not run")
+                },
+                after_preview_emit: |_: &GlobalFlags| {},
+                after_preview_apply: |_: &GlobalFlags| {},
             },
-            |_g, _, _, _| panic!("preview must not run"),
-            |_| {},
-            |_| {},
         )
         .unwrap();
         assert_eq!(code, exit::SUCCESS);
@@ -490,14 +515,18 @@ mod tests {
             dir.path(),
             report,
             true,
-            |_g, _, _| panic!("check must not run"),
-            |_g, _, _, _| panic!("apply must not run"),
-            |_g, has, _d, _p| {
-                assert!(has);
-                Ok(())
+            FinalizeCallbacks {
+                on_check: |_g: &GlobalFlags, _: bool, _: &[FileDiff]| panic!("check must not run"),
+                on_apply: |_g: &GlobalFlags, _: bool, _: &[FileDiff], _: Option<String>| {
+                    panic!("apply must not run")
+                },
+                on_preview: |_g: &GlobalFlags, has: bool, _d: &[FileDiff], _p: Option<String>| {
+                    assert!(has);
+                    Ok(())
+                },
+                after_preview_emit: |_: &GlobalFlags| {},
+                after_preview_apply: |_: &GlobalFlags| {},
             },
-            |_| {},
-            |_| {},
         )
         .unwrap();
         assert_eq!(code, exit::CHANGES_DETECTED);


### PR DESCRIPTION
## Summary

- Add `FinalizeCallbacks` for the five emit hooks used by `finalize_report`
- Drop `#[allow(clippy::too_many_arguments)]` (project prefers context structs)
- Update call sites: replace, tidy/fix, patch, md, and write_mode unit tests

Closes #1400

## Test plan

- [x] `make check-fast`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features finalize_report`