### PR TITLE
fix(cli): map clap usage errors to exit 1 not 2

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -303,8 +303,8 @@ dependencies[name=react].version # predicate filter
 | Code | Meaning |
 |------|---------|
 | 0 | Success (operation completed, or no changes needed) |
-| 1 | Failure (error during execution), or tx `rollback_failed` when mid-commit rollback could not fully restore files |
-| 2 | Changes detected (`--check` mode found pending changes) |
+| 1 | Failure (error during execution, CLI usage/invalid args/unknown flags/subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |
+| 2 | Changes detected (`--check` mode found pending changes; not used for CLI usage errors) |
 | 3 | No matches (search/replace pattern miss, undo with no sessions, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
 | 4 | Parse error (malformed input file or plan) |
 | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -49,6 +49,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI replace JSON `invalid_input`.** Validation failures (bad `--nth`, `--range` without `--whole-line`, incompatible flag combos, context without paths) set `error_kind: "invalid_input"` (exit 1).
 - **CLI search JSON `invalid_input`.** Empty pattern and `--invert-match` + `--multiline` together exit 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
+- **CLI usage errors exit 1.** Invalid flags, enum values, missing required args, and unknown subcommands exit **1** (`FAILURE`), not clap's default **2**. Exit 2 remains only `CHANGES_DETECTED` (`--check` / write preview). `--help` / `--version` still exit 0.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -128,8 +128,8 @@ Every command returns a specific exit code:
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | General error, or tx `rollback_failed` when mid-commit rollback could not fully restore files |
-| 2 | Changes detected (with `--check`) |
+| 1 | General error (including CLI usage: invalid flags, enum values, missing args, unknown subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |
+| 2 | Changes detected (with `--check` or write preview; not used for CLI usage errors) |
 | 3 | No matches found |
 | 4 | Parse error in input |
 | 5 | Ambiguous (multiple replace matches, or stale patch context) |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -269,8 +269,8 @@ This is safe; the next `--apply` run will create a fresh backup directory.
 | Code | Meaning |
 |------|---------|
 | 0 | Success |
-| 1 | General failure |
-| 2 | Changes detected (used by `--check`) |
+| 1 | General failure (including invalid CLI usage) |
+| 2 | Changes detected (used by `--check` / write preview; not CLI usage errors) |
 | 3 | No matches found |
 | 4 | Parse error |
 | 5 | Ambiguous match |

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -443,8 +443,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Code | Meaning |\n\
              |------|---------|\n\
              | 0 | Success (operation completed, or no changes needed) |\n\
-             | 1 | Failure (error during execution), or tx `rollback_failed` when mid-commit rollback could not fully restore files |\n\
-             | 2 | Changes detected (`--check` mode found pending changes) |\n\
+             | 1 | Failure (error during execution, CLI usage/invalid args/unknown flags/subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |\n\
+             | 2 | Changes detected (`--check` mode found pending changes; not used for CLI usage errors) |\n\
              | 3 | No matches (search/replace pattern miss, undo with no sessions, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
              | 4 | Parse error (malformed input file or plan) |\n\
              | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |\n\

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,11 +273,31 @@ pub fn bounded_regex_builder(pattern: &str) -> regex::RegexBuilder {
 /// Run the patchloom CLI. Returns the exit code as a u8.
 ///
 /// Requires the `cli` feature (enabled by default).
+///
+/// CLI usage errors (unknown flags, invalid enum values, missing required
+/// args, unrecognized subcommands) map to [`exit::FAILURE`] (1). Clap's
+/// default exit 2 collides with [`exit::CHANGES_DETECTED`] (preview/`--check`
+/// pending changes), so agents and scripts must not treat clap's default as
+/// "changes detected."
 #[cfg(feature = "cli")]
 pub fn run() -> anyhow::Result<u8> {
     use clap::Parser;
 
-    let cli = crate::cli::Cli::parse();
+    let cli = match crate::cli::Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(e) => {
+            // Help/version print to stdout and are success; everything else
+            // (usage, invalid value, missing arg) is a general failure.
+            let code = if e.use_stderr() {
+                exit::FAILURE
+            } else {
+                exit::SUCCESS
+            };
+            // Swallow broken-pipe on print (same as clap::Error::exit).
+            let _ = e.print();
+            return Ok(code);
+        }
+    };
 
     // Enable verbose mode from --verbose flag or PATCHLOOM_LOG env var.
     if cli.global.verbose || std::env::var_os("PATCHLOOM_LOG").is_some() {

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -543,10 +543,11 @@ fn test_ast_rename_legacy_positionals_rejected() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("rename.rs");
     fs::write(&f, "fn alpha() {}\n").unwrap();
+    // Clap usage error → FAILURE (1), not CHANGES_DETECTED (2).
     patchloom_in(dir.path())
         .args(["ast", "rename", "alpha", "beta", "rename.rs", "--apply"])
         .assert()
-        .code(2)
+        .code(1)
         .stderr(predicates::str::contains("--old"))
         .stderr(predicates::str::contains("--new"));
 }

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -631,11 +631,12 @@ fn test_completions_powershell() {
 
 #[test]
 fn test_completions_invalid_shell_fails() {
+    // Clap invalid enum → FAILURE (1), not CHANGES_DETECTED (2).
     Command::cargo_bin("patchloom")
         .unwrap()
         .args(["completions", "nonexistent"])
         .assert()
-        .code(2)
+        .code(1)
         .stderr(predicate::str::contains("invalid value"));
 }
 

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -704,6 +704,8 @@ fn test_md_apply_check_does_not_write() {
     let original = "# Title\n\n## Section\n\nold content\n";
     fs::write(&file, original).unwrap();
 
+    // --apply and --check are mutually exclusive at clap parse time (exit 1
+    // FAILURE, not CHANGES_DETECTED). No write path runs.
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("md")
@@ -716,12 +718,13 @@ fn test_md_apply_check_does_not_write() {
         .arg("--apply")
         .arg("--check")
         .assert()
-        .code(2);
+        .code(1)
+        .stderr(predicate::str::contains("cannot be used"));
 
     let content = fs::read_to_string(&file).unwrap();
     assert_eq!(
         content, original,
-        "--check should prevent writing even with --apply"
+        "mutually exclusive --apply/--check must not write"
     );
 }
 

--- a/tests/integration/parse_tests.rs
+++ b/tests/integration/parse_tests.rs
@@ -110,12 +110,50 @@ fn test_parse_write_flag_normalize_eol() {
 
 #[test]
 fn test_parse_unknown_subcommand_fails() {
+    // Usage errors exit FAILURE (1), not CHANGES_DETECTED (2).
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("nonexistent-command")
         .assert()
-        .code(2)
+        .code(1)
         .stderr(predicate::str::contains("unrecognized subcommand"));
+}
+
+#[test]
+fn test_parse_missing_required_arg_exits_failure_not_changes_detected() {
+    // Clap default is exit 2; patchloom remaps so scripts can branch on
+    // CHANGES_DETECTED without false positives from usage mistakes.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["create"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("required arguments"));
+}
+
+#[test]
+fn test_parse_unexpected_flag_exits_failure_not_changes_detected() {
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["schema", "--not-a-real-flag"])
+        .assert()
+        .code(1)
+        .stderr(predicate::str::contains("unexpected argument"));
+}
+
+#[test]
+fn test_parse_help_and_version_still_exit_success() {
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .code(0)
+        .stdout(predicate::str::contains("Usage"));
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--version")
+        .assert()
+        .code(0);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/schema_tests.rs
+++ b/tests/integration/schema_tests.rs
@@ -187,12 +187,13 @@ fn test_schema_quiet_suppresses_output() {
 
 #[test]
 fn test_schema_invalid_tier_fails() {
-    // clap ValueEnum rejects free strings at parse time (exit 2) and lists values.
+    // clap ValueEnum rejects free strings at parse time. Mapped to FAILURE (1)
+    // so it does not collide with CHANGES_DETECTED (2).
     Command::cargo_bin("patchloom")
         .unwrap()
         .args(["schema", "--tier", "invalid"])
         .assert()
-        .code(2)
+        .code(1)
         .stderr(predicate::str::contains("possible values"))
         .stderr(predicate::str::contains("weak"));
 }
@@ -204,7 +205,7 @@ fn test_schema_tier_small_is_not_accepted() {
         .unwrap()
         .args(["schema", "--tier", "small"])
         .assert()
-        .code(2)
+        .code(1)
         .stderr(predicate::str::contains("possible values"));
 }
 


### PR DESCRIPTION
## Summary

- Clap usage errors (invalid flags/enums, missing required args, unknown subcommands) now exit **1** (`FAILURE`) instead of clap's default **2**
- Exit **2** remains only `CHANGES_DETECTED` (`--check` / write preview)
- `--help` / `--version` still exit **0**
- Docs and agent-rules exit tables updated so agents do not confuse usage mistakes with pending changes

## Test plan

- [x] `make check-fast` green locally
- [x] Integration: invalid tier, unknown subcommand, missing required arg, unexpected flag, invalid completions shell → exit 1
- [x] Integration: `--help` / `--version` → exit 0
- [x] Integration: write preview still exit 2 (`CHANGES_DETECTED`)