### PR TITLE
fix: MPI cycle improve (regex, lychee 5xx, yaml escape)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ This is a quick-reference subset. For the complete list, see [AGENTS.md](./AGENT
 | `make clippy` | Run clippy with `-D warnings` |
 | `make check` | Full CI gate (run before every commit) |
 | `make check-fast` | Fast check (skips PATCHLOOM.md sync only; still checks README test count) |
+| `make audit` | Run `cargo audit` for known vulnerabilities (also in CI) |
+| `make deny` | Run `cargo deny check` for licenses/bans/sources (`deny.toml`; also in CI) |
 | `make update-readme` | Update README.md rounded test count |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/lychee.toml
+++ b/lychee.toml
@@ -30,4 +30,6 @@ exclude = [
   "patchloom\\.github\\.io",
 ]
 
-accept = [200, 429]
+# 502/503/504: GitHub (and occasional other hosts) return gateway errors under
+# load; max_retries alone still flakes post-merge Links on main (2026-07-09).
+accept = [200, 429, 502, 503, 504]

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -396,7 +396,9 @@ fn serialize_block_entries(
                 // containing newlines because YAML single-quoted scalars fold
                 // line breaks into spaces, corrupting the data.
                 if s.contains('\n') {
-                    let escaped = serde_json::to_string(s).expect("JSON string");
+                    let escaped = serde_json::to_string(s).map_err(|e| {
+                        anyhow::anyhow!("JSON-escape YAML string with newlines: {e}")
+                    })?;
                     out.push_str(&escaped);
                 } else if needs_yaml_quoting(s) {
                     out.push_str(&format!("'{}'", s.replace('\'', "''")));


### PR DESCRIPTION
## Summary

MPI cycle 1 improvements after #1486:

- **Developer:** `yaml_splice` multiline string path uses `?` instead of `expect` on `serde_json::to_string`
- **Maintainer:** `regex` 1.12.4 → 1.13.0 (`cargo outdated`)
- **Ops/SRE:** lychee accepts 502/503/504 so post-merge Links does not fail on GitHub gateway timeouts (seen after #1486)
- **End User:** CONTRIBUTING.md command table lists `make audit` / `make deny`

Other perspectives (QA, Security, PM, Spec, Perf, Compat, Adversarial, Architecture, New Contributor, Observability) returned no actionable HIGH findings after mechanical greps and runtime probes (write singularity intact, MCP tool inventory green, preview exit 2 contract holds).

## Gate notes

- Release PR **#1457** (0.11.0) left open; do not merge without explicit yes
- Dist issues #632-634, #960-963 remain external B-path

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --lib --all-features` (yaml_splice + regex filters)
- [ ] CI green