### PR TITLE
feat: Bline embedder API surfaces (#1658–#1666)

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -79,9 +79,12 @@ patchloom = { default-features = false, features = ["ast", "files"] }
 ```
 
 See the [crate documentation](https://docs.rs/patchloom) for the full API
-surface (`require_change`, `command_position`, `ast_rename_batch`, backup
-restore helper) and the [introduction](../introduction.md#as-a-rust-library)
-for a quick overview.
+surface (`require_change`, `command_position`, `ast_rename_batch`,
+`find_files_with_symbol`, `classify_error`, `restore_path_from_session`,
+`run_post_write_validation`, `match_mode`) and the
+[introduction](../introduction.md#as-a-rust-library) for a quick overview.
+Embedder tables live under [Library API](../reference/README.md#library-api)
+in the reference.
 
 ## Shell completions
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1267,3 +1267,36 @@ The operations below are the building blocks inside `operations`.
 - **Use when:** Embedding in agents (e.g. bline), custom tools, or tests without CLI spawn overhead. See `cargo doc --no-default-features --features ast --open`.
 - **Notable:** `search_directory(root, pattern, opts)` for parallel content search with globs/context (library equivalent of CLI search). Error paths and guards documented in api.rs.
 - **Related:** README "As a library", `src/api.rs`, `src/lib.rs` docs, examples/README.md entry for search_directory.
+
+### Embedder surfaces (Bline-oriented)
+
+| Need | API |
+|------|-----|
+| Fail-closed text replace | `ReplaceOptions.require_change` + `edit_error_kind` / `classify_error` |
+| Non-`anyhow` error kinds | `classify_error(&dyn Error)` / `classify_error_ref` (#1659) |
+| Shell token rename | `ReplaceOptions.command_position` / `ContentEdit::Replace` (#1666) |
+| Scoped symbol replace (literal/regex) | `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (#1658) |
+| Project symbol discovery + multi-file rename | `find_files_with_symbol` then `ast_rename_batch` (#1664) |
+| Match honesty (fuzzy confidence) | `EditResult.match_mode` / `match_score` (#1662) |
+| In-memory multi-op with real diff headers | `apply_content_edits_with_label` (#1665) |
+| Surgical undo one path | `backup::restore_path_from_session(root, ts, path)` (#1660) |
+| Post-Apply format/lint + optional revert | `run_post_write_validation` / `PostWriteHooks` (#1663) |
+| Signature rewrite complete in one write | `ast_rewrite_signature` body-gap invariant (#1661) |
+
+### Shell command-position for embedders
+
+When rewriting package managers or CLI tools in scripts (`pip` → `uv`, `wget` → `curl`), set `command_position: true` so only invocable tokens change:
+
+```text
+# before
+sudo pip install foo
+uv pip list
+pipenv run test
+
+# after (command_position)
+sudo uv install foo
+uv pip list          # argument pip kept
+pipenv run test      # longer token kept
+```
+
+Cannot combine with `regex`, `whole_line`, `multiline`, `nth`, insert-before/after, `fuzzy`, or context anchors (typed `InvalidInput`). Prefer this over `word_boundary` for shell files.

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -102,6 +102,8 @@ pub fn ast_rewrite_signature_in_content(
         diff,
         changed,
         match_count: if changed { 1 } else { 0 },
+        match_mode: None,
+        match_score: None,
     })
 }
 
@@ -158,15 +160,27 @@ pub fn ast_rename(
     Ok(result)
 }
 
+/// Options for [`ast_replace_in_symbol`] (#1658).
+#[derive(Debug, Clone, Default)]
+pub struct AstReplaceInSymbolOptions {
+    /// Use regex mode for `old` (default `false`).
+    pub regex: bool,
+}
+
 /// Replace text inside a named symbol body on disk.
 ///
-/// Zero replacements → `NoMatch`. See #1493.
+/// Supports literal and regex modes via [`AstReplaceInSymbolOptions`].
+/// - Missing symbol → `NoMatch` (message names the symbol)
+/// - Symbol found, zero pattern matches → `NoMatch` (message names the pattern)
+///
+/// Zero replacements → `NoMatch`. See #1493, #1658.
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
 pub fn ast_replace_in_symbol(
     path: &Path,
     symbol: &str,
     old: &str,
     new: &str,
+    opts: &AstReplaceInSymbolOptions,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
@@ -175,19 +189,20 @@ pub fn ast_replace_in_symbol(
     let original =
         std::fs::read_to_string(path).with_context(|| format!("failed to read {path_str}"))?;
     let lang = Language::from_path(path);
-    let replaced = match ast_replace::replace_in_symbol(&original, symbol, old, new, false, lang) {
-        Ok(Some(r)) => r,
-        Ok(None) => {
-            return Err(EditError::new(
-                EditErrorKind::NoMatch,
-                format!("symbol `{symbol}` not found in {path_str}"),
-            )
-            .into());
-        }
-        Err(e) => {
-            return Err(EditError::new(EditErrorKind::OperationFailed, e.to_string()).into());
-        }
-    };
+    let replaced =
+        match ast_replace::replace_in_symbol(&original, symbol, old, new, opts.regex, lang) {
+            Ok(Some(r)) => r,
+            Ok(None) => {
+                return Err(EditError::new(
+                    EditErrorKind::NoMatch,
+                    format!("symbol `{symbol}` not found in {path_str}"),
+                )
+                .into());
+            }
+            Err(e) => {
+                return Err(EditError::new(EditErrorKind::OperationFailed, e.to_string()).into());
+            }
+        };
     if replaced.replacements == 0 {
         return Err(EditError::new(
             EditErrorKind::NoMatch,
@@ -206,7 +221,124 @@ pub fn ast_replace_in_symbol(
         None,
     );
     result.match_count = replaced.replacements;
+    result.match_mode = Some(super::MatchMode::Exact);
     Ok(result)
+}
+
+/// Options for [`find_files_with_symbol`] (#1664).
+#[derive(Debug, Clone, Default)]
+pub struct SymbolSearchOptions {
+    /// Cap on returned paths (`None` = no limit).
+    pub max_files: Option<usize>,
+    /// Restrict to these languages (`None` = any language with a known extension).
+    pub languages: Option<Vec<Language>>,
+    /// Include hidden files/dirs (default false; same as search).
+    pub include_hidden: bool,
+}
+
+/// Paths under `root` that likely contain identifier `name` (#1664).
+///
+/// Uses the same ignore / binary skip rules as library file collection, then
+/// a word-boundary heuristic on source files with a known language extension.
+/// Compose with [`ast_rename_batch`]:
+///
+/// ```rust,no_run
+/// # #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+/// # {
+/// use patchloom::api::{
+///     ApplyMode, AstRenameBatchOptions, SymbolSearchOptions, ast_rename_batch,
+///     find_files_with_symbol,
+/// };
+/// use std::path::Path;
+///
+/// let root = Path::new(".");
+/// let paths = find_files_with_symbol(root, "OldType", &SymbolSearchOptions::default())?;
+/// let path_refs: Vec<&Path> = paths.iter().map(Path::new).collect();
+/// let _ = ast_rename_batch(
+///     &path_refs,
+///     "OldType",
+///     "NewType",
+///     &AstRenameBatchOptions {
+///         mode: ApplyMode::Preview,
+///         ..Default::default()
+///     },
+///     None,
+/// )?;
+/// # }
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub fn find_files_with_symbol(
+    root: &Path,
+    name: &str,
+    opts: &SymbolSearchOptions,
+) -> anyhow::Result<Vec<PathBuf>> {
+    if name.is_empty() {
+        return Err(EditError::new(
+            EditErrorKind::InvalidInput,
+            "find_files_with_symbol name must not be empty",
+        )
+        .into());
+    }
+    let all = crate::files::collect_file_paths(root, opts.include_hidden)?;
+    let mut out = Vec::new();
+    for path in all {
+        let lang = Language::from_path(&path);
+        if lang == Language::Unknown {
+            continue;
+        }
+        if let Some(ref allowed) = opts.languages
+            && !allowed.contains(&lang)
+        {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        if crate::files::is_binary(&bytes) {
+            continue;
+        }
+        let Ok(content) = String::from_utf8(bytes) else {
+            continue;
+        };
+        if content_has_identifier(&content, name) {
+            out.push(path);
+            if opts.max_files.is_some_and(|m| out.len() >= m) {
+                break;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Word-boundary check for an identifier (ASCII-aware; good enough for discovery).
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+fn content_has_identifier(content: &str, name: &str) -> bool {
+    if name.is_empty() || !content.contains(name) {
+        return false;
+    }
+    let bytes = content.as_bytes();
+    let name_bytes = name.as_bytes();
+    let mut start = 0usize;
+    while let Some(rel) = content[start..].find(name) {
+        let i = start + rel;
+        let before_ok = i == 0 || !is_ident_byte(bytes[i - 1]);
+        let after = i + name_bytes.len();
+        let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
+        if before_ok && after_ok {
+            return true;
+        }
+        start = i + 1;
+        if start >= content.len() {
+            break;
+        }
+    }
+    false
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
 }
 
 /// Options for [`ast_rename_batch`] (#1495).

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -67,11 +67,24 @@ pub struct ContentEditsResult {
 /// partial buffer. On success, every op has been applied in order; each op
 /// sees the result of the previous one.
 ///
+/// Diff headers use `<buffer>`. Prefer [`apply_content_edits_with_label`] when
+/// the host knows a real path (#1665).
+///
 /// Available with default features off as long as the replace path is
 /// compiled (always; no `ast` required).
 pub fn apply_content_edits(
     content: &str,
     edits: &[ContentEdit],
+) -> anyhow::Result<ContentEditsResult> {
+    apply_content_edits_with_label(content, edits, None)
+}
+
+/// Like [`apply_content_edits`], but labels unified-diff headers with
+/// `path_label` when set (e.g. `src/lib.rs`). `None` keeps `<buffer>` (#1665).
+pub fn apply_content_edits_with_label(
+    content: &str,
+    edits: &[ContentEdit],
+    path_label: Option<&str>,
 ) -> anyhow::Result<ContentEditsResult> {
     let original = content.to_string();
     let mut current = content.to_string();
@@ -87,7 +100,8 @@ pub fn apply_content_edits(
     }
 
     let changed = current != original;
-    let diff = make_diff("<buffer>", &original, &current);
+    let label = path_label.unwrap_or("<buffer>");
+    let diff = make_diff(label, &original, &current);
     Ok(ContentEditsResult {
         original,
         modified: current,
@@ -119,7 +133,8 @@ pub fn apply_content_edits_to_file(
     let path_str = path.to_string_lossy().into_owned();
     let original =
         std::fs::read_to_string(path).with_context(|| format!("failed to read {path_str}"))?;
-    let batch = apply_content_edits(&original, edits)?;
+    // Prefer real path labels in multi-op preview (#1665 / #1500).
+    let batch = apply_content_edits_with_label(&original, edits, Some(path_str.as_str()))?;
     let policy = WritePolicy::default();
     let applied = write_if_apply(path, &batch.modified, mode, &policy, guard)?;
     // build_edit_result uses path for headers (#1500) and stays field-complete.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -130,6 +130,24 @@ pub use self::ast_write::*;
 mod content_edits;
 pub use self::content_edits::*;
 
+mod post_write;
+pub use self::post_write::*;
+
+/// How a replace operation resolved its match site (#1662).
+///
+/// Embedders use this for agent honesty ("applied via fuzzy — verify") and
+/// optional policy (reject low-score fuzzy under `unique`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MatchMode {
+    /// Literal/regex exact match (default path).
+    Exact,
+    /// Similarity-based fuzzy fallback ([`ReplaceOptions::fuzzy`]).
+    Fuzzy,
+    /// Disambiguated via before/after context anchors.
+    Anchored,
+}
+
 /// The result of an editing operation.
 #[derive(Debug, Clone)]
 pub struct EditResult {
@@ -164,6 +182,10 @@ pub struct EditResult {
     /// mutation summaries so embedders can report delete outcomes without
     /// re-reading the file or parsing diffs (#1459 / #1439).
     pub removed: usize,
+    /// Match strategy used for replace ops (`None` for non-replace ops). See #1662.
+    pub match_mode: Option<MatchMode>,
+    /// Similarity score when [`MatchMode::Fuzzy`] was used; otherwise `None`.
+    pub match_score: Option<f64>,
 }
 
 /// Result of an in-memory content edit (no file path, no applied flag).
@@ -187,6 +209,10 @@ pub struct ContentEditResult {
     /// limits which match is replaced). Embedders can use this to enforce
     /// their own ambiguity policies without pre-scanning the content.
     pub match_count: usize,
+    /// Match strategy for this replace (`None` when unchanged/no-match soft path).
+    pub match_mode: Option<MatchMode>,
+    /// Similarity score when fuzzy matching was used.
+    pub match_score: Option<f64>,
 }
 
 /// Controls whether an operation writes to disk.
@@ -269,9 +295,10 @@ pub struct ReplaceOptions {
     pub command_position: bool,
 }
 
-// Re-export structured edit errors for embedders (#1492).
+// Re-export structured edit errors for embedders (#1492, #1659).
 pub use crate::fallback::{
-    EditError, EditErrorKind, edit_error_kind, edit_error_ref, find_similar_targets,
+    EditError, EditErrorKind, classify_error, classify_error_ref, edit_error_kind, edit_error_ref,
+    find_similar_targets,
 };
 
 /// Write policy options for controlling file write transformations.
@@ -462,6 +489,20 @@ pub(crate) fn build_edit_result(
         dest_path,
         match_count: 0,
         removed: 0,
+        match_mode: None,
+        match_score: None,
+    }
+}
+
+/// Map fallback match strategy to public [`MatchMode`] (#1662).
+pub(crate) fn match_mode_from_strategy(
+    strategy: crate::fallback::MatchStrategy,
+) -> (MatchMode, Option<f64>) {
+    use crate::fallback::MatchStrategy;
+    match strategy {
+        MatchStrategy::Exact => (MatchMode::Exact, None),
+        MatchStrategy::Anchor => (MatchMode::Anchored, None),
+        MatchStrategy::Similarity => (MatchMode::Fuzzy, None),
     }
 }
 

--- a/src/api/post_write.rs
+++ b/src/api/post_write.rs
@@ -1,0 +1,217 @@
+//! Post-write format/lint hooks for agent hosts (#1663).
+//!
+//! After `ApplyMode::Apply`, hosts can run project formatters or linters and
+//! optionally revert the written path via the existing backup session.
+
+use std::path::Path;
+
+use crate::backup::restore_path_from_latest_backup;
+use crate::exit::FormatFailedError;
+use crate::fallback::EditError;
+
+/// What to do when a post-write hook fails.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PostWriteOnFailure {
+    /// Leave the written content; return a structured format failure.
+    #[default]
+    KeepWithError,
+    /// Restore the path from the latest backup session that contains it.
+    Revert,
+}
+
+/// Format and/or lint hooks after an Apply write.
+#[derive(Debug, Clone, Default)]
+pub struct PostWriteHooks {
+    /// Shell command run from `project_root` (e.g. `"rustfmt src/lib.rs"`).
+    pub format_cmd: Option<String>,
+    /// Optional second shell command (lint). Runs only if format succeeds.
+    pub lint_cmd: Option<String>,
+    /// Failure policy (default keep with error).
+    pub on_failure: PostWriteOnFailure,
+    /// Per-command timeout in seconds (default 30).
+    pub timeout_secs: Option<u64>,
+}
+
+/// Run optional format then lint after a successful Apply.
+///
+/// Failures map to [`FormatFailedError`] (JSON `error_kind: format_failed`) so
+/// they peel via [`crate::api::edit_error_kind`] / [`crate::api::classify_error`]
+/// as [`EditErrorKind::OperationFailed`]. With [`PostWriteOnFailure::Revert`],
+/// restores only `path` from the latest backup that contains it (see
+/// [`restore_path_from_latest_backup`]).
+///
+/// No-op when both commands are unset.
+pub fn run_post_write_validation(
+    project_root: &Path,
+    path: &Path,
+    hooks: &PostWriteHooks,
+) -> anyhow::Result<()> {
+    let timeout = hooks.timeout_secs.unwrap_or(30);
+    for (label, cmd) in [
+        ("format", hooks.format_cmd.as_deref()),
+        ("lint", hooks.lint_cmd.as_deref()),
+    ] {
+        let Some(cmd) = cmd else {
+            continue;
+        };
+        if let Err(e) = run_hook_cmd(cmd, timeout, project_root, label) {
+            if hooks.on_failure == PostWriteOnFailure::Revert {
+                let _ = restore_path_from_latest_backup(project_root, path);
+            }
+            return Err(e);
+        }
+    }
+    Ok(())
+}
+
+fn run_hook_cmd(cmd: &str, timeout_secs: u64, cwd: &Path, label: &str) -> anyhow::Result<()> {
+    let result =
+        crate::exec::run_with_timeout(cmd, timeout_secs, cwd).map_err(|e| FormatFailedError {
+            msg: format!("{label} command failed ({cmd}): {e}"),
+        })?;
+    if !result.status.success() {
+        let stderr = if result.stderr_head.is_empty() {
+            String::new()
+        } else {
+            format!(": {}", result.stderr_head)
+        };
+        return Err(FormatFailedError {
+            msg: format!("{label} command failed ({cmd}){stderr}"),
+        }
+        .into());
+    }
+    Ok(())
+}
+
+/// Host-supplied post-write validator trait (#1663).
+///
+/// Prefer [`run_post_write_validation`] for shell format/lint; implement this
+/// when validation is pure Rust.
+pub trait PostWriteValidator {
+    /// Return `Ok(())` if `after` is acceptable; otherwise an [`EditError`].
+    fn validate(&self, path: &Path, before: &str, after: &str) -> Result<(), EditError>;
+}
+
+/// Apply a [`PostWriteValidator`] after an in-memory or disk edit.
+///
+/// On failure with `revert=true`, restores `path` from the latest backup under
+/// `project_root` (no-op if no backup).
+pub fn apply_post_write_validator<V: PostWriteValidator + ?Sized>(
+    project_root: &Path,
+    path: &Path,
+    before: &str,
+    after: &str,
+    validator: &V,
+    revert: bool,
+) -> anyhow::Result<()> {
+    match validator.validate(path, before, after) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            if revert {
+                let _ = restore_path_from_latest_backup(project_root, path);
+            }
+            // Preserve EditError when present; otherwise wrap.
+            Err(e.into())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::{ApplyMode, ReplaceOptions, replace_text};
+    use crate::fallback::{EditErrorKind, edit_error_kind};
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn post_write_format_success_is_ok() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("ok.txt");
+        fs::write(&file, "a\n").unwrap();
+        let hooks = PostWriteHooks {
+            format_cmd: Some("true".into()),
+            ..Default::default()
+        };
+        run_post_write_validation(dir.path(), &file, &hooks).unwrap();
+    }
+
+    #[test]
+    fn post_write_format_failure_is_format_failed() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("bad.txt");
+        fs::write(&file, "a\n").unwrap();
+        let hooks = PostWriteHooks {
+            format_cmd: Some("false".into()),
+            on_failure: PostWriteOnFailure::KeepWithError,
+            ..Default::default()
+        };
+        let err = run_post_write_validation(dir.path(), &file, &hooks).unwrap_err();
+        assert!(
+            crate::exit::is_format_failed(&err),
+            "expected format_failed, got {err}"
+        );
+        assert_eq!(edit_error_kind(&err), Some(EditErrorKind::OperationFailed));
+    }
+
+    #[test]
+    fn post_write_revert_restores_path() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("data.txt");
+        fs::write(&file, "before\n").unwrap();
+        let opts = ReplaceOptions {
+            require_change: true,
+            ..Default::default()
+        };
+        replace_text(&file, "before", "after", &opts, ApplyMode::Apply, None).unwrap();
+        assert_eq!(fs::read_to_string(&file).unwrap(), "after\n");
+
+        let hooks = PostWriteHooks {
+            format_cmd: Some("false".into()),
+            on_failure: PostWriteOnFailure::Revert,
+            ..Default::default()
+        };
+        let err = run_post_write_validation(dir.path(), &file, &hooks).unwrap_err();
+        assert!(crate::exit::is_format_failed(&err));
+        assert_eq!(
+            fs::read_to_string(&file).unwrap(),
+            "before\n",
+            "revert must restore pre-Apply bytes"
+        );
+    }
+
+    struct AlwaysFail;
+
+    impl PostWriteValidator for AlwaysFail {
+        fn validate(&self, _path: &Path, _before: &str, _after: &str) -> Result<(), EditError> {
+            Err(EditError::new(
+                EditErrorKind::OperationFailed,
+                "lint regression",
+            ))
+        }
+    }
+
+    #[test]
+    fn post_write_validator_trait_reverts() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("t.txt");
+        fs::write(&file, "old\n").unwrap();
+        replace_text(
+            &file,
+            "old",
+            "new",
+            &ReplaceOptions {
+                require_change: true,
+                ..Default::default()
+            },
+            ApplyMode::Apply,
+            None,
+        )
+        .unwrap();
+        let err =
+            apply_post_write_validator(dir.path(), &file, "old\n", "new\n", &AlwaysFail, true)
+                .unwrap_err();
+        assert_eq!(edit_error_kind(&err), Some(EditErrorKind::OperationFailed));
+        assert_eq!(fs::read_to_string(&file).unwrap(), "old\n");
+    }
+}

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use crate::containment::PathGuard;
 use crate::plan::Operation;
 
-use super::{ApplyMode, ContentEditResult, EditResult, ReplaceOptions};
+use super::{ApplyMode, ContentEditResult, EditResult, MatchMode, ReplaceOptions};
 
 /// Replace text in a file using literal or regex matching.
 ///
@@ -68,6 +68,8 @@ pub fn replace_text(
             None,
         );
         result.match_count = content_result.match_count;
+        result.match_mode = content_result.match_mode;
+        result.match_score = content_result.match_score;
         return Ok(result);
     }
 
@@ -93,7 +95,7 @@ pub fn replace_text(
         require_change: false,
         command_position: opts.command_position,
     };
-    let result = replace_write(op, path, mode, guard, opts.fuzzy)?;
+    let mut result = replace_write(op, path, mode, guard, opts.fuzzy)?;
     // if_exists intentionally softens zero-match (Ok unchanged). require_change
     // must not override that: both true means if_exists wins (#1492 docs).
     if opts.require_change && !opts.if_exists && !result.changed && result.match_count == 0 {
@@ -107,6 +109,10 @@ pub fn replace_text(
                 .with_similar(similar)
                 .into(),
         );
+    }
+    // Tx path does not yet thread MatchMode; default Exact when matches landed (#1662).
+    if result.match_mode.is_none() && result.match_count > 0 {
+        result.match_mode = Some(MatchMode::Exact);
     }
     Ok(result)
 }
@@ -242,6 +248,7 @@ fn replace_write(
                     None,
                 );
                 result.match_count = 1;
+                result.match_mode = Some(MatchMode::Anchored);
                 return Ok(result);
             }
         }
@@ -292,6 +299,9 @@ fn replace_write(
                         &path_str, original, fb_content, applied, "replace", None,
                     );
                     result.match_count = 1;
+                    let (mode, default_score) = super::match_mode_from_strategy(anchor.strategy);
+                    result.match_mode = Some(mode);
+                    result.match_score = anchor.score.or(default_score);
                     return Ok(result);
                 }
                 Err(edit_error) => {
@@ -334,6 +344,9 @@ fn replace_write(
         let mut result =
             super::build_edit_result(&path_str, original, new_content, applied, "replace", None);
         result.match_count = count;
+        if count > 0 {
+            result.match_mode = Some(MatchMode::Exact);
+        }
         Ok(result)
     } else {
         bail!("expected Replace operation")
@@ -467,6 +480,8 @@ pub fn replace_in_content(
             diff,
             changed: true,
             match_count: 1,
+            match_mode: Some(MatchMode::Anchored),
+            match_score: None,
         });
     }
 
@@ -503,12 +518,15 @@ pub fn replace_in_content(
                     &content[anchor.start_offset + anchor.matched_text.len()..]
                 );
                 let diff = super::make_diff("<content>", content, &fuzzy_content);
+                let (mode, default_score) = super::match_mode_from_strategy(anchor.strategy);
                 return Ok(ContentEditResult {
                     original: content.to_string(),
                     new_content: fuzzy_content,
                     diff,
                     changed: true,
                     match_count: 1,
+                    match_mode: Some(mode),
+                    match_score: anchor.score.or(default_score),
                 });
             }
             Err(edit_error) => {
@@ -519,6 +537,8 @@ pub fn replace_in_content(
                         diff: String::new(),
                         changed: false,
                         match_count: 0,
+                        match_mode: None,
+                        match_score: None,
                     });
                 }
                 let similar = fallback::find_similar_targets(content, from, 3);
@@ -569,6 +589,8 @@ fn finalize_content_replace(
             diff: String::new(),
             changed: false,
             match_count: 0,
+            match_mode: None,
+            match_score: None,
         });
     }
 
@@ -598,5 +620,11 @@ fn finalize_content_replace(
         diff,
         changed,
         match_count: count,
+        match_mode: if count > 0 {
+            Some(MatchMode::Exact)
+        } else {
+            None
+        },
+        match_score: None,
     })
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4265,8 +4265,16 @@ fn ast_replace_in_symbol_api() {
         "fn outer() {\n    let target = 1;\n}\nfn other() {\n    let target = 2;\n}\n",
     )
     .unwrap();
-    let result =
-        ast_replace_in_symbol(&file, "outer", "target", "value", ApplyMode::Apply, None).unwrap();
+    let result = ast_replace_in_symbol(
+        &file,
+        "outer",
+        "target",
+        "value",
+        &AstReplaceInSymbolOptions::default(),
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
     assert!(result.changed);
     assert!(result.applied);
     let on_disk = fs::read_to_string(&file).unwrap();
@@ -4574,4 +4582,349 @@ fn restore_path_from_latest_backup_after_apply() {
     let restored = restore_path_from_latest_backup(dir.path(), &file).unwrap();
     assert!(restored, "should find backup session for path");
     assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
+}
+
+// ── #1658–#1666 Bline embedder API batch ──────────────────────────────────
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_replace_in_symbol_regex_mode() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(
+        &file,
+        "fn parse_config() {\n    let foo_x_bar = 1;\n    let keep = 2;\n}\nfn other() {\n    let foo_x_bar = 9;\n}\n",
+    )
+    .unwrap();
+    let opts = AstReplaceInSymbolOptions { regex: true };
+    let result = ast_replace_in_symbol(
+        &file,
+        "parse_config",
+        r"foo_.*_bar",
+        "baz",
+        &opts,
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(result.changed && result.applied);
+    assert!(result.match_count >= 1);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("let baz = 1"), "got: {on_disk}");
+    assert!(
+        on_disk.contains("let foo_x_bar = 9"),
+        "other symbol must stay: {on_disk}"
+    );
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_replace_in_symbol_missing_symbol_vs_pattern() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("lib.rs");
+    fs::write(&file, "fn real() {\n    let target = 1;\n}\n").unwrap();
+    let opts = AstReplaceInSymbolOptions::default();
+
+    let err = ast_replace_in_symbol(
+        &file,
+        "missing",
+        "target",
+        "x",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NoMatch)
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("symbol") && msg.contains("missing"),
+        "symbol miss should name symbol: {msg}"
+    );
+
+    let err = ast_replace_in_symbol(
+        &file,
+        "real",
+        "no_such_pattern",
+        "x",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NoMatch)
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no matches") && msg.contains("no_such_pattern"),
+        "pattern miss should name pattern: {msg}"
+    );
+}
+
+#[test]
+fn classify_error_without_anyhow() {
+    use crate::fallback::{classify_error, classify_error_ref};
+    use std::error::Error;
+
+    let edit = EditError::new(EditErrorKind::NoMatch, "no matches for \"x\"")
+        .with_similar(vec!["y".into()]);
+    let boxed: Box<dyn Error + Send + Sync> = Box::new(edit.clone());
+    assert_eq!(classify_error(boxed.as_ref()), Some(EditErrorKind::NoMatch));
+    let got = classify_error_ref(boxed.as_ref()).expect("EditError");
+    assert_eq!(got.similar_targets, vec!["y".to_string()]);
+
+    let invalid: Box<dyn Error + Send + Sync> =
+        Box::new(crate::exit::InvalidInputError { msg: "bad".into() });
+    assert_eq!(
+        classify_error(invalid.as_ref()),
+        Some(EditErrorKind::InvalidInput)
+    );
+
+    let ambiguous: Box<dyn Error + Send + Sync> =
+        Box::new(crate::exit::AmbiguousError { msg: "many".into() });
+    assert_eq!(
+        classify_error(ambiguous.as_ref()),
+        Some(EditErrorKind::AmbiguousTarget)
+    );
+
+    // Bare EditError round-trips through classify without anyhow.
+    let e = EditError::new(EditErrorKind::GuardRejected, "nope");
+    assert_eq!(
+        classify_error(&e as &(dyn Error + 'static)),
+        Some(EditErrorKind::GuardRejected)
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn restore_path_from_session_single_file_only() {
+    use crate::backup::{list_sessions, restore_path_from_session};
+
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.txt");
+    let b = dir.path().join("b.txt");
+    fs::write(&a, "A0").unwrap();
+    fs::write(&b, "B0").unwrap();
+
+    // One session backs up both files, then both are mutated.
+    let mut session = crate::backup::BackupSession::new(dir.path()).unwrap();
+    session.save_before_write(&a).unwrap();
+    session.save_before_write(&b).unwrap();
+    session.finalize().unwrap();
+    fs::write(&a, "A1").unwrap();
+    fs::write(&b, "B1").unwrap();
+
+    let sessions = list_sessions(dir.path()).unwrap();
+    assert!(!sessions.is_empty());
+    let ts = sessions[0].timestamp.clone();
+
+    let ok = restore_path_from_session(dir.path(), &ts, &a).unwrap();
+    assert!(ok);
+    assert_eq!(fs::read_to_string(&a).unwrap(), "A0");
+    assert_eq!(
+        fs::read_to_string(&b).unwrap(),
+        "B1",
+        "sibling path must remain edited"
+    );
+
+    // Path absent from session → Ok(false).
+    let missing = dir.path().join("c.txt");
+    fs::write(&missing, "C").unwrap();
+    let ok = restore_path_from_session(dir.path(), &ts, &missing).unwrap();
+    assert!(!ok);
+
+    // Missing session → error.
+    let err = restore_path_from_session(dir.path(), "no-such-session", &a).unwrap_err();
+    assert!(
+        err.to_string().contains("no backup session") || err.to_string().contains("no-such"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn match_mode_exact_fuzzy_and_anchored() {
+    // Exact
+    let r = replace_in_content(
+        "hello world\n",
+        "world",
+        "there",
+        &ReplaceOptions::default(),
+    )
+    .unwrap();
+    assert_eq!(r.match_mode, Some(MatchMode::Exact));
+    assert!(r.match_score.is_none());
+
+    // Fuzzy similarity
+    let r = replace_in_content(
+        "fn process_data() {}\n",
+        "fn proccess_data() {}",
+        "fn process_data() {}",
+        &ReplaceOptions {
+            fuzzy: true,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(r.changed, "fuzzy should land");
+    assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
+    assert!(
+        r.match_score.is_some_and(|s| s > 0.85),
+        "fuzzy score expected, got {:?}",
+        r.match_score
+    );
+
+    // Anchored multi-match disambiguation
+    let content = "alpha\nTODO: fix\nbeta\nTODO: fix\n";
+    let r = replace_in_content(
+        content,
+        "TODO: fix",
+        "TODO: done",
+        &ReplaceOptions {
+            before_context: Some("beta".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(r.changed);
+    assert_eq!(r.match_mode, Some(MatchMode::Anchored));
+    assert_eq!(r.match_count, 1);
+    assert!(r.new_content.contains("beta\nTODO: done"));
+    assert!(r.new_content.contains("alpha\nTODO: fix"));
+}
+
+#[test]
+fn apply_content_edits_path_label() {
+    let edits = [ContentEdit::Replace {
+        old: "a".into(),
+        new: "b".into(),
+        options: ReplaceOptions::default(),
+    }];
+    let unlabeled = apply_content_edits("a\n", &edits).unwrap();
+    assert!(
+        unlabeled.diff.contains("<buffer>") || unlabeled.diff.contains("a/<buffer>"),
+        "default label: {}",
+        unlabeled.diff
+    );
+
+    let labeled = apply_content_edits_with_label("a\n", &edits, Some("src/lib.rs")).unwrap();
+    assert!(
+        labeled.diff.contains("src/lib.rs"),
+        "path label in headers: {}",
+        labeled.diff
+    );
+    assert!(
+        !labeled.diff.contains("<buffer>"),
+        "must not keep buffer placeholder when labeled: {}",
+        labeled.diff
+    );
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn find_files_with_symbol_and_batch_compose() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.rs");
+    let b = dir.path().join("b.rs");
+    let c = dir.path().join("c.rs");
+    fs::write(&a, "struct OldType {}\n").unwrap();
+    fs::write(&b, "fn use_it(x: OldType) {}\n").unwrap();
+    fs::write(&c, "struct Other {}\n").unwrap();
+
+    let paths =
+        find_files_with_symbol(dir.path(), "OldType", &SymbolSearchOptions::default()).unwrap();
+    assert!(paths.iter().any(|p| p.ends_with("a.rs")), "a.rs: {paths:?}");
+    assert!(paths.iter().any(|p| p.ends_with("b.rs")), "b.rs: {paths:?}");
+    assert!(
+        !paths.iter().any(|p| p.ends_with("c.rs")),
+        "c.rs must not match: {paths:?}"
+    );
+
+    let path_refs: Vec<&std::path::Path> = paths.iter().map(|p| p.as_path()).collect();
+    let results = ast_rename_batch(
+        &path_refs,
+        "OldType",
+        "NewType",
+        &AstRenameBatchOptions {
+            mode: ApplyMode::Apply,
+            ..Default::default()
+        },
+        None,
+    )
+    .unwrap();
+    assert!(results.iter().all(|r| r.result.is_ok()));
+    assert!(fs::read_to_string(&a).unwrap().contains("NewType"));
+    assert!(fs::read_to_string(&b).unwrap().contains("NewType"));
+    assert!(fs::read_to_string(&c).unwrap().contains("Other"));
+}
+
+#[test]
+fn content_edit_command_position_honored() {
+    // #1666: ContentEdit::Replace path must honor command_position end-to-end.
+    let edits = [ContentEdit::Replace {
+        old: "pip".into(),
+        new: "uv".into(),
+        options: ReplaceOptions {
+            command_position: true,
+            require_change: true,
+            ..Default::default()
+        },
+    }];
+    let r = apply_content_edits("sudo pip install\nuv pip list\npipenv run\n", &edits).unwrap();
+    assert!(r.changed);
+    assert!(r.modified.contains("sudo uv install"));
+    assert!(
+        r.modified.contains("uv pip list"),
+        "argument pip must stay: {}",
+        r.modified
+    );
+    assert!(
+        r.modified.contains("pipenv"),
+        "longer token must stay: {}",
+        r.modified
+    );
+
+    // Incompatible combo → InvalidInput
+    let bad = [ContentEdit::Replace {
+        old: "pip".into(),
+        new: "uv".into(),
+        options: ReplaceOptions {
+            command_position: true,
+            regex: true,
+            ..Default::default()
+        },
+    }];
+    let err = apply_content_edits("pip install\n", &bad).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
+}
+
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn signature_rewrite_params_and_return_no_host_post_pass() {
+    // #1661: structured field rewrite alone is complete (no second write).
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("sig.rs");
+    fs::write(&file, "pub fn process(a: i32) -> i32 {\n    a\n}\n").unwrap();
+    let edit = crate::ast::rewrite::FunctionSigEdit {
+        parameters: Some("(a: i32, b: i32)".into()),
+        return_type: Some("-> i64".into()),
+        ..Default::default()
+    };
+    let result = ast_rewrite_signature(&file, "process", &edit, None, ApplyMode::Apply, None)
+        .expect("structured rewrite");
+    assert!(result.applied && result.changed);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.contains("-> i64 {"),
+        "must keep space before brace without host post-pass: {on_disk}"
+    );
+    assert!(!on_disk.contains("i64{") && !on_disk.contains("){"));
+    assert!(on_disk.contains("b: i32"), "params updated: {on_disk}");
 }

--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -5,6 +5,20 @@
 //! [`rewrite_function_signature`] with [`FunctionSigEdit`] for structured
 //! multi-language edits (visibility, parameters, return type).
 //!
+//! # Body-gap invariant (#1503 / #1661)
+//!
+//! Full-string and structured rewrites **never** glue a type or `)` to the body
+//! brace for Rust (and other brace languages). A single Apply write is
+//! sufficient; hosts must not run a second spacing post-pass or rewrite.
+//!
+//! Guarantees enforced by [`splice_function_signature`]:
+//!
+//! - Logical signatures without trailing space produce `-> T {` / `) {`, never
+//!   `T{` / `){`
+//! - Original newline-before-brace style is preserved when present
+//! - Missing gaps on already-glued sources get a conventional space
+//! - Semicolon-terminated decls do not get a spurious space before `;`
+//!
 //! size-waiver: accepted single-domain bulk (policy #1408). Multi-language function signature rewrite; tests co-located; do not split for LOC alone.
 
 use super::symbol_extract::innermost_qualified_name;

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -290,6 +290,10 @@ pub fn list_sessions(project_root: &Path) -> anyhow::Result<Vec<Manifest>> {
 /// edit, run a host validator, and on failure call this helper to put the file
 /// back without re-implementing backup layout.
 ///
+/// Restores **only** the requested path (exact match), not sibling entries in
+/// the same session. Prefer [`restore_path_from_session`] when the host already
+/// knows the session timestamp.
+///
 /// Returns `true` if a backup entry was found and restored, `false` if no
 /// session had the path.
 pub fn restore_path_from_latest_backup(project_root: &Path, path: &Path) -> anyhow::Result<bool> {
@@ -307,14 +311,89 @@ pub fn restore_path_from_latest_backup(project_root: &Path, path: &Path) -> anyh
             .iter()
             .any(|e| e.path == rel_str || e.path == abs_str);
         if hit {
-            // Restore the whole session (entries are per-session atomic unit).
-            // Hosts that need single-file-only restore can filter; sessions from
-            // single-file API Apply typically contain one entry.
-            restore_session(project_root, &manifest.timestamp)?;
-            return Ok(true);
+            return restore_path_from_session(project_root, &manifest.timestamp, path);
         }
     }
     Ok(false)
+}
+
+/// Restore one path from a specific backup session (exact path match only).
+///
+/// Unlike [`restore_session`], sibling files in the same session are left
+/// untouched. Missing session is an error; session present but path absent
+/// returns `Ok(false)`.
+///
+/// See #1660.
+pub fn restore_path_from_session(
+    project_root: &Path,
+    session_timestamp: &str,
+    path: &Path,
+) -> anyhow::Result<bool> {
+    let session_dir = project_root.join(BACKUP_DIR).join(session_timestamp);
+    let manifest_path = session_dir.join("manifest.json");
+
+    let content = std::fs::read_to_string(&manifest_path).with_context(|| {
+        format!(
+            "no backup session found for {session_timestamp} (use `patchloom undo --list` to see available sessions)"
+        )
+    })?;
+    let manifest: Manifest = serde_json::from_str(&content)
+        .with_context(|| format!("parsing backup manifest for session {session_timestamp}"))?;
+
+    let rel = sanitize_rel_path(path, project_root);
+    let rel_str = rel.to_string_lossy();
+    let abs_str = path.to_string_lossy();
+
+    let Some(entry) = manifest
+        .entries
+        .iter()
+        .find(|e| e.path == rel_str || e.path == abs_str)
+    else {
+        return Ok(false);
+    };
+
+    validate_restore_path(&entry.path)?;
+    let target = resolve_restore_path(project_root, &entry.path);
+
+    match entry.action {
+        FileAction::Modified => {
+            let backup = session_dir.join(&entry.path);
+            if !backup.exists() {
+                return Ok(false);
+            }
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!("creating parent dir for restore target {}", entry.path)
+                })?;
+            }
+            std::fs::copy(&backup, &target)
+                .with_context(|| format!("restoring modified file {}", entry.path))?;
+            Ok(true)
+        }
+        FileAction::Created => {
+            if target.exists() {
+                std::fs::remove_file(&target)
+                    .with_context(|| format!("removing created file {} during undo", entry.path))?;
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }
+        FileAction::Deleted => {
+            let backup = session_dir.join(&entry.path);
+            if !backup.exists() {
+                return Ok(false);
+            }
+            if let Some(parent) = target.parent() {
+                std::fs::create_dir_all(parent).with_context(|| {
+                    format!("creating parent dir for restore target {}", entry.path)
+                })?;
+            }
+            std::fs::copy(&backup, &target)
+                .with_context(|| format!("restoring deleted file {}", entry.path))?;
+            Ok(true)
+        }
+    }
 }
 
 /// Restore a specific backup session, returning the number of files restored.
@@ -983,6 +1062,28 @@ mod tests {
         std::fs::write(&file, "x").unwrap();
         let ok = restore_path_from_latest_backup(dir.path(), &file).unwrap();
         assert!(!ok);
+    }
+
+    #[test]
+    fn restore_path_from_session_only_one_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        std::fs::write(&a, "A").unwrap();
+        std::fs::write(&b, "B").unwrap();
+
+        let mut session = BackupSession::new(dir.path()).unwrap();
+        session.save_before_write(&a).unwrap();
+        session.save_before_write(&b).unwrap();
+        session.finalize().unwrap();
+        std::fs::write(&a, "A2").unwrap();
+        std::fs::write(&b, "B2").unwrap();
+
+        let sessions = list_sessions(dir.path()).unwrap();
+        let ts = &sessions[0].timestamp;
+        assert!(restore_path_from_session(dir.path(), ts, &a).unwrap());
+        assert_eq!(std::fs::read_to_string(&a).unwrap(), "A");
+        assert_eq!(std::fs::read_to_string(&b).unwrap(), "B2");
     }
 
     #[test]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -155,36 +155,94 @@ impl EditError {
 /// Peels both [`EditError`] and the CLI/tx typed errors in [`crate::exit`]
 /// (`InvalidInputError`, `NoMatchError`, …) so library hosts can branch on
 /// kind without caring which construction path produced the failure.
+///
+/// Hosts that do **not** depend on `anyhow` should use [`classify_error`]
+/// on a `dyn Error` instead (#1659).
 pub fn edit_error_kind(err: &anyhow::Error) -> Option<EditErrorKind> {
     for cause in err.chain() {
-        if let Some(e) = cause.downcast_ref::<EditError>() {
-            return Some(e.kind);
+        if let Some(kind) = classify_error(cause) {
+            return Some(kind);
         }
     }
-    // Prefer EditError above; map CLI/tx typed errors via the shared table so
-    // library hosts stay in sync with JSON error_kind classification.
-    match crate::exit::classify_typed_error(err) {
-        Some(("no_matches", _)) => Some(EditErrorKind::NoMatch),
-        Some(("ambiguous", _)) => Some(EditErrorKind::AmbiguousTarget),
-        Some(("invalid_input", _) | ("already_exists", _) | ("type_error", _)) => {
-            Some(EditErrorKind::InvalidInput)
-        }
-        Some(("parse_error", _)) => Some(EditErrorKind::ParseError),
-        // not_found / conflicts / changes_detected / format_failed: closest
-        // library kind for hosts that only branch on EditErrorKind.
-        Some(
-            ("not_found", _) | ("conflicts", _) | ("changes_detected", _) | ("format_failed", _),
-        ) => Some(EditErrorKind::OperationFailed),
-        Some(_) | None => None,
-    }
+    None
 }
 
 /// Downcast an `anyhow` error chain to [`EditError`] when present.
 pub fn edit_error_ref(err: &anyhow::Error) -> Option<&EditError> {
     for cause in err.chain() {
-        if let Some(e) = cause.downcast_ref::<EditError>() {
+        if let Some(e) = classify_error_ref(cause) {
             return Some(e);
         }
+    }
+    None
+}
+
+/// Classify a bare `dyn Error` (no `anyhow` required) into [`EditErrorKind`].
+///
+/// Walks `source()` and peels [`EditError`] plus the CLI/tx typed errors
+/// (`NoMatchError`, `InvalidInputError`, `AmbiguousError`, …). Use this from
+/// non-anyhow agent hosts that store `Box<dyn Error>` or `Arc<dyn Error>`.
+///
+/// ```rust
+/// use patchloom::fallback::{classify_error, EditError, EditErrorKind};
+///
+/// let err: Box<dyn std::error::Error + Send + Sync> =
+///     Box::new(EditError::new(EditErrorKind::NoMatch, "no matches for \"x\""));
+/// assert_eq!(classify_error(err.as_ref()), Some(EditErrorKind::NoMatch));
+/// ```
+///
+/// See #1659.
+pub fn classify_error(err: &(dyn std::error::Error + 'static)) -> Option<EditErrorKind> {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = current {
+        if let Some(edit) = e.downcast_ref::<EditError>() {
+            return Some(edit.kind);
+        }
+        if e.downcast_ref::<crate::exit::NoMatchError>().is_some() {
+            return Some(EditErrorKind::NoMatch);
+        }
+        if e.downcast_ref::<crate::exit::AmbiguousError>().is_some() {
+            return Some(EditErrorKind::AmbiguousTarget);
+        }
+        if e.downcast_ref::<crate::exit::InvalidInputError>().is_some()
+            || e.downcast_ref::<crate::exit::AlreadyExistsError>()
+                .is_some()
+            || e.downcast_ref::<crate::exit::TypeErrorError>().is_some()
+        {
+            return Some(EditErrorKind::InvalidInput);
+        }
+        if e.downcast_ref::<crate::exit::ParseErrorError>().is_some() {
+            return Some(EditErrorKind::ParseError);
+        }
+        // Closest library kind for hosts that only branch on EditErrorKind.
+        if e.downcast_ref::<crate::exit::FormatFailedError>().is_some()
+            || e.downcast_ref::<crate::exit::ConflictsError>().is_some()
+            || e.downcast_ref::<crate::exit::ChangesDetectedError>()
+                .is_some()
+        {
+            return Some(EditErrorKind::OperationFailed);
+        }
+        if e.downcast_ref::<std::io::Error>()
+            .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
+        {
+            return Some(EditErrorKind::OperationFailed);
+        }
+        current = e.source();
+    }
+    None
+}
+
+/// Downcast a bare `dyn Error` chain to [`EditError`] when present (#1659).
+///
+/// Prefer this when you need `similar_targets` / `suggestion` without
+/// depending on `anyhow`.
+pub fn classify_error_ref<'a>(err: &'a (dyn std::error::Error + 'static)) -> Option<&'a EditError> {
+    let mut current: Option<&'a (dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = current {
+        if let Some(edit) = e.downcast_ref::<EditError>() {
+            return Some(edit);
+        }
+        current = e.source();
     }
     None
 }
@@ -403,6 +461,7 @@ pub fn anchor_match(
             matched_text: target.to_string(),
             start_offset: pos,
             strategy: MatchStrategy::Exact,
+            score: None,
         });
     }
 
@@ -508,6 +567,7 @@ pub fn anchor_match(
             matched_text,
             start_offset,
             strategy: MatchStrategy::Anchor,
+            score: None,
         });
     }
 
@@ -523,6 +583,8 @@ pub struct AnchorMatchResult {
     pub start_offset: usize,
     /// Which matching strategy succeeded.
     pub strategy: MatchStrategy,
+    /// Similarity score when [`MatchStrategy::Similarity`] succeeded (#1662).
+    pub score: Option<f64>,
 }
 
 /// Which matching strategy found the result.
@@ -562,6 +624,7 @@ pub fn resolve_with_fallback(
             matched_text: target.to_string(),
             start_offset: pos,
             strategy: MatchStrategy::Exact,
+            score: None,
         });
     }
 
@@ -600,6 +663,7 @@ pub fn resolve_with_fallback(
                 matched_text: best_match,
                 start_offset: best_offset,
                 strategy: MatchStrategy::Similarity,
+                score: Some(best_score),
             });
         }
     }
@@ -691,6 +755,26 @@ mod tests {
             "conflicting_edit"
         );
         assert_eq!(EditErrorKind::ParseError.to_string(), "parse_error");
+    }
+
+    #[test]
+    fn classify_error_peels_edit_error_and_typed() {
+        use std::error::Error;
+        let e = EditError::new(EditErrorKind::AmbiguousTarget, "many");
+        assert_eq!(
+            classify_error(&e as &(dyn Error + 'static)),
+            Some(EditErrorKind::AmbiguousTarget)
+        );
+        let e = crate::exit::NoMatchError { msg: "none".into() };
+        assert_eq!(
+            classify_error(&e as &(dyn Error + 'static)),
+            Some(EditErrorKind::NoMatch)
+        );
+        let e = crate::exit::FormatFailedError { msg: "fmt".into() };
+        assert_eq!(
+            classify_error(&e as &(dyn Error + 'static)),
+            Some(EditErrorKind::OperationFailed)
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,16 +103,30 @@
 //! }
 //! ```
 //!
-//! Shell command-position matching (#1494): opt-in `ReplaceOptions.command_position`
-//! rewrites invocable tokens (`pip install`, `sudo -E pip`, `timeout 30 pip`,
-//! `nice -n 10 pip`, `setsid pip`, `busybox wget`, `flock /tmp/l pip`,
-//! `runuser -u app pip`, `chpst -u app pip`, `with-contenv pip`, `envdir /env pip`)
-//! without touching arguments (`uv pip`) or longer words (`pipenv`). Not the same as
-//! `word_boundary`. Post-Apply validate/revert: host runs a validator, then
-//! `backup::restore_path_from_latest_backup(project_root, path)`.
+//! Shell command-position matching (#1494 / #1666): opt-in
+//! `ReplaceOptions.command_position` rewrites invocable tokens
+//! (`pip install`, `sudo -E pip`, `timeout 30 pip`, `nice -n 10 pip`, `setsid pip`,
+//! `busybox wget`, `flock /tmp/l pip`, `runuser -u app pip`, `chpst -u app pip`,
+//! `with-contenv pip`, `envdir /env pip`) without touching arguments (`uv pip`) or
+//! longer words (`pipenv`). Not the same as `word_boundary`. Incompatible with
+//! `regex`, `whole_line`, `multiline`, `nth`, insert before/after, fuzzy, and
+//! context anchors (typed `InvalidInput`). Works on `replace_text`,
+//! `replace_in_content`, `ContentEdit::Replace`, plan/MCP `command_position`, and
+//! CLI `--command-position`. Post-Apply validate/revert: use
+//! `api::run_post_write_validation` (#1663) or
+//! `backup::restore_path_from_session` / `restore_path_from_latest_backup` (#1660).
+//!
+//! Match honesty for agents (#1662): `EditResult` / `ContentEditResult` expose
+//! `match_mode` (`Exact` / `Fuzzy` / `Anchored`) and optional `match_score` so hosts
+//! can warn on low-confidence fuzzy sites without re-running the matcher.
+//!
+//! Non-anyhow hosts (#1659): branch with `api::classify_error(&*err as &dyn Error)`
+//! or `classify_error_ref` for `similar_targets`; `edit_error_kind` remains for
+//! `anyhow::Error` chains.
 //!
 //! For several ordered text edits on **one buffer** then a single write (agent intent engines):
-//! use `api::apply_content_edits` / `api::apply_content_edits_to_file` with
+//! use `api::apply_content_edits` / `apply_content_edits_with_label` /
+//! `api::apply_content_edits_to_file` with
 //! `ContentEdit::{Replace, InsertBefore, InsertAfter, Append, Prepend}` (all-or-nothing).
 //! Results expose rolled-up `match_count` across replace ops. Multi-file multi-op remains
 //! `execute_plan`.
@@ -221,9 +235,11 @@ pub use api::apply_content_edits_to_file;
 pub use api::search_one_file;
 pub use api::{
     ApplyMode, ContentEdit, ContentEditResult, ContentEditsResult, EditError, EditErrorKind,
-    EditResult, Hunk, PatchFile, PatchLine, ReplaceOptions, SearchOptions, SearchResult,
-    WritePolicyOptions, apply_content_edits, build_context_lines, edit_error_kind, edit_error_ref,
-    format_search_results, parse_unified_diff, search_file, text_diff,
+    EditResult, Hunk, MatchMode, PatchFile, PatchLine, PostWriteHooks, PostWriteOnFailure,
+    ReplaceOptions, SearchOptions, SearchResult, WritePolicyOptions, apply_content_edits,
+    apply_content_edits_with_label, apply_post_write_validator, build_context_lines,
+    classify_error, classify_error_ref, edit_error_kind, edit_error_ref, format_search_results,
+    parse_unified_diff, run_post_write_validation, search_file, text_diff,
 };
 pub use plan::Plan;
 


### PR DESCRIPTION
## Summary

Ship the Bline-oriented library surfaces from issues #1658–#1666 so agent hosts can thin dual paths and stop scraping English for recovery.

- **#1658** `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (literal/regex; distinct NoMatch messages for missing symbol vs pattern)
- **#1659** `classify_error` / `classify_error_ref` for non-`anyhow` hosts (`dyn Error`)
- **#1660** `backup::restore_path_from_session(ts, path)` and single-path restore for latest
- **#1661** document + regression tests for signature body-gap invariant (no host post-pass)
- **#1662** `MatchMode` + `match_score` on `EditResult` / `ContentEditResult`
- **#1663** `PostWriteHooks` / `run_post_write_validation` with optional backup revert
- **#1664** `find_files_with_symbol` + compose with `ast_rename_batch`
- **#1665** `apply_content_edits_with_label` for real diff headers
- **#1666** embedder docs for `command_position` (ContentEdit path already tested)

## Breaking note

`ast_replace_in_symbol` now takes `&AstReplaceInSymbolOptions` (was bare mode/guard only). Default options keep literal behavior.

## Test plan

- [x] `make check-fast` (fmt, clippy, lib/integration/pty)
- [x] Unit tests for each issue surface
- [ ] CI green on PR

Closes #1658
Closes #1659
Closes #1660
Closes #1661
Closes #1662
Closes #1663
Closes #1664
Closes #1665
Closes #1666