### PR TITLE
fix: --files-from under --cwd; contain before append exists-check

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -169,7 +169,7 @@ These flags affect how Patchloom reports results or chooses which files to touch
 <!-- ref:global-flag:files-from -->
 ### `--files-from`
 
-- **What it does:** Reads the target file list from a file, or from stdin when passed `-`.
+- **What it does:** Reads the target file list from a file, or from stdin when passed `-`. A relative list path is resolved under `--cwd` when that flag is set (absolute list paths are unchanged). Paths **inside** the list are still resolved against `--cwd` / the process cwd as usual, and under `--contain` each listed path must stay in the workspace.
 - **Use when:** Another tool already selected the exact paths and Patchloom should operate only on that set.
 - **Prefer instead:** Use `--glob` for pattern based scoping, or direct path arguments when the target set is already small and obvious.
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -395,6 +395,10 @@ impl GlobalFlags {
 
     /// Read file paths from `--files-from`. Returns `None` if the flag is not set.
     /// When the value is `-`, reads from stdin (one path per line).
+    ///
+    /// The list file path is resolved relative to `--cwd` when that flag is set
+    /// and the list path is not absolute (so `patchloom --cwd /ws --files-from
+    /// list.txt …` opens `/ws/list.txt`, not the process cwd).
     pub fn read_files_from(&self) -> anyhow::Result<Option<Vec<String>>> {
         let source = match self.files_from.as_deref() {
             Some(s) => s,
@@ -418,8 +422,19 @@ impl GlobalFlags {
                 .filter(|l| !l.is_empty())
                 .collect()
         } else {
-            let content = std::fs::read_to_string(source)
-                .map_err(|e| anyhow::anyhow!("failed to read --files-from '{}': {e}", source))?;
+            let list_path = {
+                let p = std::path::Path::new(source);
+                if p.is_absolute() {
+                    p.to_path_buf()
+                } else if let Some(ref cwd) = self.cwd {
+                    std::path::Path::new(cwd).join(p)
+                } else {
+                    p.to_path_buf()
+                }
+            };
+            let content = std::fs::read_to_string(&list_path).map_err(|e| {
+                anyhow::anyhow!("failed to read --files-from '{}': {e}", list_path.display())
+            })?;
             let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
             content
                 .lines()
@@ -754,5 +769,20 @@ mod tests {
         };
         let result = flags.read_files_from().unwrap().unwrap();
         assert_eq!(result, vec!["src/main.rs", "lib.rs"]);
+    }
+
+    #[test]
+    fn read_files_from_resolves_relative_list_under_cwd_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let list = dir.path().join("files.txt");
+        std::fs::write(&list, "a.rs\nb.rs\n").unwrap();
+        let flags = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            // Relative list name; must open under --cwd, not process cwd.
+            files_from: Some("files.txt".into()),
+            ..GlobalFlags::test_default()
+        };
+        let result = flags.read_files_from().unwrap().unwrap();
+        assert_eq!(result, vec!["a.rs", "b.rs"]);
     }
 }

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -79,6 +79,9 @@ pub(crate) fn run_content_inject(
     };
 
     let cwd = global.resolve_cwd()?;
+    // Containment before existence so --contain cannot be distinguished from
+    // "missing file" for escaped paths (agent sandbox).
+    global.check_paths_contained(&cwd, [file])?;
     let path = cwd.join(file);
     if !path.exists() {
         bail!("file does not exist: {file}");

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -54,6 +54,7 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
 
     let cwd = global.resolve_cwd()?;
+    global.check_paths_contained(&cwd, [&args.file])?;
     let path = cwd.join(&args.file);
     if path.exists() && !path.is_file() {
         bail!("target is not a file: {}", args.file);

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -27,6 +27,7 @@ struct DeleteOutput {
 pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!("delete: file={}", args.file);
     let cwd = global.resolve_cwd()?;
+    global.check_paths_contained(&cwd, [&args.file])?;
     let path = cwd.join(&args.file);
 
     if !path.exists() {

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -306,3 +306,93 @@ fn test_append_contain_allows_in_workspace() {
         "one\ntwo\n"
     );
 }
+
+#[test]
+fn test_files_from_resolves_list_under_cwd() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("inside.txt"), "findme here\n").unwrap();
+    fs::write(dir.path().join("list.txt"), "inside.txt\n").unwrap();
+
+    // Process cwd is not dir; list path is relative and must open under --cwd.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path().parent().unwrap())
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--files-from", "list.txt", "search", "findme"])
+        .assert()
+        .code(0)
+        .stdout(predicate::str::contains("findme"));
+}
+
+#[test]
+fn test_append_contain_rejects_missing_parent_escape_not_not_found() {
+    // Escaped path that does not exist must still fail with containment, not
+    // "file does not exist" (existence used to run before PathGuard).
+    let dir = TempDir::new().unwrap();
+    let escape_name = format!(
+        "patchloom-append-missing-escape-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    );
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "append",
+            &format!("../{escape_name}"),
+            "--content",
+            "x\n",
+            "--apply",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        )
+        .stderr(predicate::str::contains("does not exist").not());
+}
+
+#[test]
+fn test_prepend_contain_rejects_parent_escape() {
+    let dir = TempDir::new().unwrap();
+    let escape_name = format!(
+        "patchloom-prepend-escape-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    );
+    let outside = dir.path().parent().unwrap().join(&escape_name);
+    fs::write(&outside, "base\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "prepend",
+            &format!("../{escape_name}"),
+            "--content",
+            "hdr\n",
+            "--apply",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+
+    assert_eq!(fs::read_to_string(&outside).unwrap(), "base\n");
+    let _ = fs::remove_file(&outside);
+}


### PR DESCRIPTION
## Summary

MPI cycle 20 (End User / Security / Adversarial):

1. **`--files-from` + `--cwd`:** relative list paths open under `--cwd`
   (absolute list paths unchanged). Documented in reference docs.
2. **`append` / `prepend` / `create` / `delete` + `--contain`:** run
   `check_paths_contained` **before** existence/type probes so a missing
   `../escape` fails with a workspace-guard error, not `file not found` /
   `does not exist`.

## Test plan

- [x] `make check-fast` (first commit)
- [x] unit/integration for files-from under cwd
- [x] append missing-escape not not-found
- [x] prepend/delete/create contain tests still pass