### PR TITLE
fix: doc key alias + ast rename usage hint from runtime scenarios

### DIFF
--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -31,7 +31,24 @@ pub struct RenameArgs {
 }
 
 pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
-    let (cwd, paths) = setup_multi_file(&args.path, global)?;
+    let (cwd, paths) = match setup_multi_file(&args.path, global) {
+        Ok(v) => v,
+        Err(e) => {
+            let msg = e.to_string();
+            // fixrealloop: path-first invocation (like many other commands) is a
+            // common agent mistake; surface the real order instead of only
+            // "path not found: <new_name>".
+            if msg.contains("path not found") {
+                anyhow::bail!(
+                    "{msg}\n\
+                     hint: usage is `ast rename <OLD_NAME> <NEW_NAME> <PATH>` \
+                     (example: `ast rename alpha gamma mod.rs --apply`). \
+                     Path-first order is not accepted."
+                );
+            }
+            return Err(e);
+        }
+    };
     crate::verbose!(
         "ast rename: '{}' -> '{}' in {}",
         args.old_name,

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -58,6 +58,8 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path (e.g. "server.port", "env.0.value").
+        /// Alias `key` kept for older plans and agents that used the prior field name.
+        #[serde(alias = "key")]
         selector: String,
         /// Value to set (any JSON type).
         value: serde_json::Value,
@@ -67,6 +69,7 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path to delete.
+        #[serde(alias = "key")]
         selector: String,
     },
     #[serde(rename = "doc.merge")]
@@ -81,6 +84,7 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path to an array.
+        #[serde(alias = "key")]
         selector: String,
         /// Value to append to the array.
         value: serde_json::Value,
@@ -90,6 +94,7 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path to an array.
+        #[serde(alias = "key")]
         selector: String,
         /// Value to prepend to the array.
         value: serde_json::Value,
@@ -99,6 +104,7 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path (supports wildcards and predicates).
+        #[serde(alias = "key")]
         selector: String,
         /// New value for all matching locations.
         value: serde_json::Value,
@@ -117,6 +123,7 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path.
+        #[serde(alias = "key")]
         selector: String,
         /// Value to set only if the key does not already exist.
         value: serde_json::Value,
@@ -126,6 +133,7 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path to an array.
+        #[serde(alias = "key")]
         selector: String,
         /// Predicate in "field=value" format to match elements for deletion.
         predicate: String,

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -231,8 +231,8 @@ fn parse_all_operation_variants() {
     assert_eq!(plan.operations.len(), 45);
 }
 
-/// The CLI uses `selector` as the positional arg name for doc ops,
-/// but the Operation struct field is `key`. Both names must parse.
+/// Canonical plan field is `selector` (matches CLI help). Alias `key` must
+/// still parse so older plans and agents do not fail with "missing field".
 #[test]
 fn parse_doc_ops_with_selector_field() {
     let json = r#"{"version": 1, "operations": [
@@ -250,6 +250,31 @@ fn parse_doc_ops_with_selector_field() {
         assert_eq!(selector, "a.b");
     } else {
         panic!("expected DocSet");
+    }
+}
+
+/// Runtime scenario (fixrealloop): plan using legacy field name `key` must parse.
+#[test]
+fn parse_doc_ops_with_legacy_key_alias() {
+    let json = r#"{"version": 1, "operations": [
+            {"op": "doc.set", "path": "f.json", "key": "a.b", "value": 1},
+            {"op": "doc.delete", "path": "f.json", "key": "a.b"},
+            {"op": "doc.append", "path": "f.json", "key": "arr", "value": 1},
+            {"op": "doc.prepend", "path": "f.json", "key": "arr", "value": 0},
+            {"op": "doc.update", "path": "f.json", "key": "a.b", "value": 2},
+            {"op": "doc.ensure", "path": "f.json", "key": "a.b", "value": 1},
+            {"op": "doc.delete_where", "path": "f.json", "key": "arr", "predicate": "x=1"}
+        ]}"#;
+    let plan = parse_plan(json).unwrap();
+    assert_eq!(plan.operations.len(), 7);
+    if let Operation::DocSet {
+        selector, value, ..
+    } = &plan.operations[0]
+    {
+        assert_eq!(selector, "a.b");
+        assert_eq!(value, &serde_json::json!(1));
+    } else {
+        panic!("expected DocSet from key alias");
     }
 }
 


### PR DESCRIPTION
## Summary

Found by **fixrealloop** (real CLI scenarios against release binary):

1. **tx plan `key` vs `selector`:** `{"op":"doc.set","key":"a",...}` failed with
   `missing field selector`. Canonical field is `selector` (CLI/schema);
   add `#[serde(alias = "key")]` on all doc op selector fields.
2. **ast rename path-first confusion:** `ast rename mod.rs alpha gamma`
   reported only `path not found: gamma`. Hint the real order
   `OLD_NAME NEW_NAME PATH`.

## Test plan

- [x] `make check-fast` (key alias commit)
- [x] unit tests for key alias
- [x] re-ran tx with `key` → sets value
- [x] path-first ast rename prints usage hint