### PR TITLE
fix(cli): files-from all-missing targets return not_found

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -55,7 +55,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **`--contain` JSON `invalid_input`.** Path rejections and empty path arguments under `--contain` set `error_kind: "invalid_input"` on the global `--json`/`--jsonl` error path (typed `InvalidInputError`, not English scraping).
 - **Cleaner clap JSON usage messages.** Usage failures under `--json`/`--jsonl` strip the `error: ` prefix and help footer so agents get a short actionable string.
 - **Plan `ops` alias.** Transaction plans accept `"ops"` as a serde alias for `"operations"` so agents that emit the shorter field name parse without a `missing field` error.
-- **Missing path roots are `not_found`.** When every explicit path root for `search`, `replace`, or `tidy` is missing, exit **1** with `error_kind: "not_found"` (was soft `no_matches` / vacuous tidy success). Pattern misses and clean trees still use exit 3 / 0.
+- **Missing path roots are `not_found`.** When every explicit path root for `search`, `replace`, or `tidy` is missing (including `--files-from` lists, not stdin), exit **1** with `error_kind: "not_found"` (was soft `no_matches` / vacuous tidy success). Pattern misses and clean trees still use exit 3 / 0.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -373,7 +373,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
         }
-        if crate::files::all_explicit_paths_missing(&args.paths, Some(&cwd)) {
+        if crate::files::all_scan_targets_missing(global, &args.paths, Some(&cwd))? {
             let msg = format!(
                 "no such file or directory: {}",
                 global.path_scope_description(&args.paths)

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -369,7 +369,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
     if !has_matches {
         let cwd = global.resolve_cwd()?;
-        if crate::files::all_explicit_paths_missing(&args.paths, Some(&cwd)) {
+        if crate::files::all_scan_targets_missing(global, &args.paths, Some(&cwd))? {
             let msg = format!(
                 "no such file or directory: {}",
                 global.path_scope_description(&args.paths)

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -216,7 +216,7 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
     use crate::exit;
     crate::verbose!("tidy: checking {} path(s)", paths.len());
     let cwd = global.resolve_cwd()?;
-    if crate::files::all_explicit_paths_missing(paths, Some(&cwd)) {
+    if crate::files::all_scan_targets_missing(global, paths, Some(&cwd))? {
         let msg = format!(
             "no such file or directory: {}",
             global.path_scope_description(paths)

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -231,7 +231,7 @@ pub(super) fn run_fix(
 
     crate::verbose!("tidy: {} file(s) need fixing", dirty_rel_paths.len());
     if dirty_rel_paths.is_empty() {
-        if crate::files::all_explicit_paths_missing(&paths, Some(&cwd)) {
+        if crate::files::all_scan_targets_missing(global, &paths, Some(&cwd))? {
             let msg = format!(
                 "no such file or directory: {}",
                 global.path_scope_description(&paths)

--- a/src/files.rs
+++ b/src/files.rs
@@ -86,6 +86,26 @@ pub(crate) fn all_explicit_paths_missing(paths: &[String], root: Option<&Path>) 
     })
 }
 
+/// Like [`all_explicit_paths_missing`], but prefers `--files-from` entries when
+/// set. Does not re-read stdin (`--files-from -`); those lists skip this check.
+#[cfg(feature = "cli")]
+pub(crate) fn all_scan_targets_missing(
+    global: &GlobalFlags,
+    paths: &[String],
+    root: Option<&Path>,
+) -> anyhow::Result<bool> {
+    if global.files_from.as_deref() == Some("-") {
+        return Ok(false);
+    }
+    if global.files_from.is_some() {
+        let Some(files) = global.read_files_from()? else {
+            return Ok(false);
+        };
+        return Ok(all_explicit_paths_missing(&files, root));
+    }
+    Ok(all_explicit_paths_missing(paths, root))
+}
+
 /// Collect file paths from either `--files-from`, or by walking `paths` with
 /// `ignore::WalkBuilder` (respects `.gitignore`).  When `root` is `Some`,
 /// paths are joined with it before walking.  Tidy commands set

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -489,9 +489,10 @@ fn test_replace_no_match_quiet_suppresses_stderr() {
 
 #[test]
 fn test_replace_no_match_files_from_mentions_files_from_not_dot() {
+    // Existing file, pattern miss: soft no_matches. Missing list entries are not_found.
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
-    fs::write(dir.path().join("list.txt"), "missing.txt\n").unwrap();
+    fs::write(dir.path().join("list.txt"), "a.txt\n").unwrap();
 
     let output = Command::cargo_bin("patchloom")
         .unwrap()
@@ -500,7 +501,7 @@ fn test_replace_no_match_files_from_mentions_files_from_not_dot() {
         .arg("--files-from")
         .arg("list.txt")
         .arg("replace")
-        .arg("hello")
+        .arg("zzz_no_match_zzz")
         .arg("--new")
         .arg("bye")
         .output()

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -74,10 +74,11 @@ fn test_search_no_match_quiet_suppresses_stderr() {
 fn test_search_no_match_files_from_mentions_files_from_not_dot() {
     // When the file list is --files-from, "no matches in ." is wrong: search never
     // walked the workspace root. Scope description must name --files-from.
+    // Use an existing file with no pattern hit (missing list entries are not_found).
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
     let list = dir.path().join("list.txt");
-    fs::write(&list, "missing.txt\n").unwrap();
+    fs::write(&list, "a.txt\n").unwrap();
 
     let output = Command::cargo_bin("patchloom")
         .unwrap()
@@ -86,7 +87,7 @@ fn test_search_no_match_files_from_mentions_files_from_not_dot() {
         .arg("--files-from")
         .arg("list.txt")
         .arg("search")
-        .arg("hello")
+        .arg("zzz_no_match_zzz")
         .output()
         .unwrap();
     assert_eq!(output.status.code(), Some(3));
@@ -1186,4 +1187,22 @@ fn test_search_contain_rejects_files_from_parent_escape() {
         );
 
     let _ = fs::remove_file(&outside);
+}
+
+#[test]
+fn test_search_files_from_all_missing_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let list = dir.path().join("list.txt");
+    fs::write(&list, format!("{}/nope.txt\n", dir.path().display())).unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--files-from"])
+        .arg(&list)
+        .args(["search", "hello"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(parsed["error_kind"], "not_found");
 }


### PR DESCRIPTION
## Summary

- `all_scan_targets_missing` covers `--files-from` lists (skips stdin)
- search/replace/tidy use it for `not_found` parity with positional missing roots
- Adjust soft no-match files-from tests to use existing files

Follow-up to #1581 / #1580.

## Test plan

- [x] `test_search_files_from_all_missing_is_not_found`
- [x] Updated files-from no-match scope tests
- [x] `make check-fast`