### PR TITLE
feat: plan/tx fuzzy replace and match_mode JSON (#1668 #1669)

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -36,6 +36,7 @@
 **`replace_text` / plan replace flags (default false):**
 - `require_change`: error when the pattern matches zero times (fail closed).
 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
+- `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 Use patchloom when:
@@ -249,6 +250,7 @@ All operations succeed atomically or roll back together.
 Plan/MCP `replace` accepts library flags (default false):
 - `require_change`: fail when the pattern matches zero times (agent fail-closed).
 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
+- `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 ## AST-aware operations
@@ -321,7 +323,7 @@ dependencies[name=react].version # predicate filter
 
 ## Operations (from schema registry)
 
-- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip).
+- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches), command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip), and fuzzy (similarity fallback when exact match fails).
 - `file.append`: Append content to an existing file.
 - `file.prepend`: Prepend content to an existing file.
 - `file.create`: Create a new file with specified content.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -598,6 +598,13 @@ These are meaningful command-specific modes that change how a top-level command 
 - **Use when:** Migrating install tooling in shell scripts or agent-generated commands without breaking package names that embed the same substring.
 - **Prefer instead:** Ordinary replace or `word_boundary` for identifiers. Cannot combine with `regex`, `case_insensitive`, `word_boundary`, `fuzzy`, `nth`, multiline/whole-line, context anchors, or insert-before/after.
 
+<!-- ref:replace-mode:fuzzy -->
+### `replace --fuzzy` / library `ReplaceOptions.fuzzy` / plan `fuzzy`
+
+- **What it does:** When the exact pattern has zero matches, try similarity/anchor fallback (same chain as before/after context). Plan ops and MCP `replace_text` accept `fuzzy: true`. Pure fuzzy (no context) works on disk library and tx paths (#1668).
+- **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` in library results and CLI/MCP JSON (#1669).
+- **Prefer instead:** Exact replace when the target string is known.
+
 <!-- ref:create-mode:stdin -->
 ### `create --stdin`
 

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -101,6 +101,7 @@ pub fn replace_text(
         // require_change is applied below as structured EditError (not via tx bail).
         require_change: false,
         command_position: opts.command_position,
+        fuzzy: false,
     };
     let mut result = replace_write(op, path, mode, guard, opts.fuzzy)?;
     // if_exists intentionally softens zero-match (Ok unchanged). require_change

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2478,6 +2478,7 @@ fn adapter_unchanged_returns_no_diff() {
         unique: false,
         require_change: false,
         command_position: false,
+        fuzzy: false,
     };
 
     let result =

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -113,6 +113,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              **`replace_text` / plan replace flags (default false):**\n\
              - `require_change`: error when the pattern matches zero times (fail closed).\n\
              - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).\n\
+             - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
              \"command_position\":true,\"require_change\":true}`\n\n",
         );
@@ -387,6 +388,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  Plan/MCP `replace` accepts library flags (default false):\n\
                  - `require_change`: fail when the pattern matches zero times (agent fail-closed).\n\
                  - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).\n\
+                 - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\n");
         }

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -182,6 +182,7 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
                 unique: false,
                 require_change: false,
                 command_position: false,
+                fuzzy: false,
             })
         }
 

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -44,6 +44,7 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             if_exists,
             require_change,
             command_position,
+            fuzzy,
             ..
         } => {
             let target = path.as_deref().or(glob.as_deref()).unwrap_or("(all files)");
@@ -88,8 +89,9 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             } else {
                 ""
             };
+            let fuzzy_str = if *fuzzy { ", fuzzy" } else { "" };
             format!(
-                "Replace \"{old}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{wb_str}{ml_str}{ie_str}{rc_str}{cp_str}{range_str})"
+                "Replace \"{old}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{wb_str}{ml_str}{ie_str}{rc_str}{cp_str}{fuzzy_str}{range_str})"
             )
         }
         Operation::DocSet {
@@ -443,6 +445,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Replace "v1" with "v2" in README.md (literal)"#);
@@ -470,6 +473,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -600,6 +604,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -631,6 +636,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Insert "// added" after "use crate" in lib.rs"#);
@@ -658,6 +664,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("whole-line"), "{desc}");
@@ -771,6 +778,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -802,6 +810,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -832,6 +841,7 @@ mod tests {
             unique: false,
             require_change: true,
             command_position: true,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -863,6 +873,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains(", multiline"), "missing multiline: {desc}");
