### PR TITLE
fix(shell_token): peel run0 privilege wrapper

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,7 +31,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
 - **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.
 - **`timeout --kill-after` stacked durations.** Peels consecutive duration tokens so `timeout --kill-after 5 30 pip` and `timeout --kill-after=5 30 pip` rewrite the command (bare `5 30 pip` still stays non-command).
-- **CI isolation wrappers.** `command_position` peels `unshare`, `nsenter`, `taskset`, `prlimit`, `numactl`, `chrt`, and `setpriv` (plus list values like `taskset -c 0,1`) so sandbox and affinity-wrapped installs rewrite.
+- **CI isolation wrappers.** `command_position` peels `unshare`, `nsenter`, `taskset`, `prlimit`, `numactl`, `chrt`, `setpriv`, and `run0` (plus list values like `taskset -c 0,1`) so sandbox and affinity-wrapped installs rewrite.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -23,6 +23,8 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     "timeout", "stdbuf", "ionice",
     // Isolation / privilege wrappers used by agent and CI scripts.
     "setsid", "runuser",
+    // systemd-run0 alternative to sudo (flags like -u / --user peel as arg-taking).
+    "run0",
     // Namespace / CPU affinity / resource-limit wrappers (CI and sandbox scripts).
     "unshare", "nsenter", "taskset", "prlimit", "numactl",
     // Priority / privilege wrappers: `chrt -f 10 cmd`, `setpriv --reuid=… cmd`.
@@ -647,6 +649,22 @@ mod tests {
         // Argument-position stays non-command.
         assert_eq!(
             replace_command_position("echo unshare -n pip\n", "pip", "uv").1,
+            0
+        );
+    }
+
+    #[test]
+    fn run0_allows_command() {
+        assert_eq!(
+            replace_command_position("run0 pip install\n", "pip", "uv").0,
+            "run0 uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("run0 -u root pip install\n", "pip", "uv").0,
+            "run0 -u root uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("echo run0 pip\n", "pip", "uv").1,
             0
         );
     }


### PR DESCRIPTION
## Summary

- `command_position` peels `run0` (and `run0 -u USER`) so install rewrites work under systemd run0.
- Unit test and RELEASE_NOTES updated.

## Test plan

- [x] `cargo test --lib run0_allows --all-features`
- [x] `make check-fast`
- [ ] CI green