### PR TITLE
test: lock invalid replace regex error_kind invalid_input

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -22,6 +22,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Shared replace/search regex compile typing.** `compile_replace_regex` and CLI `build_matcher` map parse failures to `InvalidInputError`, so library `search()` / `replace_in_content`, tx replace, and CLI `search --json` set `error_kind: invalid_input` without scraping the regex crate message.
 - **`bounded_regex_build` helper.** Finishes a `bounded_regex_builder` as `InvalidInputError`. Used by replace/search compile, tx plan search, and AST in-symbol regex replace so all paths share one kind.
 - **Agent-rules / reference docs.** Document invalid search/replace regex as `error_kind: invalid_input` (exit 1) so agents do not treat compile failures as soft no-match.
+- **Replace invalid-regex JSON lock.** CLI `replace --json` with a bad pattern sets `error_kind: invalid_input` (integration coverage next to the existing text-mode regex parse test).
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1203,6 +1203,20 @@ fn search_invalid_regex_is_invalid_input() {
 }
 
 #[test]
+fn replace_in_content_invalid_regex_is_invalid_input() {
+    let opts = ReplaceOptions {
+        regex: true,
+        ..Default::default()
+    };
+    let err = replace::replace_in_content("hello\n", "(unclosed", "x", &opts).unwrap_err();
+    assert!(err.to_string().contains("regex parse error"));
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
+}
+
+#[test]
 fn search_case_insensitive() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -198,6 +198,28 @@ fn test_replace_invalid_regex_fails() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("regex parse error"));
+
+    // --json must set error_kind so agents do not scrape English.
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "--regex",
+            "[invalid(regex",
+            "--new",
+            "x",
+        ])
+        .arg(&file)
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "invalid replace regex should set error_kind: {parsed}"
+    );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extend `test_replace_invalid_regex_fails` with `--json` `error_kind: invalid_input` assert.
- Library unit: `replace_in_content` invalid regex peels `EditErrorKind::InvalidInput`.

## Test plan

- [x] `make check-fast`
- [x] Integration + unit filters for invalid replace regex