### PR TITLE
fix(shell_token): peel env --unset; docs identity JSON

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -571,7 +571,7 @@ These are meaningful command-specific modes that change how a top-level command 
 
 - **What it does:** Zero matches become an error (CLI exit 3 / structured `EditErrorKind::NoMatch`) instead of soft success. Softened by `--if-exists` / `if_exists`.
 - **Use when:** Agent hosts that treat a missed target as a tool error (fail closed). CLI already fails on no-match by default; the flag is explicit for plan/MCP/library parity.
-- **Identity:** When the pattern matches but `new` equals `old`, the match counts and `require_change` is satisfied (CLI exit 0 with an "identical (no file changes)" note). That is not a zero-match failure.
+- **Identity:** When the pattern matches but `new` equals `old`, the match counts and `require_change` is satisfied (CLI exit 0 with an "identical (no file changes)" note). That is not a zero-match failure. With `--json`, the response includes `"identity": true`.
 - **Prefer instead:** Leave the default when soft no-match is intentional. When both `require_change` and `if_exists` are set, `if_exists` wins.
 
 <!-- ref:replace-mode:command-position -->

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -274,7 +274,7 @@ fn is_option_flag(token: &str) -> bool {
 fn is_arg_taking_flag(token: &str) -> bool {
     matches!(
         token,
-        // sudo / doas / env
+        // sudo / doas / env (`-u` covers both sudo -u USER and env -u VAR)
         "-u" | "--user"
             | "-g"
             | "--group"
@@ -282,6 +282,7 @@ fn is_arg_taking_flag(token: &str) -> bool {
             | "--close-from"
             | "-p"
             | "--prompt"
+            | "--unset" // env --unset VAR
             // nice / ionice niceness
             | "-n"
             | "--adjustment"
@@ -580,6 +581,18 @@ mod tests {
         assert_eq!(
             replace_command_position("echo flock /tmp/l pip\n", "pip", "uv").1,
             0
+        );
+    }
+
+    #[test]
+    fn env_unset_space_form_allows_command() {
+        assert_eq!(
+            replace_command_position("env --unset PATH pip install\n", "pip", "uv").0,
+            "env --unset PATH uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("env -u PATH pip install\n", "pip", "uv").0,
+            "env -u PATH uv install\n"
         );
     }
 


### PR DESCRIPTION
## Summary

1. **env --unset:** `command_position` peels `env --unset VAR` (and continues to work for `env -u VAR`) so the invocable command rewrites.
2. **Docs:** Reference note that CLI replace `--json` sets `identity: true` for identity-only matches.

## Test plan

- [x] `cargo test --lib shell_token --all-features` (31 tests including env --unset)