### PR TITLE
fix(tx): non-file targets invalid_input; path_err keeps NotFound

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -413,6 +413,14 @@ pub(crate) fn run_parsed_plan(
                 }
                 return Ok(exit::FAILURE);
             }
+            if exit::is_invalid_input(&e) {
+                if structured {
+                    emit_error_json("invalid_input", &msg, None, compact);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::FAILURE);
+            }
             if structured {
                 emit_error_json("operation_failed", &msg, None, compact);
             } else {

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -1104,7 +1104,7 @@ mod integrity {
         global.apply = true;
 
         let code = run(args, &global).unwrap();
-        assert_eq!(code, exit::OPERATION_FAILED);
+        assert_eq!(code, exit::FAILURE); // not_found on missing doc path
 
         // Verify no files were modified.
         assert_eq!(fs::read_to_string(&txt).unwrap(), "hello world\n");

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -10,7 +10,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
         Operation::FileAppend { path, content } => {
             let file_path = tx.cwd.join(path);
             if file_path.exists() && !file_path.is_file() {
-                anyhow::bail!("target is not a file: {path}");
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("target is not a file: {path}"),
+                }
+                .into());
             }
             if tx.deletions.contains(&file_path) {
                 anyhow::bail!("file was deleted earlier in this transaction: {path}");
@@ -36,7 +39,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
         Operation::FilePrepend { path, content } => {
             let file_path = tx.cwd.join(path);
             if file_path.exists() && !file_path.is_file() {
-                anyhow::bail!("target is not a file: {path}");
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("target is not a file: {path}"),
+                }
+                .into());
             }
             if tx.deletions.contains(&file_path) {
                 anyhow::bail!("file was deleted earlier in this transaction: {path}");
@@ -66,7 +72,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
         } => {
             let file_path = tx.cwd.join(path);
             if file_path.exists() && !file_path.is_file() {
-                anyhow::bail!("target is not a file: {path}");
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("target is not a file: {path}"),
+                }
+                .into());
             }
             if force.unwrap_or(false) {
                 if tx.pending.contains_key(&file_path) || file_path.exists() {
@@ -101,7 +110,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
         Operation::FileDelete { path } => {
             let file_path = tx.cwd.join(path);
             if file_path.exists() && !file_path.is_file() {
-                anyhow::bail!("target is not a file: {path}");
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("target is not a file: {path}"),
+                }
+                .into());
             }
             let created_in_tx = match tx.pending.get(&file_path) {
                 Some((original, _)) => original.is_empty() && !file_path.exists(),
@@ -154,10 +166,16 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 anyhow::bail!("source file was deleted earlier in this transaction: {from}");
             }
             if src_path.exists() && !src_path.is_file() {
-                anyhow::bail!("source is not a file: {from}");
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("source is not a file: {from}"),
+                }
+                .into());
             }
             if dst_path.exists() && !dst_path.is_file() {
-                anyhow::bail!("destination is not a file: {to}");
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("destination is not a file: {to}"),
+                }
+                .into());
             }
 
             // If source and destination resolve to the same file, no-op.

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -148,9 +148,15 @@ pub(crate) fn flush_doc_cache(
 /// Wrap an error with the file path for context.
 ///
 /// This replaces 27 identical `.map_err(path_err(path))` calls
-/// throughout `execute_operation` and `get_doc_root`.
-pub(crate) fn path_err<E: std::fmt::Display>(path: &str) -> impl FnOnce(E) -> anyhow::Error + '_ {
-    move |e| anyhow::anyhow!("{path}: {e}")
+/// throughout `execute_operation` and `get_doc_root`. Preserves the
+/// source chain so typed kinds (IO NotFound, etc.) remain downcastable.
+pub(crate) fn path_err(path: &str) -> impl FnOnce(anyhow::Error) -> anyhow::Error + '_ {
+    // Include the prior Display text in the context so stderr stays informative,
+    // while keeping the source chain for is_io_not_found / typed kinds.
+    move |e| {
+        let prior = e.to_string();
+        e.context(format!("{path}: {prior}"))
+    }
 }
 
 /// Load a structured document from the cache (or parse from pending buffer)
