### PR TITLE
test: MPI cycle doc JSON coverage, agent docs, delete-where perf

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -278,6 +278,8 @@ dependencies[name=react].version # predicate filter
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
+**Doc write JSON tip:** With `--json`, every doc write success includes `changed` (bool). `doc delete` / `doc delete-where` also include `removed` (usize). Exit 0 with `removed: 0` means idempotent cleanup (nothing matched); do not assume data was deleted from exit code alone.
+
 ## Operations (from schema registry)
 
 - `replace`: Replace text in a file using literal string matching.
@@ -288,7 +290,7 @@ dependencies[name=react].version # predicate filter
 - `file.rename`: Rename (move) a file.
 - `tidy.fix`: Normalize whitespace, line endings, and final newline in a file.
 - `doc.set`: Set a value at a selector path in a JSON, YAML, or TOML file. Parser-backed; output is always valid.
-- `doc.delete`: Delete a value at a selector path in a JSON, YAML, or TOML file.
+- `doc.delete`: Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json success includes changed and removed (0 on missing key; exit 0 is idempotent).
 - `doc.merge`: Deep-merge a JSON object into the root of a document.
 - `doc.append`: Append a value to an array at a selector path.
 - `doc.move`: Move a value from one selector path to another within the same file.
@@ -302,7 +304,7 @@ dependencies[name=react].version # predicate filter
 - `patch.apply`: Apply a unified diff patch to one or more files. Supports three-way merge on stale context.
 - `doc.prepend`: Prepend a value to the beginning of an array at a selector path.
 - `doc.update`: Set a new value at every location matching a selector. Use wildcards (items[*].enabled) or selector predicates (items[name=foo].v). Not a separate --where flag; the filter is part of the selector string.
-- `doc.delete_where`: Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path.
+- `doc.delete_where`: Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path. CLI --json success includes changed and removed (0 when no elements match; exit 0 is idempotent).
 - `search`: Search for text across files with optional regex, context, and count assertion. Supports advanced layered ignores: literal (vs regex), globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.
 - `read`: Read file contents with optional line range.
 - `md.dedupe_headings`: Remove duplicate markdown headings in a file.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -629,6 +629,8 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 **Comment preservation:** All `doc` write operations preserve inline comments, section comments, and formatting in YAML and TOML files. The parser edits the concrete syntax tree (CST) directly, so only the changed values are rewritten while surrounding comments and whitespace stay intact. This includes operations that change array length (`append`, `prepend`, `delete-where`), which use text-level splicing to preserve comments on the affected file.
 
+**JSON write summary:** Every doc write success payload under `--json` / `--jsonl` includes `changed` (bool). `doc delete` and `doc delete-where` also include `removed` (usize). Agents should not treat exit 0 alone as "something was deleted"; check `removed` / `changed` for idempotent no-ops.
+
 <!-- ref:doc-action:get -->
 ### `doc get`
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -412,7 +412,11 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |\n\
              | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |\n\
              | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |\n\
-             | 9 | Tx operation staging failure (`operation_failed`) |\n\n",
+             | 9 | Tx operation staging failure (`operation_failed`) |\n\n\
+             **Doc write JSON tip:** With `--json`, every doc write success includes \
+             `changed` (bool). `doc delete` / `doc delete-where` also include `removed` \
+             (usize). Exit 0 with `removed: 0` means idempotent cleanup (nothing matched); \
+             do not assume data was deleted from exit code alone.\n\n",
         );
     }
 
