### PR TITLE
feat(cli): identity JSON flag and GNU --name=value option peeling

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,7 +24,8 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Restore path matching.** Basename-only match removed so a different path with the same file name cannot restore the wrong session. (#1499)
 - **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, `setsid`, `runuser -u USER`, `busybox` applets, and path-taking `flock` / `chroot` wrappers.
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
-- **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied.
+- **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied. JSON includes `identity: true`.
+- **GNU long options with `=`.** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -119,6 +119,9 @@ struct ReplaceOutput {
     files: Vec<ReplaceFileResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diff: Option<String>,
+    /// Set when the pattern matched but every replacement was identical (no writes).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    identity: Option<bool>,
 }
 
 /// Result of processing a single file.
@@ -306,6 +309,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         match_count: r.match_count,
                     }],
                     diff: None,
+                    identity: None,
                 };
                 global.emit_json(&output)?;
                 if !global.quiet {
@@ -336,6 +340,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 file_count: 0,
                 files: vec![],
                 diff: None,
+                identity: Some(true),
             };
             global.emit_json(&output)?;
             if !global.quiet && !global.json && !global.jsonl {
@@ -353,6 +358,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 file_count: 0,
                 files: vec![],
                 diff: None,
+                identity: None,
             };
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
@@ -363,6 +369,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             file_count: 0,
             files: vec![],
             diff: None,
+            identity: None,
         };
         global.emit_json(&output)?;
         if !global.quiet && !global.json && !global.jsonl {
@@ -423,6 +430,7 @@ fn replace_output(
         file_count,
         files: files.to_vec(),
         diff,
+        identity: None,
     };
 
     finalize_report(
@@ -534,6 +542,7 @@ fn run_context_replace(
             file_count: 0,
             files: vec![],
             diff: None,
+            identity: None,
         };
         global.emit_json(&empty)?;
         if args.if_exists {

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -254,18 +254,20 @@ fn is_env_assignment(token: &str) -> bool {
     }
 }
 
-/// Shell option flag (`-E`, `-p`, `--preserve-env`), not a command name.
+/// Shell option flag (`-E`, `-p`, `--preserve-env`, `--user=root`), not a command name.
 fn is_option_flag(token: &str) -> bool {
     if token.len() < 2 || !token.starts_with('-') {
         return false;
     }
     // Reject bare `-` / `--` and numeric tokens like `-1` used as args.
+    // GNU long options may use `--name=value` (equals-attached value).
     let body = token.trim_start_matches('-');
-    !body.is_empty()
-        && body
+    let name = body.split_once('=').map(|(n, _)| n).unwrap_or(body);
+    !name.is_empty()
+        && name
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-        && body.chars().any(|c| c.is_ascii_alphabetic())
+        && name.chars().any(|c| c.is_ascii_alphabetic())
 }
 
 /// Flags whose next token is an argument (`sudo -u root`, `sudo --user root`).
@@ -578,6 +580,22 @@ mod tests {
         assert_eq!(
             replace_command_position("echo flock /tmp/l pip\n", "pip", "uv").1,
             0
+        );
+    }
+
+    #[test]
+    fn gnu_long_option_equals_value_peels() {
+        assert_eq!(
+            replace_command_position("nice --adjustment=10 pip list\n", "pip", "uv").0,
+            "nice --adjustment=10 uv list\n"
+        );
+        assert_eq!(
+            replace_command_position("timeout --signal=TERM 30 pip install\n", "pip", "uv").0,
+            "timeout --signal=TERM 30 uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("sudo --user=root pip install\n", "pip", "uv").0,
+            "sudo --user=root uv install\n"
         );
     }
 

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1568,6 +1568,39 @@ fn test_replace_cli_identity_match_is_success_not_no_matches() {
 }
 
 #[test]
+fn test_replace_cli_identity_json_sets_identity_flag() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("install.sh");
+    fs::write(&file, "sudo pip install\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace",
+            "pip",
+            "--new",
+            "pip",
+            "--command-position",
+            "install.sh",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["match_count"], 1);
+    assert_eq!(v["file_count"], 0);
+    assert_eq!(
+        v["identity"], true,
+        "JSON should flag identity-only matches: {v}"
+    );
+}
+
+#[test]
 fn test_replace_cli_unique_rejects_identity_multi_match() {
     // --unique must count identity matches, not only content-changing ones.
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

1. **Identity JSON:** CLI `replace --json` sets `identity: true` when the pattern matched but every replacement was identical (no writes).
2. **GNU long options:** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).

## Test plan

- [x] `cargo test --test integration test_replace_cli_identity --all-features`
- [x] `cargo test --lib shell_token --all-features` (GNU equals + prior cases)
- [x] `make check-fast` (identity commit)