### PR TITLE
fix: omit .patchloom backups from status output

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -306,7 +306,8 @@ These are the main entry points. If you are deciding between commands, start her
 - **What it does:** Executes multiple operations from a simple line-oriented format. Each line is one operation with positional arguments (e.g., `doc.set config.json version "2.0.0"`). Internally builds a tx plan and delegates to the tx engine.
 - **Use when:** Editing multiple files and the JSON tx plan format is too verbose. The line format covers 27 operations (doc.set, doc.delete, doc.merge, doc.ensure, doc.append, doc.prepend, doc.update, doc.move, doc.delete_where, replace, file.append, file.prepend, file.create, file.delete, file.rename, md.upsert_bullet, md.table_append, md.replace_section, md.insert_after_heading, md.insert_before_heading, md.move_section, md.dedupe_headings, md.lint_agents, tidy.fix, ast.rename, ast.replace, ast.rewrite_signature) with minimal syntax. For AI agents, this is faster to generate than a full JSON plan.
 - **Paths:** A relative ops file path is resolved under `--cwd` (same as `tx` plan files). Paths *inside* ops lines are also resolved against `--cwd`.
-- **Prefer instead:** Use `tx` when you need format/validate lifecycle steps, strict mode, or operations not supported by the line format (patch.apply, replace with regex/nth, search, read).
+- **Quoting:** Double-quoted tokens allow only `\"` and `\\`. Sequences like `\n` are **literal** (not newlines). Prefer `tx` / MCP JSON for multi-line content, or put real newlines outside one-line quoted strings.
+- **Prefer instead:** Use `tx` when you need format/validate lifecycle steps, strict mode, multi-line content, or operations not supported by the line format (patch.apply, replace with regex/nth, search, read).
 - **Related:** `tx`
 
 <!-- ref:command:read -->
@@ -326,9 +327,10 @@ Patchloom can be used as a Rust library (disable default `cli` feature for small
 ## `status`
 
 - **What it does:** Shows which files have uncommitted changes compared to git HEAD. This command is git-backed, so it must run inside a git repository.
+- **Internal paths:** Entries under `.patchloom/` (backup sessions from `--apply`) are omitted so status reflects user project files, not Patchloom's undo store.
 - **Use when:** An agent needs a quick summary of the working tree before committing, staging, or choosing which files to process. For AI agents, native git status or terminal commands are typically equivalent.
-- **Prefer instead:** Use `git status` directly when you need full git porcelain output or staging details.
-- **Related:** `search`, `read`
+- **Prefer instead:** Use `git status` directly when you need full git porcelain output or staging details (including untracked `.patchloom/` if you care about it).
+- **Related:** `search`, `read`, `undo`
 
 <!-- ref:command:undo -->
 ## `undo`

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -31,6 +31,12 @@ enum FileCategory {
     Modified,
 }
 
+/// Paths under `.patchloom/` (backup sessions) should not appear in status.
+fn is_patchloom_internal_path(path: &str) -> bool {
+    let p = path.trim_start_matches("./");
+    p == ".patchloom" || p.starts_with(".patchloom/")
+}
+
 /// Parse one NUL-delimited `git status --porcelain=v1 -z` record.
 fn parse_porcelain_record(record: &[u8]) -> Option<(FileCategory, String)> {
     if record.len() < 4 {
@@ -92,6 +98,12 @@ pub(crate) fn collect_status(
             Some(v) => v,
             None => continue,
         };
+
+        // Internal backup store is not a user-facing repo change (#1349 for
+        // tidy; same noise on `status` after any --apply).
+        if is_patchloom_internal_path(&file) {
+            continue;
+        }
 
         let file_path = cwd.join(&file);
         if let Some(ref matcher) = glob_matcher
@@ -155,6 +167,17 @@ pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn patchloom_internal_paths_are_filtered() {
+        assert!(is_patchloom_internal_path(".patchloom"));
+        assert!(is_patchloom_internal_path(
+            ".patchloom/backups/1/manifest.json"
+        ));
+        assert!(is_patchloom_internal_path("./.patchloom/backups/x"));
+        assert!(!is_patchloom_internal_path("src/main.rs"));
+        assert!(!is_patchloom_internal_path("patchloom.toml"));
+    }
 
     #[test]
     fn parse_untracked_file() {

--- a/tests/integration/status_tests.rs
+++ b/tests/integration/status_tests.rs
@@ -243,6 +243,67 @@ fn test_status_quiet_suppresses_output() {
     );
 }
 
+#[test]
+fn test_status_excludes_patchloom_backup_dir_after_apply() {
+    // After --apply, git sees untracked .patchloom/backups/*; status must not
+    // list those as project "created" files (fixrealloop 2026-07-08).
+    let dir = TempDir::new().unwrap();
+    init_git_repo_with_committed_file(dir.path(), "a.txt", "hello\n");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("replace")
+        .arg("hello")
+        .arg("--new")
+        .arg("world")
+        .arg("a.txt")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert!(
+        dir.path().join(".patchloom/backups").is_dir(),
+        "apply should create backup sessions"
+    );
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("status")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let all: Vec<&str> = ["modified", "created", "deleted"]
+        .iter()
+        .flat_map(|k| {
+            json[k]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|v| v.as_str())
+        })
+        .collect();
+    assert!(
+        all.iter()
+            .any(|p| *p == "a.txt" || p.ends_with("/a.txt") || p.ends_with("a.txt")),
+        "modified a.txt should appear: {json}"
+    );
+    assert!(
+        !all.iter().any(|p| p.contains(".patchloom")),
+        "status must omit .patchloom backups, got: {all:?}"
+    );
+    assert_eq!(
+        json["total_changes"].as_u64(),
+        Some(1),
+        "only a.txt should count: {json}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // completions: PowerShell produces output
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Found by fixrealloop: after any `--apply`, \`patchloom status\` reported every backup file under \`.patchloom/backups/\` as \`A\` (created), so exit 2 noise and inflated \`total_changes\`.

- Filter \`.patchloom/\` paths out of git porcelain results (same internal store tidy already skips)
- Unit + integration coverage
- Docs: status omits backups; batch quoting is only \`\\\"\` / \`\\\\\` (multi-line content via tx/MCP)

## Test plan

- [x] \`patchloom_internal_paths_are_filtered\`
- [x] \`test_status_excludes_patchloom_backup_dir_after_apply\`
- [x] Manual: replace --apply then status shows only the edited file