### PR TITLE
fix(tx): file append/prepend/delete missing are not_found

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -56,6 +56,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Cleaner clap JSON usage messages.** Usage failures under `--json`/`--jsonl` strip the `error: ` prefix and help footer so agents get a short actionable string.
 - **Plan `ops` alias.** Transaction plans accept `"ops"` as a serde alias for `"operations"` so agents that emit the shorter field name parse without a `missing field` error.
 - **Missing path roots are `not_found`.** When every explicit path root for `search`, `replace`, or `tidy` is missing (including `--files-from` lists, not stdin), exit **1** with `error_kind: "not_found"` (was soft `no_matches` / vacuous tidy success). Pattern misses and clean trees still use exit 3 / 0.
+- **Tx file ops missing targets `not_found`.** Plan `file.append` / `file.prepend` / `file.delete` on missing paths emit `error_kind: "not_found"` (exit 1), not generic `operation_failed`.
 - **Tx missing-file `not_found`.** Plan/tx engine IO `NotFound` (e.g. `md.replace_section` on a missing path) sets `error_kind: "not_found"` and exit **1** instead of generic `operation_failed` (9).
 - **Engine IO not_found chain.** Tx/CLI engine read failures preserve `std::io::ErrorKind::NotFound` through context wrappers so global `--json` maps them to `error_kind: "not_found"` (e.g. `md replace-section` on a missing file).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -16,7 +16,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 anyhow::bail!("file was deleted earlier in this transaction: {path}");
             }
             if !file_path.exists() && !tx.pending.contains_key(&file_path) {
-                anyhow::bail!("file does not exist: {path}");
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("file does not exist: {path}"),
+                )
+                .into());
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let combined = crate::ops::file::append_content(existing, content);
@@ -38,7 +42,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 anyhow::bail!("file was deleted earlier in this transaction: {path}");
             }
             if !file_path.exists() && !tx.pending.contains_key(&file_path) {
-                anyhow::bail!("file does not exist: {path}");
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("file does not exist: {path}"),
+                )
+                .into());
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let combined = crate::ops::file::prepend_content(existing, content);
@@ -96,7 +104,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 Some((original, _)) => original.is_empty() && !file_path.exists(),
                 None => {
                     if !file_path.exists() {
-                        anyhow::bail!("file not found: {path}");
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::NotFound,
+                            format!("file not found: {path}"),
+                        )
+                        .into());
                     }
                     tx.existed_before.insert(file_path.clone());
                     // Try to read as text for strict rollback; fall back to

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7792,3 +7792,27 @@ fn test_tx_md_missing_file_json_not_found() {
         "tx missing file should be not_found not operation_failed: {json}"
     );
 }
+
+#[test]
+fn test_tx_file_append_missing_json_not_found() {
+    let dir = TempDir::new().unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "file.append",
+            "path": "missing.txt",
+            "content": "x\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tx", plan_file.to_str().unwrap(), "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "not_found");
+}


### PR DESCRIPTION
## Summary

- Plan `file.append` / `file.prepend` / `file.delete` missing targets → IO `NotFound`
- Tx JSON: `error_kind: "not_found"`, exit 1 (was `operation_failed` / 9)
- Follows #1585 engine NotFound mapping

## Test plan

- [x] `test_tx_file_append_missing_json_not_found`
- [x] Existing append/prepend missing still fail
- [x] `make check-fast`