### PR TITLE
test: cover batch --contain and document CLI sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Agent: batch with
 | **AST-aware code ops** | List, rename, replace, and analyze symbols across 20 languages | `ast rename src/ old_name new_name --apply` |
 | **Atomic rollback** | `strict: true` reverts every file if format or validate steps fail | `tx plan.json --apply` |
 | **MCP server** | Expose all operations as structured MCP tool calls | `patchloom mcp-server` |
+| **Optional CLI sandbox** | Reject `../` / absolute path escapes from `--cwd` (off by default; MCP always on) | `patchloom --cwd <ws> --contain create … --apply` |
 | **Cross-platform** | Identical behavior on Linux, macOS, Windows. No `sed`, `jq`, `grep` required. | Same binary everywhere |
 
 ### When to use patchloom vs native tools

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -75,7 +75,7 @@ pub fn stage(request: WriteRequest<'_>) -> anyhow::Result<WriteReport> {
             execute_single(op, request.options)
         }
         WriteSource::Operations(ops) => execute_operations(ops, request.options),
-        WriteSource::Precomputed(changes) => Ok(execute_precomputed(changes, request.options)),
+        WriteSource::Precomputed(changes) => execute_precomputed(changes, request.options),
     }
 }
 
@@ -166,13 +166,26 @@ pub fn execute_operations(
 pub type PrecomputedChange = (String, String, String);
 
 /// Stage pre-computed changes (implementation used by [`stage`]).
+///
+/// When a [`PathGuard`] is present (CLI `--contain`, MCP, library), every
+/// precomputed relative path is checked. This path is used by multi-file
+/// scan writers such as `replace` and `tidy fix`; without this check those
+/// commands could mutate files outside the workspace under `--contain`
+/// (MPI cycle 15).
 pub fn execute_precomputed(
     changes: Vec<PrecomputedChange>,
     options: ExecuteOptions<'_>,
-) -> ExecutionResult {
+) -> anyhow::Result<ExecutionResult> {
     crate::verbose!("engine: execute_precomputed changes={}", changes.len());
     use crate::write::apply_policy;
     use std::collections::{HashMap, HashSet};
+
+    if let Some(g) = options.guard {
+        for (rel_path, _, _) in &changes {
+            g.check_path(rel_path)
+                .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {e}"))?;
+        }
+    }
 
     let cwd = options.cwd().to_path_buf();
     let ctx = &options.context;
@@ -213,11 +226,11 @@ pub fn execute_precomputed(
         replace_hint: None,
     };
 
-    ExecutionResult {
+    Ok(ExecutionResult {
         exec_result,
         has_changes: !no_effective_changes,
         cwd,
-    }
+    })
 }
 
 /// Shared implementation for single-op and multi-op execution.
@@ -551,7 +564,7 @@ mod tests {
             "replaced\n".to_string(),
         )];
 
-        let result = execute_precomputed(changes, test_options(dir.path(), &global));
+        let result = execute_precomputed(changes, test_options(dir.path(), &global)).unwrap();
         assert!(result.has_changes);
 
         // Not committed yet.
@@ -575,7 +588,7 @@ mod tests {
             "same\n".to_string(),
         )];
 
-        let result = execute_precomputed(changes, test_options(dir.path(), &global));
+        let result = execute_precomputed(changes, test_options(dir.path(), &global)).unwrap();
         assert!(!result.has_changes);
     }
 
@@ -592,9 +605,36 @@ mod tests {
             "new\n".to_string(),
         )];
 
-        let result = execute_precomputed(changes, test_options(dir.path(), &global));
+        let result = execute_precomputed(changes, test_options(dir.path(), &global)).unwrap();
         let diffs = result.build_diffs();
         assert_eq!(diffs.len(), 1);
         assert!(diffs[0].has_changes);
+    }
+
+    #[test]
+    fn execute_precomputed_with_guard_rejects_parent_escape() {
+        let dir = TempDir::new().unwrap();
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.contain = true;
+        let guard = global.workspace_guard(dir.path()).unwrap().unwrap();
+        let options = ExecuteOptions::from_global(dir.path(), &global, Some(&guard));
+        let changes = vec![(
+            "../escape.txt".to_string(),
+            "old\n".to_string(),
+            "new\n".to_string(),
+        )];
+
+        match execute_precomputed(changes, options) {
+            Ok(_) => panic!("expected containment rejection for ../escape.txt"),
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("escapes")
+                        || msg.contains("rejected")
+                        || msg.contains("workspace guard"),
+                    "expected containment error, got: {msg}"
+                );
+            }
+        }
     }
 }

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -501,3 +501,57 @@ fn test_batch_unterminated_quote_fails() {
         .code(1)
         .stderr(predicates::str::contains("unterminated"));
 }
+
+// ---------------------------------------------------------------------------
+// --contain on batch (delegates to tx execute_and_collect) (MPI cycle 14)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_batch_contain_rejects_parent_escape() {
+    let dir = TempDir::new().unwrap();
+    let escape_name = format!(
+        "patchloom-batch-escape-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    );
+    let outside = dir.path().parent().unwrap().join(&escape_name);
+    let _ = fs::remove_file(&outside);
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "batch", "--apply"])
+        .write_stdin(format!("file.create ../{escape_name} \"nope\"\n"))
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+
+    assert!(!outside.exists(), "batch --contain must not write outside");
+    let _ = fs::remove_file(&outside);
+}
+
+#[test]
+fn test_batch_contain_allows_in_workspace() {
+    let dir = TempDir::new().unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "batch", "--apply"])
+        .write_stdin("file.create inside-batch.txt \"ok\"\n")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("inside-batch.txt")).unwrap(),
+        "ok"
+    );
+}

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1312,3 +1312,76 @@ fn test_replace_context_in_tx_plan() {
         "section [b] should be updated: {result}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// --contain on replace (precomputed multi-file write path) (MPI cycle 15)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_replace_contain_rejects_parent_escape() {
+    let dir = TempDir::new().unwrap();
+    let escape_name = format!(
+        "patchloom-replace-escape-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    );
+    let outside = dir.path().parent().unwrap().join(&escape_name);
+    fs::write(&outside, "foo bar\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "replace",
+            "foo",
+            "--new",
+            "ZAZ",
+            &format!("../{escape_name}"),
+            "--apply",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+
+    assert_eq!(
+        fs::read_to_string(&outside).unwrap(),
+        "foo bar\n",
+        "replace --contain must not mutate escaped path"
+    );
+    let _ = fs::remove_file(&outside);
+}
+
+#[test]
+fn test_replace_contain_allows_in_workspace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("inside.txt"), "foo bar\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "replace",
+            "foo",
+            "--new",
+            "ZAZ",
+            "inside.txt",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("inside.txt")).unwrap(),
+        "ZAZ bar\n"
+    );
+}


### PR DESCRIPTION
## Summary

MPI cycle 14–15 contain hardening after the `tx` fix (#1412):

1. **Batch regression tests** for `--contain` (batch → tx → `execute_and_collect`)
2. **README** feature row for optional CLI sandbox (`--cwd` + `--contain`)
3. **Critical:** `replace --contain` could still write outside the workspace
   because multi-file replace uses `WriteSource::Precomputed`, which never
   ran PathGuard. `execute_precomputed` now rejects escaped paths when a
   guard is present (same policy as operation plans).

## Test plan

- [x] `make check-fast`
- [x] `test_batch_contain_*`
- [x] `test_replace_contain_*`
- [x] `execute_precomputed_with_guard_rejects_parent_escape`