### PR TITLE
fix: fuzzy/context replace parity for globs and directories

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -185,6 +185,7 @@ patchloom replace 'TODO' --whole-line --range 10:200 --new '' notes.md --apply
 
 # Rewrite shell invocable tokens only (not uv pip / pipenv):
 patchloom replace pip --new uv install.sh --command-position --require-change --apply
+patchloom replace 'fn proccess_data' --new 'fn process_data' src/ --fuzzy --apply
 ```
 
 ### Edit a CI workflow

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -601,7 +601,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:fuzzy -->
 ### `replace --fuzzy` / library `ReplaceOptions.fuzzy` / plan `fuzzy`
 
-- **What it does:** When the exact pattern has zero matches, try similarity/anchor fallback (same chain as before/after context). Plan ops and MCP `replace_text` accept `fuzzy: true`. Pure fuzzy (no context) works on disk library and tx paths (#1668).
+- **What it does:** When the exact pattern has zero matches, try similarity/anchor fallback (same chain as before/after context). Plan ops and MCP `replace_text` accept `fuzzy: true`. Pure fuzzy (no context) works on disk library, single-path tx, **glob** plan ops, and CLI (including directory roots expanded like ordinary replace).
 - **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` in library results and CLI/MCP JSON (#1669).
 - **Prefer instead:** Exact replace when the target string is known.
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -317,6 +317,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              patchloom replace 'TODO' --whole-line --range 10:200 --new '' notes.md --apply\n\n\
              # Rewrite shell invocable tokens only (not uv pip / pipenv):\n\
              patchloom replace pip --new uv install.sh --command-position --require-change --apply\n\
+             patchloom replace 'fn proccess_data' --new 'fn process_data' src/ --fuzzy --apply\n\
              ```\n\n",
         );
 
@@ -688,11 +689,15 @@ mod tests {
     fn workflow_includes_plan_require_change_and_command_position() {
         let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
         assert!(
-            out.contains("require_change") && out.contains("command_position"),
+            out.contains("require_change")
+                && out.contains("command_position")
+                && out.contains("fuzzy"),
             "plan replace library flags must be documented for agents"
         );
         assert!(
-            out.contains("--command-position") && out.contains("--require-change"),
+            out.contains("--command-position")
+                && out.contains("--require-change")
+                && out.contains("--fuzzy"),
             "CLI flags must appear in agent-rules examples"
         );
         assert!(
@@ -715,7 +720,9 @@ mod tests {
         );
         let mcp = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));
         assert!(
-            mcp.contains("require_change") && mcp.contains("command_position"),
+            mcp.contains("require_change")
+                && mcp.contains("command_position")
+                && mcp.contains("fuzzy"),
             "MCP-only agent-rules must document replace_text flags"
         );
     }

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -575,46 +575,92 @@ fn replace_output(
     )
 }
 
-/// Context-based replace: routes through the tx engine where
+/// Context / pure-fuzzy replace: routes through the tx engine where
 /// `context_filtered_offset` and the fallback chain live.
 fn run_context_replace(
     args: ReplaceArgs,
     global: &GlobalFlags,
-    _cwd: &std::path::Path,
+    cwd: &std::path::Path,
 ) -> anyhow::Result<u8> {
     use crate::plan::Operation;
 
-    // Context-based replace requires explicit file paths (not directory scan).
-    if args.paths.is_empty() {
-        let msg = "--before-context/--after-context requires explicit file paths";
-        global.emit_error_json_kind(Some("invalid_input"), msg)?;
-        return Ok(exit::FAILURE);
+    // Expand directories the same way as the default replace scan so
+    // `patchloom replace --fuzzy OLD --new NEW src/` works (not only
+    // single-file paths). Empty roots default to `.` via collect.
+    let paths = if args.paths.is_empty() {
+        vec![".".to_string()]
+    } else {
+        args.paths.clone()
+    };
+    let file_paths = crate::collect_file_paths_opts(&paths, global, false, Some(cwd))?;
+    if file_paths.is_empty() {
+        if crate::files::all_scan_targets_missing(global, &paths, Some(cwd))? {
+            let msg = format!(
+                "no such file or directory: {}",
+                global.path_scope_description(&paths)
+            );
+            global.emit_error_json_kind(Some("not_found"), &msg)?;
+            return Ok(exit::FAILURE);
+        }
+        let empty = ReplaceOutput {
+            ok: args.if_exists,
+            match_count: 0,
+            file_count: 0,
+            files: vec![],
+            diff: None,
+            identity: None,
+            error_kind: if args.if_exists {
+                None
+            } else {
+                Some("no_matches")
+            },
+            match_mode: None,
+            match_score: None,
+        };
+        global.emit_json(&empty)?;
+        if args.if_exists {
+            return Ok(exit::SUCCESS);
+        }
+        if !global.quiet && !global.json && !global.jsonl {
+            eprintln!(
+                "no matches for '{}' in fuzzy/context replace ({})",
+                args.old,
+                global.path_scope_description(&paths)
+            );
+        }
+        return Ok(exit::NO_MATCHES);
     }
 
-    let ops: Vec<Operation> = args
-        .paths
+    let ops: Vec<Operation> = file_paths
         .iter()
-        .map(|p| Operation::Replace {
-            glob: None,
-            path: Some(p.clone()),
-            regex: args.regex,
-            old: args.old.clone(),
-            new_text: args.new.clone(),
-            nth: args.nth,
-            insert_before: args.insert_before.clone(),
-            insert_after: args.insert_after.clone(),
-            case_insensitive: args.case_insensitive,
-            multiline: args.multiline,
-            if_exists: args.if_exists,
-            whole_line: args.whole_line,
-            range: args.range.clone(),
-            word_boundary: args.word_boundary,
-            before_context: args.before_context.clone(),
-            after_context: args.after_context.clone(),
-            unique: args.unique,
-            require_change: args.require_change,
-            command_position: args.command_position,
-            fuzzy: args.fuzzy,
+        .map(|p| {
+            let rel = crate::files::relative_display(p, cwd)
+                .to_string_lossy()
+                .into_owned();
+            Operation::Replace {
+                glob: None,
+                path: Some(rel),
+                regex: args.regex,
+                old: args.old.clone(),
+                new_text: args.new.clone(),
+                nth: args.nth,
+                insert_before: args.insert_before.clone(),
+                insert_after: args.insert_after.clone(),
+                case_insensitive: args.case_insensitive,
+                multiline: args.multiline,
+                if_exists: args.if_exists || file_paths.len() > 1,
+                // Multi-file fuzzy: soft-miss per file so one miss does not
+                // abort the batch; overall require_change checked via has_changes.
+                whole_line: args.whole_line,
+                range: args.range.clone(),
+                word_boundary: args.word_boundary,
+                before_context: args.before_context.clone(),
+                after_context: args.after_context.clone(),
+                unique: args.unique,
+                require_change: args.require_change && file_paths.len() == 1,
+                command_position: args.command_position,
+                fuzzy: args.fuzzy,
+            }
         })
         .collect();
 

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -1413,3 +1413,42 @@ fn fuzzy_cli_json_reports_match_mode() {
     let on_disk = fs::read_to_string(&file).unwrap();
     assert!(on_disk.contains("handle_data"), "{on_disk}");
 }
+
+#[test]
+fn fuzzy_cli_expands_directory_roots() {
+    let dir = TempDir::new().unwrap();
+    let sub = dir.path().join("src");
+    fs::create_dir_all(&sub).unwrap();
+    let file = sub.join("lib.rs");
+    fs::write(&file, "fn process_data() {}\n").unwrap();
+    fs::write(dir.path().join("notes.txt"), "fn process_data() {}\n").unwrap();
+
+    let mut args = make_args(
+        "fn proccess_data() {}",
+        "fn handle_data() {}",
+        vec![sub.to_string_lossy().into_owned()],
+    );
+    args.fuzzy = true;
+    let global = GlobalFlags {
+        apply: true,
+        cwd: Some(dir.path().to_string_lossy().into_owned()),
+        ..GlobalFlags::test_default()
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(
+        code,
+        exit::SUCCESS,
+        "directory + --fuzzy should expand and apply"
+    );
+    assert!(
+        fs::read_to_string(&file).unwrap().contains("handle_data"),
+        "src/lib.rs should be rewritten"
+    );
+    // notes.txt was outside the path root and must stay unchanged.
+    assert!(
+        fs::read_to_string(dir.path().join("notes.txt"))
+            .unwrap()
+            .contains("process_data"),
+        "sibling file outside root must not change"
+    );
+}

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -1,3 +1,8 @@
+//! Tx replace operation execution.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). Path + glob replace
+//! with fuzzy/context fallback co-located; do not split for LOC alone.
+
 use super::execute::{TxState, read_and_probe, read_file_content, update_file_content};
 use crate::ops::replace::{
     compile_replace_regex, context_filtered_offset, replace_content, replace_whole_lines,
@@ -331,8 +336,52 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             } else {
                 replace_content(&content, old, &replacement, compiled_re.as_ref(), *nth)
             };
-            total_matches += match_count;
+            if *unique && match_count > 1 {
+                let rel = file_path
+                    .strip_prefix(tx.cwd)
+                    .unwrap_or(&file_path)
+                    .display();
+                return Err(crate::exit::AmbiguousError {
+                    msg: format!(
+                        "ambiguous match: pattern {:?} matches {} times in {}; use --nth or add context to disambiguate",
+                        crate::fallback::truncate_str(old, 60),
+                        match_count,
+                        rel
+                    ),
+                }
+                .into());
+            }
             if match_count > 0 {
+                // Multi-match context disambiguation (parity with single-path).
+                if match_count > 1
+                    && nth.is_none()
+                    && !*whole_line
+                    && !regex_mode
+                    && (before_context.is_some() || after_context.is_some())
+                    && let Some(target_offset) = context_filtered_offset(
+                        &content,
+                        old,
+                        before_context.as_deref(),
+                        after_context.as_deref(),
+                    )
+                {
+                    let new_content = format!(
+                        "{}{}{}",
+                        &content[..target_offset],
+                        replacement,
+                        &content[target_offset + old.len()..],
+                    );
+                    update_file_content(
+                        tx.pending,
+                        tx.deletions,
+                        tx.write_targets,
+                        &file_path,
+                        new_content,
+                    );
+                    total_matches += 1;
+                    continue;
+                }
+                total_matches += match_count;
                 update_file_content(
                     tx.pending,
                     tx.deletions,
@@ -340,6 +389,42 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     &file_path,
                     replaced.into_owned(),
                 );
+            } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some())
+            {
+                // Fuzzy/context fallback for glob paths (parity with #1668 path arm).
+                match crate::fallback::resolve_with_fallback(
+                    &content,
+                    old,
+                    before_context.as_deref(),
+                    after_context.as_deref(),
+                ) {
+                    Ok(anchor) => {
+                        let to_text = if let Some(ib) = insert_before {
+                            format!("{}{}", ib, anchor.matched_text)
+                        } else if let Some(ia) = insert_after {
+                            format!("{}{}", anchor.matched_text, ia)
+                        } else {
+                            new_text.as_deref().unwrap_or("").to_string()
+                        };
+                        let new_content = format!(
+                            "{}{}{}",
+                            &content[..anchor.start_offset],
+                            to_text,
+                            &content[anchor.start_offset + anchor.matched_text.len()..]
+                        );
+                        update_file_content(
+                            tx.pending,
+                            tx.deletions,
+                            tx.write_targets,
+                            &file_path,
+                            new_content,
+                        );
+                        total_matches += 1;
+                    }
+                    Err(_) => {
+                        // Keep scanning other files; require_change checked after loop.
+                    }
+                }
             }
         }
         if total_matches == 0 && *require_change && !if_exists {
@@ -923,6 +1008,47 @@ mod tests {
             f.pending[&file].1.contains("handle_data"),
             "pure fuzzy plan op must rewrite: {}",
             f.pending[&file].1
+        );
+    }
+
+    #[test]
+    fn replace_glob_pure_fuzzy_without_context() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "fn process_data() {}\n").unwrap();
+        std::fs::write(dir.path().join("b.txt"), "unrelated\n").unwrap();
+
+        let op = Operation::Replace {
+            path: None,
+            glob: Some("**/*.rs".into()),
+            regex: false,
+            old: "fn proccess_data() {}".into(),
+            new_text: Some("fn handle_data() {}".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
+            require_change: true,
+            command_position: false,
+            fuzzy: true,
+        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
+        assert_eq!(count, 1, "glob fuzzy should rewrite one .rs file");
+        let a = dir.path().join("a.rs");
+        assert!(
+            f.pending[&a].1.contains("handle_data"),
+            "glob pure fuzzy must rewrite: {}",
+            f.pending[&a].1
         );
     }
 }

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1402,11 +1402,11 @@ fn test_replace_after_context_disambiguates() {
 }
 
 #[test]
-fn test_replace_context_requires_explicit_file() {
+fn test_replace_context_or_fuzzy_expands_cwd_when_paths_omitted() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("f.txt"), "hello\n").unwrap();
 
-    // No file paths at all (only --cwd is set via patchloom_in).
+    // No positional paths: fuzzy/context path expands cwd (same as ordinary replace).
     patchloom_in(dir.path())
         .arg("replace")
         .arg("hello")
@@ -1416,8 +1416,11 @@ fn test_replace_context_requires_explicit_file() {
         .arg("ctx")
         .arg("--apply")
         .assert()
-        .code(1)
-        .stderr(predicates::str::contains("explicit file paths"));
+        .code(0);
+    assert_eq!(
+        fs::read_to_string(dir.path().join("f.txt")).unwrap(),
+        "world\n"
+    );
 }
 
 #[test]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8092,3 +8092,40 @@ fn test_tx_file_append_missing_json_not_found() {
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["error_kind"], "not_found");
 }
+
+#[test]
+fn test_tx_replace_fuzzy_pure_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "fn process_data() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "replace",
+            "path": "code.rs",
+            "old": "fn proccess_data() {}",
+            "new": "fn handle_data() {}",
+            "fuzzy": true,
+            "require_change": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.contains("handle_data"),
+        "plan pure fuzzy must rewrite: {on_disk}"
+    );
+}


### PR DESCRIPTION
## Summary

MPI loop cycle 1: close remaining fuzzy/context parity holes after #1668/#1671.

- **Glob plan replace:** pure fuzzy, multi-match context disambiguation, and `unique` multi-match errors (same as single-path)
- **CLI:** `--fuzzy` / context expands directories and omitted paths via the normal file collector (not single-file only)
- Agent-rules / reference docs / PATCHLOOM.md updated; integration tests for plan fuzzy and cwd expand

## Test plan

- [x] `make check-fast`
- [x] `replace_glob_pure_fuzzy_without_context`
- [x] `fuzzy_cli_expands_directory_roots`
- [x] `test_tx_replace_fuzzy_pure_in_plan`
- [ ] CI green