### PR TITLE
fix(cli): tidy dual-flag invalid_input error_kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -40,6 +40,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI undo JSON `error_kind`.** Soft no-session paths (`undo --list` empty, or no sessions to restore) set `error_kind: "no_matches"` (exit 3), matching other CLI exit-3 JSON envelopes.
 - **CLI doc JSON `error_kind: type_error`.** `doc keys` / `doc len` on the wrong value type, and write-path type failures, set `error_kind: "type_error"` (exit 1) so agents can distinguish type mismatches from soft no-matches.
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
+- **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -167,7 +167,9 @@ pub(super) fn run_fix(
 ) -> anyhow::Result<u8> {
     crate::verbose!("tidy: fixing {} path(s)", paths.len());
     if dedent.is_some() && indent.is_some() {
-        anyhow::bail!("--dedent and --indent cannot both be set");
+        let msg = "--dedent and --indent cannot both be set";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(crate::exit::FAILURE);
     }
 
     let policy_flags = effective_tidy_fix_policy(global, dedent.as_deref(), indent.as_deref());

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -508,6 +508,22 @@ fn test_tidy_fix_dedent_and_indent_rejects() {
         .current_dir(dir.path())
         .assert()
         .code(1);
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json", "tidy", "fix", ".", "--dedent", "auto", "--indent", "4", "--apply",
+        ])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "tidy dual flags should set error_kind: {parsed}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

MPI batch 6: `tidy fix` with both `--dedent` and `--indent` emits JSON `error_kind: invalid_input` (exit 1).

## Test plan

- [x] integration test extended for JSON envelope
- [x] `make check-fast`
- [ ] CI green