### PR TITLE
fix(shell_token): peel CI isolation and priority wrappers

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -35,7 +35,7 @@
 
 **`replace_text` / plan replace flags (default false):**
 - `require_change`: error when the pattern matches zero times (fail closed).
-- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`busybox` wrappers yes; `uv pip` no).
+- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`unshare`/`nsenter`/`taskset`/`busybox` wrappers yes; `uv pip` no).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 Use patchloom when:
@@ -248,7 +248,7 @@ All operations succeed atomically or roll back together.
 
 Plan/MCP `replace` accepts library flags (default false):
 - `require_change`: fail when the pattern matches zero times (agent fail-closed).
-- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`busybox` wrappers yes; `uv pip` no).
+- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`unshare`/`nsenter`/`taskset`/`busybox` wrappers yes; `uv pip` no).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 ## AST-aware operations
@@ -317,7 +317,7 @@ dependencies[name=react].version # predicate filter
 
 ## Operations (from schema registry)
 
-- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser wrappers, not uv pip).
+- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/unshare/nsenter/taskset wrappers, not uv pip).
 - `file.append`: Append content to an existing file.
 - `file.prepend`: Prepend content to an existing file.
 - `file.create`: Create a new file with specified content.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,7 +29,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
 - **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.
 - **`timeout --kill-after` stacked durations.** Peels consecutive duration tokens so `timeout --kill-after 5 30 pip` and `timeout --kill-after=5 30 pip` rewrite the command (bare `5 30 pip` still stays non-command).
-- **CI isolation wrappers.** `command_position` peels `unshare`, `nsenter`, `taskset`, `prlimit`, and `numactl` (plus list values like `taskset -c 0,1`) so sandbox and affinity-wrapped installs rewrite.
+- **CI isolation wrappers.** `command_position` peels `unshare`, `nsenter`, `taskset`, `prlimit`, `numactl`, `chrt`, and `setpriv` (plus list values like `taskset -c 0,1`) so sandbox and affinity-wrapped installs rewrite.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
 - **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.
 - **`timeout --kill-after` stacked durations.** Peels consecutive duration tokens so `timeout --kill-after 5 30 pip` and `timeout --kill-after=5 30 pip` rewrite the command (bare `5 30 pip` still stays non-command).
+- **CI isolation wrappers.** `command_position` peels `unshare`, `nsenter`, `taskset`, `prlimit`, and `numactl` (plus list values like `taskset -c 0,1`) so sandbox and affinity-wrapped installs rewrite.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -577,7 +577,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:command-position -->
 ### `replace --command-position` / library `ReplaceOptions.command_position`
 
-- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `runuser -u USER`, `busybox`, `flock /lock`, `chroot /jail`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `unshare`/`nsenter`/`taskset`/`prlimit`/`numactl`, `runuser -u USER`, `busybox`, `flock /lock`, `chroot /jail`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
 - **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -577,7 +577,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:command-position -->
 ### `replace --command-position` / library `ReplaceOptions.command_position`
 
-- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `unshare`/`nsenter`/`taskset`/`prlimit`/`numactl`, `runuser -u USER`, `busybox`, `flock /lock`, `chroot /jail`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `unshare`/`nsenter`/`taskset`/`prlimit`/`numactl`/`chrt`/`setpriv`, `runuser -u USER`, `busybox`, `flock /lock`, `chroot /jail`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
 - **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after.
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -261,10 +261,11 @@ pub struct ReplaceOptions {
     /// When true, only replace tokens in **shell command position** (start of
     /// line / after `&&` `|` `;` / newlines, after transparent prefixes like
     /// `sudo`, `env KEY=val`, `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`,
-    /// `setsid`, `busybox`, `runuser`, `flock`/`chroot` + path, and option flags
-    /// like `-E` / `-p` or arg-taking `-u USER`). Does not match inside longer
-    /// tokens (`pip` vs `pipenv`) or as arguments (`uv pip`). Opt-in; not the
-    /// same as `word_boundary`. See #1494.
+    /// `setsid`, `unshare`/`nsenter`/`taskset`/`prlimit`/`numactl`, `busybox`,
+    /// `runuser`, `flock`/`chroot` + path, and option flags like `-E` / `-p` or
+    /// arg-taking `-u USER`). Does not match inside longer tokens (`pip` vs
+    /// `pipenv`) or as arguments (`uv pip`). Opt-in; not the same as
+    /// `word_boundary`. See #1494.
     pub command_position: bool,
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -261,11 +261,11 @@ pub struct ReplaceOptions {
     /// When true, only replace tokens in **shell command position** (start of
     /// line / after `&&` `|` `;` / newlines, after transparent prefixes like
     /// `sudo`, `env KEY=val`, `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`,
-    /// `setsid`, `unshare`/`nsenter`/`taskset`/`prlimit`/`numactl`, `busybox`,
-    /// `runuser`, `flock`/`chroot` + path, and option flags like `-E` / `-p` or
-    /// arg-taking `-u USER`). Does not match inside longer tokens (`pip` vs
-    /// `pipenv`) or as arguments (`uv pip`). Opt-in; not the same as
-    /// `word_boundary`. See #1494.
+    /// `setsid`, `unshare`/`nsenter`/`taskset`/`prlimit`/`numactl`/`chrt`/
+    /// `setpriv`, `busybox`, `runuser`, `flock`/`chroot` + path, and option
+    /// flags like `-E` / `-p` or arg-taking `-u USER`). Does not match inside
+    /// longer tokens (`pip` vs `pipenv`) or as arguments (`uv pip`). Opt-in;
+    /// not the same as `word_boundary`. See #1494.
     pub command_position: bool,
 }
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -112,7 +112,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Get server version and working directory | `server_info` |\n\n\
              **`replace_text` / plan replace flags (default false):**\n\
              - `require_change`: error when the pattern matches zero times (fail closed).\n\
-             - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`busybox` wrappers yes; `uv pip` no).\n\
+             - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`unshare`/`nsenter`/`taskset`/`busybox` wrappers yes; `uv pip` no).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
              \"command_position\":true,\"require_change\":true}`\n\n",
         );
@@ -385,7 +385,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  All operations succeed atomically or roll back together.\n\n\
                  Plan/MCP `replace` accepts library flags (default false):\n\
                  - `require_change`: fail when the pattern matches zero times (agent fail-closed).\n\
-                 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`busybox` wrappers yes; `uv pip` no).\n\
+                 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`unshare`/`nsenter`/`taskset`/`busybox` wrappers yes; `uv pip` no).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\n");
         }
@@ -678,6 +678,9 @@ mod tests {
             out.contains("flock")
                 && out.contains("runuser")
                 && out.contains("setsid")
+                && out.contains("unshare")
+                && out.contains("nsenter")
+                && out.contains("taskset")
                 && out.contains("busybox"),
             "agent-rules should name isolation wrappers for command_position"
         );

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -3,7 +3,8 @@
 //! A token is in **command position** when it is the invocable command of a
 //! simple shell fragment: start of line (after whitespace), after `&&` `|` `;`,
 //! or after transparent prefixes (`sudo`, `env KEY=val`…, `timeout`, `nice`, `setsid`,
-//! `flock` / `chroot` + path, `xargs`, `eval`, and common option flags like `-E` / `-p`).
+//! `unshare` / `nsenter` / `taskset`, `flock` / `chroot` + path, `xargs`, `eval`, and
+//! common option flags like `-E` / `-p`).
 //! It is **not** command position when it is an argument (`uv pip`) or inside a longer
 //! word (`pipenv`).
 //!
@@ -22,6 +23,8 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     "timeout", "stdbuf", "ionice",
     // Isolation / privilege wrappers used by agent and CI scripts.
     "setsid", "runuser",
+    // Namespace / CPU affinity / resource-limit wrappers (CI and sandbox scripts).
+    "unshare", "nsenter", "taskset", "prlimit", "numactl",
     // Multicall binary: next token is the applet (busybox wget / busybox sh).
     "busybox", // Invokers that take a command as their first non-option arg.
     "xargs", "watch", "strace",
@@ -253,7 +256,8 @@ pub fn command_position_combo_error(c: CommandPositionIncompat) -> Option<&'stat
 }
 
 fn is_token_char(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || b == b'_' || b == b'-' || b == b'.' || b == b'/'
+    // Include `,` so CPU lists / resource lists stay one token (`taskset -c 0,1`).
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'-' || b == b'.' || b == b'/' || b == b','
 }
 
 fn is_env_assignment(token: &str) -> bool {
@@ -313,6 +317,17 @@ fn is_arg_taking_flag(token: &str) -> bool {
             | "--signal"
             | "-k"
             | "--kill-after"
+            // nsenter (target PID / root / workdir / uid)
+            | "-t"
+            | "--target"
+            | "--setuid"
+            | "--setgid"
+            | "--root"
+            | "--wd"
+            // taskset CPU list (`-c` already covered via ionice)
+            | "--cpu-list"
+            // prlimit / numactl PID (when not equals-attached)
+            | "--pid"
     )
 }
 
