### PR TITLE
docs: document missing-path not_found for search/replace/tidy

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -142,6 +142,8 @@ These codes let CI pipelines and agent frameworks branch on outcomes without par
 
 When `--json` or `--jsonl` is set, CLI usage failures (invalid flags, enum values, missing required args, unknown subcommands) emit a JSON envelope on stdout with `error_kind: "invalid_input"` and exit 1. Without those flags, clap prints human usage text on stderr. Path rejections under `--contain` (and empty path arguments) also set `error_kind: "invalid_input"` on the structured error path.
 
+When every explicit path root for `search`, `replace`, or `tidy` is missing (including a non-stdin `--files-from` list), exit 1 with `error_kind: "not_found"`. Pattern misses on existing files still use exit 3 (`no_matches`). Empty existing directories remain clean success for tidy.
+
 ## Glob filtering
 
 Most commands accept `--glob <pattern>` (repeatable) to restrict which files are processed:

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -209,6 +209,7 @@ These are the main entry points. If you are deciding between commands, start her
 - **What it does:** Searches text files with literal or regex matching, optional context, counts, and file only results. Binary and invalid UTF-8 files are skipped.
 - **Use when:** You need to locate candidate edits, audit repo state, or narrow inputs before changing files. For AI agents, native search/grep tools are typically faster for simple pattern matching.
 - **Prefer instead:** Use `replace` for actual text mutation, or `doc`, `md`, or `patch` when you already know the structured change you want.
+- **Failure behavior:** Pattern miss on existing roots exits `3` with `error_kind: "no_matches"`. When every explicit path root (or non-stdin `--files-from` entry) is missing, exit `1` with `error_kind: "not_found"`. Empty pattern and incompatible flags use `invalid_input`.
 - **Related:** `--glob`, `--files-from`, `replace`
 
 <!-- ref:command:replace -->
@@ -217,6 +218,7 @@ These are the main entry points. If you are deciding between commands, start her
 - **What it does:** Performs mechanical string replacement across one or many text files, with literal or regex matching. Binary and invalid UTF-8 files are skipped.
 - **Use when:** You are doing a rename, version bump, boilerplate rewrite, or another string level change where plain text semantics are enough. For AI agents doing single-file replacements, native search_replace tools are typically faster; use patchloom `replace` inside `tx` plans when batching multiple file edits.
 - **Prefer instead:** Use `doc` for structured data, `md` for heading aware markdown, or `patch` when you already have a unified diff.
+- **Failure behavior:** Soft pattern miss exits `3` with `error_kind: "no_matches"`; `--unique` multi-match exits `5` with `ambiguous`. All-explicit-path-missing (or all-missing `--files-from` list) exits `1` with `not_found`. Validation failures use `invalid_input`.
 - **Related:** `search`, `tx`
 
 <!-- ref:command:patch -->
@@ -249,7 +251,7 @@ These are the main entry points. If you are deciding between commands, start her
 
 - **What it does:** Checks or fixes trailing whitespace, line endings, and final newlines in text files. Binary and invalid UTF-8 files are skipped.
 - **Use when:** You need repo text normalization, or a CI guard for basic text tidiness.
-- **Failure behavior:** `tidy fix` with both `--dedent` and `--indent` exits `1` with `error_kind: "invalid_input"` under `--json`/`--jsonl`.
+- **Failure behavior:** `tidy fix` with both `--dedent` and `--indent` exits `1` with `error_kind: "invalid_input"` under `--json`/`--jsonl`. When every explicit path root is missing, exit `1` with `error_kind: "not_found"` (not vacuous clean success). Pending tidy issues under `tidy check` exit `2` (`CHANGES_DETECTED`).
 - **Prefer instead:** Use write policy flags when the cleanup should only apply to files already being touched by another command.
 - **Related:** `tidy check`, `tidy fix`, `tx tidy.fix`
 


### PR DESCRIPTION
## Summary

- Core concepts: missing explicit roots / files-from → exit 1 `not_found`
- Reference: search / replace / tidy failure behavior updated for #1581/#1582

## Test plan

- [x] Docs-only; spot-checked against shipped CLI behavior