### PR TITLE
fix: clarify doc.update uses selector predicates, not --where

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -301,8 +301,8 @@ dependencies[name=react].version # predicate filter
 - `md.move_section`: Move a heading section to a new position (same-file reorder or cross-file move). Exactly one of before or after is required.
 - `patch.apply`: Apply a unified diff patch to one or more files. Supports three-way merge on stale context.
 - `doc.prepend`: Prepend a value to the beginning of an array at a selector path.
-- `doc.update`: Update all array elements matching a predicate with new values.
-- `doc.delete_where`: Delete array elements matching a predicate.
+- `doc.update`: Set a new value at every location matching a selector. Use wildcards (items[*].enabled) or selector predicates (items[name=foo].v). Not a separate --where flag; the filter is part of the selector string.
+- `doc.delete_where`: Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path.
 - `search`: Search for text across files with optional regex, context, and count assertion. Supports advanced layered ignores: literal (vs regex), globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.
 - `read`: Read file contents with optional line range.
 - `md.dedupe_headings`: Remove duplicate markdown headings in a file.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -674,7 +674,7 @@ Use these when the top level `doc` command is right, but you need a specific str
 <!-- ref:doc-action:delete-where -->
 ### `doc delete-where`
 
-- **What it does:** Deletes array items that match a predicate (`--predicate key=value`). For scalar arrays, use `.=x`, `_=x`, or `value=x`.
+- **What it does:** Deletes array items that match a predicate (`--predicate key=value`). For scalar arrays, use `.=x`, `_=x`, or `value=x`. This is a separate filter from selector predicates used by `doc update`.
 - **Use when:** You need to remove selected objects or scalar values from a list without rebuilding the whole array by hand.
 - **Idempotency:** When no elements match the predicate, the command exits 0 and does not rewrite the file (same as `doc delete` on a missing key). Use `doc update` when a missing match should be an error.
 - **Prefer instead:** Use `doc delete` when one direct selector path can remove the target.
@@ -710,7 +710,7 @@ Use these when the top level `doc` command is right, but you need a specific str
 <!-- ref:doc-action:update -->
 ### `doc update`
 
-- **What it does:** Updates all matching nodes to the same value.
+- **What it does:** Sets the same new value at every location matching a selector. Wildcards (`items[*].enabled`) and selector predicates (`items[name=foo].v`) filter inside the selector string. There is no separate `--where` or `--predicate` flag (unlike `doc delete-where`).
 - **Use when:** A broad but uniform change should apply across many selected elements.
 - **Prefer instead:** Use `doc set` when the change only targets one path.
 
@@ -979,7 +979,7 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:doc.update -->
 ### `doc.update`
 
-- **What it does:** Updates all matching structured nodes inside a transaction.
+- **What it does:** Updates all matching structured nodes inside a transaction. Matching is via the `selector` field (wildcards and selector predicates), not a separate predicate field.
 - **Use when:** A broad structured rewrite should be coupled to other edits and validations.
 - **Related:** top level `doc update`
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -119,7 +119,10 @@ pub enum DocAction {
     Update {
         /// File path (JSON, YAML, or TOML).
         file: String,
-        /// Selector path (e.g. `server.port`, `items[*].enabled`).
+        /// Selector path. Supports wildcards and selector predicates
+        /// (e.g. `server.port`, `items[*].enabled`, `items[name=foo].v`).
+        /// Filters live in the selector string; there is no separate --where flag
+        /// (unlike `doc delete-where --predicate`).
         selector: String,
         /// New value (JSON literal or bare string).
         value: String,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -368,15 +368,27 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "doc.update",
-        description: "Update all array elements matching a predicate with new values.",
+        description: "Set a new value at every location matching a selector. Use wildcards (items[*].enabled) or selector predicates (items[name=foo].v). Not a separate --where flag; the filter is part of the selector string.",
         tier: Tier::Strong,
-        examples: &[],
+        examples: &[
+            (
+                "Update one field on matching array objects via a selector predicate",
+                r###"{"op":"doc.update","path":"config.toml","selector":"items[name=a].v","value":7}"###,
+            ),
+            (
+                "Set a field on every array element with a wildcard",
+                r###"{"op":"doc.update","path":"config.json","selector":"items[*].enabled","value":true}"###,
+            ),
+        ],
     },
     OpMeta {
         name: "doc.delete_where",
-        description: "Delete array elements matching a predicate.",
+        description: "Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path.",
         tier: Tier::Strong,
-        examples: &[],
+        examples: &[(
+            "Remove scalar array elements equal to a (agent-friendly value= form)",
+            r###"{"op":"doc.delete_where","path":"config.toml","selector":"tags","predicate":"value=a"}"###,
+        )],
     },
     OpMeta {
         name: "search",

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1508,6 +1508,39 @@ fn test_doc_update_matching_nodes() {
     assert_eq!(items[1]["s"], serde_json::json!("x"));
 }
 
+/// Selector predicates (not a separate --where flag) filter which elements update.
+/// fixrealloop: agents reading "predicate" in the schema invented --where.
+#[test]
+fn test_doc_update_selector_predicate_filters_elements() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(
+        &file,
+        r#"{"items":[{"name":"a","v":1},{"name":"b","v":2}]}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("update")
+        .arg(&file)
+        .arg("items[name=a].v")
+        .arg("7")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(v["items"][0]["v"], serde_json::json!(7));
+    assert_eq!(
+        v["items"][1]["v"],
+        serde_json::json!(2),
+        "non-matching element must stay unchanged"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // md: dedupe-headings, lint-agents
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

fixrealloop agent-facing scenario for filtered array updates:

1. Schema/`agent-rules` described `doc.update` as matching a **predicate**
2. Agent (and this loop) tried `doc update … --where name=z` → clap rejected
3. The real mechanism is **selector predicates** (`items[name=a].v`) or wildcards (`items[*].v`)

This is the same class of naming confusion as `key`/`from`/`to`, but here the fix is clearer docs and examples rather than a new flag (selector predicates already work).

### Changes
- Schema OpMeta description + examples for `doc.update` and clearer `doc.delete_where` contrast
- CLI help on `doc update` selector
- Reference docs for CLI and tx ops
- Integration test: `items[name=a].v` updates only the matching element
- `make sync-patchloom-md`

### Other fixrealloop results (healthy)
- `from`/`to` replace aliases, `key` doc alias, `old`/`new` ast rename, patch `-` stdin, `md lint`, tidy defaults, contain, delete-where `value=`, schema tier enum, preview exit 2, unique exit 5, for_each plans

## Test plan
- [x] `cargo test --test integration test_doc_update_selector_predicate`
- [x] `make sync-patchloom-md && make check-fast`