### PR TITLE
fix(cli): patch IO and binary rename invalid_input error_kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
 - **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI md JSON `invalid_input`.** `md move-section` without `--before`/`--after`, and missing `--stdin`/`--content` on insert/replace paths, set `error_kind: "invalid_input"` (exit 1).
+- **CLI patch/rename JSON `invalid_input`.** Unreadable patch targets during merge-check and binary rename with write-policy flags set `error_kind: "invalid_input"` (exit 1).
 - **CLI batch JSON `parse_error`.** Line parse failures (unknown op, bad arity, bad quotes) exit **4** with `error_kind: "parse_error"` (was unstructured exit 1). Too-many-ops limit stays exit 1 with `invalid_input`.
 - **CLI read/status/ast/doc JSON kinds.** Invalid `--lines` sets `invalid_input`; all-paths-missing read sets `not_found`; status outside a git repo sets `invalid_input`; AST missing path / non-dir map target set `not_found` / `invalid_input`; doc merge flag conflicts set `invalid_input`.
 - **CLI replace JSON `invalid_input`.** Validation failures (bad `--nth`, `--range` without `--whole-line`, incompatible flag combos, context without paths) set `error_kind: "invalid_input"` (exit 1).

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -379,7 +379,9 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 Ok(s) => s,
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
                 Err(e) => {
-                    anyhow::bail!("patch check: cannot read {}: {e}", pf.path);
+                    let msg = format!("patch check: cannot read {}: {e}", pf.path);
+                    global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+                    return Ok(exit::FAILURE);
                 }
             };
             match apply_patch_file(&original, &pf.hunks, check_options) {
@@ -567,12 +569,12 @@ mod tests {
             },
             &global,
         );
-        // Should surface the I/O error, not silently treat as empty.
-        assert!(result.is_err(), "expected I/O error for unreadable file");
-        let err_msg = result.unwrap_err().to_string();
-        assert!(
-            err_msg.contains("cannot read") || err_msg.contains("Permission denied"),
-            "expected permission error, got: {err_msg}"
+        // Should surface the I/O error as exit FAILURE, not silently treat as empty.
+        let code = result.unwrap();
+        assert_eq!(
+            code,
+            exit::FAILURE,
+            "expected I/O error for unreadable file"
         );
         // Cleanup: restore permissions so TempDir can clean up
         std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -171,10 +171,12 @@ fn run_binary_rename(
         || global.ensure_final_newline
         || global.normalize_eol.is_some()
     {
-        anyhow::bail!(
+        let msg = format!(
             "cannot apply write policy to binary file: {}",
             src.display()
         );
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(exit::FAILURE);
     }
 
     let check_msg = format!("would rename {} -> {} (binary)", args.from, args.to);


### PR DESCRIPTION
## Summary

MPI session:

- Patch merge-check unreadable target → `error_kind: invalid_input`
- Binary rename with write-policy flags → `error_kind: invalid_input`

## Test plan

- [x] patch + rename unit tests
- [x] `make check-fast`
- [ ] CI green