### PR TITLE
chore: upgrade rmcp 2.2, enforce cargo deny, fix AI findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
             code:
               - 'src/**'
               - 'Cargo.*'
+              - 'deny.toml'
               - 'tests/**'
               - 'Makefile'
               - 'fuzz/**'
@@ -528,17 +529,43 @@ jobs:
       - name: Run audit
         run: cargo audit
 
+  # Enforce deny.toml (licenses/bans/sources) so the allowlist cannot rot silently.
+  # FOSSA remains the license compliance product; cargo-audit remains the advisory scanner.
+  # cargo-deny here locks policy in-repo (addresses #1485).
+  deny:
+    needs: [changes]
+    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@16b05812d776ae1dfaabc8277e421fb6d2506419 # v2
+        with:
+          tool: cargo-deny
+
+      - name: Run cargo deny
+        run: cargo deny check
+
   ci:
     # Lightweight gate that satisfies the "ci" required status check.
     # Reports success when build-and-test passes OR was skipped (docs-only PR).
-    needs: [build-and-test, ci-windows, ci-macos, msrv, msrv-macos, coverage, bench, fuzz, agent-dry-run, audit]
+    needs: [build-and-test, ci-windows, ci-macos, msrv, msrv-macos, coverage, bench, fuzz, agent-dry-run, audit, deny]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
       - name: Gate
         run: |
-          results=("$BUILD" "$WINDOWS" "$MACOS" "$MSRV" "$MSRV_MACOS" "$COV" "$BENCH" "$FUZZ" "$AGENT" "$AUDIT")
+          results=("$BUILD" "$WINDOWS" "$MACOS" "$MSRV" "$MSRV_MACOS" "$COV" "$BENCH" "$FUZZ" "$AGENT" "$AUDIT" "$DENY")
           for r in "${results[@]}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "Upstream job failed or was cancelled: $r"
@@ -556,3 +583,4 @@ jobs:
           FUZZ: ${{ needs.fuzz.result }}
           AGENT: ${{ needs.agent-dry-run.result }}
           AUDIT: ${{ needs.audit.result }}
