### PR TITLE
fix: enforce --contain on CLI tx plans

### DIFF
--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -463,6 +463,20 @@ pub(crate) fn execute_and_collect(
     let mut doc_cache: HashMap<PathBuf, CachedDoc> = HashMap::new();
     let mut replace_hint: Option<String> = None;
 
+    // Upfront PathGuard on declared paths (same contract as execute_plan_inner /
+    // execute_plan_direct). CLI `tx` and `batch` call this function directly and
+    // previously only had guard wiring on replace glob expansion, so
+    // `file.create ../escape` under `--contain` could still write outside the
+    // workspace (MPI cycle 13).
+    if let Some(g) = guard {
+        for op in &plan.operations {
+            for p in op.declared_paths() {
+                g.check_path(&p)
+                    .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {e}"))?;
+            }
+        }
+    }
+
     crate::verbose!(
         "tx: executing plan with {} operations",
         plan.operations.len()

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -246,3 +246,63 @@ fn test_prepend_default_mode_exits_2() {
         "file should not be modified in default mode"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --contain on append (engine-backed content inject) (MPI cycle 13)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_append_contain_rejects_parent_escape() {
+    let dir = TempDir::new().unwrap();
+    let outside = dir.path().parent().unwrap().join(format!(
+        "patchloom-append-escape-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    fs::write(&outside, "base\n").unwrap();
+
+    patchloom_in(dir.path())
+        .args([
+            "--contain",
+            "append",
+            &format!("../{}", outside.file_name().unwrap().to_string_lossy()),
+            "--content",
+            "injected\n",
+            "--apply",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+
+    assert_eq!(fs::read_to_string(&outside).unwrap(), "base\n");
+    let _ = fs::remove_file(&outside);
+}
+
+#[test]
+fn test_append_contain_allows_in_workspace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("log.txt"), "one\n").unwrap();
+
+    patchloom_in(dir.path())
+        .args([
+            "--contain",
+            "append",
+            "log.txt",
+            "--content",
+            "two\n",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("log.txt")).unwrap(),
+        "one\ntwo\n"
+    );
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7193,3 +7193,83 @@ fn test_tx_ast_rename_empty_directory_fails() {
         .assert()
         .code(9); // OPERATION_FAILED
 }
+
+// ---------------------------------------------------------------------------
+// CLI --contain on tx plans (MPI cycle 13)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tx_contain_rejects_parent_escape_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let escape_name = format!(
+        "patchloom-tx-escape-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    );
+    let outside = dir.path().parent().unwrap().join(&escape_name);
+    let _ = fs::remove_file(&outside);
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "file.create",
+            "path": format!("../{escape_name}"),
+            "content": "nope\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+
+    assert!(
+        !outside.exists(),
+        "tx --contain must not create escaped path {outside:?}"
+    );
+    let _ = fs::remove_file(&outside);
+}
+
+#[test]
+fn test_tx_contain_allows_in_workspace_relative_path() {
+    let dir = TempDir::new().unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "file.create",
+            "path": "inside-tx.txt",
+            "content": "ok\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("inside-tx.txt")).unwrap(),
+        "ok\n"
+    );
+}


### PR DESCRIPTION
## Summary

Multi-perspective cycle 13 (Test Auditor / Adversarial) found that
`--contain` did **not** protect CLI `tx` (and anything else that calls
`execute_and_collect` with a guard):

- Single-op CLI writes go through `stage` / `execute_plan_inner`, which
  reject `declared_paths` escapes.
- CLI `tx` builds a guard and passes it to `execute_and_collect`, but that
  function only used the guard for replace glob defense-in-depth.
- Result: `patchloom --cwd ws --contain tx plan.json --apply` with
  `file.create` on `../escape.txt` **succeeded** and wrote outside the
  workspace.

### Fix

Run the same upfront `declared_paths` + `PathGuard::check_path` loop at the
start of `execute_and_collect` when a guard is present.

### Tests

- `test_tx_contain_rejects_parent_escape_in_plan` / allows in-workspace
- `test_append_contain_rejects_parent_escape` / allows in-workspace

## Test plan

- [x] `make check-fast`
- [x] Integration contain tests for tx and append