### PR TITLE
fix: resolve batch and patch input paths under --cwd

### DIFF
--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -385,12 +385,20 @@ pub fn tokenize(line: &str) -> anyhow::Result<Vec<String>> {
 
 pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!("batch: input={}", args.input);
-    // Read input.
+    // Read input. Relative paths are resolved under --cwd (same as `tx` plan files).
     let input = if args.input == "-" {
         std::io::read_to_string(std::io::stdin())?
     } else {
-        std::fs::read_to_string(&args.input)
-            .map_err(|e| anyhow::anyhow!("failed to read '{}': {e}", args.input))?
+        let input_path = {
+            let p = std::path::Path::new(&args.input);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                global.resolve_cwd()?.join(p)
+            }
+        };
+        std::fs::read_to_string(&input_path)
+            .map_err(|e| anyhow::anyhow!("failed to read '{}': {e}", input_path.display()))?
     };
 
     // Parse lines into operations.

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -76,14 +76,28 @@ enum DiffReadError {
     StdinError(std::io::Error),
 }
 
-fn read_diff_input(file: &Option<String>, stdin_flag: bool) -> Result<String, DiffReadError> {
+fn read_diff_input(
+    file: &Option<String>,
+    stdin_flag: bool,
+    cwd: &std::path::Path,
+) -> Result<String, DiffReadError> {
     // A bare "-" path means stdin (common CLI convention); agents often pass
     // this instead of --stdin (fixrealloop).
     if let Some(path) = file {
         if path == "-" {
             std::io::read_to_string(std::io::stdin()).map_err(DiffReadError::StdinError)
         } else {
-            std::fs::read_to_string(path).map_err(|e| DiffReadError::IoError(path.clone(), e))
+            // Relative patch paths resolve under --cwd (parity with `tx` / `batch`).
+            let full = {
+                let p = std::path::Path::new(path);
+                if p.is_absolute() {
+                    p.to_path_buf()
+                } else {
+                    cwd.join(p)
+                }
+            };
+            std::fs::read_to_string(&full)
+                .map_err(|e| DiffReadError::IoError(full.display().to_string(), e))
         }
     } else if stdin_flag {
         std::io::read_to_string(std::io::stdin()).map_err(DiffReadError::StdinError)
@@ -240,7 +254,8 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         ),
     };
 
-    let diff_text = match read_diff_input(&file, stdin_flag) {
+    let cwd = global.resolve_cwd()?;
+    let diff_text = match read_diff_input(&file, stdin_flag, &cwd) {
         Ok(text) => text,
         Err(DiffReadError::NoSource) => {
             emit_error(global, "patch: must specify --file <path> or --stdin")?;
@@ -270,7 +285,6 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         patch_files.len(),
         merge_mode
     );
-    let cwd = global.resolve_cwd()?;
 
     if matches!(args.action, PatchAction::Check { .. }) {
         let mut all_clean = true;

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -316,6 +316,34 @@ fn test_batch_json_output_on_apply() {
     assert_eq!(json["files_changed"], 1);
 }
 
+/// Relative batch input path is resolved under --cwd (parity with `tx` plan files).
+#[test]
+fn test_batch_relative_input_respects_cwd() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("data.json"), r#"{"key":"old"}"#).unwrap();
+    fs::write(
+        dir.path().join("ops.txt"),
+        "doc.set data.json key \"new\"\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("batch")
+        .arg("ops.txt")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(dir.path().join("data.json")).unwrap();
+    assert!(
+        content.contains("new"),
+        "batch input under --cwd must be found and applied: {content}"
+    );
+}
+
 /// #1439: batch --json surfaces delete-where mutation summary (shared tx path).
 #[test]
 fn test_batch_json_delete_where_mutations() {

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -59,6 +59,32 @@ fn test_patch_apply_with_apply_flag_writes_file() {
     assert_eq!(content, "line1\nnew line\nline3\n");
 }
 
+/// Relative patch path is resolved under --cwd (parity with `tx` / `batch`).
+#[test]
+fn test_patch_relative_file_respects_cwd() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("test.txt"), "line1\nold line\nline3\n").unwrap();
+    fs::write(
+        dir.path().join("change.patch"),
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("apply")
+        .arg("change.patch")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(dir.path().join("test.txt")).unwrap();
+    assert_eq!(content, "line1\nnew line\nline3\n");
+}
+
 #[test]
 fn test_patch_apply_json_parse_error_returns_error_object() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

MPI loop 3 cycle 1 (Adversarial / End User / Spec):

`--cwd` was honored for operation target paths and for `tx` plan files, but **not** for:
- `batch` ops file argument
- `patch apply|check|merge` patch file argument

Agents commonly run `patchloom --cwd <ws> batch ops.txt` or `patch apply changes.patch` and hit not-found even when the file exists under the workspace.

## Test plan

- [x] `test_batch_relative_input_respects_cwd`
- [x] `test_patch_relative_file_respects_cwd`
- [x] `make check-fast`
- [ ] CI green