### PR TITLE
docs: curate RELEASE_NOTES.md for v0.12.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,145 +1,74 @@
 # Patchloom 0.12.0
 
-Library surface for agent hosts (Bline-class embedders): fail-closed text edits, AST file mutators, shell command-position replace, batch rename, honest multi-edit diffs, and signature rewrite spacing that matches how agents write signatures. Built on 0.11 containment and plan reliability.
+Agent-host and embedder release: fail-closed library edits, shell-aware replace, richer AST writers, and machine-readable errors across CLI, plans, MCP, and the Rust API. Built for Bline-class hosts and agents that branch on `error_kind` instead of scraping English. 151 commits since 0.11.0, with 201 new tests.
 
 ## Highlights
 
-Embedders can set `ReplaceOptions.require_change` so zero matches become structured `EditErrorKind::NoMatch` instead of soft `Ok(changed=false)`. High-level AST writers cover rename, replace-in-symbol, and signature rewrite (including full-string `new_signature` and `FunctionSigEdit::parse_rust`). Multi-file `ast_rename_batch` serializes same-path work and returns per-file results. Opt-in `command_position` rewrites invocable shell tokens without touching `uv pip` / `pipenv`. Post-Apply validate/revert gets `backup::restore_path_from_latest_backup`. Multi-op content edits put the real path in unified-diff headers. Signature rewrite preserves the space (or newline) before `{` when agents omit trailing whitespace on the new signature.
+Library embedders can require a real match (`require_change`), rewrite shell command tokens without touching package names (`command_position`), rename and batch-rename symbols on disk, and restore a single path from the latest backup session. Agents get a single typed error table: missing files are `not_found`, missing symbols and selectors are `no_matches`, bad flags and regexes are `invalid_input`, post-write formatter failures are `format_failed`, and structured `--json` never returns empty stdout on serialize failure. Multi-file AST rename and reverse-deps scans are parallel. Tx verify attribute filters no longer steal a neighbor's `#[test]`.
 
 ## New features
 
