### PR TITLE
fix: use old/new consistently for ast rename across surfaces

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -127,7 +127,7 @@ CLI flags override config values. The file is searched upward from the working d
 
 ```bash
 # Prefer AST-aware rename for code identifiers (skips strings/comments)
-patchloom ast rename old_function_name new_function_name src/ --apply
+patchloom ast rename src/ --old old_function_name --new new_function_name --apply
 
 # Fallback: text-based workflow when AST mode is unavailable
 patchloom search --count "old_function_name" src/
@@ -210,7 +210,7 @@ Tree-sitter-backed operations that understand code structure (20 languages).
 
 ```bash
 # Rename an identifier across a file, skipping strings and comments
-patchloom ast rename OldName NewName src/lib.rs --apply
+patchloom ast rename src/lib.rs --old OldName --new NewName --apply
 
 # Replace text only within a specific function body
 patchloom ast replace src/config.rs --symbol default_timeout --old 30 --new 60 --apply
@@ -225,7 +225,7 @@ patchloom ast refs src/ --name my_function
 AST rename and replace can also be used in batch and tx plans:
 
 ```bash
-# In a batch file:
+# In a batch file (path, then old, then new — same names as CLI flags):
 ast.rename src/lib.rs OldStruct NewStruct
 ast.replace src/config.rs default_timeout "30" "60"
 ```

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Agent: batch with
 | **Batch N files in 1 call** | `batch` and `tx` combine operations into one tool call with rollback | `batch --apply < ops.txt` |
 | **Comment preservation** | YAML/TOML comments survive all edits, including array resizing | `doc append config.yaml tags '"v2"' --apply` |
 | **Heading-aware markdown** | Edit sections, tables, and bullets by heading, not line number | `md table-append README.md --heading "API" --row "\| new \| row \|" --apply` |
-| **AST-aware code ops** | List, rename, replace, and analyze symbols across 20 languages | `ast rename src/ old_name new_name --apply` |
+| **AST-aware code ops** | List, rename, replace, and analyze symbols across 20 languages | `ast rename src/ --old old_name --new new_name --apply` |
 | **Atomic rollback** | `strict: true` reverts every file if format or validate steps fail | `tx plan.json --apply` |
 | **MCP server** | Expose all operations as structured MCP tool calls | `patchloom mcp-server` |
 | **Optional CLI sandbox** | Reject `../` / absolute path escapes from `--cwd` on reads and writes (off by default; MCP always on) | `patchloom --cwd <ws> --contain search …` / `create … --apply` |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1126,7 +1126,7 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:ast.rename -->
 ### `ast.rename`
 
-- **What it does:** Renames all occurrences of an identifier within a file using tree-sitter AST awareness, skipping strings, comments, and documentation. References inside the renamed symbol and callers are updated atomically.
+- **What it does:** Renames all occurrences of an identifier within a file using tree-sitter AST awareness, skipping strings, comments, and documentation. References inside the renamed symbol and callers are updated atomically. Fields are `path`, `old`, and `new` (same names as `replace` / `ast.replace`). CLI: `ast rename <path> --old <OLD> --new <NEW>`.
 - **Use when:** You need a precise identifier rename that respects language semantics (e.g., renaming `old_fn` to `new_fn` without touching the string `"old_fn"` in a log message).
 - **Related:** `replace` (text-level), `ast replace`
 

--- a/examples/11-ast-operations.sh
+++ b/examples/11-ast-operations.sh
@@ -30,8 +30,8 @@ patchloom ast read src/lib.rs run --context 3
 
 # ---- ast rename: rename identifiers (AST-aware) --------------------------
 # Renames only true identifiers, skipping occurrences in strings and comments.
