### PR TITLE
docs(agent-rules): include busybox in command_position wrapper list

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -35,7 +35,7 @@
 
 **`replace_text` / plan replace flags (default false):**
 - `require_change`: error when the pattern matches zero times (fail closed).
-- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid` wrappers yes; `uv pip` no).
+- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`busybox` wrappers yes; `uv pip` no).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 Use patchloom when:
@@ -248,7 +248,7 @@ All operations succeed atomically or roll back together.
 
 Plan/MCP `replace` accepts library flags (default false):
 - `require_change`: fail when the pattern matches zero times (agent fail-closed).
-- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid` wrappers yes; `uv pip` no).
+- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`busybox` wrappers yes; `uv pip` no).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 ## AST-aware operations

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -73,11 +73,11 @@ its async dependencies.
 Agent hosts often set `ReplaceOptions.require_change = true` so missing targets
 are structured errors (`EditErrorKind::NoMatch`) instead of soft no-ops. Opt-in
 `command_position` rewrites shell command tokens without touching arguments
-(including after `sudo` / `timeout 30` / `nice -n 10` / `setsid` / `runuser` /
-`flock` / `chroot` wrappers, across lines). The same options are available on
-the CLI (`patchloom replace … --require-change --command-position`), plan/MCP
-replace, and `batch_replace`. See the [crate documentation](https://docs.rs/patchloom)
-for the full API surface.
+(including after `sudo` / `timeout 30` / `nice -n 10` / `setsid` / `busybox` /
+`runuser` / `flock` / `chroot` wrappers, across lines). The same options are
+available on the CLI (`patchloom replace … --require-change --command-position`),
+plan/MCP replace, and `batch_replace`. See the
+[crate documentation](https://docs.rs/patchloom) for the full API surface.
 
 ## Get started
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -112,7 +112,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Get server version and working directory | `server_info` |\n\n\
              **`replace_text` / plan replace flags (default false):**\n\
              - `require_change`: error when the pattern matches zero times (fail closed).\n\
-             - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid` wrappers yes; `uv pip` no).\n\
+             - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`busybox` wrappers yes; `uv pip` no).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
              \"command_position\":true,\"require_change\":true}`\n\n",
         );
@@ -385,7 +385,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  All operations succeed atomically or roll back together.\n\n\
                  Plan/MCP `replace` accepts library flags (default false):\n\
                  - `require_change`: fail when the pattern matches zero times (agent fail-closed).\n\
-                 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid` wrappers yes; `uv pip` no).\n\
+                 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`busybox` wrappers yes; `uv pip` no).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\n");
         }
@@ -675,7 +675,7 @@ mod tests {
             "CLI flags must appear in agent-rules examples"
         );
         assert!(
-            out.contains("flock") && out.contains("runuser") && out.contains("setsid"),
+            out.contains("flock") && out.contains("runuser") && out.contains("setsid") && out.contains("busybox"),
             "agent-rules should name isolation wrappers for command_position"
         );
         let mcp = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -675,7 +675,10 @@ mod tests {
             "CLI flags must appear in agent-rules examples"
         );
         assert!(
-            out.contains("flock") && out.contains("runuser") && out.contains("setsid") && out.contains("busybox"),
+            out.contains("flock")
+                && out.contains("runuser")
+                && out.contains("setsid")
+                && out.contains("busybox"),
             "agent-rules should name isolation wrappers for command_position"
         );
         let mcp = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,10 +99,10 @@
 //!
 //! Shell command-position matching (#1494): opt-in `ReplaceOptions.command_position`
 //! rewrites invocable tokens (`pip install`, `sudo -E pip`, `timeout 30 pip`,
-//! `nice -n 10 pip`, `setsid pip`, `flock /tmp/l pip`, `runuser -u app pip`) without
-//! touching arguments (`uv pip`) or longer words (`pipenv`). Not the same as
-//! `word_boundary`. Post-Apply validate/revert: host runs a validator, then
-//! `backup::restore_path_from_latest_backup(project_root, path)`.
+//! `nice -n 10 pip`, `setsid pip`, `busybox wget`, `flock /tmp/l pip`,
+//! `runuser -u app pip`) without touching arguments (`uv pip`) or longer words
+//! (`pipenv`). Not the same as `word_boundary`. Post-Apply validate/revert: host
+//! runs a validator, then `backup::restore_path_from_latest_backup(project_root, path)`.
 //!
 //! For several ordered text edits on **one buffer** then a single write (agent intent engines):
 //! use `api::apply_content_edits` / `api::apply_content_edits_to_file` with


### PR DESCRIPTION
## Summary

- Name `busybox` in agent-rules `command_position` guidance and assertions.
- Sync PATCHLOOM.md; mention busybox in introduction + crate rustdoc examples.

## Test plan

- [x] `cargo test --lib workflow_includes_plan_require --all-features`
- [x] `make check-patchloom-md`