@@ -608,6 +614,9 @@ pub(crate) fn execute_and_collect(
                 }
                 if crate::exit::is_already_exists(&e) {
                     return Err(crate::exit::AlreadyExistsError { msg }.into());
+                }
+                if crate::exit::is_invalid_input(&e) {
+                    return Err(crate::exit::InvalidInputError { msg }.into());
                 }
                 anyhow::bail!("{msg}");
             }

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -160,8 +160,18 @@ fn update_file_content_clears_deletion() {
 #[test]
 fn path_err_wraps_message() {
     let wrapper = path_err("config.yaml");
-    let err = wrapper("invalid key");
-    assert_eq!(format!("{err}"), "config.yaml: invalid key");
+    let err = wrapper(anyhow::anyhow!("invalid key"));
+    assert_eq!(err.to_string(), "config.yaml: invalid key");
+}
+
+#[test]
+fn path_err_preserves_io_not_found() {
+    let io_err: anyhow::Error = std::io::Error::new(std::io::ErrorKind::NotFound, "nope").into();
+    let err = path_err("missing.json")(io_err.context("failed to read"));
+    assert!(
+        crate::exit::is_io_not_found(&err),
+        "path_err must keep NotFound: {err:#}"
+    );
 }
 
 // ---- op_needs_doc_flush ----

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -154,6 +154,9 @@ pub fn execute_plan_direct(
             if crate::exit::is_already_exists(&e) {
                 return Ok(build_error_output("already_exists", &e.to_string(), None));
             }
+            if crate::exit::is_invalid_input(&e) {
+                return Ok(build_error_output("invalid_input", &e.to_string(), None));
+            }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }
     };

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -263,7 +263,7 @@ fn test_batch_nonexistent_target_file_rollback() {
         .arg(&ops)
         .arg("--apply")
         .assert()
-        .code(9); // OPERATION_FAILED
+        .code(1); // not_found (missing target)
 }
 
 #[test]
@@ -724,7 +724,7 @@ fn test_batch_multi_op_rollback_on_second_failure() {
         .arg(&ops)
         .arg("--apply")
         .assert()
-        .code(9); // OPERATION_FAILED
+        .code(1); // not_found on second op
 
     // data.json must be rolled back to original content.
     let content = fs::read_to_string(&file).unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -433,7 +433,7 @@ fn test_tx_rollback_on_failure() {
         .arg(&plan_file)
         .arg("--apply")
         .assert()
-        .code(9);
+        .code(1); // not_found on missing doc path
 
     let txt_content = fs::read_to_string(&txt_file).unwrap();
     assert_eq!(
@@ -471,7 +471,7 @@ fn test_tx_rollback_preserves_original_content() {
         .arg(&plan_file)
         .arg("--apply")
         .assert()
-        .code(9); // OPERATION_FAILED
+        .code(1); // not_found on missing b.json
 
     // a.json should be unchanged (no writes occurred).
     let content = fs::read_to_string(&file_a).unwrap();
@@ -866,7 +866,7 @@ fn test_tx_file_delete_directory_target_fails() {
         .arg("tx")
         .arg(&plan_file)
         .assert()
-        .code(9)
+        .code(1) // invalid_input: not a file
         .stderr(predicate::str::contains("target is not a file"));
 
     assert!(target.is_dir(), "directory should remain in place");
@@ -1171,7 +1171,7 @@ fn test_tx_file_rename_directory_source_fails() {
         .arg("tx")
         .arg(&plan_file)
         .assert()
-        .code(9)
+        .code(1) // invalid_input
         .stderr(predicate::str::contains("source is not a file"));
 
     assert!(src.is_dir(), "source directory should remain in place");
@@ -1302,7 +1302,7 @@ fn test_tx_file_rename_force_directory_destination_fails_in_dry_run() {
         .arg("tx")
         .arg(&plan_file)
         .assert()
-        .code(9)
+        .code(1) // invalid_input
         .stderr(predicate::str::contains("destination is not a file"));
 
     assert!(dir.path().join("old.txt").is_file());
@@ -1332,7 +1332,7 @@ fn test_tx_file_rename_force_directory_destination_fails_in_check_mode() {
         .arg(&plan_file)
         .arg("--check")
         .assert()
-        .code(9)
+        .code(1) // invalid_input
         .stderr(predicate::str::contains("destination is not a file"));
 
     assert!(dir.path().join("old.txt").is_file());
@@ -1362,7 +1362,7 @@ fn test_tx_file_rename_force_directory_destination_fails_in_apply_mode() {
         .arg(&plan_file)
         .arg("--apply")
         .assert()
-        .code(9)
+        .code(1) // invalid_input
         .stderr(predicate::str::contains("destination is not a file"));
 
     assert!(dir.path().join("old.txt").is_file());
@@ -1880,7 +1880,7 @@ fn test_tx_file_create_force_directory_target_fails() {
         .arg("tx")
         .arg(plan_file.to_str().unwrap())
         .assert()
-        .code(9)
+        .code(1) // invalid_input: not a file
         .stderr(predicate::str::contains("target is not a file"));
 
     assert!(target.is_dir(), "directory should remain in place");


### PR DESCRIPTION
## Summary

- Plan file ops on directories → `error_kind: "invalid_input"` (exit 1)
- `path_err` uses `context` so IO NotFound survives path prefixing (doc missing stays `not_found`)
- Batch/tx rollback tests updated for new exit codes

## Test plan

- [x] `make check-fast`