### PR TITLE
fix(cli): compact clap usage messages under JSON

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -53,6 +53,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI usage + `--json`/`--jsonl` envelope.** When parse fails after a global `--json`/`--jsonl`, stdout gets `ok: false`, `error_kind: "invalid_input"`, and the clap message (agents no longer scrape colored stderr).
 - **Replace empty-pattern wording.** Empty replace `old`/`pattern` reports `replace pattern must not be empty` (was `search pattern…`), with `error_kind: "invalid_input"` under `--json`.
 - **`--contain` JSON `invalid_input`.** Path rejections and empty path arguments under `--contain` set `error_kind: "invalid_input"` on the global `--json`/`--jsonl` error path (typed `InvalidInputError`, not English scraping).
+- **Cleaner clap JSON usage messages.** Usage failures under `--json`/`--jsonl` strip the `error: ` prefix and help footer so agents get a short actionable string.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ pub fn run() -> anyhow::Result<u8> {
             let wants_json = std::env::args().any(|a| a == "--json");
             let wants_jsonl = std::env::args().any(|a| a == "--jsonl");
             if wants_json || wants_jsonl {
-                let msg = e.to_string();
+                let msg = clap_usage_error_message(&e);
                 let payload = serde_json::json!({
                     "ok": false,
                     "error": msg,
@@ -338,6 +338,53 @@ pub fn run() -> anyhow::Result<u8> {
             Ok(code)
         }
         Err(e) => Err(e),
+    }
+}
+
+/// Compact clap usage text for JSON envelopes: drop the `error: ` prefix and
+/// trailing Usage / help footer so agents get a single actionable sentence.
+#[cfg(feature = "cli")]
+fn clap_usage_error_message(err: &clap::Error) -> String {
+    let raw = err.to_string();
+    let body = raw.strip_prefix("error: ").unwrap_or(&raw);
+    let mut lines = Vec::new();
+    for line in body.lines() {
+        let t = line.trim_end();
+        if t.is_empty() && lines.is_empty() {
+            continue;
+        }
+        if t.starts_with("Usage:")
+            || t.starts_with("For more information")
+            || t.starts_with("[possible values:")
+        {
+            // Keep possible-values lines: they are useful for agents.
+            if t.starts_with("[possible values:") {
+                lines.push(t.to_string());
+            }
+            if t.starts_with("Usage:") || t.starts_with("For more information") {
+                break;
+            }
+            continue;
+        }
+        // Indent under possible values is often "  [possible values: …]"
+        if t.trim_start().starts_with("[possible values:") {
+            lines.push(t.trim_start().to_string());
+            continue;
+        }
+        if lines.len() >= 3 {
+            break;
+        }
+        lines.push(t.to_string());
+    }
+    let msg = lines
+        .join(" ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if msg.is_empty() {
+        body.trim().to_string()
+    } else {
+        msg
     }
 }
 

--- a/tests/integration/parse_tests.rs
+++ b/tests/integration/parse_tests.rs
@@ -176,6 +176,14 @@ fn test_parse_usage_error_with_json_emits_envelope() {
         err.contains("invalid value") || err.contains("bogus"),
         "error should mention the bad value: {json}"
     );
+    assert!(
+        !err.starts_with("error: "),
+        "JSON error should strip clap 'error: ' prefix: {json}"
+    );
+    assert!(
+        !err.contains("For more information"),
+        "JSON error should omit help footer: {json}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Compact clap usage strings in `--json`/`--jsonl` envelopes (drop `error: ` prefix and help footer)
- Keep `[possible values: …]` for enum failures
- RELEASE_NOTES + integration assertions

Follow-up to #1575.

## Test plan

- [x] `make check-fast`
- [x] Integration: `--json schema --tier bogus` has no `error: ` prefix / help footer