### PR TITLE
test: MPI loop2 cycle 1 batch/tx check mutation coverage

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -117,6 +117,8 @@ Plans are JSON objects with three lifecycle arrays:
 
 `patch.apply` operations accept `on_stale: "merge"` for three-way merge when the on-disk file diverged from the patch base, and `allow_conflicts: true` to write conflict markers instead of failing.
 
+With `--json` / `--jsonl`, plan results include file-level `changes` plus, for `doc.delete` / `doc.delete_where`, a `mutations` array and aggregate `changed` / `removed` counts (including `removed: 0` for idempotent no-ops). The same fields appear on MCP write tools and `execute_plan`.
+
 Strict mode defaults to on. Use `"strict": false` in the plan, `[tx] strict = false` in `.patchloom.toml`, or `patchloom tx --no-strict` to keep writes on disk when format/validate fails (exit 6). With strict mode, a format or validation failure reverts all writes (exit 7). If a write fails mid-commit, patchloom restores already-written files from the backup session (exit 7 `rollback`, or exit 1 `rollback_failed` if restore is incomplete).
 
 ## Exit codes

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -316,6 +316,49 @@ fn test_batch_json_output_on_apply() {
     assert_eq!(json["files_changed"], 1);
 }
 
+/// #1439: batch --json surfaces delete-where mutation summary (shared tx path).
+#[test]
+fn test_batch_json_delete_where_mutations() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("data.json"),
+        r#"{"items":[{"name":"keep"},{"name":"drop"}]}"#,
+    )
+    .unwrap();
+
+    let ops = dir.path().join("ops.txt");
+    fs::write(&ops, "doc.delete_where data.json items name=drop\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("batch")
+        .arg(&ops)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "payload: {json}");
+    assert_eq!(json["changed"], true, "payload: {json}");
+    assert_eq!(json["removed"], 1, "payload: {json}");
+    assert_eq!(json["mutations"][0]["op"], "doc.delete_where");
+    assert_eq!(json["mutations"][0]["path"], "data.json");
+    assert_eq!(json["mutations"][0]["removed"], 1);
+
+    let content: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("data.json")).unwrap()).unwrap();
+    assert_eq!(content["items"].as_array().unwrap().len(), 1);
+    assert_eq!(content["items"][0]["name"], "keep");
+}
+
 #[test]
 fn test_batch_empty_quoted_string_sets_empty_value() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1066,7 +1066,6 @@ fn test_doc_delete_json_existing_key_reports_removed_one() {
     assert_eq!(v["ok"], true);
     assert_eq!(v["changed"], true, "payload: {v}");
     assert_eq!(v["removed"], 1, "payload: {v}");
-    assert!(v.get("removed").is_some());
     let content: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
     assert!(content.get("drop").is_none());

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -4021,6 +4021,57 @@ fn test_tx_json_doc_delete_mutations_summary() {
     assert_eq!(mutations[1]["changed"], false);
 }
 
+/// #1439: --check still reports mutation summaries without writing.
+#[test]
+fn test_tx_json_check_doc_delete_mutations_no_write() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("t.json"),
+        r#"{"items":[{"name":"a"},{"name":"b"}]}"#,
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "doc.delete_where",
+            "path": "t.json",
+            "selector": "items",
+            "predicate": "name=a"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg("plan.json")
+        .arg("--check")
+        .output()
+        .unwrap();
+    // --check with changes → exit 2
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "payload: {json}");
+    assert_eq!(json["changed"], true, "payload: {json}");
+    assert_eq!(json["removed"], 1, "payload: {json}");
+    assert_eq!(json["mutations"][0]["op"], "doc.delete_where");
+    // File must be unchanged under --check.
+    let on_disk = fs::read_to_string(dir.path().join("t.json")).unwrap();
+    assert!(
+        on_disk.contains("\"name\":\"a\""),
+        "must not write: {on_disk}"
+    );
+}
+
 /// #1439: for_each-expanded delete-where produces one mutation row per file.
 #[test]
 fn test_tx_json_for_each_delete_where_mutations() {


### PR DESCRIPTION
## Summary

Fresh MPI loop after prior convergence (post-#1442 surface).

- **QA:** `batch --json` delete-where mutations; `tx --check --json` mutation summary without write
- **Test Auditor:** drop redundant `is_some` after exact `removed` assert
- **End User:** concepts.md notes plan/MCP mutation fields
- Other perspectives: no-op (audit clean, deps current, gate aligned)

## Test plan

- [x] `test_batch_json_delete_where_mutations`
- [x] `test_tx_json_check_doc_delete_mutations_no_write`
- [x] `make check-fast`