### PR TITLE
fix(cli): type more AST, plan, and write-policy errors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -77,6 +77,8 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **CLI `--cwd` missing/non-dir `invalid_input`.** Bad `--cwd` paths exit **1** with `error_kind: "invalid_input"` under `--json` (typed `InvalidInputError`).
 - **Empty path strings `invalid_input`.** `resolve_user_path` rejects empty paths with typed `InvalidInputError` (same as `check_paths_contained`).
 - **Doc navigate selector mistakes typed.** Empty selectors, unsupported wildcards on write paths, bad predicates, and out-of-bounds indexes set `invalid_input`; expected-object type mismatches set `type_error`.
+- **AST split/search/symbols and plan verify typed.** Duplicate or unaccounted split symbols and overlapping symbol spans set `invalid_input`; invalid AST search patterns set `parse_error`; malformed plan `verify` specs set `invalid_input` (was unstructured exit 1).
+- **More agent JSON kinds.** Invalid `normalize_eol` values, md `table-append` row/table failures, and library doc type mismatches set `invalid_input` / `type_error`; missing git-blob paths for AST set `not_found` (was unstructured exit 1 / operation_failed).
 
 ## Agent and library notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,6 +79,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Doc navigate selector mistakes typed.** Empty selectors, unsupported wildcards on write paths, bad predicates, and out-of-bounds indexes set `invalid_input`; expected-object type mismatches set `type_error`.
 - **AST split/search/symbols and plan verify typed.** Duplicate or unaccounted split symbols and overlapping symbol spans set `invalid_input`; invalid AST search patterns set `parse_error`; malformed plan `verify` specs set `invalid_input` (was unstructured exit 1).
 - **More agent JSON kinds.** Invalid `normalize_eol` values, md `table-append` row/table failures, and library doc type mismatches set `invalid_input` / `type_error`; missing git-blob paths for AST set `not_found` (was unstructured exit 1 / operation_failed).
+- **AST symbol-not-found is `no_matches`.** extract/insert/reorder/wrap/move paths set `error_kind: "no_matches"` (exit 3) when a named symbol is missing; create race `already_exists` and unknown undo session are typed the same way.
 
 ## Agent and library notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -81,6 +81,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **More agent JSON kinds.** Invalid `normalize_eol` values, md `table-append` row/table failures, and library doc type mismatches set `invalid_input` / `type_error`; missing git-blob paths for AST set `not_found` (was unstructured exit 1 / operation_failed).
 - **AST symbol-not-found is `no_matches`.** extract/insert/reorder/wrap/move paths set `error_kind: "no_matches"` (exit 3) when a named symbol is missing; create race `already_exists` and unknown undo session are typed the same way.
 - **Patch apply/parse typed for tx.** Plan/engine patch parse failures set `parse_error`; stale context sets `ambiguous`; other apply failures set `invalid_input` (CLI path already emitted kinds via string maps).
+- **files-from / batch input / MCP bind typed.** Missing `--files-from` or batch input files set `not_found`; unreadable lists and invalid MCP bind/TLS config set `invalid_input`; AST validate parse failure sets `parse_error`.
 
 ## Agent and library notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -80,6 +80,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **AST split/search/symbols and plan verify typed.** Duplicate or unaccounted split symbols and overlapping symbol spans set `invalid_input`; invalid AST search patterns set `parse_error`; malformed plan `verify` specs set `invalid_input` (was unstructured exit 1).
 - **More agent JSON kinds.** Invalid `normalize_eol` values, md `table-append` row/table failures, and library doc type mismatches set `invalid_input` / `type_error`; missing git-blob paths for AST set `not_found` (was unstructured exit 1 / operation_failed).
 - **AST symbol-not-found is `no_matches`.** extract/insert/reorder/wrap/move paths set `error_kind: "no_matches"` (exit 3) when a named symbol is missing; create race `already_exists` and unknown undo session are typed the same way.
