### PR TITLE
feat(api): Bline embedder surface (require_change, AST mutators, shell tokens, batch rename)

### DIFF
--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -1,12 +1,22 @@
 //! AST write helpers for the public library API (feature `ast` + `files`/`cli`).
+//!
+//! Covers #1459 (signature rewrite), #1493 (rename / replace-in-symbol / in-content
+//! signature rewrite), and #1495 (batch rename).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use crate::ast::rewrite::FunctionSigEdit;
+use anyhow::Context;
+
+use crate::ast::rewrite::{FunctionSigEdit, rewrite_function_signature};
+use crate::ast::{Language, rename, replace as ast_replace};
 use crate::containment::PathGuard;
+use crate::fallback::{EditError, EditErrorKind};
 use crate::plan::Operation;
+use crate::write::WritePolicy;
 
-use super::{ApplyMode, EditResult};
+use super::{
+    ApplyMode, ContentEditResult, EditResult, ensure_contained, make_diff, write_if_apply,
+};
 
 /// Rewrite a function signature on disk (PathGuard + ApplyMode like other writers).
 ///
@@ -29,9 +39,11 @@ pub fn ast_rewrite_signature(
         && edit.parameters.is_none()
         && edit.return_type.is_none()
     {
-        anyhow::bail!(
-            "ast_rewrite_signature requires new_signature and/or visibility/parameters/return_type"
-        );
+        return Err(EditError::new(
+            EditErrorKind::InvalidInput,
+            "ast_rewrite_signature requires new_signature and/or visibility/parameters/return_type",
+        )
+        .into());
     }
     let op = Operation::AstRewriteSignature {
         path: path.to_string_lossy().into(),
@@ -44,4 +56,252 @@ pub fn ast_rewrite_signature(
     };
     let cwd = path.parent().unwrap_or_else(|| Path::new("."));
     super::execute_as_edit_result(op, mode, cwd, guard, "ast.rewrite_signature", None)
+}
+
+/// In-memory function signature rewrite (preview/apply parity with on-disk API).
+///
+/// See #1493. When `new_signature` is set, replaces the full signature span via
+/// `rewrite_function_signature_full` semantics; otherwise applies structured
+/// [`FunctionSigEdit`] fields.
+#[cfg(feature = "ast")]
+pub fn ast_rewrite_signature_in_content(
+    content: &str,
+    function_name: &str,
+    edit: &FunctionSigEdit,
+    new_signature: Option<&str>,
+    lang: Language,
+) -> anyhow::Result<ContentEditResult> {
+    let new_content = if let Some(full) = new_signature {
+        // Full-span replace is currently Rust-oriented (tree-sitter function_item).
+        let _ = lang;
+        crate::ast::rewrite::replace_function_signature(content, function_name, full).ok_or_else(
+            || {
+                EditError::new(
+                    EditErrorKind::NoMatch,
+                    format!("function `{function_name}` not found for signature rewrite"),
+                )
+            },
+        )?
+    } else {
+        rewrite_function_signature(content, function_name, edit, lang).ok_or_else(|| {
+            EditError::new(
+                EditErrorKind::NoMatch,
+                format!("function `{function_name}` not found for signature rewrite"),
+            )
+        })?
+    };
+    let changed = new_content != content;
+    let diff = if changed {
+        make_diff("<content>", content, &new_content)
+    } else {
+        String::new()
+    };
+    Ok(ContentEditResult {
+        original: content.to_string(),
+        new_content,
+        diff,
+        changed,
+        match_count: if changed { 1 } else { 0 },
+    })
+}
+
+/// Rename all identifier occurrences of `old` to `new` in a source file.
+///
+/// Tree-sitter based (skips strings/comments). Zero replacements → `NoMatch`.
+/// See #1493.
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub fn ast_rename(
+    path: &Path,
+    old: &str,
+    new: &str,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    if old.is_empty() || new.is_empty() {
+        return Err(EditError::new(
+            EditErrorKind::InvalidInput,
+            "ast_rename old/new must not be empty",
+        )
+        .into());
+    }
+    ensure_contained(guard, path)?;
+    let path_str = path.to_string_lossy().into_owned();
+    let original = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read {path_str}"))
+        .map_err(|e| EditError::new(EditErrorKind::OperationFailed, e.to_string()))?;
+    let lang = Language::from_path(path);
+    let Some(renamed) = rename::rename_in_source(&original, old, new, lang) else {
+        return Err(EditError::new(
+            EditErrorKind::ParseError,
+            format!("failed to parse {} as {:?}", path_str, lang),
+        )
+        .into());
+    };
+    if renamed.replacements == 0 {
+        return Err(EditError::new(
+            EditErrorKind::NoMatch,
+            format!("no identifier matches for `{old}` in {path_str}"),
+        )
+        .into());
+    }
+    let policy = WritePolicy::default();
+    let applied = write_if_apply(path, &renamed.content, mode, &policy, guard)?;
+    let mut result = super::build_edit_result(
+        &path_str,
+        original,
+        renamed.content,
+        applied,
+        "ast.rename",
+        None,
+    );
+    result.match_count = renamed.replacements;
+    Ok(result)
+}
+
+/// Replace text inside a named symbol body on disk.
+///
+/// Zero replacements → `NoMatch`. See #1493.
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub fn ast_replace_in_symbol(
+    path: &Path,
+    symbol: &str,
+    old: &str,
+    new: &str,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    ensure_contained(guard, path)?;
+    let path_str = path.to_string_lossy().into_owned();
+    let original =
+        std::fs::read_to_string(path).with_context(|| format!("failed to read {path_str}"))?;
+    let lang = Language::from_path(path);
+    let replaced = match ast_replace::replace_in_symbol(&original, symbol, old, new, false, lang) {
+        Ok(Some(r)) => r,
+        Ok(None) => {
+            return Err(EditError::new(
+                EditErrorKind::NoMatch,
+                format!("symbol `{symbol}` not found in {path_str}"),
+            )
+            .into());
+        }
+        Err(e) => {
+            return Err(EditError::new(EditErrorKind::OperationFailed, e.to_string()).into());
+        }
+    };
+    if replaced.replacements == 0 {
+        return Err(EditError::new(
+            EditErrorKind::NoMatch,
+            format!("no matches for `{old}` in symbol `{symbol}` in {path_str}"),
+        )
+        .into());
+    }
+    let policy = WritePolicy::default();
+    let applied = write_if_apply(path, &replaced.content, mode, &policy, guard)?;
+    let mut result = super::build_edit_result(
+        &path_str,
+        original,
+        replaced.content,
+        applied,
+        "ast.replace_in_symbol",
+        None,
+    );
+    result.match_count = replaced.replacements;
+    Ok(result)
+}
+
+/// Options for [`ast_rename_batch`] (#1495).
+#[derive(Debug, Clone)]
+pub struct AstRenameBatchOptions {
+    pub mode: ApplyMode,
+    /// Skip files with zero matches instead of recording them as errors.
+    /// Default true (agent-friendly best-effort).
+    pub continue_on_no_match: bool,
+    /// Stop after the first hard error (IO, parse, guard). Default false.
+    pub fail_fast: bool,
+}
+
+impl Default for AstRenameBatchOptions {
+    fn default() -> Self {
+        Self {
+            mode: ApplyMode::Preview,
+            continue_on_no_match: true,
+            fail_fast: false,
+        }
+    }
+}
+
+/// Per-file outcome from [`ast_rename_batch`].
+#[derive(Debug)]
+pub struct AstRenameFileResult {
+    pub path: PathBuf,
+    pub result: Result<EditResult, EditError>,
+}
+
+/// Rename identifiers across many files with same-file serialization.
+///
+/// - Duplicate paths are processed **once** (first occurrence wins order).
+/// - Never parallel-writes the same path; return order follows first-seen paths.
+/// - Outer `Err` only for empty `old`/`new`. Per-file failures are in each
+///   [`AstRenameFileResult::result`].
+///
+/// See #1495.
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub fn ast_rename_batch(
+    paths: &[&Path],
+    old: &str,
+    new: &str,
+    opts: &AstRenameBatchOptions,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<Vec<AstRenameFileResult>> {
+    if old.is_empty() || new.is_empty() {
+        return Err(EditError::new(
+            EditErrorKind::InvalidInput,
+            "ast_rename_batch old/new must not be empty",
+        )
+        .into());
+    }
+    // Dedupe while preserving first-seen order.
+    let mut seen = std::collections::HashSet::new();
+    let mut unique_paths: Vec<&Path> = Vec::new();
+    for p in paths {
+        let key = p.to_path_buf();
+        if seen.insert(key) {
+            unique_paths.push(*p);
+        }
+    }
+
+    let mut out = Vec::with_capacity(unique_paths.len());
+    for path in unique_paths {
+        match ast_rename(path, old, new, opts.mode, guard) {
+            Ok(r) => out.push(AstRenameFileResult {
+                path: path.to_path_buf(),
+                result: Ok(r),
+            }),
+            Err(e) => {
+                let edit_err = e.downcast::<EditError>().unwrap_or_else(|e| {
+                    EditError::new(EditErrorKind::OperationFailed, e.to_string())
+                });
+                let is_no_match = edit_err.kind == EditErrorKind::NoMatch;
+                if is_no_match && opts.continue_on_no_match {
+                    out.push(AstRenameFileResult {
+                        path: path.to_path_buf(),
+                        result: Err(edit_err),
+                    });
+                    continue;
+                }
+                if opts.fail_fast && !is_no_match {
+                    out.push(AstRenameFileResult {
+                        path: path.to_path_buf(),
+                        result: Err(edit_err),
+                    });
+                    break;
+                }
+                out.push(AstRenameFileResult {
+                    path: path.to_path_buf(),
+                    result: Err(edit_err),
+                });
+            }
+        }
+    }
+    Ok(out)
 }

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -3,17 +3,23 @@
 //! Compose sequential text operations on one buffer with all-or-nothing
 //! semantics, then optionally write once via [`apply_content_edits_to_file`].
 
-use std::path::Path;
-
 use anyhow::Context;
 
-use crate::containment::PathGuard;
 use crate::ops::file::{append_content, prepend_content};
 
-use super::{
-    ApplyMode, ContentEditResult, EditResult, ReplaceOptions, make_diff, replace_in_content,
-    write_if_apply,
-};
+use super::{ContentEditResult, ReplaceOptions, make_diff, replace_in_content};
+use crate::fallback::{EditError, EditErrorKind};
+
+#[cfg(any(feature = "cli", feature = "files"))]
+use std::path::Path;
+
+#[cfg(any(feature = "cli", feature = "files"))]
+use crate::containment::PathGuard;
+
+#[cfg(any(feature = "cli", feature = "files"))]
+use super::{ApplyMode, EditResult, write_if_apply};
+
+#[cfg(any(feature = "cli", feature = "files"))]
 use crate::write::WritePolicy;
 
 /// A single ordered edit on an in-memory buffer.
@@ -94,8 +100,12 @@ pub fn apply_content_edits_to_file(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     if let Some(g) = guard {
-        g.check_path(&path.to_string_lossy())
-            .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {e}"))?;
+        g.check_path(&path.to_string_lossy()).map_err(|e| {
+            EditError::new(
+                EditErrorKind::GuardRejected,
+                format!("path rejected by workspace guard: {e}"),
+            )
+        })?;
     }
     let path_str = path.to_string_lossy().into_owned();
     let original =
@@ -138,7 +148,11 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<String> {
                     out.push_str(&content[idx..]);
                     Ok(out)
                 }
-                None => anyhow::bail!("insert_before anchor not found: {anchor:?}"),
+                None => Err(EditError::new(
+                    EditErrorKind::NoMatch,
+                    format!("insert_before anchor not found: {anchor:?}"),
+                )
+                .into()),
             }
         }
         ContentEdit::InsertAfter {
@@ -157,7 +171,11 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<String> {
                     out.push_str(&content[end..]);
                     Ok(out)
                 }
-                None => anyhow::bail!("insert_after anchor not found: {anchor:?}"),
+                None => Err(EditError::new(
+                    EditErrorKind::NoMatch,
+                    format!("insert_after anchor not found: {anchor:?}"),
+                )
+                .into()),
             }
         }
         ContentEdit::Append { content: inject } => Ok(append_content(content, inject)),
