### PR TITLE
fix(doc): type YAML/TOML preserve-path serialize and re-parse errors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -89,6 +89,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Reference docs for typed extract/split/write_policy failures.** `docs/reference` documents `no_matches` / `already_exists` / `invalid_input` for extract, split, and invalid `normalize_eol`.
 - **Reference docs for insert/wrap/reorder/move failure kinds.** Missing symbols and bad wrap/reorder inputs document `no_matches` / `invalid_input`.
 - **Reference docs for replace/group/MCP bind failures.** `ast.replace` / `ast.group` missing symbols and MCP bind/TLS `invalid_input` documented.
+- **YAML/TOML preserve-path typed errors.** Comment-preserving re-parse failures set `parse_error`; serialization failures set `invalid_input` (was unstructured exit 1).
 
 ## Agent and library notes
 

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -52,8 +52,11 @@ pub fn serialize_value(value: &serde_json::Value, format: &FileFormat) -> anyhow
         }
         FileFormat::Yaml => Ok(serde_yaml_ng::to_string(value)?),
         FileFormat::Toml => {
-            let s = toml_edit::ser::to_string_pretty(value)
-                .map_err(|e| anyhow::anyhow!("TOML serialization error: {e}"))?;
+            let s = toml_edit::ser::to_string_pretty(value).map_err(|e| {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("TOML serialization error: {e}"),
+                })
+            })?;
             Ok(s)
         }
     }
@@ -80,9 +83,11 @@ pub fn serialize_value_preserving(
 ) -> anyhow::Result<String> {
     match format {
         FileFormat::Toml => {
-            let mut doc: toml_edit::DocumentMut = original_content
-                .parse()
-                .map_err(|e| anyhow::anyhow!("TOML re-parse for comment preservation: {e}"))?;
+            let mut doc: toml_edit::DocumentMut = original_content.parse().map_err(|e| {
+                anyhow::Error::new(crate::exit::ParseErrorError {
+                    msg: format!("TOML re-parse for comment preservation: {e}"),
+                })
+            })?;
             apply_value_diff(doc.as_item_mut(), old_value, new_value);
             Ok(doc.to_string())
         }
@@ -299,8 +304,11 @@ fn try_preserve_yaml(
 ) -> anyhow::Result<Option<String>> {
     use std::str::FromStr;
 
-    let file = yaml_edit::YamlFile::from_str(original_content)
-        .map_err(|e| anyhow::anyhow!("YAML re-parse for comment preservation: {e}"))?;
+    let file = yaml_edit::YamlFile::from_str(original_content).map_err(|e| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("YAML re-parse for comment preservation: {e}"),
+        })
+    })?;
 
     if let Some(doc) = file.document() {
         if let Some(mapping) = doc.as_mapping() {

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -209,13 +209,23 @@ pub(super) fn try_remove_subsequence(
 fn json_to_yaml_node(val: &serde_json::Value) -> anyhow::Result<yaml_edit::YamlNode> {
     use std::str::FromStr;
     let wrapper = serde_json::json!({ "__v__": val });
-    let yaml_text = serde_yaml_ng::to_string(&wrapper)
-        .map_err(|e| anyhow::anyhow!("YAML serialization failed: {e}"))?;
-    let doc = yaml_edit::Document::from_str(&yaml_text)
-        .map_err(|e| anyhow::anyhow!("YAML CST re-parse failed: {e}"))?;
+    let yaml_text = serde_yaml_ng::to_string(&wrapper).map_err(|e| {
+        anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!("YAML serialization failed: {e}"),
+        })
+    })?;
+    let doc = yaml_edit::Document::from_str(&yaml_text).map_err(|e| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("YAML CST re-parse failed: {e}"),
+        })
+    })?;
     doc.as_mapping()
         .and_then(|m| m.get("__v__"))
-        .ok_or_else(|| anyhow::anyhow!("YAML CST wrapper key missing"))
+        .ok_or_else(|| {
+            anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "YAML CST wrapper key missing".into(),
+            })
+        })
 }
 
 /// Convert a JSON object to a `yaml_edit::Mapping`.


### PR DESCRIPTION
## Summary

Typed errors on the comment-preserving YAML/TOML write path:

- Re-parse failures → `parse_error` (exit 4)
- Serialization / CST wrapper failures → `invalid_input` (exit 1)

## Test plan

- [x] `make check-fast`