### PR TITLE
fix: normalize absolute paths in unified-diff headers

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -287,6 +287,10 @@ pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
 /// The `path` parameter is used for the `--- a/` and `+++ b/` diff headers;
 /// pass `None` to use a generic `<content>` placeholder.
 ///
+/// Absolute Unix paths (e.g. after `canonicalize()`) are normalized so headers
+/// do not contain a double slash (`--- a//tmp/...`). Relative paths are
+/// unchanged (`--- a/src/main.rs`).
+///
 /// This is the same diff engine used internally by [`replace_in_content`],
 /// [`replace_text`], and other editing operations, exposed as a standalone
 /// public API for embedders that need to diff arbitrary strings without

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2606,6 +2606,33 @@ fn text_diff_with_custom_path() {
 }
 
 #[test]
+fn text_diff_absolute_path_no_double_slash_headers() {
+    // #1480: embedders pass absolute paths after canonicalize (macOS /private/tmp).
+    let result = text_diff("old\n", "new\n", Some("/tmp/demo/lib.rs"));
+    assert!(
+        !result.contains("--- a//") && !result.contains("+++ b//"),
+        "absolute path must not produce double-slash headers: {result}"
+    );
+    assert!(result.contains("--- a/tmp/demo/lib.rs"));
+    assert!(result.contains("+++ b/tmp/demo/lib.rs"));
+}
+
+#[test]
+fn text_diff_absolute_path_placeholder_and_relative_unchanged() {
+    let abs = text_diff("a\n", "b\n", Some("/private/tmp/x.rs"));
+    assert!(!abs.contains("//"));
+    assert!(abs.contains("--- a/private/tmp/x.rs"));
+
+    let rel = text_diff("a\n", "b\n", Some("src/main.rs"));
+    assert!(rel.contains("--- a/src/main.rs"));
+    assert!(rel.contains("+++ b/src/main.rs"));
+
+    let none = text_diff("a\n", "b\n", None);
+    assert!(none.contains("--- a/<content>"));
+    assert!(none.contains("+++ b/<content>"));
+}
+
+#[test]
 fn text_diff_empty_original() {
     let result = text_diff("", "new content\n", Some("file.txt"));
     assert!(!result.is_empty());

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -2,6 +2,19 @@
 
 use similar::TextDiff;
 
+/// Normalize a path for unified-diff headers after the fixed `a/` / `b/` prefix.
+///
+/// Absolute Unix paths start with `/`. Naively formatting `--- a/{path}` then
+/// yields `--- a//tmp/file` (double slash). Strip one leading `/` so headers
+/// stay readable. Relative paths and placeholders (e.g. `<content>`) are
+/// unchanged. Windows drive paths (`C:\...`) have no leading `/` and are
+/// unchanged.
+///
+/// Used only for header display; [`FileDiff::path`] keeps the original string.
+pub(crate) fn path_for_diff_header(path: &str) -> &str {
+    path.strip_prefix('/').unwrap_or(path)
+}
+
 /// Represents the diff for a single file.
 #[derive(Debug, Clone)]
 pub struct FileDiff {
@@ -72,10 +85,10 @@ fn format_diff_result_opt(result: &DiffResult, color: bool) -> String {
     let mut output = String::new();
     for diff in &result.diffs {
         if diff.has_changes {
+            let header_path = path_for_diff_header(&diff.path);
             let _ = write!(
                 output,
-                "{hdr}--- a/{}{reset}\n{hdr}+++ b/{}{reset}\n",
-                diff.path, diff.path
+                "{hdr}--- a/{header_path}{reset}\n{hdr}+++ b/{header_path}{reset}\n",
             );
             if color {
                 for line in diff.hunks.lines() {
@@ -126,6 +139,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn path_for_diff_header_strips_leading_slash() {
+        assert_eq!(path_for_diff_header("/tmp/demo/lib.rs"), "tmp/demo/lib.rs");
+        assert_eq!(
+            path_for_diff_header("/private/tmp/demo/src/a.rs"),
+            "private/tmp/demo/src/a.rs"
+        );
+        assert_eq!(path_for_diff_header("src/main.rs"), "src/main.rs");
+        assert_eq!(path_for_diff_header("<content>"), "<content>");
+        assert_eq!(
+            path_for_diff_header("C:\\Users\\x\\f.rs"),
+            "C:\\Users\\x\\f.rs"
+        );
+        // Only one leading slash (absolute Unix form); remaining path intact.
+        assert_eq!(path_for_diff_header("//unc/share"), "/unc/share");
+    }
+
+    #[test]
     fn single_line_change_has_correct_header() {
         let result = unified_diff("test.txt", "hello\n", "world\n");
         assert!(result.has_changes);
@@ -138,6 +168,47 @@ mod tests {
         let output = format_diff_result(&diff_result);
         assert!(output.contains("--- a/test.txt"));
         assert!(output.contains("+++ b/test.txt"));
+    }
+
+    #[test]
+    fn absolute_unix_path_header_has_no_double_slash() {
+        let result = unified_diff("/tmp/demo/lib.rs", "old\n", "new\n");
+        // Stored path stays absolute for callers.
+        assert_eq!(result.path, "/tmp/demo/lib.rs");
+        let output = format_diff_result(&DiffResult {
+            diffs: vec![result],
+        });
+        assert!(
+            !output.contains("--- a//") && !output.contains("+++ b//"),
+            "headers must not double-slash absolute paths: {output}"
+        );
+        assert!(output.contains("--- a/tmp/demo/lib.rs"));
+        assert!(output.contains("+++ b/tmp/demo/lib.rs"));
+    }
+
+    #[test]
+    fn absolute_macos_private_tmp_header_normalized() {
+        let path = "/private/tmp/demo/src/a.rs";
+        let result = unified_diff(path, "old\n", "new\n");
+        let output = format_diff_result(&DiffResult {
+            diffs: vec![result],
+        });
+        assert!(!output.contains("a//"));
+        assert!(!output.contains("b//"));
+        assert!(output.contains("--- a/private/tmp/demo/src/a.rs"));
+        assert!(output.contains("+++ b/private/tmp/demo/src/a.rs"));
+    }
+
+    #[test]
+    fn multi_file_format_normalizes_each_absolute_path() {
+        let d1 = unified_diff("/abs/one.txt", "a\n", "b\n");
+        let d2 = unified_diff("rel/two.txt", "c\n", "d\n");
+        let output = format_diff_result(&DiffResult {
+            diffs: vec![d1, d2],
+        });
+        assert!(!output.contains("a//") && !output.contains("b//"));
+        assert!(output.contains("--- a/abs/one.txt"));
+        assert!(output.contains("--- a/rel/two.txt"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1480.

`text_diff` / `format_diff_result` built headers as \`--- a/{path}\`. Absolute paths start with \`/\`, so headers became \`--- a//tmp/...\`.

- Centralize \`path_for_diff_header\` (strip one leading \`/\`) used by all \`a/\` / \`b/\` header formatting
- \`FileDiff.path\` still stores the original path (absolute or relative)
- Relative paths and \`<content>\` placeholder unchanged
- Windows drive paths have no leading \`/\` and are unchanged
- Docs on \`text_diff\` note absolute-path normalization

### Similar-issue sweep

Header generation is only in \`src/diff.rs\` \`format_diff_result_opt\` (CLI colored path included). \`unified_diff\` stores path only; patch *parsing* already strips \`a/\` / \`b/\` prefixes and is input-side. No second formatter needed.

## Test plan

- [x] \`path_for_diff_header_strips_leading_slash\`
- [x] \`absolute_unix_path_header_has_no_double_slash\`
- [x] \`absolute_macos_private_tmp_header_normalized\`
- [x] \`multi_file_format_normalizes_each_absolute_path\`
- [x] \`text_diff_absolute_path_no_double_slash_headers\`
- [x] relative / placeholder regression tests
- [x] clippy \`-D warnings\`