### PR TITLE
fix(cli): error_kind on file op validation failures

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Container entrypoint wrappers.** `command_position` peels `gosu`, `su-exec`, `tini`, and `dumb-init` so Docker/K8s install scripts rewrite the invocable command.
 - **CLI undo JSON `error_kind`.** Soft no-session paths (`undo --list` empty, or no sessions to restore) set `error_kind: "no_matches"` (exit 3), matching other CLI exit-3 JSON envelopes.
 - **CLI doc JSON `error_kind: type_error`.** `doc keys` / `doc len` on the wrong value type, and write-path type failures, set `error_kind: "type_error"` (exit 1) so agents can distinguish type mismatches from soft no-matches.
+- **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
 - **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -2,7 +2,6 @@ use crate::cli::global::GlobalFlags;
 use crate::cmd::output::WritePhase;
 use crate::cmd::output::execute_via_engine;
 use crate::plan::Operation;
-use anyhow::bail;
 use clap::Args;
 use serde::Serialize;
 
@@ -67,7 +66,9 @@ pub(crate) fn run_content_inject(
 
     crate::verbose!("{verb}: file={file}");
     if content.is_some() && stdin {
-        bail!("--content and --stdin cannot be combined");
+        let msg = "--content and --stdin cannot be combined";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(crate::exit::FAILURE);
     }
 
     let inject_content = if let Some(c) = content {
@@ -75,7 +76,9 @@ pub(crate) fn run_content_inject(
     } else if stdin {
         std::io::read_to_string(std::io::stdin())?
     } else {
-        bail!("either --content or --stdin must be provided");
+        let msg = "either --content or --stdin must be provided";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(crate::exit::FAILURE);
     };
 
     let cwd = global.resolve_cwd()?;
@@ -84,10 +87,14 @@ pub(crate) fn run_content_inject(
     global.check_paths_contained(&cwd, [file])?;
     let path = cwd.join(file);
     if !path.exists() {
-        bail!("file does not exist: {file}");
+        let msg = format!("file does not exist: {file}");
+        global.emit_error_json_kind(Some("not_found"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
     if !path.is_file() {
-        bail!("target is not a file: {file}");
+        let msg = format!("target is not a file: {file}");
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
 
     let op = match position {
@@ -183,8 +190,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::default()).unwrap_err();
-        assert!(err.to_string().contains("file does not exist"));
+        let code = run(args, &GlobalFlags::default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -222,8 +229,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::default()).unwrap_err();
-        assert!(err.to_string().contains("--content and --stdin"));
+        let code = run(args, &GlobalFlags::default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -239,12 +246,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::default()).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("either --content or --stdin must be provided"),
-            "unexpected error: {err}"
-        );
+        let code = run(args, &GlobalFlags::default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -260,7 +263,7 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::default()).unwrap_err();
-        assert!(err.to_string().contains("target is not a file"));
+        let code = run(args, &GlobalFlags::default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 }

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -2,7 +2,6 @@ use crate::cli::global::GlobalFlags;
 use crate::cmd::output::WritePhase;
 use crate::cmd::output::execute_via_engine;
 use crate::plan::Operation;
-use anyhow::bail;
 use clap::Args;
 use serde::Serialize;
 
@@ -42,7 +41,9 @@ struct CreateOutput {
 pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!("create: file={}, force={}", args.file, args.force);
     if args.content.is_some() && args.stdin {
-        bail!("--content and --stdin cannot be combined");
+        let msg = "--content and --stdin cannot be combined";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(crate::exit::FAILURE);
     }
 
     let content = if let Some(ref c) = args.content {
@@ -50,17 +51,25 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     } else if args.stdin {
         std::io::read_to_string(std::io::stdin())?
     } else {
-        bail!("either --content or --stdin must be provided");
+        let msg = "either --content or --stdin must be provided";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(crate::exit::FAILURE);
     };
 
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, [&args.file])?;
     let path = cwd.join(&args.file);
     if path.exists() && !path.is_file() {
-        bail!("target is not a file: {}", args.file);
+        let msg = format!("target is not a file: {}", args.file);
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
-    if !global.apply && !global.confirm && !args.force && path.exists() {
-        bail!("file already exists: {}", args.file);
+    // Catch exists before the engine so --json gets error_kind (apply and
+    // preview). --force continues into FileCreate overwrite.
+    if !args.force && path.exists() {
+        let msg = format!("file already exists: {}", args.file);
+        global.emit_error_json_kind(Some("already_exists"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
 
     let op = Operation::FileCreate {
@@ -263,8 +272,8 @@ mod tests {
         let mut global = GlobalFlags::test_default();
         global.apply = true;
 
-        let err = run(args, &global).unwrap_err();
-        assert!(err.to_string().contains("file already exists:"));
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
 
         // Original content should be unchanged.
         let content = fs::read_to_string(&file).unwrap();
@@ -308,8 +317,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::test_default()).unwrap_err();
-        assert!(err.to_string().contains("target is not a file"));
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -370,8 +379,8 @@ mod tests {
         };
         let global = GlobalFlags::test_default();
 
-        let err = run(args, &global).unwrap_err();
-        assert!(err.to_string().contains("--content or --stdin"));
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -449,10 +458,7 @@ mod tests {
         };
         let global = GlobalFlags::test_default();
 
-        let err = run(args, &global).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("--content and --stdin cannot be combined")
-        );
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 }

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -31,10 +31,14 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let path = cwd.join(&args.file);
 
     if !path.exists() {
-        anyhow::bail!("file not found: {}", args.file);
+        let msg = format!("file not found: {}", args.file);
+        global.emit_error_json_kind(Some("not_found"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
     if !path.is_file() {
-        anyhow::bail!("target is not a file: {}", args.file);
+        let msg = format!("target is not a file: {}", args.file);
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
 
     let op = Operation::FileDelete {
@@ -117,15 +121,12 @@ mod tests {
         let target = dir.path().join("folder");
         std::fs::create_dir(&target).unwrap();
 
-        let result = run(
+        let code = run(
             make_args(&target.to_string_lossy()),
             &GlobalFlags::default(),
-        );
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("target is not a file"),
-            "expected 'target is not a file' error, got: {err}"
-        );
+        )
+        .unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -154,14 +155,11 @@ mod tests {
 
     #[test]
     fn nonexistent_file_returns_error() {
-        let result = run(
+        let code = run(
             make_args("/tmp/nonexistent_patchloom_test_file_xyz.txt"),
             &GlobalFlags::default(),
-        );
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("file not found"),
-            "error should mention 'file not found', got: {err}"
-        );
+        )
+        .unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 }

--- a/src/cmd/prepend.rs
+++ b/src/cmd/prepend.rs
@@ -91,8 +91,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::default()).unwrap_err();
-        assert!(err.to_string().contains("file does not exist"));
+        let code = run(args, &GlobalFlags::default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -108,8 +108,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::default()).unwrap_err();
-        assert!(err.to_string().contains("--content and --stdin"));
+        let code = run(args, &GlobalFlags::default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -125,7 +125,7 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::default()).unwrap_err();
-        assert!(err.to_string().contains("target is not a file"));
+        let code = run(args, &GlobalFlags::default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 }

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -56,13 +56,19 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // Pre-validation for CLI-specific checks.
     if !src.exists() {
-        anyhow::bail!("source file not found: {}", args.from);
+        let msg = format!("source file not found: {}", args.from);
+        global.emit_error_json_kind(Some("not_found"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
     if !src.is_file() {
-        anyhow::bail!("source is not a file: {}", args.from);
+        let msg = format!("source is not a file: {}", args.from);
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
     if dst.exists() && !dst.is_file() {
-        anyhow::bail!("destination is not a file: {}", args.to);
+        let msg = format!("destination is not a file: {}", args.to);
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
 
     // Same-file no-op check. On case-insensitive filesystems (macOS APFS),
@@ -94,7 +100,9 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if !args.force && !is_case_only_change && dst.exists() {
-        anyhow::bail!("destination already exists: {}", args.to);
+        let msg = format!("destination already exists: {}", args.to);
+        global.emit_error_json_kind(Some("already_exists"), &msg)?;
+        return Ok(crate::exit::FAILURE);
     }
 
     // Binary files can't go through the tx engine (it reads as UTF-8 text).
@@ -293,8 +301,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &global).unwrap_err();
-        assert!(err.to_string().contains("already exists"));
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -312,8 +320,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::test_with_cwd(dir.path())).unwrap_err();
-        assert!(err.to_string().contains("destination is not a file"));
+        let code = run(args, &GlobalFlags::test_with_cwd(dir.path())).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -383,8 +391,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &global).unwrap_err();
-        assert!(err.to_string().contains("not found"));
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -639,8 +647,8 @@ mod tests {
             write: Default::default(),
         };
 
-        let err = run(args, &GlobalFlags::test_with_cwd(dir.path())).unwrap_err();
-        assert!(err.to_string().contains("source is not a file"));
+        let code = run(args, &GlobalFlags::test_with_cwd(dir.path())).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -685,3 +685,26 @@ fn test_create_contain_allows_in_workspace() {
         "ok\n"
     );
 }
+
+#[test]
+fn test_create_json_already_exists_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("exists.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "create"])
+        .arg(&file)
+        .args(["--content", "new\n", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "already_exists",
+        "create --json existing file should set error_kind: {parsed}"
+    );
+}

--- a/tests/integration/delete_tests.rs
+++ b/tests/integration/delete_tests.rs
@@ -398,3 +398,21 @@ fn test_delete_contain_allows_in_workspace() {
 
     assert!(!dir.path().join("inside.txt").exists());
 }
+
+#[test]
+fn test_delete_json_not_found_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "delete", "missing.txt", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "not_found",
+        "delete --json missing file should set error_kind: {parsed}"
+    );
+}

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -481,3 +481,28 @@ fn test_prepend_contain_rejects_parent_escape() {
     assert_eq!(fs::read_to_string(&outside).unwrap(), "base\n");
     let _ = fs::remove_file(&outside);
 }
+
+#[test]
+fn test_append_json_not_found_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "append",
+            "missing.txt",
+            "--content",
+            "x\n",
+            "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "not_found",
+        "append --json missing file should set error_kind: {parsed}"
+    );
+}

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -862,3 +862,23 @@ fn test_rename_empty_path_rejected() {
         .code(1)
         .stderr(predicate::str::contains("path must not be empty"));
 }
+
+#[test]
+fn test_rename_json_already_exists_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "a\n").unwrap();
+    fs::write(dir.path().join("b.txt"), "b\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "rename", "a.txt", "b.txt", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "already_exists",
+        "rename --json existing dest should set error_kind: {parsed}"
+    );
+}


### PR DESCRIPTION
## Summary

MPI batch 4:

- **create:** `already_exists` / `invalid_input` (including apply without `--force`)
- **delete / append / prepend / rename:** `not_found`, `already_exists`, `invalid_input`
- Integration tests lock `--json` envelopes

## Test plan

- [x] unit tests for create/delete/append/prepend/rename
- [x] integration error_kind tests
- [x] `make check-fast`
- [ ] CI green