### PR TITLE
docs(cli): expand agent-rules error_kind catalogue

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -305,17 +305,17 @@ dependencies[name=react].version # predicate filter
 | 0 | Success (operation completed, or no changes needed) |
 | 1 | Failure (error during execution, CLI usage/invalid args/unknown flags/subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |
 | 2 | Changes detected (`--check` / write preview, or plan/tx `search` `assert_count` mismatch; `error_kind: changes_detected` for assert_count) |
-| 3 | No matches (search/replace pattern miss, undo with no sessions, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
-| 4 | Parse error (malformed input file or plan) |
+| 3 | No matches (search/replace pattern miss, undo with no sessions, missing AST symbol for extract/insert/reorder/wrap/move, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
+| 4 | Parse error (malformed input file or plan, invalid AST search pattern/query, or AST validate parse failure; `error_kind: parse_error`) |
 | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |
 | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |
 | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |
 | 8 | Patch merge conflicts (CLI `patch merge` or plan/tx `patch.apply` with `on_stale: merge` without `allow_conflicts`; `error_kind: conflicts`) |
 | 9 | Tx operation staging failure (`operation_failed`) |
 
-**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`, `--contain` path rejections / empty paths, all-explicit-paths-missing for search/replace/tidy, and plan op option conflicts such as replace whole_line+multiline, tidy dedent+indent, md.move_section before/after, search invert_match+multiline). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type). Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.
+**JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set `already_exists` (create/rename without force, create race), `not_found` (delete/append/prepend/rename missing source, missing `--files-from`/batch input, missing plan file, missing git blob for AST, or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, `status` outside a git repo, AST map non-dir, doc merge flag conflicts, invalid `normalize_eol`, md table-append row/table failures, bad selector/for_each templates, MCP bind/TLS config, CLI usage errors under `--json`/`--jsonl`, `--contain` path rejections / empty paths, all-explicit-paths-missing for search/replace/tidy, and plan op option conflicts such as replace whole_line+multiline, tidy dedent+indent, md.move_section before/after, search invert_match+multiline). Doc type mismatches set `type_error` (`doc keys`/`len` on wrong type, library doc mutation type errors). Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.
 
-**JSON `error_kind` (exit 4):** Batch line parse failures, `explain` plan parse failures, and malformed JSON/YAML/TOML document content set `parse_error` so agents can distinguish syntax mistakes from runtime failures.
+**JSON `error_kind` (exit 4):** Batch line parse failures, `explain` plan parse failures, invalid AST search patterns/queries, AST validate parse failures, and malformed JSON/YAML/TOML document content set `parse_error` so agents can distinguish syntax mistakes from runtime failures.
 
 **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, doc delete success includes `changed` (bool) and `removed` (usize). Multi-op plans also list per-op rows under `mutations`. Exit 0 / `ok: true` with `removed: 0` means idempotent cleanup (nothing matched); do not assume data was deleted from exit status alone.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -82,6 +82,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **AST symbol-not-found is `no_matches`.** extract/insert/reorder/wrap/move paths set `error_kind: "no_matches"` (exit 3) when a named symbol is missing; create race `already_exists` and unknown undo session are typed the same way.
 - **Patch apply/parse typed for tx.** Plan/engine patch parse failures set `parse_error`; stale context sets `ambiguous`; other apply failures set `invalid_input` (CLI path already emitted kinds via string maps).
 - **files-from / batch input / MCP bind typed.** Missing `--files-from` or batch input files set `not_found`; unreadable lists and invalid MCP bind/TLS config set `invalid_input`; AST validate parse failure sets `parse_error`.
+- **Agent-rules `error_kind` catalogue expanded.** Exit 3/4 rows and exit-1 kind list cover AST symbol misses, normalize_eol, table-append, patch/plan/files-from kinds so agents match runtime envelopes.
 
 ## Agent and library notes
 

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -436,7 +436,11 @@ impl GlobalFlags {
             crate::containment::AbsolutePathPolicy::AllowIfContained,
         )
         .map(Some)
-        .map_err(|e| anyhow::anyhow!("failed to initialize --contain path guard: {e}"))
+        .map_err(|e| {
+            anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("failed to initialize --contain path guard: {e}"),
+            })
+        })
     }
 
     /// Validate user path args and, when `--contain` is set, reject escapes.

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -446,23 +446,27 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | 0 | Success (operation completed, or no changes needed) |\n\
              | 1 | Failure (error during execution, CLI usage/invalid args/unknown flags/subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |\n\
              | 2 | Changes detected (`--check` / write preview, or plan/tx `search` `assert_count` mismatch; `error_kind: changes_detected` for assert_count) |\n\
-             | 3 | No matches (search/replace pattern miss, undo with no sessions, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
-             | 4 | Parse error (malformed input file or plan) |\n\
+             | 3 | No matches (search/replace pattern miss, undo with no sessions, missing AST symbol for extract/insert/reorder/wrap/move, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
+             | 4 | Parse error (malformed input file or plan, invalid AST search pattern/query, or AST validate parse failure; `error_kind: parse_error`) |\n\
              | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |\n\
              | 6 | Validation failed (tx plan validation step returned non-zero; writes may remain when not strict) |\n\
              | 7 | Rollback (tx mid-commit failure or strict lifecycle failure; changes were rolled back) |\n\
              | 8 | Patch merge conflicts (CLI `patch merge` or plan/tx `patch.apply` with `on_stale: merge` without `allow_conflicts`; `error_kind: conflicts`) |\n\
              | 9 | Tx operation staging failure (`operation_failed`) |\n\n\
              **JSON `error_kind` (exit 1):** Prefer branching on kind, not English text. File ops set \
-             `already_exists` (create/rename without force), `not_found` (delete/append/prepend/rename missing source, \
+             `already_exists` (create/rename without force, create race), `not_found` (delete/append/prepend/rename missing source, \
+             missing `--files-from`/batch input, missing plan file, missing git blob for AST, \
              or `read` when every path fails), `invalid_input` (bad flags, non-file target, bad `read --lines`, \
-             `status` outside a git repo, AST map non-dir, doc merge flag conflicts, CLI usage errors under `--json`/`--jsonl`, \
-             `--contain` path rejections / empty paths, all-explicit-paths-missing for search/replace/tidy, \
+             `status` outside a git repo, AST map non-dir, doc merge flag conflicts, invalid `normalize_eol`, \
+             md table-append row/table failures, bad selector/for_each templates, MCP bind/TLS config, \
+             CLI usage errors under `--json`/`--jsonl`, `--contain` path rejections / empty paths, \
+             all-explicit-paths-missing for search/replace/tidy, \
              and plan op option conflicts such as replace whole_line+multiline, tidy dedent+indent, \
              md.move_section before/after, search invert_match+multiline). Doc type mismatches set \
-             `type_error` (`doc keys`/`len` on wrong type). \
+             `type_error` (`doc keys`/`len` on wrong type, library doc mutation type errors). \
              Clap usage failures with `--json`/`--jsonl` emit the same envelope on stdout before any subcommand runs.\n\n\
-             **JSON `error_kind` (exit 4):** Batch line parse failures, `explain` plan parse failures, and \
+             **JSON `error_kind` (exit 4):** Batch line parse failures, `explain` plan parse failures, \
+             invalid AST search patterns/queries, AST validate parse failures, and \
              malformed JSON/YAML/TOML document content set `parse_error` so agents can distinguish syntax \
              mistakes from runtime failures.\n\n\
              **Doc write JSON tip:** With `--json` (CLI) or MCP write tools / `execute_plan`, \

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -122,7 +122,11 @@ impl PatchloomService {
             cwd.clone(),
             crate::containment::AbsolutePathPolicy::Reject,
         )
-        .map_err(|e| anyhow::anyhow!("failed to initialize path guard: {e}"))?;
+        .map_err(|e| {
+            anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("failed to initialize path guard: {e}"),
+            })
+        })?;
         // --log flag takes precedence over PATCHLOOM_MCP_LOG env var.
         let call_log = log_flag
             .map(PathBuf::from)


### PR DESCRIPTION
## Summary

- Expand agent-rules / PATCHLOOM.md exit-code and `error_kind` catalogue for the typed-error work landed in #1609
- Type `--contain` / MCP path-guard initialization as `invalid_input`

## Test plan

- [x] `make sync-patchloom-md && make check-fast`