### PR TITLE
fix: accept singular file alias on batch_replace and batch_tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3100%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3200%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -430,7 +430,7 @@ flowchart LR
 
 ## Status
 
-3100+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3200+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -483,27 +483,27 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
+        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
     )]
     async fn batch_replace(
         &self,
         Parameters(p): Parameters<BatchReplaceParams>,
     ) -> Result<CallToolResult, McpError> {
         self.blocking(move |svc| {
-            if p.files.is_empty() {
+            let files = p.effective_files();
+            if files.is_empty() {
                 return Err(McpError::invalid_params(
-                    "files array must not be empty",
+                    "files array must not be empty (or pass singular file)",
                     None,
                 ));
             }
-            validate_batch_size("files", p.files.len())?;
+            validate_batch_size("files", files.len())?;
             validate_param_size("old", &p.old)?;
             validate_content_size("new", &p.new_text)?;
-            for f in &p.files {
+            for f in &files {
                 svc.check_path(f)?;
             }
-            let ops: Vec<Operation> = p
-                .files
+            let ops: Vec<Operation> = files
                 .into_iter()
                 .map(|file| Operation::Replace {
                     glob: None,
@@ -531,25 +531,25 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Fix whitespace in multiple files in one call: trims trailing spaces and ensures final newline. Atomic: all files succeed or none change. Example: {\"files\": [\"src/main.rs\", \"src/lib.rs\"]}"
+        description = "Fix whitespace in multiple files in one call: trims trailing spaces and ensures final newline. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"src/main.rs\", \"src/lib.rs\"]}"
     )]
     async fn batch_tidy(
         &self,
         Parameters(p): Parameters<BatchTidyParams>,
     ) -> Result<CallToolResult, McpError> {
         self.blocking(move |svc| {
-            if p.files.is_empty() {
+            let files = p.effective_files();
+            if files.is_empty() {
                 return Err(McpError::invalid_params(
-                    "files array must not be empty",
+                    "files array must not be empty (or pass singular file)",
                     None,
                 ));
             }
-            validate_batch_size("files", p.files.len())?;
-            for f in &p.files {
+            validate_batch_size("files", files.len())?;
+            for f in &files {
                 svc.check_path(f)?;
             }
-            let ops: Vec<Operation> = p
-                .files
+            let ops: Vec<Operation> = files
                 .into_iter()
                 .map(|file| Operation::TidyFix {
                     path: file,

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -212,7 +212,13 @@ pub(crate) struct DocDiffParams {
 #[serde(deny_unknown_fields)]
 pub(crate) struct BatchReplaceParams {
     /// File paths to apply the replacement to (relative to working directory).
+    /// Canonical multi-file form.
+    #[serde(default)]
     pub files: Vec<String>,
+    /// Single file (LLM prior). Equivalent to `files: [file]` when `files` is empty.
+    /// If both are set, `files` wins.
+    #[serde(default)]
+    pub file: Option<String>,
     /// Text to find in each file.
     /// Alias `from` accepted because agents often emit that name (LLM prior).
     #[serde(alias = "from")]
@@ -247,10 +253,39 @@ pub(crate) struct BatchReplaceParams {
 #[serde(deny_unknown_fields)]
 pub(crate) struct BatchTidyParams {
     /// File paths to normalize (relative to working directory).
+    /// Canonical multi-file form.
+    #[serde(default)]
     pub files: Vec<String>,
+    /// Single file (LLM prior). Equivalent to `files: [file]` when `files` is empty.
+    /// If both are set, `files` wins.
+    #[serde(default)]
+    pub file: Option<String>,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,
+}
+
+/// Resolve multi-file list: non-empty `files` wins; else single `file`; else empty.
+fn effective_file_list(files: &[String], file: &Option<String>) -> Vec<String> {
+    if !files.is_empty() {
+        files.to_vec()
+    } else if let Some(f) = file {
+        vec![f.clone()]
+    } else {
+        Vec::new()
+    }
+}
+
+impl BatchReplaceParams {
+    pub(crate) fn effective_files(&self) -> Vec<String> {
+        effective_file_list(&self.files, &self.file)
+    }
+}
+
+impl BatchTidyParams {
+    pub(crate) fn effective_files(&self) -> Vec<String> {
+        effective_file_list(&self.files, &self.file)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -223,6 +223,21 @@ mod basic {
         );
     }
 
+    #[test]
+    fn batch_replace_params_file_alias() {
+        let p: BatchReplaceParams =
+            serde_json::from_str(r#"{"file": "a.txt", "old": "x", "new": "y"}"#)
+                .expect("file alias should deserialize");
+        assert_eq!(p.effective_files(), vec!["a.txt".to_string()]);
+    }
+
+    #[test]
+    fn batch_tidy_params_file_alias() {
+        let p: BatchTidyParams =
+            serde_json::from_str(r#"{"file": "a.txt"}"#).expect("file alias should deserialize");
+        assert_eq!(p.effective_files(), vec!["a.txt".to_string()]);
+    }
+
     #[tokio::test]
     async fn mcp_server_info_has_correct_name() {
         let dir = tempfile::TempDir::new().unwrap();

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1798,6 +1798,34 @@ async fn test_mcp_batch_replace_round_trip() {
 }
 
 #[tokio::test]
+async fn test_mcp_batch_replace_accepts_file_alias() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("solo.txt"), "version = 1.0.0\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "batch_replace",
+        serde_json::json!({
+            "file": "solo.txt",
+            "old": "1.0.0",
+            "new": "3.0.0"
+        }),
+    )
+    .await;
+    assert!(!is_error, "singular file alias should work: {val}");
+    let content = fs::read_to_string(dir.path().join("solo.txt")).unwrap();
+    assert!(
+        content.contains("3.0.0"),
+        "file alias replace should apply: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_batch_replace_regex_round_trip() {
     if !has_mcp_support() {
         return;


### PR DESCRIPTION
## Summary
- `batch_replace` and `batch_tidy` accept singular `file` as an LLM-prior alias for one path (same pattern as `search_files` `path` / `paths`).
- Canonical field remains `files` (array); when both are set, `files` wins.
- Descriptions note the alias; unit + MCP integration tests cover it.

## Test plan
- [x] `batch_replace_params_file_alias` / `batch_tidy_params_file_alias`
- [x] `test_mcp_batch_replace_accepts_file_alias`
- [x] `make check-fast`