### PR TITLE
docs(examples): command_position + require_change install plan

### DIFF
--- a/examples/12-command-position.json
+++ b/examples/12-command-position.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "operations": [
+    {
+      "op": "replace",
+      "path": "scripts/install.sh",
+      "old": "pip",
+      "new": "uv",
+      "command_position": true,
+      "require_change": true
+    }
+  ]
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,7 @@ patchloom batch examples/06-batch-version-bump.txt --apply  # apply
 | [09-patch-apply.json](09-patch-apply.json) | Apply a unified diff then follow up with a glob replace to catch remaining references | `patch.apply`, `replace` |
 | [10-inspect-and-edit.json](10-inspect-and-edit.json) | Read a config, search for references, then update both config and source code in one tx | `read`, `search`, `doc.set`, `replace` |
 | [11-ast-operations.sh](11-ast-operations.sh) | AST-aware operations: list, read, rename, validate, search, refs, deps, map, diff, impact, replace | `ast list`, `ast read`, `ast rename`, `ast validate`, `ast search`, `ast refs`, `ast deps`, `ast map`, `ast diff`, `ast impact`, `ast replace` |
+| [12-command-position.json](12-command-position.json) | Shell invocable rewrite (`pip`→`uv`) with fail-closed zero-match | `replace` (`command_position`, `require_change`) |
 | search_directory (api) | Use `patchloom::api::search_directory` with context, globs, max_results (see #779) | library api example in docs and tests |
 
 ## Write modes


### PR DESCRIPTION
## Summary

- Add `examples/12-command-position.json` for agent install-script rewrites with `command_position` + `require_change`.
- Document the example in `examples/README.md`.

## Test plan

- [x] Example is valid JSON
- [x] Illustrative only (paths are templates per examples/README)