### PR TITLE
fix: shell container wrappers and undo JSON error_kind

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -35,7 +35,7 @@
 
 **`replace_text` / plan replace flags (default false):**
 - `require_change`: error when the pattern matches zero times (fail closed).
-- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`unshare`/`nsenter`/`taskset`/`busybox` wrappers yes; `uv pip` no).
+- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox` wrappers yes; `uv pip` no).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 Use patchloom when:
@@ -248,7 +248,7 @@ All operations succeed atomically or roll back together.
 
 Plan/MCP `replace` accepts library flags (default false):
 - `require_change`: fail when the pattern matches zero times (agent fail-closed).
-- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`unshare`/`nsenter`/`taskset`/`busybox` wrappers yes; `uv pip` no).
+- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox` wrappers yes; `uv pip` no).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 ## AST-aware operations

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,8 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CI isolation wrappers.** `command_position` peels `unshare`, `nsenter`, `taskset`, `prlimit`, `numactl`, `chrt`, and `setpriv` (plus list values like `taskset -c 0,1`) so sandbox and affinity-wrapped installs rewrite.
 - **Unit/sandbox wrappers.** `command_position` peels `systemd-run`, `firejail`, `dbus-run-session`, and `chronic`, plus bare `--` end-of-options markers (`dbus-run-session -- pip`).
 - **`run0` privilege wrapper.** `command_position` peels systemd `run0` (modern `sudo` alternative) so `run0 -u root pip` rewrites the command.
+- **Container entrypoint wrappers.** `command_position` peels `gosu`, `su-exec`, `tini`, and `dumb-init` so Docker/K8s install scripts rewrite the invocable command.
+- **CLI undo JSON `error_kind`.** Soft no-session paths (`undo --list` empty, or no sessions to restore) set `error_kind: "no_matches"` (exit 3), matching other CLI exit-3 JSON envelopes.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -341,6 +341,7 @@ Patchloom can be used as a Rust library (disable default `cli` feature for small
   - `--list` shows available backup sessions. `--json` emits the full session list as one array, while `--jsonl` emits one session object per line.
   - `--session <timestamp>` targets a specific session (defaults to most recent).
   - `--apply` actually restores files (dry-run by default, showing what would change).
+- **Failure behavior:** No backup sessions (`--list` empty, or restore with no sessions) exits `3` (`NO_MATCHES`). With `--json`/`--jsonl`, the error envelope includes `error_kind: "no_matches"` so agents can branch without scraping stderr.
 - **Prefer instead:** Use `git checkout` or `git stash` when working in a committed git repo.
 - **Related:** `tx`, `replace`, `tidy`
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -112,7 +112,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Get server version and working directory | `server_info` |\n\n\
              **`replace_text` / plan replace flags (default false):**\n\
              - `require_change`: error when the pattern matches zero times (fail closed).\n\
-             - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`unshare`/`nsenter`/`taskset`/`busybox` wrappers yes; `uv pip` no).\n\
+             - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox` wrappers yes; `uv pip` no).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
              \"command_position\":true,\"require_change\":true}`\n\n",
         );
@@ -385,7 +385,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  All operations succeed atomically or roll back together.\n\n\
                  Plan/MCP `replace` accepts library flags (default false):\n\
                  - `require_change`: fail when the pattern matches zero times (agent fail-closed).\n\
