### PR TITLE
test: lock ast.rename old/new contract and document canonical names

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -47,6 +47,20 @@ Use patchloom when:
 - Use `batch_replace` or `batch_tidy` only when applying the *exact same* operation to multiple files.
 - Do **not** issue parallel write calls against the same path(s) — per-call success does not guarantee a coherent combined result.
 
+## Canonical parameter names
+
+Use these names in plans, MCP args, and CLI flags (do not invent alternates):
+
+| Concept | Canonical name | Notes |
+|---------|----------------|-------|
+| Text/identifier before | `old` | CLI: `--old`. Plans/MCP: `"old"`. |
+| Text/identifier after | `new` | CLI: `--new`. Plans/MCP: `"new"`. |
+| Doc path into a document | `selector` | CLI positional. Plans/MCP: `"selector"`. |
+| AST rename / replace | path first | `ast rename PATH --old X --new Y`; plan `ast.rename` uses `path`/`old`/`new`. |
+| Schema capability filter | `weak` / `medium` / `strong` | `schema --tier` only accepts these (not `small`/`large`). |
+
+Some plan/MCP fields still **accept** legacy aliases (`from`/`to` for replace, `key` for doc selector) so older agent prompts keep working, but examples and new plans must use the canonical names above.
+
 ## Batching (the main speed win)
 
 Six file edits via native tools = six round-trips. One `batch` call = one round-trip:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3000%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3100%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -430,7 +430,7 @@ flowchart LR
 
 ## Status
 
-3000+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3100+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -138,6 +138,21 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
         );
     }
 
