### PR TITLE
test: MPI cycle 2 PlanReport/tx mutation coverage and CLI unify

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -522,6 +522,55 @@ fn execute_plan_runs_operations() {
     assert!(on_disk.contains("+appended"));
 }
 
+/// #1439: library PlanReport exposes doc delete mutation summaries.
+#[test]
+#[cfg(any(feature = "cli", feature = "files"))]
+fn execute_plan_doc_delete_reports_mutations() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("cfg.json"),
+        r#"{"items":[{"name":"keep"},{"name":"drop"},{"name":"drop"}]}"#,
+    )
+    .unwrap();
+
+    let plan = parse_plan(
+        r#"{
+            "version": 1,
+            "operations": [
+                {
+                    "op": "doc.delete_where",
+                    "path": "cfg.json",
+                    "selector": "items",
+                    "predicate": "name=drop"
+                },
+                {
+                    "op": "doc.delete",
+                    "path": "cfg.json",
+                    "selector": "missing"
+                }
+            ]
+        }"#,
+    )
+    .unwrap();
+
+    let report = execute_plan(plan, dir.path(), None).unwrap();
+    assert!(report.ok);
+    assert_eq!(report.changed, Some(true));
+    assert_eq!(report.removed, Some(2));
+    assert_eq!(report.mutations.len(), 2);
+    assert_eq!(report.mutations[0].op, "doc.delete_where");
+    assert_eq!(report.mutations[0].removed, 2);
+    assert!(report.mutations[0].changed);
+    assert_eq!(report.mutations[1].op, "doc.delete");
+    assert_eq!(report.mutations[1].removed, 0);
+    assert!(!report.mutations[1].changed);
+
+    let on_disk: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("cfg.json")).unwrap()).unwrap();
+    assert_eq!(on_disk["items"].as_array().unwrap().len(), 1);
+    assert_eq!(on_disk["items"][0]["name"], "keep");
+}
+
 #[test]
 #[cfg(any(feature = "cli", feature = "files"))]
 fn execute_plan_respects_relaxed_guard() {

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -271,48 +271,6 @@ struct DocWriteOutput {
     applied: Option<bool>,
 }
 
-/// Count of items a delete / delete-where mutation would remove (file must still
-/// have original content). Returns `None` for non-delete write ops.
-fn preview_removed_count(cwd: &std::path::Path, op: &Operation) -> Option<usize> {
-    use crate::ops::doc::{
-        DocMutation, MutationResult, apply_doc_mutation, delete_where, detect_format, parse_doc,
-    };
-    use crate::plan::op_to_doc_mutation;
-
-    let (path, mutation) = op_to_doc_mutation(op)?;
-    // Only delete ops need a remove count; skip the disk read otherwise.
-    if !matches!(
-        mutation,
-        DocMutation::Delete { .. } | DocMutation::DeleteWhere { .. }
-    ) {
-        return None;
-    }
-
-    let full = cwd.join(path);
-    let content = std::fs::read_to_string(&full).ok()?;
-    let format = detect_format(path).ok()?;
-    let mut root = parse_doc(&content, &format).ok()?;
-
-    match mutation {
-        // Single parse: delete_where returns the exact remove count.
-        DocMutation::DeleteWhere {
-            selector,
-            predicate,
-        } => {
-            let sel = crate::selector::parse_anyhow(&selector).ok()?;
-            delete_where(&mut root, &sel, &predicate).ok()
-        }
-        DocMutation::Delete { .. } => match apply_doc_mutation(&mut root, mutation).ok()? {
-            MutationResult::Removed(n) => Some(n),
-            MutationResult::NoMatch => Some(0),
-            MutationResult::Applied
-            | MutationResult::AlreadyExists
-            | MutationResult::TypeError(_) => None,
-        },
-        _ => None,
-    }
-}
-
 /// Convert a write [`DocAction`] into the corresponding [`Operation`] variant.
 fn action_to_operation(action: &DocAction) -> anyhow::Result<Operation> {
     match action {
@@ -792,23 +750,24 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let apply_msg = format!("updated {display_path}");
 
         // Stage first so we can report `changed` / `removed` in JSON for
-        // idempotent delete no-ops (exit 0 with removed: 0). See #1434.
+        // idempotent delete no-ops (exit 0 with removed: 0). See #1434 / #1439.
+        // Remove counts come from the engine mutation summary (same source as MCP/tx).
         let path_clone = display_path;
         match (|| -> anyhow::Result<u8> {
-            let cwd = global.resolve_cwd()?;
-            let removed = preview_removed_count(&cwd, &op);
             let (cwd, result) = crate::cmd::output::stage_for_write(
                 crate::tx::engine::WriteSource::Operations(vec![op]),
                 global,
             )?;
             let changed = result.has_changes;
-            // For delete ops, always report removed (0 on idempotent no-match).
-            // Prefer pre-stage count; fall back to changed-as-0/1 if preview failed.
-            let removed = match (&args.action, removed) {
-                (DocAction::Delete { .. } | DocAction::DeleteWhere { .. }, Some(n)) => Some(n),
-                (DocAction::Delete { .. } | DocAction::DeleteWhere { .. }, None) => {
-                    Some(usize::from(changed))
-                }
+            let removed = match &args.action {
+                DocAction::Delete { .. } | DocAction::DeleteWhere { .. } => Some(
+                    result
+                        .exec_result
+                        .tx_mutations
+                        .iter()
+                        .map(|m| m.removed)
+                        .sum(),
+                ),
                 _ => None,
             };
             crate::cmd::write_mode::finalize_execution_result(

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -577,40 +577,6 @@ mod edge_cases {
         assert_eq!(code, exit::SUCCESS);
     }
 
-    #[test]
-    fn preview_removed_count_delete_where_zero() {
-        let dir = TempDir::new().unwrap();
-        let path = write_file(&dir, "test.json", r#"{"users": [{"name": "alice"}]}"#);
-        let op = Operation::DocDeleteWhere {
-            path: path.clone(),
-            selector: "users".into(),
-            predicate: "name=nobody".into(),
-        };
-        assert_eq!(
-            super::super::preview_removed_count(dir.path(), &op),
-            Some(0)
-        );
-    }
-
-    #[test]
-    fn preview_removed_count_delete_where_two() {
-        let dir = TempDir::new().unwrap();
-        let path = write_file(
-            &dir,
-            "test.json",
-            r#"{"users": [{"name": "a"}, {"name": "b"}, {"name": "a"}]}"#,
-        );
-        let op = Operation::DocDeleteWhere {
-            path,
-            selector: "users".into(),
-            predicate: "name=a".into(),
-        };
-        assert_eq!(
-            super::super::preview_removed_count(dir.path(), &op),
-            Some(2)
-        );
-    }
-
     // -- ensure -------------------------------------------------------------
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,9 @@
 //! plan op, and MCP exposure deferred unless demand arises. Tracked in #821.
 //!
 //! **Note on results**: Single-file ops return `EditResult` (with `action` and `dest_path` for cross-file).
-//! `execute_plan` (library) returns `PlanReport` (typed TxOutput) directly with `ok`, `changes`, `searches`, `reads`, `error` etc (#811).
+//! `execute_plan` (library) returns `PlanReport` (typed TxOutput) directly with `ok`, `changes`,
+//! `searches`, `reads`, `error`, plus `mutations` / aggregate `changed` / `removed` for
+//! `doc.delete` and `doc.delete_where` (including idempotent `removed: 0` no-ops) (#811, #1439).
 //! See `api::PlanReport`, `api::execute_plan`, and embedding docs. CLI/MCP retain (code, json) for compatibility.
 //!
 //! For library users needing relaxed containment (e.g. agents like Bline using --yolo or temp files):

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -996,6 +996,8 @@ async fn test_mcp_doc_delete_missing_key_reports_removed_zero() {
     assert_eq!(val["files_changed"], 0, "payload: {val}");
     assert_eq!(val["changed"], false, "payload: {val}");
     assert_eq!(val["removed"], 0, "payload: {val}");
+    assert_eq!(val["mutations"][0]["path"], "config.json", "payload: {val}");
+    assert_eq!(val["mutations"][0]["op"], "doc.delete", "payload: {val}");
     assert_eq!(val["mutations"][0]["changed"], false, "payload: {val}");
     assert_eq!(val["mutations"][0]["removed"], 0, "payload: {val}");
     client.cancel().await.unwrap();

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1262,9 +1262,11 @@ async fn test_mcp_tx_plan_doc_delete_mutations_summary() {
     assert_eq!(val["removed"], 2, "2 from a + 0 from b: {val}");
     let mutations = val["mutations"].as_array().expect("mutations array");
     assert_eq!(mutations.len(), 2, "payload: {val}");
+    assert_eq!(mutations[0]["path"], "a.json", "payload: {val}");
     assert_eq!(mutations[0]["op"], "doc.delete_where");
     assert_eq!(mutations[0]["removed"], 2);
     assert_eq!(mutations[0]["changed"], true);
+    assert_eq!(mutations[1]["path"], "b.json", "payload: {val}");
     assert_eq!(mutations[1]["op"], "doc.delete");
     assert_eq!(mutations[1]["removed"], 0);
     assert_eq!(mutations[1]["changed"], false);

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -4021,6 +4021,61 @@ fn test_tx_json_doc_delete_mutations_summary() {
     assert_eq!(mutations[1]["changed"], false);
 }
 
+/// #1439: for_each-expanded delete-where produces one mutation row per file.
+#[test]
+fn test_tx_json_for_each_delete_where_mutations() {
+    let dir = TempDir::new().unwrap();
+    let sub = dir.path().join("d");
+    fs::create_dir(&sub).unwrap();
+    fs::write(sub.join("a.json"), r#"{"items":[{"name":"x"}]}"#).unwrap();
+    fs::write(sub.join("b.json"), r#"{"items":[{"name":"x"}]}"#).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "for_each": {"glob": "d/*.json", "path_var": "path"},
+        "operations": [{
+            "op": "doc.delete_where",
+            "path": "{path}",
+            "selector": "items",
+            "predicate": "name=x"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg("plan.json")
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "payload: {json}");
+    assert_eq!(json["files_changed"], 2, "payload: {json}");
+    assert_eq!(json["removed"], 2, "payload: {json}");
+    let mutations = json["mutations"].as_array().expect("mutations");
+    assert_eq!(mutations.len(), 2, "payload: {json}");
+    let mut paths: Vec<&str> = mutations
+        .iter()
+        .map(|m| m["path"].as_str().unwrap())
+        .collect();
+    paths.sort();
+    assert_eq!(paths, vec!["d/a.json", "d/b.json"]);
+    for m in mutations {
+        assert_eq!(m["op"], "doc.delete_where");
+        assert_eq!(m["removed"], 1);
+        assert_eq!(m["changed"], true);
+    }
+}
+
 #[test]
 fn test_tx_json_output_on_modified_empty_file_reports_modified() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -3959,6 +3959,68 @@ fn test_tx_json_output_on_apply() {
     assert_eq!(json["changes"][0]["action"], "modified");
 }
 
+/// #1439: tx --json includes mutations for delete / delete-where (incl. no-ops).
+#[test]
+fn test_tx_json_doc_delete_mutations_summary() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("t.json"),
+        r#"{"items":[{"name":"a"},{"name":"b"},{"name":"a"}]}"#,
+    )
+    .unwrap();
+    fs::write(dir.path().join("u.json"), r#"{"x":1}"#).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "doc.delete_where",
+                "path": "t.json",
+                "selector": "items",
+                "predicate": "name=a"
+            },
+            {
+                "op": "doc.delete",
+                "path": "u.json",
+                "selector": "missing"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg("plan.json")
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "payload: {json}");
+    assert_eq!(json["files_changed"], 1, "payload: {json}");
+    assert_eq!(json["changed"], true, "payload: {json}");
+    assert_eq!(json["removed"], 2, "payload: {json}");
+    let mutations = json["mutations"].as_array().expect("mutations");
+    assert_eq!(mutations.len(), 2, "payload: {json}");
+    assert_eq!(mutations[0]["path"], "t.json");
+    assert_eq!(mutations[0]["op"], "doc.delete_where");
+    assert_eq!(mutations[0]["removed"], 2);
+    assert_eq!(mutations[0]["changed"], true);
+    assert_eq!(mutations[1]["path"], "u.json");
+    assert_eq!(mutations[1]["op"], "doc.delete");
+    assert_eq!(mutations[1]["removed"], 0);
+    assert_eq!(mutations[1]["changed"], false);
+}
+
 #[test]
 fn test_tx_json_output_on_modified_empty_file_reports_modified() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

MPI cycle 2 after #1441 mutation surface landed.

- **Test Auditor:** library `execute_plan` + CLI `tx --json` mutation tests; stronger path asserts on MCP multi-op plan
- **Developer/Perf:** CLI `doc` write JSON uses engine `tx_mutations` only (removed dual `preview_removed_count` path)
- **End User/Spec:** `PlanReport` embedding note in `lib.rs` documents `mutations` / `changed` / `removed`
- Other perspectives: no-op after greps (audit clean, gate aligned, installers pinned)

## Test plan

- [x] `cargo test --lib execute_plan_doc_delete_reports_mutations`
- [x] `test_tx_json_doc_delete_mutations_summary`
- [x] `make check-fast`