+- **Patch apply/parse typed for tx.** Plan/engine patch parse failures set `parse_error`; stale context sets `ambiguous`; other apply failures set `invalid_input` (CLI path already emitted kinds via string maps).
 
 ## Agent and library notes
 

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -69,7 +69,7 @@ fn doc_write(
 
     let result = ops::doc::apply_doc_mutation(&mut new_value, mutation)?;
     if let MutationResult::TypeError(msg) = result {
-        anyhow::bail!("{msg}");
+        return Err(anyhow::Error::new(crate::exit::TypeErrorError { msg }));
     }
     let removed = match &result {
         MutationResult::Removed(n) => *n,

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -64,8 +64,12 @@ fn md_write(
             heading, bullet, ..
         } => ops::md::upsert_bullet_in(&original, &heading, &bullet),
         Operation::MdTableAppend { heading, row, .. } => {
-            let (body_start, body_end) = ops::md::find_section(&original, &heading)
-                .ok_or_else(|| anyhow::anyhow!("heading not found in {path_str}"))?;
+            let (body_start, body_end) =
+                ops::md::find_section(&original, &heading).ok_or_else(|| {
+                    anyhow::Error::new(crate::exit::NoMatchError {
+                        msg: format!("heading not found in {path_str}"),
+                    })
+                })?;
             return match ops::md::table_append_in(&original, body_start, body_end, &row) {
                 Ok(new_content) => {
                     let policy = WritePolicy::default();
@@ -79,14 +83,18 @@ fn md_write(
                         None,
                     ))
                 }
-                Err(e) => Err(anyhow::anyhow!(
-                    "{e} under heading {heading:?} in {path_str}"
-                )),
+                Err(e) => Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("{e} under heading {heading:?} in {path_str}"),
+                })),
             };
         }
         _ => None,
     }
