### PR TITLE
fix(cli): replace validation JSON invalid_input error_kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
 - **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI md JSON `invalid_input`.** `md move-section` without `--before`/`--after`, and missing `--stdin`/`--content` on insert/replace paths, set `error_kind: "invalid_input"` (exit 1).
+- **CLI replace JSON `invalid_input`.** Validation failures (bad `--nth`, `--range` without `--whole-line`, incompatible flag combos, context without paths) set `error_kind: "invalid_input"` (exit 1).
 - **CLI search JSON `invalid_input`.** Empty pattern and `--invert-match` + `--multiline` together exit 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -268,10 +268,11 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             },
         )
     {
-        anyhow::bail!("{msg}");
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(exit::FAILURE);
     }
     use crate::ops::replace::{ReplaceValidationParams, validate_replace_args};
-    validate_replace_args(&ReplaceValidationParams {
+    if let Err(e) = validate_replace_args(&ReplaceValidationParams {
         pattern: &args.old,
         has_to: args.new.is_some(),
         has_insert_before: args.insert_before.is_some(),
@@ -280,8 +281,10 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         whole_line: args.whole_line,
         multiline: args.multiline,
         has_range: args.range.is_some(),
-    })
-    .map_err(|e| anyhow::anyhow!("{e}"))?;
+    }) {
+        global.emit_error_json_kind(Some("invalid_input"), &e.to_string())?;
+        return Ok(exit::FAILURE);
+    }
 
     let cwd = global.resolve_cwd()?;
     // Fail closed before the parallel scan so --contain does not read
@@ -513,7 +516,9 @@ fn run_context_replace(
 
     // Context-based replace requires explicit file paths (not directory scan).
     if args.paths.is_empty() {
-        anyhow::bail!("--before-context/--after-context requires explicit file paths");
+        let msg = "--before-context/--after-context requires explicit file paths";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(exit::FAILURE);
     }
 
     let ops: Vec<Operation> = args

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -841,8 +841,8 @@ mod error_handling {
             command_position: false,
             write: Default::default(),
         };
-        let err = run(args, &GlobalFlags::test_default()).unwrap_err();
-        assert!(err.to_string().contains("1-based"), "{err}");
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -873,11 +873,8 @@ mod error_handling {
             command_position: false,
             write: Default::default(),
         };
-        let err = run(args, &GlobalFlags::test_default()).unwrap_err();
-        assert!(
-            err.to_string().contains("range requires whole_line"),
-            "{err}"
-        );
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -908,12 +905,8 @@ mod error_handling {
             command_position: false,
             write: Default::default(),
         };
-        let err = run(args, &GlobalFlags::test_default()).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("whole_line and multiline cannot be combined"),
-            "{err}"
-        );
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1680,3 +1680,25 @@ fn test_replace_cli_unique_rejects_identity_multi_match() {
         "pip install\npip list\n"
     );
 }
+
+#[test]
+fn test_replace_json_range_without_whole_line_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.txt");
+    fs::write(&file, "hello\n").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json", "replace", "hello", "--new", "hi", "--range", "1:1",
+        ])
+        .arg(&file)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "replace range without whole_line: {parsed}"
+    );
+}


### PR DESCRIPTION
## Summary

MPI batch 10: replace validation failures (flag combos, nth/range, context without paths) return exit 1 with `error_kind: invalid_input` under `--json`.

## Test plan

- [x] unit + integration
- [x] `make check-fast`
- [ ] CI green