### PR TITLE
ci: skip heavy jobs on draft and release-please PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ permissions:
 # Draft PRs must not burn Actions minutes. Job-level guards are required:
 # converting to draft does NOT cancel or skip workflows by itself. Keep one
 # non-draft PR active when serializing a merge queue.
+#
+# release-please PRs re-sync on every main merge (Cargo.toml + CHANGELOG only).
+# Skip multi-OS/fuzz/coverage matrices there; keep build-and-test + semver-checks.
 
 jobs:
   changes:
@@ -84,7 +87,10 @@ jobs:
     needs: [changes]
     if: >
       always()
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: windows-latest
     timeout-minutes: 20
@@ -121,7 +127,10 @@ jobs:
     needs: [changes]
     if: >
       always()
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: macos-latest
     timeout-minutes: 20
@@ -147,7 +156,10 @@ jobs:
     needs: [changes]
     if: >
       always()
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -176,7 +188,10 @@ jobs:
     needs: [changes]
     if: >
       always()
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: macos-latest
     timeout-minutes: 10
@@ -205,7 +220,10 @@ jobs:
     needs: [changes]
     if: >
       always()
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -351,7 +369,10 @@ jobs:
     needs: [changes]
     if: >
       always()
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -442,7 +463,10 @@ jobs:
     needs: [changes]
     if: >
       always()
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 8
@@ -495,7 +519,10 @@ jobs:
     needs: [changes]
     if: >
       always()
-      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -599,7 +626,8 @@ jobs:
 
   ci:
     # Lightweight gate that satisfies the "ci" required status check.
-    # Reports success when build-and-test passes OR was skipped (docs-only PR).
+    # Reports success when build-and-test passes OR was skipped (docs-only,
+    # draft, or release-please light path). Skipped expensive jobs count as OK.
     needs: [build-and-test, ci-windows, ci-macos, msrv, msrv-macos, coverage, bench, fuzz, agent-dry-run, audit, deny]
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    # ready_for_review re-runs CI when a draft is marked ready (drafts skip
+    # expensive jobs below; synchronize alone does not re-fire undraft).
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches: [main]
   merge_group: {}
@@ -18,13 +21,19 @@ permissions:
   contents: read
   actions: read
 
+# Draft PRs must not burn Actions minutes. Job-level guards are required:
+# converting to draft does NOT cancel or skip workflows by itself. Keep one
+# non-draft PR active when serializing a merge queue.
+
 jobs:
   changes:
     # Detect whether source code changed. On non-PR events (push, schedule,
     # merge_group) this job is skipped, which causes all downstream jobs to
     # run unconditionally via the `needs.changes.result == 'skipped'` guard.
+    # Draft PRs skip this job too; expensive jobs also require not-draft so
+    # they do not treat "changes skipped" as "run everything".
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
     permissions:
       pull-requests: read
     outputs:
@@ -47,7 +56,10 @@ jobs:
 
   build-and-test:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -70,7 +82,10 @@ jobs:
 
   ci-windows:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
@@ -104,7 +119,10 @@ jobs:
 
   ci-macos:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: macos-latest
     timeout-minutes: 20
     steps:
@@ -127,7 +145,10 @@ jobs:
 
   msrv:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -153,7 +174,10 @@ jobs:
 
   msrv-macos:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
@@ -179,7 +203,10 @@ jobs:
 
   coverage:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -322,7 +349,10 @@ jobs:
 
   bench:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -410,7 +440,10 @@ jobs:
 
   fuzz:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 8
     strategy:
@@ -460,7 +493,10 @@ jobs:
 
   agent-dry-run:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -508,7 +544,10 @@ jobs:
 
   audit:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -534,7 +573,10 @@ jobs:
   # cargo-deny here locks policy in-repo (addresses #1485).
   deny:
     needs: [changes]
-    if: always() && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
## Summary

- **Draft PRs:** GitHub does not skip CI on draft. Job-level
  `pull_request.draft == false` guards stop expensive matrices; include
  `ready_for_review` so undraft re-runs CI.
- **release-please PRs:** Every main merge re-syncs the release branch
  and was re-running the full multi-OS + fuzz matrix. Skip those heavy
  jobs when `head_ref` starts with `release-please`; keep
  `build-and-test` + `semver-checks`.
- Required aggregate `ci` gate still treats skipped expensive jobs as OK.

## Test plan

- [ ] Feature PR (ready): full matrix runs
- [ ] Draft PR push: heavy jobs skip
- [ ] Mark draft ready: CI re-runs
- [ ] release-please PR sync: light path only (no windows/macos/fuzz)