### PR TITLE
feat(plan): require_change and command_position on replace

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -963,7 +963,7 @@ The operations below are the building blocks inside `operations`.
 - **Use when:** A text rewrite needs to share atomic rollback, formatting, or validation with other operations.
 - **Requires:** Exactly one of `to`, `insert_before`, or `insert_after`, matching top level `replace`.
 - **Regex insert semantics:** In regex mode, `insert_before` and `insert_after` preserve the matched text, they do not insert the raw pattern string.
-- **Optional fields:** `case_insensitive` (bool, default false), `multiline` (bool, default false), and `if_exists` (bool, default false) match the top level `replace --case-insensitive`, `--multiline`, and `--if-exists` flags.
+- **Optional fields:** `case_insensitive` (bool, default false), `multiline` (bool, default false), and `if_exists` (bool, default false) match the top level `replace --case-insensitive`, `--multiline`, and `--if-exists` flags. Library-aligned plan fields: `require_change` (bool, default false; hard-fails the op on zero matches when `if_exists` is false) and `command_position` (bool, default false; shell invocable rewrite).
 - **Related:** top level `replace`
 
 <!-- ref:tx-op:doc.set -->

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -83,6 +83,9 @@ pub fn replace_text(
         before_context: opts.before_context.clone(),
         after_context: opts.after_context.clone(),
         unique: opts.unique,
+        // require_change is applied below as structured EditError (not via tx bail).
+        require_change: false,
+        command_position: opts.command_position,
     };
     let result = replace_write(op, path, mode, guard, opts.fuzzy)?;
     // if_exists intentionally softens zero-match (Ok unchanged). require_change

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2374,6 +2374,8 @@ fn adapter_unchanged_returns_no_diff() {
         before_context: None,
         after_context: None,
         unique: false,
+        require_change: false,
+        command_position: false,
     };
 
     let result =

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -174,6 +174,8 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
                 before_context: None,
                 after_context: None,
                 unique: false,
+                require_change: false,
+                command_position: false,
             })
         }
 

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -429,6 +429,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Replace "v1" with "v2" in README.md (literal)"#);
@@ -454,6 +456,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -582,6 +586,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -611,6 +617,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Insert "// added" after "use crate" in lib.rs"#);
@@ -636,6 +644,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("whole-line"), "{desc}");
@@ -747,6 +757,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -776,6 +788,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -805,6 +819,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains(", multiline"), "missing multiline: {desc}");
@@ -831,6 +847,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("**/*.rs"), "{desc}");
@@ -856,6 +874,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("(delete)"), "{desc}");

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -382,6 +382,8 @@ impl PatchloomService {
                 before_context: p.before_context,
                 after_context: p.after_context,
                 unique: p.unique,
+                require_change: p.require_change,
+                command_position: p.command_position,
             };
             let mut tool_result = svc.run_one_op(replace_op, Some(p.strict))?;
 
@@ -529,6 +531,8 @@ impl PatchloomService {
                     before_context: None,
                     after_context: None,
                     unique: false,
+                    require_change: false,
+                    command_position: false,
                 })
                 .collect();
             svc.run_ops(ops, Some(p.strict))

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -60,6 +60,12 @@ pub(crate) struct ReplaceParams {
     /// Fail if the pattern matches more than once (enforce unambiguous edits).
     #[serde(default)]
     pub unique: bool,
+    /// Zero matches is an error (fail closed). Softened when if_exists is true.
+    #[serde(default)]
+    pub require_change: bool,
+    /// Only rewrite shell command-position tokens (not arguments / longer words).
+    #[serde(default)]
+    pub command_position: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -456,6 +456,8 @@ fn run_context_replace(
             before_context: args.before_context.clone(),
             after_context: args.after_context.clone(),
             unique: args.unique,
+            require_change: false,
+            command_position: false,
         })
         .collect();
 

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -55,6 +55,14 @@ pub enum Operation {
         /// Fail if the pattern matches more than once (enforce unambiguous edits).
         #[serde(default)]
         unique: bool,
+        /// Zero matches is an error (library fail-closed). Soft no-match when false.
+        /// When both this and `if_exists` are true, `if_exists` wins.
+        #[serde(default)]
+        require_change: bool,
+        /// Only rewrite shell command-position tokens (not arguments / longer words).
+        /// Literal only; incompatible with regex/case_insensitive/word_boundary/fuzzy.
+        #[serde(default)]
+        command_position: bool,
     },
     #[serde(rename = "doc.set")]
     DocSet {

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -350,6 +350,8 @@ mod basic {
                     before_context: Some("ctx".into()),
                     after_context: Some("ctx".into()),
                     unique: false,
+                    require_change: false,
+                    command_position: false,
                 },
             ),
             (

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -186,6 +186,8 @@ fn op_needs_doc_flush_for_replace() {
         after_context: None,
         if_exists: false,
         unique: false,
+        require_change: false,
+        command_position: false,
     };
     assert!(op_needs_doc_flush(&op));
 }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -356,6 +356,8 @@ mod tests {
                 before_context: None,
                 after_context: None,
                 unique: false,
+                require_change: false,
+                command_position: false,
             }],
             write_policy: None,
             strict: None,

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -44,6 +44,8 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         before_context,
         after_context,
         unique,
