### PR TITLE
fix(tx): unique and require_change map to exit 5/3

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
 - **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
+- **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 
 ## Agent and library notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, `setsid`, `runuser -u USER`, `busybox` applets, and path-taking `flock` / `chroot` wrappers.
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
 - **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied.
+- **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 
 ## Agent and library notes
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -388,6 +388,15 @@ pub(crate) fn run_parsed_plan(
                 }
                 return Ok(exit::NO_MATCHES);
             }
+            // replace unique multi-match → AMBIGUOUS (5), matching CLI.
+            if exit::is_ambiguous(&e) {
+                if structured {
+                    emit_error_json("ambiguous", &msg, None, compact);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::AMBIGUOUS);
+            }
             if structured {
                 emit_error_json("operation_failed", &msg, None, compact);
             } else {

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -39,6 +39,29 @@ pub fn is_no_match(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<NoMatchError>().is_some())
 }
 
+/// Typed error for ambiguous multi-match conditions in tx engine operations.
+///
+/// Parallel to [`NoMatchError`]: lets `tx` map `unique` multi-match failures
+/// to exit code [`AMBIGUOUS`] (5) instead of generic [`OPERATION_FAILED`] (9).
+#[derive(Debug)]
+pub struct AmbiguousError {
+    pub msg: String,
+}
+
+impl std::fmt::Display for AmbiguousError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for AmbiguousError {}
+
+/// Check whether an `anyhow::Error` chain contains an [`AmbiguousError`].
+pub fn is_ambiguous(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<AmbiguousError>().is_some())
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.
@@ -119,6 +142,26 @@ mod tests {
             !is_no_match(&err),
             "is_no_match should return false for non-NoMatchError in chain"
         );
+    }
+
+    #[test]
+    fn is_ambiguous_finds_wrapped_error() {
+        let err: anyhow::Error = AmbiguousError {
+            msg: "ambiguous match: pattern \"a\" matches 2 times".to_string(),
+        }
+        .into();
+        let wrapped = err.context("operation 1 (replace) failed");
+        assert!(
+            is_ambiguous(&wrapped),
+            "is_ambiguous should find AmbiguousError through .context() wrapper"
+        );
+        assert!(!is_no_match(&wrapped));
+    }
+
+    #[test]
+    fn is_ambiguous_rejects_plain_error() {
+        let err = anyhow::anyhow!("some other error").context("operation 1 failed");
+        assert!(!is_ambiguous(&err));
     }
 
     #[test]

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -588,6 +588,16 @@ pub(crate) fn execute_and_collect(
                     }
                     .into());
                 }
