### PR TITLE
fix: CLI fuzzy match_mode from tx meta + docs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -44,6 +44,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`
+**Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`) and optional `match_score` so agents can verify low-confidence fuzzy sites (#1669, #1674).
 
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)
@@ -259,6 +260,7 @@ Plan/MCP `replace` accepts library flags (default false):
 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
 - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
+Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) on replace-backed changes plus an aggregate `match_mode` when any replace matched (#1674).
 
 ## AST-aware operations
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -120,7 +120,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - After `ApplyMode::Apply`, hosts can run validators then restore one path without shelling out to `undo`:\n\
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
-             - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\n",
+             - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
+             **Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`) and optional `match_score` so agents can verify low-confidence fuzzy sites (#1669, #1674).\n\n",
         );
     }
     if show_cli {
@@ -396,7 +397,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).\n\
                  - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
-                 \"command_position\":true,\"require_change\":true}`\n\n");
+                 \"command_position\":true,\"require_change\":true}`\n\
+                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) on replace-backed changes plus an aggregate `match_mode` when any replace matched (#1674).\n\n");
         }
     }
 
@@ -729,8 +731,9 @@ mod tests {
                 && mcp.contains("command_position")
                 && mcp.contains("fuzzy")
                 && mcp.contains("restore_path_from_session")
-                && mcp.contains("run_post_write_validation"),
-            "MCP-only agent-rules must document replace_text flags and library undo helpers"
+                && mcp.contains("run_post_write_validation")
+                && mcp.contains("match_mode"),
+            "MCP-only agent-rules must document replace_text flags, library undo helpers, and match_mode"
         );
     }
 

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -557,7 +557,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
+        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. Optional fuzzy enables similarity fallback; JSON reports match_mode (exact/fuzzy/anchored) per change and aggregate (#1674). IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
     )]
     async fn batch_replace(
         &self,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -692,7 +692,9 @@ fn run_context_replace(
         return Ok(exit::NO_MATCHES);
     }
 
-    // Re-derive match honesty via the library content path (#1669).
+    // Prefer match honesty recorded during tx replace_op (#1674). Fall back to
+    // re-running the library content path only when meta is missing (should not
+    // happen for fuzzy/context ops that changed the file).
     let lib_opts = crate::api::ReplaceOptions {
         regex: args.regex,
         nth: args.nth,
@@ -717,11 +719,15 @@ fn run_context_replace(
         .changes
         .iter()
         .map(|(p, original, _new)| {
-            let (mode, score) =
+            let (mode, score) = if let Some((m, s)) = result.exec_result.replace_match_meta.get(p) {
+                (Some(match_mode_str(*m)), *s)
+            } else {
                 match crate::api::replace_in_content(original, &args.old, to, &lib_opts) {
                     Ok(r) => (r.match_mode.map(match_mode_str), r.match_score),
-                    Err(_) => (Some("exact"), None),
-                };
+                    // Do not invent "exact" when re-derive fails (#1674 honesty).
+                    Err(_) => (None, None),
+                }
+            };
             ReplaceFileResult {
                 path: crate::files::relative_display(p, &cwd)
                     .to_string_lossy()

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -1396,7 +1396,8 @@ fn fuzzy_cli_json_reports_match_mode() {
     assert_eq!(r.match_mode, Some(crate::api::MatchMode::Fuzzy));
     assert!(r.match_score.is_some_and(|s| s > 0.85));
 
-    // CLI/tx path: pure fuzzy without context must rewrite (#1668).
+    // CLI/tx path: pure fuzzy without context must rewrite (#1668) and
+    // report match_mode from tx-recorded meta, not a silent "exact" (#1674).
     let mut args = make_args(
         "fn proccess_data() {}",
         "fn handle_data() {}",
@@ -1405,6 +1406,7 @@ fn fuzzy_cli_json_reports_match_mode() {
     args.fuzzy = true;
     let global = GlobalFlags {
         apply: true,
+        json: true,
         cwd: Some(dir.path().to_string_lossy().into_owned()),
         ..GlobalFlags::test_default()
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,12 @@
 //! `api::run_post_write_validation` (#1663) or
 //! `backup::restore_path_from_session` / `restore_path_from_latest_backup` (#1660).
 //!
-//! Match honesty for agents (#1662): `EditResult` / `ContentEditResult` expose
-//! `match_mode` (`Exact` / `Fuzzy` / `Anchored`) and optional `match_score` so hosts
-//! can warn on low-confidence fuzzy sites without re-running the matcher.
+//! Match honesty for agents (#1662 / #1669 / #1674): `EditResult` /
+//! `ContentEditResult` / `ContentEditsResult` expose `match_mode`
+//! (`Exact` / `Fuzzy` / `Anchored`) and optional `match_score` so hosts can warn on
+//! low-confidence fuzzy sites without re-running the matcher. Plan/tx JSON
+//! (`PlanReport` / `TxOutput`) and MCP `batch_replace` / `execute_plan` include
+//! the same fields on each replace-backed change plus a worst-case aggregate.
 //!
 //! Non-anyhow hosts (#1659): branch with `api::classify_error(&*err as &dyn Error)`
 //! or `classify_error_ref` for `similar_targets`; `edit_error_kind` remains for
@@ -133,9 +136,10 @@
 //!
 //! **Note on results**: Single-file ops return `EditResult` (with `action`, `dest_path`,
 //! `match_count` for replace, and `removed` for `doc.delete` / `doc.delete_where`).
-//! `execute_plan` (library) returns `PlanReport` (typed TxOutput) with `ok`, `changes`,
-//! `searches`, `reads`, `error`, plus `mutations` / aggregate `changed` / `removed` for
-//! deletes (including idempotent `removed: 0` no-ops) (#811, #1439, #1459).
+//! `execute_plan` (library) returns `PlanReport` (typed TxOutput) with `ok`, `changes`
+//! (optional per-change `match_mode` / `match_score` for replace), `searches`, `reads`,
+//! `error`, plus `mutations` / aggregate `changed` / `removed` for deletes
+//! (including idempotent `removed: 0` no-ops) (#811, #1439, #1459, #1674).
 //! See `api::PlanReport`, `api::execute_plan`, and embedding docs. CLI/MCP retain (code, json) for compatibility.
 //!
 //! For library users needing relaxed containment (e.g. agents like Bline using --yolo or temp files):


### PR DESCRIPTION
## Summary

MPI loop cycle 4 after #1676:

- **Docs:** agent-rules, embedding crate docs, and MCP `batch_replace` tool description document `match_mode` / `match_score` on plan/tx and multi-file replace JSON.
- **Fix:** CLI fuzzy/context replace JSON prefers `replace_match_meta` recorded during `replace_op` instead of re-deriving via `replace_in_content` and inventing `"exact"` when re-derive fails.

## Test plan

- [x] `make check-fast`
- [x] `fuzzy_cli_json_reports_match_mode`
- [x] agent_rules unit tests
- [ ] CI green