### PR TITLE
docs: init gitignore .patchloom; status/batch agent guidance

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -10,7 +10,7 @@
 | Task pattern | Tool to use |
 |---|---|
 | Read file contents (with optional line range) | `read_file` |
-| See uncommitted changes vs git HEAD | `git_status` |
+| See uncommitted changes vs git HEAD (omits `.patchloom/` backups) | `git_status` |
 | Set/get a value in JSON, YAML, or TOML | `doc_set`, `doc_get`, `doc_query` |
 | Delete, merge, or ensure a value exists | `doc_delete`, `doc_merge`, `doc_ensure` |
 | Compare two structured files | `doc_diff` |
@@ -94,7 +94,7 @@ md.upsert_bullet CHANGELOG.md "## Changes" "- Bumped to 2.0.0"
 EOF
 ```
 
-One line per operation. Double-quote values with spaces.
+One line per operation. Double-quote values with spaces. Escapes in quotes: only `\"` and `\\` (literal `\n` is not a newline; use `tx`/MCP JSON for multi-line content).
 
 On Windows (where heredocs are not available), write operations to a file and pass it:
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -378,12 +378,12 @@ Patchloom can be used as a Rust library (disable default `cli` feature for small
 <!-- ref:command:init -->
 ## `init`
 
-- **What it does:** Sets up patchloom in the current project: creates `AGENTS.md` if needed, otherwise appends the rules to an existing agent instructions file, prints shell completion instructions, and detects MCP configuration opportunities. When `.vscode/` or `.cursor/` already exists, it prints ready-to-copy `.vscode/mcp.json` or `.cursor/mcp.json` snippets.
+- **What it does:** Sets up patchloom in the current project: creates `AGENTS.md` if needed, otherwise appends the rules to an existing agent instructions file, prints shell completion instructions, detects MCP configuration opportunities, and ensures `.gitignore` ignores `.patchloom/` (undo backups). When `.vscode/` or `.cursor/` already exists, it prints ready-to-copy `.vscode/mcp.json` or `.cursor/mcp.json` snippets.
 - **Use when:** You just installed patchloom and want a single command to configure a project instead of running `agent-rules`, `completions`, and MCP setup separately.
 - **Notable flags:**
   - `-y, --yes`: Skip confirmation prompts and auto-accept all actions.
 - **Prefer instead:** `agent-rules` if you only need the rules text, or `completions` if you only need shell completions.
-- **Related:** `agent-rules`, `completions`, `mcp-server`
+- **Related:** `agent-rules`, `completions`, `mcp-server`, `status`, `undo`
 
 <!-- ref:command:mcp-server -->
 ## `mcp-server`

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -88,7 +88,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Task pattern | Tool to use |\n\
              |---|---|\n\
              | Read file contents (with optional line range) | `read_file` |\n\
-             | See uncommitted changes vs git HEAD | `git_status` |\n\
+             | See uncommitted changes vs git HEAD (omits `.patchloom/` backups) | `git_status` |\n\
              | Set/get a value in JSON, YAML, or TOML | `doc_set`, `doc_get`, `doc_query` |\n\
              | Delete, merge, or ensure a value exists | `doc_delete`, `doc_merge`, `doc_ensure` |\n\
              | Compare two structured files | `doc_diff` |\n\
@@ -187,7 +187,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  md.upsert_bullet CHANGELOG.md \"## Changes\" \"- Bumped to 2.0.0\"\n\
                  EOF\n\
                  ```\n\n\
-                 One line per operation. Double-quote values with spaces.\n\n",
+                 One line per operation. Double-quote values with spaces. Escapes in quotes: only `\\\"` and `\\\\` \
+                 (literal `\\n` is not a newline; use `tx`/MCP JSON for multi-line content).\n\n",
             );
         }
 
@@ -204,7 +205,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
             );
             if !show_linux {
                 out.push_str(
-                    "One line per operation in the file. Double-quote values with spaces.\n\n",
+                    "One line per operation in the file. Double-quote values with spaces. Escapes: only `\\\"` and `\\\\` \
+                     (use `tx`/MCP for multi-line content).\n\n",
                 );
             }
         }
@@ -505,6 +507,14 @@ mod tests {
         assert!(
             out.contains("meta-input") || out.contains("meta-input files"),
             "must document that --contain applies to meta-input files"
+        );
+        assert!(
+            out.contains("omits `.patchloom/` backups") || out.contains("omits `.patchloom/"),
+            "git_status tool guide must note backup omission: {out}"
+        );
+        assert!(
+            out.contains("multi-line content") || out.contains(r#"\\\""#),
+            "batch section must document quote escapes / multi-line guidance"
         );
     }
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -126,8 +126,18 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         eprintln!("  patchloom completions <bash|zsh|fish|elvish>");
     }
 
