### PR TITLE
ci: auto-triage issues; maintainers skip needs-triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,104 @@
+# Issue triage inbox: external reports get needs-triage; org/maintainers skip inbox.
+# Accept path: remove needs-triage, add ready (MPI/automation only implement ready).
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to re-label (optional backfill)"
+        required: true
+        type: string
+
+concurrency:
+  group: issue-triage-${{ github.event.issue.number || github.event.inputs.issue_number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: Label issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Apply triage labels
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          DISPATCH_ISSUE: ${{ github.event.inputs.issue_number }}
+        with:
+          script: |
+            const TRUSTED = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            async function ensureLabels(issueNumber, association, existingNames) {
+              const trusted = TRUSTED.has(association);
+              const names = new Set(existingNames);
+
+              if (trusted) {
+                // Maintainer/org-authored issues skip the inbox entirely.
+                if (!names.has("ready")) {
+                  await github.rest.issues.addLabels({
+                    owner, repo, issue_number: issueNumber, labels: ["ready"],
+                  });
+                }
+                if (names.has("needs-triage")) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      owner, repo, issue_number: issueNumber, name: "needs-triage",
+                    });
+                  } catch (e) {
+                    if (e.status !== 404) throw e;
+                  }
+                }
+                core.info(
+                  `Issue #${issueNumber}: association=${association} -> ready (skip triage)`,
+                );
+                return;
+              }
+
+              // External authors land in the inbox until a maintainer accepts.
+              if (!names.has("needs-triage")) {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: issueNumber, labels: ["needs-triage"],
+                });
+              }
+              core.info(
+                `Issue #${issueNumber}: association=${association} -> needs-triage`,
+              );
+            }
+
+            if (context.eventName === "workflow_dispatch") {
+              const n = parseInt(process.env.DISPATCH_ISSUE || "", 10);
+              if (!n) {
+                core.setFailed("workflow_dispatch requires issue_number");
+                return;
+              }
+              const { data: issue } = await github.rest.issues.get({
+                owner, repo, issue_number: n,
+              });
+              await ensureLabels(
+                n,
+                issue.author_association,
+                (issue.labels || []).map((l) => (typeof l === "string" ? l : l.name)),
+              );
+              return;
+            }
+
+            const issue = context.payload.issue;
+            await ensureLabels(
+              issue.number,
+              issue.author_association,
+              (issue.labels || []).map((l) => (typeof l === "string" ? l : l.name)),
+            );

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,22 @@ make check
 
 `make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks (`check-patchloom-md`, `check-readme`). While iterating locally, `make check-fast` is almost the same but skips only `check-patchloom-md` (still runs `check-readme` so a drifted README test badge fails before CI).
 
+## Issues and triage
+
+New issues from outside maintainers are labeled `needs-triage` automatically.
+They stay in that inbox until a maintainer accepts them by adding `ready` and
+removing `needs-triage`. Issues opened by repository owners, org members, or
+collaborators skip the inbox and receive `ready` immediately.
+
+| Label | Meaning |
+|-------|---------|
+| `needs-triage` | New external report; not yet accepted for implementation |
+| `ready` | Accepted; automation and contributors may pick it up |
+| `needs-info` | Waiting on the reporter for more detail |
+
+Please include reproduction steps (or a clear feature request), expected vs
+actual behavior, and your patchloom version when filing bugs.
+
 ## Development workflow
 
 1. Create a branch from `main`.


### PR DESCRIPTION
## Summary

- Add `issue-triage` workflow: on issue open/reopen, label external authors `needs-triage`; OWNER / MEMBER / COLLABORATOR get `ready` and never stay in the inbox
- Document triage labels and accept path in CONTRIBUTING.md
- Labels created on the repo: `needs-triage`, `ready`, `needs-info`
- Existing open maintainer issues backfilled with `ready`

## Why

Protects MPI and other automation from implementing unvetted external issues while issues you create end up ready without triage.

## Test plan

- [x] Workflow YAML loads
- [ ] Open a test issue as owner (or re-run workflow_dispatch) and confirm `ready` without `needs-triage`
- [ ] After merge, external issue would get `needs-triage` only