### PR TITLE
test: unit-lock FormatFailedError for --format fail and timeout

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Post-write format failures typed.** Explicit `--format` / format-timeout failures set `error_kind: format_failed` (exit 1) so agents can branch without scraping English (files may already be written; use `undo` or re-run the formatter).
 - **Docs: format failure kinds + library InvalidInput example.** Reference documents `--format` / `--format-timeout` `format_failed` envelopes; README library sample shows `edit_error_kind` peeling `InvalidInput` for empty patterns.
 - **Tx `--format` JSON lock.** `tx --apply --format false --json` sets `error_kind: format_failed` (exit 1) after commit, matching standalone write commands.
+- **Format unit locks.** Explicit `--format` failure and format-timeout map to `FormatFailedError` in unit tests (not only integration).
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -979,6 +979,36 @@ mod format_command_tests {
     }
 
     #[test]
+    fn explicit_format_failure_is_format_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut global = test_global_flags();
+        global.format = Some("false".into());
+        let err = run_format_command(&global, dir.path()).unwrap_err();
+        assert!(
+            crate::exit::is_format_failed(&err),
+            "explicit --format failure must be FormatFailedError: {err}"
+        );
+        assert!(err.to_string().contains("format command failed"));
+    }
+
+    #[test]
+    fn explicit_format_timeout_is_format_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut global = test_global_flags();
+        global.format = Some("sleep 60".into());
+        global.format_timeout = Some(1);
+        let err = run_format_command(&global, dir.path()).unwrap_err();
+        assert!(
+            crate::exit::is_format_failed(&err),
+            "format timeout must be FormatFailedError: {err}"
+        );
+        assert!(
+            err.to_string().contains("timed out") || err.to_string().contains("format command"),
+            "msg={err}"
+        );
+    }
+
+    #[test]
     fn run_format_command_ext_no_format_skips() {
         let dir = tempfile::tempdir().unwrap();
         let mut global = test_global_flags();


### PR DESCRIPTION
## Summary

- Unit tests: explicit `--format false` and format-timeout map to `FormatFailedError`.
- Complements integration coverage for tx `--json` `format_failed`.

## Test plan

- [x] `make check-fast`
- [x] `explicit_format_failure_is_format_failed`, `explicit_format_timeout_is_format_failed`