### PR TITLE
fix: honor --contain for --files-from path lists

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -72,6 +72,11 @@ pub(crate) fn collect_file_paths_opts(
     root: Option<&Path>,
 ) -> anyhow::Result<Vec<PathBuf>> {
     if let Some(files) = global.read_files_from()? {
+        // --files-from entries must honor --contain (paths may escape even when
+        // CLI positional paths were empty or in-workspace).
+        if let Some(r) = root {
+            global.check_paths_contained(r, &files)?;
+        }
         return Ok(files
             .iter()
             .map(|f| match root {
@@ -93,6 +98,11 @@ pub(crate) fn collect_file_paths_opts(
             None => PathBuf::from(p),
         }
     };
+    // Explicit walk roots under --contain (defense-in-depth for callers that
+    // skip an early check_paths_contained on the same list).
+    if let Some(r) = root {
+        global.check_paths_contained(r, effective)?;
+    }
     // Warn about nonexistent user-supplied paths so typos are visible
     // instead of silently producing an empty result set (exit 3).
     for p in effective {

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1029,3 +1029,39 @@ fn test_search_contain_allows_in_workspace() {
         .code(0)
         .stdout(predicate::str::contains("findme"));
 }
+
+#[test]
+fn test_search_contain_rejects_files_from_parent_escape() {
+    let dir = TempDir::new().unwrap();
+    let escape_name = format!(
+        "patchloom-files-from-escape-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    );
+    let outside = dir.path().parent().unwrap().join(&escape_name);
+    fs::write(&outside, "SECRET_VALUE=x\n").unwrap();
+    // --files-from opens the list file relative to the process cwd, so pass
+    // an absolute path to the list; entries inside are relative to --cwd.
+    let list = dir.path().join("list.txt");
+    fs::write(&list, format!("../{escape_name}\n")).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .arg("--contain")
+        .arg("--files-from")
+        .arg(&list)
+        .args(["search", "SECRET_VALUE"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+
+    let _ = fs::remove_file(&outside);
+}


### PR DESCRIPTION
## Summary

MPI cycle 19: `--files-from` entries were not checked under `--contain`
(only positional `search`/`replace` paths were). Centralize containment
in `collect_file_paths_opts` for:

- `--files-from` lists
- effective walk roots when a cwd root is set

## Test plan

- [x] `make check-fast`
- [x] `test_search_contain_rejects_files_from_parent_escape`