### PR TITLE
fix: apply --contain to meta-input paths (plans, ops, files-from)

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -140,7 +140,7 @@ These flags affect how Patchloom reports results or chooses which files to touch
 <!-- ref:global-flag:contain -->
 ### `--contain`
 
-- **What it does:** Rejects file paths that escape the working directory (via `../`, absolute paths outside the policy, or symlinks that resolve outside the workspace). Mirrors MCP / library `PathGuard` for **reads and writes**: explicit paths on `search` / `read` / `replace` / `create` / `delete` / `rename` / `append` / `prepend` / `patch` / `md` / `doc` / `tidy` / `tx` / `batch` (including binary/case-only rename).
+- **What it does:** Rejects file paths that escape the working directory (via `../`, absolute paths outside the policy, or symlinks that resolve outside the workspace). Mirrors MCP / library `PathGuard` for **reads and writes**: explicit paths on `search` / `read` / `replace` / `create` / `delete` / `rename` / `append` / `prepend` / `patch` / `md` / `doc` / `tidy` / `tx` / `batch` (including binary/case-only rename). Also applies to **meta-input files**: `tx`/`explain` plan files, `batch` ops files, `patch` patch files, and `--files-from` list files (so a list path cannot open `/etc/passwd` or `../outside.txt` under `--contain`).
 - **Use when:** An agent or automation should not be able to read or write outside `--cwd` (or the process cwd). Pair with `--cwd` for a workspace root.
 - **Default:** Off. CLI remains unrestricted for human scripts (same trust model as `make` / `sh`).
 - **Prefer instead:** Use the MCP server when the agent already has MCP tools; containment is always on there.

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -311,11 +311,22 @@ impl GlobalFlags {
     /// Relative paths become `<cwd>/<path>`. Use for meta-inputs (`tx` plans,
     /// `batch` ops files, `patch` files, `--files-from` lists) so `--cwd` is
     /// consistent across commands.
+    ///
+    /// When [`Self::contain`] is set, the user-supplied path is also checked
+    /// with the workspace [`crate::containment::PathGuard`] (same policy as
+    /// operation targets). This prevents reading plan/ops/list files from
+    /// outside the workspace under `--contain`.
     pub fn resolve_user_path(
         &self,
         path: impl AsRef<std::path::Path>,
     ) -> anyhow::Result<std::path::PathBuf> {
-        Ok(self.resolve_cwd()?.join(path.as_ref()))
+        let path = path.as_ref();
+        let cwd = self.resolve_cwd()?;
+        if self.contain {
+            let path_str = path.to_string_lossy();
+            self.check_paths_contained(&cwd, std::iter::once(path_str.as_ref()))?;
+        }
+        Ok(cwd.join(path))
     }
 
     /// Build a workspace [`PathGuard`] when `--contain` is set.
@@ -757,6 +768,83 @@ mod tests {
         };
         let resolved = g.resolve_user_path(&abs).unwrap();
         assert_eq!(resolved, abs);
+    }
+
+    #[test]
+    fn resolve_user_path_contain_rejects_parent_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let g = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            contain: true,
+            ..GlobalFlags::default()
+        };
+        let err = g
+            .resolve_user_path("../outside.txt")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("rejected") || err.contains("escapes") || err.contains("workspace guard"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_user_path_contain_rejects_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let abs = dir
+            .path()
+            .parent()
+            .unwrap()
+            .join("outside-meta.txt")
+            .to_string_lossy()
+            .into_owned();
+        let g = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            contain: true,
+            ..GlobalFlags::default()
+        };
+        let err = g.resolve_user_path(&abs).unwrap_err().to_string();
+        assert!(
+            err.contains("absolute") || err.contains("rejected") || err.contains("workspace guard"),
+            "unexpected: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_user_path_contain_allows_relative_inside() {
+        let dir = tempfile::tempdir().unwrap();
+        let g = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            contain: true,
+            ..GlobalFlags::default()
+        };
+        let resolved = g.resolve_user_path("ops.txt").unwrap();
+        assert_eq!(resolved, dir.path().join("ops.txt"));
+    }
+
+    #[test]
+    fn read_files_from_contain_rejects_list_outside_workspace() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = dir.path().parent().unwrap().join(format!(
+            "patchloom-files-from-outside-{}.txt",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis()
+        ));
+        std::fs::write(&outside, "in.txt\n").unwrap();
+        let flags = GlobalFlags {
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            contain: true,
+            files_from: Some(outside.to_string_lossy().into_owned()),
+            ..GlobalFlags::test_default()
+        };
+        let err = flags.read_files_from().unwrap_err().to_string();
+        let _ = std::fs::remove_file(&outside);
+        assert!(
+            err.contains("absolute") || err.contains("rejected") || err.contains("workspace guard"),
+            "must not open outside list under --contain: {err}"
+        );
     }
 
     #[test]

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -427,40 +427,23 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         );
     }
 
