### PR TITLE
fix: pin release installers and doc write JSON mutation summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,11 +182,25 @@ jobs:
           submodules: recursive
           ref: ${{ steps.resolve-tag.outputs.tag || github.ref }}
       - name: Install dist
-        # we specify bash to get pipefail; it guards against the `curl` command
-        # failing. otherwise `sh` won't catch that `curl` returned non-0
+        # Pin the cargo-dist binary by SHA-256 (Scorecard Pinned-Dependencies /
+        # downloadThenRun). Avoids unpinned curl|sh of cargo-dist-installer.sh.
+        # Version must match dist-workspace.toml cargo-dist-version.
+        # Update both the URL version and DIST_SHA256 when bumping dist.
+        # SHA from https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/sha256.sum
         shell: bash
         run: |
-          curl --retry 5 --retry-delay 2 --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh
+          set -euo pipefail
+          DIST_VERSION=v0.31.0
+          DIST_TRIPLE=x86_64-unknown-linux-gnu
+          DIST_SHA256=cd355dab0b4c02fb59038fef87655550021d07f45f1d82f947a34ef98560abb8
+          ARCHIVE="cargo-dist-${DIST_TRIPLE}.tar.xz"
+          URL="https://github.com/axodotdev/cargo-dist/releases/download/${DIST_VERSION}/${ARCHIVE}"
+          curl --retry 5 --retry-delay 2 --proto '=https' --tlsv1.2 -LsSf -o "/tmp/${ARCHIVE}" "${URL}"
+          echo "${DIST_SHA256}  /tmp/${ARCHIVE}" | sha256sum -c -
+          mkdir -p "${HOME}/.cargo/bin"
+          tar -xJf "/tmp/${ARCHIVE}" -C /tmp
+          install -m 755 "/tmp/cargo-dist-${DIST_TRIPLE}/dist" "${HOME}/.cargo/bin/dist"
+          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
       - name: Cache dist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -260,12 +274,37 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install Rust non-interactively if not already installed
+        # Pin rustup-init by version + SHA-256 (Scorecard Pinned-Dependencies).
+        # Avoids unpinned curl|sh of https://sh.rustup.rs.
+        # Hashes from https://static.rust-lang.org/rustup/archive/<ver>/<triple>/rustup-init.sha256
         if: ${{ matrix.container }}
+        shell: bash
         run: |
-          if ! command -v cargo > /dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          set -euo pipefail
+          if command -v cargo > /dev/null 2>&1; then
+            exit 0
           fi
+          RUSTUP_VERSION=1.29.0
+          case "$(uname -m)" in
+            x86_64)
+              RUSTUP_TRIPLE=x86_64-unknown-linux-gnu
+              RUSTUP_SHA256=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+              ;;
+            aarch64|arm64)
+              RUSTUP_TRIPLE=aarch64-unknown-linux-gnu
+              RUSTUP_SHA256=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792
+              ;;
+            *)
+              echo "unsupported architecture for pinned rustup-init: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          URL="https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_TRIPLE}/rustup-init"
+          curl --proto '=https' --tlsv1.2 -sSf -o /tmp/rustup-init "${URL}"
+          echo "${RUSTUP_SHA256}  /tmp/rustup-init" | sha256sum -c -
+          chmod +x /tmp/rustup-init
+          /tmp/rustup-init -y --no-modify-path
+          echo "${HOME}/.cargo/bin" >> "${GITHUB_PATH}"
       - name: Install dist
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,3 +39,21 @@ Maintainers should:
 ## Private Contact Scope
 
 GitHub private vulnerability reporting is the default private channel for security reports. It is not meant to become a general-purpose private contact method for product ideas, support, or partnership requests.
