### PR TITLE
fix(cli): identity replace is success, not no matches

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Restore path matching.** Basename-only match removed so a different path with the same file name cannot restore the wrong session. (#1499)
 - **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, `setsid`, `runuser -u USER`, and path-taking `flock` / `chroot` wrappers.
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
+- **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied.
 
 ## Agent and library notes
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -154,11 +154,15 @@ fn build_replacement(args: &ReplaceArgs) -> String {
     )
 }
 
-/// Walk files and collect all replacements using parallel file processing.
+/// Walk files and collect effective replacements using parallel file processing.
+///
+/// Returns `(effective_replacements, raw_match_count)` where `raw_match_count`
+/// is the total matches before identity filtering (so `require_change` and
+/// diagnostics can tell "pattern found but new == old" from "pattern absent").
 fn collect_replacements(
     args: &ReplaceArgs,
     global: &GlobalFlags,
-) -> anyhow::Result<Vec<FileReplacement>> {
+) -> anyhow::Result<(Vec<FileReplacement>, usize)> {
     let cwd = global.resolve_cwd()?;
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
     let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
@@ -218,13 +222,15 @@ fn collect_replacements(
             }
         });
 
+    let raw_match_count: usize = replacements.iter().map(|r| r.match_count).sum();
+
     // Drop files where the replacement produces identical content (e.g.
     // replacing "X" with "X").  The match count was non-zero, but there is
     // no actual change to write, diff, or report.
     replacements.retain(|r| r.original != r.replaced);
 
     replacements.sort_unstable_by(|a, b| a.path.cmp(&b.path));
