### PR TITLE
fix(cli): JSON usage errors and replace empty-pattern wording

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -313,7 +313,7 @@ dependencies[name=react].version # predicate filter
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
-**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type).
+**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.
 
 **JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set `parse_error` so agents can distinguish syntax mistakes from runtime failures.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,6 +50,8 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI search JSON `invalid_input`.** Empty pattern and `--invert-match` + `--multiline` together exit 1 with `error_kind: "invalid_input"` under `--json`.
 - **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
 - **CLI usage errors exit 1.** Invalid flags, enum values, missing required args, and unknown subcommands exit **1** (`FAILURE`), not clap's default **2**. Exit 2 remains only `CHANGES_DETECTED` (`--check` / write preview). `--help` / `--version` still exit 0.
+- **CLI usage + `--json`/`--jsonl` envelope.** When parse fails after a global `--json`/`--jsonl`, stdout gets `ok: false`, `error_kind: "invalid_input"`, and the clap message (agents no longer scrape colored stderr).
+- **Replace empty-pattern wording.** Empty replace `old`/`pattern` reports `replace pattern must not be empty` (was `search pattern…`), with `error_kind: "invalid_input"` under `--json`.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -140,6 +140,8 @@ Every command returns a specific exit code:
 
 These codes let CI pipelines and agent frameworks branch on outcomes without parsing output.
 
+When `--json` or `--jsonl` is set, CLI usage failures (invalid flags, enum values, missing required args, unknown subcommands) emit a JSON envelope on stdout with `error_kind: "invalid_input"` and exit 1. Without those flags, clap prints human usage text on stderr.
+
 ## Glob filtering
 
 Most commands accept `--glob <pattern>` (repeatable) to restrict which files are processed:

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -455,8 +455,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              **JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set \
              `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, \
              or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, \
-             `status` outside a git repo, AST map non-dir, doc merge flag conflicts). Doc type mismatches set \
-             `type_error` (`doc keys`/`len` on wrong type).\n\n\
+             `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`). \
+             Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` \
+             emit the same envelope on stdout before any subcommand runs.\n\n\
              **JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set \
              `parse_error` so agents can distinguish syntax mistakes from runtime failures.\n\n\
              **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, \

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -878,8 +878,9 @@ mod error_handling {
 
         let err = validate_operation(&plan.operations[0]).unwrap_err();
         assert!(
-            err.to_string().contains("search pattern must not be empty"),
-            "expected 'search pattern must not be empty' error, got: {}",
+            err.to_string()
+                .contains("replace pattern must not be empty"),
+            "expected 'replace pattern must not be empty' error, got: {}",
             err
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,14 +288,33 @@ pub fn run() -> anyhow::Result<u8> {
         Err(e) => {
             // Help/version print to stdout and are success; everything else
             // (usage, invalid value, missing arg) is a general failure.
-            let code = if e.use_stderr() {
-                exit::FAILURE
+            if !e.use_stderr() {
+                let _ = e.print();
+                return Ok(exit::SUCCESS);
+            }
+            // Peek argv: parse failed before GlobalFlags is available, but
+            // agents often pass --json/--jsonl globally and need a structured
+            // envelope instead of clap's human usage text.
+            let wants_json = std::env::args().any(|a| a == "--json");
+            let wants_jsonl = std::env::args().any(|a| a == "--jsonl");
+            if wants_json || wants_jsonl {
+                let msg = e.to_string();
+                let payload = serde_json::json!({
+                    "ok": false,
+                    "error": msg,
+                    "error_kind": "invalid_input",
+                });
+                let rendered = if wants_jsonl {
+                    serde_json::to_string(&payload)
+                } else {
+                    serde_json::to_string_pretty(&payload)
+                };
+                println!("{}", rendered.unwrap_or_default());
             } else {
-                exit::SUCCESS
-            };
-            // Swallow broken-pipe on print (same as clap::Error::exit).
-            let _ = e.print();
-            return Ok(code);
+                // Swallow broken-pipe on print (same as clap::Error::exit).
+                let _ = e.print();
+            }
+            return Ok(exit::FAILURE);
         }
     };
 

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -83,7 +83,7 @@ pub enum ReplaceValidationError {
 impl std::fmt::Display for ReplaceValidationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::EmptyPattern => write!(f, "search pattern must not be empty"),
+            Self::EmptyPattern => write!(f, "replace pattern must not be empty"),
             Self::NthZero => {
                 write!(
                     f,

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -59,7 +59,7 @@ mod replace_tests {
             assert!(
                 ReplaceValidationError::EmptyPattern
                     .to_string()
-                    .contains("search pattern must not be empty")
+                    .contains("replace pattern must not be empty")
             );
             assert!(ReplaceValidationError::NthZero.to_string().contains("nth"));
             assert!(

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -194,7 +194,8 @@ mod tests {
         };
         let err = validate_operation(&op).unwrap_err();
         assert!(
-            err.to_string().contains("search pattern must not be empty"),
+            err.to_string()
+                .contains("replace pattern must not be empty"),
             "unexpected error: {err}"
         );
     }

--- a/tests/integration/parse_tests.rs
+++ b/tests/integration/parse_tests.rs
@@ -156,6 +156,48 @@ fn test_parse_help_and_version_still_exit_success() {
         .code(0);
 }
 
+#[test]
+fn test_parse_usage_error_with_json_emits_envelope() {
+    // Agents pass --json before a bad flag/value; clap fails before dispatch,
+    // but the envelope must still be machine-readable on stdout.
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "schema", "--tier", "bogus"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "invalid_input");
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("invalid value") || err.contains("bogus"),
+        "error should mention the bad value: {json}"
+    );
+}
+
+#[test]
+fn test_parse_usage_error_with_jsonl_emits_compact_envelope() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--jsonl", "not-a-command"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let line = String::from_utf8_lossy(&output);
+    assert!(
+        !line.trim().contains('\n') || line.lines().count() == 1,
+        "jsonl should be a single line: {line:?}"
+    );
+    let json: serde_json::Value = serde_json::from_str(line.trim()).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "invalid_input");
+}
+
 // ---------------------------------------------------------------------------
 // doc: delete, merge, prepend, select, ensure, move, update
 // ---------------------------------------------------------------------------

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -139,10 +139,46 @@ fn test_replace_empty_from_rejected() {
         .arg("--apply")
         .arg(file.to_str().unwrap())
         .assert()
-        .failure()
-        .stderr(predicate::str::contains("search pattern must not be empty"));
+        .code(1)
+        .stderr(predicate::str::contains(
+            "replace pattern must not be empty",
+        ));
 
     assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn test_replace_empty_from_json_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "",
+            "--new",
+            "X",
+            "--apply",
+            file.to_str().unwrap(),
+        ])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "invalid_input");
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("replace pattern must not be empty"),
+        "error should name replace, not search: {json}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Usage + `--json`/`--jsonl`:** clap parse failures emit `ok: false`, `error_kind: "invalid_input"`, and the message on stdout (exit 1)
- **Replace empty pattern:** message is now `replace pattern must not be empty` (was `search pattern…`)
- Docs / agent-rules / RELEASE_NOTES updated

Continues CLI agent observability after #1574 (usage exit code remapped to 1).

## Test plan

- [x] `make check-fast` green
- [x] Integration: `--json schema --tier bogus` → JSON envelope exit 1
- [x] Integration: `--jsonl` unknown subcommand → single-line envelope
- [x] Integration: empty replace pattern text + JSON `invalid_input`