+
+## OpenSSF Scorecard notes
+
+Patchloom publishes multi-platform binaries and crates via the cargo-dist
+workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml)
+and the crates.io publish job. CI also runs `cargo deny` / advisory checks
+against the lockfile.
+
+Some Scorecard heuristics do not fully match that posture:
+
+| Check | Observed Scorecard signal | Project reality |
+|-------|---------------------------|-----------------|
+| **Packaging** | Often `-1` / "packaging workflow not detected" | Releases use cargo-dist (`release.yml`) plus crates.io and Homebrew publishing. Scorecard's packaging detector does not currently recognize this cargo-dist layout; treat a low Packaging score as a known false negative, not absence of packaging. |
+| **Vulnerabilities** | May lag OSV/RUSTSEC listings (for example historical `anyhow` advisories) | Authoritative sources for this repo are the checked-in `Cargo.lock` and CI advisory tooling (`cargo deny` / `cargo audit`). If Scorecard still flags an advisory while the lockfile and CI audit are clean (patched versions resolved), prefer the lockfile + CI result. |
+
+Pinned installers in the release workflow (cargo-dist binary and rustup-init
+with version + SHA-256) address the Pinned-Dependencies `downloadThenRun`
+findings; see issues #1433 and #1436 for history.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -669,6 +669,8 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 - **What it does:** Removes the value at a selector path.
 - **Use when:** A selector path or node is obsolete and should disappear cleanly.
+- **Idempotency:** When the selector matches nothing, the command exits 0 and does not rewrite the file.
+- **JSON summary:** With `--json` / `--jsonl`, success payloads include `changed` (bool) and `removed` (`1` when a value was deleted, `0` on no-match). Exit 0 with `"removed": 0` is expected for idempotent cleanup of a missing key.
 - **Prefer instead:** Use `doc delete-where` when the target is a subset of array items instead of one direct selector path.
 
 <!-- ref:doc-action:delete-where -->
@@ -677,6 +679,7 @@ Use these when the top level `doc` command is right, but you need a specific str
 - **What it does:** Deletes array items that match a predicate (`--predicate key=value`). For scalar arrays, use `.=x`, `_=x`, or `value=x`. This is a separate filter from selector predicates used by `doc update`.
 - **Use when:** You need to remove selected objects or scalar values from a list without rebuilding the whole array by hand.
 - **Idempotency:** When no elements match the predicate, the command exits 0 and does not rewrite the file (same as `doc delete` on a missing key). Use `doc update` when a missing match should be an error.
+- **JSON summary:** With `--json` / `--jsonl`, success payloads include `changed` (bool) and `removed` (usize). Exit 0 with `"removed": 0` and `"changed": false` means the predicate matched nothing (idempotent cleanup). A non-zero `removed` means that many array items were deleted.
 - **Prefer instead:** Use `doc delete` when one direct selector path can remove the target.
 
 <!-- ref:doc-action:merge -->

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -1,6 +1,5 @@
 use crate::cli::global::GlobalFlags;
 use crate::cmd::output::WritePhase;
-use crate::cmd::output::execute_via_engine;
 use crate::exit;
 use crate::ops::doc::{detect_format, diff_values, flatten_value, parse_doc, parse_value};
 use crate::plan::Operation;
