### PR TITLE
fix: accept value= predicate for scalar doc delete-where

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -591,8 +591,8 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:doc-mode:predicate -->
 ### `doc --predicate`
 
-- **What it does:** Supplies the key-value predicate used by `doc delete-where`.
-- **Use when:** Array cleanup should target matching objects instead of deleting by fixed index or selector path alone.
+- **What it does:** Supplies the key-value predicate used by `doc delete-where`. Object arrays use a field key (e.g. `name=react`). Scalar arrays match the element with `.=a`, `_=a`, or `value=a` (`value` is accepted as an agent-friendly alias for element match).
+- **Use when:** Array cleanup should target matching objects or scalar values instead of deleting by fixed index or selector path alone.
 - **Prefer instead:** Use `doc delete` when one direct selector path can remove the target without predicate filtering.
 
 <!-- ref:doc-mode:stdin -->
@@ -674,8 +674,8 @@ Use these when the top level `doc` command is right, but you need a specific str
 <!-- ref:doc-action:delete-where -->
 ### `doc delete-where`
 
-- **What it does:** Deletes array items that match a predicate.
-- **Use when:** You need to remove selected objects from a list without rebuilding the whole array by hand.
+- **What it does:** Deletes array items that match a predicate (`--predicate key=value`). For scalar arrays, use `.=x`, `_=x`, or `value=x`.
+- **Use when:** You need to remove selected objects or scalar values from a list without rebuilding the whole array by hand.
 - **Prefer instead:** Use `doc delete` when one direct selector path can remove the target.
 
 <!-- ref:doc-action:merge -->

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -74,7 +74,9 @@ pub enum DocAction {
         /// Selector path (e.g. `server.port`, `items[0].name`).
         selector: String,
         // ref:doc-mode:predicate
-        /// Predicate in key=value format.
+        /// Predicate in key=value format. For object arrays use a field
+        /// (e.g. `name=react`). For scalar arrays match the element with
+        /// `.=a`, `_=a`, or `value=a` (the last is accepted as an agent prior).
         #[arg(long)]
         predicate: String,
     },

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -196,8 +196,10 @@ pub fn delete_at_selector(
 /// at `segments`. Returns the number of items removed.
 ///
 /// Predicate keys support dotted paths (e.g. `settings.theme=dark`) for
-/// nested field matching. For simple (non-object) arrays, use `_=value`
-/// or `.=value` to match against the element value itself.
+/// nested field matching. For simple (non-object) arrays, use `_=value`,
+/// `.=value`, or `value=value` to match against the element value itself.
+/// The `value=` form is accepted because agents often emit that name
+/// (LLM prior) instead of `.` / `_` (fixrealloop).
 pub fn delete_where(
     root: &mut serde_json::Value,
     segments: &[selector::Segment],
@@ -225,6 +227,19 @@ pub fn delete_where(
     if pred_key == "_" || pred_key == "." {
         // Simple value matching: compare the array item itself.
         arr.retain(|item| !selector::value_matches_str(item, pred_val));
+    } else if pred_key == "value" {
+        // Agents often write value=X for scalar arrays. Prefer a real field
+        // named "value" on objects; fall back to element match for scalars.
+        arr.retain(|item| {
+            if let Some(field) = item.get("value") {
+                !selector::value_matches_str(field, pred_val)
+            } else if item.is_object() {
+                // Same as missing field: keep the item.
+                true
+            } else {
+                !selector::value_matches_str(item, pred_val)
+            }
+        });
     } else {
         arr.retain(|item| {
             selector::get_nested(item, pred_key)

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -475,6 +475,27 @@ mod edge_cases {
         assert_eq!(removed, 0);
     }
 
+    /// Agents often emit `value=X` for scalar arrays (LLM prior); treat as
+    /// element match when items are not objects with a `value` field.
+    #[test]
+    fn delete_where_value_alias_matches_scalar_elements() {
+        let mut root = json!({"tags": ["a", "b", "a"]});
+        let sel = crate::selector::parse("tags").unwrap();
+        let removed = delete_where(&mut root, &sel, "value=a").unwrap();
+        assert_eq!(removed, 2);
+        assert_eq!(root["tags"], json!(["b"]));
+    }
+
+    /// Object arrays with a real `value` field still match that field.
+    #[test]
+    fn delete_where_value_key_matches_object_field() {
+        let mut root = json!({"items": [{"value": "a"}, {"value": "b"}]});
+        let sel = crate::selector::parse("items").unwrap();
+        let removed = delete_where(&mut root, &sel, "value=a").unwrap();
+        assert_eq!(removed, 1);
+        assert_eq!(root["items"], json!([{"value": "b"}]));
+    }
+
     #[test]
     fn delete_where_trims_whitespace() {
         let mut root = json!({"items": [{"name": "a"}, {"name": "b"}]});


### PR DESCRIPTION
## Summary

fixrealloop found that `doc delete-where tags --predicate value=a` on a scalar array returned success with zero deletions. Only `.=a` / `_=a` matched elements; `value=` is the natural agent prior and was a silent no-op.

- Accept `value=` as element match for scalar (non-object) array items
- Keep field matching when objects have a real `value` field
- Document in CLI help and reference docs

## Test plan

- [x] Unit tests for scalar alias and object field
- [x] `make check-fast`