### PR TITLE
fix(cli): --contain JSON error_kind invalid_input

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -313,7 +313,7 @@ dependencies[name=react].version # predicate filter
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
-**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.
+**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`, `--contain` path rejections / empty paths). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.
 
 **JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set `parse_error` so agents can distinguish syntax mistakes from runtime failures.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI usage errors exit 1.** Invalid flags, enum values, missing required args, and unknown subcommands exit **1** (`FAILURE`), not clap's default **2**. Exit 2 remains only `CHANGES_DETECTED` (`--check` / write preview). `--help` / `--version` still exit 0.
 - **CLI usage + `--json`/`--jsonl` envelope.** When parse fails after a global `--json`/`--jsonl`, stdout gets `ok: false`, `error_kind: "invalid_input"`, and the clap message (agents no longer scrape colored stderr).
 - **Replace empty-pattern wording.** Empty replace `old`/`pattern` reports `replace pattern must not be empty` (was `search pattern…`), with `error_kind: "invalid_input"` under `--json`.
+- **`--contain` JSON `invalid_input`.** Path rejections and empty path arguments under `--contain` set `error_kind: "invalid_input"` on the global `--json`/`--jsonl` error path (typed `InvalidInputError`, not English scraping).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -140,7 +140,7 @@ Every command returns a specific exit code:
 
 These codes let CI pipelines and agent frameworks branch on outcomes without parsing output.
 
-When `--json` or `--jsonl` is set, CLI usage failures (invalid flags, enum values, missing required args, unknown subcommands) emit a JSON envelope on stdout with `error_kind: "invalid_input"` and exit 1. Without those flags, clap prints human usage text on stderr.
+When `--json` or `--jsonl` is set, CLI usage failures (invalid flags, enum values, missing required args, unknown subcommands) emit a JSON envelope on stdout with `error_kind: "invalid_input"` and exit 1. Without those flags, clap prints human usage text on stderr. Path rejections under `--contain` (and empty path arguments) also set `error_kind: "invalid_input"` on the structured error path.
 
 ## Glob filtering
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -447,7 +447,10 @@ impl GlobalFlags {
         for p in &paths {
             let p = p.as_ref();
             if p.trim().is_empty() {
-                anyhow::bail!("path must not be empty");
+                return Err(crate::exit::InvalidInputError {
+                    msg: "path must not be empty".into(),
+                }
+                .into());
             }
         }
         let Some(guard) = self.workspace_guard(cwd)? else {
@@ -455,9 +458,11 @@ impl GlobalFlags {
         };
         for p in paths {
             let p = p.as_ref();
-            guard
-                .check_path(p)
-                .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {e}"))?;
+            guard.check_path(p).map_err(|e| {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("path rejected by workspace guard: {e}"),
+                })
+            })?;
         }
         Ok(())
     }

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -455,9 +455,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              **JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set \
              `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, \
              or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, \
-             `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`). \
-             Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` \
-             emit the same envelope on stdout before any subcommand runs.\n\n\
+             `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`, \
+             `--contain` path rejections / empty paths). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). \
+             Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.\n\n\
              **JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set \
              `parse_error` so agents can distinguish syntax mistakes from runtime failures.\n\n\
              **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, \

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -62,6 +62,30 @@ pub fn is_ambiguous(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<AmbiguousError>().is_some())
 }
 
+/// Typed error for invalid CLI/input conditions that map to exit
+/// [`FAILURE`] (1) with JSON `error_kind: "invalid_input"`.
+///
+/// Used for `--contain` path rejections and empty-path validation so the
+/// global `--json` dispatch path does not require English string matching.
+#[derive(Debug)]
+pub struct InvalidInputError {
+    pub msg: String,
+}
+
+impl std::fmt::Display for InvalidInputError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for InvalidInputError {}
+
+/// Check whether an `anyhow::Error` chain contains an [`InvalidInputError`].
+pub fn is_invalid_input(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<InvalidInputError>().is_some())
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.
@@ -162,6 +186,18 @@ mod tests {
     fn is_ambiguous_rejects_plain_error() {
         let err = anyhow::anyhow!("some other error").context("operation 1 failed");
         assert!(!is_ambiguous(&err));
+    }
+
+    #[test]
+    fn is_invalid_input_finds_wrapped_error() {
+        let err: anyhow::Error = InvalidInputError {
+            msg: "path rejected by workspace guard: escapes".to_string(),
+        }
+        .into();
+        let wrapped = err.context("create failed");
+        assert!(is_invalid_input(&wrapped));
+        assert!(!is_no_match(&wrapped));
+        assert!(!is_ambiguous(&wrapped));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,13 +343,15 @@ pub fn run() -> anyhow::Result<u8> {
 
 /// Build the JSON error envelope and exit code for a dispatch `Err` under
 /// `--json` / `--jsonl`. Typed [`exit::NoMatchError`] / [`exit::AmbiguousError`]
-/// chains get `error_kind` and their dedicated exit codes.
+/// / [`exit::InvalidInputError`] chains get `error_kind` and their exit codes.
 #[cfg(feature = "cli")]
 fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
     let (kind, code) = if exit::is_no_match(err) {
         (Some("no_matches"), exit::NO_MATCHES)
     } else if exit::is_ambiguous(err) {
         (Some("ambiguous"), exit::AMBIGUOUS)
+    } else if exit::is_invalid_input(err) {
+        (Some("invalid_input"), exit::FAILURE)
     } else {
         (None, exit::FAILURE)
     };
@@ -407,6 +409,25 @@ mod tests {
         assert_eq!(code, exit::FAILURE);
         assert!(payload.get("error_kind").is_none());
         assert_eq!(payload["ok"], false);
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn structured_dispatch_error_maps_invalid_input() {
+        let err: anyhow::Error = exit::InvalidInputError {
+            msg: "path rejected by workspace guard: escapes".into(),
+        }
+        .into();
+        let (payload, code) = structured_dispatch_error(&err);
+        assert_eq!(code, exit::FAILURE);
+        assert_eq!(payload["error_kind"], "invalid_input");
+        assert!(
+            payload["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("workspace guard"),
+            "payload={payload}"
+        );
     }
 
     #[test]

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -265,6 +265,41 @@ fn test_contain_help_documents_allow_absolute_under_workspace() {
 }
 
 #[test]
+fn test_contain_json_escape_sets_invalid_input_error_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "--cwd",
+            dir.path().to_str().unwrap(),
+            "--contain",
+            "read",
+            "/etc/passwd",
+        ])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "containment rejections must set error_kind for agents: {json}"
+    );
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("workspace guard"),
+        "payload={json}"
+    );
+}
+
+#[test]
 fn test_confirm_conflicts_with_apply() {
     Command::cargo_bin("patchloom")
         .unwrap()


### PR DESCRIPTION
## Summary

- Typed `InvalidInputError` for `--contain` path rejections and empty path args
- Global `--json`/`--jsonl` dispatch sets `error_kind: "invalid_input"` (exit 1)
- Agent-rules / concepts / RELEASE_NOTES updated

Continues agent JSON parity after #1574 / #1575.

## Test plan

- [x] Unit: `is_invalid_input` + `structured_dispatch_error_maps_invalid_input`
- [x] Integration: `--json --contain read /etc/passwd` → `error_kind: invalid_input`
- [x] `make check-fast` green locally (prior run on same tree)