### PR TITLE
refactor(tx): plan_exec uses classify_typed_error

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Shared `classify_typed_error`.** One table maps typed errors to JSON `error_kind` + exit code for global dispatch and command remappers, so new kinds cannot be present in one path and dropped in another.
 - **Tx engine error remapper.** Plan execute failures use `classify_typed_error` (unknown → `operation_failed` / 9), matching the shared kind table.
 - **Library `edit_error_kind` uses `classify_typed_error`.** Exit typed errors map through the same table as CLI JSON kinds (no dual switch to drift).
+- **MCP/plan_exec error remapper.** In-process plan execute uses `classify_typed_error` for JSON error envelopes (unknown → `operation_failed`).
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -634,6 +634,9 @@ pub(crate) fn execute_and_collect(
                 if crate::exit::is_changes_detected(&e) {
                     return Err(crate::exit::ChangesDetectedError { msg }.into());
                 }
+                if crate::exit::is_format_failed(&e) {
+                    return Err(crate::exit::FormatFailedError { msg }.into());
+                }
                 anyhow::bail!("{msg}");
             }
         }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -149,34 +149,10 @@ pub fn execute_plan_direct(
     let mut result = match execute_and_collect(&plan, &engine_ctx, true, true, guard) {
         Ok(r) => r,
         Err(e) => {
-            // AST/md no-match must surface as no_matches (exit 3), not
-            // operation_failed (exit 9), with the concrete detail message.
-            if crate::exit::is_no_match(&e) {
-                return Ok(build_error_output("no_matches", &e.to_string(), None));
-            }
-            if crate::exit::is_ambiguous(&e) {
-                return Ok(build_error_output("ambiguous", &e.to_string(), None));
-            }
-            if crate::exit::is_io_not_found(&e) {
-                return Ok(build_error_output("not_found", &e.to_string(), None));
-            }
-            if crate::exit::is_already_exists(&e) {
-                return Ok(build_error_output("already_exists", &e.to_string(), None));
-            }
-            if crate::exit::is_invalid_input(&e) {
-                return Ok(build_error_output("invalid_input", &e.to_string(), None));
-            }
-            if crate::exit::is_type_error(&e) {
-                return Ok(build_error_output("type_error", &e.to_string(), None));
-            }
-            if crate::exit::is_conflicts(&e) {
-                return Ok(build_error_output("conflicts", &e.to_string(), None));
-            }
-            if crate::exit::is_parse_error(&e) {
-                return Ok(build_error_output("parse_error", &e.to_string(), None));
-            }
-            if crate::exit::is_changes_detected(&e) {
-                return Ok(build_error_output("changes_detected", &e.to_string(), None));
+            // Shared typed-kind table (no_matches, ambiguous, …); unknown →
+            // operation_failed (tx default, exit 9).
+            if let Some((kind, _)) = crate::exit::classify_typed_error(&e) {
+                return Ok(build_error_output(kind, &e.to_string(), None));
             }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }


### PR DESCRIPTION
## Summary

- `plan_exec` (MCP/library execute_plan path) uses `classify_typed_error` for error envelopes.
- Engine rewrap includes `FormatFailedError` for completeness.

## Test plan

- [x] `make check-fast`
- [x] tx lib + format_failed integration tests