### PR TITLE
feat(mcp): batch_replace require_change and command_position

### DIFF
--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -531,8 +531,8 @@ impl PatchloomService {
                     before_context: None,
                     after_context: None,
                     unique: false,
-                    require_change: false,
-                    command_position: false,
+                    require_change: p.require_change,
+                    command_position: p.command_position,
                 })
                 .collect();
             svc.run_ops(ops, Some(p.strict))

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -250,6 +250,12 @@ pub(crate) struct BatchReplaceParams {
     /// instead of returning an error. Useful for idempotent batch replacements.
     #[serde(default)]
     pub if_exists: bool,
+    /// Fail when a file has zero matches (fail closed). Softened when if_exists is true.
+    #[serde(default)]
+    pub require_change: bool,
+    /// Only rewrite shell command-position tokens (not arguments / longer words).
+    #[serde(default)]
+    pub command_position: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,


### PR DESCRIPTION
## Summary

`batch_replace` now accepts `require_change` and `command_position` (default false), matching single-file `replace_text` and plan `replace` from #1516.

## Test plan

- [x] `cargo test --lib mcp_params --all-features`
- [x] `make check-fast`