### PR TITLE
test: lock plan/API body-gap for signature rewrite

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1157,6 +1157,7 @@ The operations below are the building blocks inside `operations`.
 ### `ast.rewrite_signature`
 
 - **What it does:** Rewrites a function signature using tree-sitter. Structured fields `visibility`, `parameters`, and `return_type` map to [`FunctionSigEdit`](https://docs.rs/patchloom); optional `new_signature` replaces the whole signature span. Field `old` (alias `name`) is the function name. Library: `api::ast_rewrite_signature`. MCP: `ast_rewrite_signature`.
+- **Body gap:** High-level paths accept a logical `new_signature` without trailing whitespace and preserve the original gap before `{` (or insert a conventional space if the original was already glued). Trait/extern forms ending in `;` do not get a spurious space. See #1503 / `splice_function_signature`.
 - **Use when:** Changing parameter lists, visibility, or return types without a brittle line scan (agent hosts such as Bline).
 - **Failure behavior:** Missing function name exits 3 (`no_matches`) with the function name in the error; JSON plans report `error_kind: "no_matches"`.
 - **Related:** `ast.replace`, `ast.rename`

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3577,6 +3577,37 @@ fn ast_rewrite_signature_api_updates_params() {
     assert_eq!(result.action, "ast.rewrite_signature");
     let on_disk = fs::read_to_string(&file).unwrap();
     assert!(on_disk.contains("u64"), "got: {on_disk}");
+    assert!(
+        on_disk.contains("-> u64 {"),
+        "structured API path must keep body gap (#1503): {on_disk}"
+    );
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rewrite_signature_full_string_preserves_body_gap() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(&file, "pub fn add(a: i32, b: i32) -> i32 {\n    a + b\n}\n").unwrap();
+    let edit = crate::ast::rewrite::FunctionSigEdit::default();
+    // Logical signature with no trailing space (agent/embedder style).
+    let result = ast_rewrite_signature(
+        &file,
+        "add",
+        &edit,
+        Some("pub fn add(a: i32, b: i32, c: i32) -> i32"),
+        ApplyMode::Apply,
+        None,
+    )
+    .expect("full-string rewrite");
+    assert!(result.changed && result.applied);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.contains("-> i32 {"),
+        "full new_signature must not glue to brace: {on_disk}"
+    );
+    assert!(!on_disk.contains("i32{"), "got: {on_disk}");
+    assert!(on_disk.contains("c: i32"), "params updated: {on_disk}");
 }
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
@@ -3607,6 +3638,15 @@ fn ast_rewrite_signature_plan_execute() {
     assert!(
         on_disk.contains("name: &str"),
         "plan rewrite should update signature: {on_disk}"
+    );
+    // #1503: logical new_signature without trailing space must not glue to `{`.
+    assert!(
+        on_disk.contains("fn greet(name: &str) {"),
+        "plan path must preserve body gap, got: {on_disk}"
+    );
+    assert!(
+        !on_disk.contains("str){"),
+        "must not glue type to brace: {on_disk}"
     );
 }
 

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -1188,8 +1188,28 @@ mod tests {
 
     #[test]
     fn parse_rust_empty_is_err() {
-        assert!(FunctionSigEdit::parse_rust("").is_err());
-        assert!(FunctionSigEdit::parse_rust("   ").is_err());
+        let err = FunctionSigEdit::parse_rust("").expect_err("empty");
+        assert!(
+            err.message.contains("empty"),
+            "expected empty-signature error, got: {}",
+            err.message
+        );
+        let err2 = FunctionSigEdit::parse_rust("   ").expect_err("whitespace-only");
+        assert!(
+            err2.message.contains("empty"),
+            "expected empty-signature error, got: {}",
+            err2.message
+        );
+    }
+
+    #[test]
+    fn splice_function_signature_empty_new_sig_does_not_panic() {
+        let source = "fn f() -> i32 {\n    0\n}\n";
+        let span = find_function_span(source, "f", Language::Rust).unwrap();
+        let out = splice_function_signature(source, span.signature_range, "   ");
+        // Empty after trim: keep original gap + body; do not invent brace glue.
+        assert!(out.contains("{"), "body brace remains: {out}");
+        assert!(!out.contains("i32{"), "got: {out}");
     }
 
     // ── find_function_span tests ──────────────────────────────────

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,8 @@
 //! - In-memory: `api::ast_rewrite_signature_in_content` or
 //!   `ast::rewrite::rewrite_function_signature` with `FunctionSigEdit`
 //! - Parse Rust fragments: `FunctionSigEdit::parse_rust("pub fn f(x: i32) -> T")`
+//! - Full-string rewrites accept a logical signature without trailing space;
+//!   high-level helpers preserve the body gap before `{` (`splice_function_signature`, #1503)
 //! - On disk: `api::ast_rewrite_signature`, `api::ast_rename`, `api::ast_replace_in_symbol`
 //! - Multi-file rename: `api::ast_rename_batch` (same-file serialization, per-file results; #1495)
 //! - Plans / MCP: op `ast.rewrite_signature` / tool `ast_rewrite_signature`


### PR DESCRIPTION
## Summary

MPI cycle after #1497–#1504 Bline surface + signature body-gap fix.

### QA / Test Auditor
- Plan `ast.rewrite_signature` and file `api::ast_rewrite_signature` full-string path assert space before `{` (no `Type{`)
- Structured API path asserts `-> u64 {`
- `parse_rust` empty errors use `expect_err` + message check
- Empty/whitespace `splice_function_signature` does not panic or invent glue

### End User / Spec
- Reference `ast.rewrite_signature` documents body-gap behavior (#1503)
- `src/lib.rs` embedding notes mention `splice_function_signature`

### Other perspectives
- Maintainer: deps current, cargo-deny ok, release PR #1498 open (not merged without user OK)
- Ops: Makefile `check` vs AGENTS.md aligned
- Security / Perf / Compat / Arch / Contributor / Observability: no new actionable findings on recent surface

## Test plan
- [x] `make check-fast`
- [x] targeted lib tests for rewrite + plan paths