### PR TITLE
fix(cli): missing path roots return not_found

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -313,7 +313,7 @@ dependencies[name=react].version # predicate filter
 | 8 | Patch merge conflicts (`patch merge` or `--on-stale merge` without `--allow-conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
-**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`, `--contain` path rejections / empty paths). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.
+**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`, `--contain` path rejections / empty paths, all-explicit-paths-missing for search/replace/tidy). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.
 
 **JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set `parse_error` so agents can distinguish syntax mistakes from runtime failures.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -55,6 +55,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`--contain` JSON `invalid_input`.** Path rejections and empty path arguments under `--contain` set `error_kind: "invalid_input"` on the global `--json`/`--jsonl` error path (typed `InvalidInputError`, not English scraping).
 - **Cleaner clap JSON usage messages.** Usage failures under `--json`/`--jsonl` strip the `error: ` prefix and help footer so agents get a short actionable string.
 - **Plan `ops` alias.** Transaction plans accept `"ops"` as a serde alias for `"operations"` so agents that emit the shorter field name parse without a `missing field` error.
+- **Missing path roots are `not_found`.** When every explicit path root for `search`, `replace`, or `tidy` is missing, exit **1** with `error_kind: "not_found"` (was soft `no_matches` / vacuous tidy success). Pattern misses and clean trees still use exit 3 / 0.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -457,7 +457,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, \
              or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, \
              `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`, \
-             `--contain` path rejections / empty paths). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). \
+             `--contain` path rejections / empty paths, all-explicit-paths-missing for search/replace/tidy). Doc type mismatches set \
+             `type_error` (`doc keys`/`len` on wrong type). \
              Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.\n\n\
              **JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set \
              `parse_error` so agents can distinguish syntax mistakes from runtime failures.\n\n\

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -373,6 +373,14 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
         }
+        if crate::files::all_explicit_paths_missing(&args.paths, Some(&cwd)) {
+            let msg = format!(
+                "no such file or directory: {}",
+                global.path_scope_description(&args.paths)
+            );
+            global.emit_error_json_kind(Some("not_found"), &msg)?;
+            return Ok(exit::FAILURE);
+        }
         let output = ReplaceOutput {
             ok: false,
             match_count: 0,

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -368,6 +368,15 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         !results.matches.is_empty()
     };
     if !has_matches {
+        let cwd = global.resolve_cwd()?;
+        if crate::files::all_explicit_paths_missing(&args.paths, Some(&cwd)) {
+            let msg = format!(
+                "no such file or directory: {}",
+                global.path_scope_description(&args.paths)
+            );
+            global.emit_error_json_kind(Some("not_found"), &msg)?;
+            return Ok(exit::FAILURE);
+        }
         let payload = SearchOutput {
             ok: false,
             match_count: 0,

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -215,6 +215,15 @@ pub(super) fn render_issues(issues: &[TidyIssue], global: &GlobalFlags) {
 pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Result<u8> {
     use crate::exit;
     crate::verbose!("tidy: checking {} path(s)", paths.len());
+    let cwd = global.resolve_cwd()?;
+    if crate::files::all_explicit_paths_missing(paths, Some(&cwd)) {
+        let msg = format!(
+            "no such file or directory: {}",
+            global.path_scope_description(paths)
+        );
+        global.emit_error_json_kind(Some("not_found"), &msg)?;
+        return Ok(exit::FAILURE);
+    }
     let issues = collect_issues(paths, global)?;
     if !global.quiet || global.json || global.jsonl {
         render_issues(&issues, global);

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -231,6 +231,14 @@ pub(super) fn run_fix(
 
     crate::verbose!("tidy: {} file(s) need fixing", dirty_rel_paths.len());
     if dirty_rel_paths.is_empty() {
+        if crate::files::all_explicit_paths_missing(&paths, Some(&cwd)) {
+            let msg = format!(
+                "no such file or directory: {}",
+                global.path_scope_description(&paths)
+            );
+            global.emit_error_json_kind(Some("not_found"), &msg)?;
+            return Ok(exit::FAILURE);
+        }
         emit_tidy_fix_output(global, &[], None)?;
         return Ok(exit::SUCCESS);
     }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,3 +1,10 @@
+//! File walking, binary detection, and text-read helpers shared by CLI commands.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). One module owns
+//! ignore-aware walks, glob/exclude filtering, binary/UTF-8 guards, and
+//! path-missing helpers used by search/replace/tidy; co-located unit tests push
+//! the file over 1000 lines. Do not split for LOC alone.
+
 #[cfg(feature = "cli")]
 use crate::cli::global::GlobalFlags;
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -60,6 +67,25 @@ pub(crate) fn is_binary_file(path: &Path) -> bool {
     is_binary(&buf[..n])
 }
 
+/// True when the user supplied explicit path roots and none of them exist.
+///
+/// Empty `paths` means the caller will default to `.` and is never "all
+/// missing" here. Used so search/replace/tidy can distinguish path typos
+/// (`not_found`) from pattern/whitespace soft success (`no_matches` / clean).
+#[cfg(feature = "cli")]
+pub(crate) fn all_explicit_paths_missing(paths: &[String], root: Option<&Path>) -> bool {
+    if paths.is_empty() {
+        return false;
+    }
+    paths.iter().all(|p| {
+        let resolved = match root {
+            Some(r) if !std::path::Path::new(p).is_absolute() => r.join(p),
+            _ => std::path::PathBuf::from(p),
+        };
+        !resolved.exists()
+    })
+}
+
 /// Collect file paths from either `--files-from`, or by walking `paths` with
 /// `ignore::WalkBuilder` (respects `.gitignore`).  When `root` is `Some`,
 /// paths are joined with it before walking.  Tidy commands set
@@ -104,7 +130,9 @@ pub(crate) fn collect_file_paths_opts(
         global.check_paths_contained(r, effective)?;
     }
     // Warn about nonexistent user-supplied paths so typos are visible
-    // instead of silently producing an empty result set (exit 3).
+    // instead of silently producing an empty result set (exit 3 / soft success).
+    // Callers that want a hard not_found should also check
+    // [`all_explicit_paths_missing`].
     for p in effective {
         let resolved = resolve(p);
         if !resolved.exists() {
@@ -629,6 +657,18 @@ mod tests {
         std::fs::write(&p, b"hello world\n").unwrap();
         assert!(!is_binary_file(&p));
         assert!(!is_binary_file(&dir.path().join("nope.bin"))); // open fails -> false
+    }
+
+    #[test]
+    #[cfg(feature = "cli")]
+    fn all_explicit_paths_missing_detects_typos() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let missing = vec!["nope.txt".to_string()];
+        assert!(all_explicit_paths_missing(&missing, Some(dir.path())));
+        assert!(!all_explicit_paths_missing(&[], Some(dir.path())));
+        std::fs::write(dir.path().join("exists.txt"), b"x\n").unwrap();
+        let mixed = vec!["exists.txt".to_string(), "nope.txt".to_string()];
+        assert!(!all_explicit_paths_missing(&mixed, Some(dir.path())));
     }
 
     // ── matches_glob ──────────────────────────────────────────────────

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1738,3 +1738,19 @@ fn test_replace_json_range_without_whole_line_sets_error_kind() {
         "replace range without whole_line: {parsed}"
     );
 }
+
+#[test]
+fn test_replace_missing_path_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.txt");
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "replace", "foo", "--new", "bar"])
+        .arg(&missing)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error_kind"], "not_found");
+}

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -576,15 +576,27 @@ fn test_search_files_with_matches_no_match_exits_3() {
 }
 
 #[test]
-fn test_search_nonexistent_path_warns_on_stderr() {
+fn test_search_nonexistent_path_is_not_found() {
+    // Explicit missing roots are not soft pattern misses (exit 3); agents need
+    // not_found (exit 1) so path typos are not retried as different patterns.
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("search")
         .arg("hello")
         .arg("totally_nonexistent_dir/")
         .assert()
-        .code(3)
+        .code(1)
         .stderr(predicate::str::contains("totally_nonexistent_dir"));
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "search", "hello", "totally_nonexistent_dir/"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error_kind"], "not_found");
 }
 
 #[test]

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -589,3 +589,35 @@ fn test_tidy_fix_contain_rejects_parent_escape() {
     );
     let _ = fs::remove_file(&outside);
 }
+
+#[test]
+fn test_tidy_check_missing_path_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.txt");
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tidy", "check"])
+        .arg(&missing)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error_kind"], "not_found");
+}
+
+#[test]
+fn test_tidy_fix_missing_path_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.txt");
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tidy", "fix"])
+        .arg(&missing)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error_kind"], "not_found");
+}


### PR DESCRIPTION
## Summary

- Shared `all_explicit_paths_missing` helper
- `search` / `replace` / `tidy check` / `tidy fix`: all-missing explicit roots → exit **1**, `error_kind: "not_found"`
- Fixes tidy vacuous success on missing paths and search/replace path typos misclassified as soft no-matches

Closes #1580

## Test plan

- [x] Unit: `all_explicit_paths_missing_detects_typos`
- [x] Integration: search/replace/tidy missing path JSON not_found
- [x] `make check-fast`