@@ -286,6 +304,82 @@ mod tests {
         assert!(
             after_msg.contains("empty"),
             "insert_after empty anchor: {after_msg}"
+        );
+    }
+
+    #[test]
+    fn require_change_true_missing_is_no_match() {
+        let edits = [ContentEdit::Replace {
+            old: "missing".into(),
+            new: "x".into(),
+            options: ReplaceOptions {
+                require_change: true,
+                ..Default::default()
+            },
+        }];
+        let err = apply_content_edits("hello\n", &edits).unwrap_err();
+        assert_eq!(
+            crate::fallback::edit_error_kind(&err),
+            Some(EditErrorKind::NoMatch)
+        );
+    }
+
+    #[test]
+    fn require_change_false_missing_is_ok_unchanged() {
+        let edits = [ContentEdit::Replace {
+            old: "missing".into(),
+            new: "x".into(),
+            options: ReplaceOptions::default(),
+        }];
+        let r = apply_content_edits("hello\n", &edits).unwrap();
+        assert!(!r.changed);
+        assert_eq!(r.modified, "hello\n");
+    }
+
+    #[test]
+    fn require_change_unique_multi_is_ambiguous() {
+        let edits = [ContentEdit::Replace {
+            old: "x".into(),
+            new: "y".into(),
+            options: ReplaceOptions {
+                unique: true,
+                require_change: true,
+                ..Default::default()
+            },
+        }];
+        let err = apply_content_edits("x x\n", &edits).unwrap_err();
+        assert_eq!(
+            crate::fallback::edit_error_kind(&err),
+            Some(EditErrorKind::AmbiguousTarget)
+        );
+    }
+
+    #[test]
+    fn require_change_batch_fails_whole_batch() {
+        let edits = [
+            ContentEdit::Replace {
+                old: "a".into(),
+                new: "A".into(),
+                options: ReplaceOptions {
+                    require_change: true,
+                    ..Default::default()
+                },
+            },
+            ContentEdit::Replace {
+                old: "missing".into(),
+                new: "z".into(),
+                options: ReplaceOptions {
+                    require_change: true,
+                    ..Default::default()
+                },
+            },
+        ];
+        let err = apply_content_edits("a b\n", &edits).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("content edit 2"), "got: {msg}");
+        assert_eq!(
+            crate::fallback::edit_error_kind(&err),
+            Some(EditErrorKind::NoMatch)
         );
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7,7 +7,7 @@
 //! # Quick start
 //!
 //! ```rust,no_run
