### PR TITLE
test: lock body-gap on batch and MCP signature rewrite

### DIFF
--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -596,6 +596,15 @@ fn test_batch_ast_rewrite_signature() {
         content.contains("u64"),
         "batch rewrite_signature should update types: {content}"
     );
+    // #1503: structured batch path must keep space before body brace.
+    assert!(
+        content.contains("-> u64 {"),
+        "batch rewrite_signature must preserve body gap: {content}"
+    );
+    assert!(
+        !content.contains("u64{"),
+        "must not glue type to brace: {content}"
+    );
 }
 
 #[test]

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2775,6 +2775,14 @@ async fn test_mcp_ast_rewrite_signature_applies() {
         content.contains("u64"),
         "signature should be rewritten: {content}"
     );
+    assert!(
+        content.contains("-> u64 {"),
+        "MCP rewrite_signature must preserve body gap (#1503): {content}"
+    );
+    assert!(
+        !content.contains("u64{"),
+        "must not glue type to brace: {content}"
+    );
     client.cancel().await.unwrap();
 }
 


### PR DESCRIPTION
## Summary

MPI loop cycle 3: extend #1503 body-gap regression locks to batch CLI and
MCP `ast_rewrite_signature` integration tests (not only library unit tests).

## Test plan
- [x] test_batch_ast_rewrite_signature
- [x] test_mcp_ast_rewrite_signature_applies
- [x] make check-fast