### PR TITLE
fix(api): type replace/wrap validation and empty patch

### DIFF
--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -54,7 +54,9 @@ fn patch_write(
             .map_err(|e| anyhow::anyhow!("patch parse error: {e}"))?;
 
         if patch_files.is_empty() {
-            anyhow::bail!("no files in patch");
+            return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                msg: "no files in patch".into(),
+            }));
         }
 
         // Apply to the first file in the patch.

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -23,13 +23,19 @@ pub fn replace_text(
 ) -> anyhow::Result<EditResult> {
     // Pre-validate before building the Operation.
     if from.is_empty() && !opts.regex {
-        anyhow::bail!("empty search pattern");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "empty search pattern".into(),
+        }));
     }
     if opts.range.is_some() && !opts.whole_line {
-        anyhow::bail!("range requires whole_line to be true");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "range requires whole_line to be true".into(),
+        }));
     }
     if opts.whole_line && opts.multiline {
-        anyhow::bail!("whole_line and multiline cannot be combined");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "whole_line and multiline cannot be combined".into(),
+        }));
     }
 
     let range_str = opts.range.map(|(start, end)| {

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -141,7 +141,9 @@ fn find_symbol_range(
     lang: Language,
 ) -> anyhow::Result<(usize, usize)> {
     if symbol_names.is_empty() {
-        anyhow::bail!("symbols list must not be empty");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "symbols list must not be empty".into(),
+        }));
     }
     let symbols = extract_symbols(source, lang);
     let mut min_start = usize::MAX;
@@ -171,11 +173,15 @@ fn parse_line_range_to_indices(spec: &str, total_lines: usize) -> anyhow::Result
     } else if spec.contains('-') && !spec.starts_with('-') {
         spec.splitn(2, '-').collect()
     } else {
-        anyhow::bail!("invalid line range format: '{spec}' (expected START:END)");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("invalid line range format: '{spec}' (expected START:END)"),
+        }));
     };
 
     if parts.len() != 2 {
-        anyhow::bail!("invalid line range: '{spec}'");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("invalid line range: '{spec}'"),
+        }));
     }
 
     let start: usize = parts[0]
@@ -183,7 +189,9 @@ fn parse_line_range_to_indices(spec: &str, total_lines: usize) -> anyhow::Result
         .map_err(|_| anyhow::anyhow!("invalid start line: {}", parts[0]))?;
 
     if start == 0 {
-        anyhow::bail!("line numbers are 1-based, got 0");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "line numbers are 1-based, got 0".into(),
+        }));
     }
 
     let start_idx = start - 1;
@@ -196,7 +204,9 @@ fn parse_line_range_to_indices(spec: &str, total_lines: usize) -> anyhow::Result
         .parse()
         .map_err(|_| anyhow::anyhow!("invalid end line: {}", parts[1]))?;
     if end < start {
-        anyhow::bail!("end line {end} is before start line {start}");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("end line {end} is before start line {start}"),
+        }));
     }
 
     let end_idx = end.min(total_lines);

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -48,10 +48,12 @@ pub fn navigate_mut<'a>(
                         if current.is_null() {
                             *current = serde_json::Value::Object(serde_json::Map::new());
                         } else if !current.is_object() {
-                            anyhow::bail!(
-                                "expected object at key '{k}', found {}",
-                                value_type_name(current)
-                            );
+                            return Err(anyhow::Error::new(crate::exit::TypeErrorError {
+                                msg: format!(
+                                    "expected object at key '{k}', found {}",
+                                    value_type_name(current)
+                                ),
+                            }));
                         }
                         let needs_create = match current.as_object() {
                             Some(obj) => !obj.contains_key(k.as_str()),


### PR DESCRIPTION
## Summary

- Library `replace` validation (empty pattern, range/whole_line, whole_line+multiline) → `invalid_input`
- AST wrap line-range mistakes and empty symbol lists → `invalid_input`
- Empty patch parse → `parse_error`
- Remaining navigate expected-object mismatch → `type_error`

## Test plan

- [x] `make check-fast`
- [ ] CI green on PR