### PR TITLE
test(replace): CLI command_position coverage and shared combo validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3200%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3300%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -439,7 +439,7 @@ flowchart LR
 
 ## Status
 
-3200+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3300+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ api::doc_set(
 
 All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking and binary detection), `backup` (`restore_path_from_latest_backup` for post-Apply validate/revert), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS); see the `containment` and `api` module rustdocs.
 
-Notable library options (not CLI flags): `ReplaceOptions.require_change`, `ReplaceOptions.command_position` (shell invocable tokens only), AST mutators `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
+Replace fail-closed / shell-token options: CLI `replace --require-change` and `--command-position` (also plan/MCP fields and `ReplaceOptions` on the library). Library-only AST mutators: `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
 
 ## Getting started
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -48,4 +48,4 @@ patchloom = "0.12"
 
 **Library:** New `ReplaceOptions` fields default to false (non-breaking). New AST batch / rename APIs need `features = ["ast", "files"]` (or default features). Match structured errors with `edit_error_kind(&err)`.
 
-**Release consumers:** No CLI flag changes required for the new library-only options. Plan/MCP `ast.rewrite_signature` inherits body-gap fix automatically.
+**Release consumers:** New optional CLI flags `--require-change` and `--command-position` on `replace` (defaults off; existing scripts unchanged). Library-only AST mutators and `FunctionSigEdit::parse_rust` need no CLI action. Plan/MCP `ast.rewrite_signature` inherits body-gap fix automatically.

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -361,27 +361,24 @@ pub fn replace_in_content(
 
     // Shell command-position path (#1494): only rewrite invocable command tokens.
     if opts.command_position {
-        if is_regex
-            || opts.whole_line
-            || opts.multiline
-            || opts.nth.is_some()
-            || opts.case_insensitive
-            || opts.word_boundary
-            || opts.fuzzy
-            || opts.before_context.is_some()
-            || opts.after_context.is_some()
-        {
+        if let Some(msg) = crate::ops::shell_token::command_position_combo_error(
+            crate::ops::shell_token::CommandPositionIncompat {
+                regex: is_regex,
+                case_insensitive: opts.case_insensitive,
+                word_boundary: opts.word_boundary,
+                whole_line: opts.whole_line,
+                multiline: opts.multiline,
+                nth: opts.nth.is_some(),
+                insert_before: opts.insert_before.is_some(),
+                insert_after: opts.insert_after.is_some(),
+                before_context: opts.before_context.is_some(),
+                after_context: opts.after_context.is_some(),
+                fuzzy: opts.fuzzy,
+            },
+        ) {
             return Err(crate::fallback::EditError::new(
                 crate::fallback::EditErrorKind::InvalidInput,
-                "command_position cannot be combined with regex, whole_line, multiline, nth, \
-                 case_insensitive, word_boundary, fuzzy, or context anchors",
-            )
-            .into());
-        }
-        if opts.insert_before.is_some() || opts.insert_after.is_some() {
-            return Err(crate::fallback::EditError::new(
-                crate::fallback::EditErrorKind::InvalidInput,
-                "command_position cannot be combined with insert_before/insert_after",
+                msg,
             )
             .into());
         }

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -245,21 +245,23 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.paths
     );
     if args.command_position
-        && (args.regex
-            || args.case_insensitive
-            || args.word_boundary
-            || args.whole_line
-            || args.multiline
-            || args.nth.is_some()
-            || args.insert_before.is_some()
-            || args.insert_after.is_some()
-            || args.before_context.is_some()
-            || args.after_context.is_some())
+        && let Some(msg) = crate::ops::shell_token::command_position_combo_error(
+            crate::ops::shell_token::CommandPositionIncompat {
+                regex: args.regex,
+                case_insensitive: args.case_insensitive,
+                word_boundary: args.word_boundary,
+                whole_line: args.whole_line,
+                multiline: args.multiline,
+                nth: args.nth.is_some(),
+                insert_before: args.insert_before.is_some(),
+                insert_after: args.insert_after.is_some(),
+                before_context: args.before_context.is_some(),
+                after_context: args.after_context.is_some(),
+                fuzzy: false,
+            },
+        )
     {
-        anyhow::bail!(
-            "command_position cannot be combined with regex, whole_line, multiline, nth, \
-             case_insensitive, word_boundary, insert_before/after, or context anchors"
-        );
+        anyhow::bail!("{msg}");
     }
     use crate::ops::replace::{ReplaceValidationParams, validate_replace_args};
     validate_replace_args(&ReplaceValidationParams {

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -142,6 +142,58 @@ pub fn replace_command_position(content: &str, from: &str, to: &str) -> (String,
     (out, matches.len())
 }
 
+/// Flags that cannot be combined with `command_position` matching.
+///
+/// Shared by the library API, CLI, and tx paths so conflict messages stay
+/// consistent (avoids the prior three-copy drift, including the tx message
+/// that had a broken `"nth,              case_insensitive"` spacing).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CommandPositionIncompat {
+    pub regex: bool,
+    pub case_insensitive: bool,
+    pub word_boundary: bool,
+    pub whole_line: bool,
+    pub multiline: bool,
+    pub nth: bool,
+    pub insert_before: bool,
+    pub insert_after: bool,
+    pub before_context: bool,
+    pub after_context: bool,
+    pub fuzzy: bool,
+}
+
+impl CommandPositionIncompat {
+    /// True when any incompatible flag is set.
+    pub fn any(self) -> bool {
+        self.regex
+            || self.case_insensitive
+            || self.word_boundary
+            || self.whole_line
+            || self.multiline
+            || self.nth
+            || self.insert_before
+            || self.insert_after
+            || self.before_context
+            || self.after_context
+            || self.fuzzy
+    }
+}
+
+/// Canonical error text when `command_position` is combined with other modes.
+pub const COMMAND_POSITION_COMBO_MSG: &str = "command_position cannot be combined with regex, whole_line, multiline, nth, \
+     case_insensitive, word_boundary, fuzzy, insert_before/after, or context anchors";
+
+/// Return [`COMMAND_POSITION_COMBO_MSG`] when any incompatible option is set.
+///
+/// Call only when the caller has already decided `command_position` is true.
+pub fn command_position_combo_error(c: CommandPositionIncompat) -> Option<&'static str> {
+    if c.any() {
+        Some(COMMAND_POSITION_COMBO_MSG)
+    } else {
+        None
+    }
+}
+
 fn is_token_char(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_' || b == b'-' || b == b'.' || b == b'/'
 }
@@ -490,5 +542,38 @@ mod tests {
             replace_command_position("echo eval pip\n", "pip", "uv").1,
             0
         );
+    }
+
+    #[test]
+    fn command_position_combo_clean_is_ok() {
+        assert!(command_position_combo_error(CommandPositionIncompat::default()).is_none());
+    }
+
+    #[test]
+    fn command_position_combo_rejects_any_flag() {
+        let cases = [
+            CommandPositionIncompat {
+                regex: true,
+                ..Default::default()
+            },
+            CommandPositionIncompat {
+                fuzzy: true,
+                ..Default::default()
+            },
+            CommandPositionIncompat {
+                insert_before: true,
+                ..Default::default()
+            },
+            CommandPositionIncompat {
+                nth: true,
+                before_context: true,
+                ..Default::default()
+            },
+        ];
+        for c in cases {
+            let msg = command_position_combo_error(c).expect("should reject");
+            assert_eq!(msg, COMMAND_POSITION_COMBO_MSG);
+            assert!(msg.contains("command_position cannot be combined"));
+        }
     }
 }

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -545,6 +545,44 @@ mod tests {
     }
 
     #[test]
