### PR TITLE
fix(api): peel exit typed errors in edit_error_kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -17,6 +17,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 
 ## Bug fixes
 
+- **Library `edit_error_kind` peels exit typed errors.** `InvalidInputError`, `NoMatchError`, `AmbiguousError`, `ParseErrorError`, `AlreadyExistsError`, and related kinds from CLI/tx paths now map to `EditErrorKind` (including through `.context()` wrappers). Empty replace/search patterns on `replace_in_content` / `search` / `search_directory` emit typed `InvalidInputError` so hosts can branch without scraping English.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -341,6 +341,10 @@ mod tests {
             before_msg.contains("empty"),
             "insert_before empty anchor: {before_msg}"
         );
+        assert_eq!(
+            crate::fallback::edit_error_kind(&before),
+            Some(EditErrorKind::InvalidInput)
+        );
         let after = apply_content_edits(
             "body\n",
             &[ContentEdit::InsertAfter {
@@ -353,6 +357,10 @@ mod tests {
         assert!(
             after_msg.contains("empty"),
             "insert_after empty anchor: {after_msg}"
+        );
+        assert_eq!(
+            crate::fallback::edit_error_kind(&after),
+            Some(EditErrorKind::InvalidInput)
         );
     }
 

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -44,7 +44,9 @@ fn file_write(
         Operation::FileCreate { content, force, .. } => {
             let path_str = path.to_string_lossy();
             if path.exists() && !path.is_file() {
-                bail!("target is not a file: {}", path.display());
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("target is not a file: {}", path.display()),
+                }));
             }
             let original = if path.exists() {
                 std::fs::read_to_string(path)
@@ -54,7 +56,9 @@ fn file_write(
             };
             let force = force.unwrap_or(false);
             if !force && path.exists() && mode != ApplyMode::Preview {
-                bail!("file already exists: {}", path.display());
+                return Err(anyhow::Error::new(crate::exit::AlreadyExistsError {
+                    msg: format!("file already exists: {}", path.display()),
+                }));
             }
             let policy = crate::write::WritePolicy::default();
             let applied = super::write_if_apply(path, &content, mode, &policy, guard)?;
@@ -65,7 +69,11 @@ fn file_write(
         Operation::FileDelete { .. } => {
             let path_str = path.to_string_lossy();
             if !path.exists() {
-                bail!("file not found: {}", path.display());
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("file not found: {}", path.display()),
+                )
+                .into());
             }
             let original = std::fs::read_to_string(path)
                 .with_context(|| format!("failed to read {}", path.display()))?;
@@ -91,10 +99,16 @@ fn file_write(
             let content = content.clone();
             let path_str = path.to_string_lossy();
             if path.exists() && !path.is_file() {
-                bail!("target is not a file: {}", path.display());
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("target is not a file: {}", path.display()),
+                }));
             }
             if !path.exists() {
-                bail!("file does not exist: {}", path.display());
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("file does not exist: {}", path.display()),
+                )
+                .into());
             }
             let original = std::fs::read_to_string(path)
                 .with_context(|| format!("failed to read {}", path.display()))?;
@@ -139,10 +153,12 @@ fn file_write_cross(
     if let Operation::FileRename { to, force, .. } = _op {
         let dst = Path::new(&to);
         if !force && dst.exists() {
-            bail!(
-                "destination already exists: {} (use force to overwrite)",
-                dst.display()
-            );
+            return Err(anyhow::Error::new(crate::exit::AlreadyExistsError {
+                msg: format!(
+                    "destination already exists: {} (use force to overwrite)",
+                    dst.display()
+                ),
+            }));
         }
         let original = std::fs::read_to_string(src)
             .with_context(|| format!("failed to read {}", src.display()))?;

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -161,7 +161,9 @@ fn replace_write(
 
         let is_regex = regex_mode;
         if old.is_empty() && !is_regex {
-            bail!("empty search pattern");
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "empty search pattern".into(),
+            }));
         }
 
         let compiled_re = ops::replace::compile_replace_regex(
@@ -352,17 +354,24 @@ pub fn replace_in_content(
     opts: &ReplaceOptions,
 ) -> anyhow::Result<ContentEditResult> {
     use crate::ops;
-    use anyhow::bail;
 
     let is_regex = opts.regex;
+    // Match replace_text: typed InvalidInputError so edit_error_kind peels
+    // invalid_input without scraping English.
     if from.is_empty() && !is_regex {
-        bail!("empty search pattern");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "empty search pattern".into(),
+        }));
     }
     if opts.range.is_some() && !opts.whole_line {
-        bail!("range requires whole_line to be true");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "range requires whole_line to be true".into(),
+        }));
     }
     if opts.whole_line && opts.multiline {
-        bail!("whole_line and multiline cannot be combined");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "whole_line and multiline cannot be combined".into(),
+        }));
     }
 
     // Shell command-position path (#1494): only rewrite invocable command tokens.

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -253,11 +253,11 @@ fn replace_write(
         // engine (which bails on unique before context), but is intentional:
         // context-resolved results are unambiguous by definition.
         if unique && count > 1 {
-            bail!(
-                "ambiguous match: pattern {:?} matches {} times; use --nth or add context to disambiguate",
-                old,
-                count
-            );
+            return Err(anyhow::Error::new(crate::exit::AmbiguousError {
+                msg: format!(
+                    "ambiguous match: pattern {old:?} matches {count} times; use --nth or add context to disambiguate"
+                ),
+            }));
         }
 
         // Fuzzy/context fallback: when exact match fails and fuzzy or context
@@ -306,14 +306,14 @@ fn replace_write(
                         ));
                     }
                     let similar = fallback::find_similar_targets(&original, &old, 3);
