### PR TITLE
fix(cli): set error_kind on search --json no_matches

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
 - **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied. JSON includes `identity: true`.
 - **CLI patch JSON `error_kind`.** Stale apply/check failures set `error_kind: "ambiguous"` (exit 5), merge conflicts set `"conflicts"` (exit 8), and parse/input failures set `"parse_error"` (exit 4).
+- **CLI search JSON `error_kind`.** Soft no-match (`--json` exit 3) sets `error_kind: "no_matches"`, matching replace/tx agents that branch on kind without scraping stderr.
 - **GNU long options with `=`.** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).
 - **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
 - **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -72,6 +72,10 @@ struct SearchOutput {
     files: Vec<SearchFileEntry>,
     match_count: usize,
     file_count: usize,
+    /// Machine-readable failure kind for agents (`no_matches`), aligned with
+    /// CLI replace / tx JSON. Omitted on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_kind: Option<&'static str>,
 }
 
 #[derive(Debug, Serialize)]
@@ -181,6 +185,7 @@ pub(crate) fn format_results(
             file_count: results.file_match_counts.len(),
             matches: results.matches,
             files,
+            error_kind: None,
         };
         out = serde_json::to_string_pretty(&payload)?;
         out.push('\n');
@@ -366,6 +371,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             file_count: 0,
             matches: vec![],
             files: vec![],
+            error_kind: Some("no_matches"),
         };
         global.emit_json(&payload)?;
         if !global.quiet && !global.json && !global.jsonl {

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -253,6 +253,10 @@ fn test_search_json_no_match_emits_valid_json() {
     assert_eq!(parsed["match_count"], 0);
     assert_eq!(parsed["file_count"], 0);
     assert!(parsed["matches"].as_array().unwrap().is_empty());
+    assert_eq!(
+        parsed["error_kind"], "no_matches",
+        "search --json no-match should set error_kind: {parsed}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- CLI `search --json` soft no-match responses now include `error_kind: "no_matches"` (exit 3).
- Success responses omit the field.
- Integration test and RELEASE_NOTES updated.

## Test plan

- [x] `cargo test --test integration test_search_json_no_match --all-features`
- [x] `make check-fast`
- [ ] CI green