### PR TITLE
fix(tx): doc.delete_where non-array is type_error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -60,7 +60,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx create/rename conflicts `already_exists`.** Plan `file.create` without force and rename into an existing dest set `error_kind: "already_exists"` (exit 1), matching standalone CLI file ops.
 - **Tx missing-file `not_found`.** Plan/tx engine IO `NotFound` (e.g. `md.replace_section` on a missing path) sets `error_kind: "not_found"` and exit **1** instead of generic `operation_failed` (9).
 - **Engine IO not_found chain.** Tx/CLI engine read failures preserve `std::io::ErrorKind::NotFound` through context wrappers so global `--json` maps them to `error_kind: "not_found"` (e.g. `md replace-section` on a missing file).
-- **Tx doc type mismatches `type_error`.** Plan doc append/prepend (and similar MutationResult type failures) set `error_kind: "type_error"` (exit 1), matching CLI doc keys/len.
+- **Tx doc type mismatches `type_error`.** Plan doc append/prepend/delete_where (and similar type failures) set `error_kind: "type_error"` (exit 1), matching CLI doc keys/len.
 - **Tx non-file targets `invalid_input`.** Plan file ops against directories set `error_kind: "invalid_input"` (exit 1). Engine `path_err` keeps IO NotFound through path prefixing so missing docs stay `not_found`.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
 - **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -1279,7 +1279,7 @@ mod integrity {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::OPERATION_FAILED,
+            exit::FAILURE, // type_error
             "doc.delete_where on non-array should fail before commit"
         );
     }

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -219,9 +219,11 @@ pub fn delete_where(
     let pred_val = raw_val.trim();
 
     let target = navigate_mut(root, segments, false)?;
-    let arr = target
-        .as_array_mut()
-        .ok_or_else(|| anyhow::anyhow!("selector does not point to an array"))?;
+    let arr = target.as_array_mut().ok_or_else(|| {
+        anyhow::Error::new(crate::exit::TypeErrorError {
+            msg: "selector does not point to an array".into(),
+        })
+    })?;
 
     let before_len = arr.len();
     if pred_key == "_" || pred_key == "." {


### PR DESCRIPTION
## Summary

- `doc.delete_where` when selector is not an array uses typed `TypeErrorError`
- Tx JSON: `error_kind: "type_error"` (exit 1), matching append/prepend (#1590)

## Test plan

- [x] Unit test for delete_where non-array
- [x] `make check-fast`