### PR TITLE
docs(agent-rules): clarify exit 5 for unique multi-match and error_kind

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -307,7 +307,7 @@ dependencies[name=react].version # predicate filter
 | 2 | Changes detected (`--check` mode found pending changes) |
 | 3 | No matches (search/replace pattern miss, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
 | 4 | Parse error (malformed input file or plan) |
-| 5 | Ambiguous (replacement matched multiple locations without `--nth`, or stale/missing patch context) |
+| 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; tx `error_kind: ambiguous`) |
 | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |
 | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -447,7 +447,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 2 | Changes detected (`--check` mode found pending changes) |\n\
              | 3 | No matches (search/replace pattern miss, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
              | 4 | Parse error (malformed input file or plan) |\n\
-             | 5 | Ambiguous (replacement matched multiple locations without `--nth`, or stale/missing patch context) |\n\
+             | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; tx `error_kind: ambiguous`) |\n\
              | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |\n\
              | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |\n\
              | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |\n\


### PR DESCRIPTION
## Summary

- Exit-code table now names `unique` multi-match and tx `error_kind: ambiguous` for code 5.
- Sync PATCHLOOM.md.

## Test plan

- [x] `cargo test --lib agent_rules --all-features`
- [x] `make check-patchloom-md` (via sync)