### PR TITLE
fix(cli): more JSON error_kind for read, status, doc, AST

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
 - **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI md JSON `invalid_input`.** `md move-section` without `--before`/`--after`, and missing `--stdin`/`--content` on insert/replace paths, set `error_kind: "invalid_input"` (exit 1).
+- **CLI read/status/ast/doc JSON kinds.** Invalid `--lines` sets `invalid_input`; all-paths-missing read sets `not_found`; status outside a git repo sets `invalid_input`; AST missing path / non-dir map target set `not_found` / `invalid_input`; doc merge flag conflicts set `invalid_input`.
 - **CLI replace JSON `invalid_input`.** Validation failures (bad `--nth`, `--range` without `--whole-line`, incompatible flag combos, context without paths) set `error_kind: "invalid_input"` (exit 1).
 - **CLI search JSON `invalid_input`.** Empty pattern and `--invert-match` + `--multiline` together exit 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -109,7 +109,9 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
             }
         }
     } else {
-        anyhow::bail!("path not found: {}", args.path);
+        let msg = format!("path not found: {}", args.path);
+        global.emit_error_json_kind(Some("not_found"), &msg)?;
+        return Ok(exit::FAILURE);
     }
 
     if any_output {
@@ -561,7 +563,9 @@ pub(super) fn run_map(args: MapArgs, global: &GlobalFlags) -> anyhow::Result<u8>
     );
 
     if !target.is_dir() {
-        anyhow::bail!("path must be a directory: {}", args.path);
+        let msg = format!("path must be a directory: {}", args.path);
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(exit::FAILURE);
     }
 
     let paths = collect_source_files(&target, global)?;

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -318,6 +318,8 @@ fn action_to_operation(action: &DocAction) -> anyhow::Result<Operation> {
         DocAction::Merge { file, stdin, value } => {
             crate::verbose!("doc: merge file={}, stdin={}", file, stdin);
             if *stdin && value.is_some() {
+                // Surface as plain anyhow; run() maps merge validation via
+                // emit_error_json_kind before staging when possible.
                 anyhow::bail!("merge: --stdin and --value are mutually exclusive");
             }
             let merge_str = if *stdin {
@@ -747,7 +749,21 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     if args.action.is_write() {
         let display_path = args.action.file_path().unwrap_or("").to_string();
-        let op = action_to_operation(&args.action)?;
+        let op = match action_to_operation(&args.action) {
+            Ok(op) => op,
+            Err(e) => {
+                let msg = e.to_string();
+                // Merge flag validation and other write-op build errors.
+                if msg.contains("mutually exclusive")
+                    || msg.contains("requires --stdin or --value")
+                    || msg.contains("not a write action")
+                {
+                    global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+                    return Ok(exit::FAILURE);
+                }
+                return Err(e);
+            }
+        };
 
         let check_msg = format!("would modify {display_path}");
         let apply_msg = format!("updated {display_path}");

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -360,13 +360,8 @@ mod basic {
             value: Some(r#"{"b": 2}"#.into()),
         };
         let global = GlobalFlags::test_with_cwd(dir.path());
-        let result = run_doc(action, &global);
-        assert!(result.is_err(), "merge --stdin --value should fail");
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("mutually exclusive"),
-            "error should mention mutual exclusivity: {err_msg}"
-        );
+        let code = run_doc(action, &global).unwrap();
+        assert_eq!(code, exit::FAILURE, "merge --stdin --value should fail");
     }
 
     #[test]
@@ -938,12 +933,8 @@ mod error_paths {
             stdin: false,
             value: None,
         };
-        let err = run_doc(action, &GlobalFlags::test_default()).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("merge requires --stdin or --value"),
-            "unexpected error: {err}"
-        );
+        let code = run_doc(action, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 
     #[test]
@@ -955,11 +946,7 @@ mod error_paths {
             stdin: true,
             value: Some(r#"{"b": 2}"#.to_string()),
         };
-        let err = run_doc(action, &GlobalFlags::test_default()).unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("--stdin and --value are mutually exclusive"),
-            "unexpected error: {err}"
-        );
+        let code = run_doc(action, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
     }
 }

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -71,11 +71,8 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         match parse_line_range(spec) {
             Ok(range) => Some(range),
             Err(err) => {
-                if structured {
-                    anyhow::bail!("invalid --lines value '{spec}': {err}");
-                }
-                // Always show errors on stderr, even with --quiet (#1179).
-                eprintln!("read: {err}");
+                let msg = format!("invalid --lines value '{spec}': {err}");
+                global.emit_error_json_kind(Some("invalid_input"), &msg)?;
                 return Ok(exit::FAILURE);
             }
         }
@@ -117,9 +114,9 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if errors.len() == args.files.len() {
-        if structured {
-            anyhow::bail!(errors.join("\n"));
-        }
+        // Prefer not_found when every path failed (typical: missing files).
+        let msg = errors.join("\n");
+        global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(exit::FAILURE);
     }
 

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -138,7 +138,14 @@ pub fn run(args: StatusArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!("status: checking {} path(s)", args.paths.len());
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, &args.paths)?;
-    let out = collect_status(&args.paths, global)?;
+    let out = match collect_status(&args.paths, global) {
+        Ok(o) => o,
+        Err(e) => {
+            // Outside a git repo, missing git binary, etc.
+            global.emit_error_json_kind(Some("invalid_input"), &format!("{e:#}"))?;
+            return Ok(exit::FAILURE);
+        }
+    };
     crate::verbose!(
         "status: {} modified, {} created, {} deleted",
         out.modified.len(),

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2548,3 +2548,31 @@ fn test_doc_get_contain_rejects_parent_escape() {
 
     let _ = fs::remove_file(&outside);
 }
+
+#[test]
+fn test_doc_merge_json_stdin_and_value_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("c.json");
+    fs::write(&file, "{}").unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "doc",
+            "merge",
+            file.to_str().unwrap(),
+            "--value",
+            "{}",
+            "--stdin",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "doc merge dual inputs: {json}"
+    );
+}

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -81,6 +81,10 @@ fn test_read_json_invalid_lines_returns_error_object() {
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("invalid --lines value '0:1'"));
     assert!(error.contains("line numbers are 1-based"));
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "read invalid --lines should set error_kind: {json}"
+    );
 }
 
 #[test]
