### PR TITLE
feat(cli): replace --command-position and --require-change

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -567,18 +567,18 @@ These are meaningful command-specific modes that change how a top-level command 
 - **Prefer instead:** Use `--before-context` when the preceding lines are more distinctive.
 
 <!-- ref:replace-mode:require-change -->
-### Library `ReplaceOptions.require_change`
+### `replace --require-change` / library `ReplaceOptions.require_change`
 
-- **What it does:** Zero matches become structured `EditErrorKind::NoMatch` instead of soft `Ok(changed=false)`. Embedders can match on kind without scraping English error text (`edit_error_kind`).
-- **Use when:** Agent hosts that treat a missed target as a tool error (fail closed). Default remains soft no-match for CLI and historical library callers.
-- **Prefer instead:** Leave the default when soft no-match is intentional. When both `require_change` and `if_exists` are set, `if_exists` wins (returns Ok unchanged).
+- **What it does:** Zero matches become an error (CLI exit 3 / structured `EditErrorKind::NoMatch`) instead of soft success. Softened by `--if-exists` / `if_exists`.
+- **Use when:** Agent hosts that treat a missed target as a tool error (fail closed). CLI already fails on no-match by default; the flag is explicit for plan/MCP/library parity.
+- **Prefer instead:** Leave the default when soft no-match is intentional. When both `require_change` and `if_exists` are set, `if_exists` wins.
 
 <!-- ref:replace-mode:command-position -->
-### Library `ReplaceOptions.command_position`
+### `replace --command-position` / library `ReplaceOptions.command_position`
 
-- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only.
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
-- **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after (`InvalidInput`).
+- **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after.
 
 <!-- ref:create-mode:stdin -->
 ### `create --stdin`

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -88,6 +88,19 @@ pub struct ReplaceArgs {
     /// when multiple matches exist.
     #[arg(long, short = 'u')]
     pub unique: bool,
+    // ref:replace-mode:require-change
+    /// Fail when the pattern matches zero times (same as default CLI no-match
+    /// exit, but explicit for plan/MCP parity and agents). Softened by
+    /// `--if-exists`.
+    #[arg(long)]
+    pub require_change: bool,
+    // ref:replace-mode:command-position
+    /// Only replace tokens in shell command position (invocable names after
+    /// `sudo`/`timeout`/etc.; not arguments like `uv pip` or longer words
+    /// like `pipenv`). Literal only; cannot combine with regex/word-boundary/
+    /// multiline/nth/insert/context.
+    #[arg(long)]
+    pub command_position: bool,
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,
 }
