### PR TITLE
test(api): match_count rollup and require_change identity match

### DIFF
--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -283,7 +283,27 @@ mod tests {
         let r = apply_content_edits("same\n", &[]).unwrap();
         assert!(!r.changed);
         assert_eq!(r.ops_applied, 0);
+        assert_eq!(r.match_count, 0);
         assert_eq!(r.modified, "same\n");
+    }
+
+    #[test]
+    fn match_count_sums_multiple_replaces() {
+        let edits = [
+            ContentEdit::Replace {
+                old: "a".into(),
+                new: "A".into(),
+                options: ReplaceOptions::default(),
+            },
+            ContentEdit::Replace {
+                old: "b".into(),
+                new: "B".into(),
+                options: ReplaceOptions::default(),
+            },
+        ];
+        let r = apply_content_edits("a a b\n", &edits).unwrap();
+        assert_eq!(r.match_count, 3, "two a's + one b: {r:?}");
+        assert_eq!(r.modified, "A A B\n");
     }
 
     #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -260,9 +260,9 @@ pub struct ReplaceOptions {
     pub require_change: bool,
     /// When true, only replace tokens in **shell command position** (start of
     /// line / after `&&` `|` `;`, after transparent prefixes like `sudo` /
-    /// `env KEY=val`). Does not match inside longer tokens (`pip` vs `pipenv`)
-    /// or as arguments (`uv pip`). Opt-in; not the same as `word_boundary`.
-    /// See #1494.
+    /// `env KEY=val`, and option flags like `-E` / `-p`). Does not match inside
+    /// longer tokens (`pip` vs `pipenv`) or as arguments (`uv pip`). Opt-in;
+    /// not the same as `word_boundary`. See #1494.
     pub command_position: bool,
 }
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3838,6 +3838,23 @@ fn replace_in_content_require_change_false_no_match_ok() {
 }
 
 #[test]
+fn replace_in_content_require_change_identity_match_is_ok() {
+    // Matches exist but replacement equals the match: still Ok (not NoMatch).
+    let r = replace_in_content(
+        "hello hello",
+        "hello",
+        "hello",
+        &ReplaceOptions {
+            require_change: true,
+            ..Default::default()
+        },
+    )
+    .expect("require_change cares about zero matches, not identity replace");
+    assert!(!r.changed);
+    assert_eq!(r.match_count, 2);
+}
+
+#[test]
 fn replace_in_content_unique_multi_is_ambiguous() {
     let err = replace_in_content(
         "a a a",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,14 +98,16 @@
 //! ```
 //!
 //! Shell command-position matching (#1494): opt-in `ReplaceOptions.command_position`
-//! rewrites invocable tokens (`pip install`) without touching arguments (`uv pip`) or
-//! longer words (`pipenv`). Not the same as `word_boundary`. Post-Apply validate/revert:
-//! host runs a validator, then `backup::restore_path_from_latest_backup(project_root, path)`.
+//! rewrites invocable tokens (`pip install`, `sudo -E pip`) without touching arguments
+//! (`uv pip`) or longer words (`pipenv`). Not the same as `word_boundary`. Post-Apply
+//! validate/revert: host runs a validator, then
+//! `backup::restore_path_from_latest_backup(project_root, path)`.
 //!
 //! For several ordered text edits on **one buffer** then a single write (agent intent engines):
 //! use `api::apply_content_edits` / `api::apply_content_edits_to_file` with
 //! `ContentEdit::{Replace, InsertBefore, InsertAfter, Append, Prepend}` (all-or-nothing).
-//! Multi-file multi-op remains `execute_plan`.
+//! Results expose rolled-up `match_count` across replace ops. Multi-file multi-op remains
+//! `execute_plan`.
 //!
 //! **Note on results**: Single-file ops return `EditResult` (with `action`, `dest_path`,
 //! `match_count` for replace, and `removed` for `doc.delete` / `doc.delete_where`).


### PR DESCRIPTION
## Summary

MPI loop cycle 2 after #1506: contract locks for content_edits match_count
aggregation and require_change semantics (identity match is not NoMatch).

## Test plan
- [x] match_count_sums_multiple_replaces
- [x] require_change_identity_match_is_ok
- [x] make check-fast