### PR TITLE
fix(api): content_edits match_count, shell flags; docs for 0.12.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,47 @@
+# Patchloom 0.12.0
+
+Library surface for agent hosts (Bline-class embedders): fail-closed text edits, AST file mutators, shell command-position replace, batch rename, honest multi-edit diffs, and signature rewrite spacing that matches how agents write signatures. Built on 0.11 containment and plan reliability.
+
+## Highlights
+
+Embedders can set `ReplaceOptions.require_change` so zero matches become structured `EditErrorKind::NoMatch` instead of soft `Ok(changed=false)`. High-level AST writers cover rename, replace-in-symbol, and signature rewrite (including full-string `new_signature` and `FunctionSigEdit::parse_rust`). Multi-file `ast_rename_batch` serializes same-path work and returns per-file results. Opt-in `command_position` rewrites invocable shell tokens without touching `uv pip` / `pipenv`. Post-Apply validate/revert gets `backup::restore_path_from_latest_backup`. Multi-op content edits put the real path in unified-diff headers. Signature rewrite preserves the space (or newline) before `{` when agents omit trailing whitespace on the new signature.
+
+## New features
+
+- **Fail-closed content replace.** `ReplaceOptions.require_change` (default false). Zero matches → `EditErrorKind::NoMatch` with similar-target suggestions when available. `if_exists` still wins when both are set. Re-exports `EditError` / `EditErrorKind` / `edit_error_kind` for kind matching without scraping English. (#1492, #1497)
+- **AST file mutators.** `api::ast_rename`, `api::ast_replace_in_symbol`, `api::ast_rewrite_signature_in_content`, plus on-disk `ast_rewrite_signature`. Zero identifier/symbol matches → `NoMatch`. (#1493, #1497)
+- **`FunctionSigEdit::parse_rust`.** Rust-first parse of pub / pub(crate) / params-only / nested-paren signatures. (#1493, #1497)
+- **Shell command-position matching.** Opt-in `ReplaceOptions.command_position` (not `word_boundary`). Must-pass grammar: bare `pip`, not `pipenv` / `uv pip` / `python -m pip`; `sudo` / `env KEY=val` and option flags like `-E` / `-p` allowed before the command; separators `&&` `|` `;`. (#1494, #1497)
+- **Validate/revert helper.** `backup::restore_path_from_latest_backup(project_root, path)` restores from the newest session that contains that exact path (exact match only). (#1494, #1497)
+- **Batch AST rename.** `api::ast_rename_batch` with path dedupe, same-file serialization, `continue_on_no_match` (default true), `fail_fast` for hard errors, per-file `Result`. (#1495, #1497)
+
+## Bug fixes
+
+- **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
+- **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
+- **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)
+- **`if_exists` vs `require_change` on file replace.** File path honors the same "if_exists wins" rule as content replace. (#1499)
+- **Restore path matching.** Basename-only match removed so a different path with the same file name cannot restore the wrong session. (#1499)
+
+## Agent and library notes
+
+- Prefer `require_change: true` in agent hosts that treat zero matches as tool errors.
+- Use `command_position` only when rewriting shell invocable names; keep ordinary replace or word_boundary for identifiers.
+- Full-string signature rewrites may omit trailing space before `{`; the library normalizes the body gap.
+- Multi-op content edits expose rolled-up `match_count` on `ContentEditsResult` / file `EditResult`.
+
+## Numbers
+
+Rounded test counts and MCP inventory track the library expansions in this cycle. See the README badge and `make check-readme` for the live floor.
+
+## Upgrading
+
+```bash
+cargo install patchloom --locked
+# or
+patchloom = "0.12"
+```
+
+**Library:** New `ReplaceOptions` fields default to false (non-breaking). New AST batch / rename APIs need `features = ["ast", "files"]` (or default features). Match structured errors with `edit_error_kind(&err)`.
+
+**Release consumers:** No CLI flag changes required for the new library-only options. Plan/MCP `ast.rewrite_signature` inherits body-gap fix automatically.

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use crate::containment::PathGuard;
 
 #[cfg(any(feature = "cli", feature = "files"))]
-use super::{ApplyMode, EditResult, write_if_apply};
+use super::{ApplyMode, EditResult, build_edit_result, write_if_apply};
 
 #[cfg(any(feature = "cli", feature = "files"))]
 use crate::write::WritePolicy;
@@ -54,6 +54,9 @@ pub struct ContentEditsResult {
     pub changed: bool,
     /// Number of ops that successfully applied (equals `edits.len()` on success).
     pub ops_applied: usize,
+    /// Sum of replace match counts across all [`ContentEdit::Replace`] ops.
+    /// Insert/append/prepend contribute 0. Useful for agent ambiguity policies.
+    pub match_count: usize,
 }
 
 /// Apply ordered edits to an in-memory buffer.
@@ -71,10 +74,13 @@ pub fn apply_content_edits(
     let original = content.to_string();
     let mut current = content.to_string();
     let mut ops_applied = 0usize;
+    let mut match_count = 0usize;
 
     for (i, edit) in edits.iter().enumerate() {
-        current = apply_one(&current, edit)
+        let (next, n) = apply_one(&current, edit)
             .with_context(|| format!("content edit {} of {} failed", i + 1, edits.len()))?;
+        current = next;
+        match_count = match_count.saturating_add(n);
         ops_applied += 1;
     }
 
@@ -86,6 +92,7 @@ pub fn apply_content_edits(
         diff,
         changed,
         ops_applied,
+        match_count,
     })
 }
 
@@ -111,30 +118,27 @@ pub fn apply_content_edits_to_file(
     let original =
         std::fs::read_to_string(path).with_context(|| format!("failed to read {path_str}"))?;
     let batch = apply_content_edits(&original, edits)?;
-    // Rebuild the unified diff with the real path so EditResult.diff matches
-    // replace_text / other writers (not the in-memory `<buffer>` label). #1500
-    let diff = make_diff(&path_str, &batch.original, &batch.modified);
     let policy = WritePolicy::default();
     let applied = write_if_apply(path, &batch.modified, mode, &policy, guard)?;
-    Ok(EditResult {
-        path: path_str,
-        original_content: batch.original,
-        new_content: batch.modified,
-        diff,
+    // build_edit_result uses path for headers (#1500) and stays field-complete.
+    let mut result = build_edit_result(
+        &path_str,
+        batch.original,
+        batch.modified,
         applied,
-        changed: batch.changed,
-        action: "content.edits",
-        dest_path: None,
-        match_count: 0,
-        removed: 0,
-    })
+        "content.edits",
+        None,
+    );
+    result.match_count = batch.match_count;
+    Ok(result)
 }
 
-fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<String> {
+/// Returns (new content, replace match_count for this op).
+fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<(String, usize)> {
     match edit {
         ContentEdit::Replace { old, new, options } => {
             let result: ContentEditResult = replace_in_content(content, old, new, options)?;
-            Ok(result.new_content)
+            Ok((result.new_content, result.match_count))
         }
         ContentEdit::InsertBefore {
             anchor,
@@ -149,7 +153,7 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<String> {
                     out.push_str(&content[..idx]);
                     out.push_str(insert);
                     out.push_str(&content[idx..]);
-                    Ok(out)
+                    Ok((out, 0))
                 }
                 None => Err(EditError::new(
                     EditErrorKind::NoMatch,
@@ -172,7 +176,7 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<String> {
                     out.push_str(&content[..end]);
                     out.push_str(insert);
                     out.push_str(&content[end..]);
-                    Ok(out)
+                    Ok((out, 0))
                 }
                 None => Err(EditError::new(
                     EditErrorKind::NoMatch,
@@ -181,8 +185,8 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<String> {
                 .into()),
             }
         }
-        ContentEdit::Append { content: inject } => Ok(append_content(content, inject)),
-        ContentEdit::Prepend { content: inject } => Ok(prepend_content(content, inject)),
+        ContentEdit::Append { content: inject } => Ok((append_content(content, inject), 0)),
+        ContentEdit::Prepend { content: inject } => Ok((prepend_content(content, inject), 0)),
     }
 }
 
@@ -205,6 +209,7 @@ mod tests {
         let r = apply_content_edits("hello\n", &edits).unwrap();
         assert!(r.changed);
         assert_eq!(r.ops_applied, 2);
+        assert_eq!(r.match_count, 1, "replace match_count should roll up");
         assert_eq!(r.modified, "hi\n\nworld");
         // Pure buffer helper keeps the `<buffer>` path label (#1500).
         assert!(

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3706,6 +3706,10 @@ fn apply_content_edits_to_file_writes_once() {
     assert!(result.changed);
     assert!(result.applied);
     assert_eq!(result.action, "content.edits");
+    assert_eq!(
+        result.match_count, 1,
+        "file helper should surface rolled-up replace match_count"
+    );
     let on_disk = fs::read_to_string(&file).unwrap();
     assert_eq!(on_disk, "hi world\ndone\n");
     // #1500: file helper must name the real path, not the buffer placeholder.

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -2,9 +2,12 @@
 //!
 //! A token is in **command position** when it is the invocable command of a
 //! simple shell fragment: start of line (after whitespace), after `&&` `|` `;`,
-//! or after transparent prefixes (`sudo`, `env KEY=val`…). It is **not**
-//! command position when it is an argument (`uv pip`) or inside a longer
-//! word (`pipenv`).
+//! or after transparent prefixes (`sudo`, `env KEY=val`…, and common option
+//! flags like `-E` / `-p`). It is **not** command position when it is an
+//! argument (`uv pip`) or inside a longer word (`pipenv`).
+//!
+//! Known false positive: `command -v pip` may treat `pip` as command position
+//! because `-v` is peeled as a flag after the transparent `command` prefix.
 
 /// Transparent prefixes that may appear before a command without making the
 /// next token an argument.
@@ -53,6 +56,12 @@ pub fn is_command_position(content: &str, start: usize, end: usize) -> bool {
             return false;
         };
         if is_env_assignment(token) {
+            rest = &rest[..prefix_start];
+            continue;
+        }
+        // Option flags after sudo/time/env (`sudo -E pip`, `time -p pip`).
+        // Known false positive: `command -v pip` treats `pip` as command position.
+        if is_option_flag(token) {
             rest = &rest[..prefix_start];
             continue;
         }
@@ -112,6 +121,20 @@ fn is_env_assignment(token: &str) -> bool {
     } else {
         false
     }
+}
+
+/// Shell option flag (`-E`, `-p`, `--preserve-env`), not a command name.
+fn is_option_flag(token: &str) -> bool {
+    if token.len() < 2 || !token.starts_with('-') {
+        return false;
+    }
+    // Reject bare `-` / `--` and numeric tokens like `-1` used as args.
+    let body = token.trim_start_matches('-');
+    !body.is_empty()
+        && body
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && body.chars().any(|c| c.is_ascii_alphabetic())
 }
 
 /// Last shell token in `s` (no leading/trailing ws). Returns (byte start, token).
@@ -180,6 +203,18 @@ mod tests {
         assert_eq!(
             replace_command_position("env FOO=1 pip install\n", "pip", "uv").0,
             "env FOO=1 uv install\n"
+        );
+    }
+
+    #[test]
+    fn sudo_and_time_option_flags_allow_command() {
+        assert_eq!(
+            replace_command_position("sudo -E pip install\n", "pip", "uv").0,
+            "sudo -E uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("time -p pip install\n", "pip", "uv").0,
+            "time -p uv install\n"
         );
     }
 


### PR DESCRIPTION
## Summary

MPI loop cycle after #1505: real product gaps on the new embedder surface,
plus curated release notes for the open 0.12.0 release PR.

### Code
- **content_edits:** roll up replace `match_count`; file helper uses `build_edit_result` (path headers stay correct, struct stays field-complete)
- **shell command_position:** peel option flags (`sudo -E pip`, `time -p pip`); document `command -v` false positive

### Docs
- **RELEASE_NOTES.md** for v0.12.0 (Highlights / New features / Bug fixes / Numbers / Upgrading) so the final GitHub Release body is embedder-focused when #1498 merges

## Test plan
- [x] shell_token tests including `-E` / `-p`
- [x] content_edits match_count + file helper path tests
- [x] `make check-fast` (including verify-release-notes)