### PR TITLE
feat: MCP/tx doc delete mutation summary (changed/removed)

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -278,7 +278,7 @@ dependencies[name=react].version # predicate filter
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
-**Doc write JSON tip:** With `--json`, every doc write success includes `changed` (bool). `doc delete` / `doc delete-where` also include `removed` (usize). Exit 0 with `removed: 0` means idempotent cleanup (nothing matched); do not assume data was deleted from exit code alone.
+**Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, doc delete success includes `changed` (bool) and `removed` (usize). Multi-op plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with `removed: 0` means idempotent cleanup (nothing matched); do not assume data was deleted from exit status alone.
 
 ## Operations (from schema registry)
 
@@ -290,7 +290,7 @@ dependencies[name=react].version # predicate filter
 - `file.rename`: Rename (move) a file.
 - `tidy.fix`: Normalize whitespace, line endings, and final newline in a file.
 - `doc.set`: Set a value at a selector path in a JSON, YAML, or TOML file. Parser-backed; output is always valid.
-- `doc.delete`: Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json success includes changed and removed (0 on missing key; exit 0 is idempotent).
+- `doc.delete`: Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json and MCP/tx success include changed and removed (0 on missing key; exit 0 / ok is idempotent).
 - `doc.merge`: Deep-merge a JSON object into the root of a document.
 - `doc.append`: Append a value to an array at a selector path.
 - `doc.move`: Move a value from one selector path to another within the same file.
@@ -304,7 +304,7 @@ dependencies[name=react].version # predicate filter
 - `patch.apply`: Apply a unified diff patch to one or more files. Supports three-way merge on stale context.
 - `doc.prepend`: Prepend a value to the beginning of an array at a selector path.
 - `doc.update`: Set a new value at every location matching a selector. Use wildcards (items[*].enabled) or selector predicates (items[name=foo].v). Not a separate --where flag; the filter is part of the selector string.
-- `doc.delete_where`: Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path. CLI --json success includes changed and removed (0 when no elements match; exit 0 is idempotent).
+- `doc.delete_where`: Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path. CLI --json and MCP/tx success include changed and removed (0 when no elements match; exit 0 / ok is idempotent).
 - `search`: Search for text across files with optional regex, context, and count assertion. Supports advanced layered ignores: literal (vs regex), globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.
 - `read`: Read file contents with optional line range.
 - `md.dedupe_headings`: Remove duplicate markdown headings in a file.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -629,7 +629,7 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 **Comment preservation:** All `doc` write operations preserve inline comments, section comments, and formatting in YAML and TOML files. The parser edits the concrete syntax tree (CST) directly, so only the changed values are rewritten while surrounding comments and whitespace stay intact. This includes operations that change array length (`append`, `prepend`, `delete-where`), which use text-level splicing to preserve comments on the affected file.
 
-**JSON write summary:** Every doc write success payload under `--json` / `--jsonl` includes `changed` (bool). `doc delete` and `doc delete-where` also include `removed` (usize). Agents should not treat exit 0 alone as "something was deleted"; check `removed` / `changed` for idempotent no-ops.
+**JSON write summary:** Every doc write success payload under `--json` / `--jsonl` includes `changed` (bool). `doc delete` and `doc delete-where` also include `removed` (usize). Agents should not treat exit 0 alone as "something was deleted"; check `removed` / `changed` for idempotent no-ops. The same fields appear on MCP `doc_delete` / `doc_delete_where` and on `execute_plan` / `tx` reports (plus a `mutations` array with per-op `path`, `op`, `changed`, `removed` for multi-step plans).
 
 <!-- ref:doc-action:get -->
 ### `doc get`

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -87,7 +87,8 @@ use crate::write::{EolMode, WritePolicy, atomic_write};
 
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use crate::tx::{
-    TxChange, TxLintResult, TxOutput as PlanReport, TxReadResult, TxSearchMatch, TxSearchResult,
+    TxChange, TxDocMutation, TxLintResult, TxOutput as PlanReport, TxReadResult, TxSearchMatch,
+    TxSearchResult,
 };
 
 mod doc;

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -413,10 +413,11 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |\n\
              | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |\n\
              | 9 | Tx operation staging failure (`operation_failed`) |\n\n\
