### PR TITLE
test: make confirm-json decline unit tests TTY-safe

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -176,7 +176,53 @@ pub struct WriteFlags {
     pub no_format: bool,
 }
 
+// Test-only override for confirm_prompt. Docker and many evaluation harnesses
+// allocate a pseudo-TTY on stdin, so unit tests that need a deterministic
+// decline must not read the real terminal.
+#[cfg(test)]
+thread_local! {
+    static CONFIRM_ANSWER_OVERRIDE: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// RAII guard that forces a fixed confirm answer on the current thread.
+///
+/// Restores the previous override when dropped. Production code never sets
+/// the override; only tests use this. Needed because Docker/eval harnesses
+/// often allocate a pseudo-TTY, which would prompt and default to yes.
+#[cfg(test)]
+#[doc(hidden)]
+pub struct ConfirmAnswerGuard {
+    prev: Option<bool>,
+}
+
+#[cfg(test)]
+impl ConfirmAnswerGuard {
+    /// Force `confirm_prompt` / `should_apply` to return this answer.
+    pub fn force(answer: bool) -> Self {
+        let prev = CONFIRM_ANSWER_OVERRIDE.with(|cell| {
+            let previous = cell.get();
+            cell.set(Some(answer));
+            previous
+        });
+        Self { prev }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ConfirmAnswerGuard {
+    fn drop(&mut self) {
+        CONFIRM_ANSWER_OVERRIDE.with(|cell| cell.set(self.prev));
+    }
+}
+
 pub(crate) fn confirm_prompt(prompt: &str) -> bool {
+    #[cfg(test)]
+    {
+        if let Some(answer) = CONFIRM_ANSWER_OVERRIDE.with(|cell| cell.get()) {
+            return answer;
+        }
+    }
     // Flush stdout before the prompt writes to stderr, otherwise the diff
     // output may remain buffered and invisible in a PTY.
     use std::io::Write;
@@ -747,10 +793,34 @@ mod tests {
     }
 
     #[test]
+    fn confirm_answer_guard_forces_decline_even_with_tty_stdin() {
+        // Simulates Docker/eval harnesses that allocate a pseudo-TTY: without
+        // the guard, should_apply() would prompt and default to yes on empty.
+        let _guard = ConfirmAnswerGuard::force(false);
+        let g = GlobalFlags {
+            confirm: true,
+            ..GlobalFlags::default()
+        };
+        assert!(!g.should_apply());
+        assert!(!confirm_prompt("Apply?"));
+    }
+
+    #[test]
+    fn confirm_answer_guard_forces_accept() {
+        let _guard = ConfirmAnswerGuard::force(true);
+        let g = GlobalFlags {
+            confirm: true,
+            ..GlobalFlags::default()
+        };
+        assert!(g.should_apply());
+    }
+
+    #[test]
     fn should_apply_confirm_non_tty_returns_false() {
         if std::io::IsTerminal::is_terminal(&std::io::stdin()) {
             // Docker and devcontainers often allocate a pseudo-TTY on stdin.
-            // Non-TTY behavior is covered by confirm_prompt_non_tty_returns_false.
+            // Non-TTY behavior is covered by confirm_prompt_non_tty_returns_false
+            // and ConfirmAnswerGuard unit tests above.
             return;
         }
         let g = GlobalFlags {

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -309,7 +309,9 @@ mod tests {
         let mut global = GlobalFlags::test_with_cwd(dir.path());
         global.confirm = true;
         global.json = true;
-        // confirm + json in non-TTY -> should_apply() returns false
+        // Force decline: Docker/eval harnesses often allocate a pseudo-TTY,
+        // which would otherwise prompt and default to yes on empty input.
+        let _decline = crate::cli::global::ConfirmAnswerGuard::force(false);
 
         let op = Operation::FileCreate {
             path: "new.txt".to_string(),

--- a/src/cmd/write_dispatch.rs
+++ b/src/cmd/write_dispatch.rs
@@ -154,7 +154,9 @@ mod tests {
         let mut global = GlobalFlags::test_with_cwd(dir.path());
         global.confirm = true;
         global.json = true;
-        // confirm + json in non-TTY -> should_apply() returns false
+        // Force decline: Docker/eval harnesses often allocate a pseudo-TTY,
+        // which would otherwise prompt and default to yes on empty input.
+        let _decline = crate::cli::global::ConfirmAnswerGuard::force(false);
 
         let mut applied = false;
         let code = execute_write(


### PR DESCRIPTION
## Summary

Make `--confirm` + `--json` decline unit tests deterministic when stdin is a pseudo-TTY (Docker and many evaluation harnesses).

## Problem

On latest release (`patchloom-v0.11.0`), `cargo test --lib` in a Docker container with an allocated TTY fails two tests:

- `cmd::output::tests::execute_via_engine_confirm_json_decline_returns_changes_detected`
- `cmd::write_dispatch::tests::confirm_json_decline_returns_changes_detected`

Those tests assume non-TTY auto-decline (`should_apply() == false`). With a TTY, `confirm_prompt` prints `Apply? [Y/n]`, empty input defaults to yes, the write applies, and exit code is `0` instead of `CHANGES_DETECTED` (`2`). The tests can also hang for 60+ seconds waiting on stdin.

## Change

- Add `ConfirmAnswerGuard` (thread-local, tests only), same RAII pattern as `RestoreFailGuard`
- Force decline in the two write-path decline unit tests
- Add unit tests that cover force-accept and force-decline without reading real stdin

Production `confirm` behavior is unchanged. Non-TTY auto-decline and real PTY confirm paths remain covered by existing unit and PTY integration tests.

## Validation

- `cargo test --lib confirm` (9 tests)
- `script -q /dev/null cargo test --lib confirm_json_decline` (passes under forced TTY)
- `make check-fast` (fmt-check, clippy, lib tests, feature matrices, integration, pty)

## Notes

Reproduces in containers that allocate a pseudo-TTY on stdin. Local/CI without TTY already passed these tests.