### PR TITLE
fix: files-from no-match scope + concurrent inventory

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -1,3 +1,9 @@
+//! Global CLI flags, path resolution, and `--files-from` list loading.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). One module owns
+//! GlobalFlags/WriteFlags, cwd/contain path helpers, and files-from IO;
+//! co-located unit tests push the file over 1000 lines. Do not split for LOC alone.
+
 #[cfg(feature = "cli")]
 use clap::Args;
 use std::io::BufRead;

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -307,6 +307,25 @@ impl GlobalFlags {
         }
     }
 
+    /// Human-readable scope for "no matches" messages: `--files-from` when set,
+    /// otherwise the positional path list (or `.` when empty).
+    ///
+    /// Without this, `--files-from` runs report "no matches … in ." which is
+    /// misleading when the walk never used the workspace root.
+    pub fn path_scope_description(&self, paths: &[String]) -> String {
+        if let Some(src) = self.files_from.as_deref() {
+            if src == "-" {
+                return "--files-from -".to_string();
+            }
+            return format!("--files-from {src}");
+        }
+        if paths.is_empty() {
+            ".".to_string()
+        } else {
+            paths.join(", ")
+        }
+    }
+
     /// Resolve a user-supplied path against [`Self::resolve_cwd`].
     ///
     /// Absolute paths are returned unchanged (`Path::join` replaces the base).
@@ -982,5 +1001,31 @@ mod tests {
         };
         let result = flags.read_files_from().unwrap().unwrap();
         assert_eq!(result, vec!["a.rs", "b.rs"]);
+    }
+
+    #[test]
+    fn path_scope_description_prefers_files_from_over_empty_paths() {
+        let stdin = GlobalFlags {
+            files_from: Some("-".into()),
+            ..GlobalFlags::test_default()
+        };
+        assert_eq!(stdin.path_scope_description(&[]), "--files-from -");
+        assert_eq!(
+            stdin.path_scope_description(&["src/".into()]),
+            "--files-from -"
+        );
+
+        let list = GlobalFlags {
+            files_from: Some("paths.txt".into()),
+            ..GlobalFlags::test_default()
+        };
+        assert_eq!(list.path_scope_description(&[]), "--files-from paths.txt");
+
+        let walk = GlobalFlags::test_default();
+        assert_eq!(walk.path_scope_description(&[]), ".");
+        assert_eq!(
+            walk.path_scope_description(&["a".into(), "b".into()]),
+            "a, b"
+        );
     }
 }

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -84,11 +84,29 @@ mod basic {
                 );
             }
         }
-        // Registry write tools (and multi-file custom writers) must carry concurrent guidance.
+        // All registry write tools (and multi-file custom writers) must carry concurrent guidance.
         for tool in [
             "doc_set",
+            "doc_delete",
             "doc_merge",
+            "doc_append",
+            "doc_prepend",
+            "doc_ensure",
+            "doc_delete_where",
+            "doc_update",
+            "doc_move",
+            "md_upsert_bullet",
+            "md_table_append",
+            "md_replace_section",
+            "md_insert_after_heading",
+            "md_insert_before_heading",
+            "md_dedupe_headings",
+            "move_file",
+            "append_file",
+            "prepend_file",
             "create_file",
+            "delete_file",
+            "fix_whitespace",
             "batch_tidy",
             "apply_patch",
             "replace_text",

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -302,11 +302,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         };
         global.emit_json(&output)?;
         if !global.quiet && !global.json && !global.jsonl {
-            let path_desc = if args.paths.is_empty() {
-                ".".to_string()
-            } else {
-                args.paths.join(", ")
-            };
+            let path_desc = global.path_scope_description(&args.paths);
             eprintln!("no matches for '{}' in {path_desc}", args.old);
             if !args.regex && crate::files::has_regex_metacharacters(&args.old) {
                 eprintln!("hint: pattern contains regex characters, try --regex");

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -369,12 +369,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         };
         global.emit_json(&payload)?;
         if !global.quiet && !global.json && !global.jsonl {
-            let paths: Vec<&str> = args.paths.iter().map(|s| s.as_str()).collect();
-            let path_desc = if paths.is_empty() {
-                ".".to_string()
-            } else {
-                paths.join(", ")
-            };
+            let path_desc = global.path_scope_description(&args.paths);
             eprintln!("no matches for '{}' in {path_desc}", args.pattern);
             if args.literal && crate::files::has_regex_metacharacters(&args.pattern) {
                 eprintln!(

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -71,6 +71,37 @@ fn test_search_no_match_quiet_suppresses_stderr() {
 }
 
 #[test]
+fn test_search_no_match_files_from_mentions_files_from_not_dot() {
+    // When the file list is --files-from, "no matches in ." is wrong: search never
+    // walked the workspace root. Scope description must name --files-from.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    let list = dir.path().join("list.txt");
+    fs::write(&list, "missing.txt\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--files-from")
+        .arg("list.txt")
+        .arg("search")
+        .arg("hello")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no matches") && stderr.contains("--files-from"),
+        "stderr should mention --files-from, not bare '.', got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("in ."),
+        "must not claim workspace root walk when using --files-from: {stderr}"
+    );
+}
+
+#[test]
 fn test_search_jsonl_output_has_path_field() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("hello.txt"), "hello world\n").unwrap();


### PR DESCRIPTION
## Summary

- Fix search/replace "no matches" text when using `--files-from`: report `--files-from <list>` (or `-`) instead of misleading `.`
- Expand `mcp_lists_expected_tools` concurrent-write inventory to all registry mutators
- Unit + integration coverage for path scope description

## Test plan

- [x] `path_scope_description_prefers_files_from_over_empty_paths`
- [x] `test_search_no_match_files_from_mentions_files_from_not_dot`
- [x] `mcp_lists_expected_tools`
- [x] clippy `-D warnings`