@@ -258,10 +257,59 @@ use anyhow::Context;
 struct DocWriteOutput {
     ok: bool,
     path: String,
+    /// Whether the staged mutation would (or did) change the file.
+    /// Always present so agents can distinguish idempotent no-ops from real
+    /// writes when exit code is 0 (e.g. delete / delete-where with zero matches).
+    changed: bool,
+    /// For `doc delete` / `doc delete-where`: how many values or array items
+    /// were removed (`0` on idempotent no-match). Omitted for other write ops.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    removed: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diff: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     applied: Option<bool>,
+}
+
+/// Count of items a delete / delete-where mutation would remove (file must still
+/// have original content). Returns `None` for non-delete write ops.
+fn preview_removed_count(cwd: &std::path::Path, op: &Operation) -> Option<usize> {
+    use crate::ops::doc::{MutationResult, apply_doc_mutation, detect_format, parse_doc};
+    use crate::plan::op_to_doc_mutation;
+
+    let (path, mutation) = op_to_doc_mutation(op)?;
+    let is_delete = matches!(
+        mutation,
+        crate::ops::doc::DocMutation::Delete { .. }
+            | crate::ops::doc::DocMutation::DeleteWhere { .. }
+    );
+    if !is_delete {
+        return None;
+    }
+
+    let full = cwd.join(path);
+    let content = std::fs::read_to_string(&full).ok()?;
+    let format = detect_format(path).ok()?;
+    let mut root = parse_doc(&content, &format).ok()?;
+
+    match apply_doc_mutation(&mut root, mutation).ok()? {
+        MutationResult::Applied => match op {
+            Operation::DocDelete { .. } => Some(1),
+            Operation::DocDeleteWhere {
+                path: _,
+                selector,
+                predicate,
+            } => {
+                // Re-count via delete_where on a fresh parse (Applied loses count).
+                let mut root2 = parse_doc(&content, &format).ok()?;
+                let sel = crate::selector::parse_anyhow(selector).ok()?;
+                crate::ops::doc::delete_where(&mut root2, &sel, predicate).ok()
+            }
+            _ => None,
+        },
+        MutationResult::NoMatch => Some(0),
+        MutationResult::AlreadyExists | MutationResult::TypeError(_) => None,
+    }
 }
 
 /// Convert a write [`DocAction`] into the corresponding [`Operation`] variant.
@@ -742,22 +790,49 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let check_msg = format!("would modify {display_path}");
         let apply_msg = format!("updated {display_path}");
 
+        // Stage first so we can report `changed` / `removed` in JSON for
+        // idempotent delete no-ops (exit 0 with removed: 0). See #1434.
         let path_clone = display_path;
