### PR TITLE
fix(cli): --cwd missing or non-dir is invalid_input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -74,6 +74,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx AST extract/rewrite kinds.** `ast.extract_to_file` into an existing target without `force` sets `already_exists` (exit 1). `ast.rewrite_signature` without signature fields sets `invalid_input` (exit 1).
 - **Tx mid-plan delete then use is `not_found`.** Append/prepend/rename after `file.delete` in the same plan set `error_kind: "not_found"` (exit 1). Workspace-guard escapes set `invalid_input`.
 - **Tx search assert_count mismatch.** Plan `search` with `assert_count` when the actual match count differs exits **2** with `error_kind: "changes_detected"` (was `operation_failed` / 9), matching CLI `search --assert-count`.
+- **CLI `--cwd` missing/non-dir `invalid_input`.** Bad `--cwd` paths exit **1** with `error_kind: "invalid_input"` under `--json` (typed `InvalidInputError`).
 
 ## Agent and library notes
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -348,10 +348,16 @@ impl GlobalFlags {
         if let Some(ref cwd) = self.cwd {
             let path = std::path::PathBuf::from(cwd);
             if !path.exists() {
-                anyhow::bail!("--cwd directory does not exist: {cwd}");
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("--cwd directory does not exist: {cwd}"),
+                }
+                .into());
             }
             if !path.is_dir() {
-                anyhow::bail!("--cwd is not a directory: {cwd}");
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("--cwd is not a directory: {cwd}"),
+                }
+                .into());
             }
             Ok(path)
         } else {

--- a/tests/integration/cli_flags_tests.rs
+++ b/tests/integration/cli_flags_tests.rs
@@ -90,8 +90,38 @@ fn test_cwd_nonexistent_directory_fails() {
         .arg("hello")
         .arg(".")
         .assert()
-        .failure()
+        .code(1)
         .stderr(predicate::str::contains("--cwd directory does not exist"));
+}
+
+#[test]
+fn test_cwd_nonexistent_directory_json_invalid_input() {
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "--cwd",
+            "/nonexistent/dir/12345",
+            "search",
+            "hello",
+            ".",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "missing --cwd must set invalid_input: {json}"
+    );
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("--cwd directory does not exist"),
+        "error should name --cwd: {json}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Missing or non-directory `--cwd` exits **1** with JSON `error_kind: "invalid_input"` (typed `InvalidInputError`).

## Test plan

- [x] `test_cwd_nonexistent_directory_json_invalid_input`
- [x] `make check-fast`
- [ ] CI green on PR