### PR TITLE
fix: preserve NoMatchError through error chain wrapping

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -238,12 +238,14 @@ patchloom ast list src/lib.rs
 patchloom ast refs src/ --name my_function
 ```
 
-AST rename and replace can also be used in batch and tx plans:
+AST rename, replace, and rewrite_signature can also be used in batch and tx plans:
 
 ```bash
 # In a batch file (path, then old, then new — same names as CLI flags):
 ast.rename src/lib.rs OldStruct NewStruct
 ast.replace src/config.rs default_timeout "30" "60"
+# path old parameters [return_type]:
+ast.rewrite_signature src/lib.rs process "(x: u64)" "-> u64"
 ```
 
 ## Selector path syntax

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -377,11 +377,13 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              # Find all references to a symbol\n\
              patchloom ast refs src/ --name my_function\n\
              ```\n\n\
-             AST rename and replace can also be used in batch and tx plans:\n\n\
+             AST rename, replace, and rewrite_signature can also be used in batch and tx plans:\n\n\
              ```bash\n\
              # In a batch file (path, then old, then new — same names as CLI flags):\n\
              ast.rename src/lib.rs OldStruct NewStruct\n\
              ast.replace src/config.rs default_timeout \"30\" \"60\"\n\
+             # path old parameters [return_type]:\n\
+             ast.rewrite_signature src/lib.rs process \"(x: u64)\" \"-> u64\"\n\
              ```\n\n",
         );
     }

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -577,8 +577,12 @@ pub(crate) fn execute_and_collect(
                 // Preserve NoMatchError type (exit 3) and include the detail in
                 // the message so agents see "function X not found", not just
                 // "operation N failed" (#1459 rewrite_signature + all AST ops).
-                if e.downcast_ref::<crate::exit::NoMatchError>().is_some() {
-                    let detail = e.to_string();
+                // Walk the full chain: intermediate .context() must not drop
+                // the NoMatch classification.
+                if let Some(detail) = e.chain().find_map(|c| {
+                    c.downcast_ref::<crate::exit::NoMatchError>()
+                        .map(|n| n.msg.clone())
+                }) {
                     return Err(crate::exit::NoMatchError {
                         msg: format!("operation {} ({}) failed: {detail}", i + 1, op_label(op)),
                     }

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -399,3 +399,48 @@ fn read_only_files_skip_write_policy() {
         "file on disk should be unchanged"
     );
 }
+
+#[test]
+fn execute_and_collect_preserves_no_match_error_kind() {
+    // Missing doc.update target must remain NoMatchError (exit 3 path), not
+    // a plain anyhow operation_failed, even after op-label wrapping.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    std::fs::write(&file, r#"{"a":1}"#).unwrap();
+
+    let plan = Plan {
+        version: crate::plan::SCHEMA_VERSION,
+        operations: vec![Operation::DocUpdate {
+            path: "data.json".into(),
+            selector: "missing.key".into(),
+            value: serde_json::json!(2),
+        }],
+        write_policy: None,
+        strict: None,
+        format: None,
+        validate: None,
+        verify: None,
+        cwd: None,
+        for_each: None,
+    };
+    let ctx = crate::tx::context::EngineContext::from_global(
+        &GlobalFlags::default(),
+        dir.path().to_path_buf(),
+    );
+    match execute_and_collect(&plan, &ctx, true, false, None) {
+        Ok(_) => panic!("expected NoMatch for missing selector"),
+        Err(err) => {
+            assert!(
+                crate::exit::is_no_match(&err),
+                "NoMatch must survive execute wrap: {err:#}"
+            );
+            let msg = err.to_string();
+            assert!(
+                msg.contains("doc.update")
+                    || msg.contains("matched nothing")
+                    || msg.contains("missing"),
+                "detail should remain: {msg}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Walk the full `anyhow` chain when re-wrapping plan op failures so intermediate `.context()` cannot drop `NoMatchError` (exit 3).
- Unit test `execute_and_collect_preserves_no_match_error_kind`.
- Document `ast.rewrite_signature` in agent-rules batch examples; sync PATCHLOOM.md.

## Test plan
- [x] `cargo test --lib --all-features execute_and_collect_preserves_no_match`
- [x] `make check-fast`