### PR TITLE
fix(cli): batch parse_error error_kind with exit 4

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -313,7 +313,9 @@ dependencies[name=react].version # predicate filter
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
-**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source), `invalid_input` (bad flags or non-file target). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type).
+**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type).
+
+**JSON `error_kind` (exit 4):** Batch line parse failures set `parse_error` (unknown op, bad arity, bad quotes) so agents can distinguish syntax mistakes from runtime failures.
 
 **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, doc delete success includes `changed` (bool) and `removed` (usize). Multi-op plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with `removed: 0` means idempotent cleanup (nothing matched); do not assume data was deleted from exit status alone.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
 - **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI md JSON `invalid_input`.** `md move-section` without `--before`/`--after`, and missing `--stdin`/`--content` on insert/replace paths, set `error_kind: "invalid_input"` (exit 1).
+- **CLI batch JSON `parse_error`.** Line parse failures (unknown op, bad arity, bad quotes) exit **4** with `error_kind: "parse_error"` (was unstructured exit 1). Too-many-ops limit stays exit 1 with `invalid_input`.
 - **CLI read/status/ast/doc JSON kinds.** Invalid `--lines` sets `invalid_input`; all-paths-missing read sets `not_found`; status outside a git repo sets `invalid_input`; AST missing path / non-dir map target set `not_found` / `invalid_input`; doc merge flag conflicts set `invalid_input`.
 - **CLI replace JSON `invalid_input`.** Validation failures (bad `--nth`, `--range` without `--whole-line`, incompatible flag combos, context without paths) set `error_kind: "invalid_input"` (exit 1).
 - **CLI search JSON `invalid_input`.** Empty pattern and `--invert-match` + `--multiline` together exit 1 with `error_kind: "invalid_input"` under `--json`.

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -453,8 +453,12 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |\n\
              | 9 | Tx operation staging failure (`operation_failed`) |\n\n\
              **JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set \
-             `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source), \
-             `invalid_input` (bad flags or non-file target). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type).\n\n\
+             `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, \
+             or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, \
+             `status` outside a git repo, AST map non-dir, doc merge flag conflicts). Doc type mismatches set \
+             `type_error` (`doc keys`/`len` on wrong type).\n\n\
+             **JSON `error_kind` (exit 4):** Batch line parse failures set `parse_error` (unknown op, bad arity, \
+             bad quotes) so agents can distinguish syntax mistakes from runtime failures.\n\n\
              **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, \
              doc delete success includes `changed` (bool) and `removed` (usize). Multi-op \
              plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with \
@@ -709,8 +713,9 @@ mod tests {
         assert!(
             out.contains("already_exists")
                 && out.contains("not_found")
-                && out.contains("type_error"),
-            "exit 1 error_kind catalogue must document file-op and doc kinds"
+                && out.contains("type_error")
+                && out.contains("parse_error"),
+            "error_kind catalogue must document file-op, doc, and batch kinds"
         );
     }
 

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -507,7 +507,13 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
-        operations.push(parse_line(trimmed, i + 1)?);
+        match parse_line(trimmed, i + 1) {
+            Ok(op) => operations.push(op),
+            Err(e) => {
+                global.emit_error_json_kind(Some("parse_error"), &e.to_string())?;
+                return Ok(exit::PARSE_ERROR);
+            }
+        }
     }
 
     crate::verbose!("batch: parsed {} operations from input", operations.len());
@@ -527,10 +533,12 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if operations.len() > MAX_BATCH_OPERATIONS {
-        anyhow::bail!(
+        let msg = format!(
             "batch: too many operations ({}, max {MAX_BATCH_OPERATIONS})",
             operations.len()
         );
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(exit::FAILURE);
     }
 
     // Build a plan and run the shared tx engine in-process (no temp plan file).

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -640,10 +640,7 @@ mod security {
             write: Default::default(),
         };
         let global = GlobalFlags::test_with_cwd(dir.path());
-        let err = run(args, &global).unwrap_err();
-        assert!(
-            err.to_string().contains("too many operations"),
-            "expected limit error: {err}"
-        );
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE, "expected limit error exit");
     }
 }

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -188,7 +188,7 @@ fn test_batch_malformed_line_fails() {
         .arg(&ops)
         .arg("--apply")
         .assert()
-        .code(1)
+        .code(4) // PARSE_ERROR
         .stderr(predicates::str::contains("unknown operation"));
 }
 
@@ -201,7 +201,7 @@ fn test_batch_bare_create_suggests_file_create() {
         .arg("--apply")
         .write_stdin("create new.txt \"hi\"\n")
         .assert()
-        .code(1)
+        .code(4) // PARSE_ERROR
         .stderr(predicates::str::contains("did you mean: file.create?"));
 }
 
@@ -214,7 +214,7 @@ fn test_batch_typo_file_create_suggests_neighbors() {
         .arg("--apply")
         .write_stdin("file.creat new.txt \"hi\"\n")
         .assert()
-        .code(1)
+        .code(4) // PARSE_ERROR
         .stderr(
             predicates::str::contains("did you mean").and(predicates::str::contains("file.create")),
         );
@@ -229,7 +229,7 @@ fn test_batch_cli_only_read_redirects_to_standalone() {
         .arg("--apply")
         .write_stdin("read file.txt\n")
         .assert()
-        .code(1)
+        .code(4) // PARSE_ERROR
         .stderr(
             predicates::str::contains("not supported in batch")
                 .and(predicates::str::contains("patchloom read")),
@@ -247,7 +247,7 @@ fn test_batch_extra_args_fail() {
         .arg(&ops)
         .arg("--apply")
         .assert()
-        .code(1)
+        .code(4) // PARSE_ERROR
         .stderr(predicates::str::contains("requires exactly 1 argument"));
 }
 
@@ -745,7 +745,7 @@ fn test_batch_unterminated_quote_fails() {
         .arg(&ops)
         .arg("--apply")
         .assert()
-        .code(1)
+        .code(4) // PARSE_ERROR
         .stderr(predicates::str::contains("unterminated"));
 }
 
@@ -800,5 +800,24 @@ fn test_batch_contain_allows_in_workspace() {
     assert_eq!(
         fs::read_to_string(dir.path().join("inside-batch.txt")).unwrap(),
         "ok"
+    );
+}
+
+#[test]
+fn test_batch_json_unknown_op_sets_parse_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let ops = dir.path().join("bad.txt");
+    fs::write(&ops, "unknown.op foo bar\n").unwrap();
+    let output = patchloom_in(dir.path())
+        .args(["--json", "batch"])
+        .arg(&ops)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(4));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "parse_error",
+        "batch parse failure should set error_kind: {json}"
     );
 }


### PR DESCRIPTION
## Summary

MPI session branch:

- Batch line parse failures → exit **4** + `error_kind: "parse_error"`
- Max batch ops → exit 1 + `invalid_input`
- Agent-rules documents exit 1 and exit 4 kind catalogues

## Test plan

- [x] batch unit + integration (including JSON parse_error)
- [x] `make check-fast`
- [ ] CI green