### PR TITLE
fix(cli): explain parse_error error_kind and exit 4

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -315,7 +315,7 @@ dependencies[name=react].version # predicate filter
 
 **JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type).
 
-**JSON `error_kind` (exit 4):** Batch line parse failures set `parse_error` (unknown op, bad arity, bad quotes) so agents can distinguish syntax mistakes from runtime failures.
+**JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set `parse_error` so agents can distinguish syntax mistakes from runtime failures.
 
 **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, doc delete success includes `changed` (bool) and `removed` (usize). Multi-op plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with `removed: 0` means idempotent cleanup (nothing matched); do not assume data was deleted from exit status alone.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -42,6 +42,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
 - **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI md JSON `invalid_input`.** `md move-section` without `--before`/`--after`, and missing `--stdin`/`--content` on insert/replace paths, set `error_kind: "invalid_input"` (exit 1).
+- **CLI explain JSON kinds.** Missing/unreadable plan files set `not_found` / `invalid_input`; plan parse failures exit **4** with `error_kind: "parse_error"`.
 - **CLI patch/rename JSON `invalid_input`.** Unreadable patch targets during merge-check and binary rename with write-policy flags set `error_kind: "invalid_input"` (exit 1).
 - **CLI batch JSON `parse_error`.** Line parse failures (unknown op, bad arity, bad quotes) exit **4** with `error_kind: "parse_error"` (was unstructured exit 1). Too-many-ops limit stays exit 1 with `invalid_input`.
 - **CLI read/status/ast/doc JSON kinds.** Invalid `--lines` sets `invalid_input`; all-paths-missing read sets `not_found`; status outside a git repo sets `invalid_input`; AST missing path / non-dir map target set `not_found` / `invalid_input`; doc merge flag conflicts set `invalid_input`.

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -457,8 +457,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, \
              `status` outside a git repo, AST map non-dir, doc merge flag conflicts). Doc type mismatches set \
              `type_error` (`doc keys`/`len` on wrong type).\n\n\
-             **JSON `error_kind` (exit 4):** Batch line parse failures set `parse_error` (unknown op, bad arity, \
-             bad quotes) so agents can distinguish syntax mistakes from runtime failures.\n\n\
+             **JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set \
+             `parse_error` so agents can distinguish syntax mistakes from runtime failures.\n\n\
              **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, \
              doc delete success includes `changed` (bool) and `removed` (usize). Multi-op \
              plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with \

--- a/src/cmd/explain/mod.rs
+++ b/src/cmd/explain/mod.rs
@@ -43,17 +43,36 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
         (buf, None)
     } else {
-        let p = args
-            .path
-            .as_deref()
-            .ok_or_else(|| anyhow::anyhow!("path is required when --stdin is not set"))?;
+        let p = match args.path.as_deref() {
+            Some(p) => p,
+            None => {
+                global.emit_error_json_kind(
+                    Some("invalid_input"),
+                    "path is required when --stdin is not set",
+                )?;
+                return Ok(exit::FAILURE);
+            }
+        };
         let full = global.resolve_user_path(p)?;
-        let content = std::fs::read_to_string(&full)
-            .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", full.display()))?;
+        let content = match std::fs::read_to_string(&full) {
+            Ok(c) => c,
+            Err(e) => {
+                let msg = format!("cannot read {}: {e}", full.display());
+                global.emit_error_json_kind(Some("not_found"), &msg)?;
+                return Ok(exit::FAILURE);
+            }
+        };
         (content, Some(p.to_string()))
     };
 
-    let mut plan = crate::plan::parse_plan_auto(&input, path.as_deref(), args.format.as_deref())?;
+    let mut plan =
+        match crate::plan::parse_plan_auto(&input, path.as_deref(), args.format.as_deref()) {
+            Ok(p) => p,
+            Err(e) => {
+                global.emit_error_json_kind(Some("parse_error"), &e.to_string())?;
+                return Ok(exit::PARSE_ERROR);
+            }
+        };
     let cwd = global.resolve_cwd()?;
 
     // Expand for_each before summarizing so the explain output shows all

--- a/tests/integration/explain_tests.rs
+++ b/tests/integration/explain_tests.rs
@@ -204,8 +204,22 @@ fn test_explain_invalid_plan_fails() {
         .args(["explain"])
         .arg(&plan)
         .assert()
-        .failure()
+        .code(4) // PARSE_ERROR
         .stderr(predicate::str::contains("expected ident").or(predicate::str::contains("parse")));
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "explain"])
+        .arg(&plan)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(4));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "parse_error",
+        "explain invalid plan should set error_kind: {json}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

MPI session:

- `explain` plan parse failures → exit **4** + `error_kind: parse_error`
- Unreadable plan file → `not_found`
- Missing path without `--stdin` → `invalid_input`

## Test plan

- [x] integration explain invalid plan (JSON + text)
- [x] `make check-fast`
- [ ] CI green