@@ -164,13 +177,19 @@ fn collect_replacements(
     let from = &args.old;
     let nth = args.nth;
     let whole_line = args.whole_line;
+    let command_position = args.command_position;
+    let to = args.new.as_deref().unwrap_or("");
     let range = parse_range_arg(args.range.as_deref())?;
 
     let cwd_ref = &cwd;
     let mut replacements: Vec<FileReplacement> =
         crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let content = crate::files::read_text_file_logged(path, "replace", quiet)?;
-            let (replaced, count) = if whole_line {
+            let (replaced, count) = if command_position {
+                let (out, n) =
+                    crate::ops::shell_token::replace_command_position(&content, from, to);
+                (std::borrow::Cow::Owned(out), n)
+            } else if whole_line {
                 replace_whole_lines(
                     &content,
                     from,
@@ -225,6 +244,23 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.regex,
         args.paths
     );
+    if args.command_position
+        && (args.regex
+            || args.case_insensitive
+            || args.word_boundary
+            || args.whole_line
+            || args.multiline
+            || args.nth.is_some()
+            || args.insert_before.is_some()
+            || args.insert_after.is_some()
+            || args.before_context.is_some()
+            || args.after_context.is_some())
+    {
+        anyhow::bail!(
+            "command_position cannot be combined with regex, whole_line, multiline, nth, \
+             case_insensitive, word_boundary, insert_before/after, or context anchors"
+        );
+    }
     use crate::ops::replace::{ReplaceValidationParams, validate_replace_args};
     validate_replace_args(&ReplaceValidationParams {
         pattern: &args.old,
@@ -456,8 +492,8 @@ fn run_context_replace(
             before_context: args.before_context.clone(),
             after_context: args.after_context.clone(),
             unique: args.unique,
-            require_change: false,
-            command_position: false,
+            require_change: args.require_change,
+            command_position: args.command_position,
         })
         .collect();
 

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -21,6 +21,8 @@ fn make_args(old: &str, new: &str, paths: Vec<String>) -> ReplaceArgs {
         before_context: None,
         after_context: None,
         unique: false,
+        require_change: false,
+        command_position: false,
         write: Default::default(),
     }
 }
@@ -70,6 +72,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -103,6 +107,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -206,6 +212,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -264,6 +272,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -323,6 +333,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -363,6 +375,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -396,6 +410,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -428,6 +444,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -462,6 +480,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -500,6 +520,8 @@ mod basic {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -541,6 +563,8 @@ mod edge_cases {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -573,6 +597,8 @@ mod edge_cases {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let global = GlobalFlags {
@@ -630,6 +656,8 @@ mod edge_cases {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -705,6 +733,8 @@ mod edge_cases {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -747,6 +777,8 @@ mod edge_cases {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -803,6 +835,8 @@ mod error_handling {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let err = run(args, &GlobalFlags::test_default()).unwrap_err();
@@ -833,6 +867,8 @@ mod error_handling {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let err = run(args, &GlobalFlags::test_default()).unwrap_err();
@@ -866,6 +902,8 @@ mod error_handling {
             before_context: None,
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let err = run(args, &GlobalFlags::test_default()).unwrap_err();
@@ -900,6 +938,8 @@ mod error_handling {
             before_context: None,
             after_context: None,
             unique: true,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -938,6 +978,8 @@ mod error_handling {
             before_context: None,
             after_context: None,
             unique: true,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -980,6 +1022,8 @@ mod error_handling {
             before_context: None,
             after_context: None,
             unique: true,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -1023,6 +1067,8 @@ mod context_replace {
             before_context: None,
             after_context: Some("port = 5432".to_string()),
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1072,6 +1118,8 @@ mod context_replace {
             before_context: Some("[database]".to_string()),
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1115,6 +1163,8 @@ mod context_replace {
             before_context: Some("nonexistent".to_string()),
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
 
@@ -1146,6 +1196,8 @@ mod context_replace {
             before_context: Some("nonexistent".to_string()),
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
 
@@ -1181,6 +1233,8 @@ mod context_replace {
             before_context: Some("[database]".to_string()),
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1221,6 +1275,8 @@ mod context_replace {
             before_context: Some("aaa".to_string()),
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1262,6 +1318,8 @@ mod context_replace {
             before_context: Some("hello".to_string()),
             after_context: None,
             unique: false,
+            require_change: false,
+            command_position: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1269,5 +1327,24 @@ mod context_replace {
 
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::NO_MATCHES);
+    }
+    #[test]
+    fn command_position_cli_rewrites_sudo_pip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("install.sh");
+        std::fs::write(&file, "sudo pip install x\nuv pip install\n").unwrap();
+        let mut args = make_args("pip", "uv", vec![file.to_string_lossy().into()]);
+        args.command_position = true;
+        let global = crate::cli::global::GlobalFlags {
+            apply: true,
+            cwd: Some(dir.path().to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, 0);
+        assert_eq!(
+            std::fs::read_to_string(&file).unwrap(),
+            "sudo uv install x\nuv pip install\n"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- CLI flags `--command-position` and `--require-change` on `patchloom replace`.
- Wired through multi-file scan and context/tx path; incompatible combos rejected.
- Reference docs updated; unit test for `sudo pip` → `uv`.

## Test plan

- [x] `cargo test --lib cmd::replace --all-features`
- [x] `cargo test --lib command_position_cli --all-features`
- [x] `make check-fast`