-//! use patchloom::api::{self, ApplyMode, EditResult};
+//! use patchloom::api::{self, ApplyMode, EditResult, ReplaceOptions};
 //! use std::path::{Path, PathBuf};
 //!
 //! // Replace text in a file (preview only)
@@ -15,11 +15,15 @@
 //!     Path::new("src/config.rs"),
 //!     "old_value",
 //!     "new_value",
-//!     &api::ReplaceOptions::default(),
+//!     &ReplaceOptions::default(),
 //!     ApplyMode::Preview,
 //!     None,
 //! ).unwrap();
 //! println!("diff:\n{}", result.diff);
+//!
+//! // Fail closed when the pattern is missing (agent hosts; #1492)
+//! let opts = ReplaceOptions { require_change: true, ..Default::default() };
+//! let _ = api::replace_in_content("src", "old_value", "new_value", &opts);
 //! ```
 //!
 //! # Apply modes
@@ -247,7 +251,24 @@ pub struct ReplaceOptions {
     /// When the pattern matches multiple times, the match nearest to this
     /// anchor text is selected.
     pub after_context: Option<String>,
+    /// When true, zero matches is an error ([`EditErrorKind::NoMatch`]) instead
+    /// of `Ok(changed=false)`. Agent hosts that fail closed should set this.
+    /// Default `false` preserves historical library/CLI soft no-match behavior.
+    /// `if_exists` still wins for zero matches (returns Ok unchanged).
+    /// See #1492.
+    pub require_change: bool,
+    /// When true, only replace tokens in **shell command position** (start of
+    /// line / after `&&` `|` `;`, after transparent prefixes like `sudo` /
+    /// `env KEY=val`). Does not match inside longer tokens (`pip` vs `pipenv`)
+    /// or as arguments (`uv pip`). Opt-in; not the same as `word_boundary`.
+    /// See #1494.
+    pub command_position: bool,
 }
+
+// Re-export structured edit errors for embedders (#1492).
+pub use crate::fallback::{
+    EditError, EditErrorKind, edit_error_kind, edit_error_ref, find_similar_targets,
+};
 
 /// Write policy options for controlling file write transformations.
 #[derive(Debug, Clone, Default)]
@@ -404,15 +425,19 @@ fn write_if_apply(
 /// Private helper to centralize the guard check and eliminate duplicated
 /// inline `if let Some(g) = guard { g.check_path... }` blocks in every
 /// write path.
-fn ensure_contained(guard: Option<&PathGuard>, path: &Path) -> anyhow::Result<()> {
+pub(crate) fn ensure_contained(guard: Option<&PathGuard>, path: &Path) -> anyhow::Result<()> {
     if let Some(g) = guard {
-        g.check_path(&path.to_string_lossy())
-            .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
+        g.check_path(&path.to_string_lossy()).map_err(|e| {
+            crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::GuardRejected,
+                format!("path rejected by workspace guard: {e}"),
+            )
+        })?;
     }
     Ok(())
 }
 
-fn build_edit_result(
+pub(crate) fn build_edit_result(
     path_str: &str,
     original: String,
     new_content: String,

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -39,6 +39,32 @@ pub fn replace_text(
             format!("{start}:")
         }
     });
+    // Shell command-position is content-path only for now; for files, read +
+    // replace_in_content so require_change / command_position stay consistent.
+    if opts.command_position {
+        let original = std::fs::read_to_string(path).map_err(|e| {
+            crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::OperationFailed,
+                format!("failed to read {}: {e}", path.display()),
+            )
+        })?;
+        let content_result = replace_in_content(&original, from, to, opts)?;
+        let policy = crate::write::WritePolicy::default();
+        let applied =
+            super::write_if_apply(path, &content_result.new_content, mode, &policy, guard)?;
+        let path_str = path.to_string_lossy();
+        let mut result = super::build_edit_result(
+            &path_str,
+            content_result.original,
+            content_result.new_content,
+            applied,
+            "replace",
+            None,
+        );
+        result.match_count = content_result.match_count;
+        return Ok(result);
+    }
+
     let op = Operation::Replace {
         glob: None,
         path: Some(path.to_string_lossy().into()),
@@ -58,7 +84,20 @@ pub fn replace_text(
         after_context: opts.after_context.clone(),
         unique: opts.unique,
     };
-    replace_write(op, path, mode, guard, opts.fuzzy)
+    let result = replace_write(op, path, mode, guard, opts.fuzzy)?;
+    if opts.require_change && !result.changed && result.match_count == 0 {
+        let similar = crate::fallback::find_similar_targets(&result.original_content, from, 3);
+        let mut msg = format!("no matches for {:?}", from);
+        if !similar.is_empty() {
+            msg.push_str(&format!(" (did you mean: {}?)", similar.join(", ")));
+        }
+        return Err(
+            crate::fallback::EditError::new(crate::fallback::EditErrorKind::NoMatch, msg)
+                .with_similar(similar)
+                .into(),
+        );
+    }
+    Ok(result)
 }
 
 /// Unified write path for replace operations.
@@ -315,6 +354,27 @@ pub fn replace_in_content(
         bail!("whole_line and multiline cannot be combined");
     }
 