-- **Fail-closed content replace.** `ReplaceOptions.require_change` (default false). Zero matches → `EditErrorKind::NoMatch` with similar-target suggestions when available. `if_exists` still wins when both are set. Re-exports `EditError` / `EditErrorKind` / `edit_error_kind` for kind matching without scraping English. (#1492, #1497)
-- **AST file mutators.** `api::ast_rename`, `api::ast_replace_in_symbol`, `api::ast_rewrite_signature_in_content`, plus on-disk `ast_rewrite_signature`. Zero identifier/symbol matches → `NoMatch`. (#1493, #1497)
-- **`FunctionSigEdit::parse_rust`.** Rust-first parse of pub / pub(crate) / params-only / nested-paren signatures. (#1493, #1497)
-- **Shell command-position matching.** Opt-in `ReplaceOptions.command_position` (not `word_boundary`). Must-pass grammar: bare `pip`, not `pipenv` / `uv pip` / `python -m pip`; wrappers `sudo` / `doas` / `env KEY=val` / `timeout 30` / `nice -n 10` / `stdbuf` / `ionice` / `setsid` / `runuser` / `busybox` / `flock` / `chroot` / `xargs` / `watch` / `strace` / `eval` / `source`; option flags like `-E` / `-p` and arg-taking flags like `-u USER`; separators `&&` `|` `;`. (#1494, #1497)
-- **Validate/revert helper.** `backup::restore_path_from_latest_backup(project_root, path)` restores from the newest session that contains that exact path (exact match only). (#1494, #1497)
-- **Batch AST rename.** `api::ast_rename_batch` with path dedupe, same-file serialization, `continue_on_no_match` (default true), `fail_fast` for hard errors, per-file `Result`. (#1495, #1497)
+- **Fail-closed content replace.** `ReplaceOptions.require_change` (default false). Zero matches become structured `EditErrorKind::NoMatch` (with similar-target suggestions when available) instead of soft `Ok(changed=false)`. `if_exists` still wins when both are set. Re-exports `EditError`, `EditErrorKind`, and `edit_error_kind` for kind matching without scraping English. CLI `--require-change` and plan/MCP fields match. (#1492, #1497)
+- **Shell command-position replace.** Opt-in `ReplaceOptions.command_position` (and CLI `--command-position`) rewrites invocable shell tokens without treating `uv pip` or `pipenv` as bare `pip`. Peels common wrappers: `sudo` / `doas` / `env` / `timeout` / `nice` / `stdbuf` / `ionice` / `setsid` / `runuser` / `busybox` / `flock` / `chroot` / `xargs` / `watch` / `strace` / `eval` / `source`, plus process supervisors such as runit / daemontools / s6. Incompatible flag combinations are `invalid_input`. (#1494, #1497, #1510-#1519, #1527-#1533, #1545-#1547, #1557, #1646)
+- **AST file mutators for embedders.** `api::ast_rename`, `api::ast_replace_in_symbol`, `api::ast_rewrite_signature` / `ast_rewrite_signature_in_content`, plus `FunctionSigEdit::parse_rust` for structured or full-string signatures. Multi-file `api::ast_rename_batch` serializes same-path work and returns per-file results (`continue_on_no_match`, `fail_fast`). Zero symbol matches → `NoMatch`. (#1493, #1495, #1497)
+- **Validate/revert helper.** `backup::restore_path_from_latest_backup(project_root, path)` restores from the newest session that contains that exact path (exact match only; no basename shortcuts). (#1494, #1497)
+- **Plan `ops` alias.** Transaction plans accept `"ops"` as a co-equal alias for `"operations"` so agents that emit either shape deserialize cleanly. (#1578, #1579)
+- **Multi-op content edits use real paths in diffs.** Content-edit results put the real file path in unified-diff headers (not a buffer placeholder). Signature rewrite preserves the space or newline before `{` when agents omit trailing whitespace on a full `new_signature`. (#1502, #1504)
+
+## Agent and scripting reliability
+
+- **One typed error table for hosts.** CLI, tx, MCP plan execute, and library `edit_error_kind` share `classify_typed_error` so kinds cannot drift between surfaces. Agents can branch on `error_kind` for exit 1 / 3 / 4 / 8 / 9 without scraping messages. (#1620, #1635-#1641)
+- **Missing paths are `not_found`.** Search, replace, tidy, `--files-from` when every target is missing, file append/prepend/delete, and engine IO map to `error_kind: not_found` with exit behavior agents can trust. (#1580-#1586)
+- **No-match and count mismatches stay distinct.** Plan/CLI no-matches stay exit 3 with `no_matches`. Search `assert_count` mismatches and related "would change / count wrong" paths use `changes_detected` (exit 2) instead of looking like success or a soft empty result. Tx preview JSON reports `changes_detected` when the plan would write. (#1598, #1648, #1649)
+- **Invalid input is typed.** Empty patterns, bad regexes, clap usage under `--json`, `--contain` escapes, bad `--cwd`, non-file targets, doc/selector mistakes, and many plan flag errors set `invalid_input` (exit 1) instead of bare failure or empty success. Clap usage exits 1 (not 2) so it does not look like "changes detected." (#1574-#1577, #1594-#1609, #1621-#1625)
+- **Post-write `--format` failures are `format_failed`.** Explicit formatter or format-timeout failures set `error_kind: format_failed` (exit 1) after the write may already have committed; use `undo` or re-run the formatter. Covers standalone writes, doc, and tx. (#1626-#1634)
+- **Structured JSON never goes silent.** If serializing a structured report fails, stdout still gets a minimal `ok: false` / `error_kind: operation_failed` envelope and exit 1 (CLI entry, tx, doc value format, library search format helpers). (#1651, #1652, #1653)
+- **Doc parse and type errors.** Malformed JSON/YAML/TOML exit 4 with `parse_error`; selector type mismatches set `type_error` where the document shape is wrong for the operation. (#1590-#1592, #1595, #1618-#1619)
+- **Patch plans report conflict kinds.** Stale context and merge conflicts map to the existing conflict/ambiguous exit codes with machine-readable kinds on the plan path. (#1593)
+- **Create/rename conflicts are `already_exists`.** (#1587)
 
 ## Bug fixes
 
-- **Library `edit_error_kind` peels exit typed errors.** `InvalidInputError`, `NoMatchError`, `AmbiguousError`, `ParseErrorError`, `AlreadyExistsError`, and related kinds from CLI/tx paths now map to `EditErrorKind` (including through `.context()` wrappers). Empty replace/search patterns on `replace_in_content` / `search` / `search_directory` emit typed `InvalidInputError` so hosts can branch without scraping English.
-- **`search_directory` / `search_file` invalid regex.** Bad patterns (e.g. unclosed groups) now return `InvalidInputError` / `edit_error_kind` `InvalidInput` instead of `Ok([])`, which looked like a soft no-match. Low-level `search_one_file` still returns empty on compile failure for custom walkers; high-level APIs preflight.
-- **Shared replace/search regex compile typing.** `compile_replace_regex` and CLI `build_matcher` map parse failures to `InvalidInputError`, so library `search()` / `replace_in_content`, tx replace, and CLI `search --json` set `error_kind: invalid_input` without scraping the regex crate message.
-- **`bounded_regex_build` helper.** Finishes a `bounded_regex_builder` as `InvalidInputError`. Used by replace/search compile, tx plan search, and AST in-symbol regex replace so all paths share one kind.
-- **Agent-rules / reference docs.** Document invalid search/replace regex as `error_kind: invalid_input` (exit 1) so agents do not treat compile failures as soft no-match.
-- **Replace invalid-regex JSON lock.** CLI `replace --json` with a bad pattern sets `error_kind: invalid_input` (integration coverage next to the existing text-mode regex parse test).
-- **Post-write format failures typed.** Explicit `--format` / format-timeout failures set `error_kind: format_failed` (exit 1) so agents can branch without scraping English (files may already be written; use `undo` or re-run the formatter).
-- **Docs: format failure kinds + library InvalidInput example.** Reference documents `--format` / `--format-timeout` `format_failed` envelopes; README library sample shows `edit_error_kind` peeling `InvalidInput` for empty patterns.
-- **Tx `--format` JSON lock.** `tx --apply --format false --json` sets `error_kind: format_failed` (exit 1) after commit, matching standalone write commands.
-- **Format unit locks.** Explicit `--format` failure and format-timeout map to `FormatFailedError` in unit tests (not only integration).
-- **Crate docs: edit_error_kind peels exit types.** Library rustdoc shows `InvalidInput` for empty patterns and notes that CLI/tx typed errors map through `edit_error_kind`.
-- **Replace `--format` JSON lock.** Standalone `replace --apply --format false --json` sets `error_kind: format_failed` (exit 1); file still written (same recovery model as tx).
-- **Create/append `--format` JSON locks.** Same `format_failed` envelope on create and append write paths after apply.
-- **Prepend/delete `--format` JSON locks.** Post-apply format failures on prepend and delete also set `error_kind: format_failed` (delete still removes the file first).
-- **Doc write `format_failed`.** `doc set` (and other doc writes that remap engine errors) preserve `error_kind: format_failed` for post-write `--format` failures (was untyped exit 1).
-- **Shared `classify_typed_error`.** One table maps typed errors to JSON `error_kind` + exit code for global dispatch and command remappers, so new kinds cannot be present in one path and dropped in another.
-- **Tx engine error remapper.** Plan execute failures use `classify_typed_error` (unknown → `operation_failed` / 9), matching the shared kind table.
-- **Library `edit_error_kind` uses `classify_typed_error`.** Exit typed errors map through the same table as CLI JSON kinds (no dual switch to drift).
-- **MCP/plan_exec error remapper.** In-process plan execute uses `classify_typed_error` for JSON error envelopes (unknown → `operation_failed`).
-- **Library `edit_error_kind` peels IO not_found.** Missing-file IO maps to `EditErrorKind::OperationFailed` (was `None`), via the shared classifier.
-- **`apply_content_edits_to_file` diff headers.** File path appears in `--- a/` / `+++ b/` instead of `<buffer>`. Absolute paths still avoid `a//`. (#1500, #1502)
-- **Signature rewrite body gap.** Full-string and structured rewrites no longer produce `-> i32{` when the new signature has no trailing space. Original space or newline before `{` is preserved; glued originals get a conventional space; `;` decls do not. (#1503, #1504)
-- **`continue_on_no_match: false`.** Batch rename actually stops after the first `NoMatch` (was a no-op). (#1499)
-- **`if_exists` vs `require_change` on file replace.** File path honors the same "if_exists wins" rule as content replace. (#1499)
-- **Restore path matching.** Basename-only match removed so a different path with the same file name cannot restore the wrong session. (#1499)
-- **`command_position` multi-line wrappers.** Prefix peeling no longer strips newlines, so `timeout` / `nice` / `sudo` on a later line are not confused with tokens from the previous line. Also peels `timeout 30`, `nice -n 10`, `stdbuf`, `ionice`, `setsid`, `runuser -u USER`, `busybox` applets, and path-taking `flock` / `chroot` wrappers.
-- **`command_position` flag honesty.** Combining with `case_insensitive`, `word_boundary`, `fuzzy`, or context anchors is `InvalidInput` (was silently ignored, which looked like a soft no-match).
-- **CLI identity replace honesty.** When the pattern matches but `new` equals `old`, `replace` no longer reports "no matches" / exit 3. It reports success with the raw match count and an "identical (no file changes)" note so `require_change` stays satisfied. JSON includes `identity: true`.
-- **CLI patch JSON `error_kind`.** Stale apply/check failures set `error_kind: "ambiguous"` (exit 5), merge conflicts set `"conflicts"` (exit 8), and parse/input failures set `"parse_error"` (exit 4).
-- **CLI search JSON `error_kind`.** Soft no-match (`--json` exit 3) sets `error_kind: "no_matches"`, matching replace/tx agents that branch on kind without scraping stderr.
-- **CLI replace JSON `error_kind`.** `--json` failures set `error_kind: "no_matches"` (exit 3) or `error_kind: "ambiguous"` (exit 5 / `--unique`), matching tx plan JSON so agents can branch without scraping stderr.
-- **Shared JSON `error_kind: no_matches`.** Exit-3 paths for doc (get/keys/len), md, and AST now set `error_kind` via `GlobalFlags::emit_error_json_kind` / doc `format_no_match`, so agents can branch like tx without scraping stderr.
-- **GNU long options with `=`.** `command_position` peels `--name=value` flags (`nice --adjustment=10`, `sudo --user=root`, `timeout --signal=TERM 30`).
-- **`env --unset VAR`.** Peels `--unset` as an arg-taking flag (alongside `env -u VAR`) so the following invocable command rewrites.
-- **`env --chdir DIR`.** Peels `--chdir` the same way as `-C` so the following invocable command rewrites.
-- **`timeout --kill-after` stacked durations.** Peels consecutive duration tokens so `timeout --kill-after 5 30 pip` and `timeout --kill-after=5 30 pip` rewrite the command (bare `5 30 pip` still stays non-command).
-- **CI isolation wrappers.** `command_position` peels `unshare`, `nsenter`, `taskset`, `prlimit`, `numactl`, `chrt`, and `setpriv` (plus list values like `taskset -c 0,1`) so sandbox and affinity-wrapped installs rewrite.
-- **Unit/sandbox wrappers.** `command_position` peels `systemd-run`, `firejail`, `dbus-run-session`, and `chronic`, plus bare `--` end-of-options markers (`dbus-run-session -- pip`).
-- **`run0` privilege wrapper.** `command_position` peels systemd `run0` (modern `sudo` alternative) so `run0 -u root pip` rewrites the command.
-- **Container entrypoint wrappers.** `command_position` peels `gosu`, `su-exec`, `tini`, and `dumb-init` so Docker/K8s install scripts rewrite the invocable command.
-- **runit / daemontools / s6 wrappers.** `command_position` peels `chpst` / `softlimit` / `s6-softlimit` / `with-contenv` / `s6-sudo` / `s6-applyuidgid` (transparent flags) and path-taking `envdir` / `s6-envdir` / `setlock` / `envuidgid` / `s6-envuidgid` so supervised service and s6-overlay install scripts rewrite the invocable command.
-- **Tidy / rename / md `--format` JSON locks.** Post-apply format failures on `tidy fix`, `rename`, and `md replace-section` set `error_kind: format_failed` (exit 1), matching create/append/replace coverage.
-- **CLI `search --assert-count` JSON parity.** Count mismatch under `--json`/`--jsonl` sets `ok: false` and `error_kind: "changes_detected"` (exit 2), matching MCP `search_files`, plan/tx search, and agent-rules (was `ok: true` with no kind).
-- **Tx/batch preview JSON `status`.** Default and `--diff` plan mode with pending changes now report `status: "changes_detected"` (still exit 2), matching `--check`. Previously claimed `status: "success"` while exit was 2, which misled agents that branch on status.
-- **Tx/CLI structured output serialize errors.** If JSON serialization of a structured report fails, stdout gets a minimal `ok: false` / `error_kind: operation_failed` envelope and the process exits 1 (never empty stdout with a soft plan exit). (#1651)
-- **Doc value and library search formatters fail-closed.** `doc` `format_value` and `api::format_search_results` no longer soft-fail to empty stdout on serialize error; they reuse the shared `json_emit` fallback envelope.
-- **Tx verify attr filter neighbor steal.** `symbol_has_attr` only walks contiguous annotation lines immediately above a symbol, so a prior item's `#[test]` no longer falsely attaches to the next function within a fixed lookback window. Disk symbol snapshots use a single read for extract + attr filter.
-- **CLI undo JSON `error_kind`.** Soft no-session paths (`undo --list` empty, or no sessions to restore) set `error_kind: "no_matches"` (exit 3), matching other CLI exit-3 JSON envelopes.
-- **CLI doc JSON `error_kind: type_error`.** `doc keys` / `doc len` on the wrong value type, and write-path type failures, set `error_kind: "type_error"` (exit 1) so agents can distinguish type mismatches from soft no-matches.
-- **CLI file ops JSON error_kind.** `create`/`rename` conflicts set `already_exists`; missing targets for `delete`/`append`/`prepend`/`rename` set `not_found`; invalid flag combinations and non-file targets set `invalid_input` (all exit 1).
-- **CLI tidy JSON `invalid_input`.** `tidy fix --dedent … --indent …` together exits 1 with `error_kind: "invalid_input"` under `--json`.
-- **CLI md JSON `invalid_input`.** `md move-section` without `--before`/`--after`, and missing `--stdin`/`--content` on insert/replace paths, set `error_kind: "invalid_input"` (exit 1).
-- **CLI explain JSON kinds.** Missing/unreadable plan files set `not_found` / `invalid_input`; plan parse failures exit **4** with `error_kind: "parse_error"`.
-- **CLI patch/rename JSON `invalid_input`.** Unreadable patch targets during merge-check and binary rename with write-policy flags set `error_kind: "invalid_input"` (exit 1).
-- **CLI batch JSON `parse_error`.** Line parse failures (unknown op, bad arity, bad quotes) exit **4** with `error_kind: "parse_error"` (was unstructured exit 1). Too-many-ops limit stays exit 1 with `invalid_input`.
-- **CLI read/status/ast/doc JSON kinds.** Invalid `--lines` sets `invalid_input`; all-paths-missing read sets `not_found`; status outside a git repo sets `invalid_input`; AST missing path / non-dir map target set `not_found` / `invalid_input`; doc merge flag conflicts set `invalid_input`.
-- **CLI replace JSON `invalid_input`.** Validation failures (bad `--nth`, `--range` without `--whole-line`, incompatible flag combos, context without paths) set `error_kind: "invalid_input"` (exit 1).
-- **CLI search JSON `invalid_input`.** Empty pattern and `--invert-match` + `--multiline` together exit 1 with `error_kind: "invalid_input"` under `--json`.
-- **CLI top-level JSON typed errors.** When a command returns a typed `NoMatchError` / `AmbiguousError` through the global error path under `--json`/`--jsonl`, the envelope includes `error_kind` and exits 3/5 (was generic exit 1 without kind).
-- **CLI usage errors exit 1.** Invalid flags, enum values, missing required args, and unknown subcommands exit **1** (`FAILURE`), not clap's default **2**. Exit 2 remains only `CHANGES_DETECTED` (`--check` / write preview). `--help` / `--version` still exit 0.
-- **CLI usage + `--json`/`--jsonl` envelope.** When parse fails after a global `--json`/`--jsonl`, stdout gets `ok: false`, `error_kind: "invalid_input"`, and the clap message (agents no longer scrape colored stderr).
-- **Replace empty-pattern wording.** Empty replace `old`/`pattern` reports `replace pattern must not be empty` (was `search pattern…`), with `error_kind: "invalid_input"` under `--json`.
-- **`--contain` JSON `invalid_input`.** Path rejections and empty path arguments under `--contain` set `error_kind: "invalid_input"` on the global `--json`/`--jsonl` error path (typed `InvalidInputError`, not English scraping).
-- **Cleaner clap JSON usage messages.** Usage failures under `--json`/`--jsonl` strip the `error: ` prefix and help footer so agents get a short actionable string.
-- **Plan `ops` alias.** Transaction plans accept `"ops"` as a serde alias for `"operations"` so agents that emit the shorter field name parse without a `missing field` error.
-- **Missing path roots are `not_found`.** When every explicit path root for `search`, `replace`, or `tidy` is missing (including `--files-from` lists, not stdin), exit **1** with `error_kind: "not_found"` (was soft `no_matches` / vacuous tidy success). Pattern misses and clean trees still use exit 3 / 0.
-- **Tx file ops missing targets `not_found`.** Plan `file.append` / `file.prepend` / `file.delete` on missing paths emit `error_kind: "not_found"` (exit 1), not generic `operation_failed`.
-- **Tx create/rename conflicts `already_exists`.** Plan `file.create` without force and rename into an existing dest set `error_kind: "already_exists"` (exit 1), matching standalone CLI file ops.
-- **Tx missing-file `not_found`.** Plan/tx engine IO `NotFound` (e.g. `md.replace_section` on a missing path) sets `error_kind: "not_found"` and exit **1** instead of generic `operation_failed` (9).
-- **Engine IO not_found chain.** Tx/CLI engine read failures preserve `std::io::ErrorKind::NotFound` through context wrappers so global `--json` maps them to `error_kind: "not_found"` (e.g. `md replace-section` on a missing file).
-- **Doc navigate type mismatches `type_error`.** Parent-not-array/object and related selector type failures in plan doc ops set `error_kind: "type_error"` (exit 1).
-- **Tx doc type mismatches `type_error`.** Plan doc append/prepend/delete_where (and similar type failures) set `error_kind: "type_error"` (exit 1), matching CLI doc keys/len.
-- **Tx non-file targets `invalid_input`.** Plan file ops against directories set `error_kind: "invalid_input"` (exit 1). Engine `path_err` keeps IO NotFound through path prefixing so missing docs stay `not_found`.
-- **More shell wrappers.** `command_position` peels `eatmydata` and s6-style `s6-setuidgid` / `setuidgid` user wrappers.
-- **Tx unique multi-match exit code.** Plan/tx `replace` with `unique: true` and multiple matches now exits **5** (`ambiguous`), matching CLI `replace --unique`, instead of generic exit 9 (`operation_failed`).
-- **Tx require_change zero-match exit code.** Plan/tx `replace` with `require_change: true` and zero matches now exits **3** (`no_matches`), matching CLI, instead of generic exit 9.
-- **Tx patch.apply merge conflicts.** Plan `patch.apply` with `on_stale: "merge"` without `allow_conflicts` exits **8** with `error_kind: "conflicts"` (was generic `operation_failed` / 9), matching CLI `patch merge`.
-- **Tx op flag conflicts `invalid_input`.** Plan-level option conflicts (replace whole_line+multiline, range without whole_line, tidy dedent+indent, md.move_section before/after, search invert+multiline) exit **1** with `error_kind: "invalid_input"` (was `parse_error` / 4), matching standalone CLI flags.
-- **Doc unsupported extension `invalid_input`.** `doc` on non-JSON/YAML/TOML paths (and plan doc ops on those paths) set `error_kind: "invalid_input"` (exit 1). CLI write path no longer mislabels them as `type_error`.
-- **Tx AST empty directory `no_matches`.** Plan `ast.rename` on a directory with no source files exits **3** with `error_kind: "no_matches"` (was `operation_failed` / 9), matching CLI `ast rename`.
-- **Doc parse failures `parse_error`.** Malformed JSON/YAML/TOML content exits **4** with `error_kind: "parse_error"` (was unstructured exit 1), for CLI doc and plan/tx doc ops.
-- **Tx AST extract/rewrite kinds.** `ast.extract_to_file` into an existing target without `force` sets `already_exists` (exit 1). `ast.rewrite_signature` without signature fields sets `invalid_input` (exit 1).
-- **Tx mid-plan delete then use is `not_found`.** Append/prepend/rename after `file.delete` in the same plan set `error_kind: "not_found"` (exit 1). Workspace-guard escapes set `invalid_input`.
-- **Tx search assert_count mismatch.** Plan `search` with `assert_count` when the actual match count differs exits **2** with `error_kind: "changes_detected"` (was `operation_failed` / 9), matching CLI `search --assert-count`.
-- **CLI `--cwd` missing/non-dir `invalid_input`.** Bad `--cwd` paths exit **1** with `error_kind: "invalid_input"` under `--json` (typed `InvalidInputError`).
-- **Empty path strings `invalid_input`.** `resolve_user_path` rejects empty paths with typed `InvalidInputError` (same as `check_paths_contained`).
-- **Doc navigate selector mistakes typed.** Empty selectors, unsupported wildcards on write paths, bad predicates, and out-of-bounds indexes set `invalid_input`; expected-object type mismatches set `type_error`.
-- **AST split/search/symbols and plan verify typed.** Duplicate or unaccounted split symbols and overlapping symbol spans set `invalid_input`; invalid AST search patterns set `parse_error`; malformed plan `verify` specs set `invalid_input` (was unstructured exit 1).
-- **More agent JSON kinds.** Invalid `normalize_eol` values, md `table-append` row/table failures, and library doc type mismatches set `invalid_input` / `type_error`; missing git-blob paths for AST set `not_found` (was unstructured exit 1 / operation_failed).
-- **AST symbol-not-found is `no_matches`.** extract/insert/reorder/wrap/move paths set `error_kind: "no_matches"` (exit 3) when a named symbol is missing; create race `already_exists` and unknown undo session are typed the same way.
-- **Patch apply/parse typed for tx.** Plan/engine patch parse failures set `parse_error`; stale context sets `ambiguous`; other apply failures set `invalid_input` (CLI path already emitted kinds via string maps).
-- **files-from / batch input / MCP bind typed.** Missing `--files-from` or batch input files set `not_found`; unreadable lists and invalid MCP bind/TLS config set `invalid_input`; AST validate parse failure sets `parse_error`.
-- **Agent-rules `error_kind` catalogue expanded.** Exit 3/4 rows and exit-1 kind list cover AST symbol misses, normalize_eol, table-append, patch/plan/files-from kinds so agents match runtime envelopes.
-- **Faster multi-file `ast rename` pre-scan.** Match detection across many files uses the same adaptive parallel walker as search/replace/tidy (was sequential full-file reads).
-- **Faster reverse `ast deps`.** Project-wide importer scan uses the parallel walker (forward deps already did).
-- **Faster MCP multi-file `ast_rename` pre-scan.** Same parallel match probe as CLI `ast rename`.
-- **Reference docs for typed extract/split/write_policy failures.** `docs/reference` documents `no_matches` / `already_exists` / `invalid_input` for extract, split, and invalid `normalize_eol`.
-- **Reference docs for insert/wrap/reorder/move failure kinds.** Missing symbols and bad wrap/reorder inputs document `no_matches` / `invalid_input`.
-- **Reference docs for replace/group/MCP bind failures.** `ast.replace` / `ast.group` missing symbols and MCP bind/TLS `invalid_input` documented.
-- **YAML/TOML preserve-path typed errors.** Comment-preserving re-parse failures set `parse_error`; serialization failures set `invalid_input` (was unstructured exit 1).
-- **YAML newline-string escape typed.** Failure double-quoting multiline YAML scalars sets `invalid_input`.
+- **Tx verify `attr=` no longer steals a neighbor's attribute.** A fixed multi-line lookback could treat the next function as `#[test]` when a prior test sat nearby. Only contiguous annotation lines immediately above the symbol count; disk snapshots use a single read for extract and attr filter. (#1653)
+- **`require_change` and `if_exists` ordering.** File `replace_text` no longer lets `require_change` override a missing-file `if_exists` policy. (#1499)
+- **`continue_on_no_match: false` works.** Batch/plan multi-file paths stop after the first no-match when configured (both true and false used to keep going). (#1499)
+- **Backup restore path matching.** `restore_path_from_latest_backup` matches the exact path in the session, not a basename-only collision across sessions. (#1499)
+- **Library invalid search regex fails closed.** High-level `search` / `search_directory` return typed `InvalidInput` on bad patterns instead of `Ok([])` (soft no-match). (#1621, #1622)
+- **Doc write preserves `format_failed`.** Engine remappers no longer drop post-write format failure kinds on `doc set` and related writes. (#1634)
 
-## Agent and library notes
+## Performance
 
-- Prefer `require_change: true` in agent hosts that treat zero matches as tool errors.
-- Use `command_position` only when rewriting shell invocable names; keep ordinary replace or word_boundary for identifiers.
-- Plan `replace` and MCP replace accept the same `require_change` / `command_position` fields as the library API (default false).
-- CLI: `patchloom replace … --command-position --require-change` (and MCP `batch_replace`) expose the same flags.
-- Full-string signature rewrites may omit trailing space before `{`; the library normalizes the body gap.
-- Multi-op content edits expose rolled-up `match_count` on `ContentEditsResult` / file `EditResult`. Crate-root re-exports include `ContentEdit`, `ContentEditsResult`, and `apply_content_edits`.
+- **Multi-file AST rename pre-scan** (CLI and MCP) uses the adaptive parallel walker instead of sequential full-file reads. (#1612, #1614)
+- **Reverse `ast deps` project scan** uses the same parallel walker (forward deps already did). (#1613)
 
 ## Numbers
 
-Rounded test counts and MCP inventory track the library expansions in this cycle. See the README badge and `make check-readme` for the live floor.
+| Metric | v0.11.0 | v0.12.0 | Delta |
+|--------|---------|---------|-------|
+| Unit tests | 2,201 | 2,339 | +138 |
+| Integration tests | 1,008 | 1,071 | +63 |
+| PTY tests | 10 | 10 | -- |
+| **Total tests** | **3,219** | **3,420** | **+201** |
+| CLI commands | 23 | 23 | -- |
+| MCP tools (with `ast`) | 55 | 55 | -- |
+| Commits since v0.11.0 | -- | 151 | -- |
 
 ## Upgrading
 
 ```bash
+# Cargo
 cargo install patchloom --locked
-# or
+# or pin in Cargo.toml
 patchloom = "0.12"
+
+# Homebrew (after formula updates)
+brew upgrade patchloom
 ```
 
-**Library:** New `ReplaceOptions` fields default to false (non-breaking). New AST batch / rename APIs need `features = ["ast", "files"]` (or default features). Match structured errors with `edit_error_kind(&err)`.
+**Library hosts:** `require_change` and `command_position` default to false (non-breaking). Prefer `edit_error_kind(&err)` for branching. AST file mutators and `ast_rename_batch` need `features = ["ast", "files"]` (or default features). Use `restore_path_from_latest_backup` for per-path validate/revert.
 
-**Release consumers:** New optional CLI flags `--require-change` and `--command-position` on `replace` (defaults off; existing scripts unchanged). Library-only AST mutators and `FunctionSigEdit::parse_rust` need no CLI action. Plan/MCP `ast.rewrite_signature` inherits body-gap fix automatically.
+**CLI / scripts:** New optional flags `--require-change` and `--command-position` on `replace` (defaults off). Under `--json` / `--jsonl`, treat `error_kind` as the branch key: `not_found`, `no_matches`, `invalid_input`, `format_failed`, `parse_error`, `type_error`, `already_exists`, `changes_detected`, `conflicts`. Clap usage failures are exit 1 with `invalid_input`, not exit 2.
+
+**Plans / MCP:** `"ops"` is accepted for `"operations"`. Plan and MCP replace accept the same `require_change` / `command_position` fields as the library. Prefer structured kinds over message text when driving retries.
+
+**Tx verify:** If you use `kind=function,attr=test` (or similar), counts now ignore attributes from nearby previous items.


### PR DESCRIPTION
## Summary

Rewrite `RELEASE_NOTES.md` for the upcoming 0.12.0 GitHub Release body (override applied by the release host job when #1498 merges).

- User-facing structure aligned with 0.11.0 notes (Highlights, features, agent reliability, bug fixes, performance, Numbers, Upgrading)
- Groups the large typed-error / JSON / path work into themes instead of a per-PR micro-changelog
- Verified test counts: 2,339 unit + 1,071 integration + 10 PTY = 3,420 (+201 vs 0.11.0); 151 commits; 55 MCP tools
- `make verify-release-notes` structural checks pass

## Validation

- `make verify-release-notes`
- Test totals from `cargo test --lib/--test integration/--test pty`