### PR TITLE
fix(tx): invalid_input for runtime flags and doc extensions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,7 +68,8 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 - **Tx patch.apply merge conflicts.** Plan `patch.apply` with `on_stale: "merge"` without `allow_conflicts` exits **8** with `error_kind: "conflicts"` (was generic `operation_failed` / 9), matching CLI `patch merge`.
 - **Tx op flag conflicts `invalid_input`.** Plan-level option conflicts (replace whole_line+multiline, range without whole_line, tidy dedent+indent, md.move_section before/after, search invert+multiline) exit **1** with `error_kind: "invalid_input"` (was `parse_error` / 4), matching standalone CLI flags.
-- **Doc unsupported extension `invalid_input`.** `doc` on non-JSON/YAML/TOML paths (and plan doc ops on those paths) set `error_kind: "invalid_input"` (exit 1). CLI write path no longer mislabels them as `type_error`.
+- **Doc unsupported extension `invalid_input`.**
+- **Tx AST empty directory `no_matches`.** Plan `ast.rename` on a directory with no source files exits **3** with `error_kind: "no_matches"` (was `operation_failed` / 9), matching CLI `ast rename`. `doc` on non-JSON/YAML/TOML paths (and plan doc ops on those paths) set `error_kind: "invalid_input"` (exit 1). CLI write path no longer mislabels them as `type_error`.
 
 ## Agent and library notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,6 +68,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 - **Tx patch.apply merge conflicts.** Plan `patch.apply` with `on_stale: "merge"` without `allow_conflicts` exits **8** with `error_kind: "conflicts"` (was generic `operation_failed` / 9), matching CLI `patch merge`.
 - **Tx op flag conflicts `invalid_input`.** Plan-level option conflicts (replace whole_line+multiline, range without whole_line, tidy dedent+indent, md.move_section before/after, search invert+multiline) exit **1** with `error_kind: "invalid_input"` (was `parse_error` / 4), matching standalone CLI flags.
+- **Doc unsupported extension `invalid_input`.** `doc` on non-JSON/YAML/TOML paths (and plan doc ops on those paths) set `error_kind: "invalid_input"` (exit 1). CLI write path no longer mislabels them as `type_error`.
 
 ## Agent and library notes
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -818,8 +818,25 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     global.emit_error_json_kind(Some("no_matches"), &e.to_string())?;
                     return Ok(exit::NO_MATCHES);
                 }
-                // TypeError or other engine error → FAILURE (typed for agents)
-                global.emit_error_json_kind(Some("type_error"), &e.to_string())?;
+                // Prefer typed kinds so agents can branch without scraping English.
+                // Unsupported extension / flag mistakes are invalid_input; value
+                // shape mismatches are type_error. Do not default everything to
+                // type_error (that hid .txt extension failures as type_error).
+                let kind = if exit::is_type_error(&e) {
+                    "type_error"
+                } else if exit::is_invalid_input(&e) {
+                    "invalid_input"
+                } else if exit::is_io_not_found(&e) {
+                    "not_found"
+                } else if exit::is_already_exists(&e) {
+                    "already_exists"
+                } else {
+                    // Unknown engine failures stay generic failure without a
+                    // misleading type_error label.
+                    global.emit_error_json_kind(None, &e.to_string())?;
+                    return Ok(exit::FAILURE);
+                };
+                global.emit_error_json_kind(Some(kind), &e.to_string())?;
                 return Ok(exit::FAILURE);
             }
         }

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -30,12 +30,16 @@ pub fn detect_format(path: &str) -> anyhow::Result<FileFormat> {
         Some("json") => Ok(FileFormat::Json),
         Some("yaml" | "yml") => Ok(FileFormat::Yaml),
         Some("toml") => Ok(FileFormat::Toml),
-        Some(ext) => anyhow::bail!(
-            "unsupported file extension: .{ext} (supported: .json, .yaml, .yml, .toml)"
-        ),
-        None => anyhow::bail!(
-            "file has no extension; doc commands require .json, .yaml, .yml, or .toml"
-        ),
+        Some(ext) => Err(crate::exit::InvalidInputError {
+            msg: format!(
+                "unsupported file extension: .{ext} (supported: .json, .yaml, .yml, .toml)"
+            ),
+        }
+        .into()),
+        None => Err(crate::exit::InvalidInputError {
+            msg: "file has no extension; doc commands require .json, .yaml, .yml, or .toml".into(),
+        }
+        .into()),
     }
 }
 

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -89,7 +89,12 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             if abs.is_dir() {
                 let files = collect_ast_source_files(&abs)?;
                 if files.is_empty() {
-                    anyhow::bail!("no source files found in {}", path);
+                    // Match CLI ast rename: empty dir is no_matches (exit 3), not
+                    // generic operation_failed (9).
+                    return Err(crate::exit::NoMatchError {
+                        msg: format!("no source files found in {path}"),
+                    }
+                    .into());
                 }
                 let mut total = 0usize;
                 for file_path in &files {

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -245,12 +245,16 @@ fn execute_plan_inner(
         options.guard.is_some()
     );
     // Validate TidyFix-specific constraints (dedent + indent mutual exclusion).
+    // Defense in depth when callers skip validate_plan_operations.
     for op in &operations {
         if let Operation::TidyFix { dedent, indent, .. } = op
             && dedent.is_some()
             && indent.is_some()
         {
-            anyhow::bail!("tidy.fix: 'dedent' and 'indent' cannot both be set");
+            return Err(crate::exit::InvalidInputError {
+                msg: "tidy.fix: 'dedent' and 'indent' cannot both be set".into(),
+            }
+            .into());
         }
     }
 

--- a/src/tx/md_op.rs
+++ b/src/tx/md_op.rs
@@ -113,7 +113,12 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
             let position = match (before.as_deref(), after.as_deref()) {
                 (Some(b), None) => ("before", b),
                 (None, Some(a)) => ("after", a),
-                _ => anyhow::bail!("md.move_section requires exactly one of 'before' or 'after'"),
+                _ => {
+                    return Err(crate::exit::InvalidInputError {
+                        msg: "md.move_section requires exactly one of 'before' or 'after'".into(),
+                    }
+                    .into());
+                }
             };
             let dest_path_str = to.as_deref().unwrap_or(path.as_str());
             let source_path = tx.cwd.join(path);

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -83,7 +83,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             },
         )
     {
-        anyhow::bail!("{msg}");
+        return Err(crate::exit::InvalidInputError { msg: msg.into() }.into());
     }
     let use_regex = regex_mode || *case_insensitive || word_boundary;
     let replacement = replacement_text(
@@ -102,7 +102,10 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         word_boundary,
     )?;
     if range.is_some() && !*whole_line {
-        anyhow::bail!("range requires whole_line mode");
+        return Err(crate::exit::InvalidInputError {
+            msg: "range requires whole_line mode".into(),
+        }
+        .into());
     }
     let parsed_range = range
         .as_deref()
