### PR TITLE
feat: match honesty for tx/batch_replace + agent-rules undo docs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -39,6 +39,12 @@
 - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
+**Library embedder undo / post-write (Rust hosts, not CLI-only):**
+- After `ApplyMode::Apply`, hosts can run validators then restore one path without shelling out to `undo`:
+- `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
+- `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
+- `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`
+
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)
 - Editing markdown sections, bullets, or tables by heading

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -218,9 +218,10 @@ Returns:
   "files_deleted": 0,
   "changes": [
     { "path": "CHANGELOG.md", "action": "modified" },
-    { "path": "README.md", "action": "modified" },
+    { "path": "README.md", "action": "modified", "match_mode": "exact" },
     { "path": "package.json", "action": "modified" }
-  ]
+  ],
+  "match_mode": "exact"
 }
 ```
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1284,7 +1284,7 @@ The operations below are the building blocks inside `operations`.
 | Shell token rename | `ReplaceOptions.command_position` / `ContentEdit::Replace` (#1666) |
 | Scoped symbol replace (literal/regex) | `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (#1658) |
 | Project symbol discovery + multi-file rename | `find_files_with_symbol` then `ast_rename_batch` (#1664) |
-| Match honesty (fuzzy confidence) | `EditResult` / `ContentEditsResult` `match_mode` / `match_score` (#1662); CLI/MCP JSON (#1669) |
+| Match honesty (fuzzy confidence) | `EditResult` / `ContentEditsResult` `match_mode` / `match_score` (#1662); CLI/MCP JSON (#1669); plan/tx `TxChange` + aggregate (#1674) |
 | In-memory multi-op with real diff headers | `apply_content_edits_with_label` (#1665) |
 | Surgical undo one path | `backup::restore_path_from_session(root, ts, path)` (#1660) |
 | Post-Apply format/lint + optional revert | `run_post_write_validation` / `PostWriteHooks` (#1663) |

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -115,7 +115,12 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).\n\
              - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
-             \"command_position\":true,\"require_change\":true}`\n\n",
+             \"command_position\":true,\"require_change\":true}`\n\n\
+             **Library embedder undo / post-write (Rust hosts, not CLI-only):**\n\
+             - After `ApplyMode::Apply`, hosts can run validators then restore one path without shelling out to `undo`:\n\
+             - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
+             - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
+             - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\n",
         );
     }
     if show_cli {
@@ -722,8 +727,10 @@ mod tests {
         assert!(
             mcp.contains("require_change")
                 && mcp.contains("command_position")
-                && mcp.contains("fuzzy"),
-            "MCP-only agent-rules must document replace_text flags"
+                && mcp.contains("fuzzy")
+                && mcp.contains("restore_path_from_session")
+                && mcp.contains("run_post_write_validation"),
+            "MCP-only agent-rules must document replace_text flags and library undo helpers"
         );
     }
 

--- a/src/json_emit.rs
+++ b/src/json_emit.rs
@@ -234,6 +234,8 @@ mod tests {
             error_kind: None,
             error: None,
             backup_session: None,
+            match_mode: None,
+            match_score: None,
         };
         let emit = serialize_structured(&report, true);
         assert!(!emit.primary_ok);

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -228,6 +228,7 @@ pub fn execute_precomputed(
         no_effective_changes,
         replace_no_matches: false,
         replace_hint: None,
+        replace_match_meta: HashMap::new(),
     };
 
     Ok(ExecutionResult {

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -227,6 +227,8 @@ pub(crate) struct TxState<'a> {
     /// applied to these files, not to files loaded solely for reading (#1108).
     pub(crate) write_targets: &'a mut HashSet<PathBuf>,
     pub(crate) replace_hint: Option<String>,
+    /// Per-path replace match honesty (#1674). Accumulated across ops.
+    pub(crate) replace_match_meta: &'a mut HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
     pub(crate) cwd: &'a Path,
     pub(crate) quiet: bool,
     pub(crate) structured: bool,
@@ -250,6 +252,7 @@ pub(crate) struct TxStateFixture {
     pub lints: Vec<TxLintResult>,
     pub mutations: Vec<TxDocMutation>,
     pub write_targets: HashSet<PathBuf>,
+    pub replace_match_meta: HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
 }
 
 #[cfg(test)]
@@ -265,6 +268,7 @@ impl TxStateFixture {
             lints: Vec::new(),
             mutations: Vec::new(),
             write_targets: HashSet::new(),
+            replace_match_meta: HashMap::new(),
         }
     }
 
@@ -280,6 +284,7 @@ impl TxStateFixture {
             tx_mutations: &mut self.mutations,
             write_targets: &mut self.write_targets,
             replace_hint: None,
+            replace_match_meta: &mut self.replace_match_meta,
             cwd,
             quiet: true,
             structured: false,
@@ -509,6 +514,8 @@ pub(crate) fn execute_and_collect(
     let mut tx_mutations: Vec<TxDocMutation> = Vec::new();
     let mut doc_cache: HashMap<PathBuf, CachedDoc> = HashMap::new();
     let mut replace_hint: Option<String> = None;
+    let mut replace_match_meta: HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)> =
+        HashMap::new();
 
     // Upfront PathGuard on declared paths (same contract as execute_plan_inner /
     // execute_plan_direct). CLI `tx` and `batch` call this function directly and
@@ -562,6 +569,7 @@ pub(crate) fn execute_and_collect(
             tx_mutations: &mut tx_mutations,
             write_targets: &mut write_targets,
             replace_hint: None,
+            replace_match_meta: &mut replace_match_meta,
             cwd,
             quiet,
             structured,
@@ -689,5 +697,6 @@ pub(crate) fn execute_and_collect(
         no_effective_changes,
         replace_no_matches,
         replace_hint,
+        replace_match_meta,
     })
 }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -692,4 +692,89 @@ mod tests {
             "small file should be in snapshot"
         );
     }
+
+    /// batch_replace / execute_plan JSON must surface match_mode for fuzzy (#1674).
+    #[test]
+    fn execute_plan_fuzzy_replace_reports_match_mode() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "fn process_data() {}\n").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "fn process_data() {}\n").unwrap();
+
+        let plan = crate::plan::Plan {
+            version: crate::plan::SCHEMA_VERSION,
+            cwd: None,
+            operations: vec![
+                crate::plan::Operation::Replace {
+                    glob: None,
+                    path: Some("a.rs".into()),
+                    regex: false,
+                    old: "fn proccess_data() {}".into(),
+                    new_text: Some("fn handle() {}".into()),
+                    nth: None,
+                    insert_before: None,
+                    insert_after: None,
+                    case_insensitive: false,
+                    multiline: false,
+                    if_exists: false,
+                    whole_line: false,
+                    range: None,
+                    word_boundary: false,
+                    before_context: None,
+                    after_context: None,
+                    unique: false,
+                    require_change: true,
+                    command_position: false,
+                    fuzzy: true,
+                },
+                crate::plan::Operation::Replace {
+                    glob: None,
+                    path: Some("b.rs".into()),
+                    regex: false,
+                    old: "fn process_data() {}".into(),
+                    new_text: Some("fn handle() {}".into()),
+                    nth: None,
+                    insert_before: None,
+                    insert_after: None,
+                    case_insensitive: false,
+                    multiline: false,
+                    if_exists: false,
+                    whole_line: false,
+                    range: None,
+                    word_boundary: false,
+                    before_context: None,
+                    after_context: None,
+                    unique: false,
+                    require_change: true,
+                    command_position: false,
+                    fuzzy: false,
+                },
+            ],
+            write_policy: None,
+            strict: None,
+            format: None,
+            validate: None,
+            verify: None,
+            for_each: None,
+        };
+
+        let report = execute_plan_direct(plan, dir.path(), None).expect("plan ok");
+        assert!(report.ok, "{report:?}");
+        assert_eq!(report.files_changed, 2);
+        // Aggregate is worst-case fuzzy when any file used fuzzy.
+        assert_eq!(report.match_mode.as_deref(), Some("fuzzy"));
+        let a = report
+            .changes
+            .iter()
+            .find(|c| c.path.ends_with("a.rs"))
+            .expect("a.rs change");
+        assert_eq!(a.match_mode.as_deref(), Some("fuzzy"));
+        let b = report
+            .changes
+            .iter()
+            .find(|c| c.path.ends_with("b.rs"))
+            .expect("b.rs change");
+        assert_eq!(b.match_mode.as_deref(), Some("exact"));
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("\"match_mode\""), "{json}");
+    }
 }

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -41,6 +41,13 @@ pub struct TxOutput {
     pub error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backup_session: Option<String>,
+    /// Aggregate replace match honesty when every replace-backed change agrees
+    /// (or worst-case: fuzzy > anchored > exact). See #1674.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_mode: Option<String>,
+    /// Similarity score when aggregate [`Self::match_mode`] is fuzzy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_score: Option<f64>,
 }
 
 /// One doc delete / delete-where outcome inside a plan/tx report (#1439).
