### PR TITLE
test: lock match_mode on batch_replace and tx JSON

### DIFF
--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -431,12 +431,7 @@ impl PatchloomService {
                         let text = &mut text_content.text;
                         if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(text) {
                             if let Some(m) = mode {
-                                let s = match m {
-                                    crate::api::MatchMode::Exact => "exact",
-                                    crate::api::MatchMode::Fuzzy => "fuzzy",
-                                    crate::api::MatchMode::Anchored => "anchored",
-                                };
-                                v["match_mode"] = serde_json::json!(s);
+                                v["match_mode"] = serde_json::json!(crate::tx::match_mode_label(m));
                             }
                             if let Some(s) = score {
                                 v["match_score"] = serde_json::json!(s);

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -157,11 +157,7 @@ struct FileReplacement {
 }
 
 fn match_mode_str(mode: crate::api::MatchMode) -> &'static str {
-    match mode {
-        crate::api::MatchMode::Exact => "exact",
-        crate::api::MatchMode::Fuzzy => "fuzzy",
-        crate::api::MatchMode::Anchored => "anchored",
-    }
+    crate::tx::match_mode_label(mode)
 }
 
 /// Parse `--range` argument into (start, optional_end). Reuses the line-range

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -37,6 +37,7 @@ pub use output::{
 };
 pub(crate) use output::{
     TxExecResult, build_error_output, build_full_tx_output, format_error_with_backup_hint,
+    match_mode_label,
 };
 
 // validate.rs (test-only re-exports for src/cmd/tx.rs tests)

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1809,6 +1809,13 @@ async fn test_mcp_batch_replace_round_trip() {
         val["files_changed"], 2,
         "batch_replace files_changed: {val}"
     );
+    assert_eq!(
+        val["match_mode"], "exact",
+        "batch_replace exact match honesty (#1674): {val}"
+    );
+    for ch in val["changes"].as_array().expect("changes array") {
+        assert_eq!(ch["match_mode"], "exact", "per-file match_mode exact: {ch}");
+    }
 
     let a = fs::read_to_string(dir.path().join("a.txt")).unwrap();
     let b = fs::read_to_string(dir.path().join("b.txt")).unwrap();
@@ -1821,6 +1828,54 @@ async fn test_mcp_batch_replace_round_trip() {
     assert!(
         !b.contains("1.0.0"),
         "b.txt should not have old version: {b}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_batch_replace_fuzzy_reports_match_mode() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), "fn process_data() {}\n").unwrap();
+    fs::write(dir.path().join("b.rs"), "fn process_data() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "batch_replace",
+        serde_json::json!({
+            "files": ["a.rs", "b.rs"],
+            "old": "fn proccess_data() {}",
+            "new": "fn handle_data() {}",
+            "fuzzy": true,
+            "require_change": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "batch_replace fuzzy should succeed: {val}");
+    assert_eq!(val["ok"], true, "batch_replace fuzzy ok: {val}");
+    assert_eq!(
+        val["match_mode"], "fuzzy",
+        "aggregate match_mode fuzzy (#1674): {val}"
+    );
+    let changes = val["changes"].as_array().expect("changes");
+    assert_eq!(changes.len(), 2, "two files changed: {val}");
+    for ch in changes {
+        assert_eq!(ch["match_mode"], "fuzzy", "per-file fuzzy match_mode: {ch}");
+    }
+    assert!(
+        fs::read_to_string(dir.path().join("a.rs"))
+            .unwrap()
+            .contains("handle_data"),
+        "a.rs rewritten"
+    );
+    assert!(
+        fs::read_to_string(dir.path().join("b.rs"))
+            .unwrap()
+            .contains("handle_data"),
+        "b.rs rewritten"
     );
     client.cancel().await.unwrap();
 }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8113,15 +8113,32 @@ fn test_tx_replace_fuzzy_pure_in_plan() {
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
 
-    Command::cargo_bin("patchloom")
+    let output = Command::cargo_bin("patchloom")
         .unwrap()
+        .arg("--json")
         .arg("--cwd")
         .arg(dir.path().to_str().unwrap())
         .arg("tx")
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
-        .assert()
-        .code(0);
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(
+        json["match_mode"], "fuzzy",
+        "tx JSON match_mode (#1674): {json}"
+    );
+    assert_eq!(
+        json["changes"][0]["match_mode"], "fuzzy",
+        "per-change match_mode: {json}"
+    );
 
     let on_disk = fs::read_to_string(&file).unwrap();
     assert!(


### PR DESCRIPTION
## Summary

MPI cycle 5 after #1677:

- Integration tests assert `match_mode` on MCP `batch_replace` (exact round-trip + fuzzy multi-file) and `tx --json` pure-fuzzy plans (#1674 contract).
- Single source for mode labels: re-export `match_mode_label` from `crate::tx` for CLI replace and MCP handlers.

## Test plan

- [x] `make check-fast`
- [x] `test_mcp_batch_replace_fuzzy_reports_match_mode`
- [x] `test_mcp_batch_replace_round_trip` (match_mode exact)
- [x] `test_tx_replace_fuzzy_pure_in_plan` (JSON match_mode)
- [ ] CI green