@@ -575,6 +579,16 @@ mod tests {
         let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
         assert!(out.contains("--whole-line"));
         assert!(out.contains("--collapse-blanks"));
+    }
+
+    #[test]
+    fn exit_codes_include_doc_write_json_tip() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(
+            out.contains("Doc write JSON tip"),
+            "agents need changed/removed guidance for idempotent doc delete"
+        );
+        assert!(out.contains("removed: 0"));
     }
 
     #[test]

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -274,41 +274,29 @@ struct DocWriteOutput {
 /// Count of items a delete / delete-where mutation would remove (file must still
 /// have original content). Returns `None` for non-delete write ops.
 fn preview_removed_count(cwd: &std::path::Path, op: &Operation) -> Option<usize> {
-    use crate::ops::doc::{MutationResult, apply_doc_mutation, detect_format, parse_doc};
+    use crate::ops::doc::{
+        DocMutation, MutationResult, apply_doc_mutation, delete_where, detect_format, parse_doc,
+    };
     use crate::plan::op_to_doc_mutation;
 
     let (path, mutation) = op_to_doc_mutation(op)?;
-    let is_delete = matches!(
-        mutation,
-        crate::ops::doc::DocMutation::Delete { .. }
-            | crate::ops::doc::DocMutation::DeleteWhere { .. }
-    );
-    if !is_delete {
-        return None;
-    }
-
     let full = cwd.join(path);
     let content = std::fs::read_to_string(&full).ok()?;
     let format = detect_format(path).ok()?;
     let mut root = parse_doc(&content, &format).ok()?;
 
-    match apply_doc_mutation(&mut root, mutation).ok()? {
-        MutationResult::Applied => match op {
-            Operation::DocDelete { .. } => Some(1),
-            Operation::DocDeleteWhere {
-                path: _,
-                selector,
-                predicate,
-            } => {
-                // Re-count via delete_where on a fresh parse (Applied loses count).
-                let mut root2 = parse_doc(&content, &format).ok()?;
-                let sel = crate::selector::parse_anyhow(selector).ok()?;
-                crate::ops::doc::delete_where(&mut root2, &sel, predicate).ok()
-            }
-            _ => None,
+    match mutation {
+        // Single parse: delete_where returns the exact remove count.
+        DocMutation::DeleteWhere { selector, predicate } => {
+            let sel = crate::selector::parse_anyhow(&selector).ok()?;
+            delete_where(&mut root, &sel, &predicate).ok()
+        }
+        DocMutation::Delete { .. } => match apply_doc_mutation(&mut root, mutation).ok()? {
+            MutationResult::Applied => Some(1),
+            MutationResult::NoMatch => Some(0),
+            MutationResult::AlreadyExists | MutationResult::TypeError(_) => None,
         },
-        MutationResult::NoMatch => Some(0),
-        MutationResult::AlreadyExists | MutationResult::TypeError(_) => None,
+        _ => None,
     }
 }
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -280,6 +280,14 @@ fn preview_removed_count(cwd: &std::path::Path, op: &Operation) -> Option<usize>
     use crate::plan::op_to_doc_mutation;
 
     let (path, mutation) = op_to_doc_mutation(op)?;
+    // Only delete ops need a remove count; skip the disk read otherwise.
+    if !matches!(
+        mutation,
+        DocMutation::Delete { .. } | DocMutation::DeleteWhere { .. }
+    ) {
+        return None;
+    }
+
     let full = cwd.join(path);
     let content = std::fs::read_to_string(&full).ok()?;
     let format = detect_format(path).ok()?;
@@ -287,7 +295,10 @@ fn preview_removed_count(cwd: &std::path::Path, op: &Operation) -> Option<usize>
 
     match mutation {
         // Single parse: delete_where returns the exact remove count.
-        DocMutation::DeleteWhere { selector, predicate } => {
+        DocMutation::DeleteWhere {
+            selector,
+            predicate,
+        } => {
             let sel = crate::selector::parse_anyhow(&selector).ok()?;
             delete_where(&mut root, &sel, &predicate).ok()
         }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -256,7 +256,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "doc.delete",
-        description: "Delete a value at a selector path in a JSON, YAML, or TOML file.",
+        description: "Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json success includes changed and removed (0 on missing key; exit 0 is idempotent).",
         tier: Tier::Medium,
         examples: &[(
             "Remove a deprecated config entry",
@@ -383,7 +383,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "doc.delete_where",
-        description: "Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path.",
+        description: "Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path. CLI --json success includes changed and removed (0 when no elements match; exit 0 is idempotent).",
         tier: Tier::Strong,
         examples: &[(
             "Remove scalar array elements equal to a (agent-friendly value= form)",

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1106,6 +1106,41 @@ fn test_doc_ensure_json_existing_key_reports_changed_false() {
     assert_eq!(content["name"], "original");
 }
 
+/// Unicode predicate values must count toward removed (not silent no-op).
+#[test]
+fn test_doc_delete_where_json_unicode_predicate_reports_removed() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(
+        &file,
+        r#"{"users":[{"name":"日本語"},{"name":"🎉"},{"name":"ascii"}]}"#,
+    )
+    .unwrap();
+
+    let stdout = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("delete-where")
+        .arg(&file)
+        .arg("users")
+        .arg("--predicate")
+        .arg("name=🎉")
+        .arg("--apply")
+        .arg("--json")
+        .assert()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&stdout).expect("valid json");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["changed"], true, "payload: {v}");
+    assert_eq!(v["removed"], 1, "payload: {v}");
+    let content: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert_eq!(content["users"].as_array().unwrap().len(), 2);
+}
+
 /// set that would change content: --check JSON reports changed:true and exit 2.
 #[test]
 fn test_doc_set_json_check_reports_changed_true_exit_2() {

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1042,6 +1042,98 @@ fn test_doc_delete_json_missing_key_reports_removed_zero() {
     assert_eq!(v["removed"], 0, "payload: {v}");
 }
 
+/// #1434 follow-up: delete of an existing key reports removed:1 and changed:true.
+#[test]
+fn test_doc_delete_json_existing_key_reports_removed_one() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"name":"keep","drop":true}"#).unwrap();
+
+    let stdout = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("delete")
+        .arg(&file)
+        .arg("drop")
+        .arg("--apply")
+        .arg("--json")
+        .assert()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&stdout).expect("valid json");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["changed"], true, "payload: {v}");
+    assert_eq!(v["removed"], 1, "payload: {v}");
+    assert!(v.get("removed").is_some());
+    let content: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert!(content.get("drop").is_none());
+    assert_eq!(content["name"], "keep");
+}
+
+/// Non-delete writes always report `changed`; ensure no-op is false with no `removed`.
+#[test]
+fn test_doc_ensure_json_existing_key_reports_changed_false() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"name":"original"}"#).unwrap();
+
+    let stdout = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("ensure")
+        .arg(&file)
+        .arg("name")
+        .arg("overwritten")
+        .arg("--apply")
+        .arg("--json")
+        .assert()
+        .code(0)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&stdout).expect("valid json");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["changed"], false, "payload: {v}");
+    assert!(
+        v.get("removed").is_none(),
+        "ensure must not emit removed: {v}"
+    );
+    let content: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert_eq!(content["name"], "original");
+}
+
+/// set that would change content: --check JSON reports changed:true and exit 2.
+#[test]
+fn test_doc_set_json_check_reports_changed_true_exit_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"a":1}"#).unwrap();
+
+    let stdout = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("a")
+        .arg("2")
+        .arg("--check")
+        .arg("--json")
+        .assert()
+        .code(2)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&stdout).expect("valid json");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["changed"], true, "payload: {v}");
+    // Check mode must not mutate.
+    assert_eq!(fs::read_to_string(&file).unwrap().trim(), r#"{"a":1}"#);
+}
+
 // ---------------------------------------------------------------------------
 // md
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

MPI cycle 1 after #1437/#1438, focusing on the new doc write JSON surface and agent guidance.

- **QA:** Integration tests for ensure no-op `changed:false`, delete existing `removed:1`, set `--check` exit 2, unicode delete-where.
- **Developer/Perf:** Single-parse `preview_removed_count` for delete-where; skip disk read for non-delete writes.
- **End User:** agent-rules tip, schema op descriptions, reference intro for `changed`/`removed`, PATCHLOOM.md sync.
- **Spec/PM gap filed:** #1439 MCP/tx still lack mutation summary (CLI-only enrichment today).

## Test plan

- [x] `cargo test --lib cmd::doc`
- [x] Integration tests for new JSON cases
- [x] `make check-fast`
- [ ] CI green

Ref #1434
Ref #1439