### PR TITLE
fix(doc): more selector type mismatches are type_error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -60,6 +60,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx create/rename conflicts `already_exists`.** Plan `file.create` without force and rename into an existing dest set `error_kind: "already_exists"` (exit 1), matching standalone CLI file ops.
 - **Tx missing-file `not_found`.** Plan/tx engine IO `NotFound` (e.g. `md.replace_section` on a missing path) sets `error_kind: "not_found"` and exit **1** instead of generic `operation_failed` (9).
 - **Engine IO not_found chain.** Tx/CLI engine read failures preserve `std::io::ErrorKind::NotFound` through context wrappers so global `--json` maps them to `error_kind: "not_found"` (e.g. `md replace-section` on a missing file).
+- **Doc navigate type mismatches `type_error`.** Parent-not-array/object and related selector type failures in plan doc ops set `error_kind: "type_error"` (exit 1).
 - **Tx doc type mismatches `type_error`.** Plan doc append/prepend/delete_where (and similar type failures) set `error_kind: "type_error"` (exit 1), matching CLI doc keys/len.
 - **Tx non-file targets `invalid_input`.** Plan file ops against directories set `error_kind: "invalid_input"` (exit 1). Engine `path_err` keeps IO NotFound through path prefixing so missing docs stay `not_found`.
 - **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -56,7 +56,11 @@ pub fn navigate_mut<'a>(
                         if needs_create {
                             current
                                 .as_object_mut()
-                                .ok_or_else(|| anyhow::anyhow!("not an object at key '{k}'"))?
+                                .ok_or_else(|| {
+                                    anyhow::Error::new(crate::exit::TypeErrorError {
+                                        msg: format!("not an object at key '{k}'"),
+                                    })
+                                })?
                                 .insert(
                                     k.clone(),
                                     serde_json::Value::Object(serde_json::Map::new()),
@@ -124,13 +128,19 @@ pub fn set_at_path(
             }
             parent
                 .as_object_mut()
-                .ok_or_else(|| anyhow::anyhow!("parent is not an object"))?
+                .ok_or_else(|| {
+                    anyhow::Error::new(crate::exit::TypeErrorError {
+                        msg: "parent is not an object".into(),
+                    })
+                })?
                 .insert(k.clone(), value);
         }
         selector::Segment::Index(i) => {
-            let arr = parent
-                .as_array_mut()
-                .ok_or_else(|| anyhow::anyhow!("parent is not an array"))?;
+            let arr = parent.as_array_mut().ok_or_else(|| {
+                anyhow::Error::new(crate::exit::TypeErrorError {
+                    msg: "parent is not an array".into(),
+                })
+            })?;
             if *i < arr.len() {
                 arr[*i] = value;
             } else {
@@ -284,9 +294,11 @@ pub fn move_at_path(
         && let (selector::Segment::Index(fi), selector::Segment::Index(ti)) = (from_last, to_last)
     {
         let parent = navigate_mut(root, from_parent, false)?;
-        let arr = parent
-            .as_array_mut()
-            .ok_or_else(|| anyhow::anyhow!("parent is not an array"))?;
+        let arr = parent.as_array_mut().ok_or_else(|| {
+            anyhow::Error::new(crate::exit::TypeErrorError {
+                msg: "parent is not an array".into(),
+            })
+        })?;
         if *fi >= arr.len() {
             anyhow::bail!("source index {fi} out of bounds");
         }
@@ -308,9 +320,11 @@ pub fn move_at_path(
                 // Numeric dot-notation on arrays (#1288).
                 if parent.is_array() {
                     if let Ok(idx) = k.parse::<usize>() {
-                        let arr = parent
-                            .as_array()
-                            .ok_or_else(|| anyhow::anyhow!("source parent is not an array"))?;
+                        let arr = parent.as_array().ok_or_else(|| {
+                            anyhow::Error::new(crate::exit::TypeErrorError {
+                                msg: "source parent is not an array".into(),
+                            })
+                        })?;
                         if idx < arr.len() {
                             arr[idx].clone()
                         } else {
@@ -328,9 +342,11 @@ pub fn move_at_path(
                 }
             }
             selector::Segment::Index(i) => {
-                let arr = parent
-                    .as_array()
-                    .ok_or_else(|| anyhow::anyhow!("source parent is not an array"))?;
+                let arr = parent.as_array().ok_or_else(|| {
+                    anyhow::Error::new(crate::exit::TypeErrorError {
+                        msg: "source parent is not an array".into(),
+                    })
+                })?;
                 if *i < arr.len() {
                     arr[*i].clone()
                 } else {
@@ -401,9 +417,11 @@ pub fn move_at_path(
                 }
             }
             selector::Segment::Index(i) => {
-                let arr = parent
-                    .as_array_mut()
-                    .ok_or_else(|| anyhow::anyhow!("source parent is not an array"))?;
+                let arr = parent.as_array_mut().ok_or_else(|| {
+                    anyhow::Error::new(crate::exit::TypeErrorError {
+                        msg: "source parent is not an array".into(),
+                    })
+                })?;
                 arr.remove(*i);
             }
             _ => anyhow::bail!("cannot remove from wildcard/predicate selector"),


### PR DESCRIPTION
## Summary

- Doc navigate: parent not array/object and related type failures → `TypeErrorError`
- Plan/tx JSON: `error_kind: "type_error"` (exit 1)

## Test plan

- [x] navigate unit tests
- [x] `make check-fast`