+          DENY: ${{ needs.deny.result }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |
 | `make check-patchloom-md` | Verify PATCHLOOM.md matches `patchloom agent-rules` output (part of `check`) |
 | `make audit-test-hygiene` | Audit test names and weak assertions for staleness after refactors (run after MPI or breaking changes) |
+| `make audit` | Run `cargo audit` for known vulnerabilities (optional locally; also in CI) |
+| `make deny` | Run `cargo deny check` for licenses/bans/sources (`deny.toml`; required in CI) |
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
 | `make fuzz` | Run fuzz tests (11 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse, containment_check, fallback_resolve, ast_parse, md_heading, replace_regex). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -554,12 +554,6 @@ The goal of this work was to make more of the crate independently usable and red
 * use thread-local FORCE_RESTORE_FAIL for parallel tests ([#594](https://github.com/patchloom/patchloom/issues/594)) ([57b6f9b](https://github.com/patchloom/patchloom/commit/57b6f9bd00f123b8308ba2f81c90ee2a8ec33930))
 * warn on invalid config values and clarify batch quoting ([#585](https://github.com/patchloom/patchloom/issues/585)) ([7803291](https://github.com/patchloom/patchloom/commit/7803291f7523c2d1dc684b73cd4148a3d6c74286))
 
-## [Unreleased]
-
-### Changed
-
-- **tx** - **Breaking:** `strict` now defaults to `true` in plans, MCP write tools, and `batch`. Use `"strict": false`, `[tx] strict = false` in `.patchloom.toml`, or `patchloom tx --no-strict` to opt out. Operation staging failures now exit 4 with `error_kind: operation_failed` (was exit 7). Mid-commit write failures roll back via the backup session (exit 7 `rollback`, or exit 1 `rollback_failed` if rollback is incomplete).
-
 ## [0.1.7](https://github.com/patchloom/patchloom/compare/patchloom-v0.1.6...patchloom-v0.1.7) (2026-06-16)
 
 
@@ -760,8 +754,6 @@ The goal of this work was to make more of the crate independently usable and red
 * reduce allocations across replace, search, doc ops, diff, and selector ([5543443](https://github.com/patchloom/patchloom/commit/5543443a25147a9df4d37c8715eb0639648045d3))
 * trim agent_rules.md from 102 to 40 lines (71% smaller) ([cecbc18](https://github.com/patchloom/patchloom/commit/cecbc18d08373b8169d1e9be1a76a28e716b215e))
 * use parallel file walking for directory traversal ([4a68a85](https://github.com/patchloom/patchloom/commit/4a68a85347151d5961078cc2548a1782f291ebe6)), closes [#249](https://github.com/patchloom/patchloom/issues/249)
-
-## [Unreleased]
 
 ## [0.1.0] - 2026-06-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,9 @@ See the "Adding a new MCP tool" section in [AGENTS.md](./AGENTS.md).
 - `cargo clippy --all-targets --all-features -- -D warnings` must produce zero warnings.
 - Never use `unwrap()` or `expect()` in non-test code; use `?` with `anyhow::Context` or `.ok_or_else(|| anyhow!("msg"))?`. Exception: `expect()` is acceptable on infallible internal invariants (e.g. `Mutex::lock`).
 - `unsafe_code = "deny"` is enforced in `Cargo.toml`.
+- Dependency policy: CI runs `cargo audit` (advisories), `cargo deny check`
+  (`deny.toml` licenses/bans/sources), and FOSSA (license compliance product).
+  Locally: `make audit` and `make deny` (requires `cargo-audit` / `cargo-deny`).
 - All commits require a `Signed-off-by` line ([DCO](https://developercertificate.org/)). Use `git commit -s`.
 
 ## Troubleshooting `make check` failures

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
 dependencies = [
  "async-trait",
  "base64",
@@ -1923,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2309,9 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
 dependencies = [
  "bytes",
  "futures-util",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit-test-hygiene audit bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz git-clean clean
+.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -142,6 +142,9 @@ bench-agent-report: ## Generate comparison report from saved agent benchmark res
 
 audit: ## Run cargo audit for known vulnerabilities (requires cargo-audit)
 	cargo audit
+
+deny: ## Run cargo deny check (licenses/bans/sources; requires cargo-deny)
+	cargo deny check
 
 FUZZ_TIME ?= 60
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,15 +44,16 @@ GitHub private vulnerability reporting is the default private channel for securi
 
 Patchloom publishes multi-platform binaries and crates via the cargo-dist
 workflow in [`.github/workflows/release.yml`](.github/workflows/release.yml)
-and the crates.io publish job. CI also runs `cargo deny` / advisory checks
-against the lockfile.
+and the crates.io publish job. CI runs `cargo audit` (advisories),
+`cargo deny check` (licenses/bans/sources via `deny.toml`), and FOSSA
+(license compliance product) against the dependency graph.
 
 Some Scorecard heuristics do not fully match that posture:
 
 | Check | Observed Scorecard signal | Project reality |
 |-------|---------------------------|-----------------|
 | **Packaging** | Often `-1` / "packaging workflow not detected" | Releases use cargo-dist (`release.yml`) plus crates.io and Homebrew publishing. Scorecard's packaging detector does not currently recognize this cargo-dist layout; treat a low Packaging score as a known false negative, not absence of packaging. |
-| **Vulnerabilities** | May lag OSV/RUSTSEC listings (for example historical `anyhow` advisories) | Authoritative sources for this repo are the checked-in `Cargo.lock` and CI advisory tooling (`cargo deny` / `cargo audit`). If Scorecard still flags an advisory while the lockfile and CI audit are clean (patched versions resolved), prefer the lockfile + CI result. |
+| **Vulnerabilities** | May lag OSV/RUSTSEC listings (for example historical `anyhow` advisories) | Authoritative sources for this repo are the checked-in `Cargo.lock` and CI advisory tooling (`cargo audit`). License/source policy is enforced by `cargo deny check` (`deny.toml`) plus FOSSA. If Scorecard still flags an advisory while the lockfile and CI audit are clean (patched versions resolved), prefer the lockfile + CI result. |
 
 Pinned installers in the release workflow (cargo-dist binary and rustup-init
 with version + SHA-256) address the Pinned-Dependencies `downloadThenRun`

--- a/deny.toml
+++ b/deny.toml
@@ -1,5 +1,6 @@
-# Local / optional cargo-deny config (FOSSA is the CI license gate).
-# Run: cargo deny check
+# cargo-deny policy enforced in CI (job "deny" in .github/workflows/ci.yml).
+# FOSSA remains the license compliance product; cargo-audit covers advisories.
+# Local: `make deny` or `cargo deny check`
 [graph]
 all-features = true
 

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -370,7 +370,7 @@ pub fn replace_in_content(
         let ctx_content = format!(
             "{}{}{}",
             &content[..target_offset],
-            &replacement,
+            replacement,
             &content[target_offset + from.len()..],
         );
         let diff = super::make_diff("<content>", content, &ctx_content);

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -551,7 +551,6 @@ fn execute_plan_runs_operations() {
     // execute_plan now returns typed PlanReport directly for library users (#811).
     assert!(report.ok);
     assert_eq!(report.status, "success");
-    assert!(report.ok);
     assert!(!report.changes.is_empty()); // net file changes from the plan ops
     assert!(
         report

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -302,17 +302,33 @@ mod tests {
 
     // ---- describe_exit_status ----
 
+    /// Spawn a process that exits with the given code on both Unix and Windows.
+    fn command_for_exit_code(code: i32) -> std::process::Command {
+        #[cfg(windows)]
+        {
+            let mut cmd = std::process::Command::new("cmd");
+            cmd.args(["/C", &format!("exit {code}")]);
+            cmd
+        }
+        #[cfg(not(windows))]
+        {
+            if code == 0 {
+                std::process::Command::new("true")
+            } else {
+                std::process::Command::new("false")
+            }
+        }
+    }
+
     #[test]
     fn describe_exit_status_code_zero() {
-        use std::process::Command;
-        let status = Command::new("true").status().unwrap();
+        let status = command_for_exit_code(0).status().unwrap();
         assert_eq!(describe_exit_status(status), "exit code 0");
     }
 
     #[test]
     fn describe_exit_status_code_nonzero() {
-        use std::process::Command;
-        let status = Command::new("false").status().unwrap();
+        let status = command_for_exit_code(1).status().unwrap();
         assert_eq!(describe_exit_status(status), "exit code 1");
     }
 

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -122,7 +122,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 let new_content = format!(
                     "{}{}{}",
                     &content[..target_offset],
-                    &replacement,
+                    replacement,
                     &content[target_offset + old.len()..],
                 );
                 update_file_content(

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -238,13 +238,21 @@ fn test_smoke_example_07_yaml_plan() {
         .assert()
         .code(2);
 
-    // --apply: skip format/validate (prettier/yamllint may not exist).
-    // Instead verify the plan parses and operations apply.
-    let _ = patchloom_in(dir.path())
+    // --apply: plan sets strict: false so ops land even if format/validate tools
+    // (prettier/yamllint) are missing. Exit 0 when tools exist; exit 6
+    // (VALIDATION_FAILED) when they do not. Never discard the exit code.
+    let apply = patchloom_in(dir.path())
         .arg("tx")
         .arg(example_plan_path("07-yaml-plan.yaml"))
         .arg("--apply")
-        .assert();
+        .output()
+        .expect("tx --apply should run");
+    let code = apply.status.code().unwrap_or(1);
+    assert!(
+        code == 0 || code == 6,
+        "expected exit 0 (format tools present) or 6 (missing prettier/yamllint), got {code}: {}",
+        String::from_utf8_lossy(&apply.stderr)
+    );
 
     let config = fs::read_to_string(dir.path().join("config.yaml")).unwrap();
     assert!(


### PR DESCRIPTION
## Summary

- **#1484:** Evaluate and upgrade rmcp 2.1.0 → 2.2.0. Changelog: PKCE/auth, client conformance, cancelled-request handling. Lockfile also needed `sse-stream` 0.2.3 → 0.2.4 (`from_bytes_stream` only exists on 0.2.4).
- **#1485 option A:** Enforce `deny.toml` in CI via a new `deny` job (`cargo deny check`) wired into the aggregate `ci` gate. Add `make deny`, path-filter `deny.toml`, and document FOSSA vs audit vs deny in AGENTS.md / CONTRIBUTING.md / SECURITY.md.
- **AI findings** ([security/quality/ai-findings](https://github.com/patchloom/patchloom/security/quality/ai-findings)): fixed 4 real findings; 1 false positive documented.

## AI findings triage

| File | Verdict | Action |
|------|---------|--------|
| CHANGELOG.md duplicate Unreleased | Real | Removed orphan mid-file section and empty pre-0.1.0 heading |
| src/api/tests.rs duplicate `assert!(report.ok)` | Real | Removed second assert |
| src/tx/output.rs `true`/`false` binaries | Real | Cross-platform exit-code helper for Windows |
| smoke_tests discarded apply exit | Real | Assert exit 0 or 6 (strict:false + optional prettier/yamllint) |
| mcp_tool_tests total_lines=3 | **False positive** | Rust `str::lines()` does not count trailing empty line; matches `ops/read` |

## Test plan

- [x] `cargo test --lib --all-features` (2201 pass)
- [x] `make test-mcp-no-ast`
- [x] MCP-filtered lib tests
- [x] `make deny` / `cargo deny check`
- [x] `cargo test --test integration smoke_example_07`
- [x] clippy `-D warnings`
- [ ] CI green on PR

Closes #1484
Closes #1485