### PR TITLE
fix(tx): create/rename conflicts set already_exists

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -57,6 +57,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Plan `ops` alias.** Transaction plans accept `"ops"` as a serde alias for `"operations"` so agents that emit the shorter field name parse without a `missing field` error.
 - **Missing path roots are `not_found`.** When every explicit path root for `search`, `replace`, or `tidy` is missing (including `--files-from` lists, not stdin), exit **1** with `error_kind: "not_found"` (was soft `no_matches` / vacuous tidy success). Pattern misses and clean trees still use exit 3 / 0.
 - **Tx file ops missing targets `not_found`.** Plan `file.append` / `file.prepend` / `file.delete` on missing paths emit `error_kind: "not_found"` (exit 1), not generic `operation_failed`.
+- **Tx create/rename conflicts `already_exists`.** Plan `file.create` without force and rename into an existing dest set `error_kind: "already_exists"` (exit 1), matching standalone CLI file ops.
 - **Tx missing-file `not_found`.** Plan/tx engine IO `NotFound` (e.g. `md.replace_section` on a missing path) sets `error_kind: "not_found"` and exit **1** instead of generic `operation_failed` (9).
 - **Engine IO not_found chain.** Tx/CLI engine read failures preserve `std::io::ErrorKind::NotFound` through context wrappers so global `--json` maps them to `error_kind: "not_found"` (e.g. `md replace-section` on a missing file).
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -405,6 +405,14 @@ pub(crate) fn run_parsed_plan(
                 }
                 return Ok(exit::FAILURE);
             }
+            if exit::is_already_exists(&e) {
+                if structured {
+                    emit_error_json("already_exists", &msg, None, compact);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::FAILURE);
+            }
             if structured {
                 emit_error_json("operation_failed", &msg, None, compact);
             } else {

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -856,7 +856,7 @@ mod error_handling {
         global.apply = true;
 
         let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::OPERATION_FAILED);
+        assert_eq!(code, exit::FAILURE); // already_exists
 
         // Verify the original file was NOT modified.
         assert_eq!(fs::read_to_string(&existing).unwrap(), "original content\n");
@@ -1141,7 +1141,7 @@ mod integrity {
         global.apply = true;
 
         let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::OPERATION_FAILED);
+        assert_eq!(code, exit::FAILURE); // already_exists
         // Both files unchanged.
         assert_eq!(fs::read_to_string(&src).unwrap(), "source\n");
         assert_eq!(fs::read_to_string(&dst).unwrap(), "dest\n");

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -95,6 +95,27 @@ pub fn is_io_not_found(err: &anyhow::Error) -> bool {
     })
 }
 
+/// Typed error for create/rename conflicts that map to exit [`FAILURE`] (1)
+/// with JSON `error_kind: "already_exists"`.
+#[derive(Debug)]
+pub struct AlreadyExistsError {
+    pub msg: String,
+}
+
+impl std::fmt::Display for AlreadyExistsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for AlreadyExistsError {}
+
+/// Check whether an `anyhow::Error` chain contains an [`AlreadyExistsError`].
+pub fn is_already_exists(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<AlreadyExistsError>().is_some())
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,8 @@ fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
         (Some("invalid_input"), exit::FAILURE)
     } else if exit::is_io_not_found(err) {
         (Some("not_found"), exit::FAILURE)
+    } else if exit::is_already_exists(err) {
+        (Some("already_exists"), exit::FAILURE)
     } else {
         (None, exit::FAILURE)
     };

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -83,7 +83,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 let exists_in_tx =
                     tx.pending.contains_key(&file_path) && !tx.deletions.contains(&file_path);
                 if exists_in_tx || (!tx.deletions.contains(&file_path) && file_path.exists()) {
-                    anyhow::bail!("file already exists: {path}");
+                    return Err(crate::exit::AlreadyExistsError {
+                        msg: format!("file already exists: {path}"),
+                    }
+                    .into());
                 }
                 update_file_content(
                     tx.pending,
@@ -183,7 +186,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                     && !tx.deletions.contains(&dst_path))
                     || (!tx.deletions.contains(&dst_path) && dst_path.exists());
                 if dst_exists {
-                    anyhow::bail!("destination already exists: {to}");
+                    return Err(crate::exit::AlreadyExistsError {
+                        msg: format!("destination already exists: {to}"),
+                    }
+                    .into());
                 }
             }
 

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -599,12 +599,15 @@ pub(crate) fn execute_and_collect(
                     }
                     .into());
                 }
-                // Keep a readable Display string for stderr/tests, and when the
-                // root cause is IO NotFound re-emit as NotFound so CLI --json
-                // maps error_kind: not_found via is_io_not_found.
+                // Keep a readable Display string for stderr/tests, and re-emit
+                // typed kinds so CLI/tx --json can map error_kind without
+                // scraping English.
                 let msg = format!("operation {} ({}) failed: {e}", i + 1, op_label(op));
                 if crate::exit::is_io_not_found(&e) {
                     return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg).into());
+                }
+                if crate::exit::is_already_exists(&e) {
+                    return Err(crate::exit::AlreadyExistsError { msg }.into());
                 }
                 anyhow::bail!("{msg}");
             }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -151,6 +151,9 @@ pub fn execute_plan_direct(
             if crate::exit::is_io_not_found(&e) {
                 return Ok(build_error_output("not_found", &e.to_string(), None));
             }
+            if crate::exit::is_already_exists(&e) {
+                return Ok(build_error_output("already_exists", &e.to_string(), None));
+            }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }
     };

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -1235,8 +1235,8 @@ fn test_tx_file_rename_fails_if_dst_exists() {
         .output()
         .unwrap();
 
-    // Operation fails before commit (exit 9 = OPERATION_FAILED).
-    assert_eq!(output.status.code(), Some(9));
+    // Operation fails before commit (exit 1 = already_exists).
+    assert_eq!(output.status.code(), Some(1));
     // Both files should be untouched.
     assert_eq!(
         fs::read_to_string(dir.path().join("old.txt")).unwrap(),
@@ -1938,7 +1938,7 @@ fn test_tx_file_create_without_force_fails_on_existing() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(9); // OPERATION_FAILED
+        .code(1); // already_exists
 
     assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
 }
@@ -4492,10 +4492,10 @@ fn test_tx_json_output_on_operation_failure() {
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(9)); // OPERATION_FAILED
+    assert_eq!(output.status.code(), Some(1)); // already_exists
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
-    assert_eq!(json["error_kind"], "operation_failed");
+    assert_eq!(json["error_kind"], "already_exists");
     assert!(
         json["error"]
             .as_str()


### PR DESCRIPTION
## Summary

- Typed `AlreadyExistsError` for plan `file.create` / rename dest conflicts
- Tx JSON: `error_kind: "already_exists"`, exit 1 (was `operation_failed` / 9)
- Global dispatch and plan_exec both map the type

## Test plan

- [x] Updated integration + unit tests for create/rename exists
- [x] `make check-fast`