-    Ok(replacements)
+    Ok((replacements, raw_match_count))
 }
 
 fn make_file_results(replacements: &[FileReplacement]) -> Vec<ReplaceFileResult> {
@@ -289,9 +295,11 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // Phase 1: Parallel file scan to identify files with matches.
-    let replacements = collect_replacements(&args, global)?;
+    let (replacements, raw_match_count) = collect_replacements(&args, global)?;
 
     // Unique check: fail if any file has more than one match.
+    // Uses effective replacements (identity-filtered); identity multi-match is
+    // still multi-match on the raw scan because those rows keep match_count.
     if args.unique {
         for r in &replacements {
             if r.match_count > 1 {
@@ -320,6 +328,25 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if replacements.is_empty() {
+        // Identity-only matches (pattern found, new == old): not a soft no-match.
+        // require_change is satisfied; exit success with the raw match count.
+        if raw_match_count > 0 {
+            let output = ReplaceOutput {
+                ok: true,
+                match_count: raw_match_count,
+                file_count: 0,
+                files: vec![],
+                diff: None,
+            };
+            global.emit_json(&output)?;
+            if !global.quiet && !global.json && !global.jsonl {
+                eprintln!(
+                    "matched {raw_match_count} occurrence(s) of '{}' but replacement is identical (no file changes)",
+                    args.old
+                );
+            }
+            return Ok(exit::SUCCESS);
+        }
         if args.if_exists {
             let output = ReplaceOutput {
                 ok: true,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -154,15 +154,14 @@ fn build_replacement(args: &ReplaceArgs) -> String {
     )
 }
 
-/// Walk files and collect effective replacements using parallel file processing.
+/// Walk files and collect replacements using parallel file processing.
 ///
-/// Returns `(effective_replacements, raw_match_count)` where `raw_match_count`
-/// is the total matches before identity filtering (so `require_change` and
-/// diagnostics can tell "pattern found but new == old" from "pattern absent").
+/// Includes identity matches (`new == old`) so callers can enforce `--unique`
+/// and distinguish "pattern found" from "pattern absent" before filtering.
 fn collect_replacements(
     args: &ReplaceArgs,
     global: &GlobalFlags,
-) -> anyhow::Result<(Vec<FileReplacement>, usize)> {
+) -> anyhow::Result<Vec<FileReplacement>> {
     let cwd = global.resolve_cwd()?;
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
     let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
@@ -222,15 +221,10 @@ fn collect_replacements(
             }
         });
 
-    let raw_match_count: usize = replacements.iter().map(|r| r.match_count).sum();
-
-    // Drop files where the replacement produces identical content (e.g.
-    // replacing "X" with "X").  The match count was non-zero, but there is
-    // no actual change to write, diff, or report.
-    replacements.retain(|r| r.original != r.replaced);
-
     replacements.sort_unstable_by(|a, b| a.path.cmp(&b.path));
-    Ok((replacements, raw_match_count))
+    // Caller runs unique against this list (including identity matches), then
+    // filters identity so writes/diffs only cover real content changes.
+    Ok(replacements)
 }
 
 fn make_file_results(replacements: &[FileReplacement]) -> Vec<ReplaceFileResult> {
@@ -294,12 +288,12 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return run_context_replace(args, global, &cwd);
     }
 
-    // Phase 1: Parallel file scan to identify files with matches.
-    let (replacements, raw_match_count) = collect_replacements(&args, global)?;
+    // Phase 1: Parallel file scan to identify files with matches (includes identity).
+    let mut replacements = collect_replacements(&args, global)?;
+    let raw_match_count: usize = replacements.iter().map(|r| r.match_count).sum();
 
-    // Unique check: fail if any file has more than one match.
-    // Uses effective replacements (identity-filtered); identity multi-match is
-    // still multi-match on the raw scan because those rows keep match_count.
+    // Unique check: fail if any file has more than one match (before identity
+    // filter so `--unique` is honest when new == old).
     if args.unique {
         for r in &replacements {
             if r.match_count > 1 {
@@ -326,6 +320,11 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         }
     }
+
+    // Drop files where the replacement produces identical content (e.g.
+    // replacing "X" with "X"). Match count was non-zero, but there is no
+    // actual change to write, diff, or report.
+    replacements.retain(|r| r.original != r.replaced);
 
     if replacements.is_empty() {
         // Identity-only matches (pattern found, new == old): not a soft no-match.

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -41,7 +41,7 @@ mod basic {
             "hi",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -76,7 +76,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -111,7 +111,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
         assert_eq!(replacements.len(), 1);
         assert_eq!(
             replacements[0].replaced, "version = \"1.2.99\"\n",
@@ -130,7 +130,7 @@ mod basic {
             "new",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
         assert_eq!(replacements.len(), 1);
 
         // Verify the replacement content produces a valid diff.
@@ -181,7 +181,7 @@ mod basic {
             "hi",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 2);
         let total: usize = replacements.iter().map(|r| r.match_count).sum();
@@ -276,7 +276,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 1);
@@ -337,7 +337,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -379,7 +379,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -414,7 +414,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].replaced, "alpha\nreplaced line\ngamma\n");
@@ -448,7 +448,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         // Only the bbb on line 2 should be deleted; the one on line 4 is outside range.
@@ -484,7 +484,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 1);
@@ -524,7 +524,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -624,7 +624,7 @@ mod edge_cases {
             "replaced",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
         assert!(
             replacements.is_empty(),
             "binary files should be skipped, got {} matches",
@@ -660,7 +660,7 @@ mod edge_cases {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert!(
             replacements.is_empty(),
@@ -669,22 +669,22 @@ mod edge_cases {
     }
 
     #[test]
-    fn identity_replacement_treated_as_no_match() {
+    fn identity_replacement_kept_in_scan_for_unique_and_require_change() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("test.txt");
         fs::write(&file, "hello world\n").unwrap();
 
-        // Replacing "hello" with "hello" should produce no change.
+        // Replacing "hello" with "hello" is still a match at scan time so
+        // --unique / require_change see the real count; run() drops it later.
         let args = make_args(
             "hello",
             "hello",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
-        assert!(
-            replacements.is_empty(),
-            "identity replacement must be filtered out"
-        );
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(replacements.len(), 1);
+        assert_eq!(replacements[0].match_count, 1);
+        assert_eq!(replacements[0].original, replacements[0].replaced);
     }
 
     #[test]
@@ -739,7 +739,7 @@ mod edge_cases {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(
@@ -783,7 +783,7 @@ mod edge_cases {
             command_position: false,
             write: Default::default(),
         };
-        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         // SetupFile in the string IS matched (word boundaries don't know about strings)

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -41,7 +41,7 @@ mod basic {
             "hi",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -76,7 +76,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -111,7 +111,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
         assert_eq!(replacements.len(), 1);
         assert_eq!(
             replacements[0].replaced, "version = \"1.2.99\"\n",
@@ -130,7 +130,7 @@ mod basic {
             "new",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
         assert_eq!(replacements.len(), 1);
 
         // Verify the replacement content produces a valid diff.
@@ -181,7 +181,7 @@ mod basic {
             "hi",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 2);
         let total: usize = replacements.iter().map(|r| r.match_count).sum();
@@ -276,7 +276,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 1);
@@ -337,7 +337,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -379,7 +379,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -414,7 +414,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].replaced, "alpha\nreplaced line\ngamma\n");
@@ -448,7 +448,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         // Only the bbb on line 2 should be deleted; the one on line 4 is outside range.
@@ -484,7 +484,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 1);
@@ -524,7 +524,7 @@ mod basic {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(replacements[0].match_count, 2);
@@ -624,7 +624,7 @@ mod edge_cases {
             "replaced",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
         assert!(
             replacements.is_empty(),
             "binary files should be skipped, got {} matches",
@@ -660,7 +660,7 @@ mod edge_cases {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert!(
             replacements.is_empty(),
@@ -680,7 +680,7 @@ mod edge_cases {
             "hello",
             vec![dir.path().to_string_lossy().into_owned()],
         );
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
         assert!(
             replacements.is_empty(),
             "identity replacement must be filtered out"
@@ -688,7 +688,7 @@ mod edge_cases {
     }
 
     #[test]
-    fn identity_replacement_check_returns_no_matches() {
+    fn identity_replacement_check_returns_success() {
         let dir = TempDir::new().unwrap();
         let file = dir.path().join("test.txt");
         fs::write(&file, "hello world\n").unwrap();
@@ -702,10 +702,12 @@ mod edge_cases {
         global.check = true;
 
         let code = run(args, &global).unwrap();
+        // Pattern matched; new == old so no file changes. Do not report
+        // NO_MATCHES (exit 3) — that hides that the pattern was found.
         assert_eq!(
             code,
-            exit::NO_MATCHES,
-            "--check with identity replacement must not report changes"
+            exit::SUCCESS,
+            "--check with identity replacement is zero effective changes, not zero matches"
         );
     }
 
@@ -737,7 +739,7 @@ mod edge_cases {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         assert_eq!(
@@ -781,7 +783,7 @@ mod edge_cases {
             command_position: false,
             write: Default::default(),
         };
-        let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
+        let (replacements, _) = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
 
         assert_eq!(replacements.len(), 1);
         // SetupFile in the string IS matched (word boundaries don't know about strings)

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1525,3 +1525,44 @@ fn test_replace_cli_require_change_no_match() {
 
     assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
 }
+
+#[test]
+fn test_replace_cli_identity_match_is_success_not_no_matches() {
+    // Pattern is present but new == old: do not claim "no matches".
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "sudo pip install\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace",
+            "pip",
+            "--new",
+            "pip",
+            "--command-position",
+            "--require-change",
+            "install.sh",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "identity match should satisfy require_change: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("identical") || stderr.contains("no file changes"),
+        "should explain identity-only matches: {stderr}"
+    );
+    assert!(
+        !stderr.contains("no matches for"),
+        "must not claim no matches when the pattern was found: {stderr}"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "sudo pip install\n");
+}

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1566,3 +1566,34 @@ fn test_replace_cli_identity_match_is_success_not_no_matches() {
     );
     assert_eq!(fs::read_to_string(&file).unwrap(), "sudo pip install\n");
 }
+
+#[test]
+fn test_replace_cli_unique_rejects_identity_multi_match() {
+    // --unique must count identity matches, not only content-changing ones.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "pip install\npip list\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace",
+            "pip",
+            "--new",
+            "pip",
+            "--command-position",
+            "--unique",
+            "install.sh",
+            "--apply",
+        ])
+        .assert()
+        .code(5) // AMBIGUOUS
+        .stderr(predicate::str::contains("ambiguous match"));
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "pip install\npip list\n"
+    );
+}


### PR DESCRIPTION
## Summary

- CLI `replace` no longer reports "no matches" / exit 3 when the pattern was found but `new == old` (identity). Exit 0 with an "identical (no file changes)" note so `--require-change` stays satisfied.
- `--unique` runs before the identity filter so multi-match identity is still ambiguous (exit 5).

## Test plan

- [x] `cargo test --lib cmd::replace --all-features`
- [x] `cargo test --test integration test_replace_cli_ --all-features`
- [x] `make check-fast` (first commit; follow-up is unit+integration)