### PR TITLE
fix: bump crossbeam-epoch for RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

Post-merge CI on main failed the `audit` job after RUSTSEC-2026-0204 was published for `crossbeam-epoch` 0.9.18 (invalid pointer dereference in `fmt::Pointer` impl).

Bump lockfile to 0.9.20 (transitive via `ignore` -> `crossbeam-deque`).

## Test plan

- [x] `cargo audit` clean locally after update
- [ ] CI audit job green