@@ -58,6 +65,13 @@ pub struct TxDocMutation {
 pub struct TxChange {
     pub path: String,
     pub action: String,
+    /// Replace match honesty for this path (`exact` / `fuzzy` / `anchored`).
+    /// Omitted for non-replace changes. See #1674 / #1669.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub match_mode: Option<String>,
+    /// Similarity score when [`Self::match_mode`] is fuzzy.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub match_score: Option<f64>,
 }
 
 /// A search match in the tx output.
@@ -116,6 +130,8 @@ pub(crate) struct TxExecResult {
     pub(crate) replace_no_matches: bool,
     /// "Did you mean?" hints when a replace found zero matches.
     pub(crate) replace_hint: Option<String>,
+    /// Per-path replace match honesty recorded during plan execution (#1674).
+    pub(crate) replace_match_meta: HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
 }
 
 /// Apply mutation summaries onto a [`TxOutput`] (aggregates + list).
@@ -130,18 +146,56 @@ pub(crate) fn attach_mutations(output: &mut TxOutput, mutations: Vec<TxDocMutati
     output.mutations = mutations;
 }
 
-pub(crate) fn build_tx_output(
+/// JSON label for [`crate::api::MatchMode`] (CLI/MCP parity: snake_case strings).
+pub(crate) fn match_mode_label(mode: crate::api::MatchMode) -> &'static str {
+    match mode {
+        crate::api::MatchMode::Exact => "exact",
+        crate::api::MatchMode::Fuzzy => "fuzzy",
+        crate::api::MatchMode::Anchored => "anchored",
+    }
+}
+
+/// Worst-case rollup: fuzzy > anchored > exact (#1674 / #1673).
+pub(crate) fn merge_match_modes(
+    prev: Option<crate::api::MatchMode>,
+    next: crate::api::MatchMode,
+) -> crate::api::MatchMode {
+    match (prev, next) {
+        (Some(crate::api::MatchMode::Fuzzy), _) | (_, crate::api::MatchMode::Fuzzy) => {
+            crate::api::MatchMode::Fuzzy
+        }
+        (Some(crate::api::MatchMode::Anchored), _) | (_, crate::api::MatchMode::Anchored) => {
+            crate::api::MatchMode::Anchored
+        }
+        _ => crate::api::MatchMode::Exact,
+    }
+}
+
+fn match_meta_for_path(
+    path: &Path,
+    meta: &HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
+) -> (Option<String>, Option<f64>) {
+    match meta.get(path) {
+        Some((mode, score)) => (Some(match_mode_label(*mode).to_string()), *score),
+        None => (None, None),
+    }
+}
+
+pub(crate) fn build_tx_output_with_meta(
     status: &'static str,
     ok: bool,
     changes: &[(PathBuf, String, String)],
     deletions: &HashSet<PathBuf>,
     existed_before: &HashSet<PathBuf>,
     cwd: &Path,
+    replace_match_meta: &HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
 ) -> TxOutput {
     let mut tx_changes = Vec::new();
     let mut created = 0usize;
     let mut deleted_count = 0usize;
     let mut modified = 0usize;
+    let mut agg_mode: Option<crate::api::MatchMode> = None;
+    let mut agg_score: Option<f64> = None;
 
     let display_path = |p: &Path| -> String {
         crate::files::relative_display(p, cwd)
@@ -151,22 +205,35 @@ pub(crate) fn build_tx_output(
 
     for (path, _original, _) in changes {
         let path_str = display_path(path);
+        let (match_mode, match_score) = match_meta_for_path(path, replace_match_meta);
+        if let Some((mode, score)) = replace_match_meta.get(path) {
+            agg_mode = Some(merge_match_modes(agg_mode, *mode));
+            if matches!(mode, crate::api::MatchMode::Fuzzy) {
+                agg_score = score.or(agg_score);
+            }
+        }
         if deletions.contains(path) {
             tx_changes.push(TxChange {
                 path: path_str,
                 action: "deleted".to_string(),
+                match_mode,
+                match_score,
             });
             deleted_count += 1;
         } else if !existed_before.contains(path) {
             tx_changes.push(TxChange {
                 path: path_str,
                 action: "created".to_string(),
+                match_mode,
+                match_score,
             });
             created += 1;
         } else {
             tx_changes.push(TxChange {
                 path: path_str,
                 action: "modified".to_string(),
+                match_mode,
+                match_score,
             });
             modified += 1;
         }
@@ -174,13 +241,28 @@ pub(crate) fn build_tx_output(
     // Deletions not captured in changes (empty files).
     for path in deletions {
         if !changes.iter().any(|(c, _, _)| c == path) {
+            let (match_mode, match_score) = match_meta_for_path(path, replace_match_meta);
             tx_changes.push(TxChange {
                 path: display_path(path),
                 action: "deleted".to_string(),
+                match_mode,
+                match_score,
             });
             deleted_count += 1;
         }
     }
+
+    let (top_mode, top_score) = match agg_mode {
+        Some(m) => (
+            Some(match_mode_label(m).to_string()),
+            if matches!(m, crate::api::MatchMode::Fuzzy) {
+                agg_score
+            } else {
+                None
+            },
+        ),
+        None => (None, None),
+    };
 
     TxOutput {
         ok,
@@ -198,6 +280,8 @@ pub(crate) fn build_tx_output(
         error_kind: None,
         error: None,
         backup_session: None,
+        match_mode: top_mode,
+        match_score: top_score,
     }
 }
 
@@ -206,13 +290,14 @@ pub(crate) fn build_full_tx_output(
     result: &mut TxExecResult,
     cwd: &Path,
 ) -> TxOutput {
-    let mut output = build_tx_output(
+    let mut output = build_tx_output_with_meta(
         status,
         true,
         &result.changes,
         &result.deletions,
         &result.existed_before,
         cwd,
+        &result.replace_match_meta,
     );
     output.reads = std::mem::take(&mut result.tx_reads);
     output.searches = std::mem::take(&mut result.tx_searches);
@@ -269,6 +354,8 @@ pub(crate) fn build_error_output(
             format_error_with_backup_hint(error, backup_session)
         )),
         backup_session: backup_session.map(str::to_string),
+        match_mode: None,
+        match_score: None,
     }
 }
 
@@ -404,6 +491,8 @@ mod tests {
             error_kind: None,
             error: None,
             backup_session: None,
+            match_mode: None,
+            match_score: None,
         }
     }
 
@@ -424,6 +513,8 @@ mod tests {
             error_kind: Some(kind.to_string()),
             error: Some("test error".to_string()),
             backup_session: None,
+            match_mode: None,
+            match_score: None,
         }
     }
 
@@ -547,7 +638,15 @@ mod tests {
             ),
         ];
 
-        let out = build_tx_output("success", true, &changes, &deletions, &existed, cwd);
+        let out = build_tx_output_with_meta(
+            "success",
+            true,
+            &changes,
+            &deletions,
+            &existed,
+            cwd,
+            &HashMap::new(),
+        );
         assert!(out.ok);
         assert_eq!(out.files_changed, 1); // existing.txt modified
         assert_eq!(out.files_created, 1); // brand_new.txt
@@ -563,11 +662,45 @@ mod tests {
     #[test]
     fn build_tx_output_empty_changes() {
         let cwd = Path::new("/project");
-        let out = build_tx_output("success", true, &[], &HashSet::new(), &HashSet::new(), cwd);
+        let out = build_tx_output_with_meta(
+            "success",
+            true,
+            &[],
+            &HashSet::new(),
+            &HashSet::new(),
+            cwd,
+            &HashMap::new(),
+        );
         assert_eq!(out.files_changed, 0);
         assert_eq!(out.files_created, 0);
         assert_eq!(out.files_deleted, 0);
         assert!(out.changes.is_empty());
+    }
+
+    #[test]
+    fn build_tx_output_includes_replace_match_mode() {
+        let cwd = Path::new("/project");
+        let path = PathBuf::from("/project/a.txt");
+        let existed = HashSet::from([path.clone()]);
+        let changes = vec![(path.clone(), "old".into(), "new".into())];
+        let mut meta = HashMap::new();
+        meta.insert(path, (crate::api::MatchMode::Fuzzy, Some(0.91)));
+        let out = build_tx_output_with_meta(
+            "success",
+            true,
+            &changes,
+            &HashSet::new(),
+            &existed,
+            cwd,
+            &meta,
+        );
+        assert_eq!(out.match_mode.as_deref(), Some("fuzzy"));
+        assert_eq!(out.match_score, Some(0.91));
+        assert_eq!(out.changes.len(), 1);
+        assert_eq!(out.changes[0].match_mode.as_deref(), Some("fuzzy"));
+        assert_eq!(out.changes[0].match_score, Some(0.91));
+        let json = serde_json::to_string(&out).unwrap();
+        assert!(json.contains("\"match_mode\":\"fuzzy\""), "{json}");
     }
 
     // ---- TxOutput serde round-trip ----

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -4,15 +4,37 @@
 //! with fuzzy/context fallback co-located; do not split for LOC alone.
 
 use super::execute::{TxState, read_and_probe, read_file_content, update_file_content};
+use crate::api::MatchMode;
 use crate::ops::replace::{
     compile_replace_regex, context_filtered_offset, replace_content, replace_whole_lines,
     replacement_text,
 };
 use crate::plan::Operation;
+use crate::tx::output::merge_match_modes;
 use globset::Glob;
 use ignore::WalkBuilder;
 use std::collections::HashSet;
 use std::path::Path;
+
+/// Record replace match honesty for a path (worst-case merge if re-visited) (#1674).
+fn record_replace_match(tx: &mut TxState<'_>, path: &Path, mode: MatchMode, score: Option<f64>) {
+    let entry = tx.replace_match_meta.entry(path.to_path_buf());
+    match entry {
+        std::collections::hash_map::Entry::Vacant(e) => {
+            e.insert((mode, score));
+        }
+        std::collections::hash_map::Entry::Occupied(mut e) => {
+            let (prev, prev_score) = *e.get();
+            let merged = merge_match_modes(Some(prev), mode);
+            let merged_score = if matches!(merged, MatchMode::Fuzzy) {
+                score.or(prev_score)
+            } else {
+                None
+            };
+            e.insert((merged, merged_score));
+        }
+    }
+}
 
 /// Execute a replace operation within a transaction.
 pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Result<usize> {
@@ -176,6 +198,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     &file_path,
                     new_content,
                 );
+                record_replace_match(tx, &file_path, MatchMode::Anchored, None);
                 return Ok(1);
             }
             let owned = replaced.into_owned();
@@ -186,6 +209,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 &file_path,
                 owned,
             );
+            record_replace_match(tx, &file_path, MatchMode::Exact, None);
             Ok(match_count)
         } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some()) {
             // Tier 3: fuzzy and/or context fallback when exact match fails (#1668).
@@ -216,6 +240,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         &file_path,
                         new_content,
                     );