+    fn bare_env_assignment_allows_command() {
+        // `FOO=1 pip` without the `env` wrapper is still command position.
+        assert_eq!(
+            replace_command_position("FOO=1 pip install\n", "pip", "uv").0,
+            "FOO=1 uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("A=1 B=2 pip install\n", "pip", "uv").0,
+            "A=1 B=2 uv install\n"
+        );
+    }
+
+    #[test]
+    fn subshell_and_backtick_are_command_position() {
+        assert_eq!(
+            replace_command_position("$(pip list)\n", "pip", "uv").0,
+            "$(uv list)\n"
+        );
+        assert_eq!(
+            replace_command_position("`pip version`\n", "pip", "uv").0,
+            "`uv version`\n"
+        );
+        // Parenthesized groups after a separator.
+        assert_eq!(
+            replace_command_position("true && (pip install)\n", "pip", "uv").0,
+            "true && (uv install)\n"
+        );
+    }
+
+    #[test]
+    fn empty_replacement_removes_token() {
+        assert_eq!(
+            replace_command_position("sudo pip install\n", "pip", "").0,
+            "sudo  install\n"
+        );
+    }
+
+    #[test]
     fn command_position_combo_clean_is_ok() {
         assert!(command_position_combo_error(CommandPositionIncompat::default()).is_none());
     }

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -67,20 +67,23 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         }
     );
     if *command_position