-        match execute_via_engine(
-            op,
-            global,
-            |phase, diff| DocWriteOutput {
-                ok: true,
-                path: path_clone.clone(),
-                diff,
-                applied: match phase {
-                    WritePhase::Confirmed(a) => Some(a),
-                    _ => None,
+        match (|| -> anyhow::Result<u8> {
+            let cwd = global.resolve_cwd()?;
+            let removed = preview_removed_count(&cwd, &op);
+            let (cwd, result) = crate::cmd::output::stage_for_write(
+                crate::tx::engine::WriteSource::Operations(vec![op]),
+                global,
+            )?;
+            let changed = result.has_changes;
+            // For delete ops, always report removed (0 on idempotent no-match).
+            // Prefer pre-stage count; fall back to changed-as-0/1 if preview failed.
+            let removed = match (&args.action, removed) {
+                (DocAction::Delete { .. } | DocAction::DeleteWhere { .. }, Some(n)) => Some(n),
+                (DocAction::Delete { .. } | DocAction::DeleteWhere { .. }, None) => {
+                    Some(usize::from(changed))
+                }
+                _ => None,
+            };
+            crate::cmd::write_mode::finalize_execution_result(
+                global,
+                &cwd,
+                result,
+                |phase, diff| DocWriteOutput {
+                    ok: true,
+                    path: path_clone.clone(),
+                    changed,
+                    removed,
+                    diff,
+                    applied: match phase {
+                        WritePhase::Confirmed(a) => Some(a),
+                        _ => None,
+                    },
                 },
-            },
-            &check_msg,
-            &apply_msg,
-        ) {
+                crate::cmd::write_mode::WriteMessages {
+                    check: &check_msg,
+                    apply: &apply_msg,
+                    post_confirm: None,
+                },
+                crate::cmd::write_mode::RenderPolicy::default(),
+            )
+        })() {
             Ok(code) => return Ok(code),
             Err(e) => {
                 if exit::is_no_match(&e) {

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -577,6 +577,40 @@ mod edge_cases {
         assert_eq!(code, exit::SUCCESS);
     }
 
+    #[test]
+    fn preview_removed_count_delete_where_zero() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"users": [{"name": "alice"}]}"#);
+        let op = Operation::DocDeleteWhere {
+            path: path.clone(),
+            selector: "users".into(),
+            predicate: "name=nobody".into(),
+        };
+        assert_eq!(
+            super::super::preview_removed_count(dir.path(), &op),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn preview_removed_count_delete_where_two() {
+        let dir = TempDir::new().unwrap();
+        let path = write_file(
+            &dir,
+            "test.json",
+            r#"{"users": [{"name": "a"}, {"name": "b"}, {"name": "a"}]}"#,
+        );
+        let op = Operation::DocDeleteWhere {
+            path,
+            selector: "users".into(),
+            predicate: "name=a".into(),
+        };
+        assert_eq!(
+            super::super::preview_removed_count(dir.path(), &op),
+            Some(2)
+        );
+    }
+
     // -- ensure -------------------------------------------------------------
 
     #[test]

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -945,6 +945,103 @@ fn test_doc_delete_where() {
     assert_eq!(items[0]["name"], serde_json::json!("keep"));
 }
 
+/// #1434: delete-where zero matches is exit 0 with removed:0 / changed:false.
+#[test]
+fn test_doc_delete_where_json_zero_match_reports_removed_zero() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"items":[{"name":"keep"},{"name":"also"}]}"#).unwrap();
+
+    let stdout = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("delete-where")
+        .arg(&file)
+        .arg("items")
+        .arg("--predicate")
+        .arg("name=nobody")
+        .arg("--apply")
+        .arg("--json")
+        .assert()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&stdout).expect("valid json");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["changed"], false, "payload: {v}");
+    assert_eq!(v["removed"], 0, "payload: {v}");
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("keep") && content.contains("also"),
+        "file should be unchanged on zero-match: {content}"
+    );
+}
+
+/// #1434: delete-where with matches reports non-zero removed and changed:true.
+#[test]
+fn test_doc_delete_where_json_match_reports_removed_count() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(
+        &file,
+        r#"{"items":[{"name":"a"},{"name":"b"},{"name":"a"}]}"#,
+    )
+    .unwrap();
+
+    let stdout = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("delete-where")
+        .arg(&file)
+        .arg("items")
+        .arg("--predicate")
+        .arg("name=a")
+        .arg("--apply")
+        .arg("--json")
+        .assert()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&stdout).expect("valid json");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["changed"], true, "payload: {v}");
+    assert_eq!(v["removed"], 2, "payload: {v}");
+
+    let content = fs::read_to_string(&file).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(parsed["items"].as_array().unwrap().len(), 1);
+    assert_eq!(parsed["items"][0]["name"], "b");
+}
+
+/// #1434: doc delete missing key is exit 0 with removed:0.
+#[test]
+fn test_doc_delete_json_missing_key_reports_removed_zero() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"name":"keep"}"#).unwrap();
+
+    let stdout = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("delete")
+        .arg(&file)
+        .arg("missing")
+        .arg("--apply")
+        .arg("--json")
+        .assert()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&stdout).expect("valid json");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["changed"], false, "payload: {v}");
+    assert_eq!(v["removed"], 0, "payload: {v}");
+}
+
 // ---------------------------------------------------------------------------
 // md
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **#1433:** Replace unpinned `curl | sh` installers in `release.yml` with versioned binary/tarball downloads verified by SHA-256 (cargo-dist plan job; rustup-init in container build jobs).
- **#1434:** Doc write `--json` / `--jsonl` success payloads now include `changed` and, for `delete` / `delete-where`, `removed`. Idempotent zero-match cleanup stays exit 0 with `"removed": 0` and `"changed": false`.
- **#1436:** Document Scorecard Packaging false negative (cargo-dist not detected) and Vulnerabilities lag vs lockfile/`cargo deny` in `SECURITY.md`.

## Test plan

- [x] `cargo test --lib cmd::doc` (unit + preview_removed_count)
- [x] Integration: `test_doc_delete_where_json_*`, `test_doc_delete_json_missing_key_reports_removed_zero`
- [x] `make check-fast`
- [ ] CI green on this PR

Closes #1433
Closes #1434
Closes #1436