### PR TITLE
fix(cli): empty paths and unsupported init shell are invalid_input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -75,6 +75,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx mid-plan delete then use is `not_found`.** Append/prepend/rename after `file.delete` in the same plan set `error_kind: "not_found"` (exit 1). Workspace-guard escapes set `invalid_input`.
 - **Tx search assert_count mismatch.** Plan `search` with `assert_count` when the actual match count differs exits **2** with `error_kind: "changes_detected"` (was `operation_failed` / 9), matching CLI `search --assert-count`.
 - **CLI `--cwd` missing/non-dir `invalid_input`.** Bad `--cwd` paths exit **1** with `error_kind: "invalid_input"` under `--json` (typed `InvalidInputError`).
+- **Empty path strings `invalid_input`.** `resolve_user_path` rejects empty paths with typed `InvalidInputError` (same as `check_paths_contained`).
 
 ## Agent and library notes
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -405,7 +405,10 @@ impl GlobalFlags {
         let path = path.as_ref();
         let path_str = path.to_string_lossy();
         if path_str.trim().is_empty() {
-            anyhow::bail!("path must not be empty");
+            return Err(crate::exit::InvalidInputError {
+                msg: "path must not be empty".into(),
+            }
+            .into());
         }
         let cwd = self.resolve_cwd()?;
         // Always run empty-path + optional --contain checks via the shared helper.
@@ -1006,6 +1009,17 @@ mod tests {
         };
         let resolved = g.resolve_user_path("ops.txt").unwrap();
         assert_eq!(resolved, dir.path().join("ops.txt"));
+    }
+
+    #[test]
+    fn resolve_user_path_empty_is_invalid_input() {
+        let g = GlobalFlags::default();
+        let err = g.resolve_user_path("").unwrap_err();
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "empty path should be InvalidInputError: {err}"
+        );
+        assert!(err.to_string().contains("path must not be empty"));
     }
 
     #[test]

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -274,7 +274,12 @@ fn generate_completions(shell: &str, target: &Path) -> anyhow::Result<()> {
         "zsh" => clap_complete::Shell::Zsh,
         "fish" => clap_complete::Shell::Fish,
         "elvish" => clap_complete::Shell::Elvish,
-        _ => anyhow::bail!("unsupported shell: {shell}"),
+        _ => {
+            return Err(crate::exit::InvalidInputError {
+                msg: format!("unsupported shell: {shell}"),
+            }
+            .into());
+        }
     };
     let mut cmd = <Cli as clap::CommandFactory>::command();
     let mut buf = Vec::new();


### PR DESCRIPTION
## Summary

- `resolve_user_path` empty/whitespace paths set typed `InvalidInputError` (same as `check_paths_contained`).
- `init` completion generation rejects unknown shells as `invalid_input`.

## Test plan

- [x] Unit: `resolve_user_path_empty_is_invalid_input`
- [x] `make check-fast`
- [ ] CI green on PR