### PR TITLE
fix(doc): type YAML multiline string escape failures

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -90,6 +90,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Reference docs for insert/wrap/reorder/move failure kinds.** Missing symbols and bad wrap/reorder inputs document `no_matches` / `invalid_input`.
 - **Reference docs for replace/group/MCP bind failures.** `ast.replace` / `ast.group` missing symbols and MCP bind/TLS `invalid_input` documented.
 - **YAML/TOML preserve-path typed errors.** Comment-preserving re-parse failures set `parse_error`; serialization failures set `invalid_input` (was unstructured exit 1).
+- **YAML newline-string escape typed.** Failure double-quoting multiline YAML scalars sets `invalid_input`.
 
 ## Agent and library notes
 

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -397,7 +397,9 @@ fn serialize_block_entries(
                 // line breaks into spaces, corrupting the data.
                 if s.contains('\n') {
                     let escaped = serde_json::to_string(s).map_err(|e| {
-                        anyhow::anyhow!("JSON-escape YAML string with newlines: {e}")
+                        anyhow::Error::new(crate::exit::InvalidInputError {
+                            msg: format!("JSON-escape YAML string with newlines: {e}"),
+                        })
                     })?;
                     out.push_str(&escaped);
                 } else if needs_yaml_quoting(s) {


### PR DESCRIPTION
## Summary

YAML splice path: multiline string JSON-escape failures set `error_kind: invalid_input`.

## Test plan

- [x] `make check-fast`