### PR TITLE
fix: MCP key alias for doc params; lock ast rename order hint

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -78,6 +78,8 @@ For complex plans needing format/validate lifecycle, regex replace, or `--nth`, 
 patchloom tx plan.json --apply
 ```
 
+In plan JSON, doc ops use the field name `selector` (not `key`). `key` is accepted as an alias if a model emits it, but prefer `selector`.
+
 ## Structured edits
 
 ```bash

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -188,7 +188,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
             "For complex plans needing format/validate lifecycle, regex replace, or `--nth`, use `tx` with JSON:\n\n\
              ```bash\n\
              patchloom tx plan.json --apply\n\
-             ```\n\n",
+             ```\n\n\
+             In plan JSON, doc ops use the field name `selector` (not `key`). \
+             `key` is accepted as an alias if a model emits it, but prefer `selector`.\n\n",
         );
 
         // Structured edits section

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -225,3 +225,35 @@ pub(super) fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Re
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::global::GlobalFlags;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn rename_path_first_order_hints_correct_usage() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("mod.rs"), "fn alpha() {}\n").unwrap();
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        // Path-first (wrong): mod.rs interpreted as OLD_NAME, gamma as PATH.
+        let err = run_rename(
+            RenameArgs {
+                old_name: "mod.rs".into(),
+                new_name: "alpha".into(),
+                path: "gamma".into(),
+                lang: None,
+                write: Default::default(),
+            },
+            &global,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            err.contains("path not found") && err.contains("OLD_NAME") && err.contains("NEW_NAME"),
+            "expected usage hint, got: {err}"
+        );
+    }
+}

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -68,6 +68,8 @@ pub(crate) struct DocGetParams {
     /// File path (relative to working directory).
     pub path: String,
     /// Dot-notation selector path for the value to read (e.g., "version", "db.pool").
+    /// Alias `key` accepted so agents that emit the LLM-prior field name still work.
+    #[serde(alias = "key")]
     pub selector: String,
 }
 
@@ -166,6 +168,8 @@ pub(crate) struct DocQueryParams {
     /// File path (relative to working directory).
     pub path: String,
     /// Dot-notation selector path to query. Required for has/keys/len/select; ignored for flatten.
+    /// Alias `key` accepted because agents often emit that name (LLM prior).
+    #[serde(alias = "key")]
     pub selector: Option<String>,
 }
 
@@ -608,4 +612,24 @@ pub(crate) struct ExecutePlanParams {
     /// Overrides plan's strict field if provided.
     #[serde(default = "default_strict_true")]
     pub strict: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doc_get_params_accept_key_alias() {
+        let p: DocGetParams = serde_json::from_str(r#"{"path":"config.toml","key":"server.port"}"#)
+            .expect("key alias must deserialize");
+        assert_eq!(p.selector, "server.port");
+    }
+
+    #[test]
+    fn doc_query_params_accept_key_alias() {
+        let p: DocQueryParams =
+            serde_json::from_str(r#"{"action":"has","path":"config.toml","key":"server.port"}"#)
+                .expect("key alias must deserialize");
+        assert_eq!(p.selector.as_deref(), Some("server.port"));
+    }
 }

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -58,7 +58,7 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path (e.g. "server.port", "env.0.value").
-        /// Alias `key` kept for older plans and agents that used the prior field name.
+        /// Alias `key` accepted because agents often emit that name (LLM prior).
         #[serde(alias = "key")]
         selector: String,
         /// Value to set (any JSON type).

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -232,7 +232,7 @@ fn parse_all_operation_variants() {
 }
 
 /// Canonical plan field is `selector` (matches CLI help). Alias `key` must
-/// still parse so older plans and agents do not fail with "missing field".
+/// still parse so agents that emit the LLM-prior field name do not fail.
 #[test]
 fn parse_doc_ops_with_selector_field() {
     let json = r#"{"version": 1, "operations": [
@@ -253,9 +253,9 @@ fn parse_doc_ops_with_selector_field() {
     }
 }
 
-/// Runtime scenario (fixrealloop): plan using legacy field name `key` must parse.
+/// Agents often emit `key` (LLM prior); alias must map it onto `selector`.
 #[test]
-fn parse_doc_ops_with_legacy_key_alias() {
+fn parse_doc_ops_with_key_alias() {
     let json = r#"{"version": 1, "operations": [
             {"op": "doc.set", "path": "f.json", "key": "a.b", "value": 1},
             {"op": "doc.delete", "path": "f.json", "key": "a.b"},


### PR DESCRIPTION
## Summary

MPI cycle 24:

1. **MCP gap:** plan/tx accepted `key` as alias for `selector`, but MCP
   `DocGetParams` / `DocQueryParams` use `deny_unknown_fields` and had no
   alias, so agents sending `key` failed on read tools.
2. **Agent-rules:** state that plan JSON should use `selector` (`key`
   accepted as alias for LLM prior, not “older plan files”).
3. **QA:** unit test for path-first `ast rename` usage hint.

## Test plan

- [x] `make check-fast`
- [x] MCP params key alias unit tests
- [x] `rename_path_first_order_hints_correct_usage`