### PR TITLE
docs: note format_failed contract in write-pipeline plan

### DIFF
--- a/docs/plans/write-pipeline.md
+++ b/docs/plans/write-pipeline.md
@@ -34,6 +34,12 @@ CLI / API boundary
   → commit/format inside finalize when apply/confirm accepts
 ```
 
+**Post-write format:** Explicit `--format` (or format-timeout) failures return
+`FormatFailedError` → JSON `error_kind: format_failed` (exit 1). Files may
+already be committed; remappers must use `exit::classify_typed_error` so the
+kind is not dropped (see doc write remapper bug #1634). Config/auto by-extension
+formatters warn only and do not fail the write.
+
 **Rule:** `match classify_write_mode` must only appear in `src/cmd/write_mode.rs`.
 Emit hooks for custom paths are grouped in `FinalizeCallbacks` (no per-command
 mode matrices; no `clippy::too_many_arguments` on the entrypoint).


### PR DESCRIPTION
## Summary

- `docs/plans/write-pipeline.md` documents post-write `format_failed` and the remapper requirement.

## Test plan

- [x] `make check-fast`