### PR TITLE
fix: reject empty and whitespace-only path arguments

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -326,11 +326,13 @@ impl GlobalFlags {
         path: impl AsRef<std::path::Path>,
     ) -> anyhow::Result<std::path::PathBuf> {
         let path = path.as_ref();
-        let cwd = self.resolve_cwd()?;
-        if self.contain {
-            let path_str = path.to_string_lossy();
-            self.check_paths_contained(&cwd, std::iter::once(path_str.as_ref()))?;
+        let path_str = path.to_string_lossy();
+        if path_str.trim().is_empty() {
+            anyhow::bail!("path must not be empty");
         }
+        let cwd = self.resolve_cwd()?;
+        // Always run empty-path + optional --contain checks via the shared helper.
+        self.check_paths_contained(&cwd, std::iter::once(path_str.as_ref()))?;
         Ok(cwd.join(path))
     }
 
@@ -357,15 +359,26 @@ impl GlobalFlags {
         .map_err(|e| anyhow::anyhow!("failed to initialize --contain path guard: {e}"))
     }
 
-    /// When `--contain` is set, reject every path that escapes the workspace.
+    /// Validate user path args and, when `--contain` is set, reject escapes.
+    ///
+    /// Always rejects empty / whitespace-only path strings (agent footgun:
+    /// `ast list ''` and similar join to the workspace root and scan everything).
+    /// When containment is off, non-empty paths are not further checked.
     ///
     /// Used by read-side commands (`search`, `read`) and as an early gate on
-    /// write commands that scan before staging. No-op when containment is off.
+    /// write commands that scan before staging.
     pub fn check_paths_contained(
         &self,
         cwd: &std::path::Path,
         paths: impl IntoIterator<Item = impl AsRef<str>>,
     ) -> anyhow::Result<()> {
+        let paths: Vec<_> = paths.into_iter().collect();
+        for p in &paths {
+            let p = p.as_ref();
+            if p.trim().is_empty() {
+                anyhow::bail!("path must not be empty");
+            }
+        }
         let Some(guard) = self.workspace_guard(cwd)? else {
             return Ok(());
         };

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -135,6 +135,9 @@ fn execute_md_op(
     check_msg: &str,
     apply_msg: &str,
 ) -> anyhow::Result<u8> {
+    let cwd = global.resolve_cwd()?;
+    // Shared empty-path + --contain gate (engine also checks under --contain).
+    global.check_paths_contained(&cwd, [file])?;
     let file_owned = file.to_string();
     match execute_via_engine(
         op,

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -46,17 +46,11 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.force
     );
     let cwd = global.resolve_cwd()?;
-    // Enforce --contain for all rename paths (engine-backed text and
+    // Empty-path + --contain for all rename paths (engine-backed text and
     // binary/case-only callback via write_dispatch). Engine-backed ops also
     // check declared_paths in the tx engine; this early check covers the
     // callback path that never reaches the engine (#1409).
-    if let Some(guard) = global.workspace_guard(&cwd)? {
-        for p in [&args.from, &args.to] {
-            guard
-                .check_path(p)
-                .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {e}"))?;
-        }
-    }
+    global.check_paths_contained(&cwd, [args.from.as_str(), args.to.as_str()])?;
     let src = cwd.join(&args.from);
     let dst = cwd.join(&args.to);
 

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -842,3 +842,35 @@ fn test_ast_list_without_contain_allows_parent_escape() {
 
     let _ = fs::remove_file(&outside);
 }
+
+#[cfg(feature = "ast")]
+#[test]
+fn test_ast_list_empty_path_rejected() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn keep() {}\n").unwrap();
+
+    // Empty path previously joined to cwd and listed the entire workspace
+    // (agent footgun when a path argument is omitted or blank).
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["ast", "list", ""])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("path must not be empty"));
+}
+
+#[cfg(feature = "ast")]
+#[test]
+fn test_ast_list_whitespace_only_path_rejected() {
+    let dir = TempDir::new().unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["ast", "list", "   "])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("path must not be empty"));
+}

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -1106,3 +1106,24 @@ fn test_md_lint_alias_invokes_lint_agents() {
         .code(0)
         .stderr(predicate::str::contains("unrecognized").not());
 }
+
+#[test]
+fn test_md_empty_path_rejected() {
+    let dir = TempDir::new().unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "md",
+            "replace-section",
+            "",
+            "--heading",
+            "## X",
+            "--content",
+            "y",
+        ])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("path must not be empty"));
+}

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -548,3 +548,16 @@ fn test_read_contain_allows_in_workspace() {
         .code(0)
         .stdout(predicate::str::contains("hello"));
 }
+
+#[test]
+fn test_read_empty_path_rejected() {
+    let dir = TempDir::new().unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["read", ""])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("path must not be empty"));
+}

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -848,3 +848,17 @@ fn test_rename_without_contain_allows_parent_escape() {
     assert_eq!(fs::read_to_string(&outside).unwrap(), "move me\n");
     let _ = fs::remove_file(&outside);
 }
+
+#[test]
+fn test_rename_empty_path_rejected() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "x\n").unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["rename", "", "b.txt"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("path must not be empty"));
+}


### PR DESCRIPTION
## Summary

MPI loop (new cycle after prior contain work converged):

**Bug:** Empty or whitespace-only path strings were joined to the workspace root. Commands such as `ast list ''` scanned the entire tree; agents that omit a path get a silent full-repo walk.

**Fix:**
- `GlobalFlags::check_paths_contained` always rejects empty/whitespace paths (even when `--contain` is off).
- `resolve_user_path` uses the same validation.
- `md` write helpers and `rename` call `check_paths_contained` so they get the same clear error (not "Is a directory" / "not a file").

## Tests

- `ast list` empty + whitespace-only
- `read` / `md replace-section` / `rename` empty path

## Test plan

- [x] `make check-fast`

## Note

Open release PR **#1457** (patchloom 0.10.1) is separate (contain fix only). Do not merge without explicit approval.