### PR TITLE
fix(cli): map engine IO NotFound to JSON not_found

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Cleaner clap JSON usage messages.** Usage failures under `--json`/`--jsonl` strip the `error: ` prefix and help footer so agents get a short actionable string.
 - **Plan `ops` alias.** Transaction plans accept `"ops"` as a serde alias for `"operations"` so agents that emit the shorter field name parse without a `missing field` error.
 - **Missing path roots are `not_found`.** When every explicit path root for `search`, `replace`, or `tidy` is missing (including `--files-from` lists, not stdin), exit **1** with `error_kind: "not_found"` (was soft `no_matches` / vacuous tidy success). Pattern misses and clean trees still use exit 3 / 0.
+- **Engine IO not_found chain.** Tx/CLI engine read failures preserve `std::io::ErrorKind::NotFound` through context wrappers so global `--json` maps them to `error_kind: "not_found"` (e.g. `md replace-section` on a missing file).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -336,9 +336,10 @@ fn file_create_force_propagates_read_error() {
     let err = file_create(&file, "new", true, ApplyMode::Apply, None).unwrap_err();
     // Restore permissions so TempDir cleanup succeeds.
     fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+    let msg = format!("{err:#}");
     assert!(
-        err.to_string().contains("failed to read"),
-        "expected read error, got: {err}"
+        msg.contains("failed to read"),
+        "expected read error, got: {msg}"
     );
 }
 
@@ -730,7 +731,8 @@ fn md_table_append_column_mismatch_gives_specific_error() {
     .unwrap();
 
     let err = md_table_append(&file, "# Data", "| x |", ApplyMode::Preview, None).unwrap_err();
-    let msg = err.to_string();
+    // Engine wraps with context; use alternate Display for the full chain.
+    let msg = format!("{err:#}");
     assert!(
         msg.contains("column"),
         "error should mention column mismatch, got: {msg}"
@@ -749,7 +751,7 @@ fn md_table_append_no_table_gives_specific_error() {
     fs::write(&file, "# Data\n\nJust text, no table.\n").unwrap();
 
     let err = md_table_append(&file, "# Data", "| x |", ApplyMode::Preview, None).unwrap_err();
-    let msg = err.to_string();
+    let msg = format!("{err:#}");
     assert!(
         msg.contains("no markdown table"),
         "error should mention 'no markdown table', got: {msg}"

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -86,6 +86,15 @@ pub fn is_invalid_input(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<InvalidInputError>().is_some())
 }
 
+/// True when any cause is an IO `NotFound` (missing file/dir).
+pub fn is_io_not_found(err: &anyhow::Error) -> bool {
+    err.chain().any(|cause| {
+        cause
+            .downcast_ref::<std::io::Error>()
+            .is_some_and(|e| e.kind() == std::io::ErrorKind::NotFound)
+    })
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.
@@ -218,5 +227,17 @@ mod tests {
         for code in codes {
             assert!(seen.insert(code), "duplicate exit code: {code}");
         }
+    }
+
+    #[test]
+    fn is_io_not_found_preserves_with_context_chain() {
+        use anyhow::Context;
+        let err = std::fs::read_to_string("/tmp/patchloom-definitely-missing-xyz-99999")
+            .with_context(|| "failed to read path");
+        let err = err.unwrap_err();
+        assert!(
+            is_io_not_found(&err),
+            "with_context should keep NotFound in chain: {err:#}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,6 +399,8 @@ fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
         (Some("ambiguous"), exit::AMBIGUOUS)
     } else if exit::is_invalid_input(err) {
         (Some("invalid_input"), exit::FAILURE)
+    } else if exit::is_io_not_found(err) {
+        (Some("not_found"), exit::FAILURE)
     } else {
         (None, exit::FAILURE)
     };
@@ -475,6 +477,16 @@ mod tests {
                 .contains("workspace guard"),
             "payload={payload}"
         );
+    }
+
+    #[cfg(feature = "cli")]
+    #[test]
+    fn structured_dispatch_error_maps_io_not_found() {
+        let err: anyhow::Error = std::io::Error::new(std::io::ErrorKind::NotFound, "nope").into();
+        let err = err.context("reading missing.md");
+        let (payload, code) = structured_dispatch_error(&err);
+        assert_eq!(code, exit::FAILURE);
+        assert_eq!(payload["error_kind"], "not_found");
     }
 
     #[test]

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -12,6 +12,7 @@ use crate::ops::doc::{
 use crate::plan::{Operation, Plan};
 use crate::tx::context::EngineContext;
 use crate::write::apply_policy;
+use anyhow::Context;
 
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
@@ -44,7 +45,7 @@ pub(crate) fn read_file_content<'a>(
             // Callers pass already-resolved paths (cwd.join(rel_path)),
             // so read directly without double-joining (#385).
             let content = std::fs::read_to_string(path)
-                .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+                .with_context(|| format!("failed to read {}", path.display()))?;
             existed_before.insert(path.to_path_buf());
             Ok(&entry.insert((content.clone(), content)).1)
         }
@@ -64,8 +65,8 @@ pub(crate) fn read_and_probe(
     if pending.contains_key(path) {
         return Ok(true); // already loaded, not binary
     }
-    let bytes = std::fs::read(path)
-        .map_err(|e| anyhow::anyhow!("failed to read {}: {e}", path.display()))?;
+    let bytes =
+        std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
     if crate::files::is_binary(&bytes) {
         return Ok(false);
     }
@@ -598,7 +599,14 @@ pub(crate) fn execute_and_collect(
                     }
                     .into());
                 }
-                anyhow::bail!("operation {} ({}) failed: {e}", i + 1, op_label(op));
+                // Keep a readable Display string for stderr/tests, and when the
+                // root cause is IO NotFound re-emit as NotFound so CLI --json
+                // maps error_kind: not_found via is_io_not_found.
+                let msg = format!("operation {} ({}) failed: {e}", i + 1, op_label(op));
+                if crate::exit::is_io_not_found(&e) {
+                    return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg).into());
+                }
+                anyhow::bail!("{msg}");
             }
         }
     }

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -1157,3 +1157,30 @@ fn test_md_move_section_json_requires_before_or_after() {
         "md move-section missing before/after: {parsed}"
     );
 }
+
+#[test]
+fn test_md_missing_file_json_not_found() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.md");
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "md",
+            "replace-section",
+            missing.to_str().unwrap(),
+            "--heading",
+            "## H",
+            "--content",
+            "body",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "not_found",
+        "md missing file should set not_found: {parsed}"
+    );
+}


### PR DESCRIPTION
## Summary

- `is_io_not_found` + global `--json` dispatch → `error_kind: "not_found"`
- Engine `read_to_string` uses `with_context` (keeps IO kind)
- Op-level wrapper re-emits NotFound with a full Display message so stderr and tests stay informative
- Integration: `md replace-section` missing file JSON not_found

## Test plan

- [x] Unit: `is_io_not_found_preserves_with_context_chain`, structured_dispatch maps IO not_found
- [x] Integration: `test_md_missing_file_json_not_found`
- [x] `make check-fast`