### PR TITLE
docs: format_failed failure notes and library InvalidInput example

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,11 @@ match api::replace_in_content("body", "missing", "x", &opts) {
     Ok(r) => println!("changed={}", r.changed),
     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::NoMatch)),
 }
+// Invalid options and bad regex peel InvalidInput (CLI/tx typed errors included)
+match api::replace_in_content("body", "", "x", &ReplaceOptions::default()) {
+    Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::InvalidInput)),
+    Ok(_) => panic!("empty pattern must error"),
+}
 
 // Set a value in a JSON file
 api::doc_set(

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Agent-rules / reference docs.** Document invalid search/replace regex as `error_kind: invalid_input` (exit 1) so agents do not treat compile failures as soft no-match.
 - **Replace invalid-regex JSON lock.** CLI `replace --json` with a bad pattern sets `error_kind: invalid_input` (integration coverage next to the existing text-mode regex parse test).
 - **Post-write format failures typed.** Explicit `--format` / format-timeout failures set `error_kind: format_failed` (exit 1) so agents can branch without scraping English (files may already be written; use `undo` or re-run the formatter).
+- **Docs: format failure kinds + library InvalidInput example.** Reference documents `--format` / `--format-timeout` `format_failed` envelopes; README library sample shows `edit_error_kind` peeling `InvalidInput` for empty patterns.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -89,6 +89,7 @@ These flags shape how written content is normalized before it reaches disk.
 - **What it does:** Runs a shell command after every successful `--apply` write. Intended for formatters (e.g. `prettier --write .`, `cargo fmt`).
 - **Use when:** The repo has an autoformatter and you want Patchloom to invoke it after each mutation so files stay formatted.
 - **Prefer instead:** Omit when the formatter is already run separately, or when using `--diff`/`--check` modes (the command only fires on `--apply`).
+- **Failure behavior:** Non-zero exit or timeout exits **1** with `error_kind: "format_failed"` under `--json`/`--jsonl`. The write may already be on disk; use `undo` or re-run the formatter.
 
 <!-- ref:write-flag:format-timeout -->
 ### `--format-timeout`
@@ -96,6 +97,7 @@ These flags shape how written content is normalized before it reaches disk.
 - **What it does:** Sets the maximum time in seconds the `--format` command is allowed to run before being killed. Defaults to 30 seconds.
 - **Use when:** The formatter is slow (e.g. large monorepo) and the default 30 second timeout is insufficient.
 - **Prefer instead:** Keep the default unless the formatter demonstrably needs more time.
+- **Failure behavior:** Exceeding the timeout kills the formatter process tree and exits **1** with `error_kind: "format_failed"` (same envelope as a failing `--format` command).
 
 <!-- ref:write-flag:no-format -->
 ### `--no-format`


### PR DESCRIPTION
## Summary

- Reference: `--format` / `--format-timeout` document `error_kind: format_failed` (exit 1) when the post-write formatter fails or times out.
- README library sample peels `EditErrorKind::InvalidInput` for empty replace patterns (alongside NoMatch).

## Test plan

- [x] `make check-fast`