+    // 3. Keep undo backups out of git noise (pairs with `status` filtering).
+    match ensure_gitignore_patchloom(&cwd) {
+        Ok(GitignorePatchloom::Created) => status!("created .gitignore with .patchloom/"),
+        Ok(GitignorePatchloom::Appended) => status!("appended .patchloom/ to .gitignore"),
+        Ok(GitignorePatchloom::AlreadyPresent) => {
+            status!(".gitignore already ignores .patchloom/");
+        }
+        Err(e) => status!("could not update .gitignore: {e}"),
+    }
+
     if !quiet {
-        // 3. MCP setup hint.
+        // 4. MCP setup hint.
         eprintln!();
         if cfg!(feature = "mcp") {
             let mcp_json_hint = r#"    { "servers": { "patchloom": { "command": "patchloom", "args": ["mcp-server"] } } }"#;
@@ -156,6 +166,51 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         eprintln!("setup complete.");
     }
     Ok(exit::SUCCESS)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum GitignorePatchloom {
+    Created,
+    Appended,
+    AlreadyPresent,
+}
+
+const GITIGNORE_PATCHLOOM_LINE: &str = ".patchloom/";
+
+/// Ensure `.gitignore` ignores Patchloom backup sessions so `git status`
+/// stays clean after `--apply` (CLI `status` already filters these paths).
+fn ensure_gitignore_patchloom(cwd: &Path) -> anyhow::Result<GitignorePatchloom> {
+    let path = cwd.join(".gitignore");
+    if path.exists() {
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading {}", path.display()))?;
+        if gitignore_already_covers_patchloom(&content) {
+            return Ok(GitignorePatchloom::AlreadyPresent);
+        }
+        let mut next = content;
+        if !next.ends_with('\n') && !next.is_empty() {
+            next.push('\n');
+        }
+        next.push_str(GITIGNORE_PATCHLOOM_LINE);
+        next.push('\n');
+        std::fs::write(&path, next).with_context(|| format!("writing {}", path.display()))?;
+        return Ok(GitignorePatchloom::Appended);
+    }
+    let body =
+        format!("# Patchloom undo sessions (created by --apply)\n{GITIGNORE_PATCHLOOM_LINE}\n");
+    std::fs::write(&path, body).with_context(|| format!("writing {}", path.display()))?;
+    Ok(GitignorePatchloom::Created)
+}
+
+fn gitignore_already_covers_patchloom(content: &str) -> bool {
+    content.lines().any(|line| {
+        let t = line.trim();
+        t == ".patchloom/"
+            || t == ".patchloom"
+            || t == "**/.patchloom/"
+            || t == "**/.patchloom"
+            || t.starts_with(".patchloom/")
+    })
 }
 
 fn find_agent_file(cwd: &Path) -> Option<std::path::PathBuf> {
@@ -280,6 +335,34 @@ mod tests {
     fn find_agent_file_none_in_empty_dir() {
         let dir = tempfile::TempDir::new().unwrap();
         assert!(find_agent_file(dir.path()).is_none());
+    }
+
+    #[test]
+    fn ensure_gitignore_creates_when_missing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert_eq!(
+            ensure_gitignore_patchloom(dir.path()).unwrap(),
+            GitignorePatchloom::Created
+        );
+        let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(content.contains(GITIGNORE_PATCHLOOM_LINE));
+        assert_eq!(
+            ensure_gitignore_patchloom(dir.path()).unwrap(),
+            GitignorePatchloom::AlreadyPresent
+        );
+    }
+
+    #[test]
+    fn ensure_gitignore_appends_when_present_without_entry() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join(".gitignore"), "target/\n").unwrap();
+        assert_eq!(
+            ensure_gitignore_patchloom(dir.path()).unwrap(),
+            GitignorePatchloom::Appended
+        );
+        let content = std::fs::read_to_string(dir.path().join(".gitignore")).unwrap();
+        assert!(content.contains("target/"));
+        assert!(content.contains(GITIGNORE_PATCHLOOM_LINE));
     }
 
     #[test]

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -676,7 +676,7 @@ impl PatchloomService {
     // are auto-generated from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
 
     #[tool(
-        description = "Show uncommitted file changes vs git HEAD. Returns lists of modified, created, and deleted files. No parameters required."
+        description = "Show uncommitted file changes vs git HEAD. Returns lists of modified, created, and deleted files. Omits .patchloom/ backup paths from --apply undo sessions. No parameters required."
     )]
     async fn git_status(
         &self,

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -9,7 +9,11 @@ use std::process;
 #[command(after_help = "\
 EXAMPLES:
   patchloom status
-  patchloom status --json")]
+  patchloom status --json
+
+NOTE:
+  Paths under .patchloom/ (undo backups from --apply) are omitted so status
+  reflects project files only. Use git status if you need untracked backups.")]
 pub struct StatusArgs {
     /// Paths to check (defaults to current directory).
     pub paths: Vec<String>,


### PR DESCRIPTION
## Summary

MPI cycle after #1478 status fix and fixrealloop:

- **init:** create or append \`.patchloom/\` to \`.gitignore\` so raw \`git status\` stays clean after \`--apply\` (CLI \`status\` already filters backups)
- **agent-rules / MCP / status help:** document backup omission and batch quoting (\`\\\"\`/\`\\\\\` only; multi-line via tx/MCP)
- Reference + PATCHLOOM.md sync

## Test plan

- [x] \`ensure_gitignore_creates_when_missing\` / \`ensure_gitignore_appends_...\`
- [x] \`default_includes_all_sections\`
- [x] \`mcp_lists_expected_tools\`
- [x] clippy \`-D warnings\`