### PR TITLE
fix(api): type AST insert/wrap/reorder and plan filter errors

### DIFF
--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -147,7 +147,9 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<(String, usize
             content: insert,
         } => {
             if anchor.is_empty() {
-                anyhow::bail!("insert_before anchor must not be empty");
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: "insert_before anchor must not be empty".into(),
+                }));
             }
             // First-match only (same as String::find). Callers that need
             // unique anchors should use Replace with unique:true or a longer
@@ -172,7 +174,9 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<(String, usize
             content: insert,
         } => {
             if anchor.is_empty() {
-                anyhow::bail!("insert_after anchor must not be empty");
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: "insert_after anchor must not be empty".into(),
+                }));
             }
             // First-match only (see InsertBefore).
             match content.find(anchor.as_str()) {

--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -88,7 +88,9 @@ pub fn group_symbols(
     }
 
     if !missing.is_empty() {
-        anyhow::bail!("symbol(s) not found: {}", missing.join(", "));
+        return Err(anyhow::Error::new(crate::exit::NoMatchError {
+            msg: format!("symbol(s) not found: {}", missing.join(", ")),
+        }));
     }
 
     if to_move.is_empty() {

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -48,7 +48,9 @@ pub fn insert_code(
 ) -> anyhow::Result<InsertResult> {
     let mode_count = inside.is_some() as u8 + after.is_some() as u8 + before.is_some() as u8;
     if mode_count != 1 {
-        anyhow::bail!("exactly one of 'inside', 'after', or 'before' must be specified");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "exactly one of 'inside', 'after', or 'before' must be specified".into(),
+        }));
     }
 
     let eol = crate::write::detect_eol(source);

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -70,7 +70,9 @@ pub fn move_symbols(
     }
 
     if !missing.is_empty() {
-        anyhow::bail!("symbol(s) not found in source: {}", missing.join(", "));
+        return Err(anyhow::Error::new(crate::exit::NoMatchError {
+            msg: format!("symbol(s) not found in source: {}", missing.join(", ")),
+        }));
     }
 
     if to_move.is_empty() {

--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -260,7 +260,9 @@ pub fn parse_strategy(value: &serde_json::Value) -> anyhow::Result<ReorderStrate
             "alphabetical" => Ok(ReorderStrategy::Alphabetical),
             "reverse" => Ok(ReorderStrategy::Reverse),
             "kind-first" | "kind_first" => Ok(ReorderStrategy::KindFirst),
-            other => anyhow::bail!("unknown reorder strategy: '{other}'"),
+            other => Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("unknown reorder strategy: '{other}'"),
+            })),
         },
         serde_json::Value::Array(arr) => {
             let names: Result<Vec<String>, _> = arr
@@ -273,7 +275,9 @@ pub fn parse_strategy(value: &serde_json::Value) -> anyhow::Result<ReorderStrate
                 .collect();
             Ok(ReorderStrategy::Custom(names?))
         }
-        _ => anyhow::bail!("'order' must be a string or array of strings"),
+        _ => Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "'order' must be a string or array of strings".into(),
+        })),
     }
 }
 

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -28,7 +28,9 @@ pub fn wrap_code(
 ) -> anyhow::Result<WrapResult> {
     let mode_count = symbols_arg.is_some() as u8 + lines_arg.is_some() as u8;
     if mode_count != 1 {
-        anyhow::bail!("exactly one of 'symbols' or 'lines' must be specified");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "exactly one of 'symbols' or 'lines' must be specified".into(),
+        }));
     }
 
     let eol = crate::write::detect_eol(source);

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -400,7 +400,9 @@ fn validate_restore_path(entry_path: &str) -> anyhow::Result<()> {
             std::path::Component::ParentDir => {
                 depth -= 1;
                 if depth < 0 {
-                    anyhow::bail!("restore path escapes project root: {entry_path}");
+                    return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("restore path escapes project root: {entry_path}"),
+                    }));
                 }
             }
             std::path::Component::Normal(_) => {
@@ -408,7 +410,9 @@ fn validate_restore_path(entry_path: &str) -> anyhow::Result<()> {
             }
             std::path::Component::CurDir => {}
             _ => {
-                anyhow::bail!("unexpected path component in restore path: {entry_path}");
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("unexpected path component in restore path: {entry_path}"),
+                }));
             }
         }
     }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -119,7 +119,11 @@ impl VerifyCheck {
                 match k.trim() {
                     "kind" => kind = Some(v.trim().to_string()),
                     "attr" => attr = Some(v.trim().to_string()),
-                    other => anyhow::bail!("unknown verify key: {other}"),
+                    other => {
+                        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                            msg: format!("unknown verify key: {other}"),
+                        }));
+                    }
                 }
             } else {
                 // Bare word like "function" treated as kind
@@ -511,10 +515,14 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
             #[cfg(not(feature = "ast"))]
             {
                 let _ = sym_name;
-                anyhow::bail!("for_each filter `has_symbol(...)` requires the `ast` feature");
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: "for_each filter `has_symbol(...)` requires the `ast` feature".into(),
+                }));
             }
         } else {
-            anyhow::bail!("for_each: unsupported filter expression: {filter}");
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("for_each: unsupported filter expression: {filter}"),
+            }));
         }
     }
 


### PR DESCRIPTION
## Summary

Batch of typed exit errors for agent hosts:

- Empty multi-edit anchors → `invalid_input`
- AST insert/wrap exclusive-flag mistakes → `invalid_input`
- Unknown reorder strategy / bad `order` → `invalid_input`
- Group/move missing symbols → `no_matches`
- Plan `for_each` bad filters → `invalid_input`
- Backup restore path escapes → `invalid_input`

## Test plan

- [x] Unit tests for content_edits, group, insert, wrap, reorder
- [x] `make check-fast`
- [ ] CI green on PR