+    // Shell command-position path (#1494): only rewrite invocable command tokens.
+    if opts.command_position {
+        if is_regex || opts.whole_line || opts.multiline || opts.nth.is_some() {
+            return Err(crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::InvalidInput,
+                "command_position cannot be combined with regex, whole_line, multiline, or nth",
+            )
+            .into());
+        }
+        if opts.insert_before.is_some() || opts.insert_after.is_some() {
+            return Err(crate::fallback::EditError::new(
+                crate::fallback::EditErrorKind::InvalidInput,
+                "command_position cannot be combined with insert_before/insert_after",
+            )
+            .into());
+        }
+        let (new_content, count) =
+            crate::ops::shell_token::replace_command_position(content, from, to);
+        return finalize_content_replace(content, from, new_content, count, opts);
+    }
+
     let compiled_re = ops::replace::compile_replace_regex(
         from,
         is_regex,
@@ -386,11 +446,14 @@ pub fn replace_in_content(
     let new_content = new_content.into_owned();
 
     if opts.unique && count > 1 {
-        anyhow::bail!(
-            "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
-            from,
-            count
-        );
+        return Err(crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::AmbiguousTarget,
+            format!(
+                "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
+                from, count
+            ),
+        )
+        .into());
     }
 
     // Fuzzy/context fallback (#1286, #1315): when exact match fails and fuzzy
@@ -448,9 +511,37 @@ pub fn replace_in_content(
                 if !similar.is_empty() {
                     msg.push_str(&format!(" (did you mean: {}?)", similar.join(", ")));
                 }
-                bail!("{msg}");
+                let mut err =
+                    crate::fallback::EditError::new(crate::fallback::EditErrorKind::NoMatch, msg)
+                        .with_similar(similar);
+                if let Some(s) = edit_error.suggestion.clone() {
+                    err = err.with_suggestion(s);
+                }
+                return Err(err.into());
             }
         }
+    }
+
+    finalize_content_replace(content, from, new_content, count, opts)
+}
+
+/// Shared zero-match / success finalization for content replace paths (#1492).
+fn finalize_content_replace(
+    content: &str,
+    from: &str,
+    new_content: String,
+    count: usize,
+    opts: &ReplaceOptions,
+) -> anyhow::Result<ContentEditResult> {
+    if opts.unique && count > 1 {
+        return Err(crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::AmbiguousTarget,
+            format!(
+                "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
+                from, count
+            ),
+        )
+        .into());
     }
 
     if count == 0 && opts.if_exists {
@@ -461,6 +552,19 @@ pub fn replace_in_content(
             changed: false,
             match_count: 0,
         });
+    }
+
+    if count == 0 && opts.require_change {
+        let similar = crate::fallback::find_similar_targets(content, from, 3);
+        let mut msg = format!("no matches for {:?}", from);
+        if !similar.is_empty() {
+            msg.push_str(&format!(" (did you mean: {}?)", similar.join(", ")));
+        }
+        return Err(
+            crate::fallback::EditError::new(crate::fallback::EditErrorKind::NoMatch, msg)
+                .with_similar(similar)
+                .into(),
+        );
     }
 
     let changed = content != new_content;

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3696,6 +3696,326 @@ fn apply_content_edits_to_file_respects_guard() {
         err.to_string().contains("guard") || err.to_string().contains("escapes"),
         "got: {err}"
     );
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::GuardRejected)
+    );
     assert_eq!(fs::read_to_string(&outside).unwrap(), "secret\n");
     let _ = fs::remove_file(&outside);
