### PR TITLE
docs: mention runuser/flock in command_position crate and guide docs

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -73,10 +73,10 @@ its async dependencies.
 Agent hosts often set `ReplaceOptions.require_change = true` so missing targets
 are structured errors (`EditErrorKind::NoMatch`) instead of soft no-ops. Opt-in
 `command_position` rewrites shell command tokens without touching arguments
-(including after `sudo` / `timeout 30` / `nice -n 10` / `setsid` / `flock` /
-`chroot` wrappers, across lines). The same options are available on the CLI
-(`patchloom replace … --require-change --command-position`), plan/MCP replace,
-and `batch_replace`. See the [crate documentation](https://docs.rs/patchloom)
+(including after `sudo` / `timeout 30` / `nice -n 10` / `setsid` / `runuser` /
+`flock` / `chroot` wrappers, across lines). The same options are available on
+the CLI (`patchloom replace … --require-change --command-position`), plan/MCP
+replace, and `batch_replace`. See the [crate documentation](https://docs.rs/patchloom)
 for the full API surface.
 
 ## Get started

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -576,7 +576,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:command-position -->
 ### `replace --command-position` / library `ReplaceOptions.command_position`
 
-- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `flock /lock`, `chroot /jail`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `runuser -u USER`, `flock /lock`, `chroot /jail`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
 - **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -571,6 +571,7 @@ These are meaningful command-specific modes that change how a top-level command 
 
 - **What it does:** Zero matches become an error (CLI exit 3 / structured `EditErrorKind::NoMatch`) instead of soft success. Softened by `--if-exists` / `if_exists`.
 - **Use when:** Agent hosts that treat a missed target as a tool error (fail closed). CLI already fails on no-match by default; the flag is explicit for plan/MCP/library parity.
+- **Identity:** When the pattern matches but `new` equals `old`, the match counts and `require_change` is satisfied (CLI exit 0 with an "identical (no file changes)" note). That is not a zero-match failure.
 - **Prefer instead:** Leave the default when soft no-match is intentional. When both `require_change` and `if_exists` are set, `if_exists` wins.
 
 <!-- ref:replace-mode:command-position -->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,10 @@
 //!
 //! Shell command-position matching (#1494): opt-in `ReplaceOptions.command_position`
 //! rewrites invocable tokens (`pip install`, `sudo -E pip`, `timeout 30 pip`,
-//! `nice -n 10 pip`, `setsid pip`) without touching arguments (`uv pip`) or longer
-//! words (`pipenv`). Not the same as `word_boundary`. Post-Apply validate/revert:
-//! host runs a validator, then `backup::restore_path_from_latest_backup(project_root, path)`.
+//! `nice -n 10 pip`, `setsid pip`, `flock /tmp/l pip`, `runuser -u app pip`) without
+//! touching arguments (`uv pip`) or longer words (`pipenv`). Not the same as
+//! `word_boundary`. Post-Apply validate/revert: host runs a validator, then
+//! `backup::restore_path_from_latest_backup(project_root, path)`.
 //!
 //! For several ordered text edits on **one buffer** then a single write (agent intent engines):
 //! use `api::apply_content_edits` / `api::apply_content_edits_to_file` with


### PR DESCRIPTION
## Summary

Align crate rustdoc, introduction, and reference docs with the expanded `command_position` wrappers (`runuser`, `flock`, `chroot`, `setsid`).

## Test plan

- [x] Docs-only; wording matches `src/ops/shell_token.rs` prefix lists