### PR TITLE
feat: peel runit/daemontools/s6 wrappers in command_position

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -35,7 +35,7 @@
 
 **`replace_text` / plan replace flags (default false):**
 - `require_change`: error when the pattern matches zero times (fail closed).
-- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox` wrappers yes; `uv pip` no).
+- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 Use patchloom when:
@@ -248,7 +248,7 @@ All operations succeed atomically or roll back together.
 
 Plan/MCP `replace` accepts library flags (default false):
 - `require_change`: fail when the pattern matches zero times (agent fail-closed).
-- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox` wrappers yes; `uv pip` no).
+- `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 ## AST-aware operations
@@ -321,7 +321,7 @@ dependencies[name=react].version # predicate filter
 
 ## Operations (from schema registry)
 
-- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail wrappers, not uv pip).
+- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip).
 - `file.append`: Append content to an existing file.
 - `file.prepend`: Prepend content to an existing file.
 - `file.create`: Create a new file with specified content.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -57,6 +57,7 @@ Embedders can set `ReplaceOptions.require_change` so zero matches become structu
 - **Unit/sandbox wrappers.** `command_position` peels `systemd-run`, `firejail`, `dbus-run-session`, and `chronic`, plus bare `--` end-of-options markers (`dbus-run-session -- pip`).
 - **`run0` privilege wrapper.** `command_position` peels systemd `run0` (modern `sudo` alternative) so `run0 -u root pip` rewrites the command.
 - **Container entrypoint wrappers.** `command_position` peels `gosu`, `su-exec`, `tini`, and `dumb-init` so Docker/K8s install scripts rewrite the invocable command.
+- **runit / daemontools / s6 wrappers.** `command_position` peels `chpst` / `softlimit` / `s6-softlimit` / `with-contenv` (transparent flags) and path-taking `envdir` / `s6-envdir` / `setlock` / `envuidgid` / `s6-envuidgid` so supervised service and s6-overlay install scripts rewrite the invocable command.
 - **CLI undo JSON `error_kind`.** Soft no-session paths (`undo --list` empty, or no sessions to restore) set `error_kind: "no_matches"` (exit 3), matching other CLI exit-3 JSON envelopes.
 - **CLI doc JSON `error_kind: type_error`.** `doc keys` / `doc len` on the wrong value type, and write-path type failures, set `error_kind: "type_error"` (exit 1) so agents can distinguish type mismatches from soft no-matches.
 - **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -593,7 +593,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:command-position -->
 ### `replace --command-position` / library `ReplaceOptions.command_position`
 
-- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `unshare`/`nsenter`/`taskset`/`prlimit`/`numactl`/`chrt`/`setpriv`, `runuser -u USER`, `busybox`, `flock /lock`, `chroot /jail`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
+- **What it does:** Replaces only tokens in shell **command position** (start of line, after `&&` `|` `;` / newlines, after wrappers like `sudo`, `timeout 30`, `nice -n 10`, `setsid`, `unshare`/`nsenter`/`taskset`/`prlimit`/`numactl`/`chrt`/`setpriv`, `runuser -u USER`, `busybox`, `chpst -u app`, `softlimit -m N`, `flock /lock`, `chroot /jail`, `envdir /env`, `setlock /lock`, `xargs`, `eval`, `source`, `env KEY=val`). Does not rewrite arguments (`uv pip`) or longer words (`pipenv`). Literal only. Also available on plan/MCP replace and `batch_replace`.
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
 - **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after.
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -112,7 +112,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Get server version and working directory | `server_info` |\n\n\
              **`replace_text` / plan replace flags (default false):**\n\
              - `require_change`: error when the pattern matches zero times (fail closed).\n\
-             - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox` wrappers yes; `uv pip` no).\n\
+             - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
              \"command_position\":true,\"require_change\":true}`\n\n",
         );
@@ -386,7 +386,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  All operations succeed atomically or roll back together.\n\n\
                  Plan/MCP `replace` accepts library flags (default false):\n\
                  - `require_change`: fail when the pattern matches zero times (agent fail-closed).\n\
