### PR TITLE
docs(lib): show edit_error_kind peeling InvalidInput and exit types

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Docs: format failure kinds + library InvalidInput example.** Reference documents `--format` / `--format-timeout` `format_failed` envelopes; README library sample shows `edit_error_kind` peeling `InvalidInput` for empty patterns.
 - **Tx `--format` JSON lock.** `tx --apply --format false --json` sets `error_kind: format_failed` (exit 1) after commit, matching standalone write commands.
 - **Format unit locks.** Explicit `--format` failure and format-timeout map to `FormatFailedError` in unit tests (not only integration).
+- **Crate docs: edit_error_kind peels exit types.** Library rustdoc shows `InvalidInput` for empty patterns and notes that CLI/tx typed errors map through `edit_error_kind`.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,9 @@
 //!
 //! Fail-closed text edits for agent hosts (#1492): set `ReplaceOptions.require_change = true`
 //! so zero matches become `EditErrorKind::NoMatch` (not `Ok(changed=false)`). Match kinds via
-//! `api::edit_error_kind(&err)` without scraping English. Example:
+//! `api::edit_error_kind(&err)` without scraping English. That helper also peels CLI/tx typed
+//! errors (`InvalidInputError` for empty patterns / bad regex, `NoMatchError`, …) so hosts
+//! need not know which construction path produced the failure. Example:
 //!
 //! ```rust,no_run
 //! use patchloom::api::{self, ReplaceOptions, edit_error_kind, EditErrorKind};
@@ -94,6 +96,10 @@
 //! match api::replace_in_content("a b", "missing", "x", &opts) {
 //!     Ok(r) => assert!(r.changed),
 //!     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::NoMatch)),
+//! }
+//! match api::replace_in_content("a b", "", "x", &ReplaceOptions::default()) {
+//!     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::InvalidInput)),
+//!     Ok(_) => panic!("empty pattern must error"),
 //! }
 //! ```
 //!


### PR DESCRIPTION
## Summary

- Crate-level rustdoc: `edit_error_kind` peels exit typed errors; empty-pattern `InvalidInput` example alongside NoMatch.
- RELEASE_NOTES bullet.

## Test plan

- [x] `make check-fast`
- [x] `cargo test --doc --all-features`