### PR TITLE
fix(cli): md validation JSON invalid_input error_kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -41,6 +41,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI doc JSON `error_kind: type_error`.** `doc keys` / `doc len` on the wrong value type, and write-path type failures, set `error_kind: "type_error"` (exit 1) so agents can distinguish type mismatches from soft no-matches.
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
 - **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
+- **CLI md JSON `invalid_input`.** `md move-section` without `--before`/`--after`, and missing `--stdin`/`--content` on insert/replace paths, set `error_kind: "invalid_input"` (exit 1).
 - **CLI search JSON `invalid_input`.** Empty pattern and `--invert-match` + `--multiline` together exit 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -103,13 +103,23 @@ pub enum MdAction {
 // Helpers
 // ---------------------------------------------------------------------------
 
-fn read_content(use_stdin: bool, content: &Option<String>) -> anyhow::Result<String> {
+/// Read replacement/insertion content. Returns `Ok(None)` after emitting a
+/// structured validation error when neither stdin nor content is provided.
+fn read_content(
+    use_stdin: bool,
+    content: &Option<String>,
+    global: &GlobalFlags,
+) -> anyhow::Result<Option<String>> {
     if use_stdin {
-        Ok(std::io::read_to_string(std::io::stdin())?)
+        Ok(Some(std::io::read_to_string(std::io::stdin())?))
     } else if let Some(c) = content {
-        Ok(c.clone())
+        Ok(Some(c.clone()))
     } else {
-        anyhow::bail!("one of --stdin or --content must be provided")
+        global.emit_error_json_kind(
+            Some("invalid_input"),
+            "one of --stdin or --content must be provided",
+        )?;
+        Ok(None)
     }
 }
 
@@ -184,7 +194,9 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             content,
         } => {
             crate::verbose!("md: replace-section file={}, heading={:?}", file, heading);
-            let replacement = read_content(stdin, &content)?;
+            let Some(replacement) = read_content(stdin, &content, global)? else {
+                return Ok(exit::FAILURE);
+            };
             let op = Operation::MdReplaceSection {
                 path: file.clone(),
                 heading: heading.clone(),
@@ -210,7 +222,9 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 file,
                 heading
             );
-            let insertion = read_content(stdin, &content)?;
+            let Some(insertion) = read_content(stdin, &content, global)? else {
+                return Ok(exit::FAILURE);
+            };
             let op = Operation::MdInsertAfterHeading {
                 path: file.clone(),
                 heading: heading.clone(),
@@ -236,7 +250,9 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 file,
                 heading
             );
-            let insertion = read_content(stdin, &content)?;
+            let Some(insertion) = read_content(stdin, &content, global)? else {
+                return Ok(exit::FAILURE);
+            };
             let op = Operation::MdInsertBeforeHeading {
                 path: file.clone(),
                 heading: heading.clone(),
@@ -429,7 +445,11 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             );
             // Validate exactly one of --before or --after.
             if before.is_none() && after.is_none() {
-                anyhow::bail!("exactly one of --before or --after must be provided");
+                global.emit_error_json_kind(
+                    Some("invalid_input"),
+                    "exactly one of --before or --after must be provided",
+                )?;
+                return Ok(exit::FAILURE);
             }
 
             let dest_file = to.as_deref().unwrap_or(&file);

--- a/src/cmd/md_tests.rs
+++ b/src/cmd/md_tests.rs
@@ -635,10 +635,11 @@ mod error_handling {
             },
             write: Default::default(),
         };
-        let result = run(args, &GlobalFlags::test_apply());
-        assert!(
-            result.is_err(),
-            "expected error when neither --before nor --after is provided"
+        let code = run(args, &GlobalFlags::test_apply()).unwrap();
+        assert_eq!(
+            code,
+            crate::exit::FAILURE,
+            "expected FAILURE when neither --before nor --after is provided"
         );
     }
 }

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -1127,3 +1127,30 @@ fn test_md_empty_path_rejected() {
         .code(1)
         .stderr(predicate::str::contains("path must not be empty"));
 }
+
+#[test]
+fn test_md_move_section_json_requires_before_or_after() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.md");
+    fs::write(&file, "# A\nbody\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "md",
+            "move-section",
+            file.to_str().unwrap(),
+            "--heading",
+            "A",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "md move-section missing before/after: {parsed}"
+    );
+}


### PR DESCRIPTION
## Summary

MPI batch 9: md content source validation and `move-section` without destination heading return exit 1 with `error_kind: invalid_input` under `--json`.

## Test plan

- [x] unit + integration
- [x] `make check-fast`
- [ ] CI green