### PR TITLE
fix(tx): doc type mismatches set type_error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -60,6 +60,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx create/rename conflicts `already_exists`.** Plan `file.create` without force and rename into an existing dest set `error_kind: "already_exists"` (exit 1), matching standalone CLI file ops.
 - **Tx missing-file `not_found`.** Plan/tx engine IO `NotFound` (e.g. `md.replace_section` on a missing path) sets `error_kind: "not_found"` and exit **1** instead of generic `operation_failed` (9).
 - **Engine IO not_found chain.** Tx/CLI engine read failures preserve `std::io::ErrorKind::NotFound` through context wrappers so global `--json` maps them to `error_kind: "not_found"` (e.g. `md replace-section` on a missing file).
+- **Tx doc type mismatches `type_error`.** Plan doc append/prepend (and similar MutationResult type failures) set `error_kind: "type_error"` (exit 1), matching CLI doc keys/len.
 - **Tx non-file targets `invalid_input`.** Plan file ops against directories set `error_kind: "invalid_input"` (exit 1). Engine `path_err` keeps IO NotFound through path prefixing so missing docs stay `not_found`.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -421,6 +421,14 @@ pub(crate) fn run_parsed_plan(
                 }
                 return Ok(exit::FAILURE);
             }
+            if exit::is_type_error(&e) {
+                if structured {
+                    emit_error_json("type_error", &msg, None, compact);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::FAILURE);
+            }
             if structured {
                 emit_error_json("operation_failed", &msg, None, compact);
             } else {

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -1207,7 +1207,7 @@ mod integrity {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::OPERATION_FAILED,
+            exit::FAILURE, // type_error
             "doc.append to non-array should fail before commit"
         );
     }
@@ -1243,7 +1243,7 @@ mod integrity {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::OPERATION_FAILED,
+            exit::FAILURE, // type_error
             "doc.prepend to non-array should fail before commit"
         );
     }

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -116,6 +116,27 @@ pub fn is_already_exists(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<AlreadyExistsError>().is_some())
 }
 
+/// Typed error for doc type mismatches that map to exit [`FAILURE`] (1)
+/// with JSON `error_kind: "type_error"`.
+#[derive(Debug)]
+pub struct TypeErrorError {
+    pub msg: String,
+}
+
+impl std::fmt::Display for TypeErrorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for TypeErrorError {}
+
+/// Check whether an `anyhow::Error` chain contains a [`TypeErrorError`].
+pub fn is_type_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<TypeErrorError>().is_some())
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,8 @@ fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
         (Some("not_found"), exit::FAILURE)
     } else if exit::is_already_exists(err) {
         (Some("already_exists"), exit::FAILURE)
+    } else if exit::is_type_error(err) {
+        (Some("type_error"), exit::FAILURE)
     } else {
         (None, exit::FAILURE)
     };

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -395,9 +395,10 @@ pub(crate) fn execute_doc_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             }
             Ok(())
         }
-        MutationResult::TypeError(msg) => {
-            anyhow::bail!("{path}: {msg}");
+        MutationResult::TypeError(msg) => Err(crate::exit::TypeErrorError {
+            msg: format!("{path}: {msg}"),
         }
+        .into()),
     }
 }
 
@@ -617,6 +618,9 @@ pub(crate) fn execute_and_collect(
                 }
                 if crate::exit::is_invalid_input(&e) {
                     return Err(crate::exit::InvalidInputError { msg }.into());
+                }
+                if crate::exit::is_type_error(&e) {
+                    return Err(crate::exit::TypeErrorError { msg }.into());
                 }
                 anyhow::bail!("{msg}");
             }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -157,6 +157,9 @@ pub fn execute_plan_direct(
             if crate::exit::is_invalid_input(&e) {
                 return Ok(build_error_output("invalid_input", &e.to_string(), None));
             }
+            if crate::exit::is_type_error(&e) {
+                return Ok(build_error_output("type_error", &e.to_string(), None));
+            }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }
     };

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -5484,7 +5484,7 @@ fn test_tx_doc_prepend_on_non_array_rolls_back() {
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(9); // OPERATION_FAILED
+        .code(1); // type_error
 
     // Original content unchanged.
     assert_eq!(


### PR DESCRIPTION
## Summary

- Typed `TypeErrorError` for plan doc type mismatches (append/prepend on non-array, etc.)
- Tx JSON: `error_kind: "type_error"`, exit 1 (was `operation_failed` / 9)

## Test plan

- [x] Updated unit/integration tests for doc prepend non-array
- [x] `make check-fast`