### PR TITLE
feat(replace): peel flock/chroot/runuser wrappers in command_position

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Fail-closed content replace.** `ReplaceOptions.require_change` (default false). Zero matches → `EditErrorKind::NoMatch` with similar-target suggestions when available. `if_exists` still wins when both are set. Re-exports `EditError` / `EditErrorKind` / `edit_error_kind` for kind matching without scraping English. (#1492, #1497)
 - **AST file mutators.** `api::ast_rename`, `api::ast_replace_in_symbol`, `api::ast_rewrite_signature_in_content`, plus on-disk `ast_rewrite_signature`. Zero identifier/symbol matches → `NoMatch`. (#1493, #1497)
 - **`FunctionSigEdit::parse_rust`.** Rust-first parse of pub / pub(crate) / params-only / nested-paren signatures. (#1493, #1497)
-- **Shell command-position matching.** Opt-in `ReplaceOptions.command_position` (not `word_boundary`). Must-pass grammar: bare `pip`, not `pipenv` / `uv pip` / `python -m pip`; wrappers `sudo` / `doas` / `env KEY=val` / `timeout 30` / `nice -n 10` / `stdbuf` / `ionice` / `setsid` / `xargs` / `watch` / `strace` / `eval` / `source`; option flags like `-E` / `-p` and arg-taking flags like `-u USER`; separators `&&` `|` `;`. (#1494, #1497)
+- **Shell command-position matching.** Opt-in `ReplaceOptions.command_position` (not `word_boundary`). Must-pass grammar: bare `pip`, not `pipenv` / `uv pip` / `python -m pip`; wrappers `sudo` / `doas` / `env KEY=val` / `timeout 30` / `nice -n 10` / `stdbuf` / `ionice` / `setsid` / `flock` / `chroot` / `xargs` / `watch` / `strace` / `eval` / `source`; option flags like `-E` / `-p` and arg-taking flags like `-u USER`; separators `&&` `|` `;`. (#1494, #1497)
 - **Validate/revert helper.** `backup::restore_path_from_latest_backup(project_root, path)` restores from the newest session that contains that exact path (exact match only). (#1494, #1497)
 - **Batch AST rename.** `api::ast_rename_batch` with path dedupe, same-file serialization, `continue_on_no_match` (default true), `fail_fast` for hard errors, per-file `Result`. (#1495, #1497)
 
@@ -22,7 +22,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)
 - **`if_exists` vs `require_change` on file replace.** File path honors the same "if_exists wins" rule as content replace. (#1499)
 - **Restore path matching.** Basename-only match removed so a different path with the same file name cannot restore the wrong session. (#1499)
-- **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, and `setsid` wrappers.
+- **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, `setsid`, and path-taking `flock` / `chroot` wrappers.
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
 
 ## Agent and library notes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,7 +11,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Fail-closed content replace.** `ReplaceOptions.require_change` (default false). Zero matches → `EditErrorKind::NoMatch` with similar-target suggestions when available. `if_exists` still wins when both are set. Re-exports `EditError` / `EditErrorKind` / `edit_error_kind` for kind matching without scraping English. (#1492, #1497)
 - **AST file mutators.** `api::ast_rename`, `api::ast_replace_in_symbol`, `api::ast_rewrite_signature_in_content`, plus on-disk `ast_rewrite_signature`. Zero identifier/symbol matches → `NoMatch`. (#1493, #1497)
 - **`FunctionSigEdit::parse_rust`.** Rust-first parse of pub / pub(crate) / params-only / nested-paren signatures. (#1493, #1497)
-- **Shell command-position matching.** Opt-in `ReplaceOptions.command_position` (not `word_boundary`). Must-pass grammar: bare `pip`, not `pipenv` / `uv pip` / `python -m pip`; wrappers `sudo` / `doas` / `env KEY=val` / `timeout 30` / `nice -n 10` / `stdbuf` / `ionice` / `setsid` / `flock` / `chroot` / `xargs` / `watch` / `strace` / `eval` / `source`; option flags like `-E` / `-p` and arg-taking flags like `-u USER`; separators `&&` `|` `;`. (#1494, #1497)
+- **Shell command-position matching.** Opt-in `ReplaceOptions.command_position` (not `word_boundary`). Must-pass grammar: bare `pip`, not `pipenv` / `uv pip` / `python -m pip`; wrappers `sudo` / `doas` / `env KEY=val` / `timeout 30` / `nice -n 10` / `stdbuf` / `ionice` / `setsid` / `runuser` / `flock` / `chroot` / `xargs` / `watch` / `strace` / `eval` / `source`; option flags like `-E` / `-p` and arg-taking flags like `-u USER`; separators `&&` `|` `;`. (#1494, #1497)
 - **Validate/revert helper.** `backup::restore_path_from_latest_backup(project_root, path)` restores from the newest session that contains that exact path (exact match only). (#1494, #1497)
 - **Batch AST rename.** `api::ast_rename_batch` with path dedupe, same-file serialization, `continue_on_no_match` (default true), `fail_fast` for hard errors, per-file `Result`. (#1495, #1497)
 
@@ -22,7 +22,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)
 - **`if_exists` vs `require_change` on file replace.** File path honors the same "if_exists wins" rule as content replace. (#1499)
 - **Restore path matching.** Basename-only match removed so a different path with the same file name cannot restore the wrong session. (#1499)
-- **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, `setsid`, and path-taking `flock` / `chroot` wrappers.
+- **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, `setsid`, `runuser -u USER`, and path-taking `flock` / `chroot` wrappers.
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
 
 ## Agent and library notes

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -73,8 +73,8 @@ its async dependencies.
 Agent hosts often set `ReplaceOptions.require_change = true` so missing targets
 are structured errors (`EditErrorKind::NoMatch`) instead of soft no-ops. Opt-in
 `command_position` rewrites shell command tokens without touching arguments
-(including after `sudo` / `timeout 30` / `nice -n 10` / `setsid` wrappers, across
-lines). The same options are available on the CLI
+(including after `sudo` / `timeout 30` / `nice -n 10` / `setsid` / `flock` /
+`chroot` wrappers, across lines). The same options are available on the CLI
 (`patchloom replace … --require-change --command-position`), plan/MCP replace,
 and `batch_replace`. See the [crate documentation](https://docs.rs/patchloom)
 for the full API surface.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -576,7 +576,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:command-position -->
 ### `replace --command-position` / library `ReplaceOptions.command_position`
 
-- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `flock /lock`, `chroot /jail`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
 - **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after.
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -261,9 +261,10 @@ pub struct ReplaceOptions {
     /// When true, only replace tokens in **shell command position** (start of
     /// line / after `&&` `|` `;` / newlines, after transparent prefixes like
     /// `sudo`, `env KEY=val`, `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`,
-    /// `setsid`, and option flags like `-E` / `-p` or arg-taking `-u USER`). Does not
-    /// match inside longer tokens (`pip` vs `pipenv`) or as arguments
-    /// (`uv pip`). Opt-in; not the same as `word_boundary`. See #1494.
+    /// `setsid`, `flock`/`chroot` + path, and option flags like `-E` / `-p` or
+    /// arg-taking `-u USER`). Does not match inside longer tokens (`pip` vs
+    /// `pipenv`) or as arguments (`uv pip`). Opt-in; not the same as
+    /// `word_boundary`. See #1494.
     pub command_position: bool,
 }
 

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -2,9 +2,10 @@
 //!
 //! A token is in **command position** when it is the invocable command of a
 //! simple shell fragment: start of line (after whitespace), after `&&` `|` `;`,
-//! or after transparent prefixes (`sudo`, `env KEY=val`…, `timeout`, `nice`, `setsid`, `xargs`,
-//! `eval`, and common option flags like `-E` / `-p`). It is **not** command position
-//! when it is an argument (`uv pip`) or inside a longer word (`pipenv`).
+//! or after transparent prefixes (`sudo`, `env KEY=val`…, `timeout`, `nice`, `setsid`,
+//! `flock` / `chroot` + path, `xargs`, `eval`, and common option flags like `-E` / `-p`).
+//! It is **not** command position when it is an argument (`uv pip`) or inside a longer
+//! word (`pipenv`).
 //!
 //! Known false positive: `command -v pip` may treat `pip` as command position
 //! because `-v` is peeled as a flag after the transparent `command` prefix.
@@ -21,6 +22,10 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     // Shell builtins that re-parse a command string / file.
     "eval", "source", ".",
 ];
+
+/// Wrappers whose next non-option argument is a path (not the command):
+/// `flock /tmp/l pip`, `flock -n /var/lock/x pip`, `chroot /jail pip`.
+const PATH_TAKING_PREFIXES: &[&str] = &["flock", "chroot"];
 
 /// Return true if `token` at byte range `[start, end)` is in shell command position.
 pub fn is_command_position(content: &str, start: usize, end: usize) -> bool {
@@ -93,6 +98,11 @@ pub fn is_command_position(content: &str, start: usize, end: usize) -> bool {
             rest = &rest[..prefix_start];
             continue;
         }
+        // Path-taking wrappers themselves: `flock …`, `chroot …`.
+        if PATH_TAKING_PREFIXES.contains(&token) {
+            rest = &rest[..prefix_start];
+            continue;
+        }
         // Value for an arg-taking flag: `sudo -u root pip` → peel `root` when
         // the token before it is `-u` / `--user` / `-g` / `--group`.
         let left = rest[..prefix_start].trim_end();
@@ -102,7 +112,37 @@ pub fn is_command_position(content: &str, start: usize, end: usize) -> bool {
             rest = &left[..flag_start];
             continue;
         }
+        // Lock/jail path after path-taking wrapper (options may sit between):
+        // `flock /tmp/l pip`, `flock -n /tmp/l pip`, `chroot /jail pip`.
+        if path_taking_wrapper_active(left) {
+            rest = &rest[..prefix_start];
+            continue;
+        }
         // Preceded by a real word → argument position (e.g. `uv pip`, `python -m pip`).
+        return false;
+    }
+}
+
+/// True when `left` ends with a path-taking wrapper (`flock`/`chroot`),
+/// optionally with option flags and/or duration-like values between the wrapper
+/// and the current token (so the current token is the lock/jail path).
+fn path_taking_wrapper_active(left: &str) -> bool {
+    let mut r = left.trim_end_matches([' ', '\t']);
+    loop {
+        if r.is_empty() {
+            return false;
+        }
+        let Some((start, token)) = last_shell_token(r) else {
+            return false;
+        };
+        if PATH_TAKING_PREFIXES.contains(&token) {
+            return true;
+        }
+        // Peel options and numeric args walking left toward the wrapper.
+        if is_option_flag(token) || is_duration_or_number(token) {
+            r = r[..start].trim_end_matches([' ', '\t']);
+            continue;
+        }
         return false;
     }
 }
@@ -506,6 +546,27 @@ mod tests {
         // Argument-position after a real command stays untouched.
         assert_eq!(
             replace_command_position("echo setsid pip\n", "pip", "uv").1,
+            0
+        );
+    }
+
+    #[test]
+    fn flock_and_chroot_path_taking_allow_command() {
+        assert_eq!(
+            replace_command_position("flock /tmp/l pip install\n", "pip", "uv").0,
+            "flock /tmp/l uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("flock -n /var/lock/x pip install\n", "pip", "uv").0,
+            "flock -n /var/lock/x uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("chroot /jail pip install\n", "pip", "uv").0,
+            "chroot /jail uv install\n"
+        );
+        // Argument form stays non-command.
+        assert_eq!(
+            replace_command_position("echo flock /tmp/l pip\n", "pip", "uv").1,
             0
         );
     }

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -17,7 +17,8 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     // Agent scripts often wrap installs: `timeout 30 pip install`, `stdbuf -oL …`.
     "timeout", "stdbuf", "ionice",
     // Detach from controlling TTY (common in agent/CI isolation wrappers).
-    "setsid", // Invokers that take a command as their first non-option arg.
+    "setsid", // Drop privileges then run a command (`runuser -u app pip install`).
+    "runuser", // Invokers that take a command as their first non-option arg.
     "xargs", "watch", "strace",
     // Shell builtins that re-parse a command string / file.
     "eval", "source", ".",
@@ -567,6 +568,22 @@ mod tests {
         // Argument form stays non-command.
         assert_eq!(
             replace_command_position("echo flock /tmp/l pip\n", "pip", "uv").1,
+            0
+        );
+    }
+
+    #[test]
+    fn runuser_allows_command() {
+        assert_eq!(
+            replace_command_position("runuser -u app pip install\n", "pip", "uv").0,
+            "runuser -u app uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("runuser --user app pip install\n", "pip", "uv").0,
+            "runuser --user app uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("echo runuser pip\n", "pip", "uv").1,
             0
         );
     }

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -16,9 +16,9 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     "sudo", "doas", "env", "command", "builtin", "exec", "time", "nice", "nohup",
     // Agent scripts often wrap installs: `timeout 30 pip install`, `stdbuf -oL …`.
     "timeout", "stdbuf", "ionice",
-    // Detach from controlling TTY (common in agent/CI isolation wrappers).
-    "setsid", // Drop privileges then run a command (`runuser -u app pip install`).
-    "runuser", // Invokers that take a command as their first non-option arg.
+    // Isolation / privilege wrappers used by agent and CI scripts.
+    "setsid", "runuser",
+    // Invokers that take a command as their first non-option arg.
     "xargs", "watch", "strace",
     // Shell builtins that re-parse a command string / file.
     "eval", "source", ".",


### PR DESCRIPTION
## Summary

- Path-taking wrappers: `flock` / `chroot` peel the lock/jail path so invocable commands rewrite (`flock -n /var/lock/x pip install`).
- Privilege wrapper: `runuser -u USER` / `runuser --user USER` is transparent.
- Docs and RELEASE_NOTES updated for the expanded wrapper set.

## Test plan

- [x] `cargo test --lib shell_token --all-features` (26 tests)
- [x] `make check-fast` (on first commit; follow-up is unit tests only)