### PR TITLE
fix: batch unknown-op suggestions and deny.toml licenses

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,5 @@
+# Local / optional cargo-deny config (FOSSA is the CI license gate).
+# Run: cargo deny check
 [graph]
 all-features = true
 
@@ -10,6 +12,9 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSL-1.0",
+    "BSD-3-Clause",
+    "CDLA-Permissive-2.0",
+    "ISC",
     "Unicode-3.0",
     "Unlicense",
 ]

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -319,8 +319,91 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
             })
         }
 
-        _ => anyhow::bail!("line {line_num}: unknown operation '{op}'"),
+        _ => anyhow::bail!("{}", unknown_batch_op_msg(line_num, op)),
     }
+}
+
+/// Batch op names accepted by [`parse_line`] (for "did you mean?" suggestions).
+const KNOWN_BATCH_OPS: &[&str] = &[
+    "doc.set",
+    "doc.delete",
+    "doc.merge",
+    "doc.ensure",
+    "doc.append",
+    "doc.prepend",
+    "doc.update",
+    "doc.move",
+    "doc.delete_where",
+    "replace",
+    "file.create",
+    "file.delete",
+    "file.rename",
+    "file.append",
+    "file.prepend",
+    "md.upsert_bullet",
+    "md.table_append",
+    "md.replace_section",
+    "md.insert_after_heading",
+    "md.insert_before_heading",
+    "md.move_section",
+    "md.dedupe_headings",
+    "md.lint_agents",
+    "tidy.fix",
+    "ast.rename",
+    "ast.replace",
+    "ast.rewrite_signature",
+];
+
+/// Ops that exist as standalone CLI / tx but not in batch line format.
+fn batch_unsupported_hint(op: &str) -> Option<&'static str> {
+    match op {
+        "read" => Some("not supported in batch; use `patchloom read` or a tx plan"),
+        "search" => Some("not supported in batch; use `patchloom search` or a tx plan"),
+        "patch" | "patch.apply" => {
+            Some("not supported in batch; use `patchloom patch` or a tx plan")
+        }
+        "status" | "git_status" => Some("not supported in batch; use `patchloom status`"),
+        "undo" => Some("not supported in batch; use `patchloom undo`"),
+        "explain" => Some("not supported in batch; use `patchloom explain`"),
+        _ => None,
+    }
+}
+
+/// Suggest close batch op names for typos and bare names (`create` → `file.create`).
+fn suggest_batch_op(op: &str) -> Option<String> {
+    // Bare leaf name: `create` matches `file.create`, `append` matches both file/doc.
+    let mut suffix: Vec<&str> = KNOWN_BATCH_OPS
+        .iter()
+        .copied()
+        .filter(|k| k.rsplit_once('.').is_some_and(|(_, leaf)| leaf == op))
+        .collect();
+    if !suffix.is_empty() {
+        suffix.sort_unstable();
+        return Some(suffix.join(", "));
+    }
+
+    let mut scored: Vec<(&str, f64)> = KNOWN_BATCH_OPS
+        .iter()
+        .copied()
+        .map(|k| (k, strsim::jaro_winkler(op, k)))
+        .filter(|(_, score)| *score >= 0.86)
+        .collect();
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    if scored.is_empty() {
+        return None;
+    }
+    let top: Vec<&str> = scored.into_iter().take(3).map(|(k, _)| k).collect();
+    Some(top.join(", "))
+}
+
+fn unknown_batch_op_msg(line_num: usize, op: &str) -> String {
+    if let Some(hint) = batch_unsupported_hint(op) {
+        return format!("line {line_num}: unknown operation '{op}' ({hint})");
+    }
+    if let Some(suggestion) = suggest_batch_op(op) {
+        return format!("line {line_num}: unknown operation '{op}' (did you mean: {suggestion}?)");
+    }
+    format!("line {line_num}: unknown operation '{op}'")
 }
 
 /// Check that the exact number of arguments were provided.

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -387,25 +387,80 @@ mod error_handling {
         assert!(err.to_string().contains("unknown operation"));
     }
 
+    #[test]
+    fn known_batch_ops_inventory_stable() {
+        // docs/reference and clap after_help list 27 batch ops; keep the
+        // suggestion table in lockstep so bare-name hints stay accurate.
+        assert_eq!(KNOWN_BATCH_OPS.len(), 27);
+        let mut sorted = KNOWN_BATCH_OPS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), KNOWN_BATCH_OPS.len(), "duplicate op names");
+    }
+
+    #[test]
+    fn parse_line_suggests_file_create_for_bare_create() {
+        // Agents often type CLI-style `create` instead of batch `file.create`.
+        let err = parse_line(r#"create path.txt "hi""#, 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown operation") && msg.contains("file.create"),
+            "expected did-you-mean for file.create, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_line_suggests_file_and_doc_append() {
+        let err = parse_line(r#"append path.txt "x""#, 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("file.append") && msg.contains("doc.append"),
+            "expected both append targets, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_line_suggests_typo_file_create() {
+        let err = parse_line(r#"file.creat path.txt "hi""#, 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did you mean") && msg.contains("file.create"),
+            "expected fuzzy suggestion, got: {msg}"
+        );
+    }
+
     // Batch intentionally does not support read, search, and patch.apply.
-    // These are tx-only operations. The tests below document this as deliberate.
+    // These are tx-only operations. The tests below document this as deliberate
+    // and lock the redirect hint in the error message.
 
     #[test]
     fn parse_line_rejects_read() {
         let err = parse_line("read path.txt", 1).unwrap_err();
-        assert!(err.to_string().contains("unknown operation"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown operation") && msg.contains("patchloom read"),
+            "expected standalone redirect, got: {msg}"
+        );
     }
 
     #[test]
     fn parse_line_rejects_search() {
         let err = parse_line("search path.txt hello", 1).unwrap_err();
-        assert!(err.to_string().contains("unknown operation"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown operation") && msg.contains("patchloom search"),
+            "expected standalone redirect, got: {msg}"
+        );
     }
 
     #[test]
     fn parse_line_rejects_patch_apply() {
         let err = parse_line("patch.apply diff-text", 1).unwrap_err();
-        assert!(err.to_string().contains("unknown operation"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown operation") && msg.contains("patchloom patch"),
+            "expected standalone redirect, got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Batch parse errors** now suggest valid ops for bare names (`create` → `file.create`) and close typos (`file.creat`), and redirect when agents use CLI-only ops (`read` / `search` / `patch`) in batch lines.
- **deny.toml** allowlist includes BSD-3-Clause, ISC, and CDLA-Permissive-2.0 so local `cargo deny check licenses` matches the rustls/rmcp tree. FOSSA remains the CI license gate; deny.toml is documented as local/optional.

## MPI cycle notes (2026-07-09)

Gate: main green at `6bb64d6`; only open PR is release #1457 (awaiting explicit merge approval); accepted open issues are distribution B-path only (#632–#634, #960–#963).

Shipped from End User / Observability + Maintainer perspectives. Other perspectives were no-op after mechanical greps and runtime probes (status/.patchloom, empty `--files-from`, absolute diff headers, init gitignore).

## Test plan

- [x] `cargo test --lib batch` (61 tests including new suggestion/redirect cases)
- [x] `cargo deny check licenses`
- [x] `make check` (full local gate)
- [ ] CI green on this PR