### PR TITLE
fix(cli): set error_kind on patch --json parse/stale/conflict

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, `setsid`, `runuser -u USER`, `busybox` applets, and path-taking `flock` / `chroot` wrappers.
 - **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
 - **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied. JSON includes `identity: true`.
+- **CLI patch JSON `error_kind`.** Stale apply/check failures set `error_kind: "ambiguous"` (exit 5), merge conflicts set `"conflicts"` (exit 8), and parse/input failures set `"parse_error"` (exit 4).
 - **GNU long options with `=`.** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).
 - **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
 - **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -170,8 +170,18 @@ fn inject_stale_label(msg: &str, label: &str) -> String {
     }
 }
 
-fn emit_error(global: &GlobalFlags, error: &str) -> anyhow::Result<()> {
-    global.emit_error_json(error)
+fn emit_error(global: &GlobalFlags, error: &str, error_kind: &str) -> anyhow::Result<()> {
+    // Include error_kind so agents can branch (ambiguous=stale, conflicts=merge
+    // conflicts) without scraping the English STALE/MERGE FAILED label.
+    if !global.emit_json(&serde_json::json!({
+        "ok": false,
+        "error": error,
+        "error_kind": error_kind,
+    }))? && !global.quiet
+    {
+        eprintln!("{error}");
+    }
+    Ok(())
 }
 
 fn emit_patch_files_output(
@@ -253,15 +263,27 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let diff_text = match read_diff_input(&file, stdin_flag, global) {
         Ok(text) => text,
         Err(DiffReadError::NoSource) => {
-            emit_error(global, "patch: must specify --file <path> or --stdin")?;
+            emit_error(
+                global,
+                "patch: must specify --file <path> or --stdin",
+                "parse_error",
+            )?;
             return Ok(exit::PARSE_ERROR);
         }
         Err(DiffReadError::IoError(path, e)) => {
-            emit_error(global, &format!("patch: failed to read '{path}': {e}"))?;
+            emit_error(
+                global,
+                &format!("patch: failed to read '{path}': {e}"),
+                "parse_error",
+            )?;
             return Ok(exit::PARSE_ERROR);
         }
         Err(DiffReadError::StdinError(e)) => {
-            emit_error(global, &format!("patch: failed to read stdin: {e}"))?;
+            emit_error(
+                global,
+                &format!("patch: failed to read stdin: {e}"),
+                "parse_error",
+            )?;
             return Ok(exit::PARSE_ERROR);
         }
     };
@@ -270,7 +292,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let patch_files = match parse_patch(&diff_text) {
         Ok(pf) => pf,
         Err(msg) => {
-            emit_error(global, &format!("patch: parse error: {msg}"))?;
+            emit_error(global, &format!("patch: parse error: {msg}"), "parse_error")?;
             return Ok(exit::PARSE_ERROR);
         }
     };
@@ -407,15 +429,15 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 // The engine error from apply_patch_with_loader already includes
                 // "patch apply: <path> -- <detail>", so we add the STALE/MERGE
                 // FAILED label to match the original CLI format.
-                let exit_code = if msg.contains("conflict(s)") {
-                    exit::CONFLICTS
+                let (exit_code, kind) = if msg.contains("conflict(s)") {
+                    (exit::CONFLICTS, "conflicts")
                 } else {
-                    exit::AMBIGUOUS
+                    (exit::AMBIGUOUS, "ambiguous")
                 };
                 // Inject the STALE/MERGE FAILED label between path and error detail.
                 let label = if merge_mode { "MERGE FAILED" } else { "STALE" };
                 let err = inject_stale_label(&msg, label);
-                emit_error(global, &err)?;
+                emit_error(global, &err, kind)?;
                 return Ok(exit_code);
             }
         };

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -185,6 +185,16 @@ fn assert_patch_apply_error_object(
             .unwrap()
             .contains(expected_error_substring)
     );
+    let expected_kind = match expected_exit_code {
+        4 => "parse_error",
+        5 => "ambiguous",
+        8 => "conflicts",
+        _ => return,
+    };
+    assert_eq!(
+        json["error_kind"], expected_kind,
+        "patch --json should set error_kind for exit {expected_exit_code}: {json}"
+    );
 }
 
 fn git_ok(dir: &Path, args: &[&str]) {


### PR DESCRIPTION
## Summary

- CLI `patch` JSON failures now include `error_kind`: `parse_error` (exit 4), `ambiguous` (stale, exit 5), or `conflicts` (exit 8).
- Integration helper asserts the kind for existing parse/stale cases.
- RELEASE_NOTES updated.

## Test plan

- [x] `cargo test --test integration test_patch_apply_json --all-features`
- [x] `make check-fast`
- [ ] CI green