### PR TITLE
fix(tx): AST extract already_exists and rewrite invalid_input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -71,6 +71,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Doc unsupported extension `invalid_input`.** `doc` on non-JSON/YAML/TOML paths (and plan doc ops on those paths) set `error_kind: "invalid_input"` (exit 1). CLI write path no longer mislabels them as `type_error`.
 - **Tx AST empty directory `no_matches`.** Plan `ast.rename` on a directory with no source files exits **3** with `error_kind: "no_matches"` (was `operation_failed` / 9), matching CLI `ast rename`.
 - **Doc parse failures `parse_error`.** Malformed JSON/YAML/TOML content exits **4** with `error_kind: "parse_error"` (was unstructured exit 1), for CLI doc and plan/tx doc ops.
+- **Tx AST extract/rewrite kinds.** `ast.extract_to_file` into an existing target without `force` sets `already_exists` (exit 1). `ast.rewrite_signature` without signature fields sets `invalid_input` (exit 1).
 
 ## Agent and library notes
 

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -175,9 +175,10 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             let has_structured =
                 visibility.is_some() || parameters.is_some() || return_type.is_some();
             if new_signature.is_none() && !has_structured {
-                anyhow::bail!(
-                    "ast.rewrite_signature requires new_signature and/or visibility/parameters/return_type"
-                );
+                return Err(crate::exit::InvalidInputError {
+                    msg: "ast.rewrite_signature requires new_signature and/or visibility/parameters/return_type".into(),
+                }
+                .into());
             }
             let new_content = if let Some(new_sig) = new_signature {
                 let span = crate::ast::rewrite::find_function_span(content, old, lang_val)
@@ -455,10 +456,12 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             let abs_source = tx.cwd.join(source);
             let abs_target = tx.cwd.join(target);
             if !force && (abs_target.exists() || tx.pending.contains_key(&abs_target)) {
-                anyhow::bail!(
-                    "target file '{}' already exists (use force: true to overwrite)",
-                    target
-                );
+                return Err(crate::exit::AlreadyExistsError {
+                    msg: format!(
+                        "target file '{target}' already exists (use force: true to overwrite)"
+                    ),
+                }
+                .into());
             }
             let source_content = read_file_content(tx.pending, tx.existed_before, &abs_source)?;
             let lang_val = lang

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7582,6 +7582,72 @@ fn test_tx_ast_rename_empty_directory_fails() {
     );
 }
 
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_extract_to_file_existing_target_already_exists() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("src.rs"), "fn take_me() {}\nfn keep() {}\n").unwrap();
+    fs::write(dir.path().join("dest.rs"), "// already here\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.extract_to_file",
+            "source": "src.rs",
+            "symbol": "take_me",
+            "target": "dest.rs"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let assert = patchloom_in(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(1); // already_exists, not operation_failed (9)
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        v["error_kind"], "already_exists",
+        "extract into existing file without force: {stdout}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_rewrite_signature_missing_fields_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn process() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rewrite_signature",
+            "path": "lib.rs",
+            "old": "process"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let assert = patchloom_in(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(1); // invalid_input
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        v["error_kind"], "invalid_input",
+        "rewrite_signature without fields: {stdout}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // CLI --contain on tx plans (MPI cycle 13)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Plan `ast.extract_to_file` into an existing target without `force` exits **1** with `error_kind: "already_exists"` (was `operation_failed` / 9).
- Plan `ast.rewrite_signature` without signature fields exits **1** with `error_kind: "invalid_input"`.

## Test plan

- [x] Integration tests for both paths
- [x] `make check-fast`
- [ ] CI green on PR