### PR TITLE
fix: strip all leading slashes in diff header paths

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -288,8 +288,9 @@ pub fn make_write_policy(opts: &WritePolicyOptions) -> WritePolicy {
 /// pass `None` to use a generic `<content>` placeholder.
 ///
 /// Absolute Unix paths (e.g. after `canonicalize()`) are normalized so headers
-/// do not contain a double slash (`--- a//tmp/...`). Relative paths are
-/// unchanged (`--- a/src/main.rs`).
+/// do not contain a double slash (`--- a//tmp/...`): leading `/` characters are
+/// stripped for the header only. Relative paths are unchanged
+/// (`--- a/src/main.rs`).
 ///
 /// This is the same diff engine used internally by [`replace_in_content`],
 /// [`replace_text`], and other editing operations, exposed as a standalone

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2620,8 +2620,12 @@ fn text_diff_absolute_path_no_double_slash_headers() {
 #[test]
 fn text_diff_absolute_path_placeholder_and_relative_unchanged() {
     let abs = text_diff("a\n", "b\n", Some("/private/tmp/x.rs"));
-    assert!(!abs.contains("//"));
+    assert!(!abs.contains("--- a//") && !abs.contains("+++ b//"));
     assert!(abs.contains("--- a/private/tmp/x.rs"));
+
+    let multi_slash = text_diff("a\n", "b\n", Some("///weird/path.rs"));
+    assert!(!multi_slash.contains("--- a//") && !multi_slash.contains("+++ b//"));
+    assert!(multi_slash.contains("--- a/weird/path.rs"));
 
     let rel = text_diff("a\n", "b\n", Some("src/main.rs"));
     assert!(rel.contains("--- a/src/main.rs"));

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -4,15 +4,20 @@ use similar::TextDiff;
 
 /// Normalize a path for unified-diff headers after the fixed `a/` / `b/` prefix.
 ///
-/// Absolute Unix paths start with `/`. Naively formatting `--- a/{path}` then
-/// yields `--- a//tmp/file` (double slash). Strip one leading `/` so headers
-/// stay readable. Relative paths and placeholders (e.g. `<content>`) are
-/// unchanged. Windows drive paths (`C:\...`) have no leading `/` and are
-/// unchanged.
+/// Absolute Unix paths start with `/` (sometimes more than one after sloppy
+/// joins). Naively formatting `--- a/{path}` yields `--- a//tmp/file`.
+/// Strip all leading `/` so headers never contain `a//` or `b//`.
+/// Relative paths and placeholders (e.g. `<content>`) are unchanged.
+/// Windows drive paths (`C:\...`) have no leading `/` and are unchanged.
+/// A path that is only slashes (e.g. `/`) becomes `.`.
 ///
 /// Used only for header display; [`FileDiff::path`] keeps the original string.
 pub(crate) fn path_for_diff_header(path: &str) -> &str {
-    path.strip_prefix('/').unwrap_or(path)
+    match path.trim_start_matches('/') {
+        "" if path.is_empty() => "",
+        "" => ".", // was one or more `/` only
+        other => other,
+    }
 }
 
 /// Represents the diff for a single file.
@@ -139,7 +144,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn path_for_diff_header_strips_leading_slash() {
+    fn path_for_diff_header_strips_leading_slashes() {
         assert_eq!(path_for_diff_header("/tmp/demo/lib.rs"), "tmp/demo/lib.rs");
         assert_eq!(
             path_for_diff_header("/private/tmp/demo/src/a.rs"),
@@ -151,8 +156,11 @@ mod tests {
             path_for_diff_header("C:\\Users\\x\\f.rs"),
             "C:\\Users\\x\\f.rs"
         );
-        // Only one leading slash (absolute Unix form); remaining path intact.
-        assert_eq!(path_for_diff_header("//unc/share"), "/unc/share");
+        // Multiple leading slashes must not leave a leading / (would re-create a//).
+        assert_eq!(path_for_diff_header("//unc/share"), "unc/share");
+        assert_eq!(path_for_diff_header("///a"), "a");
+        assert_eq!(path_for_diff_header("/"), ".");
+        assert_eq!(path_for_diff_header(""), "");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up hardening after #1481 / #1480:

- Strip **all** leading \`/\` in \`path_for_diff_header\` (not just one) so \`//unc/...\` and \`///a\` cannot reintroduce \`a//\`
- Path that is only slashes becomes \`.\`
- Tighten API tests (header-specific checks; multi-slash case)

## Test plan

- [x] \`path_for_diff_header_strips_leading_slashes\`
- [x] absolute / multi-file / text_diff absolute tests
- [x] clippy \`-D warnings\`

Ref #1480