### PR TITLE
ci: include check-readme in check-fast; lock canonical names test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make test-mcp-no-ast` | Lib tests with `mcp,cli,files` and no `ast` (MCP inventory/router/instructions honesty) |
 | `make clippy` | Run `cargo clippy --all-targets --all-features -- -D warnings` |
 | `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, test-mcp-no-ast, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme |
-| `make check-fast` | Fast check: fmt-check, clippy, test, test-no-default, test-ast-only, test-mcp-no-ast, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene (skips doc verification; enforces library hygiene) |
+| `make check-fast` | Fast check: same as `check` minus `check-patchloom-md` (still runs `check-readme` so test-count drift fails locally before CI) |
 | `make update-readme` | Update README.md rounded test count (only changes when hundreds digit changes) |
 | `make check-readme` | Verify README.md rounded test count is accurate (part of `check`) |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd patchloom
 make check
 ```
 
-`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks. While iterating locally, `make check-fast` skips the doc freshness checks but adds library hygiene enforcement.
+`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks (`check-patchloom-md`, `check-readme`). While iterating locally, `make check-fast` is almost the same but skips only `check-patchloom-md` (still runs `check-readme` so a drifted README test badge fails before CI).
 
 ## Development workflow
 
@@ -38,7 +38,7 @@ This is a quick-reference subset. For the complete list, see [AGENTS.md](./AGENT
 | `make pty-test` | Run PTY-based interactive terminal tests (serial) |
 | `make clippy` | Run clippy with `-D warnings` |
 | `make check` | Full CI gate (run before every commit) |
-| `make check-fast` | Fast check (skips doc verification) |
+| `make check-fast` | Fast check (skips PATCHLOOM.md sync only; still checks README test count) |
 | `make update-readme` | Update README.md rounded test count |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clippy: ## Run clippy linter
 
 check: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme ## Run all checks (full CI gate)
 
-check-fast: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene ## Fast check (skips doc verification; includes release notes verify)
+check-fast: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-readme ## Fast check (skips PATCHLOOM.md sync check only; includes README count + release notes)
 
 audit-test-hygiene: ## Audit test names/comments for staleness and weak assertions after refactors (addresses post-refactor tech debt)
 	@echo "=== Suspicious test names (same file, core, outdated concepts) ==="

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -586,6 +586,32 @@ mod tests {
         assert!(out.contains("[tx]"));
     }
 
+    /// Canonical names table must stay present so agents do not invent alternates.
+    #[test]
+    fn agent_rules_includes_canonical_parameter_names() {
+        let out = generate_agent_rules(&args(AgentMode::All, AgentPlatform::All));
+        assert!(
+            out.contains("## Canonical parameter names"),
+            "missing Canonical parameter names section"
+        );
+        assert!(out.contains("| `old` |"), "must document canonical old");
+        assert!(out.contains("| `new` |"), "must document canonical new");
+        assert!(
+            out.contains("| `selector` |"),
+            "must document canonical selector"
+        );
+        assert!(
+            out.contains("`weak` / `medium` / `strong`"),
+            "must document schema tier names"
+        );
+        // Present in both CLI and MCP-only modes (not CLI-only prose).
+        let mcp_only = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));
+        assert!(
+            mcp_only.contains("## Canonical parameter names"),
+            "MCP-only agent-rules must still include canonical names"
+        );
+    }
+
     #[test]
     fn agent_rules_includes_patch_merge_workflow() {
         let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));


### PR DESCRIPTION
## Summary

Multi-perspective improve cycle 2 (Test Auditor + Maintainer/Ops + End User lock).

### Gate (before rotation)
- Fixed failing CI on #1427 / #1428: `make check` failed at `check-readme` because agents used `check-fast`, which skipped README count verification. Both PRs landed after a README 3100+ bump.
- Release PR #1313 left open (needs explicit approval to publish 0.10.0).
- Open issues remain distribution-only packaging work.

### This PR
1. **`make check-fast` now runs `check-readme`** so local agent gates catch test-count drift before CI.
2. **Docs:** AGENTS.md / CONTRIBUTING.md describe that check-fast only skips `check-patchloom-md`.
3. **Test Auditor:** unit test locks the **Canonical parameter names** section in agent-rules (including MCP-only mode).

### Other perspectives this cycle
No additional high-impact code changes (Security/Perf/Adversarial/Architecture: no new actionable gaps on current main).

## Test plan
- [x] `cargo test --lib agent_rules_includes_canonical`
- [x] `make check-readme`
- [x] `make check-fast` (now includes check-readme)