### PR TITLE
docs: concurrent-write guidance on remaining MCP mutators

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -47,6 +47,7 @@ Use patchloom when:
 - Use `batch_replace` or `batch_tidy` only when applying the *exact same* operation to multiple files.
 - Do **not** issue parallel write calls against the same path(s) — per-call success does not guarantee a coherent combined result.
 - Nested trees: set a **relative** `cwd` under the server workspace and keep op paths short. Do not use absolute `cwd` on MCP. Do not combine `cwd` with `for_each`.
+- `search_files`: canonical multi-root field is `paths` (array). Singular `path` is accepted as an alias for one root.
 
 Example (edit under a fixture without prefixing every path):
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -137,7 +137,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - Use `batch_replace` or `batch_tidy` only when applying the *exact same* operation to multiple files.\n\
              - Do **not** issue parallel write calls against the same path(s) — per-call success does not guarantee a coherent combined result.\n\
              - Nested trees: set a **relative** `cwd` under the server workspace and keep op paths short. \
-               Do not use absolute `cwd` on MCP. Do not combine `cwd` with `for_each`.\n\n\
+               Do not use absolute `cwd` on MCP. Do not combine `cwd` with `for_each`.\n\
+             - `search_files`: canonical multi-root field is `paths` (array). Singular `path` is accepted as an alias for one root.\n\n\
              Example (edit under a fixture without prefixing every path):\n\n\
              ```json\n\
              {\n\
@@ -533,6 +534,10 @@ mod tests {
         assert!(
             out.contains("relative") && out.contains("cwd"),
             "MCP rules must say cwd is relative under workspace"
+        );
+        assert!(
+            out.contains("search_files") && out.contains("paths") && out.contains("path"),
+            "MCP rules must document search_files path alias for paths"
         );
     }
 

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -398,7 +398,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Move a markdown heading section to a new position (same file reorder or cross-file). Exactly one of before or after is required. Omit to for same-file reorder. Example: {\"path\": \"spec.md\", \"heading\": \"## Appendix\", \"to\": \"notes.md\", \"before\": \"## References\"}"
+        description = "Move a markdown heading section to a new position (same file reorder or cross-file). Exactly one of before or after is required. Omit to for same-file reorder. IMPORTANT: do NOT issue concurrent writes against the same file(s); use execute_plan for multi-op atomicity. Example: {\"path\": \"spec.md\", \"heading\": \"## Appendix\", \"to\": \"notes.md\", \"before\": \"## References\"}"
     )]
     async fn md_move_section(
         &self,
@@ -456,7 +456,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Apply a unified diff (patch). The diff parameter is the full unified diff text. Supports multi-file diffs. Use on_stale=merge for three-way merge on stale context; allow_conflicts=true writes conflict markers. Never commit files containing conflict markers. Example: {\"diff\": \"--- a/file.txt\\n+++ b/file.txt\\n@@ -1 +1 @@\\n-old\\n+new\", \"on_stale\": \"fail\"}"
+        description = "Apply a unified diff (patch). The diff parameter is the full unified diff text. Supports multi-file diffs. Use on_stale=merge for three-way merge on stale context; allow_conflicts=true writes conflict markers. Never commit files containing conflict markers. IMPORTANT: do NOT issue concurrent patches/writes against the same files; use execute_plan for multi-op atomicity. Example: {\"diff\": \"--- a/file.txt\\n+++ b/file.txt\\n@@ -1 +1 @@\\n-old\\n+new\", \"on_stale\": \"fail\"}"
     )]
     async fn apply_patch(
         &self,
@@ -531,7 +531,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Fix whitespace in multiple files in one call: trims trailing spaces and ensures final newline. Atomic: all files succeed or none change. Example: {\"files\": [\"src/main.rs\", \"src/lib.rs\"]}"
+        description = "Fix whitespace in multiple files in one call: trims trailing spaces and ensures final newline. Atomic: all files succeed or none change. IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"src/main.rs\", \"src/lib.rs\"]}"
     )]
     async fn batch_tidy(
         &self,
@@ -831,7 +831,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Rewrite a function signature with structured fields (visibility, parameters, return_type) or a full new_signature string. Multi-language via tree-sitter. Example: {\"path\": \"src/lib.rs\", \"old\": \"process\", \"parameters\": \"(x: i32)\", \"return_type\": \"-> String\"}"
+        description = "Rewrite a function signature with structured fields (visibility, parameters, return_type) or a full new_signature string. Multi-language via tree-sitter. IMPORTANT: do NOT issue concurrent writes against the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"src/lib.rs\", \"old\": \"process\", \"parameters\": \"(x: i32)\", \"return_type\": \"-> String\"}"
     )]
     async fn ast_rewrite_signature(
         &self,
@@ -842,7 +842,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Insert code at a structurally-aware position: inside a module/impl/struct (at start or end), or after/before a named symbol. Indentation is auto-detected. Example: {\"path\": \"src/lib.rs\", \"content\": \"fn new_fn() {}\", \"after\": \"existing_fn\"}"
+        description = "Insert code at a structurally-aware position: inside a module/impl/struct (at start or end), or after/before a named symbol. Indentation is auto-detected. IMPORTANT: do NOT issue concurrent writes against the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"src/lib.rs\", \"content\": \"fn new_fn() {}\", \"after\": \"existing_fn\"}"
     )]
     async fn ast_insert(
         &self,
@@ -853,7 +853,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Wrap existing code in a structural block (module, impl, cfg, etc.). Specify symbols by name or a line range. Example: {\"path\": \"src/lib.rs\", \"symbols\": [\"helper_fn\", \"HelperStruct\"], \"wrapper\": \"mod helpers\"}"
+        description = "Wrap existing code in a structural block (module, impl, cfg, etc.). Specify symbols by name or a line range. IMPORTANT: do NOT issue concurrent writes against the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"src/lib.rs\", \"symbols\": [\"helper_fn\", \"HelperStruct\"], \"wrapper\": \"mod helpers\"}"
     )]
     async fn ast_wrap(
         &self,
@@ -864,7 +864,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Manage import/use statements: add (idempotent), remove, deduplicate. With no mutation args, lists existing imports. Example: {\"path\": \"src/main.rs\", \"add\": [\"use std::collections::HashMap;\"]}"
+        description = "Manage import/use statements: add (idempotent), remove, deduplicate. With no mutation args, lists existing imports. IMPORTANT: when mutating, do NOT issue concurrent writes against the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"src/main.rs\", \"add\": [\"use std::collections::HashMap;\"]}"
     )]
     async fn ast_imports(
         &self,
@@ -875,7 +875,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Reorder symbols within a file or scope by name, kind, or custom order. Example: {\"path\": \"src/lib.rs\", \"order\": \"alphabetical\"} or {\"path\": \"src/lib.rs\", \"order\": [\"Struct\", \"impl Struct\", \"helper\"], \"inside\": \"mod tests\"}"
+        description = "Reorder symbols within a file or scope by name, kind, or custom order. IMPORTANT: do NOT issue concurrent writes against the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"src/lib.rs\", \"order\": \"alphabetical\"} or {\"path\": \"src/lib.rs\", \"order\": [\"Struct\", \"impl Struct\", \"helper\"], \"inside\": \"mod tests\"}"
     )]
     async fn ast_reorder(
         &self,
@@ -886,7 +886,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Group symbols into a named module within a file. Creates the module if it doesn't exist, or appends to it. Example: {\"path\": \"src/tests.rs\", \"module\": \"line_endings\", \"symbols\": [\"test_crlf\", \"test_lf\"], \"preamble\": \"use super::*;\"}"
+        description = "Group symbols into a named module within a file. Creates the module if it doesn't exist, or appends to it. IMPORTANT: do NOT issue concurrent writes against the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"src/tests.rs\", \"module\": \"line_endings\", \"symbols\": [\"test_crlf\", \"test_lf\"], \"preamble\": \"use super::*;\"}"
     )]
     async fn ast_group(
         &self,

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -72,7 +72,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_delete",
         op_name: "doc.delete",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -82,7 +84,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_merge",
         op_name: "doc.merge",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -92,7 +96,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_append",
         op_name: "doc.append",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -103,7 +109,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_prepend",
         op_name: "doc.prepend",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -114,7 +122,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_ensure",
         op_name: "doc.ensure",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -126,7 +136,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         tool_name: "doc_delete_where",
         op_name: "doc.delete_where",
         extra: Some(
-            "For object arrays: predicate='role=admin'. For simple arrays: predicate='_=value'. Nested paths: predicate='settings.theme=dark'.",
+            "For object arrays: predicate='role=admin'. For simple arrays: predicate='_=value'. Nested paths: predicate='settings.theme=dark'. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: false,
         validations: &[
@@ -138,7 +148,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_update",
         op_name: "doc.update",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -149,7 +161,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "doc_move",
         op_name: "doc.move",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -167,7 +181,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_upsert_bullet",
         op_name: "md.upsert_bullet",
-        extra: Some("Idempotent: skipped if the bullet is already present."),
+        extra: Some(
+            "Idempotent: skipped if the bullet is already present. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -177,7 +193,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_table_append",
         op_name: "md.table_append",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -187,7 +205,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_replace_section",
         op_name: "md.replace_section",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -197,7 +217,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_insert_after_heading",
         op_name: "md.insert_after_heading",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -207,7 +229,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_insert_before_heading",
         op_name: "md.insert_before_heading",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -217,21 +241,27 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "md_dedupe_headings",
         op_name: "md.dedupe_headings",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[FieldValidation::Path("path")],
     },
     McpToolMeta {
         tool_name: "move_file",
         op_name: "file.rename",
-        extra: Some("Use force=true to overwrite an existing destination."),
+        extra: Some(
+            "Use force=true to overwrite an existing destination. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[FieldValidation::Path("from"), FieldValidation::Path("to")],
     },
     McpToolMeta {
         tool_name: "append_file",
         op_name: "file.append",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -241,7 +271,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "prepend_file",
         op_name: "file.prepend",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -251,7 +283,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "create_file",
         op_name: "file.create",
-        extra: Some("Fails if the file exists unless force=true."),
+        extra: Some(
+            "Fails if the file exists unless force=true. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[
             FieldValidation::Path("path"),
@@ -261,7 +295,9 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
     McpToolMeta {
         tool_name: "delete_file",
         op_name: "file.delete",
-        extra: None,
+        extra: Some(
+            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
         has_strict: false,
         validations: &[FieldValidation::Path("path")],
     },
@@ -271,7 +307,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         tool_name: "fix_whitespace",
         op_name: "tidy.fix",
         extra: Some(
-            "Defaults: trim trailing whitespace and ensure final newline when those fields are omitted.",
+            "Defaults: trim trailing whitespace and ensure final newline when those fields are omitted. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: false,
         validations: &[FieldValidation::Path("path")],

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -70,6 +70,20 @@ mod basic {
                 "ast_rename must warn about concurrent writes / execute_plan (#1468): {ast_rename_desc}"
             );
         }
+        // Registry write tools (and multi-file custom writers) must carry concurrent guidance.
+        for tool in [
+            "doc_set",
+            "doc_merge",
+            "create_file",
+            "batch_tidy",
+            "apply_patch",
+        ] {
+            let desc = descriptions.get(tool).copied().unwrap_or("");
+            assert!(
+                desc.contains("concurrent") && desc.contains("execute_plan"),
+                "{tool} must warn about concurrent writes / execute_plan: {desc}"
+            );
+        }
         assert!(names.contains(&"git_status"), "missing git_status tool");
         assert!(names.contains(&"replace_text"), "missing replace_text tool");
         assert_eq!(
@@ -83,12 +97,11 @@ mod basic {
             names.contains(&"fix_whitespace"),
             "missing fix_whitespace tool"
         );
-        let expected_fix_ws = crate::schema::mcp_tool_description(
-            "tidy.fix",
-            Some(
-                "Defaults: trim trailing whitespace and ensure final newline when those fields are omitted.",
-            ),
-        );
+        let fix_ws_extra = crate::cmd::mcp::registry::MCP_TOOL_REGISTRY
+            .iter()
+            .find(|t| t.tool_name == "fix_whitespace")
+            .and_then(|t| t.extra);
+        let expected_fix_ws = crate::schema::mcp_tool_description("tidy.fix", fix_ws_extra);
         assert_eq!(
             descriptions.get("fix_whitespace").map(|s| s.to_string()),
             Some(expected_fix_ws),


### PR DESCRIPTION
## Summary
- Extend concurrent-write / `execute_plan` guidance to remaining MCP mutators after #1468 (registry doc/file/md tools + hand-written apply_patch, batch_tidy, AST single-file mutators).
- Document `search_files` singular `path` alias in agent-rules / PATCHLOOM.md.
- Tests assert key tools include concurrent + execute_plan guidance.

## Test plan
- [x] `cargo test --lib --all-features mcp_lists_expected`
- [x] `cargo test --lib --no-default-features --features \"mcp,cli,files\" mcp_lists_expected`
- [x] `make check-fast`