### PR TITLE
test: plan command_position integration and explain flags

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 
 - Prefer `require_change: true` in agent hosts that treat zero matches as tool errors.
 - Use `command_position` only when rewriting shell invocable names; keep ordinary replace or word_boundary for identifiers.
+- Plan `replace` and MCP replace accept the same `require_change` / `command_position` fields as the library API (default false).
 - Full-string signature rewrites may omit trailing space before `{`; the library normalizes the body gap.
 - Multi-op content edits expose rolled-up `match_count` on `ContentEditsResult` / file `EditResult`. Crate-root re-exports include `ContentEdit`, `ContentEditsResult`, and `apply_content_edits`.
 

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -42,6 +42,8 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             word_boundary,
             multiline,
             if_exists,
+            require_change,
+            command_position,
             ..
         } => {
             let target = path.as_deref().or(glob.as_deref()).unwrap_or("(all files)");
@@ -76,8 +78,18 @@ pub(super) fn describe_operation(op: &Operation) -> String {
                 .unwrap_or_default();
             let ml_str = if *multiline { ", multiline" } else { "" };
             let ie_str = if *if_exists { ", if-exists" } else { "" };
+            let rc_str = if *require_change {
+                ", require-change"
+            } else {
+                ""
+            };
+            let cp_str = if *command_position {
+                ", command-position"
+            } else {
+                ""
+            };
             format!(
-                "Replace \"{old}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{wb_str}{ml_str}{ie_str}{range_str})"
+                "Replace \"{old}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{wb_str}{ml_str}{ie_str}{rc_str}{cp_str}{range_str})"
             )
         }
         Operation::DocSet {
@@ -795,6 +807,36 @@ mod tests {
         assert!(
             desc.contains(", if-exists"),
             "missing if-exists flag: {desc}"
+        );
+    }
+
+    #[test]
+    fn describe_replace_require_change_and_command_position_flags() {
+        let op = Operation::Replace {
+            path: Some("install.sh".into()),
+            glob: None,
+            regex: false,
+            old: "pip".into(),
+            new_text: Some("uv".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: false,
+            range: None,
+            word_boundary: false,
+            before_context: None,
+            after_context: None,
+            unique: false,
+            require_change: true,
+            command_position: true,
+        };
+        let desc = describe_operation(&op);
+        assert!(
+            desc.contains(", require-change") && desc.contains(", command-position"),
+            "missing flags: {desc}"
         );
     }
 

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -63,6 +63,41 @@ fn test_tx_replace_whole_line_in_plan() {
     );
 }
 
+#[test]
+fn test_tx_replace_command_position_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "sudo pip install x\nuv pip install\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "replace",
+            "path": portable_path_str(&file),
+            "old": "pip",
+            "new": "uv",
+            "command_position": true,
+            "require_change": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "sudo uv install x\nuv pip install\n"
+    );
+}
+
 // -- whole_line CR/CRLF tests (#999) ----------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary

- Integration test: plan `replace` with `command_position` + `require_change` rewrites only invocable shell tokens.
- Explain: show `require-change` and `command-position` in replace summaries when set.

## Test plan

- [x] `cargo test --test integration test_tx_replace_command_position --all-features`
- [x] `cargo test --lib describe_replace_require --all-features`
- [x] `make check-fast`