+}
+
+// ── #1492 require_change + structured EditError ───────────────────────────
+
+#[test]
+fn replace_in_content_require_change_true_no_match() {
+    let err = replace_in_content(
+        "hello world",
+        "missing",
+        "x",
+        &ReplaceOptions {
+            require_change: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NoMatch)
+    );
+    let e = crate::fallback::edit_error_ref(&err).expect("EditError in chain");
+    assert!(e.similar_targets.is_empty() || !e.message.is_empty());
+}
+
+#[test]
+fn replace_in_content_require_change_false_no_match_ok() {
+    let r = replace_in_content("hello world", "missing", "x", &ReplaceOptions::default()).unwrap();
+    assert!(!r.changed);
+    assert_eq!(r.match_count, 0);
+    assert_eq!(r.new_content, "hello world");
+}
+
+#[test]
+fn replace_in_content_unique_multi_is_ambiguous() {
+    let err = replace_in_content(
+        "a a a",
+        "a",
+        "b",
+        &ReplaceOptions {
+            unique: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::AmbiguousTarget)
+    );
+}
+
+#[test]
+fn replace_in_content_command_position_pip() {
+    let r = replace_in_content(
+        "pip install x\nuv pip install\npipenv install\n",
+        "pip",
+        "uv",
+        &ReplaceOptions {
+            command_position: true,
+            require_change: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(r.changed);
+    assert_eq!(r.match_count, 1);
+    assert_eq!(
+        r.new_content,
+        "uv install x\nuv pip install\npipenv install\n"
+    );
+}
+
+#[test]
+fn replace_in_content_command_position_no_match_with_require_change() {
+    let err = replace_in_content(
+        "uv pip install\n",
+        "pip",
+        "uv",
+        &ReplaceOptions {
+            command_position: true,
+            require_change: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NoMatch)
+    );
+}
+
+// ── #1493 AST file mutators + in-content signature ────────────────────────
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_api_apply_and_preview() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(&file, "fn foo() { let x = 1; foo(); }\n").unwrap();
+
+    let preview = ast_rename(&file, "foo", "bar", ApplyMode::Preview, None).unwrap();
+    assert!(preview.changed);
+    assert!(!preview.applied);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn foo() { let x = 1; foo(); }\n"
+    );
+
+    let applied = ast_rename(&file, "foo", "bar", ApplyMode::Apply, None).unwrap();
+    assert!(applied.applied);
+    assert!(applied.match_count >= 1);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("fn bar"), "got: {on_disk}");
+    assert!(!on_disk.contains("fn foo"));
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_no_match_is_structured() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(&file, "fn keep() {}\n").unwrap();
+    let err = ast_rename(&file, "missing", "x", ApplyMode::Preview, None).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NoMatch)
+    );
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_replace_in_symbol_api() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(
+        &file,
+        "fn outer() {\n    let target = 1;\n}\nfn other() {\n    let target = 2;\n}\n",
+    )
+    .unwrap();
+    let result =
+        ast_replace_in_symbol(&file, "outer", "target", "value", ApplyMode::Apply, None).unwrap();
+    assert!(result.changed);
+    assert!(result.applied);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("let value = 1"), "got: {on_disk}");
+    assert!(
+        on_disk.contains("let target = 2"),
+        "other symbol untouched: {on_disk}"
+    );
+}
+
+#[cfg(feature = "ast")]
+#[test]
+fn ast_rewrite_signature_in_content_structured() {
+    use crate::ast::Language;
+    use crate::ast::rewrite::FunctionSigEdit;
+
+    let src = "fn process(x: i32) {}\n";
+    let edit = FunctionSigEdit {
+        parameters: Some("(x: u64)".into()),
+        return_type: Some("-> u64".into()),
+        ..Default::default()
+    };
+    // In-content API is on ast_write module (files/cli feature).
+    #[cfg(any(feature = "cli", feature = "files"))]
+    {
+        let r =
+            ast_rewrite_signature_in_content(src, "process", &edit, None, Language::Rust).unwrap();
+        assert!(r.changed);
+        assert!(r.new_content.contains("u64"), "got: {}", r.new_content);
+    }
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rewrite_signature_in_content_no_match() {
+    use crate::ast::Language;
+    use crate::ast::rewrite::FunctionSigEdit;
+
+    let err = ast_rewrite_signature_in_content(
+        "fn keep() {}\n",
+        "missing",
+        &FunctionSigEdit {
+            parameters: Some("(x: i32)".into()),
+            ..Default::default()
+        },
+        None,
+        Language::Rust,
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NoMatch)
+    );
+}
+
+// ── #1495 batch AST rename ────────────────────────────────────────────────
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_batch_two_files_success() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.rs");
+    let b = dir.path().join("b.rs");
+    fs::write(&a, "fn foo() {}\n").unwrap();
+    fs::write(&b, "fn foo() { foo(); }\n").unwrap();
+
+    let opts = AstRenameBatchOptions {
+        mode: ApplyMode::Apply,
+        continue_on_no_match: true,
+        fail_fast: false,
+    };
+    let results = ast_rename_batch(&[&a, &b], "foo", "bar", &opts, None).unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results[0].result.as_ref().unwrap().changed);
+    assert!(results[1].result.as_ref().unwrap().changed);
+    assert!(fs::read_to_string(&a).unwrap().contains("bar"));
+    assert!(fs::read_to_string(&b).unwrap().contains("bar"));
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_batch_continue_on_no_match() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.rs");
+    let b = dir.path().join("b.rs");
+    fs::write(&a, "fn foo() {}\n").unwrap();
+    fs::write(&b, "fn other() {}\n").unwrap();
+
+    let opts = AstRenameBatchOptions {
+        mode: ApplyMode::Apply,
+        continue_on_no_match: true,
+        ..Default::default()
+    };
+    let results = ast_rename_batch(&[&a, &b], "foo", "bar", &opts, None).unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results[0].result.is_ok());
+    let err = results[1].result.as_ref().unwrap_err();
+    assert_eq!(err.kind, EditErrorKind::NoMatch);
+    assert!(fs::read_to_string(&a).unwrap().contains("bar"));
+    assert!(fs::read_to_string(&b).unwrap().contains("other"));
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_batch_dedupes_paths() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.rs");
+    fs::write(&a, "fn foo() {}\n").unwrap();
+    let opts = AstRenameBatchOptions {
+        mode: ApplyMode::Preview,
+        ..Default::default()
+    };
+    let results = ast_rename_batch(&[&a, &a, &a], "foo", "bar", &opts, None).unwrap();
+    assert_eq!(results.len(), 1, "duplicate paths processed once");
+    assert!(results[0].result.as_ref().unwrap().changed);
+    // Preview: disk unchanged
+    assert_eq!(fs::read_to_string(&a).unwrap(), "fn foo() {}\n");
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_batch_guard_rejects_outside() {
+    let dir = TempDir::new().unwrap();
+    let outside = dir.path().parent().unwrap().join(format!(
+        "patchloom-batch-escape-{}.rs",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    fs::write(&outside, "fn foo() {}\n").unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let opts = AstRenameBatchOptions {
+        mode: ApplyMode::Apply,
+        continue_on_no_match: false,
+        fail_fast: false,
+    };
+    let results = ast_rename_batch(&[&outside], "foo", "bar", &opts, Some(&guard)).unwrap();
+    assert_eq!(results.len(), 1);
+    let err = results[0].result.as_ref().unwrap_err();
+    assert_eq!(err.kind, EditErrorKind::GuardRejected);
+    assert_eq!(fs::read_to_string(&outside).unwrap(), "fn foo() {}\n");
+    let _ = fs::remove_file(&outside);
+}
+
+// ── #1494 restore from latest backup ──────────────────────────────────────
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn restore_path_from_latest_backup_after_apply() {
+    use crate::backup::restore_path_from_latest_backup;
+
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("notes.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    let result = replace_text(
+        &file,
+        "original",
+        "modified",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(result.applied);
+    assert_eq!(fs::read_to_string(&file).unwrap(), "modified\n");
+
+    // Library apply uses file parent as backup project root.
+    let restored = restore_path_from_latest_backup(dir.path(), &file).unwrap();
+    assert!(restored, "should find backup session for path");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
 }

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -257,6 +257,149 @@ pub struct FunctionSigEdit {
     pub return_type: Option<String>,
 }
 
+/// Error from [`FunctionSigEdit::parse_rust`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseSigError {
+    pub message: String,
+}
+
+impl std::fmt::Display for ParseSigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ParseSigError {}
+
+impl FunctionSigEdit {
+    /// Parse a Rust-like signature fragment or full line into structured fields.
+    ///
+    /// Accepts forms such as:
+    /// - `pub fn foo(x: i32) -> T`
+    /// - `pub(crate) async fn bar(...)`
+    /// - `(x: i32) -> bool` (params-only)
+    /// - `fn name(a: Fn(i32) -> bool, b: Vec<(u8, u8)>) -> R`
+    ///
+    /// Nested parens inside params are handled. When only a full free-form
+    /// string is reliable, callers should prefer `new_signature` on
+    /// `ast_rewrite_signature` instead. See #1493.
+    pub fn parse_rust(sig: &str) -> Result<Self, ParseSigError> {
+        let s = sig.trim();
+        if s.is_empty() {
+            return Err(ParseSigError {
+                message: "empty signature".into(),
+            });
+        }
+
+        // Params-only form: starts with `(`
+        if s.starts_with('(') {
+            return parse_params_and_return(s);
+        }
+
+        let mut rest = s;
+        let mut visibility = None;
+
+        // Visibility
+        if rest.starts_with("pub(") {
+            if let Some(end) = rest.find(')') {
+                visibility = Some(rest[..=end].to_string());
+                rest = rest[end + 1..].trim_start();
+            }
+        } else if rest.starts_with("pub")
+            && rest
+                .chars()
+                .nth(3)
+                .map(|c| c.is_whitespace())
+                .unwrap_or(false)
+        {
+            visibility = Some("pub".into());
+            rest = rest[3..].trim_start();
+        }
+
+        // Skip common qualifiers
+        for q in ["async ", "const ", "unsafe ", "extern "] {
+            if rest.starts_with(q) {
+                rest = rest[q.len()..].trim_start();
+                // extern "C" form
+                if q.starts_with("extern")
+                    && rest.starts_with('"')
+                    && let Some(end) = rest[1..].find('"')
+                {
+                    rest = rest[end + 2..].trim_start();
+                }
+            }
+        }
+
+        // Optional `fn name`
+        if rest.starts_with("fn ") {
+            rest = rest[3..].trim_start();
+            // skip name until `(`
+            if let Some(paren) = rest.find('(') {
+                rest = &rest[paren..];
+            } else {
+                return Err(ParseSigError {
+                    message: format!("expected parameters after function name in `{sig}`"),
+                });
+            }
+        } else if rest.starts_with("fn(") {
+            rest = &rest[2..]; // keep `(`
+        }
+
+        if !rest.starts_with('(') {
+            return Err(ParseSigError {
+                message: format!("could not find parameter list in `{sig}`"),
+            });
+        }
+
+        let mut parsed = parse_params_and_return(rest)?;
+        if visibility.is_some() {
+            parsed.visibility = visibility;
+        }
+        Ok(parsed)
+    }
+}
+
+fn parse_params_and_return(s: &str) -> Result<FunctionSigEdit, ParseSigError> {
+    let mut depth = 0i32;
+    let mut params_end = None;
+    for (i, ch) in s.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    params_end = Some(i + 1);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let end = params_end.ok_or_else(|| ParseSigError {
+        message: format!("unbalanced parentheses in `{s}`"),
+    })?;
+    let parameters = Some(s[..end].to_string());
+    let after = s[end..].trim_start();
+    let return_type = if after.starts_with("->") {
+        Some(after.to_string())
+    } else if after.is_empty() {
+        None
+    } else {
+        // Tolerate trailing `{` body start
+        let cleaned = after.trim_end_matches('{').trim();
+        if cleaned.starts_with("->") {
+            Some(cleaned.to_string())
+        } else {
+            None
+        }
+    };
+    Ok(FunctionSigEdit {
+        visibility: None,
+        parameters,
+        return_type,
+    })
+}
+
 /// Rewrite function signature with structured changes for visibility, parameters, return type.
 /// Preserves function name, body, and other source exactly. Uses tree-sitter for location.
 ///
@@ -932,6 +1075,49 @@ mod tests {
             ..Default::default()
         };
         assert!(rewrite_function_signature(src, "nonexistent", &edit, Language::Python).is_none());
+    }
+
+    // ── FunctionSigEdit::parse_rust (#1493) ───────────────────────────
+
+    #[test]
+    fn parse_rust_pub_fn_with_return() {
+        let e = FunctionSigEdit::parse_rust("pub fn foo(x: i32) -> String").unwrap();
+        assert_eq!(e.visibility.as_deref(), Some("pub"));
+        assert_eq!(e.parameters.as_deref(), Some("(x: i32)"));
+        assert_eq!(e.return_type.as_deref(), Some("-> String"));
+    }
+
+    #[test]
+    fn parse_rust_pub_crate() {
+        let e = FunctionSigEdit::parse_rust("pub(crate) fn bar(a: u8)").unwrap();
+        assert_eq!(e.visibility.as_deref(), Some("pub(crate)"));
+        assert_eq!(e.parameters.as_deref(), Some("(a: u8)"));
+        assert!(e.return_type.is_none());
+    }
+
+    #[test]
+    fn parse_rust_params_only() {
+        let e = FunctionSigEdit::parse_rust("(x: i32) -> bool").unwrap();
+        assert!(e.visibility.is_none());
+        assert_eq!(e.parameters.as_deref(), Some("(x: i32)"));
+        assert_eq!(e.return_type.as_deref(), Some("-> bool"));
+    }
+
+    #[test]
+    fn parse_rust_nested_parens_in_params() {
+        let e = FunctionSigEdit::parse_rust("fn name(a: Fn(i32) -> bool, b: Vec<(u8, u8)>) -> R")
+            .unwrap();
+        assert_eq!(
+            e.parameters.as_deref(),
+            Some("(a: Fn(i32) -> bool, b: Vec<(u8, u8)>)")
+        );
+        assert_eq!(e.return_type.as_deref(), Some("-> R"));
+    }
+
+    #[test]
+    fn parse_rust_empty_is_err() {
+        assert!(FunctionSigEdit::parse_rust("").is_err());
+        assert!(FunctionSigEdit::parse_rust("   ").is_err());
     }
 
     // ── find_function_span tests ──────────────────────────────────

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -280,6 +280,40 @@ pub fn list_sessions(project_root: &Path) -> anyhow::Result<Vec<Manifest>> {
     Ok(sessions)
 }
 
+/// Restore a single path from the most recent backup session that contains it.
+///
+/// Used by agent hosts for post-Apply validate/revert recipes (#1494): Apply an
+/// edit, run a host validator, and on failure call this helper to put the file
+/// back without re-implementing backup layout.
+///
+/// Returns `true` if a backup entry was found and restored, `false` if no
+/// session had the path.
+pub fn restore_path_from_latest_backup(project_root: &Path, path: &Path) -> anyhow::Result<bool> {
+    let sessions = list_sessions(project_root)?;
+    // Match the same relative form used when writing the manifest.
+    let rel = sanitize_rel_path(path, project_root);
+    let rel_str = rel.to_string_lossy();
+    let abs_str = path.to_string_lossy();
+    let file_name = path.file_name();
+
+    for manifest in &sessions {
+        let hit = manifest.entries.iter().any(|e| {
+            e.path == rel_str
+                || e.path == abs_str
+                || e.path.ends_with(rel_str.as_ref())
+                || (file_name.is_some() && Path::new(&e.path).file_name() == file_name)
+        });
+        if hit {
+            // Restore the whole session (entries are per-session atomic unit).
+            // Hosts that need single-file-only restore can filter; sessions from
+            // single-file API Apply typically contain one entry.
+            restore_session(project_root, &manifest.timestamp)?;
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Restore a specific backup session, returning the number of files restored.
 pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<usize> {
     let session_dir = project_root.join(BACKUP_DIR).join(timestamp);
@@ -915,5 +949,32 @@ mod tests {
             "v1",
             "sequential undo should reach the original content"
         );
+    }
+
+    #[test]
+    fn restore_path_from_latest_backup_restores_bytes() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("data.txt");
+        std::fs::write(&file, "before").unwrap();
+
+        let mut session = BackupSession::new(dir.path()).unwrap();
+        session.save_before_write(&file).unwrap();
+        session.finalize().unwrap();
+
+        std::fs::write(&file, "after").unwrap();
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "after");
+
+        let ok = restore_path_from_latest_backup(dir.path(), &file).unwrap();
+        assert!(ok);
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "before");
+    }
+
+    #[test]
+    fn restore_path_from_latest_backup_missing_returns_false() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("never_backed_up.txt");
+        std::fs::write(&file, "x").unwrap();
+        let ok = restore_path_from_latest_backup(dir.path(), &file).unwrap();
+        assert!(!ok);
     }
 }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -103,6 +103,12 @@ pub enum EditErrorKind {
     ConflictingEdit,
     /// The file could not be parsed.
     ParseError,
+    /// Path rejected by workspace PathGuard (#1492).
+    GuardRejected,
+    /// Invalid arguments or options for the edit.
+    InvalidInput,
+    /// I/O or other operational failure.
+    OperationFailed,
 }
 
 impl std::fmt::Display for EditErrorKind {
@@ -113,8 +119,55 @@ impl std::fmt::Display for EditErrorKind {
             EditErrorKind::SyntaxInvalid => write!(f, "syntax_invalid"),
             EditErrorKind::ConflictingEdit => write!(f, "conflicting_edit"),
             EditErrorKind::ParseError => write!(f, "parse_error"),
+            EditErrorKind::GuardRejected => write!(f, "guard_rejected"),
+            EditErrorKind::InvalidInput => write!(f, "invalid_input"),
+            EditErrorKind::OperationFailed => write!(f, "operation_failed"),
         }
     }
