### PR TITLE
test: lock create/append --format failure JSON format_failed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,6 +29,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Format unit locks.** Explicit `--format` failure and format-timeout map to `FormatFailedError` in unit tests (not only integration).
 - **Crate docs: edit_error_kind peels exit types.** Library rustdoc shows `InvalidInput` for empty patterns and notes that CLI/tx typed errors map through `edit_error_kind`.
 - **Replace `--format` JSON lock.** Standalone `replace --apply --format false --json` sets `error_kind: format_failed` (exit 1); file still written (same recovery model as tx).
+- **Create/append `--format` JSON locks.** Same `format_failed` envelope on create and append write paths after apply.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -582,6 +582,38 @@ fn test_create_format_flag_runs_after_apply() {
     );
 }
 
+#[test]
+fn test_create_format_failure_json_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("new.txt");
+
+    let output = patchloom_in(dir.path())
+        .args([
+            "--json",
+            "create",
+            "new.txt",
+            "--content",
+            "hello\n",
+            "--apply",
+            "--format",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "format_failed",
+        "create --format failure should set error_kind: {parsed}"
+    );
+    assert!(
+        file.exists() && fs::read_to_string(&file).unwrap().contains("hello"),
+        "create must still write before format failure"
+    );
+}
+
 // Regression: default (preview) mode must return exit code 2 (CHANGES_DETECTED)
 // when the operation would produce changes, not 0 (SUCCESS).
 #[test]

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -152,6 +152,39 @@ fn test_append_format_flag_runs_after_apply() {
     );
 }
 
+#[test]
+fn test_append_format_failure_json_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "line\n").unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args([
+            "--json",
+            "append",
+            "f.txt",
+            "--content",
+            "extra\n",
+            "--apply",
+            "--format",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "format_failed",
+        "append --format failure should set error_kind: {parsed}"
+    );
+    assert!(
+        fs::read_to_string(&file).unwrap().contains("extra"),
+        "append must still write before format failure"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // prepend CLI (direct subcommand, not via tx/doc)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Integration locks for create and append post-apply `--format false` under `--json` (`error_kind: format_failed`, exit 1, write still applied).

## Test plan

- [x] `make check-fast`
- [x] `test_create_format_failure_json_error_kind`, `test_append_format_failure_json_error_kind`