### PR TITLE
fix: reject empty/whitespace path alias and plan.cwd on MCP

### DIFF
--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -216,6 +216,12 @@ impl PatchloomService {
             if p.pattern.is_empty() {
                 return Err(McpError::invalid_params("pattern must not be empty", None));
             }
+            if p.path.as_ref().is_some_and(|s| s.trim().is_empty()) {
+                return Err(McpError::invalid_params(
+                    "path must not be empty or whitespace-only (use paths for multi-root, or omit for workspace root)",
+                    None,
+                ));
+            }
             validate_param_size("pattern", &p.pattern)?;
             let paths = p.effective_paths();
             for path in &paths {
@@ -610,6 +616,12 @@ impl PatchloomService {
 
             let op_path_prefix = plan.cwd.clone();
             if let Some(ref plan_cwd) = op_path_prefix {
+                if plan_cwd.trim().is_empty() {
+                    return Err(McpError::invalid_params(
+                        "plan.cwd must not be empty or whitespace-only",
+                        None,
+                    ));
+                }
                 if std::path::Path::new(plan_cwd).is_absolute() {
                     return Err(McpError::invalid_params(
                         format!(

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -370,6 +370,30 @@ async fn test_mcp_search_files_accepts_path_alias() {
     client.cancel().await.unwrap();
 }
 
+#[tokio::test]
+async fn test_mcp_search_files_rejects_empty_path_alias() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, text) = call_tool_text(
+        &client,
+        "search_files",
+        serde_json::json!({"pattern": "TODO", "path": "   "}),
+    )
+    .await;
+    assert!(
+        is_error,
+        "whitespace-only path alias must be rejected: {text}"
+    );
+    assert!(
+        text.contains("empty") || text.contains("whitespace") || text.contains("path"),
+        "error should mention empty path: {text}"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// Regression test for #939 / #1270: search_files with zero matches must
 /// return a descriptive "No matches found." message as a success (isError:
 /// false), not an error. Empty results are valid answers, not failures.
@@ -3352,6 +3376,41 @@ async fn test_mcp_execute_plan_rejects_absolute_cwd() {
     assert!(
         text.contains("relative") || text.contains("absolute") || text.contains("cwd"),
         "error should mention absolute/relative cwd policy: {text}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_execute_plan_rejects_empty_cwd() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ok.json"), r#"{}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "execute_plan",
+        serde_json::json!({
+            "plan": {
+                "version": 1,
+                "cwd": "  ",
+                "operations": [{
+                    "op": "doc.set",
+                    "path": "ok.json",
+                    "selector": "x",
+                    "value": 1
+                }]
+            }
+        }),
+    )
+    .await;
+    assert!(is_error, "whitespace-only plan.cwd must be rejected: {val}");
+    let text = val.to_string();
+    assert!(
+        text.contains("empty") || text.contains("whitespace") || text.contains("cwd"),
+        "error should mention empty cwd: {text}"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary
- Reject whitespace-only/empty singular `path` on `search_files` (would otherwise mean workspace root).
- Reject empty/whitespace `plan.cwd` on `execute_plan` the same way.
- Integration tests for both cases.

## Test plan
- [x] `test_mcp_search_files_rejects_empty_path_alias`
- [x] `test_mcp_execute_plan_rejects_empty_cwd`
- [x] `make check-fast`