+}
+
+impl EditError {
+    /// Build a structured edit error.
+    pub fn new(kind: EditErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            suggestion: None,
+            similar_targets: Vec::new(),
+        }
+    }
+
+    /// Attach similar-target suggestions (did-you-mean).
+    pub fn with_similar(mut self, similar: Vec<String>) -> Self {
+        self.similar_targets = similar;
+        self
+    }
+
+    /// Attach a single suggestion string.
+    pub fn with_suggestion(mut self, suggestion: impl Into<String>) -> Self {
+        self.suggestion = Some(suggestion.into());
+        self
+    }
+}
+
+/// Downcast an `anyhow` error chain to [`EditErrorKind`] when present.
+pub fn edit_error_kind(err: &anyhow::Error) -> Option<EditErrorKind> {
+    for cause in err.chain() {
+        if let Some(e) = cause.downcast_ref::<EditError>() {
+            return Some(e.kind);
+        }
+    }
+    None
+}
+
+/// Downcast an `anyhow` error chain to [`EditError`] when present.
+pub fn edit_error_ref(err: &anyhow::Error) -> Option<&EditError> {
+    for cause in err.chain() {
+        if let Some(e) = cause.downcast_ref::<EditError>() {
+            return Some(e);
+        }
+    }
+    None
 }
 
 /// Result of `validate_edit()`: whether the edit would produce valid output.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,13 +71,34 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 //!
