### PR TITLE
docs: reference library require_change and command_position

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,7 +30,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - Prefer `require_change: true` in agent hosts that treat zero matches as tool errors.
 - Use `command_position` only when rewriting shell invocable names; keep ordinary replace or word_boundary for identifiers.
 - Full-string signature rewrites may omit trailing space before `{`; the library normalizes the body gap.
-- Multi-op content edits expose rolled-up `match_count` on `ContentEditsResult` / file `EditResult`.
+- Multi-op content edits expose rolled-up `match_count` on `ContentEditsResult` / file `EditResult`. Crate-root re-exports include `ContentEdit`, `ContentEditsResult`, and `apply_content_edits`.
 
 ## Numbers
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -576,7 +576,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:command-position -->
 ### Library `ReplaceOptions.command_position`
 
-- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `xargs`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only.
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only.
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
 - **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after (`InvalidInput`).
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -566,6 +566,20 @@ These are meaningful command-specific modes that change how a top-level command 
 - **Use when:** The pattern matches multiple times and the distinguishing context comes after the match, not before.
 - **Prefer instead:** Use `--before-context` when the preceding lines are more distinctive.
 
+<!-- ref:replace-mode:require-change -->
+### Library `ReplaceOptions.require_change`
+
+- **What it does:** Zero matches become structured `EditErrorKind::NoMatch` instead of soft `Ok(changed=false)`. Embedders can match on kind without scraping English error text (`edit_error_kind`).
+- **Use when:** Agent hosts that treat a missed target as a tool error (fail closed). Default remains soft no-match for CLI and historical library callers.
+- **Prefer instead:** Leave the default when soft no-match is intentional. When both `require_change` and `if_exists` are set, `if_exists` wins (returns Ok unchanged).
+
+<!-- ref:replace-mode:command-position -->
+### Library `ReplaceOptions.command_position`
+
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `xargs`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only.
+- **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
+- **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after (`InvalidInput`).
+
 <!-- ref:create-mode:stdin -->
 ### `create --stdin`
 


### PR DESCRIPTION
## Summary

- Add `docs/reference` sections for library-only `ReplaceOptions.require_change` and `command_position` (embedder guidance, incompatibilities).
- Note crate-root content_edits re-exports in RELEASE_NOTES agent notes.

## Test plan

- [x] `make verify-release-notes`
- [ ] CI docs / link checks