### PR TITLE
fix(shell_token): peel timeout --kill-after stacked durations

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,8 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied. JSON includes `identity: true`.
 - **GNU long options with `=`.** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).
 - **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
+- **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.
+- **`timeout --kill-after` stacked durations.** Peels consecutive duration tokens so `timeout --kill-after 5 30 pip` and `timeout --kill-after=5 30 pip` rewrite the command (bare `5 30 pip` still stays non-command).
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -82,17 +82,28 @@ pub fn is_command_position(content: &str, start: usize, end: usize) -> bool {
         }
         // Duration / niceness after wrappers only: `timeout 30 pip`, or value after
         // an arg-taking / option flag (`nice -n 10`). Bare `5 pip` stays non-command.
+        // Also peel stacked durations: `timeout --kill-after 5 30 pip` (kill-after
+        // value then command duration).
         if is_duration_or_number(token) {
-            let left = rest[..prefix_start].trim_end();
-            if let Some((_, prev)) = last_shell_token(left)
-                && (TRANSPARENT_PREFIXES.contains(&prev)
+            let mut left = rest[..prefix_start].trim_end();
+            loop {
+                let Some((prev_start, prev)) = last_shell_token(left) else {
+                    return false;
+                };
+                if is_duration_or_number(prev) {
+                    left = left[..prev_start].trim_end();
+                    continue;
+                }
+                if TRANSPARENT_PREFIXES.contains(&prev)
                     || is_option_flag(prev)
-                    || is_arg_taking_flag(prev))
-            {
-                rest = &rest[..prefix_start];
-                continue;
+                    || is_arg_taking_flag(prev)
+                {
+                    rest = &rest[..prefix_start];
+                    break;
+                }
+                return false;
             }
-            return false;
+            continue;
         }
         // Option flags after sudo/time/env (`sudo -E pip`, `time -p pip`).
         // Known false positive: `command -v pip` treats `pip` as command position.
@@ -581,6 +592,23 @@ mod tests {
         // Argument form stays non-command.
         assert_eq!(
             replace_command_position("echo flock /tmp/l pip\n", "pip", "uv").1,
+            0
+        );
+    }
+
+    #[test]
+    fn timeout_kill_after_stacked_duration() {
+        assert_eq!(
+            replace_command_position("timeout --kill-after 5 30 pip install\n", "pip", "uv").0,
+            "timeout --kill-after 5 30 uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("timeout --kill-after=5 30 pip install\n", "pip", "uv").0,
+            "timeout --kill-after=5 30 uv install\n"
+        );
+        // Bare stacked numbers without a wrapper stay non-command.
+        assert_eq!(
+            replace_command_position("5 30 pip install\n", "pip", "uv").1,
             0
         );
     }


### PR DESCRIPTION
## Summary

- `command_position` now peels consecutive duration tokens after wrappers, so `timeout --kill-after 5 30 pip` and `timeout --kill-after=5 30 pip` rewrite the invocable command.
- Bare stacked numbers without a wrapper (`5 30 pip`) stay non-command.
- RELEASE_NOTES documents this and the prior `env --chdir` peel.

## Test plan

- [x] `cargo test --lib shell_token --all-features`
- [x] `make check-fast`
- [ ] CI green