-                    let mut msg = format!("no matches for {:?}", old);
+                    let mut msg = format!("no matches for {old:?}");
                     if let Some(suggestion) = &edit_error.suggestion {
-                        msg.push_str(&format!(" (suggestion: {})", suggestion));
+                        msg.push_str(&format!(" (suggestion: {suggestion})"));
                     }
                     if !similar.is_empty() {
                         msg.push_str(&format!(" (did you mean: {}?)", similar.join(", ")));
                     }
-                    bail!("{msg}");
+                    return Err(anyhow::Error::new(crate::exit::NoMatchError { msg }));
                 }
             }
         }

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -2,7 +2,7 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 
 use crate::ops;
 
@@ -33,7 +33,9 @@ pub fn search(
         .with_context(|| format!("failed to read {}", path.display()))?;
 
     if pattern.is_empty() {
-        bail!("search pattern must not be empty");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "search pattern must not be empty".into(),
+        }));
     }
 
     let compiled_re = if regex || case_insensitive {
@@ -184,7 +186,9 @@ pub fn search_directory(
     opts: &SearchOptions,
 ) -> anyhow::Result<Vec<SearchResult>> {
     if pattern.is_empty() {
-        bail!("search pattern must not be empty");
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "search pattern must not be empty".into(),
+        }));
     }
 
     #[cfg(any(feature = "cli", feature = "files"))]
@@ -223,10 +227,14 @@ pub fn search_directory(
     #[cfg(not(any(feature = "cli", feature = "files")))]
     {
         if opts.multiline {
-            bail!("multiline search requires the 'cli' or 'files' feature");
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "multiline search requires the 'cli' or 'files' feature".into(),
+            }));
         }
         if opts.invert_match {
-            bail!("invert_match search requires the 'cli' or 'files' feature");
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "invert_match search requires the 'cli' or 'files' feature".into(),
+            }));
         }
         // fallback to single file search (multi-match supported via basic search)
         if root.is_file() {
@@ -258,9 +266,9 @@ pub fn search_directory(
                 .collect();
             Ok(results)
         } else {
-            bail!(
-                "search_directory requires the 'files' feature to be enabled (for pure-library recursive search with ignores/parallelism)"
-            );
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "search_directory requires the 'files' feature to be enabled (for pure-library recursive search with ignores/parallelism)".into(),
+            }));
         }
     }
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -450,6 +450,11 @@ fn replace_text_empty_pattern_rejected() {
     )
     .unwrap_err();
     assert!(err.to_string().contains("empty search pattern"));
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput),
+        "library hosts must peel invalid_input without scraping English"
+    );
 }
 
 #[test]
@@ -1175,6 +1180,10 @@ fn search_empty_pattern_returns_error() {
         err.to_string().contains("empty"),
         "expected empty pattern error, got: {err}"
     );
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
 }
 
 #[test]
@@ -1639,6 +1648,10 @@ fn search_directory_empty_pattern_errors() {
     let opts = SearchOptions::default();
     let err = search_directory(dir.path(), "", &opts).unwrap_err();
     assert!(err.to_string().contains("must not be empty"));
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
 }
 
 #[test]
@@ -2538,6 +2551,12 @@ fn replace_in_content_case_insensitive() {
 fn replace_in_content_empty_pattern_errors() {
     let result = replace::replace_in_content("content", "", "x", &ReplaceOptions::default());
     assert!(result.is_err(), "expected error, got Ok: {result:?}");
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("empty search pattern"));
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
 }
 
 #[test]
@@ -2559,11 +2578,11 @@ fn replace_in_content_range_requires_whole_line() {
     };
     let result = replace::replace_in_content("aaa\nbbb\n", "aaa", "xxx", &opts);
     assert!(result.is_err(), "expected error, got Ok: {result:?}");
-    assert!(
-        result
-            .unwrap_err()
-            .to_string()
-            .contains("range requires whole_line")
+    let err = result.unwrap_err();
+    assert!(err.to_string().contains("range requires whole_line"));
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
     );
 }
 

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -151,10 +151,61 @@ impl EditError {
 }
 
 /// Downcast an `anyhow` error chain to [`EditErrorKind`] when present.
