### PR TITLE
test: lock empty --files-from does not walk workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,9 +1266,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memoffset"

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -170,6 +170,8 @@ These flags affect how Patchloom reports results or chooses which files to touch
 ### `--files-from`
 
 - **What it does:** Reads the target file list from a file, or from stdin when passed `-`. A relative list path is resolved under `--cwd` when that flag is set (absolute list paths are unchanged). Paths **inside** the list are still resolved against `--cwd` / the process cwd as usual, and under `--contain` each listed path must stay in the workspace.
+- **Exact paths only:** Each line is one file path. Directory entries are skipped (not walked). Blank lines are ignored; `#` lines are **not** comments (they are path strings).
+- **No walk fallback:** An empty list (or only blanks) searches/replaces **zero** files. Patchloom does **not** fall back to walking `.`. Search/replace "no matches" messages name `--files-from …` rather than bare `.`.
 - **Use when:** Another tool already selected the exact paths and Patchloom should operate only on that set.
 - **Prefer instead:** Use `--glob` for pattern based scoping, or direct path arguments when the target set is already small and obvious.
 

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -452,6 +452,64 @@ fn test_replace_no_match_quiet_suppresses_stderr() {
 }
 
 #[test]
+fn test_replace_no_match_files_from_mentions_files_from_not_dot() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    fs::write(dir.path().join("list.txt"), "missing.txt\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--files-from")
+        .arg("list.txt")
+        .arg("replace")
+        .arg("hello")
+        .arg("--new")
+        .arg("bye")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no matches") && stderr.contains("--files-from"),
+        "stderr should mention --files-from: {stderr}"
+    );
+    assert!(
+        !stderr.contains("in ."),
+        "must not claim workspace root when using --files-from: {stderr}"
+    );
+}
+
+#[test]
+fn test_replace_empty_files_from_does_not_mutate_workspace() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    fs::write(&file, "unique_replace_token\n").unwrap();
+    fs::write(dir.path().join("empty.txt"), "").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--files-from")
+        .arg("empty.txt")
+        .arg("replace")
+        .arg("unique_replace_token")
+        .arg("--new")
+        .arg("CHANGED")
+        .arg("--apply")
+        .assert()
+        .code(3);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "unique_replace_token\n",
+        "empty files-from must not fall back to walking workspace"
+    );
+}
+
+#[test]
 fn test_replace_ambiguous_match_text_mode_emits_stderr() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -102,6 +102,40 @@ fn test_search_no_match_files_from_mentions_files_from_not_dot() {
 }
 
 #[test]
+fn test_search_empty_files_from_does_not_walk_workspace() {
+    // Empty --files-from must not fall back to walking `.` (would match a.txt).
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "unique_token_xyz\n").unwrap();
+    fs::write(dir.path().join("empty.txt"), "").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--files-from")
+        .arg("empty.txt")
+        .arg("search")
+        .arg("unique_token_xyz")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "empty files-from must yield no matches, not walk workspace"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("unique_token_xyz"),
+        "must not search workspace files when list is empty: {stdout}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--files-from"),
+        "no-match message should mention --files-from: {stderr}"
+    );
+}
+
+#[test]
 fn test_search_jsonl_output_has_path_field() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("hello.txt"), "hello world\n").unwrap();


### PR DESCRIPTION
## Summary

- Document `--files-from` exact-path rules (no dir walk, no empty-list fallback to \`.\`, no-match text names the list)
- Integration tests: empty list never searches/mutates workspace files (search + replace)
- Replace no-match with `--files-from` must mention \`--files-from\` (parity with search #1476)
- Patch-level \`memchr\` 2.8.2 → 2.8.3

## Test plan

- [x] \`test_search_empty_files_from_does_not_walk_workspace\`
- [x] \`test_replace_empty_files_from_does_not_mutate_workspace\`
- [x] \`test_replace_no_match_files_from_mentions_files_from_not_dot\`
- [x] clippy \`-D warnings\`