### PR TITLE
feat: library embedder gaps for bline (#1459)

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -24,7 +24,7 @@
 | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |
 | Search across files | `search_files` |
 | Apply a unified diff patch | `apply_patch` |
-| List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace` |
+| List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace`, `ast_rewrite_signature` |
 | Insert, wrap, or manage imports | `ast_insert`, `ast_wrap`, `ast_imports` |
 | Reorder, group, or move symbols | `ast_reorder`, `ast_group`, `ast_move` |
 | Extract or split files by symbol | `ast_extract_to_file`, `ast_split` |
@@ -313,6 +313,7 @@ dependencies[name=react].version # predicate filter
 - `md.lint_agents`: Lint an AGENTS.md file for common issues.
 - `ast.rename`: AST-aware rename: rename identifiers skipping strings and comments.
 - `ast.replace`: Replace text within a specific symbol's body (AST-scoped).
+- `ast.rewrite_signature`: Rewrite a function signature with structured fields (visibility, parameters, return_type) or a full new_signature string. Multi-language via tree-sitter.
 - `ast.insert`: Insert code at a structurally-aware position: inside a container, or after/before a named symbol.
 - `ast.wrap`: Wrap existing code in a structural block (module, impl, cfg, etc.).
 - `ast.imports`: Manage import/use statements: add (idempotent), remove, deduplicate.

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -99,7 +99,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 ## By the numbers
 
 - **2,800+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
-- **23 commands** including MCP server with 54 structured tool calls
+- **23 commands** including MCP server with 55 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -88,7 +88,7 @@ the registry when that would lose multi-file, batch, or read UX.
 
 Custom tools are inventoried in `CUSTOM_MCP_TOOLS_CORE` (always registered)
 and `CUSTOM_MCP_TOOLS_AST` (only when the `ast` feature is enabled). Default
-builds expose **54** tools (registry + custom). Builds without `ast` omit the
+builds expose **55** tools (registry + custom). Builds without `ast` omit the
 AST tools so `list_tools` stays honest about what is callable.
 
 | Tool | Description |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1145,6 +1145,13 @@ The operations below are the building blocks inside `operations`.
 - **Use when:** You need to change a value, string, or expression inside a specific function or struct without affecting identically-named text in other symbols.
 - **Related:** `replace` (file-level), `ast.rename` (identifier rename)
 
+<!-- ref:tx-op:ast.rewrite_signature -->
+### `ast.rewrite_signature`
+
+- **What it does:** Rewrites a function signature using tree-sitter. Structured fields `visibility`, `parameters`, and `return_type` map to [`FunctionSigEdit`](https://docs.rs/patchloom); optional `new_signature` replaces the whole signature span. Field `old` (alias `name`) is the function name. Library: `api::ast_rewrite_signature`. MCP: `ast_rewrite_signature`.
+- **Use when:** Changing parameter lists, visibility, or return types without a brittle line scan (agent hosts such as Bline).
+- **Related:** `ast.replace`, `ast.rename`
+
 <!-- ref:tx-op:ast.insert -->
 ### `ast.insert`
 

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -1,0 +1,47 @@
+//! AST write helpers for the public library API (feature `ast` + `files`/`cli`).
+
+use std::path::Path;
+
+use crate::ast::rewrite::FunctionSigEdit;
+use crate::containment::PathGuard;
+use crate::plan::Operation;
+
+use super::{ApplyMode, EditResult};
+
+/// Rewrite a function signature on disk (PathGuard + ApplyMode like other writers).
+///
+/// Prefer structured fields on [`FunctionSigEdit`]. Optionally pass `new_signature`
+/// to replace the entire signature span (any language with tree-sitter support).
+/// At least one of the structured fields or `new_signature` must be set.
+///
+/// Available with `features = ["ast"]` and `files` or `cli` for the write path.
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub fn ast_rewrite_signature(
+    path: &Path,
+    name: &str,
+    edit: &FunctionSigEdit,
+    new_signature: Option<&str>,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    if new_signature.is_none()
+        && edit.visibility.is_none()
+        && edit.parameters.is_none()
+        && edit.return_type.is_none()
+    {
+        anyhow::bail!(
+            "ast_rewrite_signature requires new_signature and/or visibility/parameters/return_type"
+        );
+    }
+    let op = Operation::AstRewriteSignature {
+        path: path.to_string_lossy().into(),
+        old: name.into(),
+        new_signature: new_signature.map(str::to_string),
+        visibility: edit.visibility.clone(),
+        parameters: edit.parameters.clone(),
+        return_type: edit.return_type.clone(),
+        lang: None,
+    };
+    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    super::execute_as_edit_result(op, mode, cwd, guard, "ast.rewrite_signature", None)
+}

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -1,0 +1,253 @@
+//! Multi-op in-memory content edits for agent hosts (#1459 Feature 2).
+//!
+//! Compose sequential text operations on one buffer with all-or-nothing
+//! semantics, then optionally write once via [`apply_content_edits_to_file`].
+
+use std::path::Path;
+
+use anyhow::Context;
+
+use crate::containment::PathGuard;
+use crate::ops::file::{append_content, prepend_content};
+
+use super::{
+    ApplyMode, ContentEditResult, EditResult, ReplaceOptions, make_diff, replace_in_content,
+    write_if_apply,
+};
+use crate::write::WritePolicy;
+
+/// A single ordered edit on an in-memory buffer.
+#[derive(Debug, Clone)]
+pub enum ContentEdit {
+    /// Text replacement (reuses [`ReplaceOptions`]).
+    Replace {
+        old: String,
+        new: String,
+        options: ReplaceOptions,
+    },
+    /// Insert `content` immediately before the first exact match of `anchor`.
+    InsertBefore { anchor: String, content: String },
+    /// Insert `content` immediately after the first exact match of `anchor`.
+    InsertAfter { anchor: String, content: String },
+    /// Append content to the end of the buffer.
+    Append { content: String },
+    /// Prepend content to the start of the buffer.
+    Prepend { content: String },
+}
+
+/// Result of applying a sequence of [`ContentEdit`]s to a buffer.
+#[derive(Debug, Clone)]
+pub struct ContentEditsResult {
+    /// Original buffer before any edits.
+    pub original: String,
+    /// Buffer after all edits (or unchanged when `changed` is false).
+    pub modified: String,
+    /// Unified diff from original to modified.
+    pub diff: String,
+    /// Whether any edit changed the buffer.
+    pub changed: bool,
+    /// Number of ops that successfully applied (equals `edits.len()` on success).
+    pub ops_applied: usize,
+}
+
+/// Apply ordered edits to an in-memory buffer.
+///
+/// **All-or-nothing:** if any op fails, returns `Err` and does not expose a
+/// partial buffer. On success, every op has been applied in order; each op
+/// sees the result of the previous one.
+///
+/// Available with default features off as long as the replace path is
+/// compiled (always; no `ast` required).
+pub fn apply_content_edits(
+    content: &str,
+    edits: &[ContentEdit],
+) -> anyhow::Result<ContentEditsResult> {
+    let original = content.to_string();
+    let mut current = content.to_string();
+    let mut ops_applied = 0usize;
+
+    for (i, edit) in edits.iter().enumerate() {
+        current = apply_one(&current, edit)
+            .with_context(|| format!("content edit {} of {} failed", i + 1, edits.len()))?;
+        ops_applied += 1;
+    }
+
+    let changed = current != original;
+    let diff = make_diff("<buffer>", &original, &current);
+    Ok(ContentEditsResult {
+        original,
+        modified: current,
+        diff,
+        changed,
+        ops_applied,
+    })
+}
+
+/// Read a file, apply multi-op content edits, and write according to `mode`.
+///
+/// Requires `files` or `cli` for PathGuard / write policy integration.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn apply_content_edits_to_file(
+    path: &Path,
+    edits: &[ContentEdit],
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    if let Some(g) = guard {
+        g.check_path(&path.to_string_lossy())
+            .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {e}"))?;
+    }
+    let path_str = path.to_string_lossy().into_owned();
+    let original =
+        std::fs::read_to_string(path).with_context(|| format!("failed to read {path_str}"))?;
+    let batch = apply_content_edits(&original, edits)?;
+    let policy = WritePolicy::default();
+    let applied = write_if_apply(path, &batch.modified, mode, &policy, guard)?;
+    Ok(EditResult {
+        path: path_str,
+        original_content: batch.original,
+        new_content: batch.modified,
+        diff: batch.diff,
+        applied,
+        changed: batch.changed,
+        action: "content.edits",
+        dest_path: None,
+        match_count: 0,
+        removed: 0,
+    })
+}
+
+fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<String> {
+    match edit {
+        ContentEdit::Replace { old, new, options } => {
+            let result: ContentEditResult = replace_in_content(content, old, new, options)?;
+            Ok(result.new_content)
+        }
+        ContentEdit::InsertBefore {
+            anchor,
+            content: insert,
+        } => {
+            if anchor.is_empty() {
+                anyhow::bail!("insert_before anchor must not be empty");
+            }
+            match content.find(anchor.as_str()) {
+                Some(idx) => {
+                    let mut out = String::with_capacity(content.len() + insert.len());
+                    out.push_str(&content[..idx]);
+                    out.push_str(insert);
+                    out.push_str(&content[idx..]);
+                    Ok(out)
+                }
+                None => anyhow::bail!("insert_before anchor not found: {anchor:?}"),
+            }
+        }
+        ContentEdit::InsertAfter {
+            anchor,
+            content: insert,
+        } => {
+            if anchor.is_empty() {
+                anyhow::bail!("insert_after anchor must not be empty");
+            }
+            match content.find(anchor.as_str()) {
+                Some(idx) => {
+                    let end = idx + anchor.len();
+                    let mut out = String::with_capacity(content.len() + insert.len());
+                    out.push_str(&content[..end]);
+                    out.push_str(insert);
+                    out.push_str(&content[end..]);
+                    Ok(out)
+                }
+                None => anyhow::bail!("insert_after anchor not found: {anchor:?}"),
+            }
+        }
+        ContentEdit::Append { content: inject } => Ok(append_content(content, inject)),
+        ContentEdit::Prepend { content: inject } => Ok(prepend_content(content, inject)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn multi_op_replace_then_append() {
+        let edits = [
+            ContentEdit::Replace {
+                old: "hello".into(),
+                new: "hi".into(),
+                options: ReplaceOptions::default(),
+            },
+            ContentEdit::Append {
+                content: "\nworld".into(),
+            },
+        ];
+        let r = apply_content_edits("hello\n", &edits).unwrap();
+        assert!(r.changed);
+        assert_eq!(r.ops_applied, 2);
+        assert_eq!(r.modified, "hi\n\nworld");
+    }
+
+    #[test]
+    fn multi_op_all_or_nothing_on_failure() {
+        let edits = [
+            ContentEdit::Replace {
+                old: "a".into(),
+                new: "A".into(),
+                options: ReplaceOptions::default(),
+            },
+            ContentEdit::InsertBefore {
+                anchor: "missing".into(),
+                content: "x".into(),
+            },
+        ];
+        let err = apply_content_edits("a b\n", &edits).unwrap_err();
+        assert!(
+            err.to_string().contains("content edit 2"),
+            "error should identify failing op: {err}"
+        );
+    }
+
+    #[test]
+    fn multi_op_unique_failure() {
+        let edits = [ContentEdit::Replace {
+            old: "x".into(),
+            new: "y".into(),
+            options: ReplaceOptions {
+                unique: true,
+                ..Default::default()
+            },
+        }];
+        let err = apply_content_edits("x x\n", &edits).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("ambiguous") || msg.contains("matches"),
+            "expected unique/ambiguous failure, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn multi_op_insert_before_after() {
+        let edits = [
+            ContentEdit::InsertBefore {
+                anchor: "B".into(),
+                content: "A".into(),
+            },
+            ContentEdit::InsertAfter {
+                anchor: "B".into(),
+                content: "C".into(),
+            },
+        ];
+        let r = apply_content_edits("B", &edits).unwrap();
+        assert_eq!(r.modified, "ABC");
+    }
+
+    #[test]
+    fn multi_op_prepend() {
+        let edits = [ContentEdit::Prepend {
+            content: "pre\n".into(),
+        }];
+        let r = apply_content_edits("body\n", &edits).unwrap();
+        assert_eq!(r.modified, "pre\nbody\n");
+        assert_eq!(r.ops_applied, 1);
+    }
+}

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -71,18 +71,25 @@ fn doc_write(
     if let MutationResult::TypeError(msg) = result {
         anyhow::bail!("{msg}");
     }
+    let removed = match &result {
+        MutationResult::Removed(n) => *n,
+        MutationResult::NoMatch if matches!(action, "doc.delete" | "doc.delete_where") => 0,
+        _ => 0,
+    };
 
     let new_content = ops::doc::serialize_value_preserving(&original, &value, &new_value, &format)?;
     let policy = WritePolicy::default();
-    let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;
-    Ok(super::build_edit_result(
-        &path_str,
-        original,
-        new_content,
-        applied,
-        action,
-        None,
-    ))
+    // Do not write (or report applied) when the mutation is a no-op.
+    let content_changed = original != new_content;
+    let applied = if content_changed {
+        super::write_if_apply(path, &new_content, mode, &policy, guard)?
+    } else {
+        false
+    };
+    let mut edit =
+        super::build_edit_result(&path_str, original, new_content, applied, action, None);
+    edit.removed = removed;
+    Ok(edit)
 }
 
 /// Set a value at a selector path in a JSON, YAML, or TOML file.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -118,6 +118,14 @@ pub use self::read::*;
 mod plan;
 pub use self::plan::*;
 
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+mod ast_write;
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub use self::ast_write::*;
+
+mod content_edits;
+pub use self::content_edits::*;
+
 /// The result of an editing operation.
 #[derive(Debug, Clone)]
 pub struct EditResult {
@@ -144,6 +152,14 @@ pub struct EditResult {
     /// Only meaningful for replace operations; defaults to `0` for other
     /// operation types (doc, md, file, patch, tidy).
     pub match_count: usize,
+    /// Number of items removed by the operation (keys, array elements, etc.).
+    ///
+    /// Meaningful for `doc.delete` and `doc.delete_where` (including
+    /// idempotent no-ops where `removed == 0` and `changed == false`).
+    /// Defaults to `0` for other operation types. Mirrors MCP/tx JSON
+    /// mutation summaries so embedders can report delete outcomes without
+    /// re-reading the file or parsing diffs (#1459 / #1439).
+    pub removed: usize,
 }
 
 /// Result of an in-memory content edit (no file path, no applied flag).
@@ -411,6 +427,7 @@ fn build_edit_result(
         action,
         dest_path,
         match_count: 0,
+        removed: 0,
     }
 }
 
@@ -469,6 +486,19 @@ fn execution_result_to_edit_result(
     dest_path: Option<String>,
 ) -> anyhow::Result<EditResult> {
     let has_changes = result.has_changes;
+    let removed: usize = result
+        .exec_result
+        .tx_mutations
+        .iter()
+        .map(|m| m.removed)
+        .sum();
+    // Prefer mutation path when the engine recorded a doc delete/delete-where
+    // outcome (including idempotent no-ops with empty `changes`).
+    let mutation_path = result
+        .exec_result
+        .tx_mutations
+        .first()
+        .map(|m| m.path.clone());
 
     // Extract path + content from the engine result before potentially consuming it.
     let (path_str, original, new_content) =
@@ -485,10 +515,12 @@ fn execution_result_to_edit_result(
                 .map(|(orig, _)| orig.clone())
                 .unwrap_or_default();
             (rel.to_string_lossy().to_string(), original, String::new())
+        } else if let Some(p) = mutation_path {
+            // No file content change (e.g. idempotent doc.delete) but mutations
+            // still carry path + removed counts for embedders (#1459).
+            (p, String::new(), String::new())
         } else {
             // No changes at all (e.g., replace with no matches + if_exists).
-            // Return an unchanged result. We need the path from the operation,
-            // but we don't have it here. Use empty path as fallback.
             (String::new(), String::new(), String::new())
         };
 
@@ -500,14 +532,9 @@ fn execution_result_to_edit_result(
         false
     };
 
-    Ok(build_edit_result(
-        &path_str,
-        original,
-        new_content,
-        applied,
-        action,
-        dest_path,
-    ))
+    let mut edit = build_edit_result(&path_str, original, new_content, applied, action, dest_path);
+    edit.removed = removed;
+    Ok(edit)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -103,8 +103,50 @@ fn doc_delete_removes_key() {
     let result = doc_delete(&file, "b", ApplyMode::Apply, None).unwrap();
     assert!(result.changed);
     assert!(result.applied);
+    assert_eq!(
+        result.removed, 1,
+        "library EditResult must report removed (#1459)"
+    );
+    assert_eq!(result.action, "doc.delete");
     let on_disk = fs::read_to_string(&file).unwrap();
     assert!(!on_disk.contains("\"b\""));
+}
+
+#[test]
+fn doc_delete_missing_key_reports_removed_zero() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.json");
+    fs::write(&file, r#"{"a": 1}"#).unwrap();
+
+    let result = doc_delete(&file, "missing", ApplyMode::Apply, None).unwrap();
+    assert!(!result.changed);
+    assert!(!result.applied);
+    assert_eq!(
+        result.removed, 0,
+        "idempotent delete must report removed: 0 (#1459 / #1439)"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), r#"{"a": 1}"#);
+}
+
+#[test]
+fn doc_delete_where_reports_removed_count() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("items.json");
+    fs::write(
+        &file,
+        r#"{"items":[{"name":"a"},{"name":"b"},{"name":"a"}]}"#,
+    )
+    .unwrap();
+
+    let result = doc_delete_where(&file, "items", "name=a", ApplyMode::Apply, None).unwrap();
+    assert!(result.changed);
+    assert_eq!(result.removed, 2);
+    assert_eq!(result.action, "doc.delete_where");
+
+    let preview = doc_delete_where(&file, "items", "name=zzz", ApplyMode::Preview, None).unwrap();
+    assert!(!preview.changed);
+    assert_eq!(preview.removed, 0);
+    assert!(!preview.applied);
 }
 
 #[test]
@@ -3482,4 +3524,114 @@ fn replace_text_fuzzy_with_if_exists_any_path() {
     )
     .unwrap();
     assert!(!result.changed);
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rewrite_signature_api_updates_params() {
+    use crate::ast::rewrite::FunctionSigEdit;
+
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(&file, "fn process(x: i32) {}\n").unwrap();
+
+    let edit = FunctionSigEdit {
+        parameters: Some("(x: u64)".into()),
+        return_type: Some("-> u64".into()),
+        ..Default::default()
+    };
+    let result = ast_rewrite_signature(&file, "process", &edit, None, ApplyMode::Apply, None)
+        .expect("rewrite should succeed");
+    assert!(result.changed);
+    assert!(result.applied);
+    assert_eq!(result.action, "ast.rewrite_signature");
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("u64"), "got: {on_disk}");
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rewrite_signature_plan_execute() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.rs");
+    fs::write(&file, "fn greet() {}\n").unwrap();
+
+    let plan = parse_plan(
+        r#"{
+            "version": 1,
+            "operations": [
+                {
+                    "op": "ast.rewrite_signature",
+                    "path": "m.rs",
+                    "old": "greet",
+                    "new_signature": "fn greet(name: &str)",
+                    "lang": "rust"
+                }
+            ]
+        }"#,
+    )
+    .unwrap();
+    let report = execute_plan(plan, dir.path(), None).unwrap();
+    assert!(report.ok, "plan should succeed: status={}", report.status);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.contains("name: &str"),
+        "plan rewrite should update signature: {on_disk}"
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_content_edits_to_file_writes_once() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("notes.txt");
+    fs::write(&file, "hello world\n").unwrap();
+
+    let edits = [
+        ContentEdit::Replace {
+            old: "hello".into(),
+            new: "hi".into(),
+            options: ReplaceOptions::default(),
+        },
+        ContentEdit::Append {
+            content: "done\n".into(),
+        },
+    ];
+    let result =
+        apply_content_edits_to_file(&file, &edits, ApplyMode::Apply, None).expect("file edits");
+    assert!(result.changed);
+    assert!(result.applied);
+    assert_eq!(result.action, "content.edits");
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert_eq!(on_disk, "hi world\ndone\n");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_content_edits_to_file_respects_guard() {
+    let dir = TempDir::new().unwrap();
+    let outside = dir.path().parent().unwrap().join(format!(
+        "patchloom-content-edit-escape-{}.txt",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    fs::write(&outside, "secret\n").unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let edits = [ContentEdit::Append {
+        content: "x\n".into(),
+    }];
+    let err = apply_content_edits_to_file(&outside, &edits, ApplyMode::Apply, Some(&guard))
+        .expect_err("must reject outside path");
+    assert!(
+        err.to_string().contains("guard") || err.to_string().contains("escapes"),
+        "got: {err}"
+    );
+    assert_eq!(fs::read_to_string(&outside).unwrap(), "secret\n");
+    let _ = fs::remove_file(&outside);
 }

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -272,9 +272,9 @@ pub struct FunctionSigEdit {
 /// - Go: `"error"` or `"(*Response, error)"` (no prefix)
 /// - Java: `"Response"` (placed before the method name)
 ///
-/// Per #821: this remains a library-only helper for now (no CLI `ast signature`, no plan op, no MCP tool).
-/// Record of decision lives in #821 and src/lib.rs embedding docs.
-/// See #797, #1266.
+/// Plan op `ast.rewrite_signature`, library `api::ast_rewrite_signature`, and MCP
+/// `ast_rewrite_signature` wrap this helper for on-disk / agent use (#1459).
+/// See #797, #1266, #821.
 pub fn rewrite_function_signature(
     source: &str,
     old_name: &str,

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -102,7 +102,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |\n\
              | Search across files | `search_files` |\n\
              | Apply a unified diff patch | `apply_patch` |\n\
-             | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace` |\n\
+             | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace`, `ast_rewrite_signature` |\n\
              | Insert, wrap, or manage imports | `ast_insert`, `ast_wrap`, `ast_imports` |\n\
              | Reorder, group, or move symbols | `ast_reorder`, `ast_group`, `ast_move` |\n\
              | Extract or split files by symbol | `ast_extract_to_file`, `ast_split` |\n\

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -4,6 +4,8 @@
 //! ([`crate::schema::operation_description`]) supplies the stable op label
 //! (what agents see in `patchloom schema` / MCP tool prose) so explain and
 //! schema stay aligned on naming.
+//!
+//! size-waiver: single-domain Operation match arms for explain (one variant per plan op); co-located with catalog blurb alignment; do not split for LOC alone #1408.
 
 use crate::plan::Operation;
 use crate::schema;
@@ -254,6 +256,37 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             ..
         } => {
             format!("AST replace \"{old}\" with \"{new_text}\" in {symbol} in {path}")
+        }
+        #[cfg(feature = "ast")]
+        Operation::AstRewriteSignature {
+            path,
+            old,
+            new_signature,
+            visibility,
+            parameters,
+            return_type,
+            ..
+        } => {
+            if let Some(sig) = new_signature {
+                format!("AST rewrite signature of \"{old}\" to \"{sig}\" in {path}")
+            } else {
+                let mut parts = Vec::new();
+                if visibility.is_some() {
+                    parts.push("visibility");
+                }
+                if parameters.is_some() {
+                    parts.push("parameters");
+                }
+                if return_type.is_some() {
+                    parts.push("return type");
+                }
+                let what = if parts.is_empty() {
+                    "signature".to_string()
+                } else {
+                    parts.join("/")
+                };
+                format!("AST rewrite {what} of \"{old}\" in {path}")
+            }
         }
         #[cfg(feature = "ast")]
         Operation::AstInsert {

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -588,6 +588,27 @@ pub(super) fn handle_ast_replace(
     svc.run_one_op(op, None)
 }
 
+pub(super) fn handle_ast_rewrite_signature(
+    svc: &PatchloomService,
+    p: AstRewriteSignatureParams,
+) -> Result<CallToolResult, McpError> {
+    svc.check_path(&p.path)?;
+    validate_param_size("old", &p.old)?;
+    if let Some(ref sig) = p.new_signature {
+        validate_content_size("new_signature", sig)?;
+    }
+    let op = crate::plan::Operation::AstRewriteSignature {
+        path: p.path,
+        old: p.old,
+        new_signature: p.new_signature,
+        visibility: p.visibility,
+        parameters: p.parameters,
+        return_type: p.return_type,
+        lang: p.lang,
+    };
+    svc.run_one_op(op, None)
+}
+
 pub(super) fn handle_ast_insert(
     svc: &PatchloomService,
     p: AstInsertParams,

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -759,6 +759,17 @@ impl PatchloomService {
     }
 
     #[tool(
+        description = "Rewrite a function signature with structured fields (visibility, parameters, return_type) or a full new_signature string. Multi-language via tree-sitter. Example: {\"path\": \"src/lib.rs\", \"old\": \"process\", \"parameters\": \"(x: i32)\", \"return_type\": \"-> String\"}"
+    )]
+    async fn ast_rewrite_signature(
+        &self,
+        Parameters(p): Parameters<AstRewriteSignatureParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| ast_tools::handle_ast_rewrite_signature(svc, p))
+            .await
+    }
+
+    #[tool(
         description = "Insert code at a structurally-aware position: inside a module/impl/struct (at start or end), or after/before a named symbol. Indentation is auto-detected. Example: {\"path\": \"src/lib.rs\", \"content\": \"fn new_fn() {}\", \"after\": \"existing_fn\"}"
     )]
     async fn ast_insert(

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -420,6 +420,32 @@ pub(crate) struct AstReplaceParams {
 #[cfg(feature = "ast")]
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
+pub(crate) struct AstRewriteSignatureParams {
+    /// File containing the function (relative to working directory).
+    pub path: String,
+    /// Function name to rewrite. Alias `name` accepted for agents.
+    #[serde(alias = "name")]
+    pub old: String,
+    /// Full replacement signature text (optional).
+    #[serde(default)]
+    pub new_signature: Option<String>,
+    /// New visibility (e.g. "pub", "pub(crate)", or "").
+    #[serde(default)]
+    pub visibility: Option<String>,
+    /// New parameter list including parens.
+    #[serde(default)]
+    pub parameters: Option<String>,
+    /// New return type using language-native syntax.
+    #[serde(default)]
+    pub return_type: Option<String>,
+    /// Language hint.
+    #[serde(default)]
+    pub lang: Option<String>,
+}
+
+#[cfg(feature = "ast")]
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct AstInsertParams {
     /// File to insert code into (relative to working directory).
     pub path: String,

--- a/src/cmd/mcp/surface.rs
+++ b/src/cmd/mcp/surface.rs
@@ -188,6 +188,11 @@ pub(super) const CUSTOM_MCP_TOOLS_AST: &[CustomMcpTool] = &[
         kind: CustomKind::Ast,
     },
     CustomMcpTool {
+        name: "ast_rewrite_signature",
+        why: "function signature rewrite (structured + full text)",
+        kind: CustomKind::Ast,
+    },
+    CustomMcpTool {
         name: "ast_insert",
         why: "AST insert with position/container resolve",
         kind: CustomKind::Ast,
@@ -279,7 +284,7 @@ mod tests {
         // Core tools always; AST tools only with `ast` (matches list_tools registration).
         let registry_n = MCP_TOOL_REGISTRY.len();
         let custom_n = custom_mcp_tools().count();
-        let expected_total = if cfg!(feature = "ast") { 54 } else { 35 };
+        let expected_total = if cfg!(feature = "ast") { 55 } else { 35 };
         assert_eq!(
             registry_n + custom_n,
             expected_total,
@@ -287,7 +292,7 @@ mod tests {
         );
         assert_eq!(CUSTOM_MCP_TOOLS_CORE.len(), 13, "core custom tool count");
         #[cfg(feature = "ast")]
-        assert_eq!(CUSTOM_MCP_TOOLS_AST.len(), 19, "ast custom tool count");
+        assert_eq!(CUSTOM_MCP_TOOLS_AST.len(), 20, "ast custom tool count");
         #[cfg(not(feature = "ast"))]
         assert!(CUSTOM_MCP_TOOLS_AST.is_empty());
     }

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -113,6 +113,10 @@ mod basic {
         #[cfg(feature = "ast")]
         {
             assert!(names.contains(&"ast_insert"), "missing ast_insert tool");
+            assert!(
+                names.contains(&"ast_rewrite_signature"),
+                "missing ast_rewrite_signature tool"
+            );
             assert!(names.contains(&"ast_wrap"), "missing ast_wrap tool");
             assert!(names.contains(&"ast_imports"), "missing ast_imports tool");
             assert!(names.contains(&"ast_reorder"), "missing ast_reorder tool");

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -36,7 +36,7 @@ fn server_instructions() -> String {
     #[cfg(feature = "ast")]
     s.push_str(
         "- AST ops (code-aware, 20 languages): ast_list, ast_read, ast_rename, \
-         ast_replace, ast_search, ast_refs, ast_impact, ast_deps, ast_diff, ast_imports, \
+         ast_replace, ast_rewrite_signature, ast_search, ast_refs, ast_impact, ast_deps, ast_diff, ast_imports, \
          ast_insert, ast_wrap, ast_move, ast_reorder, ast_group, ast_extract_to_file, \
          ast_split, ast_map, ast_validate\n",
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,18 +71,24 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 //!
-//! For AST signature edits (replacing line-scan heuristics):
-//! Use `ast::rewrite::rewrite_function_signature` with `FunctionSigEdit` and a `Language`
-//! for structured changes to visibility, parameters, return type across all supported languages.
-//! See `ast::symbols` docs and #1266.
+//! For AST signature edits (bline #1459 / #821 follow-through):
 //!
-//! Decision for #821: kept library-only (specialized, currently Rust-focused). Full CLI (`ast signature`),
-//! plan op, and MCP exposure deferred unless demand arises. Tracked in #821.
+//! - In-memory: `ast::rewrite::rewrite_function_signature` with `FunctionSigEdit`
+//! - On disk: `api::ast_rewrite_signature(path, name, &edit, new_signature, mode, guard?)`
+//! - Plans / MCP: op `ast.rewrite_signature` / tool `ast_rewrite_signature`
 //!
-//! **Note on results**: Single-file ops return `EditResult` (with `action` and `dest_path` for cross-file).
-//! `execute_plan` (library) returns `PlanReport` (typed TxOutput) directly with `ok`, `changes`,
+//! CLI `ast rewrite-signature` is still optional; library + plan + MCP cover embedders.
+//!
+//! For several ordered text edits on **one buffer** then a single write (agent intent engines):
+//! use `api::apply_content_edits` / `api::apply_content_edits_to_file` with
+//! `ContentEdit::{Replace, InsertBefore, InsertAfter, Append, Prepend}` (all-or-nothing).
+//! Multi-file multi-op remains `execute_plan`.
+//!
+//! **Note on results**: Single-file ops return `EditResult` (with `action`, `dest_path`,
+//! `match_count` for replace, and `removed` for `doc.delete` / `doc.delete_where`).
+//! `execute_plan` (library) returns `PlanReport` (typed TxOutput) with `ok`, `changes`,
 //! `searches`, `reads`, `error`, plus `mutations` / aggregate `changed` / `removed` for
-//! `doc.delete` and `doc.delete_where` (including idempotent `removed: 0` no-ops) (#811, #1439).
+//! deletes (including idempotent `removed: 0` no-ops) (#811, #1439, #1459).
 //! See `api::PlanReport`, `api::execute_plan`, and embedding docs. CLI/MCP retain (code, json) for compatibility.
 //!
 //! For library users needing relaxed containment (e.g. agents like Bline using --yolo or temp files):

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -304,6 +304,7 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<String> {
         #[cfg(feature = "ast")]
         Operation::AstRename { path, .. }
         | Operation::AstReplace { path, .. }
+        | Operation::AstRewriteSignature { path, .. }
         | Operation::AstInsert { path, .. }
         | Operation::AstWrap { path, .. }
         | Operation::AstImports { path, .. }

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -299,6 +299,37 @@ pub enum Operation {
         #[serde(default)]
         lang: Option<String>,
     },
+    /// Rewrite a function signature (structured fields and/or full signature text).
+    ///
+    /// Prefer structured `visibility` / `parameters` / `return_type` for multi-language
+    /// edits via [`crate::ast::rewrite::rewrite_function_signature`]. Use
+    /// `new_signature` to replace the entire signature span (any language with
+    /// tree-sitter support). At least one of the structured fields or
+    /// `new_signature` must be set.
+    #[cfg(feature = "ast")]
+    #[serde(rename = "ast.rewrite_signature")]
+    AstRewriteSignature {
+        /// Source file containing the function.
+        path: String,
+        /// Function name to rewrite (aliases `name` for agents).
+        #[serde(alias = "name")]
+        old: String,
+        /// Full replacement signature text (replaces the signature span).
+        #[serde(default)]
+        new_signature: Option<String>,
+        /// New visibility (e.g. `"pub"`, `"pub(crate)"`, or `""` for private).
+        #[serde(default)]
+        visibility: Option<String>,
+        /// New parameter list including parens (e.g. `"(x: i32)"`).
+        #[serde(default)]
+        parameters: Option<String>,
+        /// New return type using language-native syntax (e.g. `"-> String"`).
+        #[serde(default)]
+        return_type: Option<String>,
+        /// Language hint (e.g. "rust", "python"). Overrides extension detection.
+        #[serde(default)]
+        lang: Option<String>,
+    },
     #[cfg(feature = "ast")]
     #[serde(rename = "ast.insert")]
     AstInsert {
@@ -498,6 +529,8 @@ impl Operation {
             Operation::AstRename { .. } => "ast.rename",
             #[cfg(feature = "ast")]
             Operation::AstReplace { .. } => "ast.replace",
+            #[cfg(feature = "ast")]
+            Operation::AstRewriteSignature { .. } => "ast.rewrite_signature",
             #[cfg(feature = "ast")]
             Operation::AstInsert { .. } => "ast.insert",
             #[cfg(feature = "ast")]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -438,6 +438,15 @@ const AST_OPERATION_REGISTRY: &[OpMeta] = &[
         )],
     },
     OpMeta {
+        name: "ast.rewrite_signature",
+        description: "Rewrite a function signature with structured fields (visibility, parameters, return_type) or a full new_signature string. Multi-language via tree-sitter.",
+        tier: Tier::Medium,
+        examples: &[(
+            "Change parameters and return type",
+            r###"{"op":"ast.rewrite_signature","path":"src/lib.rs","old":"process","parameters":"(x: i32)","return_type":"-> String"}"###,
+        )],
+    },
+    OpMeta {
         name: "ast.insert",
         description: "Insert code at a structurally-aware position: inside a container, or after/before a named symbol.",
         tier: Tier::Medium,

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -152,6 +152,63 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             }
         }
 
+        Operation::AstRewriteSignature {
+            path,
+            old,
+            new_signature,
+            visibility,
+            parameters,
+            return_type,
+            lang,
+        } => {
+            let abs = tx.cwd.join(path);
+            let content = read_file_content(tx.pending, tx.existed_before, &abs)?;
+            let lang_val = lang
+                .as_deref()
+                .map(crate::ast::Language::from_name_or_ext)
+                .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
+            let has_structured =
+                visibility.is_some() || parameters.is_some() || return_type.is_some();
+            if new_signature.is_none() && !has_structured {
+                anyhow::bail!(
+                    "ast.rewrite_signature requires new_signature and/or visibility/parameters/return_type"
+                );
+            }
+            let new_content = if let Some(new_sig) = new_signature {
+                let span = crate::ast::rewrite::find_function_span(content, old, lang_val)
+                    .ok_or_else(|| crate::exit::NoMatchError {
+                        msg: format!("function '{}' not found in {}", old, path),
+                    })?;
+                format!(
+                    "{}{}{}",
+                    &content[..span.signature_range.start],
+                    new_sig,
+                    &content[span.signature_range.end..]
+                )
+            } else {
+                let edit = crate::ast::rewrite::FunctionSigEdit {
+                    visibility: visibility.clone(),
+                    parameters: parameters.clone(),
+                    return_type: return_type.clone(),
+                };
+                crate::ast::rewrite::rewrite_function_signature(content, old, &edit, lang_val)
+                    .ok_or_else(|| crate::exit::NoMatchError {
+                        msg: format!("function '{}' not found in {}", old, path),
+                    })?
+            };
+            if new_content == content {
+                return Ok(0);
+            }
+            update_file_content(
+                tx.pending,
+                tx.deletions,
+                tx.write_targets,
+                &abs,
+                new_content,
+            );
+            Ok(1)
+        }
+
         Operation::AstInsert {
             path,
             content: insert_content,

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -456,6 +456,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
         #[cfg(feature = "ast")]
         Operation::AstRename { .. }
         | Operation::AstReplace { .. }
+        | Operation::AstRewriteSignature { .. }
         | Operation::AstInsert { .. }
         | Operation::AstWrap { .. }
         | Operation::AstImports { .. }

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -58,6 +58,7 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
         #[cfg(feature = "ast")]
         Operation::AstRename { .. }
         | Operation::AstReplace { .. }
+        | Operation::AstRewriteSignature { .. }
         | Operation::AstInsert { .. }
         | Operation::AstWrap { .. }
         | Operation::AstImports { .. }

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -793,7 +793,7 @@ fn test_smoke_readme_command_examples() {
         "launch announcement CLI command count drifted"
     );
     assert!(
-        launch.contains("54 structured tool calls"),
+        launch.contains("55 structured tool calls"),
         "launch announcement MCP tool count drifted"
     );
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
## Summary

Implements [issue #1459](https://github.com/patchloom/patchloom/issues/1459) for Bline and other `ast`+`files` embedders.

### F3 — `EditResult.removed` (first)
- Additive `removed: usize` on `EditResult` (default 0)
- Populated from engine `tx_mutations` for `doc.delete` / `doc.delete_where` (including idempotent `removed: 0`)
- Non-tx fallback path also sets `removed` and avoids spurious apply when content unchanged

### F1 — Signature rewrite plan + on-disk API
- Plan op `ast.rewrite_signature` (`old` / structured fields / optional `new_signature`)
- Library `api::ast_rewrite_signature` with PathGuard + ApplyMode
- MCP `ast_rewrite_signature` (custom AST tool; total tools **55** with `ast`)
- Schema registry + explain + reference docs
- CLI deferred (documented); no `ast::symbols` re-export

### F2 — Multi-op content edits
- `ContentEdit::{Replace, InsertBefore, InsertAfter, Append, Prepend}`
- `apply_content_edits` (all-or-nothing in-memory)
- `apply_content_edits_to_file` (single write + guard)
- Reuses `ReplaceOptions` for replace steps

## Tests
- Library: delete removed counts, rewrite API + plan, multi-op success/failure/unique, file helper + guard
- Matrix: `cargo test --lib --no-default-features --features "ast,files"`
- `make check-fast`

Closes #1459

## Test plan
- [x] `make check-fast`
- [x] `cargo test --lib --no-default-features --features "ast,files"` (focused new tests)