+        require_change,
+        command_position,
         ..
     } = op
     else {
@@ -57,6 +59,29 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             ..
         }
     );
+    let if_exists = matches!(
+        op,
+        Operation::Replace {
+            if_exists: true,
+            ..
+        }
+    );
+    if *command_position
+        && (regex_mode
+            || *case_insensitive
+            || word_boundary
+            || *whole_line
+            || *multiline
+            || nth.is_some()
+            || insert_before.is_some()
+            || insert_after.is_some()
+            || before_context.is_some()
+            || after_context.is_some())
+    {
+        anyhow::bail!(
+            "command_position cannot be combined with regex, whole_line, multiline, nth,              case_insensitive, word_boundary, insert_before/after, or context anchors"
+        );
+    }
     let use_regex = regex_mode || *case_insensitive || word_boundary;
     let replacement = replacement_text(
         old,
@@ -84,7 +109,11 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
     if let Some(p) = path {
         let file_path = tx.cwd.join(p);
         let content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
-        let (replaced, match_count) = if *whole_line {
+        let (replaced, match_count) = if *command_position {
+            let to = new_text.as_deref().unwrap_or("");
+            let (out, n) = crate::ops::shell_token::replace_command_position(content, old, to);
+            (std::borrow::Cow::Owned(out), n)
+        } else if *whole_line {
             replace_whole_lines(
                 content,
                 old,
@@ -196,6 +225,13 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     ));
                 }
             }
+            if *require_change && !if_exists {
+                let msg = tx
+                    .replace_hint
+                    .clone()
+                    .unwrap_or_else(|| format!("no matches for {old:?} in {p}"));
+                anyhow::bail!(msg);
+            }
             Ok(0)
         }
     } else if let Some(pattern) = glob {
@@ -269,7 +305,11 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 .get(&file_path)
                 .map(|(_, c)| c.clone())
                 .expect("read_and_probe guarantees entry exists in pending");
-            let (replaced, match_count) = if *whole_line {
+            let (replaced, match_count) = if *command_position {
+                let to = new_text.as_deref().unwrap_or("");
+                let (out, n) = crate::ops::shell_token::replace_command_position(&content, old, to);
+                (std::borrow::Cow::Owned(out), n)
+            } else if *whole_line {
                 replace_whole_lines(
                     &content,
                     old,
@@ -291,6 +331,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     replaced.into_owned(),
                 );
             }
+        }
+        if total_matches == 0 && *require_change && !if_exists {
+            anyhow::bail!("no matches for {old:?} (glob {pattern})");
         }
         Ok(total_matches)
     } else {
@@ -329,6 +372,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -363,6 +408,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -395,6 +442,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -429,6 +478,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -461,6 +512,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -495,6 +548,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -532,6 +587,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -581,6 +638,8 @@ mod tests {
             after_context: Some("port = 5432".into()),
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -627,6 +686,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -669,6 +730,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -709,6 +772,8 @@ mod tests {
             after_context: None,
             if_exists: false,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -718,5 +783,70 @@ mod tests {
             err.to_string().contains("range requires whole_line"),
             "should reject range without whole_line: {err}"
         );
+    }
+    #[test]
+    fn command_position_rewrites_sudo_pip() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("install.sh");
+        std::fs::write(&file, "sudo pip install x\nuv pip install\n").unwrap();
+        let op = Operation::Replace {
+            path: Some("install.sh".into()),
+            glob: None,
+            regex: false,
+            old: "pip".into(),
+            new_text: Some("uv".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            if_exists: false,
+            unique: false,
+            require_change: true,
+            command_position: true,
+        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
+        assert_eq!(count, 1);
+        assert_eq!(f.pending[&file].1, "sudo uv install x\nuv pip install\n");
+    }
+
+    #[test]
+    fn require_change_bails_on_zero_matches() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("f.txt");
+        std::fs::write(&file, "hello\n").unwrap();
+        let op = Operation::Replace {
+            path: Some("f.txt".into()),
+            glob: None,
+            regex: false,
+            old: "missing".into(),
+            new_text: Some("x".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            if_exists: false,
+            unique: false,
+            require_change: true,
+            command_position: false,
+        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        let err = execute_replace_op(&op, &mut tx).unwrap_err();
+        assert!(err.to_string().contains("no matches"), "{err}");
     }
 }

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -132,6 +132,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         }
     }
 
@@ -187,6 +189,8 @@ mod tests {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
         };
         let err = validate_operation(&op).unwrap_err();
         assert!(

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -515,6 +515,8 @@ mod tests {
                 before_context: None,
                 after_context: None,
                 unique: false,
+                require_change: false,
+                command_position: false,
             }],
             write_policy: None,
             format: None,


### PR DESCRIPTION
## Summary

- Add `require_change` and `command_position` (default false) to plan `Operation::Replace`.
- Wire through `tx/replace_op` (shell-token path + hard-fail on zero matches when `require_change` and not `if_exists`).
- MCP `ReplaceParams` + handler mapping; reference docs for tx replace.
- Unit tests for plan command_position and require_change.

Closes #1515

## Test plan

- [x] `cargo test --lib replace_op --all-features`
- [x] `cargo test --lib mcp_params_fields --all-features`
- [x] `make check-fast`