@@ -293,6 +297,10 @@ fn test_read_json_all_fail_returns_error_object() {
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("no-1-json-read-fail"));
     assert!(error.contains("no-2-json-read-fail"));
+    assert_eq!(
+        json["error_kind"], "not_found",
+        "read all-fail should set error_kind: {json}"
+    );
 }
 
 #[test]
@@ -317,6 +325,10 @@ fn test_read_jsonl_all_fail_returns_error_object() {
     let error = json["error"].as_str().unwrap();
     assert!(error.contains("no-1-jsonl-read-fail"));
     assert!(error.contains("no-2-jsonl-read-fail"));
+    assert_eq!(
+        json["error_kind"], "not_found",
+        "read jsonl all-fail should set error_kind: {json}"
+    );
 }
 
 #[test]

--- a/tests/integration/status_tests.rs
+++ b/tests/integration/status_tests.rs
@@ -32,6 +32,30 @@ fn test_status_outside_git_repo_shows_actionable_hint() {
 }
 
 #[test]
+fn test_status_json_outside_git_repo_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .arg("status")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "status outside git should set error_kind: {json}"
+    );
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("git status failed") || err.contains("git init"),
+        "expected git-related error, got: {err}"
+    );
+}
+
+#[test]
 fn test_status_modified_file() {
     let dir = TempDir::new().unwrap();
     init_git_repo_with_committed_file(dir.path(), "a.txt", "hello\n");


### PR DESCRIPTION
## Summary

MPI session branch (find many, land few):

| Surface | Kind | When |
|---------|------|------|
| `read --lines` | `invalid_input` | Bad line range |
| `read` all missing | `not_found` | Every path failed |
| `status` | `invalid_input` | Not a git repo / git status fail |
| `doc merge` | `invalid_input` | `--stdin`+`--value` or neither |
| `ast list` path | `not_found` | Path missing |
| `ast map` | `invalid_input` | Path not a directory |

## Test plan

- [x] unit + integration for read/status/doc
- [x] `make check-fast`
- [ ] CI green