### PR TITLE
fix(api): peel IO not_found in edit_error_kind

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -36,6 +36,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Tx engine error remapper.** Plan execute failures use `classify_typed_error` (unknown → `operation_failed` / 9), matching the shared kind table.
 - **Library `edit_error_kind` uses `classify_typed_error`.** Exit typed errors map through the same table as CLI JSON kinds (no dual switch to drift).
 - **MCP/plan_exec error remapper.** In-process plan execute uses `classify_typed_error` for JSON error envelopes (unknown → `operation_failed`).
+- **Library `edit_error_kind` peels IO not_found.** Missing-file IO maps to `EditErrorKind::OperationFailed` (was `None`), via the shared classifier.
 - **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
 - **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
 - **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -170,10 +170,11 @@ pub fn edit_error_kind(err: &anyhow::Error) -> Option<EditErrorKind> {
             Some(EditErrorKind::InvalidInput)
         }
         Some(("parse_error", _)) => Some(EditErrorKind::ParseError),
-        // conflicts / changes_detected / format_failed: closest library kind
-        Some(("conflicts", _) | ("changes_detected", _) | ("format_failed", _)) => {
-            Some(EditErrorKind::OperationFailed)
-        }
+        // not_found / conflicts / changes_detected / format_failed: closest
+        // library kind for hosts that only branch on EditErrorKind.
+        Some(
+            ("not_found", _) | ("conflicts", _) | ("changes_detected", _) | ("format_failed", _),
+        ) => Some(EditErrorKind::OperationFailed),
         Some(_) | None => None,
     }
 }
@@ -734,6 +735,15 @@ mod tests {
         assert_eq!(
             edit_error_kind(&format_failed),
             Some(EditErrorKind::OperationFailed)
+        );
+
+        let not_found: anyhow::Error =
+            std::io::Error::new(std::io::ErrorKind::NotFound, "missing").into();
+        let not_found = not_found.context("failed to read path");
+        assert_eq!(
+            edit_error_kind(&not_found),
+            Some(EditErrorKind::OperationFailed),
+            "IO NotFound should peel via classify not_found"
         );
 
         // Intermediate .context() must not hide the typed kind.


### PR DESCRIPTION
## Summary

- `edit_error_kind` maps CLI `not_found` (IO NotFound via `classify_typed_error`) to `EditErrorKind::OperationFailed` instead of `None`.
- Unit lock.

## Test plan

- [x] `make check-fast`
- [x] `edit_error_kind_maps_exit_typed_errors`