### PR TITLE
fix(cli): emit error_kind no_matches on doc/md/AST JSON exits

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI patch JSON `error_kind`.** Stale apply/check failures set `error_kind: "ambiguous"` (exit 5), merge conflicts set `"conflicts"` (exit 8), and parse/input failures set `"parse_error"` (exit 4).
 - **CLI search JSON `error_kind`.** Soft no-match (`--json` exit 3) sets `error_kind: "no_matches"`, matching replace/tx agents that branch on kind without scraping stderr.
 - **CLI replace JSON `error_kind`.** `--json` failures set `error_kind: "no_matches"` (exit 3) or `error_kind: "ambiguous"` (exit 5 / `--unique`), matching tx plan JSON so agents can branch without scraping stderr.
+- **Shared JSON `error_kind: no_matches`.** Exit-3 paths for doc (get/keys/len), md, and AST now set `error_kind` via `GlobalFlags::emit_error_json_kind` / doc `format_no_match`, so agents can branch like tx without scraping stderr.
 - **GNU long options with `=`.** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).
 - **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
 - **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -436,11 +436,23 @@ impl GlobalFlags {
     /// Emit a `{"ok": false, "error": msg}` payload in structured format,
     /// with a stderr fallback in text mode (unless `--quiet`).
     ///
-    /// This is the standard error-reporting pattern for NO_MATCHES and
-    /// similar error paths. In JSON/JSONL mode the payload is printed to
-    /// stdout; in text mode the message goes to stderr.
+    /// Prefer [`Self::emit_error_json_kind`] when the exit path has a stable
+    /// machine-readable kind (for example `no_matches` for exit 3). In
+    /// JSON/JSONL mode the payload is printed to stdout; in text mode the
+    /// message goes to stderr.
     pub fn emit_error_json(&self, msg: &str) -> anyhow::Result<()> {
-        if !self.emit_json(&serde_json::json!({"ok": false, "error": msg}))? && !self.quiet {
+        self.emit_error_json_kind(None, msg)
+    }
+
+    /// Like [`Self::emit_error_json`], but includes `error_kind` when `kind`
+    /// is `Some` so agents can branch without scraping stderr (aligned with
+    /// tx plan JSON and CLI search/replace soft no-match payloads).
+    pub fn emit_error_json_kind(&self, kind: Option<&str>, msg: &str) -> anyhow::Result<()> {
+        let mut payload = serde_json::json!({"ok": false, "error": msg});
+        if let Some(k) = kind {
+            payload["error_kind"] = serde_json::Value::String(k.to_string());
+        }
+        if !self.emit_json(&payload)? && !self.quiet {
             eprintln!("{msg}");
         }
         Ok(())
@@ -647,6 +659,22 @@ mod tests {
     fn emit_error_json_does_not_panic_in_text_mode() {
         let g = GlobalFlags::test_default();
         g.emit_error_json("something went wrong").unwrap();
+    }
+
+    #[test]
+    fn emit_error_json_kind_serializes_kind_field() {
+        // Build the same payload shape the helper emits so we lock the contract
+        // without capturing stdout in unit tests.
+        let mut payload = serde_json::json!({"ok": false, "error": "missing"});
+        payload["error_kind"] = serde_json::Value::String("no_matches".into());
+        assert_eq!(payload["error_kind"], "no_matches");
+        assert_eq!(payload["ok"], false);
+        let g = GlobalFlags {
+            json: true,
+            ..GlobalFlags::test_default()
+        };
+        g.emit_error_json_kind(Some("no_matches"), "missing")
+            .unwrap();
     }
 
     #[test]

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -82,7 +82,7 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
 
     if operations.is_empty() {
         let msg = format!("symbol '{}' not found in {}", args.old, args.path);
-        global.emit_error_json(&msg)?;
+        global.emit_error_json_kind(Some("no_matches"), &msg)?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -91,7 +91,7 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
         Ok(v) => v,
         Err(e) if exit::is_no_match(&e) => {
             let msg = e.to_string();
-            global.emit_error_json(&msg)?;
+            global.emit_error_json_kind(Some("no_matches"), &msg)?;
             return Ok(exit::NO_MATCHES);
         }
         Err(e) => return Err(e),
@@ -202,7 +202,7 @@ pub(super) fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Re
         Ok(code) => Ok(code),
         Err(e) => {
             if exit::is_no_match(&e) {
-                global.emit_error_json(&e.to_string())?;
+                global.emit_error_json_kind(Some("no_matches"), &e.to_string())?;
                 Ok(exit::NO_MATCHES)
             } else {
                 Err(e)

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -57,7 +57,7 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
                  TOML, YAML, JSON, Shell.",
                 lang, args.path,
             );
-            global.emit_error_json(&msg)?;
+            global.emit_error_json_kind(Some("no_matches"), &msg)?;
             return Ok(exit::NO_MATCHES);
         }
         let symbols = symbols::extract_symbols_from_file(&target, Some(lang));
@@ -116,7 +116,7 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
         Ok(exit::SUCCESS)
     } else {
         let msg = format!("no symbols found in {}", args.path);
-        global.emit_error_json(&msg)?;
+        global.emit_error_json_kind(Some("no_matches"), &msg)?;
         Ok(exit::NO_MATCHES)
     }
 }
@@ -151,7 +151,7 @@ pub(super) fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u
         Some(s) => s,
         None => {
             let msg = format!("symbol '{}' not found in {}", args.symbol, args.path);
-            global.emit_error_json(&msg)?;
+            global.emit_error_json_kind(Some("no_matches"), &msg)?;
             return Ok(exit::NO_MATCHES);
         }
     };
@@ -347,7 +347,7 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
 
     if total_matches == 0 {
         let msg = format!("no matches for pattern in {}", args.path);
-        global.emit_error_json(&msg)?;
+        global.emit_error_json_kind(Some("no_matches"), &msg)?;
         Ok(exit::NO_MATCHES)
     } else {
         Ok(exit::SUCCESS)
@@ -395,7 +395,7 @@ pub(super) fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u
 
     if all_refs.is_empty() {
         let msg = format!("no references found for '{}' in {}", args.symbol, args.path);
-        global.emit_error_json(&msg)?;
+        global.emit_error_json_kind(Some("no_matches"), &msg)?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -527,7 +527,7 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
         Ok(exit::SUCCESS)
     } else {
         let msg = format!("no imports found in {}", args.path);
-        global.emit_error_json(&msg)?;
+        global.emit_error_json_kind(Some("no_matches"), &msg)?;
         Ok(exit::NO_MATCHES)
     }
 }
@@ -584,7 +584,7 @@ pub(super) fn run_map(args: MapArgs, global: &GlobalFlags) -> anyhow::Result<u8>
 
     if entries.is_empty() {
         let msg = format!("no symbols found in {}", args.path);
-        global.emit_error_json(&msg)?;
+        global.emit_error_json_kind(Some("no_matches"), &msg)?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -628,7 +628,10 @@ pub(super) fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Resu
     let nodes = crate::ast::impact::compute_impact(&args.symbol, &file_pairs, args.depth);
 
     if nodes.is_empty() {
-        global.emit_error_json(&format!("no references found for '{}'", args.symbol))?;
+        global.emit_error_json_kind(
+            Some("no_matches"),
+            &format!("no references found for '{}'", args.symbol),
+        )?;
         return Ok(exit::NO_MATCHES);
     }
 
@@ -689,7 +692,7 @@ pub(super) fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u
     let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
 
     if changes.is_empty() {
-        global.emit_error_json("no structural changes")?;
+        global.emit_error_json_kind(Some("no_matches"), "no structural changes")?;
         return Ok(exit::NO_MATCHES);
     }
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -465,27 +465,28 @@ fn format_values(values: &[&serde_json::Value], mode: OutputMode) -> anyhow::Res
 /// Used by read-only doc subcommands (get, keys, len, flatten) to produce
 /// consistent no-match output without repeating the Json/Jsonl/Text match.
 fn format_no_match(error_msg: &str, mode: OutputMode, quiet: bool) -> anyhow::Result<(String, u8)> {
-    format_error(error_msg, mode, quiet, exit::NO_MATCHES)
+    format_error(error_msg, mode, quiet, exit::NO_MATCHES, Some("no_matches"))
 }
 
 /// Format an error result for the given output mode and exit code.
 ///
 /// In Json/Jsonl mode, wraps the message in a `{"ok": false, "error": ...}`
-/// envelope. In Text mode, prints to stderr (unless quiet). Returns the
-/// supplied exit code.
+/// envelope (plus optional `error_kind`). In Text mode, prints to stderr
+/// (unless quiet). Returns the supplied exit code.
 fn format_error(
     error_msg: &str,
     mode: OutputMode,
     quiet: bool,
     code: u8,
+    error_kind: Option<&'static str>,
 ) -> anyhow::Result<(String, u8)> {
+    let mut payload = serde_json::json!({"ok": false, "error": error_msg});
+    if let Some(kind) = error_kind {
+        payload["error_kind"] = serde_json::Value::String(kind.into());
+    }
     let output = match mode {
-        OutputMode::Json => {
-            serde_json::to_string_pretty(&serde_json::json!({"ok": false, "error": error_msg}))?
-        }
-        OutputMode::Jsonl => {
-            serde_json::to_string(&serde_json::json!({"ok": false, "error": error_msg}))?
-        }
+        OutputMode::Json => serde_json::to_string_pretty(&payload)?,
+        OutputMode::Jsonl => serde_json::to_string(&payload)?,
         OutputMode::Text => {
             if !quiet {
                 eprintln!("{error_msg}");
@@ -562,6 +563,7 @@ fn execute_with_mode_inner(
                     output_mode,
                     quiet,
                     exit::FAILURE,
+                    None,
                 ),
                 crate::ops::doc::query::QueryKeysResult::Keys(keys) => {
                     let output = match output_mode {
@@ -592,6 +594,7 @@ fn execute_with_mode_inner(
                     output_mode,
                     quiet,
                     exit::FAILURE,
+                    None,
                 ),
                 crate::ops::doc::query::QueryLenResult::Len(len) => {
                     let output = match output_mode {
@@ -796,7 +799,7 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             Ok(code) => return Ok(code),
             Err(e) => {
                 if exit::is_no_match(&e) {
-                    global.emit_error_json(&e.to_string())?;
+                    global.emit_error_json_kind(Some("no_matches"), &e.to_string())?;
                     return Ok(exit::NO_MATCHES);
                 }
                 // TypeError or other engine error → FAILURE

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -161,7 +161,7 @@ fn execute_md_op(
         Ok(code) => Ok(code),
         Err(e) => {
             if exit::is_no_match(&e) {
-                global.emit_error_json(&e.to_string())?;
+                global.emit_error_json_kind(Some("no_matches"), &e.to_string())?;
                 Ok(exit::NO_MATCHES)
             } else {
                 Err(e)
@@ -375,7 +375,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             match find_section(&content, &heading) {
                 None => {
                     let msg = format!("heading {:?} not found in {file}", heading);
-                    global.emit_error_json(&msg)?;
+                    global.emit_error_json_kind(Some("no_matches"), &msg)?;
                     Ok(exit::NO_MATCHES)
                 }
                 Some((body_start, body_end)) => {

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2262,6 +2262,36 @@ fn test_doc_get_no_match_text_mode_emits_stderr() {
 }
 
 #[test]
+fn test_doc_get_no_match_json_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(&file, r#"{"a": 1}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("doc")
+        .arg("get")
+        .arg(&file)
+        .arg("nonexistent")
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("valid JSON");
+    assert_eq!(v["ok"], false);
+    assert_eq!(
+        v["error_kind"], "no_matches",
+        "doc get --json no-match should set error_kind: {v}"
+    );
+    assert!(
+        v["error"].as_str().unwrap_or("").contains("no match"),
+        "error message should remain human-readable: {v}"
+    );
+}
+
+#[test]
 fn test_doc_keys_no_match_text_mode_emits_stderr() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.json");


### PR DESCRIPTION
## Summary

- New `GlobalFlags::emit_error_json_kind` for structured failures with `error_kind`.
- Exit-3 (NO_MATCHES) paths in doc write/md/AST call it with `no_matches`.
- Doc read-only `format_no_match` JSON also includes `error_kind: "no_matches"`.
- Integration test for `doc get --json` + RELEASE_NOTES.

## Test plan

- [x] `cargo test --lib emit_error_json --all-features`
- [x] `cargo test --test integration test_doc_get_no_match_json_sets_error_kind --all-features`
- [x] `make check-fast`
- [ ] CI green