### PR TITLE
refactor: unify --cwd meta-input path resolution

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -132,8 +132,8 @@ These flags affect how Patchloom reports results or chooses which files to touch
 <!-- ref:global-flag:cwd -->
 ### `--cwd`
 
-- **What it does:** Sets the working directory used to resolve relative paths.
-- **Use when:** You are invoking Patchloom from outside the target repo, or you want scripts to behave predictably regardless of the caller's current directory.
+- **What it does:** Sets the working directory used to resolve relative paths for operation targets **and** meta-input files: `tx` plan files, `batch` ops files, `patch` patch files, `explain` plan files, and `--files-from` list files (absolute meta paths are unchanged).
+- **Use when:** You are invoking Patchloom from outside the target repo, or you want scripts to behave predictably regardless of the caller's current directory. Example: `patchloom --cwd /repo batch ops.txt` finds `/repo/ops.txt`.
 - **Prefer instead:** Use a plan level `cwd` in `tx` when the directory choice should travel with the plan itself, but keep it inside the invocation root. Relative plan `cwd` values resolve from the caller's working directory (`--cwd` or the process cwd), not from the plan file location.
 - **Not a sandbox:** Without `--contain`, paths may escape via `../` or absolute paths. MCP always enforces containment; use `--contain` for the same on CLI.
 
@@ -222,6 +222,7 @@ These are the main entry points. If you are deciding between commands, start her
 
 - **What it does:** Checks or applies a unified diff.
 - **Use when:** The change already exists as a patch, or you want stale context detection instead of search and replace semantics.
+- **Paths:** A relative patch file path is resolved under `--cwd`. Paths *inside* the unified diff are also resolved against `--cwd`.
 - **Prefer instead:** Use `replace`, `doc`, or `md` when you want to describe the mutation directly instead of carrying a diff artifact.
 - **Related:** `patch check`, `patch apply`, `patch merge`, `tx patch.apply`
 
@@ -302,6 +303,7 @@ These are the main entry points. If you are deciding between commands, start her
 
 - **What it does:** Executes multiple operations from a simple line-oriented format. Each line is one operation with positional arguments (e.g., `doc.set config.json version "2.0.0"`). Internally builds a tx plan and delegates to the tx engine.
 - **Use when:** Editing multiple files and the JSON tx plan format is too verbose. The line format covers 26 operations (doc.set, doc.delete, doc.merge, doc.ensure, doc.append, doc.prepend, doc.update, doc.move, doc.delete_where, replace, file.append, file.prepend, file.create, file.delete, file.rename, md.upsert_bullet, md.table_append, md.replace_section, md.insert_after_heading, md.insert_before_heading, md.move_section, md.dedupe_headings, md.lint_agents, tidy.fix, ast.rename, ast.replace) with minimal syntax. For AI agents, this is faster to generate than a full JSON plan.
+- **Paths:** A relative ops file path is resolved under `--cwd` (same as `tx` plan files). Paths *inside* ops lines are also resolved against `--cwd`.
 - **Prefer instead:** Use `tx` when you need format/validate lifecycle steps, strict mode, or operations not supported by the line format (patch.apply, replace with regex/nth, search, read).
 - **Related:** `tx`
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -305,6 +305,19 @@ impl GlobalFlags {
         }
     }
 
+    /// Resolve a user-supplied path against [`Self::resolve_cwd`].
+    ///
+    /// Absolute paths are returned unchanged (`Path::join` replaces the base).
+    /// Relative paths become `<cwd>/<path>`. Use for meta-inputs (`tx` plans,
+    /// `batch` ops files, `patch` files, `--files-from` lists) so `--cwd` is
+    /// consistent across commands.
+    pub fn resolve_user_path(
+        &self,
+        path: impl AsRef<std::path::Path>,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        Ok(self.resolve_cwd()?.join(path.as_ref()))
+    }
+
     /// Build a workspace [`PathGuard`] when `--contain` is set.
     ///
     /// Returns `Ok(None)` when containment is off (default CLI behavior).
