### PR TITLE
fix: tidy JSON emit and check-fast README accuracy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2654,9 +2654,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
 dependencies = [
  "cc",
  "regex",

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ at your option.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-For local verification before opening a pull request, run `make check`. It matches the main Linux CI gate: formatting, clippy, unit tests, integration tests, and generated-doc freshness checks. While iterating locally, `make check-fast` runs the Rust formatting, lint, and test path without the generated-doc freshness checks.
+For local verification before opening a pull request, run `make check`. It matches the main Linux CI gate: formatting, clippy, unit tests (including feature-matrix jobs), integration tests, PTY tests, release-notes structure, test hygiene, and generated-doc freshness (`check-patchloom-md`, `check-readme`). While iterating locally, `make check-fast` is the same except it skips only `check-patchloom-md` (it still runs `check-readme` so a drifted test-count badge fails before CI).
 
 All commits must be signed off with `git commit -s`.
 

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -190,16 +190,20 @@ struct TidyCheckOutput {
 }
 
 /// Render issues to stdout.
-pub(super) fn render_issues(issues: &[TidyIssue], global: &GlobalFlags) {
+///
+/// Structured modes propagate serialize errors (`?`) instead of discarding
+/// them (`let _ =` / `if let Ok`), so `--json`/`--jsonl` never looks empty
+/// while the exit code still reports issues (#1651 class).
+pub(super) fn render_issues(issues: &[TidyIssue], global: &GlobalFlags) -> anyhow::Result<()> {
     if global.json {
         let output = TidyCheckOutput {
             ok: issues.is_empty(),
             issue_count: issues.len(),
             issues: issues.to_vec(),
         };
-        let _ = global.emit_json(&output);
-    } else if let Ok(true) = global.emit_json_items(issues) {
-        // emitted per-item JSONL
+        global.emit_json(&output)?;
+    } else if global.jsonl {
+        global.emit_json_items(issues)?;
     } else {
         for issue in issues {
             if let Some(line) = issue.line {
@@ -209,6 +213,7 @@ pub(super) fn render_issues(issues: &[TidyIssue], global: &GlobalFlags) {
             }
         }
     }
+    Ok(())
 }
 
 /// Run `tidy check` for the given paths.
@@ -226,7 +231,7 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
     }
     let issues = collect_issues(paths, global)?;
     if !global.quiet || global.json || global.jsonl {
-        render_issues(&issues, global);
+        render_issues(&issues, global)?;
     }
     if issues.is_empty() {
         Ok(exit::SUCCESS)

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -95,6 +95,10 @@ pub(super) fn tidy_fix_output(
 }
 
 /// Emit structured JSON/JSONL output for tidy fix.
+///
+/// Propagates serialize failures (`?`) so agents never see empty stdout under
+/// `--json`/`--jsonl` while the command still returns a soft success code
+/// (same fail-closed class as #1651 / `json_emit`).
 fn emit_tidy_fix_output(
     global: &GlobalFlags,
     fix_files: &[TidyFixFileResult],
@@ -107,9 +111,9 @@ fn emit_tidy_fix_output(
             files: fix_files.to_vec(),
             diff: diff_text,
         };
-        let _ = global.emit_json(&output);
+        global.emit_json(&output)?;
     } else if global.jsonl {
-        let _ = global.emit_json_items(fix_files);
+        global.emit_json_items(fix_files)?;
     }
     Ok(())
 }

--- a/src/cmd/tidy/tests.rs
+++ b/src/cmd/tidy/tests.rs
@@ -1,6 +1,6 @@
 //! Unit tests for tidy check/fix.
 
-use super::check::{check_file, collect_issues};
+use super::check::{check_file, collect_issues, render_issues};
 use super::fix::eol_mode_to_str;
 use super::*;
 use crate::cli::global::GlobalFlags;
@@ -456,6 +456,37 @@ fn eol_mode_conversion_round_trips() {
     assert_eq!(eol_mode_to_str(EolMode::Crlf), "crlf");
     assert_eq!(eol_mode_to_str(EolMode::Cr), "cr");
     assert_eq!(eol_mode_to_str(EolMode::Keep), "keep");
+}
+
+/// Regression: structured emit must not discard serialize errors (`let _ =`).
+/// `render_issues` returns `Result` and uses `emit_json`/`emit_json_items` with
+/// `?` so agent `--json`/`--jsonl` paths stay fail-closed (#1651 class).
+#[test]
+fn check_render_issues_json_ok() {
+    let issues = vec![TidyIssue {
+        path: "f.txt".into(),
+        line: Some(1),
+        issue: "trailing whitespace",
+    }];
+    let global = GlobalFlags {
+        json: true,
+        ..GlobalFlags::default()
+    };
+    render_issues(&issues, &global).expect("json emit must succeed for TidyIssue");
+}
+
+#[test]
+fn check_render_issues_jsonl_ok() {
+    let issues = vec![TidyIssue {
+        path: "f.txt".into(),
+        line: None,
+        issue: "missing final newline",
+    }];
+    let global = GlobalFlags {
+        jsonl: true,
+        ..GlobalFlags::default()
+    };
+    render_issues(&issues, &global).expect("jsonl emit must succeed for TidyIssue");
 }
 
 /// Regression: `tidy check --quiet --json` must still emit JSON output.


### PR DESCRIPTION
## Summary

MPI cycle after 0.12.0 release.

- **fix:** tidy check/fix no longer discard `emit_json` / `emit_json_items` results. Structured `--json`/`--jsonl` paths propagate serialize failures instead of empty stdout with a soft exit code (#1651 class).
- **test:** unit coverage for `render_issues` JSON and JSONL.
- **chore:** tree-sitter 0.26.10 → 0.26.11.
- **docs:** README `make check-fast` description matches AGENTS.md / CONTRIBUTING.md (skips only `check-patchloom-md`).

## Validation

- `make check-fast` passed