### PR TITLE
fix: search_files path alias and AST concurrent-write guidance

### DIFF
--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -194,7 +194,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for Bline parity: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .blineignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".blineignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
+        description = "Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for Bline parity: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .blineignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Canonical multi-root field is paths (array); singular path is accepted as an alias for one root (same as paths:[path]). Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".blineignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
     )]
     async fn search_files(
         &self,
@@ -217,7 +217,8 @@ impl PatchloomService {
                 return Err(McpError::invalid_params("pattern must not be empty", None));
             }
             validate_param_size("pattern", &p.pattern)?;
-            for path in &p.paths {
+            let paths = p.effective_paths();
+            for path in &paths {
                 svc.check_path(path)?;
             }
             // Validate custom ignore filenames too (new in #821 for layered ignores).
@@ -227,11 +228,7 @@ impl PatchloomService {
             }
             let search_args = crate::cmd::search::SearchArgs {
                 pattern: p.pattern,
-                paths: if p.paths.is_empty() {
-                    vec![".".into()]
-                } else {
-                    p.paths
-                },
+                paths,
                 literal: p.literal,
                 regex: !p.literal,
                 context: p.context,
@@ -486,7 +483,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
+        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
     )]
     async fn batch_replace(
         &self,
@@ -735,7 +732,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Rename identifiers across files using AST-aware renaming (skips strings and comments). Example: {\"path\": \"src/\", \"old\": \"process_data\", \"new\": \"transform_data\"}"
+        description = "Rename identifiers across files using AST-aware renaming (skips strings and comments). IMPORTANT: do NOT issue concurrent renames (or other writes) against the same file or directory tree; use execute_plan for multi-op atomicity (e.g. multiple renames). Example: {\"path\": \"src/\", \"old\": \"process_data\", \"new\": \"transform_data\"}"
     )]
     async fn ast_rename(
         &self,
@@ -823,7 +820,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace text only within a specific symbol's body using AST scoping. Precise: only changes code inside the named symbol, leaving everything else untouched. Example: {\"path\": \"src/lib.rs\", \"symbol\": \"parse_config\", \"old\": \"unwrap()\", \"new\": \"expect(\\\"parse failed\\\")\"}"
+        description = "Replace text only within a specific symbol's body using AST scoping. Precise: only changes code inside the named symbol, leaving everything else untouched. IMPORTANT: do NOT issue concurrent writes against the same file or directory tree; use execute_plan for multi-op atomicity. Example: {\"path\": \"src/lib.rs\", \"symbol\": \"parse_config\", \"old\": \"unwrap()\", \"new\": \"expect(\\\"parse failed\\\")\"}"
     )]
     async fn ast_replace(
         &self,
@@ -900,7 +897,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Move symbols between files. Removes from source, inserts into target (creating it if needed). Example: {\"path\": \"src/big.rs\", \"target\": \"src/helpers.rs\", \"symbols\": [\"helper_fn\"], \"target_prepend\": \"use super::*;\"}"
+        description = "Move symbols between files. Removes from source, inserts into target (creating it if needed). IMPORTANT: do NOT issue concurrent moves/writes against the same files; use execute_plan for multi-op atomicity. Example: {\"path\": \"src/big.rs\", \"target\": \"src/helpers.rs\", \"symbols\": [\"helper_fn\"], \"target_prepend\": \"use super::*;\"}"
     )]
     async fn ast_move(
         &self,
@@ -911,7 +908,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Extract a symbol (module, function, struct) to a separate file. For modules with unwrap=true, content is un-indented. Example: {\"source\": \"src/lib.rs\", \"symbol\": \"tests\", \"target\": \"src/lib_tests.rs\", \"replacement\": \"mod tests;\", \"prepend\": \"use super::*;\"}"
+        description = "Extract a symbol (module, function, struct) to a separate file. For modules with unwrap=true, content is un-indented. IMPORTANT: do NOT issue concurrent extracts/writes against the same files; use execute_plan for multi-op atomicity. Example: {\"source\": \"src/lib.rs\", \"symbol\": \"tests\", \"target\": \"src/lib_tests.rs\", \"replacement\": \"mod tests;\", \"prepend\": \"use super::*;\"}"
     )]
     async fn ast_extract_to_file(
         &self,
@@ -922,7 +919,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Split a file into multiple target files by distributing symbols. Atomic: all targets succeed or all roll back. Example: {\"source\": \"src/big.rs\", \"targets\": [{\"path\": \"src/types.rs\", \"symbols\": [\"Config\", \"Mode\"], \"prepend\": \"use super::*;\"}], \"keep_in_source\": [\"main\"], \"source_suffix\": \"mod types;\"}"
+        description = "Split a file into multiple target files by distributing symbols. Atomic: all targets succeed or all roll back. IMPORTANT: do NOT issue concurrent splits/writes against the same files; use execute_plan for multi-op atomicity. Example: {\"source\": \"src/big.rs\", \"targets\": [{\"path\": \"src/types.rs\", \"symbols\": [\"Config\", \"Mode\"], \"prepend\": \"use super::*;\"}], \"keep_in_source\": [\"main\"], \"source_suffix\": \"mod types;\"}"
     )]
     async fn ast_split(
         &self,

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -120,8 +120,14 @@ pub(crate) struct SearchParams {
     /// Pattern to search for.
     pub pattern: String,
     /// Paths to search in, relative to working directory (defaults to working directory root).
+    /// Canonical multi-root form. Prefer this when searching multiple roots.
     #[serde(default)]
     pub paths: Vec<String>,
+    /// Single search root (LLM prior: most MCP tools use singular `path`).
+    /// Equivalent to `paths: [path]` when `paths` is empty. If both are set,
+    /// `paths` wins.
+    #[serde(default)]
+    pub path: Option<String>,
     /// Treat pattern as a literal string instead of regex.
     #[serde(default)]
     pub literal: bool,
@@ -160,6 +166,19 @@ pub(crate) struct SearchParams {
     /// Max detailed results (0 = unlimited).
     #[serde(default)]
     pub max_results: usize,
+}
+
+impl SearchParams {
+    /// Resolve search roots: non-empty `paths` wins; else single `path`; else cwd root.
+    pub(crate) fn effective_paths(&self) -> Vec<String> {
+        if !self.paths.is_empty() {
+            self.paths.clone()
+        } else if let Some(ref path) = self.path {
+            vec![path.clone()]
+        } else {
+            vec![".".into()]
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -58,10 +58,18 @@ mod basic {
         assert_eq!(
             descriptions.get("search_files"),
             Some(
-                &"Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for Bline parity: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .blineignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".blineignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
+                &"Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for Bline parity: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .blineignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Canonical multi-root field is paths (array); singular path is accepted as an alias for one root (same as paths:[path]). Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".blineignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
             ),
             "search_files description drifted"
         );
+        #[cfg(feature = "ast")]
+        {
+            let ast_rename_desc = descriptions.get("ast_rename").copied().unwrap_or("");
+            assert!(
+                ast_rename_desc.contains("execute_plan") && ast_rename_desc.contains("concurrent"),
+                "ast_rename must warn about concurrent writes / execute_plan (#1468): {ast_rename_desc}"
+            );
+        }
         assert!(names.contains(&"git_status"), "missing git_status tool");
         assert!(names.contains(&"replace_text"), "missing replace_text tool");
         assert_eq!(
@@ -181,6 +189,38 @@ mod basic {
             serde_json::from_str(json).expect("SearchParams deserial with new ignore/max fields");
         assert_eq!(p.globs.len(), 1);
         assert_eq!(p.max_results, 10);
+    }
+
+    #[test]
+    fn search_params_path_alias_maps_to_paths() {
+        // #1467: singular path is LLM prior (matches other tools).
+        let p: SearchParams = serde_json::from_str(r#"{"pattern": "TODO", "path": "src/lib.rs"}"#)
+            .expect("path alias should deserialize");
+        assert_eq!(p.effective_paths(), vec!["src/lib.rs".to_string()]);
+        assert!(p.paths.is_empty());
+        assert_eq!(p.path.as_deref(), Some("src/lib.rs"));
+    }
+
+    #[test]
+    fn search_params_paths_wins_over_path() {
+        let p: SearchParams = serde_json::from_str(
+            r#"{"pattern": "TODO", "paths": ["a/", "b/"], "path": "ignored/"}"#,
+        )
+        .expect("both path and paths should deserialize");
+        assert_eq!(
+            p.effective_paths(),
+            vec!["a/".to_string(), "b/".to_string()]
+        );
+    }
+
+    #[test]
+    fn search_params_unknown_field_still_rejected() {
+        let err = serde_json::from_str::<SearchParams>(r#"{"pattern": "TODO", "root": "src/"}"#)
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown field") || err.to_string().contains("root"),
+            "deny_unknown_fields must still reject unrelated keys: {err}"
+        );
     }
 
     #[tokio::test]
@@ -382,8 +422,9 @@ mod basic {
             Check {
                 op_name: "search",
                 mcp_keys: schema_keys_for::<SearchParams>(),
+                // path is shared with Operation; paths/files_with_matches/count/literal are MCP-shaped
                 mcp_only_allowed: &["paths", "files_with_matches", "count", "literal"],
-                op_only_allowed: &["path", "regex"],
+                op_only_allowed: &["regex"],
             },
         ];
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -330,6 +330,46 @@ async fn test_mcp_doc_get_reads_value() {
     client.cancel().await.unwrap();
 }
 
+/// #1467: singular `path` is accepted as an alias for `paths: [path]`.
+#[tokio::test]
+async fn test_mcp_search_files_accepts_path_alias() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("fixtures").join("ast-rename");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("svc.py"), "class OrderService:\n    pass\n").unwrap();
+    fs::write(
+        dir.path().join("root.py"),
+        "class OrderService:\n    pass\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "search_files",
+        serde_json::json!({
+            "pattern": "OrderService",
+            "path": "fixtures/ast-rename",
+            "literal": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "path alias must deserialize and run: {text}");
+    assert!(
+        text.contains("OrderService") || text.contains("svc.py"),
+        "should find match under path alias root: {text}"
+    );
+    // Should not search workspace root when path is nested.
+    assert!(
+        !text.contains("root.py"),
+        "search should be scoped to path alias root, not workspace root: {text}"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// Regression test for #939 / #1270: search_files with zero matches must
 /// return a descriptive "No matches found." message as a success (isError:
 /// false), not an error. Empty results are valid answers, not failures.


### PR DESCRIPTION
## Summary
- **#1467:** MCP `search_files` accepts singular `path` as an alias for one search root (`paths` remains canonical; if both set, `paths` wins). `deny_unknown_fields` still rejects unrelated keys.
- **#1468:** Multi-file AST mutators (`ast_rename`, `ast_replace`, `ast_move`, `ast_extract_to_file`, `ast_split`) and `batch_replace` tool descriptions warn not to issue concurrent writes on the same tree; use `execute_plan` for multi-op atomicity (parity with `replace_text` / `doc_set`).

Closes #1467
Closes #1468

## Test plan
- [x] Unit: `search_params_path_alias_maps_to_paths`, `paths_wins`, unknown field rejected
- [x] Unit: `mcp_lists_expected_tools` (search description + ast_rename concurrent note under `ast`)
- [x] Integration: `test_mcp_search_files_accepts_path_alias`
- [x] `make check-fast`