@@ -571,6 +586,51 @@ mod tests {
         // Argument-position after a real command stays untouched.
         assert_eq!(
             replace_command_position("echo setsid pip\n", "pip", "uv").1,
+            0
+        );
+    }
+
+    #[test]
+    fn isolation_wrappers_allow_command() {
+        // unshare boolean flags then command.
+        assert_eq!(
+            replace_command_position("unshare -n pip install\n", "pip", "uv").0,
+            "unshare -n uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("unshare -m -u pip install\n", "pip", "uv").0,
+            "unshare -m -u uv install\n"
+        );
+        // nsenter target PID + boolean namespaces.
+        assert_eq!(
+            replace_command_position("nsenter -t 1 -m pip install\n", "pip", "uv").0,
+            "nsenter -t 1 -m uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("nsenter --target=1 -n pip install\n", "pip", "uv").0,
+            "nsenter --target=1 -n uv install\n"
+        );
+        // taskset CPU affinity.
+        assert_eq!(
+            replace_command_position("taskset -c 0 pip install\n", "pip", "uv").0,
+            "taskset -c 0 uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("taskset --cpu-list 0,1 pip install\n", "pip", "uv").0,
+            "taskset --cpu-list 0,1 uv install\n"
+        );
+        // prlimit / numactl equals-attached resource limits.
+        assert_eq!(
+            replace_command_position("prlimit --as=1000000 pip install\n", "pip", "uv").0,
+            "prlimit --as=1000000 uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("numactl --cpunodebind=0 pip install\n", "pip", "uv").0,
+            "numactl --cpunodebind=0 uv install\n"
+        );
+        // Argument-position stays non-command.
+        assert_eq!(
+            replace_command_position("echo unshare -n pip\n", "pip", "uv").1,
             0
         );
     }

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -25,6 +25,8 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     "setsid", "runuser",
     // Namespace / CPU affinity / resource-limit wrappers (CI and sandbox scripts).
     "unshare", "nsenter", "taskset", "prlimit", "numactl",
+    // Priority / privilege wrappers: `chrt -f 10 cmd`, `setpriv --reuid=… cmd`.
+    "chrt", "setpriv",
     // Multicall binary: next token is the applet (busybox wget / busybox sh).
     "busybox", // Invokers that take a command as their first non-option arg.
     "xargs", "watch", "strace",
@@ -627,6 +629,20 @@ mod tests {
         assert_eq!(
             replace_command_position("numactl --cpunodebind=0 pip install\n", "pip", "uv").0,
             "numactl --cpunodebind=0 uv install\n"
+        );
+        // Priority / privilege wrappers.
+        assert_eq!(
+            replace_command_position("chrt -f 10 pip install\n", "pip", "uv").0,
+            "chrt -f 10 uv install\n"
+        );
+        assert_eq!(
+            replace_command_position(
+                "setpriv --reuid=1000 --regid=1000 --clear-groups pip install\n",
+                "pip",
+                "uv"
+            )
+            .0,
+            "setpriv --reuid=1000 --regid=1000 --clear-groups uv install\n"
         );
         // Argument-position stays non-command.
         assert_eq!(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -183,7 +183,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     // --- Weak tier ---
     OpMeta {
         name: "replace",
-        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser wrappers, not uv pip).",
+        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/unshare/nsenter/taskset wrappers, not uv pip).",
         tier: Tier::Weak,
         examples: &[
             (


### PR DESCRIPTION
## Summary

- `command_position` peels `unshare`, `nsenter`, `taskset`, `prlimit`, `numactl`, `chrt`, and `setpriv`.
- Arg-taking peels for nsenter target/root/wd and taskset `--cpu-list` / `--pid`.
- Comma stays a token character so CPU lists like `taskset -c 0,1` peel as one value.
- Agent-rules, schema, API docs, reference, and RELEASE_NOTES updated.

## Test plan

- [x] `cargo test --lib shell_token --all-features`
- [x] `make check-fast`
- [ ] CI green