-    .ok_or_else(|| anyhow::anyhow!("heading not found in {path_str}"))?;
+    .ok_or_else(|| {
+        anyhow::Error::new(crate::exit::NoMatchError {
+            msg: format!("heading not found in {path_str}"),
+        })
+    })?;
 
     let policy = WritePolicy::default();
     let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -205,7 +205,11 @@ pub fn md_move_section(
 
     let (new_source, new_dest) =
         ops::md::move_section_in(&original, heading, &dest_content, position, to.is_none())
-            .ok_or_else(|| anyhow::anyhow!("heading '{}' not found", heading))?;
+            .ok_or_else(|| {
+                anyhow::Error::new(crate::exit::NoMatchError {
+                    msg: format!("heading '{heading}' not found"),
+                })
+            })?;
 
     let policy = crate::write::WritePolicy::default();
     // Write the destination file for cross-file moves.

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -50,8 +50,11 @@ fn patch_write(
     use crate::ops;
 
     if let Operation::PatchApply { diff, .. } = _op {
-        let patch_files = ops::patch::parse_patch(&diff)
-            .map_err(|e| anyhow::anyhow!("patch parse error: {e}"))?;
+        let patch_files = ops::patch::parse_patch(&diff).map_err(|e| {
+            anyhow::Error::new(crate::exit::ParseErrorError {
+                msg: format!("patch parse error: {e}"),
+            })
+        })?;
 
         if patch_files.is_empty() {
             return Err(anyhow::Error::new(crate::exit::ParseErrorError {
@@ -65,8 +68,17 @@ fn patch_write(
         let original = std::fs::read_to_string(&file_path)
             .with_context(|| format!("failed to read {}", file_path.display()))?;
 
-        let new_content = ops::patch::apply_hunks(&original, &pf.hunks)
-            .map_err(|e| anyhow::anyhow!("patch apply error: {e}"))?;
+        let new_content = ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
+            if e.contains("stale context") {
+                anyhow::Error::new(crate::exit::AmbiguousError {
+                    msg: format!("patch apply error: {e}"),
+                })
+            } else {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("patch apply error: {e}"),
+                })
+            }
+        })?;
 
         let policy = crate::write::WritePolicy::default();
         let applied = super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
@@ -94,8 +106,11 @@ pub fn apply_patch_file(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<Vec<EditResult>> {
-    let patch_files = crate::ops::patch::parse_patch(patch_text)
-        .map_err(|e| anyhow::anyhow!("patch parse error: {e}"))?;
+    let patch_files = crate::ops::patch::parse_patch(patch_text).map_err(|e| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("patch parse error: {e}"),
+        })
+    })?;
 
     let mut results = Vec::new();
     for pf in &patch_files {
@@ -103,8 +118,17 @@ pub fn apply_patch_file(
         let original = std::fs::read_to_string(&file_path)
             .with_context(|| format!("failed to read {}", file_path.display()))?;
 
-        let new_content = crate::ops::patch::apply_hunks(&original, &pf.hunks)
-            .map_err(|e| anyhow::anyhow!("patch apply error for {}: {e}", pf.path))?;
+        let new_content = crate::ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
+            if e.contains("stale context") {
+                anyhow::Error::new(crate::exit::AmbiguousError {
+                    msg: format!("patch apply error for {}: {e}", pf.path),
+                })
+            } else {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("patch apply error for {}: {e}", pf.path),
+                })
+            }
+        })?;
 
         let policy = crate::write::WritePolicy::default();
         let applied = super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;

--- a/src/ast/extract_to_file.rs
+++ b/src/ast/extract_to_file.rs
@@ -33,8 +33,11 @@ pub fn extract_to_file(
 ) -> anyhow::Result<ExtractResult> {
     let eol = crate::write::detect_eol(source);
     let symbols = extract_symbols(source, lang);
-    let sym = find_symbol(&symbols, symbol)
-        .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", symbol))?;
+    let sym = find_symbol(&symbols, symbol).ok_or_else(|| {
+        anyhow::Error::new(crate::exit::NoMatchError {
+            msg: format!("symbol '{symbol}' not found"),
+        })
+    })?;
 
     let (full_start, full_end) = full_symbol_span(source, sym, lang);
     let lines: Vec<&str> = source.lines().collect();

--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -82,8 +82,11 @@ fn insert_inside(
     container_name: &str,
     position: InsertPosition,
 ) -> anyhow::Result<InsertResult> {
-    let sym = find_symbol(ctx.symbols, container_name)
-        .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", container_name))?;
+    let sym = find_symbol(ctx.symbols, container_name).ok_or_else(|| {
+        anyhow::Error::new(crate::exit::NoMatchError {
+            msg: format!("symbol '{container_name}' not found"),
+        })
+    })?;
 
     let start_idx = sym.start_line.saturating_sub(1);
     let end_idx = sym.end_line.min(ctx.lines.len());
@@ -222,8 +225,11 @@ fn insert_adjacent(
     symbol_name: &str,
     after: bool,
 ) -> anyhow::Result<InsertResult> {
-    let sym = find_symbol(ctx.symbols, symbol_name)
-        .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", symbol_name))?;
+    let sym = find_symbol(ctx.symbols, symbol_name).ok_or_else(|| {
+        anyhow::Error::new(crate::exit::NoMatchError {
+            msg: format!("symbol '{symbol_name}' not found"),
+        })
+    })?;
 
     // Use the symbol's indentation level for the new content
     let sym_start_idx = sym.start_line.saturating_sub(1);

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -177,8 +177,11 @@ fn insert_into_target(
         }
         MovePosition::After(sym_name) => {
             let symbols = extract_symbols(target, lang);
-            let sym = find_symbol(&symbols, sym_name)
-                .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in target", sym_name))?;
+            let sym = find_symbol(&symbols, sym_name).ok_or_else(|| {
+                anyhow::Error::new(crate::exit::NoMatchError {
+                    msg: format!("symbol '{sym_name}' not found in target"),
+                })
+            })?;
             let end_0 = sym.end_line.min(lines.len());
             let mut result = String::new();
             for line in &lines[..end_0] {
@@ -198,8 +201,11 @@ fn insert_into_target(
         }
         MovePosition::Before(sym_name) => {
             let symbols = extract_symbols(target, lang);
-            let sym = find_symbol(&symbols, sym_name)
-                .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found in target", sym_name))?;
+            let sym = find_symbol(&symbols, sym_name).ok_or_else(|| {
+                anyhow::Error::new(crate::exit::NoMatchError {
+                    msg: format!("symbol '{sym_name}' not found in target"),
+                })
+            })?;
             let (full_start, _) = full_symbol_span(target, sym, lang);
             let start_0 = full_start.saturating_sub(1);
             let mut result = String::new();

--- a/src/ast/reorder.rs
+++ b/src/ast/reorder.rs
@@ -42,8 +42,11 @@ pub fn reorder_symbols(
     let lines: Vec<&str> = source.lines().collect();
 
     let (scope_symbols, scope_start_0, scope_end_0) = if let Some(container) = inside {
-        let parent = find_symbol(&all_symbols, container)
-            .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", container))?;
+        let parent = find_symbol(&all_symbols, container).ok_or_else(|| {
+            anyhow::Error::new(crate::exit::NoMatchError {
+                msg: format!("symbol '{container}' not found"),
+            })
+        })?;
         // Find the opening brace line of the container
         let open_line_0 = find_opening_line(&lines, parent.start_line.saturating_sub(1));
         let close_line_0 = parent.end_line.min(lines.len()).saturating_sub(1);
@@ -268,9 +271,11 @@ pub fn parse_strategy(value: &serde_json::Value) -> anyhow::Result<ReorderStrate
             let names: Result<Vec<String>, _> = arr
                 .iter()
                 .map(|v| {
-                    v.as_str()
-                        .map(String::from)
-                        .ok_or_else(|| anyhow::anyhow!("custom order items must be strings"))
+                    v.as_str().map(String::from).ok_or_else(|| {
+                        anyhow::Error::new(crate::exit::InvalidInputError {
+                            msg: "custom order items must be strings".into(),
+                        })
+                    })
                 })
                 .collect();
             Ok(ReorderStrategy::Custom(names?))

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -155,9 +155,11 @@ pub fn compile_pattern_query(pattern: &str, lang: Language) -> anyhow::Result<St
 
     let root = tree.root_node();
     if root.has_error() {
-        anyhow::bail!(
-            "pattern is not valid {lang} syntax (after meta-variable substitution): {sanitized}"
-        );
+        return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!(
+                "pattern is not valid {lang} syntax (after meta-variable substitution): {sanitized}"
+            ),
+        }));
     }
 
     // Walk to the first meaningful child (skip source_file wrapper)

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -43,11 +43,17 @@ pub fn search_query(
     lang: Language,
     max_results: Option<usize>,
 ) -> anyhow::Result<Vec<SearchMatch>> {
-    let (tree, ts_lang) =
-        parse_source(source, lang).ok_or_else(|| anyhow::anyhow!("no grammar for {lang}"))?;
+    let (tree, ts_lang) = parse_source(source, lang).ok_or_else(|| {
+        anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("no grammar for {lang}"),
+        })
+    })?;
 
-    let query = tree_sitter_lib::Query::new(&ts_lang, query_str)
-        .map_err(|e| anyhow::anyhow!("invalid query: {e}"))?;
+    let query = tree_sitter_lib::Query::new(&ts_lang, query_str).map_err(|e| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("invalid query: {e}"),
+        })
+    })?;
 
     let mut cursor = tree_sitter_lib::QueryCursor::new();
     let source_bytes = source.as_bytes();
@@ -150,8 +156,11 @@ pub fn compile_pattern_query(pattern: &str, lang: Language) -> anyhow::Result<St
         sanitized.replace_range(start..end, &placeholder);
     }
 
-    let (tree, _) = parse_source(&sanitized, lang)
-        .ok_or_else(|| anyhow::anyhow!("cannot parse pattern for {lang}"))?;
+    let (tree, _) = parse_source(&sanitized, lang).ok_or_else(|| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("cannot parse pattern for {lang}"),
+        })
+    })?;
 
     let root = tree.root_node();
     if root.has_error() {

--- a/src/ast/split.rs
+++ b/src/ast/split.rs
@@ -47,12 +47,12 @@ pub fn split_file(
     for (idx, target) in targets.iter().enumerate() {
         for name in &target.symbols {
             if let Some(prev_idx) = sym_to_target.insert(name.as_str(), idx) {
-                anyhow::bail!(
-                    "symbol '{}' assigned to multiple targets: '{}' and '{}'",
-                    name,
-                    targets[prev_idx].path,
-                    target.path
-                );
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!(
+                        "symbol '{}' assigned to multiple targets: '{}' and '{}'",
+                        name, targets[prev_idx].path, target.path
+                    ),
+                }));
             }
         }
     }