+                // Preserve AmbiguousError (exit 5) for replace --unique multi-match.
+                if let Some(detail) = e.chain().find_map(|c| {
+                    c.downcast_ref::<crate::exit::AmbiguousError>()
+                        .map(|n| n.msg.clone())
+                }) {
+                    return Err(crate::exit::AmbiguousError {
+                        msg: format!("operation {} ({}) failed: {detail}", i + 1, op_label(op)),
+                    }
+                    .into());
+                }
                 anyhow::bail!("operation {} ({}) failed: {e}", i + 1, op_label(op));
             }
         }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -145,6 +145,9 @@ pub fn execute_plan_direct(
             if crate::exit::is_no_match(&e) {
                 return Ok(build_error_output("no_matches", &e.to_string(), None));
             }
+            if crate::exit::is_ambiguous(&e) {
+                return Ok(build_error_output("ambiguous", &e.to_string(), None));
+            }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }
     };

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -284,6 +284,7 @@ pub fn exit_code_from_tx_output(report: &TxOutput) -> u8 {
         match report.error_kind.as_deref() {
             Some("no_matches") => exit::NO_MATCHES,
             Some("parse_error") => exit::PARSE_ERROR,
+            Some("ambiguous") => exit::AMBIGUOUS,
             Some("rollback") => exit::ROLLBACK,
             Some("rollback_failed") => exit::FAILURE,
             Some("validation_failed") | Some("format_failed") | Some("verification_failed") => {
@@ -507,6 +508,10 @@ mod tests {
         assert_eq!(
             exit_code_from_tx_output(&err_output("operation_failed")),
             exit::OPERATION_FAILED
+        );
+        assert_eq!(
+            exit_code_from_tx_output(&err_output("ambiguous")),
+            exit::AMBIGUOUS
         );
         assert_eq!(
             exit_code_from_tx_output(&err_output("unknown_kind")),

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -129,12 +129,15 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             replace_content(content, old, &replacement, compiled_re.as_ref(), *nth)
         };
         if *unique && match_count > 1 {
-            anyhow::bail!(
-                "ambiguous match: pattern {:?} matches {} times in {}; provide more context to disambiguate",
-                crate::fallback::truncate_str(old, 60),
-                match_count,
-                p
-            );
+            return Err(crate::exit::AmbiguousError {
+                msg: format!(
+                    "ambiguous match: pattern {:?} matches {} times in {}; provide more context to disambiguate",
+                    crate::fallback::truncate_str(old, 60),
+                    match_count,
+                    p
+                ),
+            }
+            .into());
         }
         if match_count > 0 {
             // When there are multiple exact matches and context is provided

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -236,7 +236,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     .replace_hint
                     .clone()
                     .unwrap_or_else(|| format!("no matches for {old:?} in {p}"));
-                anyhow::bail!(msg);
+                return Err(crate::exit::NoMatchError { msg }.into());
             }
             Ok(0)
         }
@@ -339,7 +339,10 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             }
         }
         if total_matches == 0 && *require_change && !if_exists {
-            anyhow::bail!("no matches for {old:?} (glob {pattern})");
+            return Err(crate::exit::NoMatchError {
+                msg: format!("no matches for {old:?} (glob {pattern})"),
+            }
+            .into());
         }
         Ok(total_matches)
     } else {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -137,6 +137,38 @@ fn test_tx_replace_command_position_rejects_regex() {
     );
 }
 
+#[test]
+fn test_tx_replace_unique_ambiguous_exit_5() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "a a\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "replace",
+            "path": portable_path_str(&file),
+            "old": "a",
+            "new": "b",
+            "unique": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(5) // AMBIGUOUS, not OPERATION_FAILED (9)
+        .stderr(predicate::str::contains("ambiguous match"));
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "a a\n");
+}
+
 // -- whole_line CR/CRLF tests (#999) ----------------------------------------
 
 #[test]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -169,6 +169,38 @@ fn test_tx_replace_unique_ambiguous_exit_5() {
     assert_eq!(fs::read_to_string(&file).unwrap(), "a a\n");
 }
 
+#[test]
+fn test_tx_replace_require_change_no_match_exit_3() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "replace",
+            "path": portable_path_str(&file),
+            "old": "missing",
+            "new": "x",
+            "require_change": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(3) // NO_MATCHES, not OPERATION_FAILED (9)
+        .stderr(predicate::str::contains("no matches"));
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
 // -- whole_line CR/CRLF tests (#999) ----------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary

Plan/tx replace exit codes now match CLI agent tables:

| Condition | Before | After |
|-----------|--------|-------|
| `unique: true` multi-match | exit 9 `operation_failed` | exit **5** `ambiguous` |
| `require_change: true` zero match | exit 9 `operation_failed` | exit **3** `no_matches` |

Adds `exit::AmbiguousError` / `is_ambiguous` (parallel to `NoMatchError`) and preserves both types through the tx execute wrapper.

## Test plan

- [x] `cargo test --test integration test_tx_replace_unique_ambiguous --all-features` (exit 5)
- [x] `cargo test --test integration test_tx_replace_require_change_no_match --all-features` (exit 3)
- [x] `make check-fast` (first commit)