### PR TITLE
test: lock prepend/delete --format failure JSON format_failed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,6 +30,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Crate docs: edit_error_kind peels exit types.** Library rustdoc shows `InvalidInput` for empty patterns and notes that CLI/tx typed errors map through `edit_error_kind`.
 - **Replace `--format` JSON lock.** Standalone `replace --apply --format false --json` sets `error_kind: format_failed` (exit 1); file still written (same recovery model as tx).
 - **Create/append `--format` JSON locks.** Same `format_failed` envelope on create and append write paths after apply.
+- **Prepend/delete `--format` JSON locks.** Post-apply format failures on prepend and delete also set `error_kind: format_failed` (delete still removes the file first).
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -185,6 +185,63 @@ fn test_append_format_failure_json_error_kind() {
     );
 }
 
+#[test]
+fn test_prepend_format_failure_json_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "line\n").unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args([
+            "--json",
+            "prepend",
+            "f.txt",
+            "--content",
+            "head\n",
+            "--apply",
+            "--format",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "format_failed",
+        "prepend --format failure should set error_kind: {parsed}"
+    );
+    assert!(
+        fs::read_to_string(&file).unwrap().starts_with("head"),
+        "prepend must still write before format failure"
+    );
+}
+
+#[test]
+fn test_delete_format_failure_json_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "line\n").unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "delete", "f.txt", "--apply", "--format", "false"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "format_failed",
+        "delete --format failure should set error_kind: {parsed}"
+    );
+    assert!(
+        !file.exists(),
+        "delete must still remove the file before format failure"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // prepend CLI (direct subcommand, not via tx/doc)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Integration locks for prepend and delete post-apply `--format false` under `--json`.
- Completes core file-op coverage for `format_failed` (create/append/replace/tx already locked).

## Test plan

- [x] `make check-fast`
- [x] prepend/delete format_failed integration tests