@@ -68,10 +68,12 @@ pub fn split_file(
             }
         }
         if !unaccounted.is_empty() {
-            anyhow::bail!(
-                "unaccounted symbols (use keep_in_source or add to a target): {}",
-                unaccounted.join(", ")
-            );
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!(
+                    "unaccounted symbols (use keep_in_source or add to a target): {}",
+                    unaccounted.join(", ")
+                ),
+            }));
         }
     }
 

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -257,10 +257,12 @@ pub fn check_no_overlapping_spans(spans: &[(usize, usize)], names: &[&str]) -> a
     if overlaps.is_empty() {
         Ok(())
     } else {
-        anyhow::bail!(
-            "overlapping symbol spans would corrupt content: {}",
-            overlaps.join("; ")
-        )
+        Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!(
+                "overlapping symbol spans would corrupt content: {}",
+                overlaps.join("; ")
+            ),
+        }))
     }
 }
 

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -56,8 +56,11 @@ pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result
     }
     let source =
         std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
-    validate_source(&source, lang)
-        .ok_or_else(|| anyhow::anyhow!("failed to parse {}", path.display()))
+    validate_source(&source, lang).ok_or_else(|| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("failed to parse {}", path.display()),
+        })
+    })
 }
 
 fn collect_errors(node: tree_sitter_lib::Node, source: &str, errors: &mut Vec<SyntaxError>) {

--- a/src/ast/wrap.rs
+++ b/src/ast/wrap.rs
@@ -150,8 +150,11 @@ fn find_symbol_range(
     let mut max_end = 0usize;
 
     for name in symbol_names {
-        let sym = find_symbol(&symbols, name)
-            .ok_or_else(|| anyhow::anyhow!("symbol '{}' not found", name))?;
+        let sym = find_symbol(&symbols, name).ok_or_else(|| {
+            anyhow::Error::new(crate::exit::NoMatchError {
+                msg: format!("symbol '{name}' not found"),
+            })
+        })?;
         let (full_start, full_end) = full_symbol_span(source, sym, lang);
         let start = full_start.saturating_sub(1);
         let end = full_end;
@@ -184,9 +187,11 @@ fn parse_line_range_to_indices(spec: &str, total_lines: usize) -> anyhow::Result
         }));
     }
 
