### PR TITLE
test(api): content_edits crate-root re-exports and sudo -u -E peel

### DIFF
--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -2,6 +2,8 @@
 //!
 //! Compose sequential text operations on one buffer with all-or-nothing
 //! semantics, then optionally write once via [`apply_content_edits_to_file`].
+//! Results include rolled-up [`ContentEditsResult::match_count`] from replace
+//! ops (and the file helper surfaces the same on [`EditResult::match_count`]).
 
 use anyhow::Context;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,10 +207,10 @@ pub mod write;
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use api::search_one_file;
 pub use api::{
-    ApplyMode, ContentEditResult, EditError, EditErrorKind, EditResult, Hunk, PatchFile, PatchLine,
-    ReplaceOptions, SearchOptions, SearchResult, WritePolicyOptions, build_context_lines,
-    edit_error_kind, edit_error_ref, format_search_results, parse_unified_diff, search_file,
-    text_diff,
+    ApplyMode, ContentEdit, ContentEditResult, ContentEditsResult, EditError, EditErrorKind,
+    EditResult, Hunk, PatchFile, PatchLine, ReplaceOptions, SearchOptions, SearchResult,
+    WritePolicyOptions, apply_content_edits, build_context_lines, edit_error_kind, edit_error_ref,
+    format_search_results, parse_unified_diff, search_file, text_diff,
 };
 pub use plan::Plan;
 

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -245,6 +245,11 @@ mod tests {
             replace_command_position("sudo --user alice pip install\n", "pip", "uv").0,
             "sudo --user alice uv install\n"
         );
+        // Combined: user flag value then no-arg flags.
+        assert_eq!(
+            replace_command_position("sudo -u root -E pip install\n", "pip", "uv").0,
+            "sudo -u root -E uv install\n"
+        );
         // Still do not rewrite argument-position pip.
         assert_eq!(
             replace_command_position("echo -u pip\n", "pip", "uv").1,


### PR DESCRIPTION
## Summary

- Re-export `ContentEdit`, `ContentEditsResult`, and `apply_content_edits` from the crate root (alongside existing `ContentEditResult` / replace helpers) so embedders do not need the `api::` path for the multi-op buffer API.
- Document rolled-up `match_count` on the `content_edits` module docs.
- Regression test: `sudo -u root -E pip` peels both the user-flag value and subsequent no-arg flags before command-position match.

## Test plan

- [x] `cargo test --lib shell_token --all-features`
- [x] `cargo test --lib content_edits --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `make check-fast`