-//! For AST signature edits (bline #1459 / #821 follow-through):
+//! For AST signature edits (bline #1459 / #821 follow-through, #1493):
 //!
-//! - In-memory: `ast::rewrite::rewrite_function_signature` with `FunctionSigEdit`
-//! - On disk: `api::ast_rewrite_signature(path, name, &edit, new_signature, mode, guard?)`
+//! - In-memory: `api::ast_rewrite_signature_in_content` or
+//!   `ast::rewrite::rewrite_function_signature` with `FunctionSigEdit`
+//! - Parse Rust fragments: `FunctionSigEdit::parse_rust("pub fn f(x: i32) -> T")`
+//! - On disk: `api::ast_rewrite_signature`, `api::ast_rename`, `api::ast_replace_in_symbol`
+//! - Multi-file rename: `api::ast_rename_batch` (same-file serialization, per-file results; #1495)
 //! - Plans / MCP: op `ast.rewrite_signature` / tool `ast_rewrite_signature`
 //!
 //! CLI `ast rewrite-signature` is still optional; library + plan + MCP cover embedders.
+//!
+//! Fail-closed text edits for agent hosts (#1492): set `ReplaceOptions.require_change = true`
+//! so zero matches become `EditErrorKind::NoMatch` (not `Ok(changed=false)`). Match kinds via
+//! `api::edit_error_kind(&err)` without scraping English. Example:
+//!
+//! ```rust,no_run
+//! use patchloom::api::{self, ReplaceOptions, edit_error_kind, EditErrorKind};
+//! let opts = ReplaceOptions { require_change: true, ..Default::default() };
+//! match api::replace_in_content("a b", "missing", "x", &opts) {
+//!     Ok(r) => assert!(r.changed),
+//!     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::NoMatch)),
+//! }
+//! ```
+//!
+//! Shell command-position matching (#1494): opt-in `ReplaceOptions.command_position`
+//! rewrites invocable tokens (`pip install`) without touching arguments (`uv pip`) or
+//! longer words (`pipenv`). Not the same as `word_boundary`. Post-Apply validate/revert:
+//! host runs a validator, then `backup::restore_path_from_latest_backup(project_root, path)`.
 //!
 //! For several ordered text edits on **one buffer** then a single write (agent intent engines):
 //! use `api::apply_content_edits` / `api::apply_content_edits_to_file` with
@@ -182,9 +203,10 @@ pub mod write;
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use api::search_one_file;
 pub use api::{
-    ApplyMode, ContentEditResult, EditResult, Hunk, PatchFile, PatchLine, ReplaceOptions,
-    SearchOptions, SearchResult, WritePolicyOptions, build_context_lines, format_search_results,
-    parse_unified_diff, search_file, text_diff,
+    ApplyMode, ContentEditResult, EditError, EditErrorKind, EditResult, Hunk, PatchFile, PatchLine,
+    ReplaceOptions, SearchOptions, SearchResult, WritePolicyOptions, build_context_lines,
+    edit_error_kind, edit_error_ref, format_search_results, parse_unified_diff, search_file,
+    text_diff,
 };
 pub use plan::Plan;
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -5,3 +5,4 @@ pub mod patch;
 pub mod read;
 pub mod replace;
 pub mod search;