-    let start: usize = parts[0]
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid start line: {}", parts[0]))?;
+    let start: usize = parts[0].parse().map_err(|_| {
+        anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("invalid start line: {}", parts[0]),
+        })
+    })?;
 
     if start == 0 {
         return Err(anyhow::Error::new(crate::exit::InvalidInputError {
@@ -200,9 +205,11 @@ fn parse_line_range_to_indices(spec: &str, total_lines: usize) -> anyhow::Result
         return Ok((start_idx, total_lines));
     }
 
-    let end: usize = parts[1]
-        .parse()
-        .map_err(|_| anyhow::anyhow!("invalid end line: {}", parts[1]))?;
+    let end: usize = parts[1].parse().map_err(|_| {
+        anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("invalid end line: {}", parts[1]),
+        })
+    })?;
     if end < start {
         return Err(anyhow::Error::new(crate::exit::InvalidInputError {
             msg: format!("end line {end} is before start line {start}"),

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -555,7 +555,17 @@ impl GlobalFlags {
         } else {
             let list_path = self.resolve_user_path(source)?;
             let content = std::fs::read_to_string(&list_path).map_err(|e| {
-                anyhow::anyhow!("failed to read --files-from '{}': {e}", list_path.display())
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("failed to read --files-from '{}': {e}", list_path.display()),
+                    )
+                    .into()
+                } else {
+                    anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("failed to read --files-from '{}': {e}", list_path.display()),
+                    })
+                }
             })?;
             let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
             content
@@ -578,8 +588,11 @@ fn collect_files_from_line_results(
 ) -> anyhow::Result<Vec<String>> {
     let mut out = Vec::new();
     for (i, line_res) in lines.into_iter().enumerate() {
-        let mut l =
-            line_res.map_err(|e| anyhow::anyhow!("failed to read --files-from from stdin: {e}"))?;
+        let mut l = line_res.map_err(|e| {
+            anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("failed to read --files-from from stdin: {e}"),
+            })
+        })?;
         // BOM is not Unicode whitespace: strip it before trim on the first line.
         if i == 0
             && let Some(stripped) = l.strip_prefix('\u{FEFF}')

--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -83,7 +83,11 @@ pub(crate) fn get_git_file_content(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        anyhow::bail!("git show {git_ref}:{file_path} failed: {}", stderr.trim());
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("git show {git_ref}:{file_path} failed: {}", stderr.trim()),
+        )
+        .into());
     }
 
     Ok(String::from_utf8(output.stdout)?)

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -520,8 +520,19 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         std::io::read_to_string(std::io::stdin())?
     } else {
         let input_path = global.resolve_user_path(&args.input)?;
-        std::fs::read_to_string(&input_path)
-            .map_err(|e| anyhow::anyhow!("failed to read '{}': {e}", input_path.display()))?
+        std::fs::read_to_string(&input_path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("failed to read '{}': {e}", input_path.display()),
+                )
+                .into()
+            } else {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("failed to read '{}': {e}", input_path.display()),
+                })
+            }
+        })?
     };
 
     // Parse lines into operations.

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -124,16 +124,22 @@ pub(crate) fn run_mcp_http_server(
     );
 
     let app = axum::Router::new().nest_service("/mcp", service);