+    // Canonical parameter names (same on CLI flags, tx/MCP JSON, and batch positionals).
+    out.push_str(
+        "## Canonical parameter names\n\n\
+         Use these names in plans, MCP args, and CLI flags (do not invent alternates):\n\n\
+         | Concept | Canonical name | Notes |\n\
+         |---------|----------------|-------|\n\
+         | Text/identifier before | `old` | CLI: `--old`. Plans/MCP: `\"old\"`. |\n\
+         | Text/identifier after | `new` | CLI: `--new`. Plans/MCP: `\"new\"`. |\n\
+         | Doc path into a document | `selector` | CLI positional. Plans/MCP: `\"selector\"`. |\n\
+         | AST rename / replace | path first | `ast rename PATH --old X --new Y`; plan `ast.rename` uses `path`/`old`/`new`. |\n\
+         | Schema capability filter | `weak` / `medium` / `strong` | `schema --tier` only accepts these (not `small`/`large`). |\n\n\
+         Some plan/MCP fields still **accept** legacy aliases (`from`/`to` for replace, `key` for doc selector) \
+         so older agent prompts keep working, but examples and new plans must use the canonical names above.\n\n",
+    );
+
     // Batching section
     if show_cli {
         out.push_str("## Batching (the main speed win)\n\n\

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -300,6 +300,37 @@ fn parse_replace_ops_with_from_to_aliases() {
     }
 }
 
+/// Canonical ast.rename fields are `old`/`new` (same as replace / ast.replace).
+#[cfg(feature = "ast")]
+#[test]
+fn parse_ast_rename_with_old_new() {
+    let json = r#"{"version": 1, "operations": [
+            {"op": "ast.rename", "path": "lib.rs", "old": "Foo", "new": "Bar"}
+        ]}"#;
+    let plan = parse_plan(json).unwrap();
+    if let Operation::AstRename { path, old, new, .. } = &plan.operations[0] {
+        assert_eq!(path, "lib.rs");
+        assert_eq!(old, "Foo");
+        assert_eq!(new, "Bar");
+    } else {
+        panic!("expected AstRename with old/new");
+    }
+}
+
+/// Legacy plan keys old_name/new_name are not co-equal API (consistency rename).
+#[cfg(feature = "ast")]
+#[test]
+fn parse_ast_rename_rejects_legacy_old_name_fields() {
+    let json = r#"{"version": 1, "operations": [
+            {"op": "ast.rename", "path": "lib.rs", "old_name": "Foo", "new_name": "Bar"}
+        ]}"#;
+    let err = parse_plan(json).unwrap_err().to_string();
+    assert!(
+        err.contains("old") || err.contains("missing field"),
+        "expected missing field `old` (or similar), got: {err}"
+    );
+}
+
 #[test]
 fn parse_plan_with_for_each() {
     let json = r#"{

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -31,30 +31,29 @@ fn collect_ast_source_files_recursive(dir: &Path, out: &mut Vec<PathBuf>) -> any
 fn ast_rename_single_file(
     tx: &mut TxState<'_>,
     abs: &Path,
-    old_name: &str,
-    new_name: &str,
+    old: &str,
+    new: &str,
     lang_hint: Option<&str>,
 ) -> anyhow::Result<usize> {
     let content = read_file_content(tx.pending, tx.existed_before, abs)?;
     let lang_val = lang_hint
         .map(crate::ast::Language::from_name_or_ext)
         .unwrap_or_else(|| crate::ast::Language::from_path(abs));
-    let result = crate::ast::rename::rename_in_source(content, old_name, new_name, lang_val);
+    let result = crate::ast::rename::rename_in_source(content, old, new, lang_val);
     match result {
         Some(r) if r.replacements > 0 => {
             update_file_content(tx.pending, tx.deletions, tx.write_targets, abs, r.content);
             Ok(r.replacements)
         }
         Some(_) => Err(crate::exit::NoMatchError {
-            msg: format!("no matches for '{}' in {}", old_name, abs.display()),
+            msg: format!("no matches for '{}' in {}", old, abs.display()),
         }
         .into()),
         None => {
             // Tree-sitter couldn't parse. Fallback to word-boundary replace.
-            let re =
-                crate::ops::replace::compile_replace_regex(old_name, false, false, false, true)?;
+            let re = crate::ops::replace::compile_replace_regex(old, false, false, false, true)?;
             if let Some(re) = re {
-                let new_content = re.replace_all(content, new_name).to_string();
+                let new_content = re.replace_all(content, new).to_string();
                 let count = re.find_iter(content).count();
                 if count > 0 {
                     update_file_content(
@@ -68,7 +67,7 @@ fn ast_rename_single_file(
                 }
             }
             Err(crate::exit::NoMatchError {
-                msg: format!("no matches for '{}' in {}", old_name, abs.display()),
+                msg: format!("no matches for '{}' in {}", old, abs.display()),
             }
             .into())
         }


### PR DESCRIPTION
## Summary

Multi-perspective improvement follow-up after the `old`/`new` consistency work (#1426) and schema tier enum (#1427).

### Gate
- Main CI healthy
- Open PR #1427 (schema tier ValueEnum) auto-merging separately
- Release PR #1313 left unmerged (needs explicit approval to publish 0.10.0)
- Open issues are distribution packaging only (npm/winget/Scoop/etc., MCP directories); left open as large external work

### This PR (QA / Developer / End User+Spec)
1. **QA:** Plan-parse regression tests for `ast.rename` using canonical `old`/`new`, and rejection of legacy `old_name`/`new_name`
2. **Developer:** Internal `ast_rename_single_file` parameters renamed to `old`/`new` to match the public contract
3. **End User / Spec:** New **Canonical parameter names** table in agent-rules / PATCHLOOM so agents use one vocabulary (and know legacy aliases are accept-only, not co-equal)

### Other perspectives (this cycle)
- Security / Adversarial / Ops / Maintainer: no new actionable gaps (contain tests present; dist issues already tracked)
- `doc delete-where` zero-match exit 0 is **intentional idempotency** (same as `doc delete`); not changed

## Test plan
- [x] `cargo test --lib parse_ast_rename`
- [x] `make sync-patchloom-md && make check-fast`