### PR TITLE
fix(cli): doc type_error error_kind and wrapper docs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -305,7 +305,7 @@ dependencies[name=react].version # predicate filter
 | 0 | Success (operation completed, or no changes needed) |
 | 1 | Failure (error during execution), or tx `rollback_failed` when mid-commit rollback could not fully restore files |
 | 2 | Changes detected (`--check` mode found pending changes) |
-| 3 | No matches (search/replace pattern miss, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
+| 3 | No matches (search/replace pattern miss, undo with no sessions, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
 | 4 | Parse error (malformed input file or plan) |
 | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |
 | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |
@@ -317,7 +317,7 @@ dependencies[name=react].version # predicate filter
 
 ## Operations (from schema registry)
 
-- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/unshare/nsenter/taskset wrappers, not uv pip).
+- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail wrappers, not uv pip).
 - `file.append`: Append content to an existing file.
 - `file.prepend`: Prepend content to an existing file.
 - `file.create`: Create a new file with specified content.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -38,6 +38,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`run0` privilege wrapper.** `command_position` peels systemd `run0` (modern `sudo` alternative) so `run0 -u root pip` rewrites the command.
 - **Container entrypoint wrappers.** `command_position` peels `gosu`, `su-exec`, `tini`, and `dumb-init` so Docker/K8s install scripts rewrite the invocable command.
 - **CLI undo JSON `error_kind`.** Soft no-session paths (`undo --list` empty, or no sessions to restore) set `error_kind: "no_matches"` (exit 3), matching other CLI exit-3 JSON envelopes.
+- **CLI doc JSON `error_kind: type_error`.** `doc keys` / `doc len` on the wrong value type, and write-path type failures, set `error_kind: "type_error"` (exit 1) so agents can distinguish type mismatches from soft no-matches.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -445,7 +445,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 0 | Success (operation completed, or no changes needed) |\n\
              | 1 | Failure (error during execution), or tx `rollback_failed` when mid-commit rollback could not fully restore files |\n\
              | 2 | Changes detected (`--check` mode found pending changes) |\n\
-             | 3 | No matches (search/replace pattern miss, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
+             | 3 | No matches (search/replace pattern miss, undo with no sessions, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
              | 4 | Parse error (malformed input file or plan) |\n\
              | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |\n\
              | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |\n\

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -563,7 +563,7 @@ fn execute_with_mode_inner(
                     output_mode,
                     quiet,
                     exit::FAILURE,
-                    None,
+                    Some("type_error"),
                 ),
                 crate::ops::doc::query::QueryKeysResult::Keys(keys) => {
                     let output = match output_mode {
@@ -594,7 +594,7 @@ fn execute_with_mode_inner(
                     output_mode,
                     quiet,
                     exit::FAILURE,
-                    None,
+                    Some("type_error"),
                 ),
                 crate::ops::doc::query::QueryLenResult::Len(len) => {
                     let output = match output_mode {
@@ -802,8 +802,8 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     global.emit_error_json_kind(Some("no_matches"), &e.to_string())?;
                     return Ok(exit::NO_MATCHES);
                 }
-                // TypeError or other engine error → FAILURE
-                global.emit_error_json(&e.to_string())?;
+                // TypeError or other engine error → FAILURE (typed for agents)
+                global.emit_error_json_kind(Some("type_error"), &e.to_string())?;
                 return Ok(exit::FAILURE);
             }
         }

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -759,6 +759,11 @@ mod error_handling {
         .unwrap();
         assert_eq!(json_code, exit::FAILURE);
         assert!(json_output.contains("not an object"));
+        assert!(
+            json_output.contains(r#""error_kind": "type_error""#)
+                || json_output.contains(r#""error_kind":"type_error""#),
+            "JSON type mismatch should set error_kind type_error: {json_output}"
+        );
     }
 
     #[test]
@@ -786,6 +791,11 @@ mod error_handling {
         .unwrap();
         assert_eq!(json_code, exit::FAILURE);
         assert!(json_output.contains("not an array or object"));
+        assert!(
+            json_output.contains(r#""error_kind": "type_error""#)
+                || json_output.contains(r#""error_kind":"type_error""#),
+            "JSON type mismatch should set error_kind type_error: {json_output}"
+        );
     }
 
     #[test]

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -1006,6 +1006,10 @@ mod tests {
             "tini -- uv install\n"
         );
         assert_eq!(
+            replace_command_position("tini -g -- pip install\n", "pip", "uv").0,
+            "tini -g -- uv install\n"
+        );
+        assert_eq!(
             replace_command_position("dumb-init -- pip install\n", "pip", "uv").0,
             "dumb-init -- uv install\n"
         );

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -183,7 +183,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     // --- Weak tier ---
     OpMeta {
         name: "replace",
-        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/unshare/nsenter/taskset wrappers, not uv pip).",
+        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail wrappers, not uv pip).",
         tier: Tier::Weak,
         examples: &[
             (

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2454,6 +2454,11 @@ fn test_doc_keys_not_an_object_returns_failure() {
         stdout.contains("not an object"),
         "JSON output should contain error, got: {stdout}"
     );
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed["error_kind"], "type_error",
+        "doc keys type mismatch should set error_kind: {parsed}"
+    );
 }
 
 #[test]
@@ -2497,6 +2502,11 @@ fn test_doc_len_not_array_or_object_returns_failure() {
     assert!(
         stdout.contains("not an array or object"),
         "JSON output should contain error, got: {stdout}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(
+        parsed["error_kind"], "type_error",
+        "doc len type mismatch should set error_kind: {parsed}"
     );
 }
 


### PR DESCRIPTION
## Summary

MPI batch 2 (one PR):

1. **doc:** JSON type mismatches (`keys`/`len` wrong value type, write TypeError path) set `error_kind: "type_error"` (exit 1).
2. **docs:** agent-rules / schema / PATCHLOOM wrapper lists include container and unit peels; exit 3 documents undo no-sessions.
3. **test:** `tini -g -- pip` covered for container entrypoints.

## Test plan

- [x] unit + integration doc type_error tests
- [x] `make check-fast`
- [ ] CI green