### PR TITLE
docs: show patch apply --stdin in agent-rules

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -163,6 +163,9 @@ patchloom patch merge changes.patch --apply
 # If merge produces conflicts, allow them to be written as markers
 # WARNING: never commit files containing conflict markers
 patchloom patch merge changes.patch --apply --allow-conflicts
+
+# Diff from stdin (use --stdin; a bare '-' path is not special)
+cat changes.patch | patchloom patch apply --stdin --apply
 ```
 
 ```bash

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -291,6 +291,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              # If merge produces conflicts, allow them to be written as markers\n\
              # WARNING: never commit files containing conflict markers\n\
              patchloom patch merge changes.patch --apply --allow-conflicts\n\
+             \n\
+             # Diff from stdin (use --stdin; a bare '-' path is not special)\n\
+             cat changes.patch | patchloom patch apply --stdin --apply\n\
              ```\n\n",
         );
 


### PR DESCRIPTION
## Summary

MPI cycle 25 (End User / fixrealloop lesson): agents and scripts often try
`patch apply -`; the supported form is `patch apply --stdin` (or a real
path such as `/dev/stdin`). Add an example to agent-rules / PATCHLOOM.md.

## Test plan

- [x] `make sync-patchloom-md`
- [x] agent-rules unit smoke