### PR TITLE
fix(shell_token): peel env --chdir; note env --unset in RELEASE_NOTES

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
 - **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied. JSON includes `identity: true`.
 - **GNU long options with `=`.** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).
+- **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -283,6 +283,7 @@ fn is_arg_taking_flag(token: &str) -> bool {
             | "-p"
             | "--prompt"
             | "--unset" // env --unset VAR
+            | "--chdir" // env --chdir DIR (env -C already listed above as -C)
             // nice / ionice niceness
             | "-n"
             | "--adjustment"
@@ -581,6 +582,18 @@ mod tests {
         assert_eq!(
             replace_command_position("echo flock /tmp/l pip\n", "pip", "uv").1,
             0
+        );
+    }
+
+    #[test]
+    fn env_chdir_space_form_allows_command() {
+        assert_eq!(
+            replace_command_position("env --chdir /tmp pip install\n", "pip", "uv").0,
+            "env --chdir /tmp uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("env --chdir=/var/tmp pip install\n", "pip", "uv").0,
+            "env --chdir=/var/tmp uv install\n"
         );
     }
 


### PR DESCRIPTION
## Summary

1. Peel `env --chdir DIR` (and `--chdir=/tmp`) so invocable commands rewrite under command_position.
2. RELEASE_NOTES note for `env --unset VAR` peeling.

## Test plan

- [x] `cargo test --lib shell_token --all-features` (32 tests)