@@ -346,7 +349,10 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         }
         Ok(total_matches)
     } else {
-        anyhow::bail!("replace operation requires either 'path' or 'glob'");
+        Err(crate::exit::InvalidInputError {
+            msg: "replace operation requires either 'path' or 'glob'".into(),
+        }
+        .into())
     }
 }
 
@@ -528,8 +534,15 @@ mod tests {
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
         let result = execute_replace_op(&op, &mut tx);
-        assert!(result.is_err(), "expected error, got Ok: {result:?}");
-        assert!(result.unwrap_err().to_string().contains("'path' or 'glob'"));
+        let err = result.expect_err("expected error when path and glob are both None");
+        assert!(
+            err.to_string().contains("'path' or 'glob'"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "missing path/glob should be InvalidInputError: {err}"
+        );
     }
 
     #[test]

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -52,10 +52,16 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
     };
 
     if *invert_match && *multiline {
-        anyhow::bail!("invert_match and multiline cannot be combined");
+        return Err(crate::exit::InvalidInputError {
+            msg: "invert_match and multiline cannot be combined".into(),
+        }
+        .into());
     }
     if *literal && *regex {
-        anyhow::bail!("search: literal and regex cannot be combined");
+        return Err(crate::exit::InvalidInputError {
+            msg: "search: literal and regex cannot be combined".into(),
+        }
+        .into());
     }
 
     // Treat pattern as literal text only when explicitly requested.

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1827,12 +1827,50 @@ fn test_doc_get_unsupported_extension_json_envelope() {
         .args(["doc", "get", &file.to_string_lossy(), "key", "--json"])
         .output()
         .unwrap();
-    assert!(!out.status.success());
+    assert_eq!(out.status.code(), Some(1));
 
     let json: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("error should be wrapped in JSON envelope");
     assert_eq!(json["ok"], false);
-    assert!(json["error"].is_string());
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "unsupported extension should be invalid_input, not type_error: {json}"
+    );
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("unsupported file extension"),
+        "error should mention extension: {json}"
+    );
+}
+
+#[test]
+fn test_doc_set_unsupported_extension_json_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "not structured\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "doc",
+            "set",
+            &file.to_string_lossy(),
+            "key",
+            "val",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "doc write unsupported extension must not be type_error: {json}"
+    );
 }
 
 #[test]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7567,12 +7567,19 @@ fn test_tx_ast_rename_empty_directory_fails() {
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
 
-    patchloom_in(dir.path())
+    let assert = patchloom_in(dir.path())
+        .arg("--json")
         .arg("tx")
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(9); // OPERATION_FAILED
+        .code(3); // NO_MATCHES (CLI empty-dir parity), not OPERATION_FAILED (9)
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        v["error_kind"], "no_matches",
+        "empty dir ast.rename should be no_matches: {stdout}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2026,13 +2026,20 @@ fn test_tx_doc_set_unsupported_format_rolls_back() {
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
 
-    Command::cargo_bin("patchloom")
+    let assert = Command::cargo_bin("patchloom")
         .unwrap()
+        .arg("--json")
         .arg("tx")
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .code(9); // OPERATION_FAILED
+        .code(1); // invalid_input (unsupported extension), not operation_failed (9)
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        v["error_kind"], "invalid_input",
+        "unsupported doc extension should be invalid_input: {stdout}"
+    );
 
     // Original content must be preserved.
     assert_eq!(


### PR DESCRIPTION
## Summary

Agent-grade `error_kind` parity follow-ups after #1593:

1. **Runtime dual-path flag checks** raise `InvalidInputError` (search, replace, md.move_section, tidy) when callers skip plan validation.
2. **Doc unsupported extension** is `invalid_input` (exit 1). CLI write path no longer mislabels every engine error as `type_error`.
3. **Tx `ast.rename` empty directory** is `no_matches` (exit 3), matching CLI (was `operation_failed` / 9).

## Test plan

- [x] Unit: `replace_missing_path_and_glob_errors` asserts `is_invalid_input`
- [x] Integration: doc get/set unsupported extension JSON `invalid_input`
- [x] Integration: tx doc.set on `.txt` exits 1 with `invalid_input`
- [x] Integration: tx ast.rename empty dir exits 3 with `no_matches`
- [x] `make check-fast`
- [ ] CI green on PR