### PR TITLE
fix(tx): map IO NotFound to error_kind not_found

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Cleaner clap JSON usage messages.** Usage failures under `--json`/`--jsonl` strip the `error: ` prefix and help footer so agents get a short actionable string.
 - **Plan `ops` alias.** Transaction plans accept `"ops"` as a serde alias for `"operations"` so agents that emit the shorter field name parse without a `missing field` error.
 - **Missing path roots are `not_found`.** When every explicit path root for `search`, `replace`, or `tidy` is missing (including `--files-from` lists, not stdin), exit **1** with `error_kind: "not_found"` (was soft `no_matches` / vacuous tidy success). Pattern misses and clean trees still use exit 3 / 0.
+- **Tx missing-file `not_found`.** Plan/tx engine IO `NotFound` (e.g. `md.replace_section` on a missing path) sets `error_kind: "not_found"` and exit **1** instead of generic `operation_failed` (9).
 - **Engine IO not_found chain.** Tx/CLI engine read failures preserve `std::io::ErrorKind::NotFound` through context wrappers so global `--json` maps them to `error_kind: "not_found"` (e.g. `md replace-section` on a missing file).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -397,6 +397,14 @@ pub(crate) fn run_parsed_plan(
                 }
                 return Ok(exit::AMBIGUOUS);
             }
+            if exit::is_io_not_found(&e) {
+                if structured {
+                    emit_error_json("not_found", &msg, None, compact);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::FAILURE);
+            }
             if structured {
                 emit_error_json("operation_failed", &msg, None, compact);
             } else {

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -1319,8 +1319,8 @@ mod integrity {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::OPERATION_FAILED,
-            "strict plan with failing op should fail before commit"
+            exit::FAILURE,
+            "strict plan with failing op (missing path → not_found) should fail before commit"
         );
 
         // File should remain untouched because execution failed before any writes.
@@ -1428,8 +1428,8 @@ mod integrity {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::OPERATION_FAILED,
-            "strict plan with failing op should fail"
+            exit::FAILURE,
+            "strict plan with failing op (missing path → not_found) should fail"
         );
         assert!(
             !created.exists(),
@@ -1473,8 +1473,8 @@ mod integrity {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::OPERATION_FAILED,
-            "strict plan with failing op should fail"
+            exit::FAILURE,
+            "strict plan with failing op (missing path → not_found) should fail"
         );
         assert!(
             victim.exists(),

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -148,6 +148,9 @@ pub fn execute_plan_direct(
             if crate::exit::is_ambiguous(&e) {
                 return Ok(build_error_output("ambiguous", &e.to_string(), None));
             }
+            if crate::exit::is_io_not_found(&e) {
+                return Ok(build_error_output("not_found", &e.to_string(), None));
+            }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }
     };

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2615,7 +2615,7 @@ fn test_tx_md_replace_section_nonexistent_file_rolls_back() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(9); // OPERATION_FAILED
+        .code(1); // not_found (missing path), was OPERATION_FAILED (9)
 }
 
 #[test]
@@ -7757,5 +7757,38 @@ fn test_tx_ast_rename_missing_exits_3_with_detail() {
     assert!(
         err.contains("gone") || err.contains("no matches") || err.contains("not found"),
         "error should identify the missing symbol, got: {err}"
+    );
+}
+
+#[test]
+fn test_tx_md_missing_file_json_not_found() {
+    let dir = TempDir::new().unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "md.replace_section",
+            "path": "missing.md",
+            "heading": "## H",
+            "content": "body"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--cwd")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "not_found",
+        "tx missing file should be not_found not operation_failed: {json}"
     );
 }


### PR DESCRIPTION
## Summary

- Tx CLI + plan_exec: `is_io_not_found` → `error_kind: "not_found"`, exit **1**
- Was generic `operation_failed` / exit 9
- Aligns with CLI md/doc JSON after #1584

## Test plan

- [x] `test_tx_md_missing_file_json_not_found`
- [x] Updated strict rollback unit tests expecting FAILURE
- [x] `make check-fast`