### PR TITLE
refactor(tx): use classify_typed_error for plan execute failures

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -33,6 +33,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Prepend/delete `--format` JSON locks.** Post-apply format failures on prepend and delete also set `error_kind: format_failed` (delete still removes the file first).
 - **Doc write `format_failed`.** `doc set` (and other doc writes that remap engine errors) preserve `error_kind: format_failed` for post-write `--format` failures (was untyped exit 1).
 - **Shared `classify_typed_error`.** One table maps typed errors to JSON `error_kind` + exit code for global dispatch and command remappers, so new kinds cannot be present in one path and dropped in another.
+- **Tx engine error remapper.** Plan execute failures use `classify_typed_error` (unknown → `operation_failed` / 9), matching the shared kind table.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -387,95 +387,18 @@ pub(crate) fn run_parsed_plan(
         Ok(r) => r,
         Err(e) => {
             let msg = e.to_string();
-            // AST/md no-match must surface as no_matches (exit 3), not
-            // operation_failed (exit 9), with the concrete detail message.
-            if exit::is_no_match(&e) {
-                if structured {
-                    emit_error_json("no_matches", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::NO_MATCHES);
-            }
-            // replace unique multi-match → AMBIGUOUS (5), matching CLI.
-            if exit::is_ambiguous(&e) {
-                if structured {
-                    emit_error_json("ambiguous", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::AMBIGUOUS);
-            }
-            if exit::is_io_not_found(&e) {
-                if structured {
-                    emit_error_json("not_found", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::FAILURE);
-            }
-            if exit::is_already_exists(&e) {
-                if structured {
-                    emit_error_json("already_exists", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::FAILURE);
-            }
-            if exit::is_invalid_input(&e) {
-                if structured {
-                    emit_error_json("invalid_input", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::FAILURE);
-            }
-            if exit::is_type_error(&e) {
-                if structured {
-                    emit_error_json("type_error", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::FAILURE);
-            }
-            if exit::is_conflicts(&e) {
-                if structured {
-                    emit_error_json("conflicts", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::CONFLICTS);
-            }
-            if exit::is_parse_error(&e) {
-                if structured {
-                    emit_error_json("parse_error", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::PARSE_ERROR);
-            }
-            if exit::is_changes_detected(&e) {
-                if structured {
-                    emit_error_json("changes_detected", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::CHANGES_DETECTED);
-            }
-            if exit::is_format_failed(&e) {
-                if structured {
-                    emit_error_json("format_failed", &msg, None, compact);
-                } else {
-                    eprintln!("tx: {msg}");
-                }
-                return Ok(exit::FAILURE);
-            }
+            // Shared typed-kind table (no_matches, ambiguous, format_failed, …).
+            // Unknown engine failures stay operation_failed (exit 9) for tx.
+            let (kind, code) = match exit::classify_typed_error(&e) {
+                Some((k, c)) => (k, c),
+                None => ("operation_failed", exit::OPERATION_FAILED),
+            };
             if structured {
-                emit_error_json("operation_failed", &msg, None, compact);
+                emit_error_json(kind, &msg, None, compact);
             } else {
                 eprintln!("tx: {msg}");
             }
-            return Ok(exit::OPERATION_FAILED);
+            return Ok(code);
         }
     };
 


### PR DESCRIPTION
## Summary

- Tx plan execute error remapping uses `exit::classify_typed_error`.
- Unknown failures still map to `operation_failed` / exit 9 (tx-specific default).

## Test plan

- [x] `make check-fast`
- [x] lib tx tests + `test_tx_global_format_failure_json_error_kind`