### PR TITLE
fix(tx): mid-plan delete is not_found; contain escapes invalid_input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -72,6 +72,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx AST empty directory `no_matches`.** Plan `ast.rename` on a directory with no source files exits **3** with `error_kind: "no_matches"` (was `operation_failed` / 9), matching CLI `ast rename`.
 - **Doc parse failures `parse_error`.** Malformed JSON/YAML/TOML content exits **4** with `error_kind: "parse_error"` (was unstructured exit 1), for CLI doc and plan/tx doc ops.
 - **Tx AST extract/rewrite kinds.** `ast.extract_to_file` into an existing target without `force` sets `already_exists` (exit 1). `ast.rewrite_signature` without signature fields sets `invalid_input` (exit 1).
+- **Tx mid-plan delete then use is `not_found`.** Append/prepend/rename after `file.delete` in the same plan set `error_kind: "not_found"` (exit 1). Workspace-guard escapes set `invalid_input`.
 
 ## Agent and library notes
 

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -182,8 +182,11 @@ pub fn execute_precomputed(
 
     if let Some(g) = options.guard {
         for (rel_path, _, _) in &changes {
-            g.check_path(rel_path)
-                .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {e}"))?;
+            g.check_path(rel_path).map_err(|e| {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("path rejected by workspace guard: {e}"),
+                })
+            })?;
         }
     }
 
@@ -262,8 +265,11 @@ fn execute_plan_inner(
     if let Some(g) = options.guard {
         for op in &operations {
             for p in op.declared_paths() {
-                g.check_path(&p)
-                    .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
+                g.check_path(&p).map_err(|e| {
+                    anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("path rejected by workspace guard: {e}"),
+                    })
+                })?;
             }
         }
     }

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -16,7 +16,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 .into());
             }
             if tx.deletions.contains(&file_path) {
-                anyhow::bail!("file was deleted earlier in this transaction: {path}");
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("file was deleted earlier in this transaction: {path}"),
+                )
+                .into());
             }
             if !file_path.exists() && !tx.pending.contains_key(&file_path) {
                 return Err(std::io::Error::new(
@@ -45,7 +49,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 .into());
             }
             if tx.deletions.contains(&file_path) {
-                anyhow::bail!("file was deleted earlier in this transaction: {path}");
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("file was deleted earlier in this transaction: {path}"),
+                )
+                .into());
             }
             if !file_path.exists() && !tx.pending.contains_key(&file_path) {
                 return Err(std::io::Error::new(
@@ -163,7 +171,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             let dst_path = tx.cwd.join(to);
 
             if tx.deletions.contains(&src_path) {
-                anyhow::bail!("source file was deleted earlier in this transaction: {from}");
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("source file was deleted earlier in this transaction: {from}"),
+                )
+                .into());
             }
             if src_path.exists() && !src_path.is_file() {
                 return Err(crate::exit::InvalidInputError {

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -518,8 +518,11 @@ pub(crate) fn execute_and_collect(
     if let Some(g) = guard {
         for op in &plan.operations {
             for p in op.declared_paths() {
-                g.check_path(&p)
-                    .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {e}"))?;
+                g.check_path(&p).map_err(|e| {
+                    anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("path rejected by workspace guard: {e}"),
+                    })
+                })?;
             }
         }
     }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -102,19 +102,25 @@ pub fn execute_plan_direct(
                 .canonicalize()
                 .unwrap_or_else(|_| effective_cwd.clone());
             if !canon_cwd.starts_with(g.canon_root()) {
-                anyhow::bail!(
-                    "plan cwd '{}' escapes workspace root '{}'",
-                    effective_cwd.display(),
-                    g.root().display()
-                );
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!(
+                        "plan cwd '{}' escapes workspace root '{}'",
+                        effective_cwd.display(),
+                        g.root().display()
+                    ),
+                }
+                .into());
             }
         }
         // Upfront check on declared paths using shared helper; dynamic (globs
         // patterns, patch embedded paths) are best-effort or handled by loaders.
         for op in &plan.operations {
             for p in op.declared_paths() {
-                g.check_path(&p)
-                    .map_err(|e| anyhow::anyhow!("path rejected by workspace guard: {}", e))?;
+                g.check_path(&p).map_err(|e| {
+                    anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("path rejected by workspace guard: {e}"),
+                    })
+                })?;
             }
         }
     }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7676,26 +7676,64 @@ fn test_tx_contain_rejects_parent_escape_in_plan() {
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
 
-    Command::cargo_bin("patchloom")
+    let assert = Command::cargo_bin("patchloom")
         .unwrap()
         .args(["--cwd"])
         .arg(dir.path())
-        .args(["--contain", "tx"])
+        .args(["--json", "--contain", "tx"])
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
         .assert()
-        .failure()
-        .stderr(
-            predicate::str::contains("escapes")
-                .or(predicate::str::contains("rejected"))
-                .or(predicate::str::contains("workspace guard")),
-        );
+        .code(1);
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        v["error_kind"], "invalid_input",
+        "contain escape should be invalid_input: {stdout}"
+    );
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("escapes") || err.contains("rejected") || err.contains("workspace guard"),
+        "error should mention containment: {stdout}"
+    );
 
     assert!(
         !outside.exists(),
         "tx --contain must not create escaped path {outside:?}"
     );
     let _ = fs::remove_file(&outside);
+}
+
+#[test]
+fn test_tx_append_after_delete_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("gone.txt");
+    fs::write(&file, "hi\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {"op": "file.delete", "path": portable_path_str(&file)},
+            {"op": "file.append", "path": portable_path_str(&file), "content": "nope\n"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let assert = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(1);
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        v["error_kind"], "not_found",
+        "append after delete in same plan: {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Append/prepend/rename after `file.delete` in the same plan exit **1** with `error_kind: "not_found"` (was `operation_failed` / 9).
- Workspace `--contain` / PathGuard rejections set `error_kind: "invalid_input"`.

## Test plan

- [x] `test_tx_append_after_delete_is_not_found`
- [x] `test_tx_contain_rejects_parent_escape_in_plan` asserts `invalid_input`
- [x] `make check-fast`
- [ ] CI green on PR