### PR TITLE
docs: document TTY-safe confirm unit tests in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,8 @@ if fs::read_to_string(&file).is_ok() {
 }
 ```
 
+- **Confirm / TTY-gated unit tests must not depend on ambient stdin.** Docker, devcontainers, and eval harnesses often allocate a pseudo-TTY on stdin. Unit tests that set `confirm = true` and assume non-TTY auto-decline hang, print `Apply? [Y/n]`, default to yes, and return exit 0 instead of decline. Prefer inject (`confirm_prompt_interactive(false, reader)`) or force decline with `ConfirmAnswerGuard::force(false)` (thread-local, same RAII pattern as `RestoreFailGuard`). If you must call production confirm on real stdin, skip when `IsTerminal::is_terminal(&stdin)`. `assert_cmd` subprocesses (piped stdin) and `tests/pty.rs` (intentional TTY) are separate paths. After adding confirm unit tests, grep for `confirm = true` without a guard or inject nearby. See #579, #1556.
+
 ### Writes
 
 All file mutations go through `write::atomic_write()`, which uses `tempfile::NamedTempFile` + rename for crash safety. The `WritePolicy` struct controls transformations applied before writing.


### PR DESCRIPTION
## Summary

Document the Docker/pseudo-TTY confirm unit-test rule in AGENTS.md so it sits next to the existing root `chmod 000` guard.

## Problem

#579 fixed three Docker portability issues (color, confirm hang, root chmod). Only the chmod half was elevated to AGENTS.md. Confirm/TTY stayed a code comment, so #1352 reintroduced ambient non-TTY decline tests that failed under Docker/eval TTY on v0.11.0 (#1556 fixed the tests).

## Change

Add a Testing bullet: inject or use `ConfirmAnswerGuard`, skip ambient TTY when necessary, grep after new confirm unit tests. Refs #579, #1556.

Durable skill rule also added in `rust-conventions` (local agent skills; not in this PR).

## Validation

Docs-only; no code change.