### PR TITLE
test: lock replace --format failure JSON error_kind format_failed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,6 +28,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx `--format` JSON lock.** `tx --apply --format false --json` sets `error_kind: format_failed` (exit 1) after commit, matching standalone write commands.
 - **Format unit locks.** Explicit `--format` failure and format-timeout map to `FormatFailedError` in unit tests (not only integration).
 - **Crate docs: edit_error_kind peels exit types.** Library rustdoc shows `InvalidInput` for empty patterns and notes that CLI/tx typed errors map through `edit_error_kind`.
+- **Replace `--format` JSON lock.** Standalone `replace --apply --format false --json` sets `error_kind: format_failed` (exit 1); file still written (same recovery model as tx).
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1315,6 +1315,30 @@ fn test_replace_format_flag_skipped_in_diff_mode() {
 }
 
 #[test]
+fn test_replace_format_failure_json_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "aaa\n").unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args([
+            "--json", "replace", "aaa", "--new", "bbb", "--apply", "--format", "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "format_failed",
+        "standalone replace --format failure should set error_kind: {parsed}"
+    );
+    // Write still applied before format failure.
+    assert_eq!(fs::read_to_string(&file).unwrap(), "bbb\n");
+}
+
+#[test]
 fn test_replace_before_context_disambiguates() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("f.txt");


### PR DESCRIPTION
## Summary

- Integration: standalone `replace --apply --format false --json` sets `error_kind: format_failed`.
- Asserts write still applied before format failure (recovery via undo).

## Test plan

- [x] `make check-fast`
- [x] `test_replace_format_failure_json_error_kind`