### PR TITLE
fix: EditResult match_mode and match_count from tx

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -575,7 +575,12 @@ fn execution_result_to_edit_result(
         .first()
         .map(|m| m.path.clone());
 
-    // Extract path + content from the engine result before potentially consuming it.
+    // Extract path + content + replace meta before potentially consuming `result`.
+    let replace_meta = result
+        .exec_result
+        .changes
+        .first()
+        .and_then(|(abs_path, _, _)| result.exec_result.replace_match_meta.get(abs_path).copied());
     let (path_str, original, new_content) =
         if let Some((abs_path, orig, new)) = result.exec_result.changes.first() {
             let rel = crate::files::relative_display(abs_path, cwd);
@@ -609,6 +614,18 @@ fn execution_result_to_edit_result(
 
     let mut edit = build_edit_result(&path_str, original, new_content, applied, action, dest_path);
     edit.removed = removed;
+    // Thread replace honesty from the engine (#1674 / #1662).
+    if let Some(meta) = replace_meta {
+        edit.match_mode = Some(meta.mode);
+        edit.match_score = meta.score;
+        edit.match_count = meta.match_count;
+    } else if has_changes && action == "replace" {
+        // Legacy fallback if meta was not recorded (should be rare).
+        edit.match_mode = Some(MatchMode::Exact);
+        if edit.match_count == 0 {
+            edit.match_count = 1;
+        }
+    }
     Ok(edit)
 }
 

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -118,9 +118,13 @@ pub fn replace_text(
                 .into(),
         );
     }
-    // Tx path does not yet thread MatchMode; default Exact when matches landed (#1662).
-    if result.match_mode.is_none() && result.match_count > 0 {
+    // execute_as_edit_result now threads match_mode/count from replace_op meta.
+    // Keep a conservative fallback for any path that still omits meta (#1662).
+    if result.match_mode.is_none() && (result.match_count > 0 || result.changed) {
         result.match_mode = Some(MatchMode::Exact);
+        if result.match_count == 0 && result.changed {
+            result.match_count = 1;
+        }
     }
     Ok(result)
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -5006,3 +5006,51 @@ fn signature_rewrite_params_and_return_no_host_post_pass() {
     assert!(!on_disk.contains("i64{") && !on_disk.contains("){"));
     assert!(on_disk.contains("b: i32"), "params updated: {on_disk}");
 }
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_exact_disk_match_mode_and_count() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.txt");
+    fs::write(&file, "hello world\n").unwrap();
+    let r = replace_text(
+        &file,
+        "world",
+        "there",
+        &ReplaceOptions::default(),
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(r.changed, "content should change");
+    assert_eq!(
+        r.match_count, 1,
+        "exact disk replace must report match_count"
+    );
+    assert_eq!(
+        r.match_mode,
+        Some(MatchMode::Exact),
+        "exact disk replace must report match_mode Exact, got {:?}",
+        r.match_mode
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_exact_disk_multi_match_count() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.txt");
+    fs::write(&file, "aa aa aa\n").unwrap();
+    let r = replace_text(
+        &file,
+        "aa",
+        "bb",
+        &ReplaceOptions::default(),
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(r.changed);
+    assert_eq!(r.match_count, 3, "multi exact match_count: {:?}", r);
+    assert_eq!(r.match_mode, Some(MatchMode::Exact));
+}

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -715,20 +715,25 @@ fn run_context_replace(
         .changes
         .iter()
         .map(|(p, original, _new)| {
-            let (mode, score) = if let Some((m, s)) = result.exec_result.replace_match_meta.get(p) {
-                (Some(match_mode_str(*m)), *s)
+            let (mode, score, count) = if let Some(m) = result.exec_result.replace_match_meta.get(p)
+            {
+                (Some(match_mode_str(m.mode)), m.score, m.match_count.max(1))
             } else {
                 match crate::api::replace_in_content(original, &args.old, to, &lib_opts) {
-                    Ok(r) => (r.match_mode.map(match_mode_str), r.match_score),
+                    Ok(r) => (
+                        r.match_mode.map(match_mode_str),
+                        r.match_score,
+                        r.match_count.max(1),
+                    ),
                     // Do not invent "exact" when re-derive fails (#1674 honesty).
-                    Err(_) => (None, None),
+                    Err(_) => (None, None, 1),
                 }
             };
             ReplaceFileResult {
                 path: crate::files::relative_display(p, &cwd)
                     .to_string_lossy()
                     .into_owned(),
-                match_count: 1,
+                match_count: count,
                 match_mode: mode,
                 match_score: score,
             }

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -228,7 +228,7 @@ pub(crate) struct TxState<'a> {
     pub(crate) write_targets: &'a mut HashSet<PathBuf>,
     pub(crate) replace_hint: Option<String>,
     /// Per-path replace match honesty (#1674). Accumulated across ops.
-    pub(crate) replace_match_meta: &'a mut HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
+    pub(crate) replace_match_meta: &'a mut HashMap<PathBuf, super::output::ReplaceMatchMeta>,
     pub(crate) cwd: &'a Path,
     pub(crate) quiet: bool,
     pub(crate) structured: bool,
@@ -252,7 +252,7 @@ pub(crate) struct TxStateFixture {
     pub lints: Vec<TxLintResult>,
     pub mutations: Vec<TxDocMutation>,
     pub write_targets: HashSet<PathBuf>,
-    pub replace_match_meta: HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
+    pub replace_match_meta: HashMap<PathBuf, crate::tx::output::ReplaceMatchMeta>,
 }
 
 #[cfg(test)]
@@ -514,8 +514,7 @@ pub(crate) fn execute_and_collect(
     let mut tx_mutations: Vec<TxDocMutation> = Vec::new();
     let mut doc_cache: HashMap<PathBuf, CachedDoc> = HashMap::new();
     let mut replace_hint: Option<String> = None;
-    let mut replace_match_meta: HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)> =
-        HashMap::new();
+    let mut replace_match_meta: HashMap<PathBuf, super::output::ReplaceMatchMeta> = HashMap::new();
 
     // Upfront PathGuard on declared paths (same contract as execute_plan_inner /
     // execute_plan_direct). CLI `tx` and `batch` call this function directly and

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -131,7 +131,15 @@ pub(crate) struct TxExecResult {
     /// "Did you mean?" hints when a replace found zero matches.
     pub(crate) replace_hint: Option<String>,
     /// Per-path replace match honesty recorded during plan execution (#1674).
-    pub(crate) replace_match_meta: HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
+    pub(crate) replace_match_meta: HashMap<PathBuf, ReplaceMatchMeta>,
+}
+
+/// Per-path replace match honesty recorded during plan execution.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ReplaceMatchMeta {
+    pub mode: crate::api::MatchMode,
+    pub score: Option<f64>,
+    pub match_count: usize,
 }
 
 /// Apply mutation summaries onto a [`TxOutput`] (aggregates + list).
@@ -173,10 +181,10 @@ pub(crate) fn merge_match_modes(
 
 fn match_meta_for_path(
     path: &Path,
-    meta: &HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
+    meta: &HashMap<PathBuf, ReplaceMatchMeta>,
 ) -> (Option<String>, Option<f64>) {
     match meta.get(path) {
-        Some((mode, score)) => (Some(match_mode_label(*mode).to_string()), *score),
+        Some(m) => (Some(match_mode_label(m.mode).to_string()), m.score),
         None => (None, None),
     }
 }
@@ -188,7 +196,7 @@ pub(crate) fn build_tx_output_with_meta(
     deletions: &HashSet<PathBuf>,
     existed_before: &HashSet<PathBuf>,
     cwd: &Path,
-    replace_match_meta: &HashMap<PathBuf, (crate::api::MatchMode, Option<f64>)>,
+    replace_match_meta: &HashMap<PathBuf, ReplaceMatchMeta>,
 ) -> TxOutput {
     let mut tx_changes = Vec::new();
     let mut created = 0usize;
@@ -206,10 +214,10 @@ pub(crate) fn build_tx_output_with_meta(
     for (path, _original, _) in changes {
         let path_str = display_path(path);
         let (match_mode, match_score) = match_meta_for_path(path, replace_match_meta);
-        if let Some((mode, score)) = replace_match_meta.get(path) {
-            agg_mode = Some(merge_match_modes(agg_mode, *mode));
-            if matches!(mode, crate::api::MatchMode::Fuzzy) {
-                agg_score = score.or(agg_score);
+        if let Some(m) = replace_match_meta.get(path) {
+            agg_mode = Some(merge_match_modes(agg_mode, m.mode));
+            if matches!(m.mode, crate::api::MatchMode::Fuzzy) {
+                agg_score = m.score.or(agg_score);
             }
         }
         if deletions.contains(path) {
@@ -684,7 +692,14 @@ mod tests {
         let existed = HashSet::from([path.clone()]);
         let changes = vec![(path.clone(), "old".into(), "new".into())];
         let mut meta = HashMap::new();
-        meta.insert(path, (crate::api::MatchMode::Fuzzy, Some(0.91)));
+        meta.insert(
+            path,
+            ReplaceMatchMeta {
+                mode: crate::api::MatchMode::Fuzzy,
+                score: Some(0.91),
+                match_count: 1,
+            },
+        );
         let out = build_tx_output_with_meta(
             "success",
             true,

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -17,21 +17,36 @@ use std::collections::HashSet;
 use std::path::Path;
 
 /// Record replace match honesty for a path (worst-case merge if re-visited) (#1674).
-fn record_replace_match(tx: &mut TxState<'_>, path: &Path, mode: MatchMode, score: Option<f64>) {
+fn record_replace_match(
+    tx: &mut TxState<'_>,
+    path: &Path,
+    mode: MatchMode,
+    score: Option<f64>,
+    match_count: usize,
+) {
+    use crate::tx::output::ReplaceMatchMeta;
     let entry = tx.replace_match_meta.entry(path.to_path_buf());
     match entry {
         std::collections::hash_map::Entry::Vacant(e) => {
-            e.insert((mode, score));
+            e.insert(ReplaceMatchMeta {
+                mode,
+                score,
+                match_count,
+            });
         }
         std::collections::hash_map::Entry::Occupied(mut e) => {
-            let (prev, prev_score) = *e.get();
-            let merged = merge_match_modes(Some(prev), mode);
+            let prev = *e.get();
+            let merged = merge_match_modes(Some(prev.mode), mode);
             let merged_score = if matches!(merged, MatchMode::Fuzzy) {
-                score.or(prev_score)
+                score.or(prev.score)
             } else {
                 None
             };
-            e.insert((merged, merged_score));
+            e.insert(ReplaceMatchMeta {
+                mode: merged,
+                score: merged_score,
+                match_count: prev.match_count.saturating_add(match_count),
+            });
         }
     }
 }
@@ -198,7 +213,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     &file_path,
                     new_content,
                 );
-                record_replace_match(tx, &file_path, MatchMode::Anchored, None);
+                record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1);
                 return Ok(1);
             }
             let owned = replaced.into_owned();
@@ -209,7 +224,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 &file_path,
                 owned,
             );
-            record_replace_match(tx, &file_path, MatchMode::Exact, None);
+            record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count);
             Ok(match_count)
         } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some()) {
             // Tier 3: fuzzy and/or context fallback when exact match fails (#1668).
@@ -242,7 +257,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     );
                     let (mode, default_score) =
                         crate::api::match_mode_from_strategy(anchor.strategy);
-                    record_replace_match(tx, &file_path, mode, anchor.score.or(default_score));
+                    record_replace_match(tx, &file_path, mode, anchor.score.or(default_score), 1);
                     tx.replace_hint = Some(format!(
                         "fallback matched via {:?} strategy in {}",
                         anchor.strategy, p,
@@ -405,7 +420,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         &file_path,
                         new_content,
                     );
-                    record_replace_match(tx, &file_path, MatchMode::Anchored, None);
+                    record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1);
                     total_matches += 1;
                     continue;
                 }
@@ -417,7 +432,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     &file_path,
                     replaced.into_owned(),
                 );
-                record_replace_match(tx, &file_path, MatchMode::Exact, None);
+                record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count);
             } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some())
             {
                 // Fuzzy/context fallback for glob paths (parity with #1668 path arm).
@@ -450,7 +465,13 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         );
                         let (mode, default_score) =
                             crate::api::match_mode_from_strategy(anchor.strategy);
-                        record_replace_match(tx, &file_path, mode, anchor.score.or(default_score));
+                        record_replace_match(
+                            tx,
+                            &file_path,
+                            mode,
+                            anchor.score.or(default_score),
+                            1,
+                        );
                         total_matches += 1;
                     }
                     Err(_) => {
@@ -1041,9 +1062,10 @@ mod tests {
             "pure fuzzy plan op must rewrite: {}",
             f.pending[&file].1
         );
-        let (mode, score) = f.replace_match_meta.get(&file).expect("fuzzy meta");
-        assert_eq!(*mode, crate::api::MatchMode::Fuzzy);
-        assert!(score.is_some(), "similarity fallback should set score");
+        let meta = f.replace_match_meta.get(&file).expect("fuzzy meta");
+        assert_eq!(meta.mode, crate::api::MatchMode::Fuzzy);
+        assert!(meta.score.is_some(), "similarity fallback should set score");
+        assert_eq!(meta.match_count, 1);
     }
 
     #[test]
@@ -1078,9 +1100,10 @@ mod tests {
         let mut tx = f.state(dir.path());
         assert_eq!(execute_replace_op(&op, &mut tx).unwrap(), 1);
         drop(tx);
-        let (mode, score) = f.replace_match_meta.get(&file).expect("exact meta");
-        assert_eq!(*mode, crate::api::MatchMode::Exact);
-        assert!(score.is_none());
+        let meta = f.replace_match_meta.get(&file).expect("exact meta");
+        assert_eq!(meta.mode, crate::api::MatchMode::Exact);
+        assert!(meta.score.is_none());
+        assert_eq!(meta.match_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

MPI cycle 6: library honesty gap on the exact `replace_text` path.

- **Bug:** `execute_as_edit_result` did not copy replace honesty from the engine, so successful exact disk replaces reported `match_count: 0` and `match_mode: None` (hosts only saw `changed: true`).
- **Fix:** `ReplaceMatchMeta` now stores `match_count`; `replace_op` records it; adapter threads `match_mode` / `match_score` / `match_count` onto `EditResult`.
- **Tests:** `replace_text_exact_disk_match_mode_and_count`, multi-match count.

## Test plan

- [x] `make check-fast`
- [x] `replace_text_exact_disk_match_mode_and_count`
- [x] `replace_text_exact_disk_multi_match_count`
- [ ] CI green