### PR TITLE
test: reject legacy ast rename positionals; document delete-where idempotency

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -676,6 +676,7 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 - **What it does:** Deletes array items that match a predicate (`--predicate key=value`). For scalar arrays, use `.=x`, `_=x`, or `value=x`.
 - **Use when:** You need to remove selected objects or scalar values from a list without rebuilding the whole array by hand.
+- **Idempotency:** When no elements match the predicate, the command exits 0 and does not rewrite the file (same as `doc delete` on a missing key). Use `doc update` when a missing match should be an error.
 - **Prefer instead:** Use `doc delete` when one direct selector path can remove the target.
 
 <!-- ref:doc-action:merge -->

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -536,6 +536,21 @@ fn test_ast_rename_apply_exits_0() {
     );
 }
 
+/// Legacy path-last positionals are no longer accepted (canonical: path + --old/--new).
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_rename_legacy_positionals_rejected() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("rename.rs");
+    fs::write(&f, "fn alpha() {}\n").unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "rename", "alpha", "beta", "rename.rs", "--apply"])
+        .assert()
+        .code(2)
+        .stderr(predicates::str::contains("--old"))
+        .stderr(predicates::str::contains("--new"));
+}
+
 #[test]
 #[cfg(feature = "ast")]
 fn test_ast_rename_nonexistent_symbol_exits_3() {


### PR DESCRIPTION
## Summary

Multi-perspective improve cycle 3 after gate (main green; only release PR #1313 and dist issues open).

### Changes
1. **QA:** CLI regression for the pre-consistency `ast rename OLD NEW PATH` shape (must fail exit 2 and mention `--old` / `--new`).
2. **End User / Observability:** Document that `doc delete-where` with zero matches is **idempotent success** (exit 0), matching `doc delete` on a missing key, so agents do not treat it as a failed cleanup.

### Gate notes
- Release PR #1313 not merged (needs explicit approval to publish 0.10.0).
- Dist issues #632–#634, #960–#963 unchanged (external packaging).

## Test plan
- [x] `cargo test --test integration test_ast_rename_legacy_positionals`
- [x] `make check-fast` (includes check-readme)