### PR TITLE
docs(schema): replace example for command_position and require_change

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -304,7 +304,7 @@ dependencies[name=react].version # predicate filter
 
 ## Operations (from schema registry)
 
-- `replace`: Replace text in a file using literal string matching.
+- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only).
 - `file.append`: Append content to an existing file.
 - `file.prepend`: Prepend content to an existing file.
 - `file.create`: Create a new file with specified content.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -183,12 +183,18 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     // --- Weak tier ---
     OpMeta {
         name: "replace",
-        description: "Replace text in a file using literal string matching.",
+        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only).",
         tier: Tier::Weak,
-        examples: &[(
-            "Replace a function name",
-            r###"{"op":"replace","path":"src/main.rs","old":"old_name","new":"new_name"}"###,
-        )],
+        examples: &[
+            (
+                "Replace a function name",
+                r###"{"op":"replace","path":"src/main.rs","old":"old_name","new":"new_name"}"###,
+            ),
+            (
+                "Rewrite shell command tokens only",
+                r###"{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}"###,
+            ),
+        ],
     },
     OpMeta {
         name: "file.append",


### PR DESCRIPTION
## Summary

- Extend plan `replace` schema description for `require_change` and `command_position`.
- Add catalog example rewriting shell invocable tokens with both flags set.

## Test plan

- [x] `cargo test --lib schema --all-features`
- [x] `cargo test --lib mcp_example_argument_keys_match_schemas --all-features`