### PR TITLE
fix(cli): set error_kind on replace --json no_matches/ambiguous

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -307,7 +307,7 @@ dependencies[name=react].version # predicate filter
 | 2 | Changes detected (`--check` mode found pending changes) |
 | 3 | No matches (search/replace pattern miss, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
 | 4 | Parse error (malformed input file or plan) |
-| 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; tx `error_kind: ambiguous`) |
+| 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |
 | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |
 | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied. JSON includes `identity: true`.
 - **CLI patch JSON `error_kind`.** Stale apply/check failures set `error_kind: "ambiguous"` (exit 5), merge conflicts set `"conflicts"` (exit 8), and parse/input failures set `"parse_error"` (exit 4).
 - **CLI search JSON `error_kind`.** Soft no-match (`--json` exit 3) sets `error_kind: "no_matches"`, matching replace/tx agents that branch on kind without scraping stderr.
+- **CLI replace JSON `error_kind`.** `--json` failures set `error_kind: "no_matches"` (exit 3) or `error_kind: "ambiguous"` (exit 5 / `--unique`), matching tx plan JSON so agents can branch without scraping stderr.
 - **GNU long options with `=`.** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).
 - **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
 - **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -572,6 +572,7 @@ These are meaningful command-specific modes that change how a top-level command 
 - **What it does:** Zero matches become an error (CLI exit 3 / structured `EditErrorKind::NoMatch`) instead of soft success. Softened by `--if-exists` / `if_exists`.
 - **Use when:** Agent hosts that treat a missed target as a tool error (fail closed). CLI already fails on no-match by default; the flag is explicit for plan/MCP/library parity.
 - **Identity:** When the pattern matches but `new` equals `old`, the match counts and `require_change` is satisfied (CLI exit 0 with an "identical (no file changes)" note). That is not a zero-match failure. With `--json`, the response includes `"identity": true`.
+- **JSON `error_kind`:** Soft no-match and `--unique` multi-match failures include `error_kind: "no_matches"` (exit 3) or `error_kind: "ambiguous"` (exit 5), matching tx plan JSON. Success responses omit the field.
 - **Prefer instead:** Leave the default when soft no-match is intentional. When both `require_change` and `if_exists` are set, `if_exists` wins.
 
 <!-- ref:replace-mode:command-position -->

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -447,7 +447,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 2 | Changes detected (`--check` mode found pending changes) |\n\
              | 3 | No matches (search/replace pattern miss, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
              | 4 | Parse error (malformed input file or plan) |\n\
-             | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; tx `error_kind: ambiguous`) |\n\
+             | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |\n\
              | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |\n\
              | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |\n\
              | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |\n\

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -122,6 +122,10 @@ struct ReplaceOutput {
     /// Set when the pattern matched but every replacement was identical (no writes).
     #[serde(skip_serializing_if = "Option::is_none")]
     identity: Option<bool>,
+    /// Machine-readable failure kind for agents (`no_matches`, `ambiguous`),
+    /// aligned with tx JSON `error_kind`. Omitted on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_kind: Option<&'static str>,
 }
 
 /// Result of processing a single file.
@@ -310,6 +314,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     }],
                     diff: None,
                     identity: None,
+                    error_kind: Some("ambiguous"),
                 };
                 global.emit_json(&output)?;
                 if !global.quiet {
@@ -341,6 +346,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 files: vec![],
                 diff: None,
                 identity: Some(true),
+                error_kind: None,
             };
             global.emit_json(&output)?;
             if !global.quiet && !global.json && !global.jsonl {
@@ -359,6 +365,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 files: vec![],
                 diff: None,
                 identity: None,
+                error_kind: None,
             };
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
@@ -370,6 +377,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             files: vec![],
             diff: None,
             identity: None,
+            error_kind: Some("no_matches"),
         };
         global.emit_json(&output)?;
         if !global.quiet && !global.json && !global.jsonl {
@@ -431,6 +439,7 @@ fn replace_output(
         files: files.to_vec(),
         diff,
         identity: None,
+        error_kind: None,
     };
 
     finalize_report(
@@ -543,6 +552,11 @@ fn run_context_replace(
             files: vec![],
             diff: None,
             identity: None,
+            error_kind: if args.if_exists {
+                None
+            } else {
+                Some("no_matches")
+            },
         };
         global.emit_json(&empty)?;
         if args.if_exists {

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1598,6 +1598,56 @@ fn test_replace_cli_identity_json_sets_identity_flag() {
         v["identity"], true,
         "JSON should flag identity-only matches: {v}"
     );
+    assert!(
+        v.get("error_kind").is_none() || v["error_kind"].is_null(),
+        "success identity JSON must omit error_kind: {v}"
+    );
+}
+
+#[test]
+fn test_replace_cli_json_error_kind_no_matches() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["replace", "missing", "--new", "x", "a.txt"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("valid JSON");
+    assert_eq!(v["ok"], false);
+    assert_eq!(
+        v["error_kind"], "no_matches",
+        "CLI replace no-match JSON should set error_kind: {v}"
+    );
+}
+
+#[test]
+fn test_replace_cli_json_error_kind_ambiguous() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    fs::write(&file, "pip\npip\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["replace", "pip", "--new", "uv", "--unique", "a.txt"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(5));
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("valid JSON");
+    assert_eq!(v["ok"], false);
+    assert_eq!(
+        v["error_kind"], "ambiguous",
+        "CLI replace unique multi-match JSON should set error_kind: {v}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- CLI `replace --json` failures now include `error_kind: "no_matches"` (exit 3) or `error_kind: "ambiguous"` (exit 5 / `--unique`), matching tx plan JSON.
- Success / identity responses omit the field.
- Agent-rules, reference docs, RELEASE_NOTES, and integration tests updated.

## Test plan

- [x] `cargo test --test integration replace_cli_json_error_kind --all-features`
- [x] `make sync-patchloom-md && make check-fast`
- [ ] CI green