-patchloom ast rename OldName NewName src/lib.rs --diff    # preview
-patchloom ast rename OldName NewName src/ --apply          # apply across directory
+patchloom ast rename src/lib.rs --old OldName --new NewName --diff    # preview
+patchloom ast rename src/ --old OldName --new NewName --apply          # apply across directory
 
 # ---- ast validate: check syntax of source files --------------------------
 # Reports parse errors without modifying files. Useful as a CI gate.

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -254,7 +254,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
             "### Rename a function across a codebase\n\n\
              ```bash\n\
              # Prefer AST-aware rename for code identifiers (skips strings/comments)\n\
-             patchloom ast rename old_function_name new_function_name src/ --apply\n\n\
+             patchloom ast rename src/ --old old_function_name --new new_function_name --apply\n\n\
              # Fallback: text-based workflow when AST mode is unavailable\n\
              patchloom search --count \"old_function_name\" src/\n\
              patchloom replace \"old_function_name\" --new \"new_function_name\" src/ --apply\n\
@@ -347,7 +347,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              Tree-sitter-backed operations that understand code structure (20 languages).\n\n\
              ```bash\n\
              # Rename an identifier across a file, skipping strings and comments\n\
-             patchloom ast rename OldName NewName src/lib.rs --apply\n\n\
+             patchloom ast rename src/lib.rs --old OldName --new NewName --apply\n\n\
              # Replace text only within a specific function body\n\
              patchloom ast replace src/config.rs --symbol default_timeout --old 30 --new 60 --apply\n\n\
              # List all symbol definitions\n\
@@ -357,7 +357,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              ```\n\n\
              AST rename and replace can also be used in batch and tx plans:\n\n\
              ```bash\n\
-             # In a batch file:\n\
+             # In a batch file (path, then old, then new — same names as CLI flags):\n\
              ast.rename src/lib.rs OldStruct NewStruct\n\
              ast.replace src/config.rs default_timeout \"30\" \"60\"\n\
              ```\n\n",

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -13,14 +13,16 @@ use serde::Serialize;
 
 #[derive(Debug, Args)]
 pub struct RenameArgs {
+    /// File or directory to rename in (path-first, same as `ast replace` / batch / plan).
+    pub path: String,
+
     /// The identifier to rename.
-    pub old_name: String,
+    #[arg(long)]
+    pub old: String,
 
     /// The new identifier name.
-    pub new_name: String,
-
-    /// File or directory to rename in.
-    pub path: String,
+    #[arg(long)]
+    pub new: String,
 
     /// Language hint.
     #[arg(long)]
@@ -31,28 +33,11 @@ pub struct RenameArgs {
 }
 
 pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
-    let (cwd, paths) = match setup_multi_file(&args.path, global) {
-        Ok(v) => v,
-        Err(e) => {
-            let msg = e.to_string();
-            // fixrealloop: path-first invocation (like many other commands) is a
-            // common agent mistake; surface the real order instead of only
-            // "path not found: <new_name>".
-            if msg.contains("path not found") {
-                anyhow::bail!(
-                    "{msg}\n\
-                     hint: usage is `ast rename <OLD_NAME> <NEW_NAME> <PATH>` \
-                     (example: `ast rename alpha gamma mod.rs --apply`). \
-                     Path-first order is not accepted."
-                );
-            }
-            return Err(e);
-        }
-    };
+    let (cwd, paths) = setup_multi_file(&args.path, global)?;
     crate::verbose!(
         "ast rename: '{}' -> '{}' in {}",
-        args.old_name,
-        args.new_name,
+        args.old,
+        args.new,
         args.path
     );
     crate::verbose!("ast rename: scanning {} files", paths.len());
@@ -68,13 +53,13 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
 
         // Check if this file has any matches (AST or word-boundary fallback).
         let has_match = if lang.has_grammar() {
-            crate::ast::rename::rename_in_source(&source, &args.old_name, &args.new_name, lang)
+            crate::ast::rename::rename_in_source(&source, &args.old, &args.new, lang)
                 .is_some_and(|r| r.replacements > 0)
         } else {
             false
         } || {
             // Word-boundary fallback
-            crate::ops::replace::compile_replace_regex(&args.old_name, false, false, false, true)
+            crate::ops::replace::compile_replace_regex(&args.old, false, false, false, true)
                 .ok()
                 .flatten()
                 .is_some_and(|re| re.is_match(&source))
@@ -88,15 +73,15 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
                 .into_owned();
             operations.push(Operation::AstRename {
                 path: rel,
-                old_name: args.old_name.clone(),
-                new_name: args.new_name.clone(),
+                old: args.old.clone(),
+                new: args.new.clone(),
                 lang: args.lang.clone(),
             });
         }
     }
 
     if operations.is_empty() {
-        let msg = format!("symbol '{}' not found in {}", args.old_name, args.path);
+        let msg = format!("symbol '{}' not found in {}", args.old, args.path);
         global.emit_error_json(&msg)?;
         return Ok(exit::NO_MATCHES);
     }
