### PR TITLE
docs(mcp): name command_position wrappers in schema and tool params

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -317,7 +317,7 @@ dependencies[name=react].version # predicate filter
 
 ## Operations (from schema registry)
 
-- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only).
+- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser wrappers, not uv pip).
 - `file.append`: Append content to an existing file.
 - `file.prepend`: Prepend content to an existing file.
 - `file.create`: Create a new file with specified content.

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -64,6 +64,7 @@ pub(crate) struct ReplaceParams {
     #[serde(default)]
     pub require_change: bool,
     /// Only rewrite shell command-position tokens (not arguments / longer words).
+    /// Peels wrappers like sudo, timeout, busybox, flock, runuser, setsid.
     #[serde(default)]
     pub command_position: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.
@@ -254,6 +255,7 @@ pub(crate) struct BatchReplaceParams {
     #[serde(default)]
     pub require_change: bool,
     /// Only rewrite shell command-position tokens (not arguments / longer words).
+    /// Peels wrappers like sudo, timeout, busybox, flock, runuser, setsid.
     #[serde(default)]
     pub command_position: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -183,7 +183,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     // --- Weak tier ---
     OpMeta {
         name: "replace",
-        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only).",
+        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser wrappers, not uv pip).",
         tier: Tier::Weak,
         examples: &[
             (


### PR DESCRIPTION
## Summary

- Expand the replace OpMeta description and MCP `command_position` field docs to name peeled wrappers (sudo, timeout, busybox, flock, runuser, setsid).

## Test plan

- [x] `cargo test --lib schema --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`