### PR TITLE
docs: accept single-domain monofiles; soften size policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -382,7 +382,14 @@ grep -ri "tool_name" --include="*.md" --include="*.rs" --include="*.json" .
 - `ast::rewrite` — function signature rewrite helpers (use this path only; `ast::symbols` no longer re-exports them, #1386).
 - Shared position parsers: `ast::group::parse_group_position`, `ast::move_symbols::parse_position` (tx must call these, not re-parse `after:`).
 
-Production files over 1000 lines must carry `size-waiver: … #1376` (enforced by `module_hygiene_tests`).
+## Module size (hygiene, not a split mandate)
+
+The 1000-line check in `module_hygiene_tests` is a **multi-concern alert**, not a requirement to split single-domain files.
+
+- Prefer **one conceptual unit per module**. Cohesive domain logic (edit fallback chain, YAML comment-preserving splice, multi-language signature rewrite) and co-located MCP unit tests may stay large.
+- Production sources over ~1000 lines (excluding co-located `tests.rs` / `*_tests.rs`) need a short `size-waiver: … #NNNN` note naming the domain reason and a policy/history issue for provenance (enforced by `module_hygiene_tests`). Closed issues are fine (policy decision, not open tech-debt).
+- **Do not** split only to shrink line counts. Vanity splits that create dual writers, re-export noise, or weaker navigation are a net loss (see closed #1408).
+- Split when a **natural seam** appears during real work (a second independent subsystem), not because a counter crossed a threshold.
 
 ## Coding conventions
 

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -5,7 +5,7 @@
 //! [`rewrite_function_signature`] with [`FunctionSigEdit`] for structured
 //! multi-language edits (visibility, parameters, return type).
 //!
-//! size-waiver: domain bulk, see #1408. Multi-language function signature rewrite domain; tests co-located in module.
+//! size-waiver: accepted single-domain bulk (policy #1408). Multi-language function signature rewrite; tests co-located; do not split for LOC alone.
 
 use super::symbol_extract::innermost_qualified_name;
 use super::{Language, child_text_by_kind, child_text_by_kinds, parse_source};

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -1,4 +1,4 @@
-// size-waiver: co-located MCP unit tests, see #1408. Intentionally co-located with the server module for shared test helpers; not unfinished Phase 4 work.
+// size-waiver: co-located MCP unit tests (policy #1408). Intentionally co-located with the server module for shared helpers; not unfinished Phase 4 work.
 use super::*;
 use rmcp::ServiceExt;
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -57,7 +57,7 @@
 //! assert!(result.valid);
 //! ```
 //!
-//! size-waiver: domain bulk, see #1408. Multi-strategy edit recovery chain is one conceptual unit.
+//! size-waiver: accepted single-domain bulk (policy #1408). Multi-strategy edit recovery chain is one conceptual unit; do not split for LOC alone.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -1,4 +1,4 @@
-// size-waiver: domain bulk, see #1408. YAML comment-preserving splice is cohesive domain logic; further split risks dual writers.
+// size-waiver: accepted single-domain bulk (policy #1408). YAML comment-preserving splice is one unit; split risks dual writers.
 /// Check if there are any arrays that grew between `old` and `new`.
 pub(super) fn has_array_growth_diffs(old: &serde_json::Value, new: &serde_json::Value) -> bool {
     if old == new {

--- a/tests/integration/module_hygiene_tests.rs
+++ b/tests/integration/module_hygiene_tests.rs
@@ -1,5 +1,7 @@
 //! Module layout and size-policy hygiene for the structural rewrite program
-//! (#1372 / #1376). Remaining domain monofiles are tracked in #1408.
+//! (#1372 / #1376). Large single-domain files are accepted with a short
+//! waiver (policy: closed #1408); the 1000-line check is a multi-concern
+//! alert, not a vanity-split mandate.
 
 use std::fs;
 use std::path::PathBuf;
@@ -9,13 +11,13 @@ fn repo_root() -> PathBuf {
 }
 
 /// Production sources (excluding co-located `tests.rs` / `*_tests.rs`) over
-/// 1000 lines must carry an explicit `size-waiver:` linked to an open tracker
-/// issue (currently #1408; historically #1376).
+/// 1000 lines must carry an explicit `size-waiver:` with a domain reason and
+/// a provenance issue id (closed issues are fine; see AGENTS.md "Module size").
 #[test]
 fn large_production_src_files_have_size_waiver() {
     let src_root = repo_root().join("src");
     let mut offenders = Vec::new();
-    // Require a GitHub issue reference so waivers stay tracked (not free-form).
+    // Provenance issue id (open or closed) so waivers are not free-form.
     let issue_ref = regex::Regex::new(r"size-waiver:.*#\d+").unwrap();
 
     for entry in walkdir_rs_files(&src_root) {
@@ -31,7 +33,7 @@ fn large_production_src_files_have_size_waiver() {
         }
         if !issue_ref.is_match(&text) {
             offenders.push(format!(
-                "{} ({} lines) missing `size-waiver: ... #NNNN`",
+                "{} ({} lines) missing `size-waiver: … #NNNN` (domain reason + provenance)",
                 path.strip_prefix(repo_root()).unwrap().display(),
                 lines
             ));
@@ -40,7 +42,7 @@ fn large_production_src_files_have_size_waiver() {
 
     assert!(
         offenders.is_empty(),
-        "large production files need `size-waiver: ... #NNNN` (see #1408):\n{}",
+        "large production files need an intentional size-waiver (not a split mandate; see AGENTS.md / #1408):\n{}",
         offenders.join("\n")
     );
 }


### PR DESCRIPTION
## Summary

Closes #1408 by treating the remaining large modules as **accepted
single-domain bulk**, not unfinished Phase 4 work.

- Soften AGENTS.md: 1000-line gate is a multi-concern alert; do not split
  for LOC alone; split only on natural seams
- Rewrite size-waiver comments on `fallback`, `ast/rewrite`,
  `yaml_splice`, and `mcp/tests` as accepted policy (#1408 provenance)
- Align `module_hygiene_tests` docs with the same intent (waiver still
  required for provenance, closed issues OK)

## Test plan

- [x] `cargo test --test integration large_production_src_files_have_size_waiver`

Closes #1408