@@ -422,16 +435,7 @@ impl GlobalFlags {
                 .filter(|l| !l.is_empty())
                 .collect()
         } else {
-            let list_path = {
-                let p = std::path::Path::new(source);
-                if p.is_absolute() {
-                    p.to_path_buf()
-                } else if let Some(ref cwd) = self.cwd {
-                    std::path::Path::new(cwd).join(p)
-                } else {
-                    p.to_path_buf()
-                }
-            };
+            let list_path = self.resolve_user_path(source)?;
             let content = std::fs::read_to_string(&list_path).map_err(|e| {
                 anyhow::anyhow!("failed to read --files-from '{}': {e}", list_path.display())
             })?;
@@ -730,6 +734,29 @@ mod tests {
         };
         let err = g.resolve_cwd().unwrap_err().to_string();
         assert!(err.contains("not a directory"), "unexpected: {err}");
+    }
+
+    #[test]
+    fn resolve_user_path_joins_relative_under_cwd() {
+        let dir = tempfile::tempdir().unwrap();
+        let g = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            ..GlobalFlags::default()
+        };
+        let resolved = g.resolve_user_path("ops.txt").unwrap();
+        assert_eq!(resolved, dir.path().join("ops.txt"));
+    }
+
+    #[test]
+    fn resolve_user_path_keeps_absolute() {
+        let dir = tempfile::tempdir().unwrap();
+        let abs = dir.path().join("abs.txt");
+        let g = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            ..GlobalFlags::default()
+        };
+        let resolved = g.resolve_user_path(&abs).unwrap();
+        assert_eq!(resolved, abs);
     }
 
     #[test]

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -389,14 +389,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let input = if args.input == "-" {
         std::io::read_to_string(std::io::stdin())?
     } else {
-        let input_path = {
-            let p = std::path::Path::new(&args.input);
-            if p.is_absolute() {
-                p.to_path_buf()
-            } else {
-                global.resolve_cwd()?.join(p)
-            }
-        };
+        let input_path = global.resolve_user_path(&args.input)?;
         std::fs::read_to_string(&input_path)
             .map_err(|e| anyhow::anyhow!("failed to read '{}': {e}", input_path.display()))?
     };

--- a/src/cmd/explain/mod.rs
+++ b/src/cmd/explain/mod.rs
@@ -47,8 +47,7 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             .path
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("path is required when --stdin is not set"))?;
-        let cwd = global.resolve_cwd()?;
-        let full = cwd.join(p);
+        let full = global.resolve_user_path(p)?;
         let content = std::fs::read_to_string(&full)
             .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", full.display()))?;
         (content, Some(p.to_string()))

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -79,7 +79,7 @@ enum DiffReadError {
 fn read_diff_input(
     file: &Option<String>,
     stdin_flag: bool,
-    cwd: &std::path::Path,
+    global: &GlobalFlags,
 ) -> Result<String, DiffReadError> {
     // A bare "-" path means stdin (common CLI convention); agents often pass
     // this instead of --stdin (fixrealloop).
@@ -88,14 +88,9 @@ fn read_diff_input(
             std::io::read_to_string(std::io::stdin()).map_err(DiffReadError::StdinError)
         } else {
             // Relative patch paths resolve under --cwd (parity with `tx` / `batch`).
-            let full = {
-                let p = std::path::Path::new(path);
-                if p.is_absolute() {
-                    p.to_path_buf()
-                } else {
-                    cwd.join(p)
-                }
-            };
+            let full = global
+                .resolve_user_path(path)
+                .map_err(|e| DiffReadError::IoError(path.clone(), std::io::Error::other(e)))?;
             std::fs::read_to_string(&full)
                 .map_err(|e| DiffReadError::IoError(full.display().to_string(), e))
         }
@@ -255,7 +250,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
 
     let cwd = global.resolve_cwd()?;
-    let diff_text = match read_diff_input(&file, stdin_flag, &cwd) {
+    let diff_text = match read_diff_input(&file, stdin_flag, global) {
         Ok(text) => text,
         Err(DiffReadError::NoSource) => {
             emit_error(global, "patch: must specify --file <path> or --stdin")?;

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -220,7 +220,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let plan_path = if args.plan == "-" {
         None
     } else {
-        Some(global.resolve_cwd()?.join(&args.plan))
+        Some(global.resolve_user_path(&args.plan)?)
     };
     let plan_text = if args.plan == "-" {
         std::io::read_to_string(std::io::stdin())?


### PR DESCRIPTION
## Summary

MPI loop 4 cycle 1 after #1444:

- **Developer / Architecture:** add `GlobalFlags::resolve_user_path` and use it for `tx` plans, `batch` ops files, `patch` files, `explain` plans, and `--files-from` lists (one join rule; absolute paths still work via `Path::join` replacement).
- **End User / Spec:** document meta-input resolution on `--cwd`, `batch`, and `patch` in the reference.
- **Tests:** unit coverage for relative and absolute resolve.

## Test plan

- [x] `resolve_user_path_*` unit tests
- [x] existing batch/patch `--cwd` integration tests
- [x] `make check-fast`
- [ ] CI green