@@ -891,6 +902,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("**/*.rs"), "{desc}");
@@ -918,6 +930,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("(delete)"), "{desc}");

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -7,6 +7,9 @@
 //! **Every tool in this module must appear in
 //! [`super::surface::custom_mcp_tools`] inventory with a reason.** Prefer the registry
 //! for new 1:1 `Operation` writes. See `surface` module docs for the policy.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). Custom MCP tool
+//! handlers and match_mode JSON enrichment co-located; do not split for LOC alone.
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -368,6 +371,35 @@ impl PatchloomService {
                 Vec::new()
             };
 
+            // Capture match honesty before Apply mutates the file (#1669).
+            let match_meta = {
+                let abs = svc.cwd().join(&p.path);
+                std::fs::read_to_string(&abs).ok().and_then(|content| {
+                    let opts = crate::api::ReplaceOptions {
+                        regex: p.regex,
+                        nth: p.nth,
+                        case_insensitive: p.case_insensitive,
+                        multiline: p.multiline,
+                        insert_before: p.insert_before.clone(),
+                        insert_after: p.insert_after.clone(),
+                        whole_line: p.whole_line,
+                        range: None,
+                        if_exists: true,
+                        word_boundary: p.word_boundary,
+                        unique: p.unique,
+                        fuzzy: p.fuzzy,
+                        before_context: p.before_context.clone(),
+                        after_context: p.after_context.clone(),
+                        require_change: false,
+                        command_position: p.command_position,
+                    };
+                    let to = p.new_text.as_deref().unwrap_or("");
+                    crate::api::replace_in_content(&content, &p.old, to, &opts)
+                        .ok()
+                        .map(|r| (r.match_mode, r.match_score, r.match_count))
+                })
+            };
+
             let replace_op = Operation::Replace {
                 glob: None,
                 path: Some(p.path),
@@ -388,8 +420,38 @@ impl PatchloomService {
                 unique: p.unique,
                 require_change: p.require_change,
                 command_position: p.command_position,
+                fuzzy: p.fuzzy,
             };
             let mut tool_result = svc.run_one_op(replace_op, Some(p.strict))?;
+
+            // Inject match_mode / match_score into structured JSON content (#1669).
+            if let Some((mode, score, count)) = match_meta {
+                for block in &mut tool_result.content {
+                    if let ContentBlock::Text(text_content) = block {
+                        let text = &mut text_content.text;
+                        if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(text) {
+                            if let Some(m) = mode {
+                                let s = match m {
+                                    crate::api::MatchMode::Exact => "exact",
+                                    crate::api::MatchMode::Fuzzy => "fuzzy",
+                                    crate::api::MatchMode::Anchored => "anchored",
+                                };
+                                v["match_mode"] = serde_json::json!(s);
+                            }
+                            if let Some(s) = score {
+                                v["match_score"] = serde_json::json!(s);
+                            }
+                            if count > 0 {
+                                v["match_count"] = serde_json::json!(count);
+                            }
+                            if let Ok(s) = serde_json::to_string(&v) {
+                                *text = s;
+                            }
+                            break;
+                        }
+                    }
+                }
+            }
 
             // Append validation warnings to the response.
             if !validation_warnings.is_empty() {
@@ -537,6 +599,7 @@ impl PatchloomService {
                     unique: false,
                     require_change: p.require_change,
                     command_position: p.command_position,
+                    fuzzy: p.fuzzy,
                 })
                 .collect();
             svc.run_ops(ops, Some(p.strict))

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -67,6 +67,9 @@ pub(crate) struct ReplaceParams {
     /// Peels wrappers like sudo, timeout, busybox, flock, runuser, setsid.
     #[serde(default)]
     pub command_position: bool,
+    /// When exact match fails, try fuzzy/similarity fallback (#1668).
+    #[serde(default)]
+    pub fuzzy: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,
@@ -258,6 +261,9 @@ pub(crate) struct BatchReplaceParams {
     /// Peels wrappers like sudo, timeout, busybox, flock, runuser, setsid.
     #[serde(default)]
     pub command_position: bool,
+    /// When exact match fails, try fuzzy/similarity fallback (#1668).
+    #[serde(default)]
+    pub fuzzy: bool,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -101,6 +101,11 @@ pub struct ReplaceArgs {
     /// regex/word-boundary/multiline/nth/insert/context.
     #[arg(long)]
     pub command_position: bool,
+    // ref:replace-mode:fuzzy
+    /// When exact match fails, try fuzzy/similarity fallback (and when
+    /// `--before-context` / `--after-context` is set). Literal only.
+    #[arg(long)]
+    pub fuzzy: bool,
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,
 }
@@ -109,6 +114,12 @@ pub struct ReplaceArgs {
 struct ReplaceFileResult {
     path: String,
     match_count: usize,
+    /// How the match was resolved (`exact` / `fuzzy` / `anchored`). #1669
+    #[serde(skip_serializing_if = "Option::is_none")]
+    match_mode: Option<&'static str>,
+    /// Similarity score when match_mode is fuzzy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    match_score: Option<f64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -126,6 +137,11 @@ struct ReplaceOutput {
     /// aligned with tx JSON `error_kind`. Omitted on success.
     #[serde(skip_serializing_if = "Option::is_none")]
     error_kind: Option<&'static str>,
+    /// Aggregate match strategy when all files share one mode (#1669).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    match_mode: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    match_score: Option<f64>,
 }
 
 /// Result of processing a single file.
@@ -136,6 +152,16 @@ struct FileReplacement {
     original: String,
     replaced: String,
     match_count: usize,
+    match_mode: Option<&'static str>,
+    match_score: Option<f64>,
+}
+
+fn match_mode_str(mode: crate::api::MatchMode) -> &'static str {
+    match mode {
+        crate::api::MatchMode::Exact => "exact",
+        crate::api::MatchMode::Fuzzy => "fuzzy",
+        crate::api::MatchMode::Anchored => "anchored",
+    }
 }
 
 /// Parse `--range` argument into (start, optional_end). Reuses the line-range
@@ -222,6 +248,8 @@ fn collect_replacements(
                     original: content,
                     replaced,
                     match_count: count,
+                    match_mode: Some("exact"),
+                    match_score: None,
                 })
             } else {
                 None
@@ -240,8 +268,29 @@ fn make_file_results(replacements: &[FileReplacement]) -> Vec<ReplaceFileResult>
         .map(|r| ReplaceFileResult {
             path: r.display_path.clone(),
             match_count: r.match_count,
+            match_mode: r.match_mode,
+            match_score: r.match_score,
         })
         .collect()
+}
+
+/// Prefer a single top-level match_mode when every file agrees (#1669).
+fn aggregate_match_meta(files: &[ReplaceFileResult]) -> (Option<&'static str>, Option<f64>) {
+    let modes: Vec<_> = files.iter().filter_map(|f| f.match_mode).collect();
+    if modes.is_empty() {
+        return (None, None);
+    }
+    let first = modes[0];
+    if modes.iter().all(|m| *m == first) {
+        let score = if first == "fuzzy" {
+            files.iter().find_map(|f| f.match_score)
+        } else {
+            None
+        };
+        (Some(first), score)
+    } else {
+        (None, None)
+    }
 }
 
 pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
@@ -264,7 +313,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 insert_after: args.insert_after.is_some(),
                 before_context: args.before_context.is_some(),
                 after_context: args.after_context.is_some(),
-                fuzzy: false,
+                fuzzy: args.fuzzy,
             },
         )
     {
@@ -292,9 +341,9 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // guard remains defense-in-depth).
     global.check_paths_contained(&cwd, &args.paths)?;
 
-    // Context-based replace: route through the tx engine where the
-    // context_filtered_offset and fallback chain live.
-    if args.before_context.is_some() || args.after_context.is_some() {
+    // Context / pure fuzzy: route through the tx engine where the
+    // context_filtered_offset and fallback chain live (#1668).
+    if args.fuzzy || args.before_context.is_some() || args.after_context.is_some() {
         return run_context_replace(args, global, &cwd);
     }
 
@@ -314,10 +363,14 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     files: vec![ReplaceFileResult {
                         path: r.display_path.clone(),
                         match_count: r.match_count,
+                        match_mode: r.match_mode,
+                        match_score: r.match_score,
                     }],
                     diff: None,
                     identity: None,
                     error_kind: Some("ambiguous"),
+                    match_mode: None,
+                    match_score: None,
                 };
                 global.emit_json(&output)?;
                 if !global.quiet {
@@ -350,6 +403,8 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 diff: None,
                 identity: Some(true),
                 error_kind: None,
+                match_mode: Some("exact"),
+                match_score: None,
             };
             global.emit_json(&output)?;
             if !global.quiet && !global.json && !global.jsonl {
@@ -369,6 +424,8 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 diff: None,
                 identity: None,
                 error_kind: None,
+                match_mode: None,
+                match_score: None,
             };
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
@@ -389,6 +446,8 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             diff: None,
             identity: None,
             error_kind: Some("no_matches"),
+            match_mode: None,
+            match_score: None,
         };
         global.emit_json(&output)?;
         if !global.quiet && !global.json && !global.jsonl {
@@ -443,6 +502,7 @@ fn replace_output(
 ) -> anyhow::Result<u8> {
     use crate::cmd::write_mode::{FinalizeCallbacks, finalize_report};
 
+    let (agg_mode, agg_score) = aggregate_match_meta(files);
     let build_output = |diff: Option<String>| ReplaceOutput {
         ok: true,
         match_count: total_matches,
@@ -451,6 +511,8 @@ fn replace_output(
         diff,
         identity: None,
         error_kind: None,
+        match_mode: agg_mode,
+        match_score: agg_score,
     };
 
     finalize_report(
@@ -552,6 +614,7 @@ fn run_context_replace(
             unique: args.unique,
             require_change: args.require_change,
             command_position: args.command_position,
+            fuzzy: args.fuzzy,
         })
         .collect();
 
@@ -570,6 +633,8 @@ fn run_context_replace(
             } else {
                 Some("no_matches")
             },
+            match_mode: None,
+            match_score: None,
         };
         global.emit_json(&empty)?;
         if args.if_exists {
@@ -581,15 +646,44 @@ fn run_context_replace(
         return Ok(exit::NO_MATCHES);
     }
 
+    // Re-derive match honesty via the library content path (#1669).
+    let lib_opts = crate::api::ReplaceOptions {
+        regex: args.regex,
+        nth: args.nth,
+        case_insensitive: args.case_insensitive,
+        multiline: args.multiline,
+        insert_before: args.insert_before.clone(),
+        insert_after: args.insert_after.clone(),
+        whole_line: args.whole_line,
+        range: None,
+        if_exists: true,
+        word_boundary: args.word_boundary,
+        unique: args.unique,
+        fuzzy: args.fuzzy,
+        before_context: args.before_context.clone(),
+        after_context: args.after_context.clone(),
+        require_change: false,
+        command_position: args.command_position,
+    };
+    let to = args.new.as_deref().unwrap_or("");
     let files: Vec<ReplaceFileResult> = result
         .exec_result
         .changes
         .iter()
-        .map(|(p, _, _)| ReplaceFileResult {
-            path: crate::files::relative_display(p, &cwd)
-                .to_string_lossy()
-                .into_owned(),
-            match_count: 1,
+        .map(|(p, original, _new)| {
+            let (mode, score) =
+                match crate::api::replace_in_content(original, &args.old, to, &lib_opts) {
+                    Ok(r) => (r.match_mode.map(match_mode_str), r.match_score),
+                    Err(_) => (Some("exact"), None),
+                };
+            ReplaceFileResult {
+                path: crate::files::relative_display(p, &cwd)
+                    .to_string_lossy()
+                    .into_owned(),
+                match_count: 1,
+                match_mode: mode,
+                match_score: score,
+            }
         })
         .collect();
     let total_matches = files.len();

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -23,6 +23,7 @@ fn make_args(old: &str, new: &str, paths: Vec<String>) -> ReplaceArgs {
         unique: false,
         require_change: false,
         command_position: false,
+        fuzzy: false,
         write: Default::default(),
     }
 }
@@ -74,6 +75,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -109,6 +111,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -214,6 +217,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -274,6 +278,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -335,6 +340,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -377,6 +383,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -412,6 +419,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -446,6 +454,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -482,6 +491,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -522,6 +532,7 @@ mod basic {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -565,6 +576,7 @@ mod edge_cases {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -599,6 +611,7 @@ mod edge_cases {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let global = GlobalFlags {
@@ -658,6 +671,7 @@ mod edge_cases {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -737,6 +751,7 @@ mod edge_cases {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -781,6 +796,7 @@ mod edge_cases {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -839,6 +855,7 @@ mod error_handling {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -871,6 +888,7 @@ mod error_handling {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -903,6 +921,7 @@ mod error_handling {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -935,6 +954,7 @@ mod error_handling {
             unique: true,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -975,6 +995,7 @@ mod error_handling {
             unique: true,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1019,6 +1040,7 @@ mod error_handling {
             unique: true,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -1064,6 +1086,7 @@ mod context_replace {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1115,6 +1138,7 @@ mod context_replace {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1160,6 +1184,7 @@ mod context_replace {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
 
@@ -1193,6 +1218,7 @@ mod context_replace {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
 
@@ -1230,6 +1256,7 @@ mod context_replace {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1272,6 +1299,7 @@ mod context_replace {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1315,6 +1343,7 @@ mod context_replace {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1342,4 +1371,45 @@ mod context_replace {
             "sudo uv install x\nuv pip install\n"
         );
     }
+}
+
+#[test]
+fn fuzzy_cli_json_reports_match_mode() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "fn process_data() {}\n").unwrap();
+
+    // Library path honesty (match_mode / match_score).
+    let content = fs::read_to_string(&file).unwrap();
+    let opts = crate::api::ReplaceOptions {
+        fuzzy: true,
+        require_change: true,
+        ..Default::default()
+    };
+    let r = crate::api::replace_in_content(
+        &content,
+        "fn proccess_data() {}",
+        "fn handle_data() {}",
+        &opts,
+    )
+    .unwrap();
+    assert_eq!(r.match_mode, Some(crate::api::MatchMode::Fuzzy));
+    assert!(r.match_score.is_some_and(|s| s > 0.85));
+
+    // CLI/tx path: pure fuzzy without context must rewrite (#1668).
+    let mut args = make_args(
+        "fn proccess_data() {}",
+        "fn handle_data() {}",
+        vec![file.to_string_lossy().into_owned()],
+    );
+    args.fuzzy = true;
+    let global = GlobalFlags {
+        apply: true,
+        cwd: Some(dir.path().to_string_lossy().into_owned()),
+        ..GlobalFlags::test_default()
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(code, exit::SUCCESS);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(on_disk.contains("handle_data"), "{on_disk}");
 }

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -63,6 +63,10 @@ pub enum Operation {
         /// Literal only; incompatible with regex/case_insensitive/word_boundary/fuzzy.
         #[serde(default)]
         command_position: bool,
+        /// When exact match fails, try fuzzy/similarity fallback (library/plan/MCP).
+        /// Also enabled implicitly when before_context/after_context is set.
+        #[serde(default)]
+        fuzzy: bool,
     },
     #[serde(rename = "doc.set")]
     DocSet {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -183,7 +183,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     // --- Weak tier ---
     OpMeta {
         name: "replace",
-        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches) and command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip).",
+        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches), command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip), and fuzzy (similarity fallback when exact match fails).",
         tier: Tier::Weak,
         examples: &[
             (

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -352,6 +352,7 @@ mod basic {
                     unique: false,
                     require_change: false,
                     command_position: false,
+                    fuzzy: false,
                 },
             ),
             (

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -198,6 +198,7 @@ fn op_needs_doc_flush_for_replace() {
         unique: false,
         require_change: false,
         command_position: false,
+        fuzzy: false,
     };
     assert!(op_needs_doc_flush(&op));
 }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -367,6 +367,7 @@ mod tests {
                 unique: false,
                 require_change: false,
                 command_position: false,
+                fuzzy: false,
             }],
             write_policy: None,
             strict: None,

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -46,6 +46,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         unique,
         require_change,
         command_position,
+        fuzzy,
         ..
     } = op
     else {
@@ -79,7 +80,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 insert_after: insert_after.is_some(),
                 before_context: before_context.is_some(),
                 after_context: after_context.is_some(),
-                fuzzy: false,
+                fuzzy: *fuzzy,
             },
         )
     {
@@ -181,8 +182,8 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 owned,
             );
             Ok(match_count)
-        } else if !regex_mode && (before_context.is_some() || after_context.is_some()) {
-            // Tier 3: Use context-based fallback when exact match fails.
+        } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some()) {
+            // Tier 3: fuzzy and/or context fallback when exact match fails (#1668).
             match crate::fallback::resolve_with_fallback(
                 content,
                 old,
@@ -389,6 +390,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -425,6 +427,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -459,6 +462,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -495,6 +499,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -529,6 +534,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -572,6 +578,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -611,6 +618,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -662,6 +670,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -710,6 +719,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -754,6 +764,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -796,6 +807,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
 
         let mut f = TxStateFixture::new();
@@ -831,6 +843,7 @@ mod tests {
             unique: false,
             require_change: true,
             command_position: true,
+            fuzzy: false,
         };
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
@@ -865,10 +878,51 @@ mod tests {
             unique: false,
             require_change: true,
             command_position: false,
+            fuzzy: false,
         };
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
         let err = execute_replace_op(&op, &mut tx).unwrap_err();
         assert!(err.to_string().contains("no matches"), "{err}");
+    }
+
+    #[test]
+    fn replace_pure_fuzzy_without_context() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("code.rs");
+        std::fs::write(&file, "fn process_data() {}\n").unwrap();
+
+        let op = Operation::Replace {
+            path: Some("code.rs".into()),
+            glob: None,
+            regex: false,
+            old: "fn proccess_data() {}".into(),
+            new_text: Some("fn handle_data() {}".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
+            require_change: true,
+            command_position: false,
+            fuzzy: true,
+        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
+        assert_eq!(count, 1);
+        assert!(
+            f.pending[&file].1.contains("handle_data"),
+            "pure fuzzy plan op must rewrite: {}",
+            f.pending[&file].1
+        );
     }
 }

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -154,6 +154,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         }
     }
 
@@ -211,6 +212,7 @@ mod tests {
             unique: false,
             require_change: false,
             command_position: false,
+            fuzzy: false,
         };
         let err = validate_operation(&op).unwrap_err();
         assert!(

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -532,6 +532,7 @@ mod tests {
                 unique: false,
                 require_change: false,
                 command_position: false,
+                fuzzy: false,
             }],
             write_policy: None,
             format: None,


### PR DESCRIPTION
## Summary

Gate work for accepted issues after the Bline API batch:

- **#1668:** `Operation::Replace.fuzzy` on plan/tx/MCP/CLI so pure fuzzy (no context) works end-to-end, matching library `ReplaceOptions.fuzzy`
- **#1669:** CLI `replace --json` and MCP `replace_text` report `match_mode` (`exact` / `fuzzy` / `anchored`) and optional `match_score`

## Test plan

- [x] `make check-fast`
- [x] `replace_pure_fuzzy_without_context` (tx)
- [x] `fuzzy_cli_json_reports_match_mode`
- [ ] CI green

Closes #1668
Closes #1669