### PR TITLE
fix(tx): search assert_count mismatch is changes_detected

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -304,7 +304,7 @@ dependencies[name=react].version # predicate filter
 |------|---------|
 | 0 | Success (operation completed, or no changes needed) |
 | 1 | Failure (error during execution, CLI usage/invalid args/unknown flags/subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |
-| 2 | Changes detected (`--check` mode found pending changes; not used for CLI usage errors) |
+| 2 | Changes detected (`--check` / write preview, or plan/tx `search` `assert_count` mismatch; `error_kind: changes_detected` for assert_count) |
 | 3 | No matches (search/replace pattern miss, undo with no sessions, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
 | 4 | Parse error (malformed input file or plan) |
 | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |
@@ -315,7 +315,7 @@ dependencies[name=react].version # predicate filter
 
 **JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`, `--contain` path rejections / empty paths, all-explicit-paths-missing for search/replace/tidy, and plan op option conflicts such as replace whole_line+multiline, tidy dedent+indent, md.move_section before/after, search invert_match+multiline). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.
 
-**JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set `parse_error` so agents can distinguish syntax mistakes from runtime failures.
+**JSON `error_kind` (exit 4):** Batch line parse failures, `explain` plan parse failures, and malformed JSON/YAML/TOML document content set `parse_error` so agents can distinguish syntax mistakes from runtime failures.
 
 **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, doc delete success includes `changed` (bool) and `removed` (usize). Multi-op plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with `removed: 0` means idempotent cleanup (nothing matched); do not assume data was deleted from exit status alone.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -73,6 +73,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Doc parse failures `parse_error`.** Malformed JSON/YAML/TOML content exits **4** with `error_kind: "parse_error"` (was unstructured exit 1), for CLI doc and plan/tx doc ops.
 - **Tx AST extract/rewrite kinds.** `ast.extract_to_file` into an existing target without `force` sets `already_exists` (exit 1). `ast.rewrite_signature` without signature fields sets `invalid_input` (exit 1).
 - **Tx mid-plan delete then use is `not_found`.** Append/prepend/rename after `file.delete` in the same plan set `error_kind: "not_found"` (exit 1). Workspace-guard escapes set `invalid_input`.
+- **Tx search assert_count mismatch.** Plan `search` with `assert_count` when the actual match count differs exits **2** with `error_kind: "changes_detected"` (was `operation_failed` / 9), matching CLI `search --assert-count`.
 
 ## Agent and library notes
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -445,7 +445,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              |------|---------|\n\
              | 0 | Success (operation completed, or no changes needed) |\n\
              | 1 | Failure (error during execution, CLI usage/invalid args/unknown flags/subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |\n\
-             | 2 | Changes detected (`--check` mode found pending changes; not used for CLI usage errors) |\n\
+             | 2 | Changes detected (`--check` / write preview, or plan/tx `search` `assert_count` mismatch; `error_kind: changes_detected` for assert_count) |\n\
              | 3 | No matches (search/replace pattern miss, undo with no sessions, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
              | 4 | Parse error (malformed input file or plan) |\n\
              | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |\n\
@@ -462,8 +462,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              md.move_section before/after, search invert_match+multiline). Doc type mismatches set \
              `type_error` (`doc keys`/`len` on wrong type). \
              Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.\n\n\
-             **JSON `error_kind` (exit 4):** Batch line parse failures and `explain` plan parse failures set \
-             `parse_error` so agents can distinguish syntax mistakes from runtime failures.\n\n\
+             **JSON `error_kind` (exit 4):** Batch line parse failures, `explain` plan parse failures, and \
+             malformed JSON/YAML/TOML document content set `parse_error` so agents can distinguish syntax \
+             mistakes from runtime failures.\n\n\
              **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, \
              doc delete success includes `changed` (bool) and `removed` (usize). Multi-op \
              plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with \

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -444,6 +444,14 @@ pub(crate) fn run_parsed_plan(
                 }
                 return Ok(exit::PARSE_ERROR);
             }
+            if exit::is_changes_detected(&e) {
+                if structured {
+                    emit_error_json("changes_detected", &msg, None, compact);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::CHANGES_DETECTED);
+            }
             if structured {
                 emit_error_json("operation_failed", &msg, None, compact);
             } else {

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -179,6 +179,28 @@ pub fn is_parse_error(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<ParseErrorError>().is_some())
 }
 
+/// Typed error for assert-count / soft mismatch that map to exit
+/// [`CHANGES_DETECTED`] (2) with JSON `error_kind: "changes_detected"`.
+/// Matches CLI `search --assert-count` when the actual count differs.
+#[derive(Debug)]
+pub struct ChangesDetectedError {
+    pub msg: String,
+}
+
+impl std::fmt::Display for ChangesDetectedError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+impl std::error::Error for ChangesDetectedError {}
+
+/// Check whether an `anyhow::Error` chain contains a [`ChangesDetectedError`].
+pub fn is_changes_detected(err: &anyhow::Error) -> bool {
+    err.chain()
+        .any(|cause| cause.downcast_ref::<ChangesDetectedError>().is_some())
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -409,6 +409,8 @@ fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
         (Some("conflicts"), exit::CONFLICTS)
     } else if exit::is_parse_error(err) {
         (Some("parse_error"), exit::PARSE_ERROR)
+    } else if exit::is_changes_detected(err) {
+        (Some("changes_detected"), exit::CHANGES_DETECTED)
     } else {
         (None, exit::FAILURE)
     };

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -631,6 +631,9 @@ pub(crate) fn execute_and_collect(
                 if crate::exit::is_parse_error(&e) {
                     return Err(crate::exit::ParseErrorError { msg }.into());
                 }
+                if crate::exit::is_changes_detected(&e) {
+                    return Err(crate::exit::ChangesDetectedError { msg }.into());
+                }
                 anyhow::bail!("{msg}");
             }
         }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -175,6 +175,9 @@ pub fn execute_plan_direct(
             if crate::exit::is_parse_error(&e) {
                 return Ok(build_error_output("parse_error", &e.to_string(), None));
             }
+            if crate::exit::is_changes_detected(&e) {
+                return Ok(build_error_output("changes_detected", &e.to_string(), None));
+            }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }
     };

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -292,6 +292,7 @@ pub fn exit_code_from_tx_output(report: &TxOutput) -> u8 {
             }
             Some("operation_failed") => exit::OPERATION_FAILED,
             Some("conflicts") => exit::CONFLICTS,
+            Some("changes_detected") => exit::CHANGES_DETECTED,
             // parse_error already handled above; keep exhaustive for clarity
             _ => exit::FAILURE,
         }

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -223,13 +223,14 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
     if let Some(expected) = assert_count
         && total_match_count != *expected
     {
-        anyhow::bail!(
-            "search assert_count: expected {} matches for '{}' in {}, found {}",
-            expected,
-            pattern,
-            path,
-            total_match_count
-        );
+        // CLI search --assert-count mismatch is CHANGES_DETECTED (2), not a
+        // hard operation_failed. Keep the same exit for plan/tx.
+        return Err(crate::exit::ChangesDetectedError {
+            msg: format!(
+                "search assert_count: expected {expected} matches for '{pattern}' in {path}, found {total_match_count}"
+            ),
+        }
+        .into());
     }
 
     // Cap after assertion check. Append order matches walk order.

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -3931,11 +3931,18 @@ fn test_tx_search_assert_count_fail() {
         .output()
         .unwrap();
 
-    assert!(
-        !output.status.success(),
-        "assert_count=5 should fail when there are only 2 matches"
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "assert_count mismatch should be CHANGES_DETECTED (CLI parity): {}",
+        String::from_utf8_lossy(&output.stdout)
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        v["error_kind"], "changes_detected",
+        "assert_count mismatch kind: {stdout}"
+    );
     assert!(
         stdout.contains("assert_count") || stdout.contains("expected 5"),
         "error should mention assert_count: {stdout}"


### PR DESCRIPTION
## Summary

- Plan/tx `search` with `assert_count` when the actual match count differs exits **2** with `error_kind: "changes_detected"` (was `operation_failed` / 9).
- Matches CLI `search --assert-count` exit semantics for agent hosts.

## Test plan

- [x] `test_tx_search_assert_count_fail` expects exit 2 + `changes_detected`
- [x] `make check-fast`
- [ ] CI green on PR