### PR TITLE
docs: catalogue CLI exit 1 error_kind values for agents

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -313,6 +313,8 @@ dependencies[name=react].version # predicate filter
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
+**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source), `invalid_input` (bad flags or non-file target). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type).
+
 **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, doc delete success includes `changed` (bool) and `removed` (usize). Multi-op plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with `removed: 0` means idempotent cleanup (nothing matched); do not assume data was deleted from exit status alone.
 
 ## Operations (from schema registry)

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -452,6 +452,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |\n\
              | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |\n\
              | 9 | Tx operation staging failure (`operation_failed`) |\n\n\
+             **JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set \
+             `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source), \
+             `invalid_input` (bad flags or non-file target). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type).\n\n\
              **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, \
              doc delete success includes `changed` (bool) and `removed` (usize). Multi-op \
              plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with \
@@ -703,6 +706,12 @@ mod tests {
             "agents need changed/removed guidance for idempotent doc delete"
         );
         assert!(out.contains("removed: 0"));
+        assert!(
+            out.contains("already_exists")
+                && out.contains("not_found")
+                && out.contains("type_error"),
+            "exit 1 error_kind catalogue must document file-op and doc kinds"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

MPI batch 5: agent-rules / PATCHLOOM document JSON `error_kind` values used on exit 1 (`already_exists`, `not_found`, `invalid_input`, `type_error`) so agents can branch without scraping English.

## Test plan

- [x] agent_rules unit test asserts kinds present
- [x] `make sync-patchloom-md` + `check-patchloom-md`
- [ ] CI green