### PR TITLE
fix: expose schema --tier as clap ValueEnum

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3000%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3100%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -430,7 +430,7 @@ flowchart LR
 
 ## Status
 
-3000+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3100+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -353,7 +353,7 @@ Patchloom can be used as a Rust library (disable default `cli` feature for small
 - **Use when:** You are building an AI agent that uses patchloom programmatically and need machine-readable operation schemas, or you want to generate a system prompt tailored to a specific model tier.
 - **Notable flags:**
   - `--format json|prompt` (default: `json`): `json` outputs operation schemas as JSON, `prompt` outputs markdown suitable for LLM system prompts.
-  - `--tier weak|medium|strong`: Filter operations by minimum capability tier.
+  - `--tier weak|medium|strong`: Filter operations by minimum capability tier. Help lists these as the only allowed values (clap enum; no `small`/`large` aliases).
   - `--examples`: Include usage examples in JSON output (omitted by default).
 - **Prefer instead:** Nothing; this is the only programmatic way to discover available operations and their schemas.
 - **Related:** `agent-rules`, `mcp-server`

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -14,10 +14,11 @@ pub struct SchemaArgs {
     #[arg(long, default_value = "json")]
     pub format: SchemaFormat,
 
-    /// Capability tier to filter operations by.
-    /// Omit to include all operations.
-    #[arg(long)]
-    pub tier: Option<String>,
+    /// Capability tier to filter operations by (weak, medium, or strong).
+    /// Omit to include all operations. Only these three names are accepted
+    /// (not industry size labels like small/large).
+    #[arg(long, value_enum)]
+    pub tier: Option<Tier>,
 
     /// Include examples in the output.
     #[arg(long, default_value_t = false)]
@@ -39,15 +40,8 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.tier,
         args.examples
     );
-    let tier: Option<Tier> = match &args.tier {
-        Some(s) => {
-            let t: Tier = s.parse().map_err(|e: String| anyhow::anyhow!("{e}"))?;
-            Some(t)
-        }
-        None => None,
-    };
 
-    let ops = match tier {
+    let ops = match args.tier {
         Some(t) => schema::operations_for_tier(t)?,
         None => schema::operation_schemas()?,
     };
@@ -85,7 +79,7 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             println!("{output}");
         }
         SchemaFormat::Prompt => {
-            let prompt = match tier {
+            let prompt = match args.tier {
                 Some(t) => schema::system_prompt_for_tier(t)?,
                 None => schema::system_prompt_for_tier(Tier::Strong)?,
             };
@@ -116,21 +110,22 @@ mod tests {
     }
 
     #[test]
-    fn invalid_tier_returns_error() {
-        let args = SchemaArgs {
-            format: SchemaFormat::Json,
-            tier: Some("invalid".into()),
-            examples: false,
-        };
-        let global = GlobalFlags::default();
-        assert!(run(args, &global).is_err());
-    }
-
-    #[test]
     fn prompt_format_produces_markdown() {
         let args = SchemaArgs {
             format: SchemaFormat::Prompt,
-            tier: Some("medium".into()),
+            tier: Some(Tier::Medium),
+            examples: false,
+        };
+        let global = GlobalFlags::default();
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+    }
+
+    #[test]
+    fn weak_tier_runs_successfully() {
+        let args = SchemaArgs {
+            format: SchemaFormat::Json,
+            tier: Some(Tier::Weak),
             examples: false,
         };
         let global = GlobalFlags::default();

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -96,8 +96,12 @@ pub fn is_compatible_version(version: &str) -> bool {
 ///
 /// Operations are annotated with a minimum tier. Weaker models get fewer,
 /// simpler operations; stronger models get the full set.
+///
+/// CLI accepts only these names (`weak`, `medium`, `strong`) via clap
+/// `ValueEnum` so help lists the enum; no industry-size aliases (`small`/`large`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum Tier {
     /// Simple operations: replace_text, file create/delete, fix_whitespace.
     Weak,

--- a/tests/integration/schema_tests.rs
+++ b/tests/integration/schema_tests.rs
@@ -187,12 +187,38 @@ fn test_schema_quiet_suppresses_output() {
 
 #[test]
 fn test_schema_invalid_tier_fails() {
+    // clap ValueEnum rejects free strings at parse time (exit 2) and lists values.
     Command::cargo_bin("patchloom")
         .unwrap()
         .args(["schema", "--tier", "invalid"])
         .assert()
-        .code(1)
-        .stderr(predicate::str::contains("unknown tier"));
+        .code(2)
+        .stderr(predicate::str::contains("possible values"))
+        .stderr(predicate::str::contains("weak"));
+}
+
+#[test]
+fn test_schema_tier_small_is_not_accepted() {
+    // Industry model-size prior; product tiers are weak/medium/strong only.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["schema", "--tier", "small"])
+        .assert()
+        .code(2)
+        .stderr(predicate::str::contains("possible values"));
+}
+
+#[test]
+fn test_schema_help_lists_tier_enum() {
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["schema", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Possible values"))
+        .stdout(predicate::str::contains("weak"))
+        .stdout(predicate::str::contains("medium"))
+        .stdout(predicate::str::contains("strong"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`--tier` was a free string, so help never listed allowed values and agents/humans only learned `weak|medium|strong` from examples or errors.

- Derive clap `ValueEnum` on `Tier` (cli feature)
- Wire `schema --tier` to `Option<Tier>` instead of `Option<String>`
- Help now shows possible values: weak, medium, strong
- Invalid values (including `small`) fail at clap parse (exit 2) with the enum list
- **No** `small`/`large` aliases (product vocabulary stays weak/medium/strong)

## Test plan

- [x] Unit tests for schema run with Tier enum
- [x] Integration: help lists values; `invalid` and `small` rejected
- [x] `make check-fast`