### PR TITLE
docs: note CLI and batch_replace command_position in RELEASE_NOTES

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - Prefer `require_change: true` in agent hosts that treat zero matches as tool errors.
 - Use `command_position` only when rewriting shell invocable names; keep ordinary replace or word_boundary for identifiers.
 - Plan `replace` and MCP replace accept the same `require_change` / `command_position` fields as the library API (default false).
+- CLI: `patchloom replace … --command-position --require-change` (and MCP `batch_replace`) expose the same flags.
 - Full-string signature rewrites may omit trailing space before `{`; the library normalizes the body gap.
 - Multi-op content edits expose rolled-up `match_count` on `ContentEditsResult` / file `EditResult`. Crate-root re-exports include `ContentEdit`, `ContentEditsResult`, and `apply_content_edits`.
 


### PR DESCRIPTION
Document full surface for require_change / command_position after #1522/#1523.

## Test plan
- [x] verify-release-notes structural check via make check-fast