+pub mod shell_token;

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -1,0 +1,203 @@
+//! Shell command-position token matching for agent hosts (#1494).
+//!
+//! A token is in **command position** when it is the invocable command of a
+//! simple shell fragment: start of line (after whitespace), after `&&` `|` `;`,
+//! or after transparent prefixes (`sudo`, `env KEY=val`…). It is **not**
+//! command position when it is an argument (`uv pip`) or inside a longer
+//! word (`pipenv`).
+
+/// Transparent prefixes that may appear before a command without making the
+/// next token an argument.
+const TRANSPARENT_PREFIXES: &[&str] = &[
+    "sudo", "doas", "env", "command", "builtin", "exec", "time", "nice", "nohup",
+];
+
+/// Return true if `token` at byte range `[start, end)` is in shell command position.
+pub fn is_command_position(content: &str, start: usize, end: usize) -> bool {
+    if start > content.len() || end > content.len() || start >= end {
+        return false;
+    }
+    // Must be a standalone token (word boundary).
+    let bytes = content.as_bytes();
+    if start > 0 && is_token_char(bytes[start - 1]) {
+        return false;
+    }
+    if end < bytes.len() && is_token_char(bytes[end]) {
+        return false;
+    }
+
+    let before = &content[..start];
+    // Walk backward over whitespace and transparent prefixes on this command fragment.
+    let mut rest = before;
+    loop {
+        rest = rest.trim_end();
+        if rest.is_empty() {
+            return true;
+        }
+        let last = rest.as_bytes()[rest.len() - 1];
+        // Command separator → command position.
+        if matches!(last, b'|' | b';' | b'\n' | b'\r') {
+            return true;
+        }
+        // `&&` or `||`
+        if rest.ends_with("&&") || rest.ends_with("||") {
+            return true;
+        }
+        // After `$(` or backtick open is still a subshell command position.
+        if last == b'(' || last == b'`' {
+            return true;
+        }
+
+        // Peel one transparent prefix token (or env assignment) from the end.
+        let Some((prefix_start, token)) = last_shell_token(rest) else {
+            return false;
+        };
+        if is_env_assignment(token) {
+            rest = &rest[..prefix_start];
+            continue;
+        }
+        if TRANSPARENT_PREFIXES.contains(&token) {
+            rest = &rest[..prefix_start];
+            continue;
+        }
+        // Preceded by a real word → argument position (e.g. `uv pip`, `python -m pip`).
+        return false;
+    }
+}
+
+/// Collect all non-overlapping command-position matches of `token` (literal).
+pub fn find_command_position_matches(content: &str, token: &str) -> Vec<(usize, usize)> {
+    if token.is_empty() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut search_from = 0;
+    while let Some(rel) = content[search_from..].find(token) {
+        let start = search_from + rel;
+        let end = start + token.len();
+        if is_command_position(content, start, end) {
+            out.push((start, end));
+        }
+        search_from = start + token.len().max(1);
+    }
+    out
+}
+
+/// Replace all command-position occurrences of `from` with `to`.
+/// Returns (new_content, match_count).
+pub fn replace_command_position(content: &str, from: &str, to: &str) -> (String, usize) {
+    let matches = find_command_position_matches(content, from);
+    if matches.is_empty() {
+        return (content.to_string(), 0);
+    }
+    let mut out = String::with_capacity(content.len());
+    let mut last = 0;
+    for (start, end) in &matches {
+        out.push_str(&content[last..*start]);
+        out.push_str(to);
+        last = *end;
+    }
+    out.push_str(&content[last..]);
+    (out, matches.len())
+}
+
+fn is_token_char(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-' || b == b'.' || b == b'/'
+}
+
+fn is_env_assignment(token: &str) -> bool {
+    // KEY=value form used after `env`.
+    if let Some((k, _)) = token.split_once('=') {
+        !k.is_empty() && k.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    } else {
+        false
+    }
+}
+
+/// Last shell token in `s` (no leading/trailing ws). Returns (byte start, token).
+fn last_shell_token(s: &str) -> Option<(usize, &str)> {
+    let s = s.trim_end();
+    if s.is_empty() {
+        return None;
+    }
+    let bytes = s.as_bytes();
+    let end = s.len();
+    // Include KEY=val as one token.
+    let mut i = end;
+    while i > 0 {
+        let b = bytes[i - 1];
+        if is_token_char(b) || b == b'=' {
+            i -= 1;
+        } else {
+            break;
+        }
+    }
+    if i == end {
+        return None;
+    }
+    Some((i, &s[i..end]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pip_install_is_command() {
+        let c = "pip install x\n";
+        assert!(is_command_position(c, 0, 3));
+        let (out, n) = replace_command_position(c, "pip", "uv");
+        assert_eq!(n, 1);
+        assert_eq!(out, "uv install x\n");
+    }
+
+    #[test]
+    fn pipenv_not_command_for_pip() {
+        let c = "pipenv install\n";
+        assert!(find_command_position_matches(c, "pip").is_empty());
+        let (_, n) = replace_command_position(c, "pip", "uv");
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn uv_pip_argument_not_command() {
+        let c = "uv pip install\n";
+        assert!(find_command_position_matches(c, "pip").is_empty());
+    }
+
+    #[test]
+    fn python_m_pip_not_command() {
+        let c = "python -m pip install\n";
+        assert!(find_command_position_matches(c, "pip").is_empty());
+    }
+
+    #[test]
+    fn sudo_and_env_allow_command() {
+        assert_eq!(
+            replace_command_position("sudo pip install\n", "pip", "uv").0,
+            "sudo uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("env FOO=1 pip install\n", "pip", "uv").0,
+            "env FOO=1 uv install\n"
+        );
+    }
+
+    #[test]
+    fn separators_allow_command() {
+        for sep in ["&&", "|", ";"] {
+            let c = format!("cmd1 {sep} pip install\n");
+            let (out, n) = replace_command_position(&c, "pip", "uv");
+            assert_eq!(n, 1, "sep={sep}");
+            assert!(out.contains("uv install"), "sep={sep}: {out}");
+        }
+    }
+
+    #[test]
+    fn hyphenated_token() {
+        let c = "my-tool run\n";
+        let (out, n) = replace_command_position(c, "my-tool", "other");
+        assert_eq!(n, 1);
+        assert_eq!(out, "other run\n");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Bline-driven library API expansions refined in issues #1492–#1495.

- **#1492** `ReplaceOptions.require_change` (default false) turns zero matches into `EditErrorKind::NoMatch`; re-exports `EditError` / `EditErrorKind` / `edit_error_kind`; adds `GuardRejected` for PathGuard failures.
- **#1493** High-level AST writers: `ast_rename`, `ast_replace_in_symbol`, `ast_rewrite_signature_in_content`; `FunctionSigEdit::parse_rust` for Rust signature fragments.
- **#1494** Opt-in `command_position` shell token matching (fixed small grammar); `backup::restore_path_from_latest_backup` for host validate/revert recipes.
- **#1495** `ast_rename_batch` with path dedupe, same-file serialization, `continue_on_no_match`, per-file `EditResult` / `EditError`.

## Test plan

- [x] Unit tests for require_change (true/false, unique ambiguous, multi-op batch)
- [x] Shell command-position must-pass cases (`pip`, `pipenv`, `uv pip`, `python -m pip`, `sudo`/`env`, separators, hyphenated)
- [x] `parse_rust` (pub / pub(crate) / params-only / nested parens)
- [x] AST rename / replace_in_symbol / signature in-content NoMatch
- [x] Batch rename: two files, continue on no-match, path dedupe, Preview no write, guard reject
- [x] restore_path_from_latest_backup round-trip
- [x] `make check-fast` green
- [x] `cargo test --lib --no-default-features --features "ast,files"` green

Closes #1492
Closes #1493
Closes #1494
Closes #1495