### PR TITLE
fix(cli): type doc merge, status, and AST grammar errors

### DIFF
--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -50,7 +50,9 @@ pub fn validate_source(source: &str, lang: Language) -> Option<ValidationResult>
 pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result<ValidationResult> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
     if !lang.has_grammar() {
-        anyhow::bail!("no grammar available for {lang}");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("no grammar available for {lang}"),
+        }));
     }
     let source =
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -320,14 +320,18 @@ fn action_to_operation(action: &DocAction) -> anyhow::Result<Operation> {
             if *stdin && value.is_some() {
                 // Surface as plain anyhow; run() maps merge validation via
                 // emit_error_json_kind before staging when possible.
-                anyhow::bail!("merge: --stdin and --value are mutually exclusive");
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: "merge: --stdin and --value are mutually exclusive".into(),
+                }));
             }
             let merge_str = if *stdin {
                 std::io::read_to_string(std::io::stdin())?
             } else if let Some(v) = value {
                 v.clone()
             } else {
-                anyhow::bail!("merge requires --stdin or --value");
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: "merge requires --stdin or --value".into(),
+                }));
             };
             Ok(Operation::DocMerge {
                 path: file.clone(),

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -81,9 +81,11 @@ pub(crate) fn collect_status(
         .context("failed to run `git status` -- is git installed?")?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        anyhow::bail!(
-            "git status failed: {stderr}\nhint: run `git init` first, or run patchloom status from inside an existing git repository"
-        );
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!(
+                "git status failed: {stderr}\nhint: run `git init` first, or run patchloom status from inside an existing git repository"
+            ),
+        }));
     }
 
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;


### PR DESCRIPTION
## Summary

- Doc merge `--stdin`/`--value` conflicts → typed `invalid_input`
- `status` outside a git repo → typed `invalid_input` (already emitted as kind at CLI boundary)
- AST validate missing grammar → `invalid_input`

## Test plan

- [x] `make check-fast`
- [ ] CI green on PR