-    // Build a plan and delegate to tx.
-    let plan_json = {
-        let plan = Plan {
-            version: crate::plan::SCHEMA_VERSION,
-            cwd: None,
-            write_policy: None,
-            strict: None,
-            operations,
-            format: None,
-            validate: None,
-            verify: None,
-            for_each: None,
-        };
-        serde_json::to_string(&plan)?
+    // Build a plan and run the shared tx engine in-process (no temp plan file).
+    // Under --contain, re-entering via an absolute NamedTempFile path would be
+    // rejected by resolve_user_path; keep the Plan in memory instead.
+    let plan = Plan {
+        version: crate::plan::SCHEMA_VERSION,
+        cwd: None,
+        write_policy: None,
+        strict: None,
+        operations,
+        format: None,
+        validate: None,
+        verify: None,
+        for_each: None,
     };
-
-    // Write the plan to a temp file and invoke tx.
-    let tmp = tempfile::NamedTempFile::new()?;
-    std::fs::write(tmp.path(), &plan_json)?;
-
-    let tx_args = crate::tx::TxArgs {
-        plan: tmp
-            .path()
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("temp file path is not valid UTF-8"))?
-            .to_string(),
-        plan_format: None,
-        no_strict: false,
-        verify: Vec::new(),
-        write: args.write,
-    };
-    // Delegate to tx, which handles --apply / --confirm / --format / plan lifecycle.
-    let result = crate::cmd::tx::run(tx_args, global)?;
-    Ok(result)
+    // Write flags are already merged into global by dispatch before run().
+    let _ = args.write;
+    crate::cmd::tx::run_parsed_plan(plan, false, &[], global)
 }
 
 #[path = "batch_tests.rs"]

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -254,7 +254,24 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     };
 