-             **Doc write JSON tip:** With `--json`, every doc write success includes \
-             `changed` (bool). `doc delete` / `doc delete-where` also include `removed` \
-             (usize). Exit 0 with `removed: 0` means idempotent cleanup (nothing matched); \
-             do not assume data was deleted from exit code alone.\n\n",
+             **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, \
+             doc delete success includes `changed` (bool) and `removed` (usize). Multi-op \
+             plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with \
+             `removed: 0` means idempotent cleanup (nothing matched); do not assume data \
+             was deleted from exit status alone.\n\n",
         );
     }
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -303,9 +303,11 @@ fn preview_removed_count(cwd: &std::path::Path, op: &Operation) -> Option<usize>
             delete_where(&mut root, &sel, &predicate).ok()
         }
         DocMutation::Delete { .. } => match apply_doc_mutation(&mut root, mutation).ok()? {
-            MutationResult::Applied => Some(1),
+            MutationResult::Removed(n) => Some(n),
             MutationResult::NoMatch => Some(0),
-            MutationResult::AlreadyExists | MutationResult::TypeError(_) => None,
+            MutationResult::Applied
+            | MutationResult::AlreadyExists
+            | MutationResult::TypeError(_) => None,
         },
         _ => None,
     }

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -778,6 +778,12 @@ pub enum DocMutation {
 pub enum MutationResult {
     /// The mutation was applied and the document was modified.
     Applied,
+    /// A delete / delete-where removed this many items (always >= 1).
+    ///
+    /// Callers that only care about "did anything change" can treat this like
+    /// [`Applied`](Self::Applied). Callers that need counts (CLI/MCP JSON)
+    /// use the payload for `removed`.
+    Removed(usize),
     /// The selector matched nothing (e.g. delete on a missing key).
     NoMatch,
     /// The path already exists (used by `Ensure` when no write is needed).
@@ -807,7 +813,7 @@ pub fn apply_doc_mutation(
         DocMutation::Delete { selector } => {
             let sel = selector::parse_anyhow(&selector)?;
             if delete_at_selector(root, &sel)? {
-                Ok(MutationResult::Applied)
+                Ok(MutationResult::Removed(1))
             } else {
                 Ok(MutationResult::NoMatch)
             }
@@ -874,7 +880,7 @@ pub fn apply_doc_mutation(
             if removed == 0 {
                 Ok(MutationResult::NoMatch)
             } else {
-                Ok(MutationResult::Applied)
+                Ok(MutationResult::Removed(removed))
             }
         }
     }

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -250,7 +250,7 @@ mod basic {
             },
         )
         .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
+        assert!(matches!(result, MutationResult::Removed(1)));
         assert_eq!(root, json!({"a": 1}));
     }
 
@@ -354,7 +354,7 @@ mod basic {
             },
         )
         .unwrap();
