### PR TITLE
test: strengthen bare is_err assertions (MPI cycle 2)

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2533,7 +2533,7 @@ fn replace_in_content_case_insensitive() {
 #[test]
 fn replace_in_content_empty_pattern_errors() {
     let result = replace::replace_in_content("content", "", "x", &ReplaceOptions::default());
-    assert!(result.is_err());
+    assert!(result.is_err(), "expected error, got Ok: {result:?}");
 }
 
 #[test]
@@ -2554,7 +2554,7 @@ fn replace_in_content_range_requires_whole_line() {
         ..Default::default()
     };
     let result = replace::replace_in_content("aaa\nbbb\n", "aaa", "xxx", &opts);
-    assert!(result.is_err());
+    assert!(result.is_err(), "expected error, got Ok: {result:?}");
     assert!(
         result
             .unwrap_err()
@@ -2571,7 +2571,7 @@ fn replace_in_content_whole_line_multiline_conflict() {
         ..Default::default()
     };
     let result = replace::replace_in_content("aaa\nbbb\n", "aaa", "xxx", &opts);
-    assert!(result.is_err());
+    assert!(result.is_err(), "expected error, got Ok: {result:?}");
     assert!(
         result
             .unwrap_err()

--- a/src/ast/extract_to_file.rs
+++ b/src/ast/extract_to_file.rs
@@ -249,7 +249,7 @@ mod tests {
     fn extract_symbol_not_found() {
         let source = "fn foo() {}\n";
         let result = extract_to_file(source, "nonexistent", None, false, None, Language::Rust);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
     }
 
     #[test]

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -346,7 +346,7 @@ mod tests {
             position: GroupPosition::FirstSymbol,
         };
         let result = group_symbols(source, &spec, Language::Rust);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
 

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -497,7 +497,7 @@ mod tests {
             InsertPosition::End,
             Language::Rust,
         );
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
 
@@ -514,7 +514,7 @@ mod tests {
             InsertPosition::End,
             Language::Rust,
         );
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
 
         // Two specified
         let result = insert_code(
@@ -526,7 +526,7 @@ mod tests {
             InsertPosition::End,
             Language::Rust,
         );
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
     }
 
     #[test]

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -291,7 +291,7 @@ mod tests {
             MovePosition::End,
             Language::Rust,
         );
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
     }
 
     #[test]

--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -386,7 +386,7 @@ mod tests {
             &ReorderStrategy::Alphabetical,
             Language::Rust,
         );
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]
@@ -429,19 +429,19 @@ mod tests {
     #[test]
     fn parse_strategy_unknown_string() {
         let v = serde_json::json!("bogus");
-        assert!(parse_strategy(&v).is_err());
+        parse_strategy(&v).expect_err("expected error");
     }
 
     #[test]
     fn parse_strategy_array_non_string_item() {
         let v = serde_json::json!(["a", 42, "c"]);
-        assert!(parse_strategy(&v).is_err());
+        parse_strategy(&v).expect_err("expected error");
     }
 
     #[test]
     fn parse_strategy_invalid() {
         let v = serde_json::json!(42);
-        assert!(parse_strategy(&v).is_err());
+        parse_strategy(&v).expect_err("expected error");
     }
 
     // Regression: reorder must preserve non-symbol content (use statements,

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -255,7 +255,7 @@ fn main() {
     #[test]
     fn search_query_invalid_query_returns_error() {
         let result = search_query("fn main() {}", "(invalid query !!!", Language::Rust, None);
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]
@@ -278,7 +278,7 @@ fn main() {
     #[test]
     fn unknown_language_returns_error() {
         let result = search_query("anything", "(identifier)", Language::Unknown, None);
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -213,7 +213,7 @@ mod tests {
             prepend: None,
         }];
         let result = split_file(source, &targets, &[], None, None, true, Language::Rust);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("beta"));
     }
 
@@ -407,7 +407,7 @@ mod tests {
             },
         ];
         let result = split_file(source, &targets, &[], None, None, false, Language::Rust);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         let err = result.unwrap_err().to_string();
         assert!(err.contains("alpha"));
         assert!(err.contains("a.rs"));

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -296,7 +296,7 @@ mod tests {
             None,
             Language::Rust,
         );
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("not found"));
     }
 
