### PR TITLE
test: lock explain --cwd plan path and agent-rules meta-input note

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -92,6 +92,8 @@ For complex plans needing format/validate lifecycle, regex replace, or `--nth`, 
 patchloom tx plan.json --apply
 ```
 
+Relative paths for batch ops files, `tx`/`explain` plan files, `patch` files, and `--files-from` lists resolve under `--cwd` (same base as operation targets). Absolute meta-input paths are unchanged.
+
 In plan JSON, doc ops use the field name `selector` (not `key`). `key` is accepted as an alias if a model emits it, but prefer `selector`.
 
 ## Structured edits

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -204,6 +204,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              ```bash\n\
              patchloom tx plan.json --apply\n\
              ```\n\n\
+             Relative paths for batch ops files, `tx`/`explain` plan files, `patch` files, and \
+             `--files-from` lists resolve under `--cwd` (same base as operation targets). \
+             Absolute meta-input paths are unchanged.\n\n\
              In plan JSON, doc ops use the field name `selector` (not `key`). \
              `key` is accepted as an alias if a model emits it, but prefer `selector`.\n\n",
         );
@@ -473,6 +476,10 @@ mod tests {
         assert!(out.contains("## Exit codes"));
         assert!(out.contains("<<'EOF'"));
         assert!(out.contains("batch ops.txt"));
+        assert!(
+            out.contains("resolve under `--cwd`"),
+            "must document that batch/tx/explain/patch/--files-from meta paths honor --cwd"
+        );
     }
 
     #[test]

--- a/tests/integration/explain_tests.rs
+++ b/tests/integration/explain_tests.rs
@@ -30,6 +30,28 @@ fn test_explain_prints_human_summary() {
         .stdout(predicates::str::contains("Validate: echo ok (required)"));
 }
 
+/// Relative explain plan path is resolved under --cwd (parity with `tx` / `batch` / `patch`).
+#[test]
+fn test_explain_relative_plan_respects_cwd() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("plan.json"),
+        r#"{"version": 1, "operations": [{"op": "file.create", "path": "test.txt", "content": "hi"}]}"#,
+    )
+    .unwrap();
+
+    // Process cwd is not dir; plan path is relative and must open under --cwd.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path().parent().unwrap())
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["explain", "plan.json"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Create file test.txt"));
+}
+
 #[test]
 fn test_explain_json_output() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1042,10 +1042,9 @@ fn test_search_contain_rejects_files_from_parent_escape() {
     );
     let outside = dir.path().parent().unwrap().join(&escape_name);
     fs::write(&outside, "SECRET_VALUE=x\n").unwrap();
-    // --files-from opens the list file relative to the process cwd, so pass
-    // an absolute path to the list; entries inside are relative to --cwd.
-    let list = dir.path().join("list.txt");
-    fs::write(&list, format!("../{escape_name}\n")).unwrap();
+    // List path can be relative under --cwd; entries inside are also relative
+    // to --cwd. Use a relative list name so the test exercises resolve_user_path.
+    fs::write(dir.path().join("list.txt"), format!("../{escape_name}\n")).unwrap();
 
     Command::cargo_bin("patchloom")
         .unwrap()
@@ -1053,7 +1052,7 @@ fn test_search_contain_rejects_files_from_parent_escape() {
         .arg(dir.path())
         .arg("--contain")
         .arg("--files-from")
-        .arg(&list)
+        .arg("list.txt")
         .args(["search", "SECRET_VALUE"])
         .assert()
         .failure()


### PR DESCRIPTION
## Summary

MPI loop4 cycle 2 follow-up after #1445 unified `GlobalFlags::resolve_user_path`:

- Integration test: `explain` relative plan path under `--cwd` (parity with `tx` / `batch` / `patch`)
- Stronger containment test: `--files-from` escape case uses a relative list path under `--cwd`
- Agent-facing docs: agent-rules / `PATCHLOOM.md` note that batch/tx/explain/patch/`--files-from` meta-inputs resolve under `--cwd`

## Test plan

- [x] `make check-fast`
- [x] `cargo test --test integration explain_relative_plan_respects_cwd`
- [x] `cargo test --test integration search_contain_rejects_files_from`
- [x] `make check-patchloom-md`