### PR TITLE
fix: box plan validation errors and strengthen verify/explain asserts

### DIFF
--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -972,7 +972,17 @@ mod tests {
             value: serde_json::json!(1),
         };
         assert_eq!(operation_op_name(&op), "doc.set");
-        assert!(schema::operation_description("doc.set").is_some());
-        assert!(describe_operation(&op).contains("a.json"));
+        let desc = schema::operation_description("doc.set")
+            .expect("doc.set must have a schema description");
+        assert!(!desc.is_empty(), "doc.set description must not be empty");
+        let summary = describe_operation(&op);
+        assert!(
+            summary.contains("a.json"),
+            "explain text must include the path: {summary}"
+        );
+        assert!(
+            summary.contains("doc.set") || summary.to_lowercase().contains("set"),
+            "explain text must identify the operation: {summary}"
+        );
     }
 }

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -285,13 +285,10 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 } else {
                     exit::FAILURE
                 };
-                let msg = output
-                    .error
-                    .clone()
-                    .unwrap_or_else(|| "plan validation failed".to_string());
-                let bs = output.backup_session.clone();
+                let msg = output.error.as_deref().unwrap_or("plan validation failed");
+                let bs = output.backup_session.as_deref();
                 if structured {
-                    emit_error_json("parse_error", &msg, bs.as_deref(), compact);
+                    emit_error_json("parse_error", msg, bs, compact);
                 } else {
                     eprintln!("tx: {msg}");
                 }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -26,22 +26,28 @@ fn config_tx_strict(cwd: &Path) -> Option<bool> {
 /// This is the in-process equivalent used by the library API (`api::execute_plan`)
 /// and (via serialization) by the CLI tx command and MCP.
 /// Library users get a typed `PlanReport` directly (addresses #811).
-#[allow(clippy::result_large_err)]
+///
+/// Errors are boxed so the `Result` stays under clippy's large-err threshold
+/// (TxOutput is intentionally rich for structured CLI/MCP reporting).
 pub(crate) fn validate_and_prepare_plan(
     plan: &Plan,
     cwd: &Path,
     no_strict: bool,
-) -> Result<(PathBuf, bool, GlobalFlags), TxOutput> {
+) -> Result<(PathBuf, bool, GlobalFlags), Box<TxOutput>> {
     if plan.version != crate::plan::SCHEMA_VERSION {
         let msg = format!(
             "unsupported plan version '{}' (this build supports version {})",
             plan.version,
             crate::plan::SCHEMA_VERSION
         );
-        return Err(build_error_output("parse_error", &msg, None));
+        return Err(Box::new(build_error_output("parse_error", &msg, None)));
     }
     if let Err(e) = validate_plan_operations(plan) {
-        return Err(build_error_output("parse_error", &e.to_string(), None));
+        return Err(Box::new(build_error_output(
+            "parse_error",
+            &e.to_string(),
+            None,
+        )));
     }
 
     let effective_cwd = resolve_plan_cwd(cwd, plan.cwd.as_deref());
@@ -78,7 +84,7 @@ pub fn execute_plan_direct(
 
     let (effective_cwd, strict, global) = match validate_and_prepare_plan(&plan, cwd, false) {
         Ok(v) => v,
-        Err(output) => return Ok(output),
+        Err(output) => return Ok(*output),
     };
 
     // PathGuard enforcement for library callers of execute_plan (addresses #755).

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -658,8 +658,8 @@ fn my_test() {
         let result = compare_snapshots(&before, &after, &check, Path::new("/tmp"));
         assert!(!result.passed);
         assert!(
-            result.message.contains("-2"),
-            "should show count diff: {}",
+            result.message.contains("before=10, after=8 (-2)"),
+            "should show exact before/after and signed delta: {}",
             result.message
         );
         assert!(


### PR DESCRIPTION
## Summary

- Box `TxOutput` errors from `validate_and_prepare_plan` (drops `clippy::result_large_err`)
- Strengthen `compare_snapshots_mismatch` to require `before=10, after=8 (-2)`
- Strengthen explain registry test: non-empty schema description + path/op identity

## Test plan

- [x] `make check-fast`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features compare_snapshots_mismatch`
- [x] `cargo test --lib --all-features operation_op_name_matches_registry`
- [x] `cargo test --lib --all-features plan_exec`