-    let addr: std::net::SocketAddr = format!("{host}:{port}")
-        .parse()
-        .map_err(|e| anyhow::anyhow!("invalid bind address: {e}"))?;
+    let addr: std::net::SocketAddr = format!("{host}:{port}").parse().map_err(|e| {
+        anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("invalid bind address: {e}"),
+        })
+    })?;
 
     let rt = tokio::runtime::Runtime::new()?;
     rt.block_on(async {
         if let (Some(cert), Some(key)) = (tls_cert, tls_key) {
             let tls_config = axum_server::tls_rustls::RustlsConfig::from_pem_file(cert, key)
                 .await
-                .map_err(|e| anyhow::anyhow!("TLS config error: {e}"))?;
+                .map_err(|e| {
+                    anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("TLS config error: {e}"),
+                    })
+                })?;
 
             let handle = axum_server::Handle::new();
             let h = handle.clone();

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -399,7 +399,9 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     if let Err(e) =
                         crate::ops::md::table_append_in(&content, body_start, body_end, &row)
                     {
-                        anyhow::bail!("{e} under heading {:?}", heading);
+                        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                            msg: format!("{e} under heading {:?}", heading),
+                        }));
                     }
                     let op = Operation::MdTableAppend {
                         path: file.clone(),

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -224,7 +224,17 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("internal error: plan path missing"))?;
         std::fs::read_to_string(plan_path).map_err(|e| {
-            anyhow::anyhow!("failed to read plan file '{}': {e}", plan_path.display())
+            if e.kind() == std::io::ErrorKind::NotFound {
+                std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("failed to read plan file '{}': {e}", plan_path.display()),
+                )
+                .into()
+            } else {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("failed to read plan file '{}': {e}", plan_path.display()),
+                })
+            }
         })?
     };
 

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -982,13 +982,15 @@ mod error_handling {
 
     #[test]
     fn parse_eol_mode_invalid_value_returns_error() {
-        let result = crate::write::parse_eol_mode("bogus");
-        let msg = result
-            .expect_err("invalid eol value should fail")
-            .to_string();
+        let err = crate::write::parse_eol_mode("bogus").expect_err("invalid eol value should fail");
+        let msg = err.to_string();
         assert!(
             msg.contains("invalid normalize_eol"),
             "error should name the field: {msg}"
+        );
+        assert!(
+            exit::is_invalid_input(&err),
+            "invalid normalize_eol must be typed InvalidInputError"
         );
     }
 
@@ -1023,8 +1025,8 @@ mod error_handling {
         let code = run(args, &global).unwrap();
         assert_eq!(
             code,
-            exit::OPERATION_FAILED,
-            "invalid normalize_eol should fail before commit"
+            exit::FAILURE,
+            "invalid normalize_eol should fail with invalid_input (exit 1)"
         );
     }
 

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -94,7 +94,13 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let session = sessions
             .iter()
             .find(|s| s.timestamp == timestamp)
-            .ok_or_else(|| anyhow::anyhow!("session {timestamp} not in session list (use `patchloom undo --list` to see available sessions)"))?;
+            .ok_or_else(|| {
+                anyhow::Error::new(crate::exit::NoMatchError {
+                    msg: format!(
+                        "session {timestamp} not in session list (use `patchloom undo --list` to see available sessions)"
+                    ),
+                })
+            })?;
 
         let entries: Vec<UndoPreviewEntry> = session
             .entries

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -707,8 +707,11 @@ pub(crate) fn apply_patch_with_loader<F>(
 where
     F: FnMut(&str) -> anyhow::Result<String>,
 {
-    let patch_files =
-        parse_patch(diff_text).map_err(|msg| anyhow::anyhow!("patch parse error: {msg}"))?;
+    let patch_files = parse_patch(diff_text).map_err(|msg| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("patch parse error: {msg}"),
+        })
+    })?;
     let mut results = Vec::new();
     for pf in &patch_files {
         // New file creation: original is empty, don't try to load from disk.
@@ -739,8 +742,16 @@ where
                 }
                 .into());
             }