@@ -234,26 +219,28 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn rename_path_first_order_hints_correct_usage() {
+    fn rename_path_first_with_old_new_flags_applies() {
         let dir = TempDir::new().unwrap();
         fs::write(dir.path().join("mod.rs"), "fn alpha() {}\n").unwrap();
-        let global = GlobalFlags::test_with_cwd(dir.path());
-        // Path-first (wrong): mod.rs interpreted as OLD_NAME, gamma as PATH.
-        let err = run_rename(
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run_rename(
             RenameArgs {
-                old_name: "mod.rs".into(),
-                new_name: "alpha".into(),
-                path: "gamma".into(),
+                path: "mod.rs".into(),
+                old: "alpha".into(),
+                new: "beta".into(),
                 lang: None,
                 write: Default::default(),
             },
             &global,
         )
-        .unwrap_err()
-        .to_string();
+        .unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let content = fs::read_to_string(dir.path().join("mod.rs")).unwrap();
         assert!(
-            err.contains("path not found") && err.contains("OLD_NAME") && err.contains("NEW_NAME"),
-            "expected usage hint, got: {err}"
+            content.contains("fn beta()"),
+            "expected rename, got: {content}"
         );
+        assert!(!content.contains("fn alpha()"), "old name should be gone");
     }
 }

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -37,8 +37,8 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
 /// md.dedupe_headings <path>
 /// md.lint_agents <path>
 /// tidy.fix <path>
-/// ast.rename <path> <old_name> <new_name>
-/// ast.replace <path> <symbol> <from> <to>
+/// ast.rename <path> <old> <new>
+/// ast.replace <path> <symbol> <old> <new>
 /// ```
 ///
 /// Lines starting with `#` are comments. Empty lines are ignored.
@@ -280,8 +280,8 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
             require_args(op, args, 3, line_num)?;
             op!(AstRename {
                 path: args[0].clone(),
-                old_name: args[1].clone(),
-                new_name: args[2].clone(),
+                old: args[1].clone(),
+                new: args[2].clone(),
                 lang: None
             })
         }

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -242,13 +242,8 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             format!("Lint {path} for AGENTS.md issues")
         }
         #[cfg(feature = "ast")]
