### PR TITLE
test: lock tx --format failure JSON error_kind format_failed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -25,6 +25,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Replace invalid-regex JSON lock.** CLI `replace --json` with a bad pattern sets `error_kind: invalid_input` (integration coverage next to the existing text-mode regex parse test).
 - **Post-write format failures typed.** Explicit `--format` / format-timeout failures set `error_kind: format_failed` (exit 1) so agents can branch without scraping English (files may already be written; use `undo` or re-run the formatter).
 - **Docs: format failure kinds + library InvalidInput example.** Reference documents `--format` / `--format-timeout` `format_failed` envelopes; README library sample shows `edit_error_kind` peeling `InvalidInput` for empty patterns.
+- **Tx `--format` JSON lock.** `tx --apply --format false --json` sets `error_kind: format_failed` (exit 1) after commit, matching standalone write commands.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7427,6 +7427,52 @@ fn test_tx_global_format_failure_includes_undo_hint() {
     );
 }
 
+/// Same as undo-hint test, but `--json` must set `error_kind: format_failed`.
+#[test]
+fn test_tx_global_format_failure_json_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("target.txt");
+    fs::write(&file, "old\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "replace",
+            "path": portable_path_str(&file),
+            "old": "old",
+            "new": "new"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "tx",
+            plan_file.to_str().unwrap(),
+            "--apply",
+            "--format",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "format_failed",
+        "post-write --format failure should set error_kind: {parsed}"
+    );
+    let err = parsed["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("format command failed") || err.contains("formatting failed"),
+        "error text should mention format failure: {parsed}"
+    );
+}
+
 /// TX engine should resolve lang hint via lang_from_str (language names),
 /// not just from_extension (#1170).
 #[test]


### PR DESCRIPTION
## Summary

- Integration test: `tx --apply --format false --json` sets `error_kind: format_failed` (exit 1).
- Complements the existing undo-hint text-mode test for the same path.

## Test plan

- [x] `make check-fast`
- [x] `test_tx_global_format_failure_json_error_kind`