### PR TITLE
fix(api): fail closed on invalid search regex

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 ## Bug fixes
 
 - **Library `edit_error_kind` peels exit typed errors.** `InvalidInputError`, `NoMatchError`, `AmbiguousError`, `ParseErrorError`, `AlreadyExistsError`, and related kinds from CLI/tx paths now map to `EditErrorKind` (including through `.context()` wrappers). Empty replace/search patterns on `replace_in_content` / `search` / `search_directory` emit typed `InvalidInputError` so hosts can branch without scraping English.
+- **`search_directory` / `search_file` invalid regex.** Bad patterns (e.g. unclosed groups) now return `InvalidInputError` / `edit_error_kind` `InvalidInput` instead of `Ok([])`, which looked like a soft no-match. Low-level `search_one_file` still returns empty on compile failure for custom walkers; high-level APIs preflight.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -190,6 +190,11 @@ pub fn search_directory(
             msg: "search pattern must not be empty".into(),
         }));
     }
+    // Fail closed on invalid regex before scanning: search_one_file soft-skips
+    // bad patterns (returns empty) so a directory walk would look like "no
+    // matches" (agent-hostile). Preflight matches CLI/search() erroring on
+    // compile failure.
+    validate_search_pattern(pattern, opts)?;
 
     #[cfg(any(feature = "cli", feature = "files"))]
     {
@@ -273,7 +278,31 @@ pub fn search_directory(
     }
 }
 
-#[cfg(any(feature = "cli", feature = "files"))]
+/// Compile the pattern the same way [`search_one_file`] does, or error.
+///
+/// Used by high-level APIs so invalid regex is not mistaken for zero matches.
+fn validate_search_pattern(pattern: &str, opts: &SearchOptions) -> anyhow::Result<()> {
+    if !(opts.regex || opts.case_insensitive || opts.multiline) {
+        return Ok(());
+    }
+    let pat = if opts.literal || (opts.multiline && !opts.regex) {
+        regex::escape(pattern)
+    } else {
+        pattern.to_string()
+    };
+    crate::bounded_regex_builder(&pat)
+        .case_insensitive(opts.case_insensitive)
+        .multi_line(true)
+        .dot_matches_new_line(opts.multiline)
+        .build()
+        .map_err(|e| {
+            anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("regex parse error: {e}"),
+            })
+        })?;
+    Ok(())
+}
+
 /// Low-level single-file matcher for callers that already selected the files.
 ///
 /// Returns rich [`SearchResult`]s (including `column` and context when requested
@@ -283,6 +312,13 @@ pub fn search_directory(
 ///
 /// Prefer [`search_file`] for simple per-file use and [`search_directory`] for
 /// full directory walking with built-in ignore support.
+///
+/// **Invalid regex:** this low-level helper returns an empty `Vec` when the
+/// pattern fails to compile (so walkers can keep going). High-level
+/// [`search_directory`] / [`search_file`] preflight and return
+/// `InvalidInputError` instead — prefer those when agents must not treat a
+/// bad pattern as "no matches."
+#[cfg(any(feature = "cli", feature = "files"))]
 pub fn search_one_file(
     path: &Path,
     pattern: &str,

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1656,6 +1656,45 @@ fn search_directory_empty_pattern_errors() {
 
 #[test]
 #[cfg(any(feature = "cli", feature = "files"))]
+fn search_directory_invalid_regex_errors() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("f.txt"), "hello\n").unwrap();
+    let opts = SearchOptions {
+        regex: true,
+        ..Default::default()
+    };
+    // Must not soft-succeed with empty hits (agent-hostile "no matches").
+    let err = search_directory(dir.path(), "(unclosed", &opts).unwrap_err();
+    assert!(
+        err.to_string().contains("regex parse error"),
+        "expected regex parse error, got: {err}"
+    );
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "cli", feature = "files"))]
+fn search_file_invalid_regex_errors() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    std::fs::write(&file, "hello\n").unwrap();
+    let opts = SearchOptions {
+        regex: true,
+        ..Default::default()
+    };
+    let err = search_file(&file, "(unclosed", &opts).unwrap_err();
+    assert!(err.to_string().contains("regex parse error"));
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
+}
+
+#[test]
+#[cfg(any(feature = "cli", feature = "files"))]
 fn search_directory_invalid_glob_errors() {
     let dir = TempDir::new().unwrap();
     std::fs::write(


### PR DESCRIPTION
## Summary

- `search_directory` / `search_file` preflight regex compile and return typed `InvalidInputError` (`edit_error_kind` → `InvalidInput`) for bad patterns such as `(unclosed`.
- Previously these returned `Ok([])`, which agents treat as soft no-match.
- Document that low-level `search_one_file` still returns empty on compile failure for custom walkers.

## Test plan

- [x] `make check-fast`
- [x] Unit: `search_directory_invalid_regex_errors`, `search_file_invalid_regex_errors`