+                    let (mode, default_score) =
+                        crate::api::match_mode_from_strategy(anchor.strategy);
+                    record_replace_match(tx, &file_path, mode, anchor.score.or(default_score));
                     tx.replace_hint = Some(format!(
                         "fallback matched via {:?} strategy in {}",
                         anchor.strategy, p,
@@ -378,6 +405,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         &file_path,
                         new_content,
                     );
+                    record_replace_match(tx, &file_path, MatchMode::Anchored, None);
                     total_matches += 1;
                     continue;
                 }
@@ -389,6 +417,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     &file_path,
                     replaced.into_owned(),
                 );
+                record_replace_match(tx, &file_path, MatchMode::Exact, None);
             } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some())
             {
                 // Fuzzy/context fallback for glob paths (parity with #1668 path arm).
@@ -419,6 +448,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             &file_path,
                             new_content,
                         );
+                        let (mode, default_score) =
+                            crate::api::match_mode_from_strategy(anchor.strategy);
+                        record_replace_match(tx, &file_path, mode, anchor.score.or(default_score));
                         total_matches += 1;
                     }
                     Err(_) => {
@@ -1009,6 +1041,46 @@ mod tests {
             "pure fuzzy plan op must rewrite: {}",
             f.pending[&file].1
         );
+        let (mode, score) = f.replace_match_meta.get(&file).expect("fuzzy meta");
+        assert_eq!(*mode, crate::api::MatchMode::Fuzzy);
+        assert!(score.is_some(), "similarity fallback should set score");
+    }
+
+    #[test]
+    fn replace_exact_records_match_mode_exact() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("t.txt");
+        std::fs::write(&file, "hello world\n").unwrap();
+
+        let op = Operation::Replace {
+            path: Some("t.txt".into()),
+            glob: None,
+            regex: false,
+            old: "hello".into(),
+            new_text: Some("hi".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
+            require_change: true,
+            command_position: false,
+            fuzzy: false,
+        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        assert_eq!(execute_replace_op(&op, &mut tx).unwrap(), 1);
+        drop(tx);
+        let (mode, score) = f.replace_match_meta.get(&file).expect("exact meta");
+        assert_eq!(*mode, crate::api::MatchMode::Exact);
+        assert!(score.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

MPI loop cycle 3 batch on library/agent honesty surfaces:

- **#1675:** Document library undo helpers (`restore_path_from_session`, `restore_path_from_latest_backup`) and `run_post_write_validation` / `FormatFailed` in agent-rules and PATCHLOOM.md for embedders that do not shell out to CLI `undo`.
- **#1674:** Plan/tx JSON (including MCP `batch_replace` and `execute_plan`) reports `match_mode` (`exact` / `fuzzy` / `anchored`) and optional `match_score` on each replace-backed `TxChange`, plus a worst-case aggregate on `TxOutput`. Recorded during `replace_op` for path and glob arms. Quickstart smoke JSON updated.

## Test plan

- [x] `make check-fast`
- [x] `execute_plan_fuzzy_replace_reports_match_mode`
- [x] `replace_exact_records_match_mode_exact` / pure fuzzy meta
- [x] `build_tx_output_includes_replace_match_mode`
- [x] `test_smoke_quickstart_transaction_snippet`
- [ ] CI green

Closes #1675
Closes #1674