### PR TITLE
refactor(fallback): map edit_error_kind via classify_typed_error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -34,6 +34,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Doc write `format_failed`.** `doc set` (and other doc writes that remap engine errors) preserve `error_kind: format_failed` for post-write `--format` failures (was untyped exit 1).
 - **Shared `classify_typed_error`.** One table maps typed errors to JSON `error_kind` + exit code for global dispatch and command remappers, so new kinds cannot be present in one path and dropped in another.
 - **Tx engine error remapper.** Plan execute failures use `classify_typed_error` (unknown → `operation_failed` / 9), matching the shared kind table.
+- **Library `edit_error_kind` uses `classify_typed_error`.** Exit typed errors map through the same table as CLI JSON kinds (no dual switch to drift).
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -160,61 +160,22 @@ pub fn edit_error_kind(err: &anyhow::Error) -> Option<EditErrorKind> {
         if let Some(e) = cause.downcast_ref::<EditError>() {
             return Some(e.kind);
         }
-        // Map exit::* typed errors used by CLI/tx and many api::* paths.
-        // Prefer EditError when both appear (checked first above).
-        if cause.downcast_ref::<crate::exit::NoMatchError>().is_some() {
-            return Some(EditErrorKind::NoMatch);
-        }
-        if cause
-            .downcast_ref::<crate::exit::AmbiguousError>()
-            .is_some()
-        {
-            return Some(EditErrorKind::AmbiguousTarget);
-        }
-        if cause
-            .downcast_ref::<crate::exit::InvalidInputError>()
-            .is_some()
-        {
-            return Some(EditErrorKind::InvalidInput);
-        }
-        if cause
-            .downcast_ref::<crate::exit::ParseErrorError>()
-            .is_some()
-        {
-            return Some(EditErrorKind::ParseError);
-        }
-        if cause
-            .downcast_ref::<crate::exit::AlreadyExistsError>()
-            .is_some()
-            || cause
-                .downcast_ref::<crate::exit::TypeErrorError>()
-                .is_some()
-        {
-            return Some(EditErrorKind::InvalidInput);
-        }
-        if cause
-            .downcast_ref::<crate::exit::ConflictsError>()
-            .is_some()
-        {
-            // Patch merge conflicts are not region batch conflicts, but both
-            // mean "edit could not apply cleanly"; OperationFailed is the
-            // closest shared kind for hosts that only branch on EditErrorKind.
-            return Some(EditErrorKind::OperationFailed);
-        }
-        if cause
-            .downcast_ref::<crate::exit::ChangesDetectedError>()
-            .is_some()
-        {
-            return Some(EditErrorKind::OperationFailed);
-        }
-        if cause
-            .downcast_ref::<crate::exit::FormatFailedError>()
-            .is_some()
-        {
-            return Some(EditErrorKind::OperationFailed);
-        }
     }
-    None
+    // Prefer EditError above; map CLI/tx typed errors via the shared table so
+    // library hosts stay in sync with JSON error_kind classification.
+    match crate::exit::classify_typed_error(err) {
+        Some(("no_matches", _)) => Some(EditErrorKind::NoMatch),
+        Some(("ambiguous", _)) => Some(EditErrorKind::AmbiguousTarget),
+        Some(("invalid_input", _) | ("already_exists", _) | ("type_error", _)) => {
+            Some(EditErrorKind::InvalidInput)
+        }
+        Some(("parse_error", _)) => Some(EditErrorKind::ParseError),
+        // conflicts / changes_detected / format_failed: closest library kind
+        Some(("conflicts", _) | ("changes_detected", _) | ("format_failed", _)) => {
+            Some(EditErrorKind::OperationFailed)
+        }
+        Some(_) | None => None,
+    }
 }
 
 /// Downcast an `anyhow` error chain to [`EditError`] when present.


### PR DESCRIPTION
## Summary

- `edit_error_kind` peels exit typed errors through `exit::classify_typed_error` instead of a parallel match chain.
- Keeps EditError first; maps CLI/tx kinds to EditErrorKind without dual tables.

## Test plan

- [x] `make check-fast`
- [x] `edit_error_kind_maps_exit_typed_errors`, classify unit tests