-        && (regex_mode
-            || *case_insensitive
-            || word_boundary
-            || *whole_line
-            || *multiline
-            || nth.is_some()
-            || insert_before.is_some()
-            || insert_after.is_some()
-            || before_context.is_some()
-            || after_context.is_some())
+        && let Some(msg) = crate::ops::shell_token::command_position_combo_error(
+            crate::ops::shell_token::CommandPositionIncompat {
+                regex: regex_mode,
+                case_insensitive: *case_insensitive,
+                word_boundary,
+                whole_line: *whole_line,
+                multiline: *multiline,
+                nth: nth.is_some(),
+                insert_before: insert_before.is_some(),
+                insert_after: insert_after.is_some(),
+                before_context: before_context.is_some(),
+                after_context: after_context.is_some(),
+                fuzzy: false,
+            },
+        )
     {
-        anyhow::bail!(
-            "command_position cannot be combined with regex, whole_line, multiline, nth,              case_insensitive, word_boundary, insert_before/after, or context anchors"
-        );
+        anyhow::bail!("{msg}");
     }
     let use_regex = regex_mode || *case_insensitive || word_boundary;
     let replacement = replacement_text(

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1822,6 +1822,50 @@ async fn test_mcp_batch_replace_round_trip() {
 }
 
 #[tokio::test]
+async fn test_mcp_batch_replace_command_position() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("a.sh"),
+        "sudo pip install x\nuv pip install\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("b.sh"),
+        "timeout 30 pip install y\necho pip\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "batch_replace",
+        serde_json::json!({
+            "files": ["a.sh", "b.sh"],
+            "old": "pip",
+            "new": "uv",
+            "command_position": true,
+            "require_change": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "batch_replace command_position should succeed: {val}");
+    assert_eq!(val["ok"], true, "batch_replace command_position ok: {val}");
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("a.sh")).unwrap(),
+        "sudo uv install x\nuv pip install\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("b.sh")).unwrap(),
+        "timeout 30 uv install y\necho pip\n"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_batch_replace_accepts_file_alias() {
     if !has_mcp_support() {
         return;

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1851,7 +1851,10 @@ async fn test_mcp_batch_replace_command_position() {
         }),
     )
     .await;
-    assert!(!is_error, "batch_replace command_position should succeed: {val}");
+    assert!(
+        !is_error,
+        "batch_replace command_position should succeed: {val}"
+    );
     assert_eq!(val["ok"], true, "batch_replace command_position ok: {val}");
 
     assert_eq!(

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2140,6 +2140,40 @@ async fn test_mcp_replace_command_position_round_trip() {
 }
 
 #[tokio::test]
+async fn test_mcp_replace_command_position_rejects_regex() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("install.sh"), "sudo pip install\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "install.sh",
+            "old": "pip",
+            "new": "uv",
+            "command_position": true,
+            "regex": true
+        }),
+    )
+    .await;
+    assert!(is_error, "command_position+regex must fail: {val}");
+    let err = val.to_string();
+    assert!(
+        err.contains("command_position") || err.contains("combined") || err.contains("Invalid"),
+        "error should mention conflict: {val}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("install.sh")).unwrap(),
+        "sudo pip install\n"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_replace_whole_line_round_trip() {
     if !has_mcp_support() {
         return;

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1443,3 +1443,85 @@ fn test_replace_contain_allows_in_workspace() {
         "ZAZ bar\n"
     );
 }
+
+// -- command_position CLI surface (#1494 / MPI loop21) ----------------------
+
+#[test]
+fn test_replace_cli_command_position_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "sudo pip install x\nuv pip install\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace",
+            "pip",
+            "--new",
+            "uv",
+            "--command-position",
+            "install.sh",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "sudo uv install x\nuv pip install\n"
+    );
+}
+
+#[test]
+fn test_replace_cli_command_position_rejects_regex() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "sudo pip install\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace",
+            "pip",
+            "--new",
+            "uv",
+            "--command-position",
+            "--regex",
+            "install.sh",
+            "--apply",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "command_position cannot be combined",
+        ));
+}
+
+#[test]
+fn test_replace_cli_require_change_no_match() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "hello\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace",
+            "missing",
+            "--new",
+            "x",
+            "--require-change",
+            "install.sh",
+            "--apply",
+        ])
+        .assert()
+        .code(3); // NO_MATCHES
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -126,7 +126,9 @@ fn test_tx_replace_command_position_rejects_regex() {
         .arg("--apply")
         .assert()
         .failure()
-        .stderr(predicate::str::contains("command_position cannot be combined"));
+        .stderr(predicate::str::contains(
+            "command_position cannot be combined",
+        ));
 
     assert_eq!(
         fs::read_to_string(&file).unwrap(),

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -98,6 +98,43 @@ fn test_tx_replace_command_position_in_plan() {
     );
 }
 
+#[test]
+fn test_tx_replace_command_position_rejects_regex() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "sudo pip install\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "replace",
+            "path": portable_path_str(&file),
+            "old": "pip",
+            "new": "uv",
+            "regex": true,
+            "command_position": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("command_position cannot be combined"));
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "sudo pip install\n",
+        "conflict must not mutate the file"
+    );
+}
+
 // -- whole_line CR/CRLF tests (#999) ----------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary

- Share `command_position` incompatibility validation via `ops::shell_token::command_position_combo_error` (API, CLI, and tx) so conflict messages stay consistent (fixes the prior tx message with broken spacing).
- Add CLI integration tests for `replace --command-position --apply`, regex conflict rejection, and `--require-change` zero-match exit 3.
- Refresh README rounded test count (3300+).

## Test plan

- [x] `cargo test --lib command_position --all-features`
- [x] `cargo test --test integration test_replace_cli_command_position --all-features`
- [x] `cargo test --test integration test_replace_cli_require_change --all-features`
- [x] `make check-fast`