### PR TITLE
refactor: unify ambiguous multi-match guidance wording

### DIFF
--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -246,7 +246,7 @@ fn replace_write(
         // context-resolved results are unambiguous by definition.
         if unique && count > 1 {
             bail!(
-                "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
+                "ambiguous match: pattern {:?} matches {} times; use --nth or add context to disambiguate",
                 old,
                 count
             );
@@ -540,7 +540,7 @@ fn finalize_content_replace(
         return Err(crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::AmbiguousTarget,
             format!(
-                "ambiguous match: pattern {:?} matches {} times; provide more context to disambiguate",
+                "ambiguous match: pattern {:?} matches {} times; use --nth or add context to disambiguate",
                 from, count
             ),
         )

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -131,7 +131,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         if *unique && match_count > 1 {
             return Err(crate::exit::AmbiguousError {
                 msg: format!(
-                    "ambiguous match: pattern {:?} matches {} times in {}; provide more context to disambiguate",
+                    "ambiguous match: pattern {:?} matches {} times in {}; use --nth or add context to disambiguate",
                     crate::fallback::truncate_str(old, 60),
                     match_count,
                     p


### PR DESCRIPTION
## Summary

- Align unique multi-match error text across CLI, tx, and library API.

## Test plan

- [x] `cargo test --lib unique --all-features`