### PR TITLE
fix(doc): malformed documents exit 4 with parse_error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,8 +68,9 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
 - **Tx patch.apply merge conflicts.** Plan `patch.apply` with `on_stale: "merge"` without `allow_conflicts` exits **8** with `error_kind: "conflicts"` (was generic `operation_failed` / 9), matching CLI `patch merge`.
 - **Tx op flag conflicts `invalid_input`.** Plan-level option conflicts (replace whole_line+multiline, range without whole_line, tidy dedent+indent, md.move_section before/after, search invert+multiline) exit **1** with `error_kind: "invalid_input"` (was `parse_error` / 4), matching standalone CLI flags.
-- **Doc unsupported extension `invalid_input`.**
-- **Tx AST empty directory `no_matches`.** Plan `ast.rename` on a directory with no source files exits **3** with `error_kind: "no_matches"` (was `operation_failed` / 9), matching CLI `ast rename`. `doc` on non-JSON/YAML/TOML paths (and plan doc ops on those paths) set `error_kind: "invalid_input"` (exit 1). CLI write path no longer mislabels them as `type_error`.
+- **Doc unsupported extension `invalid_input`.** `doc` on non-JSON/YAML/TOML paths (and plan doc ops on those paths) set `error_kind: "invalid_input"` (exit 1). CLI write path no longer mislabels them as `type_error`.
+- **Tx AST empty directory `no_matches`.** Plan `ast.rename` on a directory with no source files exits **3** with `error_kind: "no_matches"` (was `operation_failed` / 9), matching CLI `ast rename`.
+- **Doc parse failures `parse_error`.** Malformed JSON/YAML/TOML content exits **4** with `error_kind: "parse_error"` (was unstructured exit 1), for CLI doc and plan/tx doc ops.
 
 ## Agent and library notes
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -822,6 +822,10 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 // Unsupported extension / flag mistakes are invalid_input; value
                 // shape mismatches are type_error. Do not default everything to
                 // type_error (that hid .txt extension failures as type_error).
+                if exit::is_parse_error(&e) {
+                    global.emit_error_json_kind(Some("parse_error"), &e.to_string())?;
+                    return Ok(exit::PARSE_ERROR);
+                }
                 let kind = if exit::is_type_error(&e) {
                     "type_error"
                 } else if exit::is_invalid_input(&e) {

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -436,6 +436,14 @@ pub(crate) fn run_parsed_plan(
                 }
                 return Ok(exit::CONFLICTS);
             }
+            if exit::is_parse_error(&e) {
+                if structured {
+                    emit_error_json("parse_error", &msg, None, compact);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::PARSE_ERROR);
+            }
             if structured {
                 emit_error_json("operation_failed", &msg, None, compact);
             } else {

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -158,6 +158,27 @@ pub fn is_conflicts(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<ConflictsError>().is_some())
 }
 
+/// Typed error for plan/patch/document parse failures that map to exit
+/// [`PARSE_ERROR`] (4) with JSON `error_kind: "parse_error"`.
+#[derive(Debug)]
+pub struct ParseErrorError {
+    pub msg: String,
+}
+
+impl std::fmt::Display for ParseErrorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for ParseErrorError {}
+
+/// Check whether an `anyhow::Error` chain contains a [`ParseErrorError`].
+pub fn is_parse_error(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<ParseErrorError>().is_some())
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -389,8 +389,8 @@ fn clap_usage_error_message(err: &clap::Error) -> String {
 }
 
 /// Build the JSON error envelope and exit code for a dispatch `Err` under