+            Err(msg) if msg.contains("stale context") => {
+                return Err(crate::exit::AmbiguousError {
+                    msg: format!("patch apply: {} -- {msg}", pf.path),
+                }
+                .into());
+            }
             Err(msg) => {
-                return Err(anyhow::anyhow!("patch apply: {} -- {msg}", pf.path));
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("patch apply: {} -- {msg}", pf.path),
+                }));
             }
         };
         results.push(PatchApplyFileResult {

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -592,8 +592,11 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
             .replace("\x00LBRACE\x00", "{")
             .replace("\x00RBRACE\x00", "}");
 
-        let file_ops: Vec<Operation> = serde_json::from_str(&substituted)
-            .map_err(|e| anyhow::anyhow!("for_each: template expansion failed: {e}"))?;
+        let file_ops: Vec<Operation> = serde_json::from_str(&substituted).map_err(|e| {
+            anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("for_each: template expansion failed: {e}"),
+            })
+        })?;
         expanded.extend(file_ops);
     }
 

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -133,9 +133,9 @@ impl VerifyCheck {
         if let Some(kind) = kind {
             Ok(VerifyCheck::SymbolCount { kind, attr })
         } else {
-            anyhow::bail!(
-                "verify spec must contain 'kind=<type>' or a named check (unique_names, no_orphans)"
-            )
+            Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "verify spec must contain 'kind=<type>' or a named check (unique_names, no_orphans)".into(),
+            }))
         }
     }
 }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -473,8 +473,12 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
     };
 
     // 1. Collect matching files.
-    let glob_set = crate::files::build_glob_matcher(std::slice::from_ref(&fe.glob))?
-        .ok_or_else(|| anyhow::anyhow!("for_each: invalid glob pattern"))?;
+    let glob_set =
+        crate::files::build_glob_matcher(std::slice::from_ref(&fe.glob))?.ok_or_else(|| {
+            anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "for_each: invalid glob pattern".into(),
+            })
+        })?;
 
     let all_files = crate::files::collect_file_paths(cwd, false)?;
     let mut matched: Vec<std::path::PathBuf> = all_files

--- a/src/selector/mod.rs
+++ b/src/selector/mod.rs
@@ -7,7 +7,11 @@ pub use parser::{Segment, Selector, parse};
 /// Parse a selector string, mapping parse errors to `anyhow::Error` with
 /// a "selector error:" prefix for consistent error formatting.
 pub fn parse_anyhow(input: &str) -> anyhow::Result<Selector> {
-    parse(input).map_err(|e| anyhow::anyhow!("selector error: {e}"))
+    parse(input).map_err(|e| {
+        anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("selector error: {e}"),
+        })
+    })
 }
 
 /// Navigate a dotted path like `"settings.theme"` into a JSON value.