-                 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`unshare`/`nsenter`/`taskset`/`busybox` wrappers yes; `uv pip` no).\n\
+                 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox` wrappers yes; `uv pip` no).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\n");
         }
@@ -678,11 +678,15 @@ mod tests {
             out.contains("flock")
                 && out.contains("runuser")
                 && out.contains("setsid")
+                && out.contains("run0")
+                && out.contains("gosu")
                 && out.contains("unshare")
                 && out.contains("nsenter")
                 && out.contains("taskset")
+                && out.contains("systemd-run")
+                && out.contains("firejail")
                 && out.contains("busybox"),
-            "agent-rules should name isolation wrappers for command_position"
+            "agent-rules should name isolation/container wrappers for command_position"
         );
         let mcp = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));
         assert!(

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -51,10 +51,9 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if args.list {
         let sessions = backup::list_sessions(&cwd)?;
         if sessions.is_empty() {
-            let empty: Vec<()> = vec![];
-            if !global.emit_json(&empty)? && !global.quiet {
-                eprintln!("no backup sessions found");
-            }
+            // Match other CLI exit-3 paths: agents branch on error_kind without
+            // scraping stderr (empty array alone was inconsistent with undo apply).
+            global.emit_error_json_kind(Some("no_matches"), "no backup sessions found")?;
             return Ok(exit::NO_MATCHES);
         }
 
@@ -83,13 +82,7 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         // Use the most recent session.
         let sessions = backup::list_sessions(&cwd)?;
         if sessions.is_empty() {
-            if !global.emit_json(&serde_json::json!({
-                "ok": false,
-                "error": "no backup sessions found",
-            }))? && !global.quiet
-            {
-                eprintln!("no backup sessions found");
-            }
+            global.emit_error_json_kind(Some("no_matches"), "no backup sessions found")?;
             return Ok(exit::NO_MATCHES);
         }
         sessions[0].timestamp.clone()
@@ -315,9 +308,25 @@ mod tests {
         };
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::NO_MATCHES);
-        // JSON error object is emitted via global.emit_json which writes to
-        // stdout. We verify the exit code; emit_json return-value correctness
-        // is covered by unit tests in cli/global.rs.
+        // JSON error envelope (ok/error/error_kind) is emitted via
+        // emit_error_json_kind. Exit code is the unit-test contract; payload
+        // shape is covered by emit_error_json_kind tests in cli/global.rs and
+        // by integration coverage for other exit-3 commands.
+    }
+
+    #[test]
+    fn list_empty_json_exits_no_matches() {
+        let dir = TempDir::new().unwrap();
+        let mut global = GlobalFlags::test_default();
+        global.json = true;
+        global.cwd = Some(dir.path().to_string_lossy().to_string());
+        let args = UndoArgs {
+            list: true,
+            session: None,
+            apply: false,
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
     }
 
     #[test]

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -40,6 +40,11 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     "runuser",
     // systemd-run0 alternative to sudo (flags like -u / --user peel as arg-taking).
     "run0",
+    // Container entrypoint / drop-privilege wrappers (Docker/K8s agent scripts).
+    "gosu",
+    "su-exec",
+    "tini",
+    "dumb-init",
     // Namespace / CPU affinity / resource-limit wrappers (CI and sandbox scripts).
     "unshare",
     "nsenter",
@@ -66,9 +71,10 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     ".",
 ];
 
-/// Wrappers whose next non-option argument is a path (not the command):
-/// `flock /tmp/l pip`, `flock -n /var/lock/x pip`, `chroot /jail pip`.
-const PATH_TAKING_PREFIXES: &[&str] = &["flock", "chroot"];
+/// Wrappers whose next non-option argument is a path or user (not the command):
+/// `flock /tmp/l pip`, `flock -n /var/lock/x pip`, `chroot /jail pip`,
+/// `gosu app pip`, `su-exec nobody pip`.
+const PATH_TAKING_PREFIXES: &[&str] = &["flock", "chroot", "gosu", "su-exec"];
 
 /// Return true if `token` at byte range `[start, end)` is in shell command position.
 pub fn is_command_position(content: &str, start: usize, end: usize) -> bool {
@@ -981,6 +987,30 @@ mod tests {
         );
         assert_eq!(
             replace_command_position("echo run0 pip\n", "pip", "uv").1,
+            0
+        );
+    }
+
+    #[test]
+    fn container_entrypoint_wrappers_allow_command() {
+        assert_eq!(
+            replace_command_position("gosu app pip install\n", "pip", "uv").0,
+            "gosu app uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("su-exec nobody pip install\n", "pip", "uv").0,
+            "su-exec nobody uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("tini -- pip install\n", "pip", "uv").0,
+            "tini -- uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("dumb-init -- pip install\n", "pip", "uv").0,
+            "dumb-init -- uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("echo gosu pip\n", "pip", "uv").1,
             0
         );
     }

--- a/tests/integration/undo_tests.rs
+++ b/tests/integration/undo_tests.rs
@@ -326,7 +326,7 @@ fn test_undo_no_sessions_exits_3() {
 }
 
 #[test]
-fn test_undo_list_json_empty_emits_array() {
+fn test_undo_list_json_empty_sets_error_kind() {
     let dir = TempDir::new().unwrap();
 
     let output = Command::cargo_bin("patchloom")
@@ -338,8 +338,38 @@ fn test_undo_list_json_empty_emits_array() {
 
     assert_eq!(output.status.code(), Some(3));
     let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(parsed.is_array(), "empty undo --list --json should emit []");
-    assert_eq!(parsed.as_array().unwrap().len(), 0);
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "no_matches",
+        "empty undo --list --json should set error_kind: {parsed}"
+    );
+    assert!(
+        parsed["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("no backup sessions found"),
+        "expected no-sessions error message: {parsed}"
+    );
+}
+
+#[test]
+fn test_undo_json_no_sessions_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "undo", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "no_matches",
+        "undo --json with no sessions should set error_kind: {parsed}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

MPI batch (one PR, multiple logical commits):

1. **shell_token:** peel container entrypoint wrappers `gosu`, `su-exec`, `tini`, `dumb-init` (`gosu`/`su-exec` as user-taking like path-taking wrappers).
2. **undo:** empty sessions (`--list` or restore) emit JSON `error_kind: "no_matches"` (exit 3) via `emit_error_json_kind`, matching other CLI soft no-match paths.
3. **agent-rules / PATCHLOOM.md:** name the expanded wrapper set for `command_position`.

## Test plan

- [x] `cargo test --lib shell_token` / `cmd::undo`
- [x] `cargo test --test integration undo`
- [x] `make check-fast` (before final docs tweak; agent-rules tests + PATCHLOOM sync re-run)
- [ ] CI green