+///
+/// Peels both [`EditError`] and the CLI/tx typed errors in [`crate::exit`]
+/// (`InvalidInputError`, `NoMatchError`, …) so library hosts can branch on
+/// kind without caring which construction path produced the failure.
 pub fn edit_error_kind(err: &anyhow::Error) -> Option<EditErrorKind> {
     for cause in err.chain() {
         if let Some(e) = cause.downcast_ref::<EditError>() {
             return Some(e.kind);
+        }
+        // Map exit::* typed errors used by CLI/tx and many api::* paths.
+        // Prefer EditError when both appear (checked first above).
+        if cause.downcast_ref::<crate::exit::NoMatchError>().is_some() {
+            return Some(EditErrorKind::NoMatch);
+        }
+        if cause
+            .downcast_ref::<crate::exit::AmbiguousError>()
+            .is_some()
+        {
+            return Some(EditErrorKind::AmbiguousTarget);
+        }
+        if cause
+            .downcast_ref::<crate::exit::InvalidInputError>()
+            .is_some()
+        {
+            return Some(EditErrorKind::InvalidInput);
+        }
+        if cause
+            .downcast_ref::<crate::exit::ParseErrorError>()
+            .is_some()
+        {
+            return Some(EditErrorKind::ParseError);
+        }
+        if cause
+            .downcast_ref::<crate::exit::AlreadyExistsError>()
+            .is_some()
+            || cause
+                .downcast_ref::<crate::exit::TypeErrorError>()
+                .is_some()
+        {
+            return Some(EditErrorKind::InvalidInput);
+        }
+        if cause
+            .downcast_ref::<crate::exit::ConflictsError>()
+            .is_some()
+        {
+            // Patch merge conflicts are not region batch conflicts, but both
+            // mean "edit could not apply cleanly"; OperationFailed is the
+            // closest shared kind for hosts that only branch on EditErrorKind.
+            return Some(EditErrorKind::OperationFailed);
+        }
+        if cause
+            .downcast_ref::<crate::exit::ChangesDetectedError>()
+            .is_some()
+        {
+            return Some(EditErrorKind::OperationFailed);
         }
     }
     None
@@ -672,6 +723,49 @@ mod tests {
             "conflicting_edit"
         );
         assert_eq!(EditErrorKind::ParseError.to_string(), "parse_error");
+    }
+
+    #[test]
+    fn edit_error_kind_maps_exit_typed_errors() {
+        let invalid: anyhow::Error = crate::exit::InvalidInputError {
+            msg: "empty search pattern".into(),
+        }
+        .into();
+        assert_eq!(edit_error_kind(&invalid), Some(EditErrorKind::InvalidInput));
+
+        let no_match: anyhow::Error = crate::exit::NoMatchError {
+            msg: "no matches".into(),
+        }
+        .into();
+        assert_eq!(edit_error_kind(&no_match), Some(EditErrorKind::NoMatch));
+
+        let ambiguous: anyhow::Error = crate::exit::AmbiguousError {
+            msg: "multiple matches".into(),
+        }
+        .into();
+        assert_eq!(
+            edit_error_kind(&ambiguous),
+            Some(EditErrorKind::AmbiguousTarget)
+        );
+
+        let parse: anyhow::Error = crate::exit::ParseErrorError {
+            msg: "bad yaml".into(),
+        }
+        .into();
+        assert_eq!(edit_error_kind(&parse), Some(EditErrorKind::ParseError));
+
+        let exists: anyhow::Error = crate::exit::AlreadyExistsError {
+            msg: "file already exists".into(),
+        }
+        .into();
+        assert_eq!(edit_error_kind(&exists), Some(EditErrorKind::InvalidInput));
+
+        // Intermediate .context() must not hide the typed kind.
+        let wrapped = invalid.context("operation 1 (replace) failed");
+        assert_eq!(edit_error_kind(&wrapped), Some(EditErrorKind::InvalidInput));
+
+        let plain = anyhow::anyhow!("plain error");
+        assert_eq!(edit_error_kind(&plain), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extend `edit_error_kind` to map CLI/tx typed errors (`InvalidInputError`, `NoMatchError`, `AmbiguousError`, `ParseErrorError`, `AlreadyExistsError`, `TypeErrorError`, `ConflictsError`, `ChangesDetectedError`) so library hosts can branch without scraping English (including through `.context()` wrappers).
- Type residual library validation: empty replace/search patterns, `replace_in_content` range/whole_line conflicts, no-cli file create/rename already-exists and not-found paths.
- Type pure-library `replace_write` no-match / ambiguous failures; lock `apply_content_edits` empty-anchor paths with `edit_error_kind` asserts.
- RELEASE_NOTES and unit tests.

## Test plan

- [x] `make check-fast` (first commit)
- [x] Unit: `edit_error_kind_maps_exit_typed_errors`, empty-pattern / empty-anchor kind asserts
- [x] clippy on second commit