-        assert!(matches!(result, MutationResult::Applied));
+        assert!(matches!(result, MutationResult::Removed(1)));
         assert_eq!(root["items"].as_array().unwrap().len(), 1);
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -256,7 +256,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "doc.delete",
-        description: "Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json success includes changed and removed (0 on missing key; exit 0 is idempotent).",
+        description: "Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json and MCP/tx success include changed and removed (0 on missing key; exit 0 / ok is idempotent).",
         tier: Tier::Medium,
         examples: &[(
             "Remove a deprecated config entry",
@@ -383,7 +383,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "doc.delete_where",
-        description: "Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path. CLI --json success includes changed and removed (0 when no elements match; exit 0 is idempotent).",
+        description: "Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path. CLI --json and MCP/tx success include changed and removed (0 when no elements match; exit 0 / ok is idempotent).",
         tier: Tier::Strong,
         examples: &[(
             "Remove scalar array elements equal to a (agent-friendly value= form)",

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -221,6 +221,7 @@ pub fn execute_precomputed(
         tx_reads: Vec::new(),
         tx_searches: Vec::new(),
         tx_lints: Vec::new(),
+        tx_mutations: Vec::new(),
         no_effective_changes,
         replace_no_matches: false,
         replace_hint: None,

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -3,7 +3,7 @@
 //! File mutations: [`file_ops`]. Write policy: [`policy`].
 //! Other handlers: `tx/{ast,md,patch,replace,search,tidy}_op`.
 
-use super::output::{TxExecResult, TxLintResult, TxReadResult, TxSearchResult};
+use super::output::{TxDocMutation, TxExecResult, TxLintResult, TxReadResult, TxSearchResult};
 use super::validate::op_label;
 use crate::ops::doc::{
     FileFormat, MutationResult, apply_doc_mutation, detect_format, parse_doc,
@@ -213,6 +213,8 @@ pub(crate) struct TxState<'a> {
     pub(crate) tx_reads: &'a mut Vec<TxReadResult>,
     pub(crate) tx_searches: &'a mut Vec<TxSearchResult>,
     pub(crate) tx_lints: &'a mut Vec<TxLintResult>,
+    /// Doc delete / delete-where summaries for plan/MCP JSON (#1439).
+    pub(crate) tx_mutations: &'a mut Vec<TxDocMutation>,
     /// Files targeted by write operations (Replace, TidyFix, Doc mutations,
     /// Md mutations, Patch, AST transforms, etc.). Write policy is only
     /// applied to these files, not to files loaded solely for reading (#1108).
@@ -239,6 +241,7 @@ pub(crate) struct TxStateFixture {
     pub reads: Vec<TxReadResult>,
     pub searches: Vec<TxSearchResult>,
     pub lints: Vec<TxLintResult>,
+    pub mutations: Vec<TxDocMutation>,
     pub write_targets: HashSet<PathBuf>,
 }
 
@@ -253,6 +256,7 @@ impl TxStateFixture {
             reads: Vec::new(),
             searches: Vec::new(),
             lints: Vec::new(),
+            mutations: Vec::new(),
             write_targets: HashSet::new(),
         }
     }
@@ -266,6 +270,7 @@ impl TxStateFixture {
             tx_reads: &mut self.reads,
             tx_searches: &mut self.searches,
             tx_lints: &mut self.lints,
+            tx_mutations: &mut self.mutations,
             write_targets: &mut self.write_targets,
             replace_hint: None,
             cwd,
@@ -341,16 +346,48 @@ pub(crate) fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
     // (the old code silently discarded the bool/count return value).
     // Update is strict: no-match means the selector was wrong.
     let strict_no_match = matches!(op, Operation::DocUpdate { .. });
+    let is_delete = matches!(
+        op,
+        Operation::DocDelete { .. } | Operation::DocDeleteWhere { .. }
+    );
+    let op_name = match op {
+        Operation::DocDelete { .. } => "doc.delete",
+        Operation::DocDeleteWhere { .. } => "doc.delete_where",
+        _ => "",
+    };
 
     match apply_doc_mutation(root, mutation).map_err(path_err(path))? {
         MutationResult::Applied | MutationResult::AlreadyExists => Ok(()),
+        MutationResult::Removed(count) => {
+            if is_delete {
+                tx.tx_mutations.push(TxDocMutation {
+                    path: path.to_string(),
+                    op: op_name.to_string(),
+                    changed: true,
+                    removed: count,
+                });
+            }
+            Ok(())
+        }
         MutationResult::NoMatch if strict_no_match => {
             let label = op_label(op);
             Err(crate::exit::NoMatchError {
                 msg: format!("{path}: {label} matched nothing"),
             })?
         }
-        MutationResult::NoMatch => Ok(()),
+        MutationResult::NoMatch => {
+            // Idempotent delete/delete-where: still report removed:0 so MCP/tx
+            // JSON can distinguish no-op from real deletes (#1439).
+            if is_delete {
+                tx.tx_mutations.push(TxDocMutation {
+                    path: path.to_string(),
+                    op: op_name.to_string(),
+                    changed: false,
+                    removed: 0,
+                });
+            }
+            Ok(())
+        }
         MutationResult::TypeError(msg) => {
             anyhow::bail!("{path}: {msg}");
         }
@@ -460,6 +497,7 @@ pub(crate) fn execute_and_collect(
     let mut tx_reads: Vec<TxReadResult> = Vec::new();
     let mut tx_searches: Vec<TxSearchResult> = Vec::new();
     let mut tx_lints: Vec<TxLintResult> = Vec::new();
+    let mut tx_mutations: Vec<TxDocMutation> = Vec::new();
     let mut doc_cache: HashMap<PathBuf, CachedDoc> = HashMap::new();
     let mut replace_hint: Option<String> = None;
 
@@ -509,6 +547,7 @@ pub(crate) fn execute_and_collect(
             tx_reads: &mut tx_reads,
             tx_searches: &mut tx_searches,
             tx_lints: &mut tx_lints,
+            tx_mutations: &mut tx_mutations,
             write_targets: &mut write_targets,
             replace_hint: None,
             cwd,
@@ -589,6 +628,7 @@ pub(crate) fn execute_and_collect(
         tx_reads,
         tx_searches,
         tx_lints,
+        tx_mutations,
         no_effective_changes,
         replace_no_matches,
         replace_hint,

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -32,7 +32,7 @@ mod tidy_op;
 
 // output.rs
 pub use output::{
-    TxChange, TxLintResult, TxOutput, TxReadResult, TxSearchMatch, TxSearchResult,
+    TxChange, TxDocMutation, TxLintResult, TxOutput, TxReadResult, TxSearchMatch, TxSearchResult,
     exit_code_from_tx_output,
 };
 pub(crate) use output::{

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -22,12 +22,35 @@ pub struct TxOutput {
     pub searches: Vec<TxSearchResult>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub lints: Vec<TxLintResult>,
+    /// Per-op doc delete / delete-where summaries (#1439). Empty when the plan
+    /// had no such ops. Prefer this for multi-op plans; top-level `changed` /
+    /// `removed` are aggregates when present.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub mutations: Vec<TxDocMutation>,
+    /// Aggregate of [`TxDocMutation::changed`] when `mutations` is non-empty.
+    /// Mirrors CLI doc write JSON so agents can treat exit 0 + `removed: 0`
+    /// as an idempotent no-op without re-reading the file.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub changed: Option<bool>,
+    /// Sum of [`TxDocMutation::removed`] when `mutations` is non-empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub removed: Option<usize>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error_kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_session: Option<String>,
+}
+
+/// One doc delete / delete-where outcome inside a plan/tx report (#1439).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TxDocMutation {
+    pub path: String,
+    /// Plan op name, e.g. `doc.delete` or `doc.delete_where`.
+    pub op: String,
+    pub changed: bool,
+    pub removed: usize,
 }
 
 /// A single file change in a plan/tx report.
@@ -88,10 +111,23 @@ pub(crate) struct TxExecResult {
     pub(crate) tx_reads: Vec<TxReadResult>,
     pub(crate) tx_searches: Vec<TxSearchResult>,
     pub(crate) tx_lints: Vec<TxLintResult>,
+    pub(crate) tx_mutations: Vec<TxDocMutation>,
     pub(crate) no_effective_changes: bool,
     pub(crate) replace_no_matches: bool,
     /// "Did you mean?" hints when a replace found zero matches.
     pub(crate) replace_hint: Option<String>,
+}
+
+/// Apply mutation summaries onto a [`TxOutput`] (aggregates + list).
+pub(crate) fn attach_mutations(output: &mut TxOutput, mutations: Vec<TxDocMutation>) {
+    if mutations.is_empty() {
+        return;
+    }
+    let changed = mutations.iter().any(|m| m.changed);
+    let removed = mutations.iter().map(|m| m.removed).sum();
+    output.changed = Some(changed);
+    output.removed = Some(removed);
+    output.mutations = mutations;
 }
 
 pub(crate) fn build_tx_output(
@@ -156,6 +192,9 @@ pub(crate) fn build_tx_output(
         reads: Vec::new(),
         searches: Vec::new(),
         lints: Vec::new(),
+        mutations: Vec::new(),
+        changed: None,
+        removed: None,
         error_kind: None,
         error: None,
         backup_session: None,
@@ -178,6 +217,7 @@ pub(crate) fn build_full_tx_output(
     output.reads = std::mem::take(&mut result.tx_reads);
     output.searches = std::mem::take(&mut result.tx_searches);
     output.lints = std::mem::take(&mut result.tx_lints);
+    attach_mutations(&mut output, std::mem::take(&mut result.tx_mutations));
     output
 }
 
@@ -220,6 +260,9 @@ pub(crate) fn build_error_output(
         reads: Vec::new(),
         searches: Vec::new(),
         lints: Vec::new(),
+        mutations: Vec::new(),
+        changed: None,
+        removed: None,
         error_kind: Some(error_kind.to_string()),
         error: Some(format!(
             "{error_kind}: {}",
@@ -335,6 +378,9 @@ mod tests {
             reads: Vec::new(),
             searches: Vec::new(),
             lints: Vec::new(),
+            mutations: Vec::new(),
+            changed: None,
+            removed: None,
             error_kind: None,
             error: None,
             backup_session: None,
@@ -352,10 +398,48 @@ mod tests {
             reads: Vec::new(),
             searches: Vec::new(),
             lints: Vec::new(),
+            mutations: Vec::new(),
+            changed: None,
+            removed: None,
             error_kind: Some(kind.to_string()),
             error: Some("test error".to_string()),
             backup_session: None,
         }
+    }
+
+    #[test]
+    fn attach_mutations_sets_aggregates() {
+        let mut out = ok_output("success");
+        attach_mutations(
+            &mut out,
+            vec![
+                TxDocMutation {
+                    path: "a.json".into(),
+                    op: "doc.delete_where".into(),
+                    changed: true,
+                    removed: 2,
+                },
+                TxDocMutation {
+                    path: "b.json".into(),
+                    op: "doc.delete".into(),
+                    changed: false,
+                    removed: 0,
+                },
+            ],
+        );
+        assert_eq!(out.changed, Some(true));
+        assert_eq!(out.removed, Some(2));
+        assert_eq!(out.mutations.len(), 2);
+        assert_eq!(out.mutations[0].removed, 2);
+    }
+
+    #[test]
+    fn attach_mutations_empty_is_noop() {
+        let mut out = ok_output("success");
+        attach_mutations(&mut out, Vec::new());
+        assert_eq!(out.changed, None);
+        assert_eq!(out.removed, None);
+        assert!(out.mutations.is_empty());
     }
 
     #[test]

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -957,11 +957,47 @@ async fn test_mcp_doc_delete_round_trip() {
     assert!(!is_error, "doc_delete should succeed: {val}");
     assert_eq!(val["ok"], true, "doc_delete ok: {val}");
     assert_eq!(val["files_changed"], 1, "doc_delete files_changed: {val}");
+    assert_eq!(val["changed"], true, "doc_delete changed: {val}");
+    assert_eq!(val["removed"], 1, "doc_delete removed: {val}");
+    assert_eq!(
+        val["mutations"][0]["op"], "doc.delete",
+        "mutations[0].op: {val}"
+    );
+    assert_eq!(
+        val["mutations"][0]["removed"], 1,
+        "mutations[0].removed: {val}"
+    );
 
     let content = fs::read_to_string(dir.path().join("config.json")).unwrap();
     let v: serde_json::Value = serde_json::from_str(&content).unwrap();
     assert!(v.get("debug").is_none(), "doc_delete should remove key");
     assert_eq!(v["name"], "app", "doc_delete should preserve other keys");
+    client.cancel().await.unwrap();
+}
+
+/// #1439: MCP doc_delete missing key is ok with removed:0 / changed:false.
+#[tokio::test]
+async fn test_mcp_doc_delete_missing_key_reports_removed_zero() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("config.json"), r#"{"name":"app"}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_delete",
+        serde_json::json!({"path": "config.json", "selector": "missing"}),
+    )
+    .await;
+    assert!(!is_error, "idempotent delete should not be an error: {val}");
+    assert_eq!(val["ok"], true, "payload: {val}");
+    assert_eq!(val["files_changed"], 0, "payload: {val}");
+    assert_eq!(val["changed"], false, "payload: {val}");
+    assert_eq!(val["removed"], 0, "payload: {val}");
+    assert_eq!(val["mutations"][0]["changed"], false, "payload: {val}");
+    assert_eq!(val["mutations"][0]["removed"], 0, "payload: {val}");
     client.cancel().await.unwrap();
 }
 
@@ -1125,6 +1161,12 @@ async fn test_mcp_doc_delete_where_round_trip() {
         val["files_changed"], 1,
         "doc_delete_where files_changed: {val}"
     );
+    assert_eq!(val["changed"], true, "doc_delete_where changed: {val}");
+    assert_eq!(val["removed"], 1, "doc_delete_where removed: {val}");
+    assert_eq!(
+        val["mutations"][0]["op"], "doc.delete_where",
+        "mutations op: {val}"
+    );
 
     let content = fs::read_to_string(dir.path().join("config.json")).unwrap();
     let v: serde_json::Value = serde_json::from_str(&content).unwrap();
@@ -1136,6 +1178,101 @@ async fn test_mcp_doc_delete_where_round_trip() {
     );
     assert_eq!(items[0]["name"], "keep");
     assert_eq!(items[1]["name"], "keep2");
+    client.cancel().await.unwrap();
+}
+
+/// #1439: MCP delete-where zero matches is ok with removed:0.
+#[tokio::test]
+async fn test_mcp_doc_delete_where_zero_match_reports_removed_zero() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("config.json"),
+        r#"{"items":[{"name":"keep"},{"name":"also"}]}"#,
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_delete_where",
+        serde_json::json!({
+            "path": "config.json",
+            "selector": "items",
+            "predicate": "name=nobody"
+        }),
+    )
+    .await;
+    assert!(!is_error, "idempotent delete-where should succeed: {val}");
+    assert_eq!(val["ok"], true, "payload: {val}");
+    assert_eq!(val["files_changed"], 0, "payload: {val}");
+    assert_eq!(val["changed"], false, "payload: {val}");
+    assert_eq!(val["removed"], 0, "payload: {val}");
+    assert_eq!(val["mutations"].as_array().unwrap().len(), 1);
+    assert_eq!(val["mutations"][0]["removed"], 0, "payload: {val}");
+
+    let content = fs::read_to_string(dir.path().join("config.json")).unwrap();
+    assert!(
+        content.contains("keep") && content.contains("also"),
+        "file unchanged: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// #1439: multi-op plan surfaces per-op mutation stats and aggregates.
+#[tokio::test]
+async fn test_mcp_tx_plan_doc_delete_mutations_summary() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("a.json"),
+        r#"{"items":[{"name":"a"},{"name":"b"},{"name":"a"}]}"#,
+    )
+    .unwrap();
+    fs::write(dir.path().join("b.json"), r#"{"x":1}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "doc.delete_where",
+                "path": "a.json",
+                "selector": "items",
+                "predicate": "name=a"
+            },
+            {
+                "op": "doc.delete",
+                "path": "b.json",
+                "selector": "missing"
+            }
+        ]
+    });
+    let (is_error, val) =
+        call_tool_value(&client, "execute_plan", serde_json::json!({"plan": plan})).await;
+    assert!(!is_error, "plan should succeed: {val}");
+    assert_eq!(val["ok"], true, "payload: {val}");
+    // One file modified (a.json), b.json is no-op.
+    assert_eq!(val["files_changed"], 1, "payload: {val}");
+    assert_eq!(val["changed"], true, "any mutation changed: {val}");
+    assert_eq!(val["removed"], 2, "2 from a + 0 from b: {val}");
+    let mutations = val["mutations"].as_array().expect("mutations array");
+    assert_eq!(mutations.len(), 2, "payload: {val}");
+    assert_eq!(mutations[0]["op"], "doc.delete_where");
+    assert_eq!(mutations[0]["removed"], 2);
+    assert_eq!(mutations[0]["changed"], true);
+    assert_eq!(mutations[1]["op"], "doc.delete");
+    assert_eq!(mutations[1]["removed"], 0);
+    assert_eq!(mutations[1]["changed"], false);
+
+    let a: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("a.json")).unwrap()).unwrap();
+    assert_eq!(a["items"].as_array().unwrap().len(), 1);
+    assert_eq!(a["items"][0]["name"], "b");
     client.cancel().await.unwrap();
 }
 


### PR DESCRIPTION
## Summary

Implements #1439 so MCP and plan/tx JSON can distinguish idempotent delete no-ops from real deletes without re-reading files.

- `MutationResult::Removed(n)` for successful delete / delete-where
- `TxDocMutation` list on `TxOutput` / `PlanReport` plus aggregate `changed` and `removed`
- Wired through `execute_doc_op` so CLI MCP `doc_delete` / `doc_delete_where` and `execute_plan` share one path
- Docs: reference, schema descriptions, agent-rules tip, PATCHLOOM.md

## Test plan

- [x] Unit: `attach_mutations_*`, `mutation_delete_*`, CLI `preview_removed_*`
- [x] MCP integration: existing round-trips assert `removed`/`changed`; new zero-match tests; multi-op `execute_plan` mutations summary
- [x] `make check-fast`

Closes #1439