@@ -305,7 +305,7 @@ mod tests {
         let source = "fn foo() {}\n";
         // None specified
         let result = wrap_code(source, None, None, "mod x", None, Language::Rust);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
 
         // Both specified
         let result = wrap_code(
@@ -316,7 +316,7 @@ mod tests {
             None,
             Language::Rust,
         );
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
     }
 
     #[test]

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -861,7 +861,7 @@ mod security {
             selector: "a".into(),
         };
         let result = execute_with_mode(&action, OutputMode::Text);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(
             result
                 .unwrap_err()

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -859,7 +859,7 @@ impl Point {
         };
 
         let result = handle_ast_list(&svc, params);
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]
@@ -895,7 +895,7 @@ impl Point {
         };
 
         let result = handle_ast_read(&svc, params);
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -167,12 +167,12 @@ mod tests {
 
     #[test]
     fn parse_range_zero_fails() {
-        assert!(parse_line_range("0:5").is_err());
+        parse_line_range("0:5").expect_err("expected error");
     }
 
     #[test]
     fn parse_range_end_before_start_fails() {
-        assert!(parse_line_range("10:5").is_err());
+        parse_line_range("10:5").expect_err("expected error");
     }
 
     #[test]
@@ -306,7 +306,7 @@ mod tests {
     #[test]
     fn read_one_file_nonexistent_returns_error() {
         let result = read_one_file("/tmp/does-not-exist-patchloom-test.txt", None);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
     }
 
     #[test]

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -713,7 +713,7 @@ mod tests {
         };
         // Should propagate the I/O error, not misclassify as binary
         let result = run(args, &global);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         let err_msg = result.unwrap_err().to_string();
         assert!(
             !err_msg.contains("binary"),

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -284,7 +284,7 @@ mod tests {
             apply: false,
         };
         let result = run(args, &global);
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]

--- a/src/cmd/write_dispatch.rs
+++ b/src/cmd/write_dispatch.rs
@@ -189,7 +189,7 @@ mod tests {
             test_msgs(),
         );
 
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("write failed"));
     }
 }

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -584,14 +584,16 @@ mod tests {
     fn single_parent_rejected() {
         let dir = tempfile::TempDir::new().unwrap();
         let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        assert!(guard.check_path("..").is_err());
+        guard.check_path("..").expect_err("expected error");
     }
 
     #[test]
     fn deep_traversal_rejected() {
         let dir = tempfile::TempDir::new().unwrap();
         let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        assert!(guard.check_path("a/b/../../../escape").is_err());
+        guard
+            .check_path("a/b/../../../escape")
+            .expect_err("expected error");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,9 @@ mod tests {
 
     #[test]
     fn bounded_regex_builder_rejects_invalid_pattern() {
-        assert!(bounded_regex_builder(r"(unclosed").build().is_err());
+        bounded_regex_builder(r"(unclosed")
+            .build()
+            .expect_err("expected error");
     }
 
     #[test]

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -535,7 +535,7 @@ mod tests {
     fn navigate_mut_missing_key_errors() {
         let mut root = json!({"a": 1});
         let result = navigate_mut(&mut root, &segs("b"), false);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("key not found"));
     }
 
@@ -557,7 +557,7 @@ mod tests {
     fn set_at_path_empty_selector_errors() {
         let mut root = json!({});
         let result = set_at_path(&mut root, &[], json!(1));
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]
@@ -601,7 +601,7 @@ mod tests {
     fn delete_where_invalid_predicate() {
         let mut root = json!({"items": []});
         let result = delete_where(&mut root, &segs("items"), "noequalssign");
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]
@@ -649,7 +649,7 @@ mod tests {
     fn delete_where_empty_key_errors() {
         let mut root = json!({"items": []});
         let result = delete_where(&mut root, &segs("items"), "=val");
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("key is empty"));
     }
 
@@ -657,7 +657,7 @@ mod tests {
     fn delete_where_double_equals_errors() {
         let mut root = json!({"items": []});
         let result = delete_where(&mut root, &segs("items"), "k==v");
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         let err_msg = result.unwrap_err().to_string();
         assert!(
             err_msg.contains("predicate uses '=='"),
@@ -696,7 +696,7 @@ mod tests {
     fn move_at_path_empty_to_selector_fails() {
         let mut root = json!({"src": 42});
         let result = move_at_path(&mut root, &segs("src"), &[]);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(
             result
                 .unwrap_err()
@@ -800,7 +800,7 @@ mod tests {
     fn set_at_path_numeric_dot_notation_out_of_bounds() {
         let mut root = json!({"items": [10, 20]});
         let result = set_at_path(&mut root, &segs("items.99"), json!(0));
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(
             result.unwrap_err().to_string().contains("out of bounds"),
             "should report out of bounds"
@@ -856,7 +856,7 @@ mod tests {
         let to = segs("blocker.nested");
         // Destination parent "blocker" is a string, not an object.
         let result = move_at_path(&mut root, &from, &to);
-        assert!(result.is_err());
+        result.expect_err("expected error");
         // Source must still be present after the failed move.
         assert_eq!(
             root.get("src"),

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -687,40 +687,40 @@ mod error_handling {
 
     #[test]
     fn detect_format_unsupported() {
-        assert!(detect_format("readme.txt").is_err());
+        detect_format("readme.txt").expect_err("expected error");
     }
 
     #[test]
     fn detect_format_no_extension() {
-        assert!(detect_format("Makefile").is_err());
+        detect_format("Makefile").expect_err("expected error");
     }
 
     #[test]
     fn navigate_mut_missing_key_no_create() {
         let mut val = json!({"a": 1});
         let seg = crate::selector::parse("b").unwrap();
-        assert!(navigate_mut(&mut val, &seg, false).is_err());
+        navigate_mut(&mut val, &seg, false).expect_err("expected error");
     }
 
     #[test]
     fn navigate_mut_index_out_of_bounds() {
         let mut val = json!({"items": [10]});
         let seg = crate::selector::parse("items[5]").unwrap();
-        assert!(navigate_mut(&mut val, &seg, false).is_err());
+        navigate_mut(&mut val, &seg, false).expect_err("expected error");
     }
 
     #[test]
     fn set_at_path_out_of_bounds_index_fails() {
         let mut root = json!({"items": [1]});
         let sel = crate::selector::parse("items[5]").unwrap();
-        assert!(set_at_path(&mut root, &sel, json!(99)).is_err());
+        set_at_path(&mut root, &sel, json!(99)).expect_err("expected error");
     }
 
     #[test]
     fn delete_where_non_array_fails() {
         let mut root = json!({"items": "not-an-array"});
         let sel = crate::selector::parse("items").unwrap();
-        assert!(delete_where(&mut root, &sel, "k=v").is_err());
+        delete_where(&mut root, &sel, "k=v").expect_err("expected error");
     }
 
     #[test]
@@ -753,7 +753,7 @@ mod error_handling {
         let mut root = json!({"a": 1});
         let from = crate::selector::parse("nonexistent").unwrap();
         let to = crate::selector::parse("b").unwrap();
-        assert!(move_at_path(&mut root, &from, &to).is_err());
+        move_at_path(&mut root, &from, &to).expect_err("expected error");
     }
 
     #[test]
@@ -761,7 +761,7 @@ mod error_handling {
         let mut root = json!({"a": 1});
         let from: Vec<crate::selector::Segment> = vec![];
         let to = crate::selector::parse("b").unwrap();
-        assert!(move_at_path(&mut root, &from, &to).is_err());
+        move_at_path(&mut root, &from, &to).expect_err("expected error");
     }
 
     #[test]

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -676,7 +676,7 @@ mod edge_cases {
                 PatchLine::Add("TARGET".into()),
             ],
         }];
-        assert!(apply_hunks(original, &hunks).is_err());
+        apply_hunks(original, &hunks).expect_err("expected error");
     }
 
     #[test]
@@ -750,13 +750,13 @@ mod error_handling {
     #[test]
     fn parse_patch_no_files() {
         let diff = "just some text\n";
-        assert!(parse_patch(diff).is_err());
+        parse_patch(diff).expect_err("expected error");
     }
 
     #[test]
     fn parse_patch_no_hunks() {
         let diff = "--- a/f.txt\n+++ b/f.txt\n";
-        assert!(parse_patch(diff).is_err());
+        parse_patch(diff).expect_err("expected error");
     }
 
     #[test]
@@ -772,7 +772,7 @@ mod error_handling {
                 PatchLine::Add("x".into()),
             ],
         }];
-        assert!(apply_hunks(original, &hunks).is_err());
+        apply_hunks(original, &hunks).expect_err("expected error");
     }
 
     #[test]
@@ -785,7 +785,7 @@ mod error_handling {
             allow_conflicts: false,
         };
         let result = apply_hunks_with_options(ours, &hunks, opts);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().contains("conflict"));
     }
 
@@ -799,7 +799,7 @@ mod error_handling {
             allow_conflicts: false,
         };
         let result = apply_hunks_with_options(ours, &hunks, opts);
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 }
 
@@ -880,7 +880,7 @@ mod regression {
             lines: vec![PatchLine::Context("x".into())],
         }];
         // Must return Err, never panic.
-        assert!(apply_hunks("x\n", &hunks).is_err());
+        apply_hunks("x\n", &hunks).expect_err("expected error");
     }
 
     /// Regression: merge_hunks must produce correct ConflictRange line

--- a/src/ops/read.rs
+++ b/src/ops/read.rs
@@ -131,18 +131,25 @@ mod tests {
 
     #[test]
     fn parse_zero_start_errors() {
-        assert!(parse_line_range("0").is_err());
-        assert!(parse_line_range("0:5").is_err());
+        let err = parse_line_range("0").unwrap_err().to_string();
+        assert!(err.contains("1-based"), "got: {err}");
+        let err = parse_line_range("0:5").unwrap_err().to_string();
+        assert!(err.contains("1-based"), "got: {err}");
     }
 
     #[test]
     fn parse_end_before_start_errors() {
-        assert!(parse_line_range("10:5").is_err());
+        let err = parse_line_range("10:5").unwrap_err().to_string();
+        assert!(
+            err.contains("end line 5 is before start line 10"),
+            "got: {err}"
+        );
     }
 
     #[test]
     fn parse_missing_start_errors() {
-        assert!(parse_line_range(":5").is_err());
+        let err = parse_line_range(":5").unwrap_err().to_string();
+        assert!(err.contains("missing start line"), "got: {err}");
     }
 
     #[test]
@@ -153,13 +160,16 @@ mod tests {
 
     #[test]
     fn parse_open_ended_zero_start_errors() {
-        assert!(parse_line_range("0:").is_err());
+        let err = parse_line_range("0:").unwrap_err().to_string();
+        assert!(err.contains("1-based"), "got: {err}");
     }
 
     #[test]
     fn parse_non_numeric_errors() {
-        assert!(parse_line_range("abc").is_err());
-        assert!(parse_line_range("1:abc").is_err());
+        let err = parse_line_range("abc").unwrap_err().to_string();
+        assert!(err.contains("invalid line number"), "got: {err}");
+        let err = parse_line_range("1:abc").unwrap_err().to_string();
+        assert!(err.contains("invalid end line"), "got: {err}");
     }
 
     #[test]
@@ -170,8 +180,8 @@ mod tests {
             err.to_string().contains("1-based"),
             "expected 1-based error, got: {err}"
         );
-        // Also check "5:0"
-        assert!(parse_line_range("5:0").is_err());
+        let err = parse_line_range("5:0").unwrap_err().to_string();
+        assert!(err.contains("1-based"), "got: {err}");
     }
 
     #[test]
@@ -182,7 +192,8 @@ mod tests {
     #[test]
     fn parse_negative_dash_is_not_range() {
         // A leading dash is not a separator, so "-5" should fail as invalid number.
-        assert!(parse_line_range("-5").is_err());
+        let err = parse_line_range("-5").unwrap_err().to_string();
+        assert!(err.contains("invalid line number"), "got: {err}");
     }
 
     // ---- select_lines ----

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -710,7 +710,7 @@ mod replace_tests {
         #[test]
         fn compile_invalid_regex_returns_error() {
             let result = compile_replace_regex("(unclosed", true, false, false, false);
-            assert!(result.is_err());
+            result.expect_err("expected error");
         }
 
         // Regression: --whole-line + --insert-before/after silently drops

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -168,13 +168,13 @@ fn parse_plan_with_all_fields() {
 #[test]
 fn parse_plan_unknown_op_fails() {
     let json = r#"{"version": 1, "operations": [{"op": "unknown", "x": 1}]}"#;
-    assert!(parse_plan(json).is_err());
+    parse_plan(json).expect_err("expected error");
 }
 
 #[test]
 fn parse_plan_missing_operations_fails() {
     let json = r#"{"version": 1, "cwd": "/tmp"}"#;
-    assert!(parse_plan(json).is_err());
+    parse_plan(json).expect_err("expected error");
 }
 
 #[test]

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -696,7 +696,7 @@ mod error_handling {
 
     #[test]
     fn tier_parse_invalid() {
-        assert!("unknown".parse::<Tier>().is_err());
+        "unknown".parse::<Tier>().expect_err("expected error");
     }
 }
 

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -517,7 +517,7 @@ mod tests {
         };
 
         let result = execute_single(op, test_options(dir.path(), &global));
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected containment rejection");
     }
 
     #[test]

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -48,7 +48,7 @@ fn read_file_content_missing_file_errors() {
     let path = PathBuf::from("/nonexistent/file.txt");
 
     let result = read_file_content(&mut pending, &mut existed, &path);
-    assert!(result.is_err());
+    result.expect_err("expected error");
 }
 
 // ---- read_and_probe ----

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -466,7 +466,7 @@ mod tests {
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
         let result = execute_replace_op(&op, &mut tx);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("'path' or 'glob'"));
     }
 

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -418,7 +418,7 @@ mod tests {
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
         let result = execute_search_op(&op, &mut tx);
-        assert!(result.is_err());
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
         assert!(result.unwrap_err().to_string().contains("assert_count"));
     }
 
@@ -448,7 +448,7 @@ mod tests {
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
         let result = execute_search_op(&op, &mut tx);
-        assert!(result.is_err());
+        result.expect_err("expected error");
     }
 
     #[test]

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -595,7 +595,7 @@ mod tests {
     #[test]
     #[cfg(feature = "cli")]
     fn parse_verify_unknown_key_errors() {
-        assert!(VerifyCheck::parse("foo=bar").is_err());
+        VerifyCheck::parse("foo=bar").expect_err("expected error");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

MPI cycle 2 (Test Auditor): strengthen bare `assert!(x.is_err())` unit-test assertions so failures show the Err (or Ok) value.

- Prefer `result.expect_err("expected error")` when the value is not used again
- Prefer `assert!(result.is_err(), "expected error, got Ok: {result:?}")` when a later `unwrap_err()` / message check still needs the binding
- `parse_line_range` tests assert concrete error substrings (`1-based`, `missing start line`, end-before-start, etc.)

## Gate notes

- Release **#1457** (0.11.0) still open; never merge without explicit user yes
- Dist #632-634, #960-963 remain external B-path

## Test plan

- [x] `cargo test --lib --all-features` (2201 pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] CI green

Closes #1488