### PR TITLE
fix(api): real path in apply_content_edits_to_file diff headers

### DIFF
--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -111,13 +111,16 @@ pub fn apply_content_edits_to_file(
     let original =
         std::fs::read_to_string(path).with_context(|| format!("failed to read {path_str}"))?;
     let batch = apply_content_edits(&original, edits)?;
+    // Rebuild the unified diff with the real path so EditResult.diff matches
+    // replace_text / other writers (not the in-memory `<buffer>` label). #1500
+    let diff = make_diff(&path_str, &batch.original, &batch.modified);
     let policy = WritePolicy::default();
     let applied = write_if_apply(path, &batch.modified, mode, &policy, guard)?;
     Ok(EditResult {
         path: path_str,
         original_content: batch.original,
         new_content: batch.modified,
-        diff: batch.diff,
+        diff,
         applied,
         changed: batch.changed,
         action: "content.edits",
@@ -203,6 +206,17 @@ mod tests {
         assert!(r.changed);
         assert_eq!(r.ops_applied, 2);
         assert_eq!(r.modified, "hi\n\nworld");
+        // Pure buffer helper keeps the `<buffer>` path label (#1500).
+        assert!(
+            r.diff.contains("--- a/<buffer>") && r.diff.contains("+++ b/<buffer>"),
+            "buffer helper must label headers as <buffer>, got:\n{}",
+            r.diff
+        );
+        assert!(
+            !r.diff.contains("a//") && !r.diff.contains("b//"),
+            "buffer headers must not double-slash: {}",
+            r.diff
+        );
     }
 
     #[test]

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3668,6 +3668,65 @@ fn apply_content_edits_to_file_writes_once() {
     assert_eq!(result.action, "content.edits");
     let on_disk = fs::read_to_string(&file).unwrap();
     assert_eq!(on_disk, "hi world\ndone\n");
+    // #1500: file helper must name the real path, not the buffer placeholder.
+    assert!(
+        result.diff.contains("notes.txt"),
+        "diff headers should include target path, got:\n{}",
+        result.diff
+    );
+    assert!(
+        !result.diff.contains("<buffer>"),
+        "file helper must not keep <buffer> label:\n{}",
+        result.diff
+    );
+    assert!(
+        !result.diff.contains("--- a//") && !result.diff.contains("+++ b//"),
+        "absolute path headers must not double-slash:\n{}",
+        result.diff
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_content_edits_to_file_diff_path_vs_buffer() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("cfg.toml");
+    fs::write(&file, "name = old\n").unwrap();
+    let edits = [ContentEdit::Replace {
+        old: "old".into(),
+        new: "new".into(),
+        options: ReplaceOptions::default(),
+    }];
+
+    let file_result =
+        apply_content_edits_to_file(&file, &edits, ApplyMode::Preview, None).expect("file preview");
+    let buffer_result = apply_content_edits("name = old\n", &edits).expect("buffer");
+
+    assert!(file_result.changed && buffer_result.changed);
+    assert!(
+        file_result.diff.contains("cfg.toml")
+            && file_result.diff.contains("--- a/")
+            && file_result.diff.contains("+++ b/"),
+        "file EditResult.diff should header the real path:\n{}",
+        file_result.diff
+    );
+    assert!(
+        !file_result.diff.contains("<buffer>"),
+        "file path headers must not use <buffer>:\n{}",
+        file_result.diff
+    );
+    assert!(
+        buffer_result.diff.contains("--- a/<buffer>")
+            && buffer_result.diff.contains("+++ b/<buffer>"),
+        "pure buffer helper keeps <buffer>:\n{}",
+        buffer_result.diff
+    );
+    // Absolute path (TempDir) must not produce a// after path_for_diff_header.
+    assert!(
+        !file_result.diff.contains("a//") && !file_result.diff.contains("b//"),
+        "no double-slash headers:\n{}",
+        file_result.diff
+    );
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]


### PR DESCRIPTION
## Summary

`apply_content_edits_to_file` reuses the in-memory batch diff labeled
`<buffer>`, so embedders (bline multi-op `edit_file`) see:

```diff
--- a/<buffer>
+++ b/<buffer>
```

instead of the path they passed in.

After the content batch succeeds, rebuild the unified diff with the real
path via `make_diff` (same path-for-header normalization as other writers,
so absolute paths do not become `a//`).

Pure `apply_content_edits` still uses `<buffer>`.

## Test plan

- [x] Unit: buffer helper keeps `<buffer>` headers
- [x] Unit: file helper headers include target path, no `<buffer>`, no `a//`
- [x] Side-by-side file vs buffer comparison test
- [x] `make check-fast`

Closes #1500