-    // 2b. Expand for_each (glob-driven batch) before validation.
+    run_parsed_plan(plan, args.no_strict, &args.verify, global)
+}
+
+/// Execute an already-parsed plan (shared by `tx` CLI and in-process `batch`).
+///
+/// Batch builds a `Plan` in memory and must not re-enter via a temp plan path:
+/// under `--contain`, absolute temp paths outside the workspace are rejected by
+/// [`GlobalFlags::resolve_user_path`].
+pub(crate) fn run_parsed_plan(
+    plan: Plan,
+    no_strict: bool,
+    verify: &[String],
+    global: &GlobalFlags,
+) -> anyhow::Result<u8> {
+    let structured = global.json || global.jsonl;
+    let compact = global.jsonl;
+
+    // Expand for_each (glob-driven batch) before validation.
     let base_cwd = global.resolve_cwd()?;
     let mut plan = plan;
     if plan.for_each.is_some()
@@ -277,7 +294,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // 3. Validate plan and resolve working directory.
     let (cwd, strict, _resolved_global) =
-        match crate::tx::validate_and_prepare_plan(&plan, &base_cwd, args.no_strict) {
+        match crate::tx::validate_and_prepare_plan(&plan, &base_cwd, no_strict) {
             Ok(v) => v,
             Err(output) => {
                 let code = if output.error_kind.as_deref() == Some("parse_error") {
@@ -309,12 +326,12 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::PARSE_ERROR);
     }
 
-    // 3b. Merge --verify CLI args with plan's verify field.
+    // Merge --verify CLI args with plan's verify field.
     #[cfg(feature = "ast")]
     let verify_checks = {
         use crate::plan::VerifyCheck;
         let mut checks: Vec<VerifyCheck> = plan.verify.clone().unwrap_or_default();
-        for raw in &args.verify {
+        for raw in verify {
             match VerifyCheck::parse(raw) {
                 Ok(c) => checks.push(c),
                 Err(e) => {

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -344,6 +344,47 @@ fn test_batch_relative_input_respects_cwd() {
     );
 }
 
+/// Under --contain, the batch ops *file path* must stay in the workspace (meta-input).
+#[test]
+fn test_batch_contain_rejects_ops_file_parent_escape() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("data.json"), r#"{"key":"old"}"#).unwrap();
+    let outside = dir.path().parent().unwrap().join(format!(
+        "patchloom-batch-ops-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    fs::write(&outside, "doc.set data.json key \"new\"\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "batch",
+            &format!("../{}", outside.file_name().unwrap().to_string_lossy()),
+            "--apply",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicates::str::contains("escapes")
+                .or(predicates::str::contains("rejected"))
+                .or(predicates::str::contains("workspace guard")),
+        );
+
+    // Must not have applied the outside ops file.
+    let content = fs::read_to_string(dir.path().join("data.json")).unwrap();
+    assert!(
+        content.contains("old"),
+        "contain must block reading outside ops file: {content}"
+    );
+    let _ = fs::remove_file(&outside);
+}
+
 /// #1439: batch --json surfaces delete-where mutation summary (shared tx path).
 #[test]
 fn test_batch_json_delete_where_mutations() {

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -325,6 +325,69 @@ fn test_files_from_resolves_list_under_cwd() {
         .stdout(predicate::str::contains("findme"));
 }
 
+/// Under --contain, the --files-from *list file* itself must not escape the workspace
+/// (meta-input read). Previously only entries inside the list were checked, so an
+/// absolute list path like /etc/passwd was opened and leaked via skip messages.
+#[test]
+fn test_files_from_contain_rejects_absolute_list_path() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("inside.txt"), "ok\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "--files-from",
+            "/etc/hosts",
+            "search",
+            "localhost",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("absolute")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+}
+
+#[test]
+fn test_files_from_contain_rejects_parent_list_path() {
+    let dir = TempDir::new().unwrap();
+    let outside = dir.path().parent().unwrap().join(format!(
+        "patchloom-meta-list-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    fs::write(&outside, "inside.txt\n").unwrap();
+    fs::write(dir.path().join("inside.txt"), "findme\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "--files-from",
+            &format!("../{}", outside.file_name().unwrap().to_string_lossy()),
+            "search",
+            "findme",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+
+    let _ = fs::remove_file(&outside);
+}
+
 #[test]
 fn test_append_contain_rejects_missing_parent_escape_not_not_found() {
     // Escaped path that does not exist must still fail with containment, not

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -605,7 +605,8 @@ fn test_search_context_flag() {
 fn test_search_before_context() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
-    fs::write(&file, "aaa\nbbb\nccc\ntarget\nddd\neee\n").unwrap();
+    // Use distinctive markers: plain "ddd" can appear in tempfile path names.
+    fs::write(&file, "aaa\nbbb\nccc\ntarget\nAFTER_CTX_MARKER\neee\n").unwrap();
 
     Command::cargo_bin("patchloom")
         .unwrap()
@@ -620,7 +621,7 @@ fn test_search_before_context() {
         .stdout(predicate::str::contains("ccc"))
         .stdout(predicate::str::contains("target"))
         // no after-context lines
-        .stdout(predicate::str::contains("ddd").not());
+        .stdout(predicate::str::contains("AFTER_CTX_MARKER").not());
 }
 
 #[test]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7423,16 +7423,18 @@ fn test_tx_contain_allows_in_workspace_relative_path() {
             "content": "ok\n"
         }]
     });
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
 
+    // Meta-input plan path must be relative under --contain (absolute paths are rejected).
     Command::cargo_bin("patchloom")
         .unwrap()
         .args(["--cwd"])
         .arg(dir.path())
-        .args(["--contain", "tx"])
-        .arg(plan_file.to_str().unwrap())
-        .arg("--apply")
+        .args(["--contain", "tx", "plan.json", "--apply"])
         .assert()
         .code(0);
 


### PR DESCRIPTION
## Summary

MPI loop4 cycle 3 (Security / Adversarial): under `--contain`, meta-input files were not guard-checked.

- **Bug:** `--files-from /etc/passwd` (or any absolute/outside list path) was opened even with `--contain`. List lines became workspace-relative search paths and leaked passwd-style content into `search: skipping …` stderr.
- **Fix:** `GlobalFlags::resolve_user_path` applies the workspace PathGuard when `contain` is set (covers `tx`/`explain` plans, `batch` ops files, `patch` files, `--files-from` lists).
- **Batch:** stop re-entering `tx` via a system temp plan path (absolute paths are rejected under `--contain`). Use in-process `run_parsed_plan` instead.
- **Docs:** `--contain` reference notes meta-input coverage.
- **Tests:** unit + integration regressions; de-flake `search -B` context assert vs tempfile names containing `ddd`.

## Test plan

- [x] `make check-fast`
- [x] Manual: `--contain --files-from /etc/passwd search` fails with workspace guard (not NO_MATCHES skip flood)
- [x] Manual: `--contain batch` via stdin still creates files in workspace