### PR TITLE
refactor(exit): share classify_typed_error for JSON error kinds

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,6 +32,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Create/append `--format` JSON locks.** Same `format_failed` envelope on create and append write paths after apply.
 - **Prepend/delete `--format` JSON locks.** Post-apply format failures on prepend and delete also set `error_kind: format_failed` (delete still removes the file first).
 - **Doc write `format_failed`.** `doc set` (and other doc writes that remap engine errors) preserve `error_kind: format_failed` for post-write `--format` failures (was untyped exit 1).
+- **Shared `classify_typed_error`.** One table maps typed errors to JSON `error_kind` + exit code for global dispatch and command remappers, so new kinds cannot be present in one path and dropped in another.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -818,37 +818,21 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         })() {
             Ok(code) => return Ok(code),
             Err(e) => {
-                if exit::is_no_match(&e) {
-                    global.emit_error_json_kind(Some("no_matches"), &e.to_string())?;
-                    return Ok(exit::NO_MATCHES);
+                // Prefer shared classification so new typed kinds (e.g.
+                // format_failed) cannot be dropped here while present in
+                // global --json dispatch.
+                match exit::classify_typed_error(&e) {
+                    Some((kind, code)) => {
+                        global.emit_error_json_kind(Some(kind), &e.to_string())?;
+                        return Ok(code);
+                    }
+                    None => {
+                        // Unknown engine failures stay generic failure without
+                        // a misleading type_error label.
+                        global.emit_error_json_kind(None, &e.to_string())?;
+                        return Ok(exit::FAILURE);
+                    }
                 }
-                // Prefer typed kinds so agents can branch without scraping English.
-                // Unsupported extension / flag mistakes are invalid_input; value
-                // shape mismatches are type_error. Do not default everything to
-                // type_error (that hid .txt extension failures as type_error).
-                if exit::is_parse_error(&e) {
-                    global.emit_error_json_kind(Some("parse_error"), &e.to_string())?;
-                    return Ok(exit::PARSE_ERROR);
-                }
-                let kind = if exit::is_type_error(&e) {
-                    "type_error"
-                } else if exit::is_invalid_input(&e) {
-                    "invalid_input"
-                } else if exit::is_io_not_found(&e) {
-                    "not_found"
-                } else if exit::is_already_exists(&e) {
-                    "already_exists"
-                } else if exit::is_format_failed(&e) {
-                    // Post-write --format / timeout (FormatFailedError).
-                    "format_failed"
-                } else {
-                    // Unknown engine failures stay generic failure without a
-                    // misleading type_error label.
-                    global.emit_error_json_kind(None, &e.to_string())?;
-                    return Ok(exit::FAILURE);
-                };
-                global.emit_error_json_kind(Some(kind), &e.to_string())?;
-                return Ok(exit::FAILURE);
             }
         }
     }

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -226,6 +226,37 @@ pub fn is_format_failed(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<FormatFailedError>().is_some())
 }
 
+/// Classify a typed error for JSON `error_kind` + exit code.
+///
+/// Shared by global `--json` dispatch and command remappers (e.g. doc write)
+/// so new kinds cannot be dropped in one path and present in another.
+/// Returns `None` when the chain has no recognized typed kind.
+pub fn classify_typed_error(err: &anyhow::Error) -> Option<(&'static str, u8)> {
+    if is_no_match(err) {
+        Some(("no_matches", NO_MATCHES))
+    } else if is_ambiguous(err) {
+        Some(("ambiguous", AMBIGUOUS))
+    } else if is_invalid_input(err) {
+        Some(("invalid_input", FAILURE))
+    } else if is_io_not_found(err) {
+        Some(("not_found", FAILURE))
+    } else if is_already_exists(err) {
+        Some(("already_exists", FAILURE))
+    } else if is_type_error(err) {
+        Some(("type_error", FAILURE))
+    } else if is_conflicts(err) {
+        Some(("conflicts", CONFLICTS))
+    } else if is_parse_error(err) {
+        Some(("parse_error", PARSE_ERROR))
+    } else if is_changes_detected(err) {
+        Some(("changes_detected", CHANGES_DETECTED))
+    } else if is_format_failed(err) {
+        Some(("format_failed", FAILURE))
+    } else {
+        None
+    }
+}
+
 /// Plan, patch, or structured document could not be parsed.
 pub const PARSE_ERROR: u8 = 4;
 /// Multiple candidates matched and the command could not pick one.
@@ -242,6 +273,25 @@ pub const OPERATION_FAILED: u8 = 9;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn classify_typed_error_maps_format_failed() {
+        let err: anyhow::Error = FormatFailedError {
+            msg: "format command failed".into(),
+        }
+        .into();
+        let wrapped = err.context("files were written but formatting failed");
+        assert_eq!(
+            classify_typed_error(&wrapped),
+            Some(("format_failed", FAILURE))
+        );
+    }
+
+    #[test]
+    fn classify_typed_error_none_for_plain() {
+        let err = anyhow::anyhow!("plain");
+        assert_eq!(classify_typed_error(&err), None);
+    }
 
     #[test]
     fn exit_code_values() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,28 +410,9 @@ fn clap_usage_error_message(err: &clap::Error) -> String {
 /// `InvalidInputError`, `ParseErrorError`, …) get `error_kind` and exit codes.
 #[cfg(feature = "cli")]
 fn structured_dispatch_error(err: &anyhow::Error) -> (serde_json::Value, u8) {
-    let (kind, code) = if exit::is_no_match(err) {
-        (Some("no_matches"), exit::NO_MATCHES)
-    } else if exit::is_ambiguous(err) {
-        (Some("ambiguous"), exit::AMBIGUOUS)
-    } else if exit::is_invalid_input(err) {
-        (Some("invalid_input"), exit::FAILURE)
-    } else if exit::is_io_not_found(err) {
-        (Some("not_found"), exit::FAILURE)
-    } else if exit::is_already_exists(err) {
-        (Some("already_exists"), exit::FAILURE)
-    } else if exit::is_type_error(err) {
-        (Some("type_error"), exit::FAILURE)
-    } else if exit::is_conflicts(err) {
-        (Some("conflicts"), exit::CONFLICTS)
-    } else if exit::is_parse_error(err) {
-        (Some("parse_error"), exit::PARSE_ERROR)
-    } else if exit::is_changes_detected(err) {
-        (Some("changes_detected"), exit::CHANGES_DETECTED)
-    } else if exit::is_format_failed(err) {
-        (Some("format_failed"), exit::FAILURE)
-    } else {
-        (None, exit::FAILURE)
+    let (kind, code) = match exit::classify_typed_error(err) {
+        Some((k, c)) => (Some(k), c),
+        None => (None, exit::FAILURE),
     };
     let mut output = serde_json::json!({
         "ok": false,


### PR DESCRIPTION
## Summary

- Add `exit::classify_typed_error` as the single table of typed error → (`error_kind`, exit code).
- Use it in global `structured_dispatch_error` and doc write error remapping (where FormatFailedError was previously dropped).
- Unit locks for format_failed and plain errors.

## Test plan

- [x] `make check-fast`
- [x] `classify_typed_error_*`, `test_doc_set_format_failure_json_error_kind`