### PR TITLE
fix: Bline API follow-ups (fuzzy disk, FormatFailed, max_files)

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1273,7 +1273,7 @@ The operations below are the building blocks inside `operations`.
 | Need | API |
 |------|-----|
 | Fail-closed text replace | `ReplaceOptions.require_change` + `edit_error_kind` / `classify_error` |
-| Non-`anyhow` error kinds | `classify_error(&dyn Error)` / `classify_error_ref` (#1659) |
+| Non-`anyhow` error kinds | `classify_error(&dyn Error)` / `classify_error_ref` (#1659); `EditErrorKind::FormatFailed` for post-write hooks |
 | Shell token rename | `ReplaceOptions.command_position` / `ContentEdit::Replace` (#1666) |
 | Scoped symbol replace (literal/regex) | `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (#1658) |
 | Project symbol discovery + multi-file rename | `find_files_with_symbol` then `ast_rename_batch` (#1664) |

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -280,6 +280,10 @@ pub fn find_files_with_symbol(
         )
         .into());
     }
+    // max_files: 0 means empty result (not "one file" via `len >= 0` after push).
+    if opts.max_files == Some(0) {
+        return Ok(Vec::new());
+    }
     let all = crate::files::collect_file_paths(root, opts.include_hidden)?;
     let mut out = Vec::new();
     for path in all {

--- a/src/api/post_write.rs
+++ b/src/api/post_write.rs
@@ -36,7 +36,7 @@ pub struct PostWriteHooks {
 ///
 /// Failures map to [`FormatFailedError`] (JSON `error_kind: format_failed`) so
 /// they peel via [`crate::api::edit_error_kind`] / [`crate::api::classify_error`]
-/// as [`EditErrorKind::OperationFailed`]. With [`PostWriteOnFailure::Revert`],
+/// as [`EditErrorKind::FormatFailed`]. With [`PostWriteOnFailure::Revert`],
 /// restores only `path` from the latest backup that contains it (see
 /// [`restore_path_from_latest_backup`]).
 ///
@@ -194,7 +194,7 @@ mod tests {
             crate::exit::is_format_failed(&err),
             "expected format_failed, got {err}"
         );
-        assert_eq!(edit_error_kind(&err), Some(EditErrorKind::OperationFailed));
+        assert_eq!(edit_error_kind(&err), Some(EditErrorKind::FormatFailed));
     }
 
     #[test]

--- a/src/api/post_write.rs
+++ b/src/api/post_write.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use crate::backup::restore_path_from_latest_backup;
 use crate::exit::FormatFailedError;
-use crate::fallback::EditError;
+use crate::fallback::{EditError, EditErrorKind};
 
 /// What to do when a post-write hook fails.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -56,7 +56,29 @@ pub fn run_post_write_validation(
         };
         if let Err(e) = run_hook_cmd(cmd, timeout, project_root, label) {
             if hooks.on_failure == PostWriteOnFailure::Revert {
-                let _ = restore_path_from_latest_backup(project_root, path);
+                // Surface restore failure: silent Ok(false)/Err left the file
+                // mutated while the host only saw the format error.
+                match restore_path_from_latest_backup(project_root, path) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        return Err(FormatFailedError {
+                            msg: format!(
+                                "{e}; also failed to revert {}: no backup session for path",
+                                path.display()
+                            ),
+                        }
+                        .into());
+                    }
+                    Err(restore_err) => {
+                        return Err(FormatFailedError {
+                            msg: format!(
+                                "{e}; also failed to revert {}: {restore_err}",
+                                path.display()
+                            ),
+                        }
+                        .into());
+                    }
+                }
             }
             return Err(e);
         }
@@ -108,9 +130,30 @@ pub fn apply_post_write_validator<V: PostWriteValidator + ?Sized>(
         Ok(()) => Ok(()),
         Err(e) => {
             if revert {
-                let _ = restore_path_from_latest_backup(project_root, path);
+                match restore_path_from_latest_backup(project_root, path) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        return Err(EditError::new(
+                            EditErrorKind::OperationFailed,
+                            format!(
+                                "{e}; also failed to revert {}: no backup session for path",
+                                path.display()
+                            ),
+                        )
+                        .into());
+                    }
+                    Err(restore_err) => {
+                        return Err(EditError::new(
+                            EditErrorKind::OperationFailed,
+                            format!(
+                                "{e}; also failed to revert {}: {restore_err}",
+                                path.display()
+                            ),
+                        )
+                        .into());
+                    }
+                }
             }
-            // Preserve EditError when present; otherwise wrap.
             Err(e.into())
         }
     }

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -45,9 +45,16 @@ pub fn replace_text(
             format!("{start}:")
         }
     });
-    // Shell command-position is content-path only for now; for files, read +
-    // replace_in_content so require_change / command_position stay consistent.
-    if opts.command_position {
+    // Library-only match options that the plan/tx Operation does not carry
+    // (`fuzzy`) or that need honest `match_mode` (#1662): use the same
+    // content path as command_position so disk and in-memory parity hold.
+    // Pure `fuzzy: true` without context was previously a no-op on the
+    // default files/cli path (tx only falls back when context is set).
+    if opts.command_position
+        || opts.fuzzy
+        || opts.before_context.is_some()
+        || opts.after_context.is_some()
+    {
         let original = std::fs::read_to_string(path).map_err(|e| {
             crate::fallback::EditError::new(
                 crate::fallback::EditErrorKind::OperationFailed,

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4797,6 +4797,48 @@ fn match_mode_exact_fuzzy_and_anchored() {
     assert!(r.new_content.contains("alpha\nTODO: fix"));
 }
 
+/// Disk `replace_text` must honor pure `fuzzy: true` (no context).
+///
+/// Regression: the files/cli path used to drop `fuzzy` because plan
+/// `Operation::Replace` has no fuzzy field and tx only fell back on context.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_pure_fuzzy_without_context() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "fn process_data() {}\n").unwrap();
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        require_change: true,
+        ..Default::default()
+    };
+    let result = replace_text(
+        &file,
+        "fn proccess_data() {}",
+        "fn handle_data() {}",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .expect("pure fuzzy must resolve on disk path");
+    assert!(result.changed, "got: {}", result.new_content);
+    assert!(
+        result.new_content.contains("handle_data"),
+        "got: {}",
+        result.new_content
+    );
+    assert_eq!(
+        result.match_mode,
+        Some(MatchMode::Fuzzy),
+        "disk fuzzy must report Fuzzy, not Exact"
+    );
+    assert!(
+        result.match_score.is_some_and(|s| s > 0.85),
+        "score: {:?}",
+        result.match_score
+    );
+}
+
 #[test]
 fn apply_content_edits_path_label() {
     let edits = [ContentEdit::Replace {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4886,6 +4886,31 @@ fn find_files_with_symbol_and_batch_compose() {
         "c.rs must not match: {paths:?}"
     );
 
+    let zero = find_files_with_symbol(
+        dir.path(),
+        "OldType",
+        &SymbolSearchOptions {
+            max_files: Some(0),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert!(
+        zero.is_empty(),
+        "max_files=0 must not return hits (got {zero:?})"
+    );
+
+    let capped = find_files_with_symbol(
+        dir.path(),
+        "OldType",
+        &SymbolSearchOptions {
+            max_files: Some(1),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(capped.len(), 1, "max_files=1: {capped:?}");
+
     let path_refs: Vec<&std::path::Path> = paths.iter().map(|p| p.as_path()).collect();
     let results = ast_rename_batch(
         &path_refs,
@@ -4898,7 +4923,17 @@ fn find_files_with_symbol_and_batch_compose() {
         None,
     )
     .unwrap();
-    assert!(results.iter().all(|r| r.result.is_ok()));
+    assert!(
+        results.iter().all(|r| r.result.is_ok()),
+        "batch rename failed: {:?}",
+        results
+            .iter()
+            .map(|r| match &r.result {
+                Ok(e) => format!("{}:ok({})", r.path.display(), e.match_count),
+                Err(e) => format!("{}:{:?}", r.path.display(), e.kind),
+            })
+            .collect::<Vec<_>>()
+    );
     assert!(fs::read_to_string(&a).unwrap().contains("NewType"));
     assert!(fs::read_to_string(&b).unwrap().contains("NewType"));
     assert!(fs::read_to_string(&c).unwrap().contains("Other"));

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -109,6 +109,10 @@ pub enum EditErrorKind {
     InvalidInput,
     /// I/O or other operational failure.
     OperationFailed,
+    /// Post-write format/lint hook failed (`format_failed` / #1663).
+    /// Distinct from generic [`Self::OperationFailed`] so hosts can branch
+    /// without scraping English.
+    FormatFailed,
 }
 
 impl std::fmt::Display for EditErrorKind {
@@ -122,6 +126,7 @@ impl std::fmt::Display for EditErrorKind {
             EditErrorKind::GuardRejected => write!(f, "guard_rejected"),
             EditErrorKind::InvalidInput => write!(f, "invalid_input"),
             EditErrorKind::OperationFailed => write!(f, "operation_failed"),
+            EditErrorKind::FormatFailed => write!(f, "format_failed"),
         }
     }
 }
@@ -214,9 +219,11 @@ pub fn classify_error(err: &(dyn std::error::Error + 'static)) -> Option<EditErr
         if e.downcast_ref::<crate::exit::ParseErrorError>().is_some() {
             return Some(EditErrorKind::ParseError);
         }
+        if e.downcast_ref::<crate::exit::FormatFailedError>().is_some() {
+            return Some(EditErrorKind::FormatFailed);
+        }
         // Closest library kind for hosts that only branch on EditErrorKind.
-        if e.downcast_ref::<crate::exit::FormatFailedError>().is_some()
-            || e.downcast_ref::<crate::exit::ConflictsError>().is_some()
+        if e.downcast_ref::<crate::exit::ConflictsError>().is_some()
             || e.downcast_ref::<crate::exit::ChangesDetectedError>()
                 .is_some()
         {
@@ -773,7 +780,7 @@ mod tests {
         let e = crate::exit::FormatFailedError { msg: "fmt".into() };
         assert_eq!(
             classify_error(&e as &(dyn Error + 'static)),
-            Some(EditErrorKind::OperationFailed)
+            Some(EditErrorKind::FormatFailed)
         );
     }
 
@@ -818,7 +825,7 @@ mod tests {
         .into();
         assert_eq!(
             edit_error_kind(&format_failed),
-            Some(EditErrorKind::OperationFailed)
+            Some(EditErrorKind::FormatFailed)
         );
 
         let not_found: anyhow::Error =


### PR DESCRIPTION
## Summary

MPI cycle after #1667. Fixes embedder correctness gaps found in the new Bline API surfaces.

- **Disk pure fuzzy:** `replace_text` with `fuzzy: true` (no context) was a no-op on the default files/cli path; now routes through the content path with honest `match_mode` / `match_score`
- **Post-write revert:** fail when backup restore cannot complete (no silent partial success)
- **`max_files: 0`:** `find_files_with_symbol` returns empty (not one hit)
- **`EditErrorKind::FormatFailed`:** classify format/lint hook failures distinctly from `OperationFailed`

## Test plan

- [x] `make check-fast`
- [x] `replace_text_pure_fuzzy_without_context`
- [x] `find_files_with_symbol` max_files 0/1
- [x] post_write + classify_error FormatFailed tests
- [ ] CI green

## Notes

Release PR #1657 (0.13.0) is open and needs explicit approval to merge (includes #1667). This PR is a follow-up for 0.13.x or 0.14.