-/// `--json` / `--jsonl`. Typed [`exit::NoMatchError`] / [`exit::AmbiguousError`]
-/// / [`exit::InvalidInputError`] chains get `error_kind` and their exit codes.
+/// `--json` / `--jsonl`. Typed exit kinds (`NoMatchError`, `AmbiguousError`,
+/// `InvalidInputError`, `ParseErrorError`, …) get `error_kind` and exit codes.
 #[cfg(feature = "cli")]
 fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
     let (kind, code) = if exit::is_no_match(err) {
@@ -407,6 +407,8 @@ fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
         (Some("type_error"), exit::FAILURE)
     } else if exit::is_conflicts(err) {
         (Some("conflicts"), exit::CONFLICTS)
+    } else if exit::is_parse_error(err) {
+        (Some("parse_error"), exit::PARSE_ERROR)
     } else {
         (None, exit::FAILURE)
     };

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -395,17 +395,28 @@ fn try_preserve_yaml_array(
 
 pub fn parse_doc(content: &str, format: &FileFormat) -> anyhow::Result<serde_json::Value> {
     match format {
-        FileFormat::Json => Ok(serde_json::from_str(content)?),
+        FileFormat::Json => serde_json::from_str(content)
+            .map_err(|e| anyhow::Error::new(crate::exit::ParseErrorError { msg: e.to_string() })),
         FileFormat::Yaml => {
             if is_multi_document_yaml(content) {
-                parse_multi_document_yaml(content)
+                parse_multi_document_yaml(content).map_err(|e| {
+                    // Multi-doc path may already be typed; re-wrap plain anyhow.
+                    if crate::exit::is_parse_error(&e) {
+                        e
+                    } else {
+                        anyhow::Error::new(crate::exit::ParseErrorError { msg: e.to_string() })
+                    }
+                })
             } else {
-                let mut val: serde_json::Value = serde_yaml_ng::from_str(content)?;
+                let mut val: serde_json::Value = serde_yaml_ng::from_str(content).map_err(|e| {
+                    anyhow::Error::new(crate::exit::ParseErrorError { msg: e.to_string() })
+                })?;
                 resolve_yaml_merge_keys(&mut val);
                 Ok(val)
             }
         }
-        FileFormat::Toml => Ok(toml_edit::de::from_str(content)?),
+        FileFormat::Toml => toml_edit::de::from_str(content)
+            .map_err(|e| anyhow::Error::new(crate::exit::ParseErrorError { msg: e.to_string() })),
     }
 }
 

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -625,6 +625,9 @@ pub(crate) fn execute_and_collect(
                 if crate::exit::is_conflicts(&e) {
                     return Err(crate::exit::ConflictsError { msg }.into());
                 }
+                if crate::exit::is_parse_error(&e) {
+                    return Err(crate::exit::ParseErrorError { msg }.into());
+                }
                 anyhow::bail!("{msg}");
             }
         }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -166,6 +166,9 @@ pub fn execute_plan_direct(
             if crate::exit::is_conflicts(&e) {
                 return Ok(build_error_output("conflicts", &e.to_string(), None));
             }
+            if crate::exit::is_parse_error(&e) {
+                return Ok(build_error_output("parse_error", &e.to_string(), None));
+            }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }
     };

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -292,6 +292,7 @@ pub fn exit_code_from_tx_output(report: &TxOutput) -> u8 {
             }
             Some("operation_failed") => exit::OPERATION_FAILED,
             Some("conflicts") => exit::CONFLICTS,
+            // parse_error already handled above; keep exhaustive for clarity
             _ => exit::FAILURE,
         }
     }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1874,6 +1874,31 @@ fn test_doc_set_unsupported_extension_json_invalid_input() {
 }
 
 #[test]
+fn test_doc_get_malformed_json_parse_error() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("bad.json");
+    fs::write(&file, "{bad").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get", &file.to_string_lossy(), "key"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "malformed JSON should be parse_error exit 4: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "parse_error",
+        "malformed document must set parse_error: {json}"
+    );
+}
+
+#[test]
 fn test_doc_select_no_matches_exits_3() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.json");


### PR DESCRIPTION
## Summary

- Malformed JSON/YAML/TOML content now exits **4** with JSON `error_kind: "parse_error"` for CLI `doc` and plan/tx doc ops (was unstructured exit 1).
- Adds typed `ParseErrorError` and wires it through engine/tx/CLI error paths alongside the other agent exit kinds.

## Test plan

- [x] `test_doc_get_malformed_json_parse_error` (exit 4 + `parse_error`)
- [x] `make check-fast`
- [ ] CI green on PR