### PR TITLE
fix(doc): preserve format_failed error_kind on post-write format

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3300%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3400%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -444,7 +444,7 @@ flowchart LR
 
 ## Status
 
-3300+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3400+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Replace `--format` JSON lock.** Standalone `replace --apply --format false --json` sets `error_kind: format_failed` (exit 1); file still written (same recovery model as tx).
 - **Create/append `--format` JSON locks.** Same `format_failed` envelope on create and append write paths after apply.
 - **Prepend/delete `--format` JSON locks.** Post-apply format failures on prepend and delete also set `error_kind: format_failed` (delete still removes the file first).
+- **Doc write `format_failed`.** `doc set` (and other doc writes that remap engine errors) preserve `error_kind: format_failed` for post-write `--format` failures (was untyped exit 1).
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -838,6 +838,9 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     "not_found"
                 } else if exit::is_already_exists(&e) {
                     "already_exists"
+                } else if exit::is_format_failed(&e) {
+                    // Post-write --format / timeout (FormatFailedError).
+                    "format_failed"
                 } else {
                     // Unknown engine failures stay generic failure without a
                     // misleading type_error label.

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -462,6 +462,14 @@ pub(crate) fn run_parsed_plan(
                 }
                 return Ok(exit::CHANGES_DETECTED);
             }
+            if exit::is_format_failed(&e) {
+                if structured {
+                    emit_error_json("format_failed", &msg, None, compact);
+                } else {
+                    eprintln!("tx: {msg}");
+                }
+                return Ok(exit::FAILURE);
+            }
             if structured {
                 emit_error_json("operation_failed", &msg, None, compact);
             } else {

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2646,3 +2646,38 @@ fn test_doc_merge_json_stdin_and_value_sets_error_kind() {
         "doc merge dual inputs: {json}"
     );
 }
+
+#[test]
+fn test_doc_set_format_failure_json_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("c.json");
+    fs::write(&file, r#"{"a":1}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "doc",
+            "set",
+            file.to_str().unwrap(),
+            "a",
+            "2",
+            "--apply",
+            "--format",
+            "false",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "format_failed",
+        "doc write path must not drop FormatFailedError: {json}"
+    );
+    assert!(
+        fs::read_to_string(&file).unwrap().contains('2'),
+        "doc set must still write before format failure"
+    );
+}


### PR DESCRIPTION
## Summary

- Bug: `doc set --apply --format false --json` returned exit 1 without `error_kind` because doc write error remapping treated FormatFailedError as unknown.
- Map `is_format_failed` → `format_failed` in doc (and tx remapper for consistency).
- Integration lock; README test count 3400+.

## Test plan

- [x] `make check-fast`
- [x] `test_doc_set_format_failure_json_error_kind`