### PR TITLE
fix(cli): typed JSON dispatch errors and more shell wrappers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,8 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Container entrypoint wrappers.** `command_position` peels `gosu`, `su-exec`, `tini`, and `dumb-init` so Docker/K8s install scripts rewrite the invocable command.
 - **CLI undo JSON `error_kind`.** Soft no-session paths (`undo --list` empty, or no sessions to restore) set `error_kind: "no_matches"` (exit 3), matching other CLI exit-3 JSON envelopes.
 - **CLI doc JSON `error_kind: type_error`.** `doc keys` / `doc len` on the wrong value type, and write-path type failures, set `error_kind: "type_error"` (exit 1) so agents can distinguish type mismatches from soft no-matches.
+- **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
+- **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,25 +289,86 @@ pub fn run() -> anyhow::Result<u8> {
     match cmd::dispatch(cli) {
         Ok(code) => Ok(code),
         Err(e) if structured => {
-            let output = serde_json::json!({
-                "ok": false,
-                "error": format!("{e:#}")
-            });
+            let (output, code) = structured_dispatch_error(&e);
             let serialized = if compact {
                 serde_json::to_string(&output)
             } else {
                 serde_json::to_string_pretty(&output)
             };
             println!("{}", serialized.unwrap_or_default());
-            Ok(exit::FAILURE)
+            Ok(code)
         }
         Err(e) => Err(e),
     }
 }
 
+/// Build the JSON error envelope and exit code for a dispatch `Err` under
+/// `--json` / `--jsonl`. Typed [`exit::NoMatchError`] / [`exit::AmbiguousError`]
+/// chains get `error_kind` and their dedicated exit codes.
+#[cfg(feature = "cli")]
+fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
+    let (kind, code) = if exit::is_no_match(err) {
+        (Some("no_matches"), exit::NO_MATCHES)
+    } else if exit::is_ambiguous(err) {
+        (Some("ambiguous"), exit::AMBIGUOUS)
+    } else {
+        (None, exit::FAILURE)
+    };
+    let mut output = serde_json::json!({
+        "ok": false,
+        "error": format!("{err:#}")
+    });
+    if let Some(k) = kind {
+        output["error_kind"] = serde_json::Value::String(k.to_string());
+    }
+    (output, code)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn structured_dispatch_error_maps_no_match() {
+        let err: anyhow::Error = exit::NoMatchError {
+            msg: "missing target".into(),
+        }
+        .into();
+        let (payload, code) = structured_dispatch_error(&err);
+        assert_eq!(code, exit::NO_MATCHES);
+        assert_eq!(payload["ok"], false);
+        assert_eq!(payload["error_kind"], "no_matches");
+        assert!(
+            payload["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("missing target"),
+            "payload={payload}"
+        );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn structured_dispatch_error_maps_ambiguous() {
+        let err: anyhow::Error = exit::AmbiguousError {
+            msg: "two hits".into(),
+        }
+        .into();
+        let (payload, code) = structured_dispatch_error(&err);
+        assert_eq!(code, exit::AMBIGUOUS);
+        assert_eq!(payload["error_kind"], "ambiguous");
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn structured_dispatch_error_generic_stays_failure() {
+        let err = anyhow::anyhow!("file already exists");
+        let (payload, code) = structured_dispatch_error(&err);
+        assert_eq!(code, exit::FAILURE);
+        assert!(payload.get("error_kind").is_none());
+        assert_eq!(payload["ok"], false);
+    }
 
     #[test]
     fn bounded_regex_builder_compiles_valid_pattern() {

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -45,6 +45,8 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     "su-exec",
     "tini",
     "dumb-init",
+    // s6 / packaging wrappers common in CI and container entrypoints.
+    "eatmydata",
     // Namespace / CPU affinity / resource-limit wrappers (CI and sandbox scripts).
     "unshare",
     "nsenter",
@@ -73,8 +75,15 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
 
 /// Wrappers whose next non-option argument is a path or user (not the command):
 /// `flock /tmp/l pip`, `flock -n /var/lock/x pip`, `chroot /jail pip`,
-/// `gosu app pip`, `su-exec nobody pip`.
-const PATH_TAKING_PREFIXES: &[&str] = &["flock", "chroot", "gosu", "su-exec"];
+/// `gosu app pip`, `su-exec nobody pip`, `s6-setuidgid app pip`.
+const PATH_TAKING_PREFIXES: &[&str] = &[
+    "flock",
+    "chroot",
+    "gosu",
+    "su-exec",
+    "s6-setuidgid",
+    "setuidgid",
+];
 
 /// Return true if `token` at byte range `[start, end)` is in shell command position.
 pub fn is_command_position(content: &str, start: usize, end: usize) -> bool {
@@ -1012,6 +1021,18 @@ mod tests {
         assert_eq!(
             replace_command_position("dumb-init -- pip install\n", "pip", "uv").0,
             "dumb-init -- uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("eatmydata apt-get install -y foo\n", "apt-get", "apt").0,
+            "eatmydata apt install -y foo\n"
+        );
+        assert_eq!(
+            replace_command_position("s6-setuidgid app pip install\n", "pip", "uv").0,
+            "s6-setuidgid app uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("setuidgid app pip install\n", "pip", "uv").0,
+            "setuidgid app uv install\n"
         );
         assert_eq!(
             replace_command_position("echo gosu pip\n", "pip", "uv").1,


### PR DESCRIPTION
## Summary

MPI batch 3:

1. **Top-level JSON errors:** `structured_dispatch_error` maps typed `NoMatchError` / `AmbiguousError` to `error_kind` + exit 3/5 under `--json`/`--jsonl`.
2. **shell_token:** peel `eatmydata`, `s6-setuidgid`, `setuidgid`.

## Test plan

- [x] unit tests for structured_dispatch_error + container wrappers
- [x] `make check-fast`
- [ ] CI green