### PR TITLE
docs(agent-rules): document replace flags for MCP-only mode

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -33,6 +33,11 @@
 | Apply same operation to many files | `execute_plan` with `for_each` glob |
 | Get server version and working directory | `server_info` |
 
+**`replace_text` / plan replace flags (default false):**
+- `require_change`: error when the pattern matches zero times (fail closed).
+- `command_position`: rewrite only shell invocable tokens (`sudo pip` yes; `uv pip` no).
+Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
+
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)
 - Editing markdown sections, bullets, or tables by heading

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -109,7 +109,12 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Validate syntax, find refs, or analyze impact | `ast_validate`, `ast_refs`, `ast_impact`, `ast_search` |\n\
              | Repo map, imports, or structural diff | `ast_map`, `ast_deps`, `ast_diff` |\n\
              | Apply same operation to many files | `execute_plan` with `for_each` glob |\n\
-             | Get server version and working directory | `server_info` |\n\n",
+             | Get server version and working directory | `server_info` |\n\n\
+             **`replace_text` / plan replace flags (default false):**\n\
+             - `require_change`: error when the pattern matches zero times (fail closed).\n\
+             - `command_position`: rewrite only shell invocable tokens (`sudo pip` yes; `uv pip` no).\n\
+             Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
+             \"command_position\":true,\"require_change\":true}`\n\n",
         );
     }
     if show_cli {
@@ -662,6 +667,11 @@ mod tests {
         assert!(
             out.contains("require_change") && out.contains("command_position"),
             "plan replace library flags must be documented for agents"
+        );
+        let mcp = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));
+        assert!(
+            mcp.contains("require_change") && mcp.contains("command_position"),
+            "MCP-only agent-rules must document replace_text flags"
         );
     }
 


### PR DESCRIPTION
## Summary

MCP-only `agent-rules` now documents `require_change` and `command_position` under the tool selection guide (CLI transaction section already had them). Unit test covers both `AgentMode::Cli` and `AgentMode::Mcp`.

## Test plan

- [x] `cargo test --lib workflow_includes_plan_require --all-features`
- [x] `make sync-patchloom-md && make check-fast`