--- a/src/tx/md_op.rs
+++ b/src/tx/md_op.rs
@@ -92,8 +92,13 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
                     msg: format!("heading not found: {heading}"),
                 })?;
             let new_content =
-                crate::ops::md::table_append_in(file_content, body_start, body_end, row)
-                    .map_err(|e| anyhow::anyhow!("{e} under heading {heading:?}"))?;
+                crate::ops::md::table_append_in(file_content, body_start, body_end, row).map_err(
+                    |e| {
+                        anyhow::Error::new(crate::exit::InvalidInputError {
+                            msg: format!("{e} under heading {heading:?}"),
+                        })
+                    },
+                )?;
             update_file_content(
                 tx.pending,
                 tx.deletions,

--- a/src/write.rs
+++ b/src/write.rs
@@ -117,11 +117,11 @@ pub fn parse_eol_mode(mode: &str) -> anyhow::Result<EolMode> {
         "crlf" => Ok(EolMode::Crlf),
         "cr" => Ok(EolMode::Cr),
         "keep" => Ok(EolMode::Keep),
-        _ => {
-            anyhow::bail!(
+        _ => Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!(
                 "invalid normalize_eol value '{mode}': expected 'lf', 'crlf', 'cr', or 'keep'"
-            )
-        }
+            ),
+        })),
     }
 }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -654,7 +654,9 @@ pub(crate) fn atomic_create_new(
 
     tmp.persist_noclobber(path).map_err(|e| {
         if e.error.kind() == std::io::ErrorKind::AlreadyExists {
-            anyhow::anyhow!("file already exists: {}", path.display())
+            anyhow::Error::new(crate::exit::AlreadyExistsError {
+                msg: format!("file already exists: {}", path.display()),
+            })
         } else {
             anyhow::Error::from(e.error)
                 .context(format!("failed to persist tempfile to {}", path.display()))

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -910,6 +910,10 @@ mod error_handling {
             err.to_string().contains("invalid normalize_eol value"),
             "expected invalid eol error, got: {err}"
         );
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "invalid normalize_eol must be typed InvalidInputError for JSON error_kind"
+        );
         // Policy should not have been partially mutated before the error.
         assert!(matches!(policy.normalize_eol, EolMode::Keep));
     }

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -896,6 +896,10 @@ mod error_handling {
             err.to_string().contains("already exists"),
             "error should mention 'already exists': {err}"
         );
+        assert!(
+            crate::exit::is_already_exists(&err),
+            "create race must be typed AlreadyExistsError for JSON error_kind"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Continues agent-grade JSON `error_kind` parity so hosts can branch without scraping English. One batch PR (find many, land few). Five commits covering residual typed-error surface.

### AST / plan
- Split: duplicate / unaccounted symbols → `invalid_input`
- Search: invalid pattern / query → `parse_error`; no grammar → `invalid_input`
- Symbols: overlapping spans → `invalid_input`
- extract/insert/reorder/wrap/move missing symbols → `no_matches`
- Plan `verify` parse and `for_each` glob/template failures → `invalid_input`
- AST validate parse failure → `parse_error`

### Write / md / doc / undo
- Invalid `normalize_eol` → `invalid_input` (tx exit 1, was operation_failed)
- md table-append row/table failures (CLI + tx + API) → `invalid_input`
- Library doc mutation type errors → `type_error`
- Missing git blob for AST → `not_found`
- Create race → `already_exists`; unknown undo session → `no_matches`
- API md heading miss → `no_matches`

### Patch
- Engine + library: parse → `parse_error`; stale → `ambiguous`; other apply → `invalid_input`
- Missing/unreadable plan file → `not_found` / `invalid_input`

### CLI plumbing
- Missing `--files-from` / batch input → `not_found`
- Unreadable files-from stdin / MCP bind and TLS config → `invalid_input`

## Test plan

- [x] `make check-fast` green on each commit batch
- [x] Strengthened typed-error unit assertions for normalize_eol and create race
- [x] Updated `tx_invalid_normalize_eol_in_plan` to expect exit 1