### PR TITLE
fix: agent-friendly replace aliases and patch - stdin

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -164,8 +164,9 @@ patchloom patch merge changes.patch --apply
 # WARNING: never commit files containing conflict markers
 patchloom patch merge changes.patch --apply --allow-conflicts
 
-# Diff from stdin (use --stdin; a bare '-' path is not special)
+# Diff from stdin (--stdin or a bare '-' path both work)
 cat changes.patch | patchloom patch apply --stdin --apply
+cat changes.patch | patchloom patch apply - --apply
 ```
 
 ```bash

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -292,8 +292,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              # WARNING: never commit files containing conflict markers\n\
              patchloom patch merge changes.patch --apply --allow-conflicts\n\
              \n\
-             # Diff from stdin (use --stdin; a bare '-' path is not special)\n\
+             # Diff from stdin (--stdin or a bare '-' path both work)\n\
              cat changes.patch | patchloom patch apply --stdin --apply\n\
+             cat changes.patch | patchloom patch apply - --apply\n\
              ```\n\n",
         );
 

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -16,9 +16,12 @@ pub(crate) struct ReplaceParams {
     /// File path (relative to working directory).
     pub path: String,
     /// Text to find.
+    /// Alias `from` accepted because agents often emit that name (LLM prior).
+    #[serde(alias = "from")]
     pub old: String,
     /// Text to replace with. Mutually exclusive with insert_before/insert_after.
-    #[serde(rename = "new")]
+    /// Alias `to` accepted because agents often emit that name (LLM prior).
+    #[serde(rename = "new", alias = "to")]
     pub new_text: Option<String>,
     /// Insert text before each match instead of replacing. Mutually exclusive with new/insert_after.
     pub insert_before: Option<String>,
@@ -192,9 +195,12 @@ pub(crate) struct BatchReplaceParams {
     /// File paths to apply the replacement to (relative to working directory).
     pub files: Vec<String>,
     /// Text to find in each file.
+    /// Alias `from` accepted because agents often emit that name (LLM prior).
+    #[serde(alias = "from")]
     pub old: String,
     /// Text to replace with.
-    #[serde(rename = "new")]
+    /// Alias `to` accepted because agents often emit that name (LLM prior).
+    #[serde(rename = "new", alias = "to")]
     pub new_text: String,
     /// Use regex mode for the `old` pattern.
     #[serde(default)]
@@ -397,9 +403,12 @@ pub(crate) struct AstReplaceParams {
     /// Symbol name to scope the replacement to.
     pub symbol: String,
     /// Text or regex pattern to find.
+    /// Alias `from` accepted because agents often emit that name (LLM prior).
+    #[serde(alias = "from")]
     pub old: String,
     /// Replacement text.
-    #[serde(rename = "new")]
+    /// Alias `to` accepted because agents often emit that name (LLM prior).
+    #[serde(rename = "new", alias = "to")]
     pub new_text: String,
     /// Treat `old` as a regex pattern.
     #[serde(default)]
@@ -631,5 +640,13 @@ mod tests {
             serde_json::from_str(r#"{"action":"has","path":"config.toml","key":"server.port"}"#)
                 .expect("key alias must deserialize");
         assert_eq!(p.selector.as_deref(), Some("server.port"));
+    }
+
+    #[test]
+    fn replace_params_accept_from_to_aliases() {
+        let p: ReplaceParams = serde_json::from_str(r#"{"path":"VERSION","from":"v1","to":"v2"}"#)
+            .expect("from/to aliases must deserialize");
+        assert_eq!(p.old, "v1");
+        assert_eq!(p.new_text.as_deref(), Some("v2"));
     }
 }

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -69,6 +69,7 @@ pub enum MdAction {
     /// Remove duplicate headings.
     DedupeHeadings { file: String },
     /// Lint common AGENTS.md problems.
+    #[command(name = "lint-agents", alias = "lint")]
     LintAgents { file: String },
     /// Append a row to a markdown table under a heading.
     TableAppend {

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -77,8 +77,14 @@ enum DiffReadError {
 }
 
 fn read_diff_input(file: &Option<String>, stdin_flag: bool) -> Result<String, DiffReadError> {
+    // A bare "-" path means stdin (common CLI convention); agents often pass
+    // this instead of --stdin (fixrealloop).
     if let Some(path) = file {
-        std::fs::read_to_string(path).map_err(|e| DiffReadError::IoError(path.clone(), e))
+        if path == "-" {
+            std::io::read_to_string(std::io::stdin()).map_err(DiffReadError::StdinError)
+        } else {
+            std::fs::read_to_string(path).map_err(|e| DiffReadError::IoError(path.clone(), e))
+        }
     } else if stdin_flag {
         std::io::read_to_string(std::io::stdin()).map_err(DiffReadError::StdinError)
     } else {

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -18,9 +18,12 @@ pub enum Operation {
         #[serde(default)]
         regex: bool,
         /// Pattern to find (literal string or regex).
+        /// Alias `from` accepted because agents often emit that name (LLM prior).
+        #[serde(alias = "from")]
         old: String,
         /// Replacement text. Supports $1/$2 capture group references in regex mode.
-        #[serde(rename = "new")]
+        /// Alias `to` accepted because agents often emit that name (LLM prior).
+        #[serde(rename = "new", alias = "to")]
         new_text: Option<String>,
         /// Replace only the Nth occurrence (1-based).
         nth: Option<usize>,
@@ -284,9 +287,10 @@ pub enum Operation {
         /// Symbol name to scope the replacement to.
         symbol: String,
         /// Text or pattern to find within the symbol body.
+        #[serde(alias = "from")]
         old: String,
         /// Replacement text.
-        #[serde(rename = "new")]
+        #[serde(rename = "new", alias = "to")]
         new_text: String,
         /// Treat `old` as a regex pattern.
         #[serde(default)]

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -278,6 +278,28 @@ fn parse_doc_ops_with_key_alias() {
     }
 }
 
+/// Agents often emit `from`/`to` for replace (LLM prior); aliases map to old/new.
+#[test]
+fn parse_replace_ops_with_from_to_aliases() {
+    let json = r#"{"version": 1, "operations": [
+            {"op": "replace", "path": "VERSION", "from": "v1", "to": "v2"}
+        ]}"#;
+    let plan = parse_plan(json).unwrap();
+    if let Operation::Replace {
+        old,
+        new_text,
+        path,
+        ..
+    } = &plan.operations[0]
+    {
+        assert_eq!(old, "v1");
+        assert_eq!(new_text.as_deref(), Some("v2"));
+        assert_eq!(path.as_deref(), Some("VERSION"));
+    } else {
+        panic!("expected Replace from from/to aliases");
+    }
+}
+
 #[test]
 fn parse_plan_with_for_each() {
     let json = r#"{

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -426,8 +426,12 @@ fn collect_struct_field_names(path: &Path, anchor: &str) -> Vec<String> {
 
 fn collect_serde_rename_values(path: &Path, anchor: &str) -> Vec<String> {
     let block = read_anchored_block(path, anchor);
-    // Match only variant-level renames (which always have an alias), not field-level renames.
-    let re = regex::Regex::new(r#"#\[serde\(rename = "([^"]+)",\s*alias"#).unwrap();
+    // Variant-level renames are a single-attribute attribute:
+    //   #[serde(rename = "doc.set")]
+    // Field renames that accept LLM aliases add extra attrs on the same line:
+    //   #[serde(rename = "new", alias = "to")]
+    // Only collect the bare form so field renames are not treated as op names.
+    let re = regex::Regex::new(r#"#\[serde\(rename = "([^"]+)"\)\]"#).unwrap();
     re.captures_iter(&block)
         .map(|caps| caps[1].to_string())
         .collect::<std::collections::BTreeSet<_>>()


### PR DESCRIPTION
## Summary

Runtime scenarios (fixrealloop) hit agent naming and stdin conventions that already work in other tools:

1. **`patch apply -`** as stdin (same as `patch apply --stdin`)
2. **`from` / `to`** as aliases for replace `old` / `new` in tx plans and MCP `replace_text` / batch / ast replace params
3. **`md lint`** as CLI alias for `md lint-agents`
4. **Reference inventory** only collects bare `#[serde(rename = "...")]` variant names so field-level `rename + alias` is not mistaken for a tx op

## Test plan

- [x] `make check-fast`
- [x] Unit tests for plan and MCP from/to aliases
- [x] Release binary scenarios: tx plan with from/to, patch apply via `-`, `md lint` alias