### PR TITLE
test: lock concurrent-write notes on all AST mutators

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -99,6 +99,16 @@ jobs:
                 return;
               }
 
+              // Maintainer already accepted (ready present). Do not re-inbox on
+              // reopen or re-dispatch for external authors; dual labels confuse
+              // automation that keys off needs-triage.
+              if (names.has("ready")) {
+                core.info(
+                  `Issue #${issueNumber} (@${login}): ${reason} -> keep ready (already accepted)`,
+                );
+                return;
+              }
+
               if (!names.has("needs-triage")) {
                 await github.rest.issues.addLabels({
                   owner, repo, issue_number: issueNumber, labels: ["needs-triage"],

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ collaborators skip the inbox and receive `ready` immediately.
 | `ready` | Accepted; automation and contributors may pick it up |
 | `needs-info` | Waiting on the reporter for more detail |
 
+Once an issue is accepted (`ready`), reopening it does not put it back in
+`needs-triage` automatically. Remove `ready` (or add `needs-info`) if work
+should pause.
+
 Please include reproduction steps (or a clear feature request), expected vs
 actual behavior, and your patchloom version when filing bugs.
 

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -64,11 +64,25 @@ mod basic {
         );
         #[cfg(feature = "ast")]
         {
-            let ast_rename_desc = descriptions.get("ast_rename").copied().unwrap_or("");
-            assert!(
-                ast_rename_desc.contains("execute_plan") && ast_rename_desc.contains("concurrent"),
-                "ast_rename must warn about concurrent writes / execute_plan (#1468): {ast_rename_desc}"
-            );
+            // All AST mutators must carry concurrent / execute_plan guidance.
+            for tool in [
+                "ast_rename",
+                "ast_replace",
+                "ast_rewrite_signature",
+                "ast_insert",
+                "ast_wrap",
+                "ast_reorder",
+                "ast_group",
+                "ast_move",
+                "ast_extract_to_file",
+                "ast_split",
+            ] {
+                let desc = descriptions.get(tool).copied().unwrap_or("");
+                assert!(
+                    desc.contains("execute_plan") && desc.contains("concurrent"),
+                    "{tool} must warn about concurrent writes / execute_plan (#1468): {desc}"
+                );
+            }
         }
         // Registry write tools (and multi-file custom writers) must carry concurrent guidance.
         for tool in [
@@ -77,6 +91,9 @@ mod basic {
             "create_file",
             "batch_tidy",
             "apply_patch",
+            "replace_text",
+            "batch_replace",
+            "md_move_section",
         ] {
             let desc = descriptions.get(tool).copied().unwrap_or("");
             assert!(


### PR DESCRIPTION
## Summary

- Expand MCP unit inventory so every AST mutator (and key custom writers) must mention concurrent writes + `execute_plan`
- Issue triage Action: if `ready` is already present, do not re-add `needs-triage` on reopen/dispatch (avoids dual labels after accept)
- CONTRIBUTING: note that accepted issues stay out of the inbox on reopen

## Test plan

- [x] `cargo test --lib --all-features mcp_lists_expected_tools`
- [x] `cargo fmt --check` + clippy `-D warnings`