### PR TITLE
feat(plan): accept ops as alias for operations

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -82,7 +82,7 @@ Use these names in plans, MCP args, and CLI flags (do not invent alternates):
 | AST rename / replace | path first | `ast rename PATH --old X --new Y`; plan `ast.rename` uses `path`/`old`/`new`. |
 | Schema capability filter | `weak` / `medium` / `strong` | `schema --tier` only accepts these (not `small`/`large`). |
 
-Some plan/MCP fields still **accept** legacy aliases (`from`/`to` for replace, `key` for doc selector) so older agent prompts keep working, but examples and new plans must use the canonical names above.
+Some plan/MCP fields still **accept** legacy aliases (`from`/`to` for replace, `key` for doc selector, `ops` for the plan `operations` array) so older agent prompts keep working, but examples and new plans must use the canonical names above.
 
 ## Batching (the main speed win)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -54,6 +54,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Replace empty-pattern wording.** Empty replace `old`/`pattern` reports `replace pattern must not be empty` (was `search pattern…`), with `error_kind: "invalid_input"` under `--json`.
 - **`--contain` JSON `invalid_input`.** Path rejections and empty path arguments under `--contain` set `error_kind: "invalid_input"` on the global `--json`/`--jsonl` error path (typed `InvalidInputError`, not English scraping).
 - **Cleaner clap JSON usage messages.** Usage failures under `--json`/`--jsonl` strip the `error: ` prefix and help footer so agents get a short actionable string.
+- **Plan `ops` alias.** Transaction plans accept `"ops"` as a serde alias for `"operations"` so agents that emit the shorter field name parse without a `missing field` error.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -923,6 +923,7 @@ Use these when newline and whitespace correctness is the main concern.
 ### `operations`
 
 - **What it does:** Lists the ordered mutations that make up the transaction.
+- **Alias:** `ops` is accepted on deserialize (common agent shorthand). Serialized plans still emit `operations`.
 - **Use when:** One logical change spans several steps or several mutation types.
 - **Prefer instead:** Use a standalone command when one direct operation is enough.
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -171,8 +171,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
          | Doc path into a document | `selector` | CLI positional. Plans/MCP: `\"selector\"`. |\n\
          | AST rename / replace | path first | `ast rename PATH --old X --new Y`; plan `ast.rename` uses `path`/`old`/`new`. |\n\
          | Schema capability filter | `weak` / `medium` / `strong` | `schema --tier` only accepts these (not `small`/`large`). |\n\n\
-         Some plan/MCP fields still **accept** legacy aliases (`from`/`to` for replace, `key` for doc selector) \
-         so older agent prompts keep working, but examples and new plans must use the canonical names above.\n\n",
+         Some plan/MCP fields still **accept** legacy aliases (`from`/`to` for replace, `key` for doc selector, \
+         `ops` for the plan `operations` array) so older agent prompts keep working, but examples and new plans \
+         must use the canonical names above.\n\n",
     );
 
     // Batching section

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -51,6 +51,8 @@ pub struct Plan {
     /// When omitted from the plan, defaults to strict mode at execution time.
     #[serde(default)]
     pub strict: Option<bool>,
+    /// Operations to run. Accepts alias `ops` (common agent shorthand).
+    #[serde(alias = "ops")]
     pub operations: Vec<Operation>,
     pub format: Option<Vec<FormatStep>>,
     pub validate: Option<Vec<ValidationStep>>,

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -178,6 +178,15 @@ fn parse_plan_missing_operations_fails() {
 }
 
 #[test]
+fn parse_plan_ops_alias_accepted() {
+    // Agents often emit "ops" instead of "operations".
+    let json =
+        r#"{"version": 1, "ops": [{"op": "replace", "path": "f.txt", "old": "a", "new": "b"}]}"#;
+    let plan = parse_plan(json).expect("ops alias should parse");
+    assert_eq!(plan.operations.len(), 1);
+}
+
+#[test]
 #[cfg(feature = "ast")]
 fn parse_all_operation_variants() {
     let json = r#"{"version": 1, "operations": [

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -30,6 +30,37 @@ fn test_tx_replace_empty_from_rejected() {
 }
 
 #[test]
+fn test_tx_ops_alias_accepted() {
+    // Agents often emit "ops" instead of the canonical "operations" field.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "hello world\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": dir.path().to_str().unwrap(),
+        "ops": [{
+            "op": "replace",
+            "path": "test.txt",
+            "old": "hello",
+            "new": "hi"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hi world\n");
+}
+
+#[test]
 fn test_tx_replace_whole_line_in_plan() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("data.txt");


### PR DESCRIPTION
## Summary

- Transaction plans accept serde alias `ops` for the `operations` array
- Canonical field remains `operations` on serialize and in examples
- Agent-rules, reference docs, unit + integration tests

## Test plan

- [x] `parse_plan_ops_alias_accepted`
- [x] `test_tx_ops_alias_accepted` (CLI apply)
- [x] `make check-fast`