### PR TITLE
test: MPI cycle harden Bline API surface (#1492-#1495 follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,18 +272,25 @@ patchloom = { default-features = false }
 ```
 
 ```rust
-use patchloom::api::{self, ApplyMode};
+use patchloom::api::{self, ApplyMode, ReplaceOptions, edit_error_kind, EditErrorKind};
 use std::path::Path;
 
 // Replace text (preview only, no disk write)
 let result = api::replace_text(
     Path::new("src/config.rs"),
     "old_value", "new_value",
-    &api::ReplaceOptions::default(),
+    &ReplaceOptions::default(),
     ApplyMode::Preview,
     None,
 )?;
 println!("{}", result.diff);
+
+// Fail closed: zero matches become EditErrorKind::NoMatch (agent hosts)
+let opts = ReplaceOptions { require_change: true, ..Default::default() };
+match api::replace_in_content("body", "missing", "x", &opts) {
+    Ok(r) => println!("changed={}", r.changed),
+    Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::NoMatch)),
+}
 
 // Set a value in a JSON file
 api::doc_set(
@@ -295,7 +302,9 @@ api::doc_set(
 )?;
 ```
 
-All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking and binary detection), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS per #781); see the `containment` and `api` module rustdocs. See the `patchloom::api` module docs for the full surface (includes `search_directory` with context/globs/max_results for content search, added in recent library expansions). Recent work: #785 merged (assertion hygiene); gate addressed #779 (full context+multi for search_directory) and #784 (test auditor).
+All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking and binary detection), `backup` (`restore_path_from_latest_backup` for post-Apply validate/revert), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS); see the `containment` and `api` module rustdocs.
+
+Notable library options (not CLI flags): `ReplaceOptions.require_change`, `ReplaceOptions.command_position` (shell invocable tokens only), AST mutators `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
 
 ## Getting started
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -71,15 +71,17 @@ Rust tools. Disable default features to omit CLI (clap), MCP server, and AST:
 patchloom = { default-features = false }
 ```
 
-To add AST support without CLI/MCP:
+To add AST support without CLI/MCP (embedders such as Bline typically use
+`ast` + `files` for plan execution and AST file mutators):
 
 ```toml
-patchloom = { default-features = false, features = ["ast"] }
+patchloom = { default-features = false, features = ["ast", "files"] }
 ```
 
 See the [crate documentation](https://docs.rs/patchloom) for the full API
-surface and the [introduction](../introduction.md#as-a-rust-library) for
-a quick overview.
+surface (`require_change`, `command_position`, `ast_rename_batch`, backup
+restore helper) and the [introduction](../introduction.md#as-a-rust-library)
+for a quick overview.
 
 ## Shell completions
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -65,8 +65,14 @@ Patchloom is also a Rust library. Add it as a dependency to embed structured fil
 patchloom = { default-features = false }
 ```
 
-The `api` module exposes doc, replace, markdown, file, and patch operations. All API types are `Send + Sync`. Disabling default features omits the MCP server and its async dependencies.
+The `api` module exposes doc, replace, markdown, file, patch, multi-op content
+edits, and (with `ast` + `files`) AST rename / signature rewrite helpers. All
+API types are `Send + Sync`. Disabling default features omits the MCP server and
+its async dependencies.
 
+Agent hosts often set `ReplaceOptions.require_change = true` so missing targets
+are structured errors (`EditErrorKind::NoMatch`) instead of soft no-ops. Opt-in
+`command_position` rewrites shell command tokens without touching arguments.
 See the [crate documentation](https://docs.rs/patchloom) for the full API surface.
 
 ## Get started

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -213,10 +213,13 @@ pub fn ast_replace_in_symbol(
 #[derive(Debug, Clone)]
 pub struct AstRenameBatchOptions {
     pub mode: ApplyMode,
-    /// Skip files with zero matches instead of recording them as errors.
-    /// Default true (agent-friendly best-effort).
+    /// When true (default), a per-file `NoMatch` is recorded and remaining
+    /// paths still run (agent-friendly best-effort). When false, the batch
+    /// stops after the first `NoMatch` (that error is still in the results).
     pub continue_on_no_match: bool,
     /// Stop after the first hard error (IO, parse, guard). Default false.
+    /// Independent of [`Self::continue_on_no_match`] (which only covers
+    /// `NoMatch`).
     pub fail_fast: bool,
 }
 
@@ -282,24 +285,18 @@ pub fn ast_rename_batch(
                     EditError::new(EditErrorKind::OperationFailed, e.to_string())
                 });
                 let is_no_match = edit_err.kind == EditErrorKind::NoMatch;
-                if is_no_match && opts.continue_on_no_match {
-                    out.push(AstRenameFileResult {
-                        path: path.to_path_buf(),
-                        result: Err(edit_err),
-                    });
-                    continue;
-                }
-                if opts.fail_fast && !is_no_match {
-                    out.push(AstRenameFileResult {
-                        path: path.to_path_buf(),
-                        result: Err(edit_err),
-                    });
-                    break;
-                }
                 out.push(AstRenameFileResult {
                     path: path.to_path_buf(),
                     result: Err(edit_err),
                 });
+                // NoMatch: stop when continue_on_no_match is false.
+                if is_no_match && !opts.continue_on_no_match {
+                    break;
+                }
+                // Hard errors: stop when fail_fast is true.
+                if !is_no_match && opts.fail_fast {
+                    break;
+                }
             }
         }
     }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -254,7 +254,8 @@ pub struct ReplaceOptions {
     /// When true, zero matches is an error ([`EditErrorKind::NoMatch`]) instead
     /// of `Ok(changed=false)`. Agent hosts that fail closed should set this.
     /// Default `false` preserves historical library/CLI soft no-match behavior.
-    /// `if_exists` still wins for zero matches (returns Ok unchanged).
+    /// When both this and [`Self::if_exists`] are true, `if_exists` wins
+    /// (returns Ok unchanged for zero matches).
     /// See #1492.
     pub require_change: bool,
     /// When true, only replace tokens in **shell command position** (start of

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -85,7 +85,9 @@ pub fn replace_text(
         unique: opts.unique,
     };
     let result = replace_write(op, path, mode, guard, opts.fuzzy)?;
-    if opts.require_change && !result.changed && result.match_count == 0 {
+    // if_exists intentionally softens zero-match (Ok unchanged). require_change
+    // must not override that: both true means if_exists wins (#1492 docs).
+    if opts.require_change && !opts.if_exists && !result.changed && result.match_count == 0 {
         let similar = crate::fallback::find_similar_targets(&result.original_content, from, 3);
         let mut msg = format!("no matches for {:?}", from);
         if !similar.is_empty() {

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -447,20 +447,11 @@ pub fn replace_in_content(
 
     let new_content = new_content.into_owned();
 
-    if opts.unique && count > 1 {
-        return Err(crate::fallback::EditError::new(
-            crate::fallback::EditErrorKind::AmbiguousTarget,
-            format!(
-                "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
-                from, count
-            ),
-        )
-        .into());
-    }
-
     // Fuzzy/context fallback (#1286, #1315): when exact match fails and fuzzy
     // or context is enabled, try resolve_with_fallback for anchor/similarity
     // matching (matches replace_write and tx engine behavior).
+    // Ambiguous (unique + count>1) is finalized below so command_position and
+    // the normal path share one check in finalize_content_replace.
     if count == 0
         && !is_regex
         && (opts.fuzzy || opts.before_context.is_some() || opts.after_context.is_some())

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4123,23 +4123,30 @@ fn ast_rename_batch_fail_fast_stops_after_hard_error() {
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
 #[test]
-fn ast_rename_batch_continue_on_no_match_false_records_error() {
+fn ast_rename_batch_continue_on_no_match_false_stops() {
     let dir = TempDir::new().unwrap();
-    let a = dir.path().join("a.rs");
-    let b = dir.path().join("b.rs");
-    fs::write(&a, "fn foo() {}\n").unwrap();
-    fs::write(&b, "fn other() {}\n").unwrap();
+    let miss = dir.path().join("miss.rs");
+    let after = dir.path().join("after.rs");
+    fs::write(&miss, "fn other() {}\n").unwrap();
+    fs::write(&after, "fn foo() {}\n").unwrap();
     let opts = AstRenameBatchOptions {
-        mode: ApplyMode::Preview,
+        mode: ApplyMode::Apply,
         continue_on_no_match: false,
         fail_fast: false,
     };
-    let results = ast_rename_batch(&[&a, &b], "foo", "bar", &opts, None).unwrap();
-    assert_eq!(results.len(), 2);
-    assert!(results[0].result.is_ok());
+    let results = ast_rename_batch(&[&miss, &after], "foo", "bar", &opts, None).unwrap();
     assert_eq!(
-        results[1].result.as_ref().unwrap_err().kind,
+        results.len(),
+        1,
+        "continue_on_no_match=false must stop after first NoMatch"
+    );
+    assert_eq!(
+        results[0].result.as_ref().unwrap_err().kind,
         EditErrorKind::NoMatch
+    );
+    assert!(
+        fs::read_to_string(&after).unwrap().contains("foo"),
+        "later paths must not run after NoMatch stop"
     );
 }
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4162,6 +4162,26 @@ fn ast_rename_batch_empty_names_are_invalid_input() {
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
 #[test]
+fn ast_rename_batch_empty_paths_is_ok_empty() {
+    let results = ast_rename_batch(&[], "foo", "bar", &AstRenameBatchOptions::default(), None)
+        .expect("empty path list is valid");
+    assert!(results.is_empty());
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_check_mode_does_not_write() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(&file, "fn foo() {}\n").unwrap();
+    let r = ast_rename(&file, "foo", "bar", ApplyMode::Check, None).unwrap();
+    assert!(r.changed);
+    assert!(!r.applied);
+    assert_eq!(fs::read_to_string(&file).unwrap(), "fn foo() {}\n");
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
 fn ast_rename_batch_guard_rejects_outside() {
     let dir = TempDir::new().unwrap();
     let outside = dir.path().parent().unwrap().join(format!(

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3792,6 +3792,118 @@ fn replace_in_content_command_position_no_match_with_require_change() {
     );
 }
 
+#[test]
+fn replace_in_content_if_exists_wins_over_require_change() {
+    let r = replace_in_content(
+        "hello",
+        "missing",
+        "x",
+        &ReplaceOptions {
+            require_change: true,
+            if_exists: true,
+            ..Default::default()
+        },
+    )
+    .expect("if_exists must soften require_change");
+    assert!(!r.changed);
+    assert_eq!(r.match_count, 0);
+}
+
+#[test]
+fn replace_in_content_command_position_rejects_regex() {
+    let err = replace_in_content(
+        "pip install\n",
+        "pip",
+        "uv",
+        &ReplaceOptions {
+            command_position: true,
+            regex: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_require_change_file_no_match() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "hello\n").unwrap();
+    let err = replace_text(
+        &file,
+        "missing",
+        "x",
+        &ReplaceOptions {
+            require_change: true,
+            ..Default::default()
+        },
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NoMatch)
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_if_exists_wins_over_require_change() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "hello\n").unwrap();
+    let r = replace_text(
+        &file,
+        "missing",
+        "x",
+        &ReplaceOptions {
+            require_change: true,
+            if_exists: true,
+            ..Default::default()
+        },
+        ApplyMode::Apply,
+        None,
+    )
+    .expect("if_exists must win on file path too");
+    assert!(!r.changed);
+    assert!(!r.applied);
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_command_position_on_file() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "pip install x\nuv pip install\n").unwrap();
+    let r = replace_text(
+        &file,
+        "pip",
+        "uv",
+        &ReplaceOptions {
+            command_position: true,
+            require_change: true,
+            ..Default::default()
+        },
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(r.applied);
+    assert_eq!(r.match_count, 1);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "uv install x\nuv pip install\n"
+    );
+}
+
 // ── #1493 AST file mutators + in-content signature ────────────────────────
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
@@ -3959,6 +4071,86 @@ fn ast_rename_batch_dedupes_paths() {
     assert!(results[0].result.as_ref().unwrap().changed);
     // Preview: disk unchanged
     assert_eq!(fs::read_to_string(&a).unwrap(), "fn foo() {}\n");
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_batch_fail_fast_stops_after_hard_error() {
+    let dir = TempDir::new().unwrap();
+    let good = dir.path().join("good.rs");
+    let outside = dir.path().parent().unwrap().join(format!(
+        "patchloom-fail-fast-{}.rs",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis()
+    ));
+    let after = dir.path().join("after.rs");
+    fs::write(&good, "fn foo() {}\n").unwrap();
+    fs::write(&outside, "fn foo() {}\n").unwrap();
+    fs::write(&after, "fn foo() {}\n").unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let opts = AstRenameBatchOptions {
+        mode: ApplyMode::Apply,
+        continue_on_no_match: true,
+        fail_fast: true,
+    };
+    // Process good first (ok), then outside (guard), then after must not run.
+    let results = ast_rename_batch(
+        &[&good, &outside, &after],
+        "foo",
+        "bar",
+        &opts,
+        Some(&guard),
+    )
+    .unwrap();
+    assert_eq!(results.len(), 2, "fail_fast should stop before third path");
+    assert!(results[0].result.is_ok());
+    assert_eq!(
+        results[1].result.as_ref().unwrap_err().kind,
+        EditErrorKind::GuardRejected
+    );
+    assert!(
+        fs::read_to_string(&after).unwrap().contains("foo"),
+        "third file must not be rewritten under fail_fast"
+    );
+    let _ = fs::remove_file(&outside);
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_batch_continue_on_no_match_false_records_error() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.rs");
+    let b = dir.path().join("b.rs");
+    fs::write(&a, "fn foo() {}\n").unwrap();
+    fs::write(&b, "fn other() {}\n").unwrap();
+    let opts = AstRenameBatchOptions {
+        mode: ApplyMode::Preview,
+        continue_on_no_match: false,
+        fail_fast: false,
+    };
+    let results = ast_rename_batch(&[&a, &b], "foo", "bar", &opts, None).unwrap();
+    assert_eq!(results.len(), 2);
+    assert!(results[0].result.is_ok());
+    assert_eq!(
+        results[1].result.as_ref().unwrap_err().kind,
+        EditErrorKind::NoMatch
+    );
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_batch_empty_names_are_invalid_input() {
+    let err = ast_rename_batch(&[], "", "x", &AstRenameBatchOptions::default(), None).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
 }
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -1,5 +1,9 @@
 //! Backup session management for undo safety net.
 //!
+//! size-waiver: accepted single-domain bulk (policy #1408). Session create,
+//! path sanitization, list/restore/prune, and host restore helper are one
+//! unit; tests co-located. Do not split for LOC alone (#1494 restore API).
+//!
 //! Before any `--apply` write, commands save the original content of each
 //! affected file to `.patchloom/backups/<timestamp>/`. The `patchloom undo`
 //! command restores the most recent (or a chosen) backup.

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -290,19 +290,18 @@ pub fn list_sessions(project_root: &Path) -> anyhow::Result<Vec<Manifest>> {
 /// session had the path.
 pub fn restore_path_from_latest_backup(project_root: &Path, path: &Path) -> anyhow::Result<bool> {
     let sessions = list_sessions(project_root)?;
-    // Match the same relative form used when writing the manifest.
+    // Match the same relative form used when writing the manifest. Exact
+    // match only: bare file-name matching would restore the wrong session
+    // when two paths share a basename under the same project root.
     let rel = sanitize_rel_path(path, project_root);
     let rel_str = rel.to_string_lossy();
     let abs_str = path.to_string_lossy();
-    let file_name = path.file_name();
 
     for manifest in &sessions {
-        let hit = manifest.entries.iter().any(|e| {
-            e.path == rel_str
-                || e.path == abs_str
-                || e.path.ends_with(rel_str.as_ref())
-                || (file_name.is_some() && Path::new(&e.path).file_name() == file_name)
-        });
+        let hit = manifest
+            .entries
+            .iter()
+            .any(|e| e.path == rel_str || e.path == abs_str);
         if hit {
             // Restore the whole session (entries are per-session atomic unit).
             // Hosts that need single-file-only restore can filter; sessions from
@@ -976,5 +975,30 @@ mod tests {
         std::fs::write(&file, "x").unwrap();
         let ok = restore_path_from_latest_backup(dir.path(), &file).unwrap();
         assert!(!ok);
+    }
+
+    #[test]
+    fn restore_path_does_not_match_on_basename_alone() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let a = dir.path().join("a");
+        let b = dir.path().join("b");
+        std::fs::create_dir_all(&a).unwrap();
+        std::fs::create_dir_all(&b).unwrap();
+        let file_a = a.join("same.txt");
+        let file_b = b.join("same.txt");
+        std::fs::write(&file_a, "A").unwrap();
+        std::fs::write(&file_b, "B").unwrap();
+
+        // Backup only a/same.txt under project root.
+        let mut session = BackupSession::new(dir.path()).unwrap();
+        session.save_before_write(&file_a).unwrap();
+        session.finalize().unwrap();
+        std::fs::write(&file_a, "A2").unwrap();
+
+        // Requesting b/same.txt must not restore a's session by basename.
+        let ok = restore_path_from_latest_backup(dir.path(), &file_b).unwrap();
+        assert!(!ok, "basename-only match would restore the wrong path");
+        assert_eq!(std::fs::read_to_string(&file_a).unwrap(), "A2");
+        assert_eq!(std::fs::read_to_string(&file_b).unwrap(), "B");
     }
 }

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -200,4 +200,26 @@ mod tests {
         assert_eq!(n, 1);
         assert_eq!(out, "other run\n");
     }
+
+    #[test]
+    fn empty_token_is_noop() {
+        let (out, n) = replace_command_position("pip install\n", "", "x");
+        assert_eq!(n, 0);
+        assert_eq!(out, "pip install\n");
+    }
+
+    #[test]
+    fn multiple_command_positions_on_line() {
+        // Second command after semicolon is rewritten; first too.
+        let (out, n) = replace_command_position("pip install; pip list\n", "pip", "uv");
+        assert_eq!(n, 2);
+        assert_eq!(out, "uv install; uv list\n");
+    }
+
+    #[test]
+    fn quoted_path_not_command_when_after_word() {
+        // `echo pip` should not rewrite pip as command.
+        let (_, n) = replace_command_position("echo pip\n", "pip", "uv");
+        assert_eq!(n, 0);
+    }
 }


### PR DESCRIPTION
## Summary

Multi-perspective improve cycle after #1497 landed the Bline embedder surface.

### Fixes
- **`continue_on_no_match: false` actually stops** the batch after first `NoMatch` (was a no-op)
- **`if_exists` wins over `require_change`** on the file `replace_text` path (content path already correct)
- **`restore_path_from_latest_backup` exact-path match** (basename-only match could restore the wrong session)

### Tests
- require_change / if_exists / command_position / fail_fast / empty batch / Check mode
- adversarial shell_token edges (empty token, multi-command, argument position)

### Docs
- README + introduction + installation document fail-closed replace, command_position, and `ast`+`files` embedder combo

## Test plan
- [x] `make check-fast`
- [x] targeted lib tests for new edges

Ref #1492
Ref #1493
Ref #1494
Ref #1495