### PR TITLE
fix(cli): search validation JSON invalid_input error_kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI doc JSON `error_kind: type_error`.** `doc keys` / `doc len` on the wrong value type, and write-path type failures, set `error_kind: "type_error"` (exit 1) so agents can distinguish type mismatches from soft no-matches.
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
 - **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
+- **CLI search JSON `invalid_input`.** Empty pattern and `--invert-match` + `--multiline` together exit 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -1,7 +1,6 @@
 use crate::cli::global::GlobalFlags;
 use crate::exit;
 use crate::ops::search::{self as ops_search, SearchMatch, SearchResults};
-use anyhow::bail;
 use clap::Args;
 use serde::Serialize;
 
@@ -316,10 +315,14 @@ pub(crate) fn format_results(
 
 pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if args.pattern.is_empty() {
-        bail!("search pattern must not be empty");
+        let msg = "search pattern must not be empty";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(exit::FAILURE);
     }
     if args.invert_match && args.multiline {
-        bail!("--invert-match and --multiline cannot be combined");
+        let msg = "--invert-match and --multiline cannot be combined";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(exit::FAILURE);
     }
 
     let results = collect_matches(&args, global)?;
@@ -441,14 +444,8 @@ mod tests {
     fn empty_pattern_rejected() {
         let dir = make_test_dir();
         let args = make_args("", vec![dir.path().to_string_lossy().into_owned()]);
-        let result = run(args, &GlobalFlags::test_default());
-        let msg = result
-            .expect_err("empty pattern should be rejected")
-            .to_string();
-        assert!(
-            msg.contains("must not be empty"),
-            "error should mention empty pattern: {msg}"
-        );
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -706,12 +703,8 @@ mod tests {
         let mut args = make_args("Hello", vec![dir.path().to_string_lossy().into_owned()]);
         args.invert_match = true;
         args.multiline = true;
-        let err = run(args, &GlobalFlags::test_default()).unwrap_err();
-        assert!(
-            err.to_string().contains("--invert-match and --multiline"),
-            "should reject incompatible flags: {}",
-            err
-        );
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -602,6 +602,38 @@ fn test_search_invert_match_multiline_rejected() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("--invert-match and --multiline"));
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "search", "--multiline", "-v", "hello"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "search dual flags should set error_kind: {parsed}"
+    );
+}
+
+#[test]
+fn test_search_json_empty_pattern_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("test.txt"), "hello\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "search", "", dir.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "empty search pattern should set error_kind: {parsed}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

MPI batch 8: search empty pattern and incompatible `--invert-match` + `--multiline` return exit 1 with `error_kind: invalid_input` under `--json`.

## Test plan

- [x] unit + integration tests
- [x] `make check-fast`
- [ ] CI green