### PR TITLE
feat(replace): peel setsid in command_position; docs CLI surface

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Fail-closed content replace.** `ReplaceOptions.require_change` (default false). Zero matches → `EditErrorKind::NoMatch` with similar-target suggestions when available. `if_exists` still wins when both are set. Re-exports `EditError` / `EditErrorKind` / `edit_error_kind` for kind matching without scraping English. (#1492, #1497)
 - **AST file mutators.** `api::ast_rename`, `api::ast_replace_in_symbol`, `api::ast_rewrite_signature_in_content`, plus on-disk `ast_rewrite_signature`. Zero identifier/symbol matches → `NoMatch`. (#1493, #1497)
 - **`FunctionSigEdit::parse_rust`.** Rust-first parse of pub / pub(crate) / params-only / nested-paren signatures. (#1493, #1497)
-- **Shell command-position matching.** Opt-in `ReplaceOptions.command_position` (not `word_boundary`). Must-pass grammar: bare `pip`, not `pipenv` / `uv pip` / `python -m pip`; wrappers `sudo` / `doas` / `env KEY=val` / `timeout 30` / `nice -n 10` / `stdbuf` / `ionice` / `xargs` / `watch` / `strace` / `eval` / `source`; option flags like `-E` / `-p` and arg-taking flags like `-u USER`; separators `&&` `|` `;`. (#1494, #1497)
+- **Shell command-position matching.** Opt-in `ReplaceOptions.command_position` (not `word_boundary`). Must-pass grammar: bare `pip`, not `pipenv` / `uv pip` / `python -m pip`; wrappers `sudo` / `doas` / `env KEY=val` / `timeout 30` / `nice -n 10` / `stdbuf` / `ionice` / `setsid` / `xargs` / `watch` / `strace` / `eval` / `source`; option flags like `-E` / `-p` and arg-taking flags like `-u USER`; separators `&&` `|` `;`. (#1494, #1497)
 - **Validate/revert helper.** `backup::restore_path_from_latest_backup(project_root, path)` restores from the newest session that contains that exact path (exact match only). (#1494, #1497)
 - **Batch AST rename.** `api::ast_rename_batch` with path dedupe, same-file serialization, `continue_on_no_match` (default true), `fail_fast` for hard errors, per-file `Result`. (#1495, #1497)
 
@@ -22,7 +22,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)
 - **`if_exists` vs `require_change` on file replace.** File path honors the same "if_exists wins" rule as content replace. (#1499)
 - **Restore path matching.** Basename-only match removed so a different path with the same file name cannot restore the wrong session. (#1499)
-- **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, and `ionice` wrappers.
+- **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, and `setsid` wrappers.
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
 
 ## Agent and library notes

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -73,8 +73,11 @@ its async dependencies.
 Agent hosts often set `ReplaceOptions.require_change = true` so missing targets
 are structured errors (`EditErrorKind::NoMatch`) instead of soft no-ops. Opt-in
 `command_position` rewrites shell command tokens without touching arguments
-(including after `sudo` / `timeout 30` / `nice -n 10` wrappers, across lines).
-See the [crate documentation](https://docs.rs/patchloom) for the full API surface.
+(including after `sudo` / `timeout 30` / `nice -n 10` / `setsid` wrappers, across
+lines). The same options are available on the CLI
+(`patchloom replace … --require-change --command-position`), plan/MCP replace,
+and `batch_replace`. See the [crate documentation](https://docs.rs/patchloom)
+for the full API surface.
 
 ## Get started
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -576,7 +576,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:command-position -->
 ### `replace --command-position` / library `ReplaceOptions.command_position`
 
-- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
 - **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after.
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -261,7 +261,7 @@ pub struct ReplaceOptions {
     /// When true, only replace tokens in **shell command position** (start of
     /// line / after `&&` `|` `;` / newlines, after transparent prefixes like
     /// `sudo`, `env KEY=val`, `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`,
-    /// and option flags like `-E` / `-p` or arg-taking `-u USER`). Does not
+    /// `setsid`, and option flags like `-E` / `-p` or arg-taking `-u USER`). Does not
     /// match inside longer tokens (`pip` vs `pipenv`) or as arguments
     /// (`uv pip`). Opt-in; not the same as `word_boundary`. See #1494.
     pub command_position: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,9 @@
 //!
 //! Shell command-position matching (#1494): opt-in `ReplaceOptions.command_position`
 //! rewrites invocable tokens (`pip install`, `sudo -E pip`, `timeout 30 pip`,
-//! `nice -n 10 pip`) without touching arguments (`uv pip`) or longer words (`pipenv`).
-//! Not the same as `word_boundary`. Post-Apply validate/revert: host runs a validator,
-//! then `backup::restore_path_from_latest_backup(project_root, path)`.
+//! `nice -n 10 pip`, `setsid pip`) without touching arguments (`uv pip`) or longer
+//! words (`pipenv`). Not the same as `word_boundary`. Post-Apply validate/revert:
+//! host runs a validator, then `backup::restore_path_from_latest_backup(project_root, path)`.
 //!
 //! For several ordered text edits on **one buffer** then a single write (agent intent engines):
 //! use `api::apply_content_edits` / `api::apply_content_edits_to_file` with

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -2,8 +2,8 @@
 //!
 //! A token is in **command position** when it is the invocable command of a
 //! simple shell fragment: start of line (after whitespace), after `&&` `|` `;`,
-//! or after transparent prefixes (`sudo`, `env KEY=val`…, `timeout`, `nice`, `xargs`, `eval`,
-//! and common option flags like `-E` / `-p`). It is **not** command position
+//! or after transparent prefixes (`sudo`, `env KEY=val`…, `timeout`, `nice`, `setsid`, `xargs`,
+//! `eval`, and common option flags like `-E` / `-p`). It is **not** command position
 //! when it is an argument (`uv pip`) or inside a longer word (`pipenv`).
 //!
 //! Known false positive: `command -v pip` may treat `pip` as command position
@@ -15,7 +15,8 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     "sudo", "doas", "env", "command", "builtin", "exec", "time", "nice", "nohup",
     // Agent scripts often wrap installs: `timeout 30 pip install`, `stdbuf -oL …`.
     "timeout", "stdbuf", "ionice",
-    // Invokers that take a command as their first non-option arg.
+    // Detach from controlling TTY (common in agent/CI isolation wrappers).
+    "setsid", // Invokers that take a command as their first non-option arg.
     "xargs", "watch", "strace",
     // Shell builtins that re-parse a command string / file.
     "eval", "source", ".",
@@ -490,6 +491,23 @@ mod tests {
         let (out, n) = replace_command_position(content, "pip", "uv");
         assert_eq!(n, 1, "out={out:?}");
         assert!(out.contains("uv install"), "{out:?}");
+    }
+
+    #[test]
+    fn setsid_allows_command() {
+        assert_eq!(
+            replace_command_position("setsid pip install\n", "pip", "uv").0,
+            "setsid uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("setsid -f pip install\n", "pip", "uv").0,
+            "setsid -f uv install\n"
+        );
+        // Argument-position after a real command stays untouched.
+        assert_eq!(
+            replace_command_position("echo setsid pip\n", "pip", "uv").1,
+            0
+        );
     }
 
     #[test]

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2210,8 +2210,8 @@ async fn test_mcp_replace_command_position_rejects_regex() {
     assert!(is_error, "command_position+regex must fail: {val}");
     let err = val.to_string();
     assert!(
-        err.contains("command_position") || err.contains("combined") || err.contains("Invalid"),
-        "error should mention conflict: {val}"
+        err.contains("command_position cannot be combined"),
+        "error should name the command_position combo conflict: {val}"
     );
     assert_eq!(
         fs::read_to_string(dir.path().join("install.sh")).unwrap(),


### PR DESCRIPTION
## Summary

- Treat `setsid` / `setsid -f` as transparent prefixes for `command_position` (agent/CI isolation wrappers).
- Document CLI/plan/MCP parity for `--require-change` / `--command-position` in introduction + reference.
- Refresh RELEASE_NOTES / rustdoc wrapper lists; strengthen MCP `command_position`+regex conflict assertion.

## Test plan

- [x] `cargo test --lib setsid --all-features`
- [x] `cargo test --test integration test_mcp_replace_command_position_rejects_regex --all-features`
- [x] `make check-fast`