-        Operation::AstRename {
-            path,
-            old_name,
-            new_name,
-            ..
-        } => {
-            format!("AST rename \"{old_name}\" to \"{new_name}\" in {path}")
+        Operation::AstRename { path, old, new, .. } => {
+            format!("AST rename \"{old}\" to \"{new}\" in {path}")
         }
         #[cfg(feature = "ast")]
         Operation::AstReplace {

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -134,10 +134,10 @@ pub(super) fn handle_ast_rename(
     p: AstRenameParams,
 ) -> Result<CallToolResult, McpError> {
     svc.check_path(&p.path)?;
-    validate_param_size("old_name", &p.old_name)?;
-    validate_param_size("new_name", &p.new_name)?;
-    if p.old_name == p.new_name {
-        return exit_code_to_result(exit::NO_MATCHES, "", "old_name and new_name are identical.");
+    validate_param_size("old", &p.old)?;
+    validate_param_size("new", &p.new)?;
+    if p.old == p.new {
+        return exit_code_to_result(exit::NO_MATCHES, "", "old and new are identical.");
     }
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
@@ -164,12 +164,12 @@ pub(super) fn handle_ast_rename(
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
 
         let has_match = if lang.has_grammar() {
-            crate::ast::rename::rename_in_source(&source, &p.old_name, &p.new_name, lang)
+            crate::ast::rename::rename_in_source(&source, &p.old, &p.new, lang)
                 .is_some_and(|r| r.replacements > 0)
         } else {
             false
         } || {
-            crate::ops::replace::compile_replace_regex(&p.old_name, false, false, false, true)
+            crate::ops::replace::compile_replace_regex(&p.old, false, false, false, true)
                 .ok()
                 .flatten()
                 .is_some_and(|re| re.is_match(&source))
@@ -178,8 +178,8 @@ pub(super) fn handle_ast_rename(
         if has_match {
             operations.push(crate::plan::Operation::AstRename {
                 path: rel,
-                old_name: p.old_name.clone(),
-                new_name: p.new_name.clone(),
+                old: p.old.clone(),
+                new: p.new.clone(),
                 lang: p.lang.clone(),
             });
         }
@@ -935,9 +935,9 @@ impl Point {
 
         let svc = make_service(&dir);
         let params = AstRenameParams {
-            old_name: "greet".into(),
-            new_name: "salute".into(),
             path: "rename.rs".into(),
+            old: "greet".into(),
+            new: "salute".into(),
             lang: Some("rs".into()),
         };
 
@@ -957,9 +957,9 @@ impl Point {
 
         let svc = make_service(&dir);
         let params = AstRenameParams {
-            old_name: "greet".into(),
-            new_name: "greet".into(),
             path: "sample.rs".into(),
+            old: "greet".into(),
+            new: "greet".into(),
             lang: Some("rs".into()),
         };
 

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -660,7 +660,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Rename identifiers across files using AST-aware renaming (skips strings and comments). Example: {\"old_name\": \"process_data\", \"new_name\": \"transform_data\", \"path\": \"src/\"}"
+        description = "Rename identifiers across files using AST-aware renaming (skips strings and comments). Example: {\"path\": \"src/\", \"old\": \"process_data\", \"new\": \"transform_data\"}"
     )]
     async fn ast_rename(
         &self,

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -269,12 +269,12 @@ pub(crate) struct AstReadParams {
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AstRenameParams {
-    /// The identifier to rename.
-    pub old_name: String,
-    /// The new identifier name.
-    pub new_name: String,
     /// File or directory to rename in (relative to working directory).
     pub path: String,
+    /// The identifier to rename (same name as replace / plan `old`).
+    pub old: String,
+    /// The new identifier name (same name as replace / plan `new`).
+    pub new: String,
     /// Language hint.
     pub lang: Option<String>,
 }

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -271,10 +271,10 @@ pub enum Operation {
     AstRename {
         /// File or directory to rename in. Directories are walked recursively.
         path: String,
-        /// The identifier to rename.
-        old_name: String,
-        /// The new identifier name.
-        new_name: String,
+        /// The identifier to rename (same field name as replace / ast.replace).
+        old: String,
+        /// The new identifier name (same field name as replace / ast.replace JSON `new`).
+        new: String,
         /// Language hint (e.g. "rust", "go"). Overrides extension-based detection.
         #[serde(default)]
         lang: Option<String>,

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -215,7 +215,7 @@ fn parse_all_operation_variants() {
             {"op": "search", "path": "f.txt", "pattern": "he.*o", "regex": true, "case_insensitive": true, "multiline": true},
             {"op": "search", "path": "f.txt", "pattern": "TODO", "invert_match": true, "assert_count": 5},
             {"op": "search", "path": ".", "pattern": "foo", "literal": true, "exclude_patterns": ["target/**"], "custom_ignore_filenames": [".blineignore"], "max_results": 10},
-            {"op": "ast.rename", "path": "f.rs", "old_name": "Foo", "new_name": "Bar"},
+            {"op": "ast.rename", "path": "f.rs", "old": "Foo", "new": "Bar"},
             {"op": "ast.replace", "path": "f.rs", "symbol": "main", "old": "a", "new": "b"},
             {"op": "ast.insert", "path": "f.rs", "content": "fn new() {}", "after": "main"},
             {"op": "ast.wrap", "path": "f.rs", "symbols": ["helper"], "wrapper": "mod internal"},

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -409,7 +409,7 @@ const AST_OPERATION_REGISTRY: &[OpMeta] = &[
         tier: Tier::Medium,
         examples: &[(
             "Rename a struct",
-            r###"{"op":"ast.rename","path":"src/lib.rs","old_name":"OldStruct","new_name":"NewStruct"}"###,
+            r###"{"op":"ast.rename","path":"src/lib.rs","old":"OldStruct","new":"NewStruct"}"###,
         )],
     },
     OpMeta {

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -567,8 +567,8 @@ mod basic {
                 "ast.rename",
                 Operation::AstRename {
                     path: "f.rs".into(),
-                    old_name: "old".into(),
-                    new_name: "new".into(),
+                    old: "old".into(),
+                    new: "new".into(),
                     lang: None,
                 },
             ));

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -80,8 +80,8 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
     match op {
         Operation::AstRename {
             path,
-            old_name,
-            new_name,
+            old,
+            new,
             lang,
         } => {
             let abs = tx.cwd.join(path);
@@ -94,22 +94,21 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 }
                 let mut total = 0usize;
                 for file_path in &files {
-                    let count =
-                        ast_rename_single_file(tx, file_path, old_name, new_name, lang.as_deref());
+                    let count = ast_rename_single_file(tx, file_path, old, new, lang.as_deref());
                     if let Ok(n) = count {
                         total += n;
                     }
                 }
                 if total == 0 {
                     return Err(crate::exit::NoMatchError {
-                        msg: format!("no matches for '{}' in {}", old_name, path),
+                        msg: format!("no matches for '{}' in {}", old, path),
                     }
                     .into());
                 }
                 return Ok(total);
             }
 
-            ast_rename_single_file(tx, &abs, old_name, new_name, lang.as_deref())
+            ast_rename_single_file(tx, &abs, old, new, lang.as_deref())
         }
 
         Operation::AstReplace {

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -516,9 +516,11 @@ fn test_ast_rename_apply_exits_0() {
         .args([
             "ast",
             "rename",
-            "old_name",
-            "new_name",
             "rename.rs",
+            "--old",
+            "old_name",
+            "--new",
+            "new_name",
             "--apply",
         ])
         .assert()
@@ -544,9 +546,11 @@ fn test_ast_rename_nonexistent_symbol_exits_3() {
         .args([
             "ast",
             "rename",
-            "nonexistent",
-            "new_name",
             "rename.rs",
+            "--old",
+            "nonexistent",
+            "--new",
+            "new_name",
             "--apply",
         ])
         .assert()
@@ -563,9 +567,11 @@ fn test_ast_rename_check_mode_exits_2() {
         .args([
             "ast",
             "rename",
-            "old_name",
-            "new_name",
             "rename.rs",
+            "--old",
+            "old_name",
+            "--new",
+            "new_name",
             "--check",
         ])
         .assert()

--- a/tests/integration/explain_tests.rs
+++ b/tests/integration/explain_tests.rs
@@ -170,7 +170,7 @@ fn test_explain_ast_rename_description() {
     let plan = dir.path().join("plan.json");
     fs::write(
         &plan,
-        r#"{"version": 1, "operations": [{"op": "ast.rename", "path": "lib.rs", "old_name": "foo", "new_name": "bar"}]}"#,
+        r#"{"version": 1, "operations": [{"op": "ast.rename", "path": "lib.rs", "old": "foo", "new": "bar"}]}"#,
     )
     .unwrap();
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2497,7 +2497,7 @@ async fn test_mcp_ast_rename_applies() {
     let (is_error, val) = call_tool_value(
         &client,
         "ast_rename",
-        serde_json::json!({"path": "lib.rs", "old_name": "old_name", "new_name": "new_name"}),
+        serde_json::json!({"path": "lib.rs", "old": "old_name", "new": "new_name"}),
     )
     .await;
     assert!(!is_error, "ast_rename should succeed: {val}");

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -5689,8 +5689,8 @@ fn test_tx_ast_rename_in_plan() {
         "operations": [{
             "op": "ast.rename",
             "path": portable_path_str(&file),
-            "old_name": "old_name",
-            "new_name": "new_name"
+            "old": "old_name",
+            "new": "new_name"
         }]
     });
     let plan_file = dir.path().join("plan.json");
@@ -7054,8 +7054,8 @@ fn test_tx_ast_list_with_lang_name_hint() {
         "operations": [{
             "op": "ast.rename",
             "path": portable_path_str(&file),
-            "old_name": "hello",
-            "new_name": "world",
+            "old": "hello",
+            "new": "world",
             "lang": "rust"
         }]
     });
@@ -7098,8 +7098,8 @@ fn test_tx_ast_rename_directory_walks_recursively() {
         "operations": [{
             "op": "ast.rename",
             "path": "src",
-            "old_name": "old_func",
-            "new_name": "new_func"
+            "old": "old_func",
+            "new": "new_func"
         }]
     });
     let plan_file = dir.path().join("plan.json");
@@ -7146,8 +7146,8 @@ fn test_tx_ast_rename_directory_no_matches_fails() {
         "operations": [{
             "op": "ast.rename",
             "path": "src",
-            "old_name": "nonexistent_func",
-            "new_name": "renamed"
+            "old": "nonexistent_func",
+            "new": "renamed"
         }]
     });
     let plan_file = dir.path().join("plan.json");
@@ -7179,8 +7179,8 @@ fn test_tx_ast_rename_empty_directory_fails() {
         "operations": [{
             "op": "ast.rename",
             "path": "empty",
-            "old_name": "x",
-            "new_name": "y"
+            "old": "x",
+            "new": "y"
         }]
     });
     let plan_file = dir.path().join("plan.json");


### PR DESCRIPTION
## Summary

Agents were inventing `ast rename --old/--new` because `ast replace` and text `replace` already use `old`/`new`, while rename used path-last positionals and plan/MCP `old_name`/`new_name`. That multi-surface mismatch is not justified.

This change makes **one vocabulary** everywhere for the before/after pair:

| Surface | Before | After |
|---------|--------|--------|
| CLI | `ast rename OLD NEW PATH` | `ast rename PATH --old OLD --new NEW` |
| Plan / tx JSON | `old_name` / `new_name` | `old` / `new` |
| MCP `ast_rename` | `old_name` / `new_name` | `old` / `new` (path first in struct) |
| Batch | `path old new` (unchanged order) | same; documented as old/new |
| Docs / agent-rules | mixed | path-first + `--old` / `--new` only |

**Breaking:** plans and MCP clients that still send `old_name`/`new_name` must switch to `old`/`new`. CLI positional rename order is no longer accepted.

## Test plan

- [x] Unit test: path-first CLI rename with `--old`/`--new`
- [x] Integration: ast rename CLI, tx plans, MCP, explain
- [x] `make sync-patchloom-md && make check-fast`