-                 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox` wrappers yes; `uv pip` no).\n\
+                 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\n");
         }
@@ -704,8 +704,12 @@ mod tests {
                 && out.contains("taskset")
                 && out.contains("systemd-run")
                 && out.contains("firejail")
-                && out.contains("busybox"),
-            "agent-rules should name isolation/container wrappers for command_position"
+                && out.contains("busybox")
+                && out.contains("chpst")
+                && out.contains("softlimit")
+                && out.contains("envdir")
+                && out.contains("setlock"),
+            "agent-rules should name isolation/container/runit wrappers for command_position"
         );
         let mcp = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));
         assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,10 @@
 //! Shell command-position matching (#1494): opt-in `ReplaceOptions.command_position`
 //! rewrites invocable tokens (`pip install`, `sudo -E pip`, `timeout 30 pip`,
 //! `nice -n 10 pip`, `setsid pip`, `busybox wget`, `flock /tmp/l pip`,
-//! `runuser -u app pip`) without touching arguments (`uv pip`) or longer words
-//! (`pipenv`). Not the same as `word_boundary`. Post-Apply validate/revert: host
-//! runs a validator, then `backup::restore_path_from_latest_backup(project_root, path)`.
+//! `runuser -u app pip`, `chpst -u app pip`, `with-contenv pip`, `envdir /env pip`)
+//! without touching arguments (`uv pip`) or longer words (`pipenv`). Not the same as
+//! `word_boundary`. Post-Apply validate/revert: host runs a validator, then
+//! `backup::restore_path_from_latest_backup(project_root, path)`.
 //!
 //! For several ordered text edits on **one buffer** then a single write (agent intent engines):
 //! use `api::apply_content_edits` / `api::apply_content_edits_to_file` with

--- a/src/ops/shell_token.rs
+++ b/src/ops/shell_token.rs
@@ -7,8 +7,8 @@
 //! A token is in **command position** when it is the invocable command of a
 //! simple shell fragment: start of line (after whitespace), after `&&` `|` `;`,
 //! or after transparent prefixes (`sudo`, `env KEY=val`…, `timeout`, `nice`, `setsid`,
-//! `unshare` / `nsenter` / `taskset`, `flock` / `chroot` + path, `xargs`, `eval`, and
-//! common option flags like `-E` / `-p`).
+//! `unshare` / `nsenter` / `taskset`, `chpst` / `softlimit`, `flock` / `chroot` /
+//! `envdir` / `setlock` + path, `xargs`, `eval`, and common option flags like `-E` / `-p`).
 //! It is **not** command position when it is an argument (`uv pip`) or inside a longer
 //! word (`pipenv`).
 //!
@@ -71,11 +71,19 @@ const TRANSPARENT_PREFIXES: &[&str] = &[
     "eval",
     "source",
     ".",
+    // runit / daemontools process supervisors (flags peel; path-taking below).
+    // `chpst -u app pip`, `softlimit -m 1000000 pip`, `s6-softlimit -m N pip`.
+    "chpst",
+    "softlimit",
+    "s6-softlimit",
+    // s6-overlay: inject container env then run command.
+    "with-contenv",
 ];
 
 /// Wrappers whose next non-option argument is a path or user (not the command):
 /// `flock /tmp/l pip`, `flock -n /var/lock/x pip`, `chroot /jail pip`,
-/// `gosu app pip`, `su-exec nobody pip`, `s6-setuidgid app pip`.
+/// `gosu app pip`, `su-exec nobody pip`, `s6-setuidgid app pip`,
+/// `envdir /env pip`, `setlock /tmp/l pip`, `envuidgid app pip`.
 const PATH_TAKING_PREFIXES: &[&str] = &[
     "flock",
     "chroot",
@@ -83,6 +91,13 @@ const PATH_TAKING_PREFIXES: &[&str] = &[
     "su-exec",
     "s6-setuidgid",
     "setuidgid",
+    // daemontools / s6: env dir then command; setlock like flock.
+    "envdir",
+    "s6-envdir",
+    "setlock",
+    // user then command (daemontools / s6).
+    "envuidgid",
+    "s6-envuidgid",
 ];
 
 /// Return true if `token` at byte range `[start, end)` is in shell command position.
@@ -1036,6 +1051,56 @@ mod tests {
         );
         assert_eq!(
             replace_command_position("echo gosu pip\n", "pip", "uv").1,
+            0
+        );
+    }
+
+    #[test]
+    fn runit_daemontools_wrappers_allow_command() {
+        // runit process supervisor: flags then invocable command.
+        assert_eq!(
+            replace_command_position("chpst -u app pip install\n", "pip", "uv").0,
+            "chpst -u app uv install\n"
+        );
+        // daemontools resource limits: flag + number then command.
+        assert_eq!(
+            replace_command_position("softlimit -m 1000000 pip install\n", "pip", "uv").0,
+            "softlimit -m 1000000 uv install\n"
+        );
+        // envdir / s6-envdir: path then command.
+        assert_eq!(
+            replace_command_position("envdir /env pip install\n", "pip", "uv").0,
+            "envdir /env uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("s6-envdir /env pip install\n", "pip", "uv").0,
+            "s6-envdir /env uv install\n"
+        );
+        // setlock like flock: path then command.
+        assert_eq!(
+            replace_command_position("setlock /tmp/l pip install\n", "pip", "uv").0,
+            "setlock /tmp/l uv install\n"
+        );
+        // s6-overlay / s6 resource limit + envuidgid.
+        assert_eq!(
+            replace_command_position("with-contenv pip install\n", "pip", "uv").0,
+            "with-contenv uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("s6-softlimit -m 1000 pip install\n", "pip", "uv").0,
+            "s6-softlimit -m 1000 uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("s6-envuidgid app pip install\n", "pip", "uv").0,
+            "s6-envuidgid app uv install\n"
+        );
+        assert_eq!(
+            replace_command_position("envuidgid app pip install\n", "pip", "uv").0,
+            "envuidgid app uv install\n"
+        );
+        // Still argument-position when after a real word.
+        assert_eq!(
+            replace_command_position("echo chpst pip\n", "pip", "uv").1,
             0
         );
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -183,7 +183,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     // --- Weak tier ---
     OpMeta {
         name: "replace",
-        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail wrappers, not uv pip).",
+        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip).",
         tier: Tier::Weak,
         examples: &[
             (


### PR DESCRIPTION
## Summary

- Extend `command_position` shell-token peeling for runit/daemontools/s6 supervised install scripts: transparent `chpst`, `softlimit`, `s6-softlimit`, `with-contenv`; path-taking `envdir`, `s6-envdir`, `setlock`, `envuidgid`, `s6-envuidgid`.
- Unit coverage for the new wrappers; agent-rules, schema, reference, crate docs, and RELEASE_NOTES updated.

## Test plan

- [x] `cargo test --lib --all-features shell_token`
- [x] `cargo test --lib --all-features workflow_includes_plan_require_change`
- [x] CLI probes: chpst/softlimit/envdir/setlock/with-contenv/s6-envuidgid rewrite `pip` correctly
- [x] `make check-fast`

MPI adversarial residual after the error_kind series (#1620–#1645). Release PR #1498 held.