### PR TITLE
docs: reframe product language for LLM agent hosts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make test` | Run unit tests (`cargo test --lib --all-features`) |
 | `make integration-test` | Run integration tests (`cargo test --test integration --all-features`) |
 | `make pty-test` | Run PTY-based interactive terminal tests (`cargo test --test pty --all-features -- --test-threads=1`) |
-| `make test-library-hygiene` | Enforce Bline library set: clippy + tests under `--no-default-features --features "ast,files"` (catches dead_code, hygiene for #800 #802) |
+| `make test-library-hygiene` | Enforce pure-library embedder set: clippy + tests under `--no-default-features --features "ast,files"` (catches dead_code, hygiene for #800 #802) |
 | `make test-mcp-no-ast` | Lib tests with `mcp,cli,files` and no `ast` (MCP inventory/router/instructions honesty) |
 | `make clippy` | Run `cargo clippy --all-targets --all-features -- -D warnings` |
 | `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, test-mcp-no-ast, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme |
@@ -51,7 +51,7 @@ Keep the working tree clean:
 - After a core PR merges mid-session (e.g. #753 while polish for #754 was in flight): the feature branch tip is no longer ancestor of main ("has merged PR" from pre-commit hook). Recovery: `gh pr view N --json state` (confirm merged), `git checkout -b fix/review-continue-YYYYMMDD origin/main`, cherry-pick the useful commits (or `git show <oldsha> | patch -p1`), `git add <explicit files only>`, commit -s, push, create PR. See patchloom-contrib for full "Follow-up polish after base PR".
   For review/polish sessions you can temporarily set `REVIEW_CONTINUE=1` (or `ALLOW_MERGED_COMMIT=1`) to skip the hook block (see the global pre-commit hook for details). Always unset after the session.
 
-- **PR bodies must contain explicit issue links for traceability (addresses #819).** Every PR that resolves GitHub issues (including library follow-ups after a base PR has merged, Bline feedback polish, etc.) MUST list `Closes #N` or `Fixes #N` (one per line) in the PR *body/description*. GitHub only auto-closes from the PR body under squash-merge (individual commit messages are dropped). Use `Ref #N` for related but non-closing references. Never rely on commit message only. See `~/.grok/skills/owned-repo-gate/SKILL.md` (Phase 4) and `~/.grok/skills/github-interaction/SKILL.md` for the full rule and recovery. For follow-up PRs, edit the body with `gh pr edit` if the initial description was minimal. Verify with issue audit before claiming closure.
+- **PR bodies must contain explicit issue links for traceability (addresses #819).** Every PR that resolves GitHub issues (including library follow-ups after a base PR has merged, embedder/API polish, etc.) MUST list `Closes #N` or `Fixes #N` (one per line) in the PR *body/description*. GitHub only auto-closes from the PR body under squash-merge (individual commit messages are dropped). Use `Ref #N` for related but non-closing references. Never rely on commit message only. See `~/.grok/skills/owned-repo-gate/SKILL.md` (Phase 4) and `~/.grok/skills/github-interaction/SKILL.md` for the full rule and recovery. For follow-up PRs, edit the body with `gh pr edit` if the initial description was minimal. Verify with issue audit before claiming closure.
 
 See also the branch hygiene rules in `~/.grok/skills/patchloom-contrib/SKILL.md`.
 
@@ -60,7 +60,7 @@ See also the branch hygiene rules in `~/.grok/skills/patchloom-contrib/SKILL.md`
 - The open release-please PR (#724 etc.) title must be correct. Use `gh pr edit --title` when it shows the wrong version.
 - The PR *body* can be very long and may temporarily show the wrong next version header (release-please behavior). This is tracked as tech-debt #740.
 - When updating library embedding examples (in lib.rs, README, docs/), keep the version string in sync with the current Cargo.toml / .release-please-manifest.json (avoids the 0.4 vs 0.5 drift reported in #816 follow-up).
-- **Library follow-up PRs and high-level API changes must use explicit Closes links in the PR body** (see #819 and the new rule in Git hygiene above). The #811-#815 Bline library work + #817/#818 follow-ups exposed the gap where minimal PR bodies left issues open after squash-merge. Always include them for traceability.
+- **Library follow-up PRs and high-level API changes must use explicit Closes links in the PR body** (see #819 and the new rule in Git hygiene above). The #811-#815 library embedder work + #817/#818 follow-ups exposed the gap where minimal PR bodies left issues open after squash-merge. Always include them for traceability.
 - Primary curation is done via `RELEASE_NOTES.md` (applied to the final GitHub Release by the host job, not the PR body).
 - See `patchloom-contrib` skill ("Curated release notes" and "Major version bumps" sections) for the full process.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Minimal `ast::symbols::replace_function_signature` starter for Rust sig updates.
   - Re-exports for ergonomics (Plan, EditResult, etc.).
   - Expanded embedding docs + examples in lib.rs and api.
-  - Addresses all gaps in #792 for Bline full adoption (search layering docs, guard+append examples, no dup shims).
+  - Addresses all gaps in #792 for LLM agent embedder adoption (search layering docs, guard+append examples, no dup shims).
 * Tests and matrix verification for no-cli builds.
 
 ### Changed
@@ -34,7 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Features
 
-* **api:** Bline embedder surface (require_change, AST mutators, shell tokens, batch rename) ([#1497](https://github.com/patchloom/patchloom/issues/1497)) ([afd19b2](https://github.com/patchloom/patchloom/commit/afd19b215b2122d721fbff65f323a265ae8a05cf)), closes [#1492](https://github.com/patchloom/patchloom/issues/1492) [#1493](https://github.com/patchloom/patchloom/issues/1493) [#1494](https://github.com/patchloom/patchloom/issues/1494) [#1495](https://github.com/patchloom/patchloom/issues/1495)
+* **api:** LLM agent embedder surface (require_change, AST mutators, shell tokens, batch rename) ([#1497](https://github.com/patchloom/patchloom/issues/1497)) ([afd19b2](https://github.com/patchloom/patchloom/commit/afd19b215b2122d721fbff65f323a265ae8a05cf)), closes [#1492](https://github.com/patchloom/patchloom/issues/1492) [#1493](https://github.com/patchloom/patchloom/issues/1493) [#1494](https://github.com/patchloom/patchloom/issues/1494) [#1495](https://github.com/patchloom/patchloom/issues/1495)
 * **api:** crate-root apply_content_edits_to_file re-export ([#1512](https://github.com/patchloom/patchloom/issues/1512)) ([1604d2e](https://github.com/patchloom/patchloom/commit/1604d2e3328bfa84d07aea76a35cedd634c163c9))
 * **cli:** identity JSON flag and GNU --name=value option peeling ([#1543](https://github.com/patchloom/patchloom/issues/1543)) ([8615bb9](https://github.com/patchloom/patchloom/commit/8615bb994baa3f6b9f8eb197bc33b9a5a7d15070))
 * **cli:** replace --command-position and --require-change ([#1523](https://github.com/patchloom/patchloom/issues/1523)) ([0c53415](https://github.com/patchloom/patchloom/commit/0c53415c224a9fe455552ffc311797918064f7de))
@@ -135,7 +135,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Features
 
-* library embedder gaps for bline ([#1459](https://github.com/patchloom/patchloom/issues/1459)) ([#1461](https://github.com/patchloom/patchloom/issues/1461)) ([37d4573](https://github.com/patchloom/patchloom/commit/37d457373af009d293653a7440c23c860d923e7a))
+* library embedder gaps for LLM agents ([#1459](https://github.com/patchloom/patchloom/issues/1459)) ([#1461](https://github.com/patchloom/patchloom/issues/1461)) ([37d4573](https://github.com/patchloom/patchloom/commit/37d457373af009d293653a7440c23c860d923e7a))
 
 
 ### Bug Fixes
@@ -228,7 +228,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 * add --before-context/--after-context to CLI replace and new prepend command ([#1290](https://github.com/patchloom/patchloom/issues/1290)) ([8a576dd](https://github.com/patchloom/patchloom/commit/8a576dd55d106de02b6dd2bd6152d7f9f38f125b))
 * add fuzzy fallback to replace_in_content ([#1286](https://github.com/patchloom/patchloom/issues/1286)) ([#1292](https://github.com/patchloom/patchloom/issues/1292)) ([a7c009e](https://github.com/patchloom/patchloom/commit/a7c009e4dbbdecabc6ec813269100d3dc86ba2d2))
-* implement Bline issues [#1287](https://github.com/patchloom/patchloom/issues/1287), [#1288](https://github.com/patchloom/patchloom/issues/1288), [#1289](https://github.com/patchloom/patchloom/issues/1289) ([#1291](https://github.com/patchloom/patchloom/issues/1291)) ([d24dd45](https://github.com/patchloom/patchloom/commit/d24dd45b1b6a08667acd998d30628a4171e77bdc))
+* implement agent-host issues [#1287](https://github.com/patchloom/patchloom/issues/1287), [#1288](https://github.com/patchloom/patchloom/issues/1288), [#1289](https://github.com/patchloom/patchloom/issues/1289) ([#1291](https://github.com/patchloom/patchloom/issues/1291)) ([d24dd45](https://github.com/patchloom/patchloom/commit/d24dd45b1b6a08667acd998d30628a4171e77bdc))
 
 
 ### Bug Fixes
@@ -423,10 +423,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Features
 
 * add Streamable HTTP/HTTPS transport to mcp-server ([#866](https://github.com/patchloom/patchloom/issues/866)) ([30124e3](https://github.com/patchloom/patchloom/commit/30124e3ff7ca8120882684f8876b1f8c079fa57b))
-* Bline [#805](https://github.com/patchloom/patchloom/issues/805) downstream polish (PlanReport, search/AST docs, versions) ([#810](https://github.com/patchloom/patchloom/issues/810)) ([be7db34](https://github.com/patchloom/patchloom/commit/be7db3413ff02b7c763b005336d5b666d83e422b))
-* Bline library follow-ups ([#811](https://github.com/patchloom/patchloom/issues/811)-[#815](https://github.com/patchloom/patchloom/issues/815)) ([#817](https://github.com/patchloom/patchloom/issues/817)) ([f421f57](https://github.com/patchloom/patchloom/commit/f421f57c95145372b7aed22aea2cc0ef3a7f685b))
-* Bline library follow-ups for execute_plan typed return, search primitives/format/ignore helper, richer types, errors, versions sync ([#811](https://github.com/patchloom/patchloom/issues/811)-[#815](https://github.com/patchloom/patchloom/issues/815)) ([#816](https://github.com/patchloom/patchloom/issues/816)) ([4dcddf4](https://github.com/patchloom/patchloom/commit/4dcddf47e96e91ccae94fe231ecbf5189a2b7539))
-* full CLI/MCP/plan parity for Bline search ignore layering ([#821](https://github.com/patchloom/patchloom/issues/821)) ([#822](https://github.com/patchloom/patchloom/issues/822)) ([f7c0a8f](https://github.com/patchloom/patchloom/commit/f7c0a8fde8c2f04591ec0c22eb36374380e4f043))
+* Agent embedder [#805](https://github.com/patchloom/patchloom/issues/805) downstream polish (PlanReport, search/AST docs, versions) ([#810](https://github.com/patchloom/patchloom/issues/810)) ([be7db34](https://github.com/patchloom/patchloom/commit/be7db3413ff02b7c763b005336d5b666d83e422b))
+* Library embedder follow-ups ([#811](https://github.com/patchloom/patchloom/issues/811)-[#815](https://github.com/patchloom/patchloom/issues/815)) ([#817](https://github.com/patchloom/patchloom/issues/817)) ([f421f57](https://github.com/patchloom/patchloom/commit/f421f57c95145372b7aed22aea2cc0ef3a7f685b))
+* Library embedder follow-ups for execute_plan typed return, search primitives/format/ignore helper, richer types, errors, versions sync ([#811](https://github.com/patchloom/patchloom/issues/811)-[#815](https://github.com/patchloom/patchloom/issues/815)) ([#816](https://github.com/patchloom/patchloom/issues/816)) ([4dcddf4](https://github.com/patchloom/patchloom/commit/4dcddf47e96e91ccae94fe231ecbf5189a2b7539))
+* full CLI/MCP/plan parity for agent search ignore layering ([#821](https://github.com/patchloom/patchloom/issues/821)) ([#822](https://github.com/patchloom/patchloom/issues/822)) ([f7c0a8f](https://github.com/patchloom/patchloom/commit/f7c0a8fde8c2f04591ec0c22eb36374380e4f043))
 * library embedding gaps for pure 'ast'+'files' ([#792](https://github.com/patchloom/patchloom/issues/792)) ([#793](https://github.com/patchloom/patchloom/issues/793)) ([f0f99ef](https://github.com/patchloom/patchloom/commit/f0f99ef2b137633463312aad4be782868f2fda6e))
 * **lib:** ungate files helpers + add directory search API ([#773](https://github.com/patchloom/patchloom/issues/773) [#774](https://github.com/patchloom/patchloom/issues/774)) ([#775](https://github.com/patchloom/patchloom/issues/775)) ([505240c](https://github.com/patchloom/patchloom/commit/505240c6d48894e937ad775863147d12345b890f))
 * **mcp:** add execute_plan tool for multi-step tx plans + document cross-call semantics ([#827](https://github.com/patchloom/patchloom/issues/827)) ([#829](https://github.com/patchloom/patchloom/issues/829)) ([9b66e9a](https://github.com/patchloom/patchloom/commit/9b66e9abc5442b3a47001ce1e723268fc34559ba))
@@ -435,7 +435,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Bug Fixes
 
-* align version strings to 0.4 and expose search_one_file (Bline feedback on [#817](https://github.com/patchloom/patchloom/issues/817)) ([#818](https://github.com/patchloom/patchloom/issues/818)) ([1637cb3](https://github.com/patchloom/patchloom/commit/1637cb33cdebf06cb3a5af45f495aef5299cd85d))
+* align version strings to 0.4 and expose search_one_file (embedder feedback on [#817](https://github.com/patchloom/patchloom/issues/817)) ([#818](https://github.com/patchloom/patchloom/issues/818)) ([1637cb3](https://github.com/patchloom/patchloom/commit/1637cb33cdebf06cb3a5af45f495aef5299cd85d))
 * **containment:** make allow_temp_directory() and allow_workspace_and_temp_dir() handle conventional /tmp paths on macOS ([#781](https://github.com/patchloom/patchloom/issues/781)) ([#782](https://github.com/patchloom/patchloom/issues/782)) ([15bdc53](https://github.com/patchloom/patchloom/commit/15bdc53c52563f1a0288fb50a6f8ac3c29c8a123))
 * FOSSA false positive and TLS error path test ([#870](https://github.com/patchloom/patchloom/issues/870)) ([2c81d04](https://github.com/patchloom/patchloom/commit/2c81d04c6f09d6d478c160cc9ff2a0041f691208))
 * HTTPS banner shows real port; add TLS round-trip test ([#869](https://github.com/patchloom/patchloom/issues/869)) ([df6839f](https://github.com/patchloom/patchloom/commit/df6839ffba996a2a3464498c9687d43c6f29a74d)), closes [#867](https://github.com/patchloom/patchloom/issues/867) [#868](https://github.com/patchloom/patchloom/issues/868)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-ast-only: ## Run lib tests with only the ast feature (no cli, no mcp)
 test-mcp-no-ast: ## MCP without ast (inventory, tool_router merge, instructions honesty; #1395 #1396)
 	cargo test --lib --no-default-features --features "mcp,cli,files"
 
-test-library-hygiene: ## Run clippy + lib tests under exact Bline pure-library set (ast+files) to enforce no dead_code and hygiene (addresses #800 #802)
+test-library-hygiene: ## Run clippy + lib tests under pure-library embedder set (ast+files) to enforce no dead_code and hygiene (addresses #800 #802)
 	cargo clippy --no-default-features --features "ast,files" -- -D warnings
 	cargo test --no-default-features --features "ast,files" --lib
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Replace fail-closed / shell-token options: CLI `replace --require-change` and `-
 
 | Command | Description |
 |---|---|
-| `search` | Fast literal or regex search across text files (supports --glob/--exclude/--ignore-file for .blineignore-style layered filtering, --max-results, -C context, etc.) |
+| `search` | Fast literal or regex search across text files (supports --glob/--exclude/--ignore-file for layered custom ignore files, --max-results, -C context, etc.) |
 | `replace` | Mechanical string replacement across text files with diff preview |
 | `append` | Append content to an existing file |
 | `prepend` | Prepend content to an existing file |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -71,7 +71,7 @@ Rust tools. Disable default features to omit CLI (clap), MCP server, and AST:
 patchloom = { default-features = false }
 ```
 
-To add AST support without CLI/MCP (embedders such as Bline typically use
+To add AST support without CLI/MCP (LLM agent embedders typically use
 `ast` + `files` for plan execution and AST file mutators):
 
 ```toml

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -158,14 +158,14 @@ These flags affect how Patchloom reports results or chooses which files to touch
 ### `--exclude`
 
 - **What it does:** Excludes paths matching the given glob patterns (applied after .gitignore and any custom ignore files). May be repeated. Complements `--glob`.
-- **Use when:** You want to layer additional excludes (e.g. `target/**` or build artifacts) on top of `.blineignore` / `.gitignore` for search, replace, or tidy.
+- **Use when:** You want to layer additional excludes (e.g. `target/**` or build artifacts) on top of custom ignore files / `.gitignore` for search, replace, or tidy.
 - **Parity:** Matches `SearchOptions.exclude_patterns` and the library `collect_file_paths_with_ignores` precedence.
 
 <!-- ref:global-flag:ignore-file -->
 ### `--ignore-file`
 
-- **What it does:** Specifies additional gitignore-style ignore files (e.g. `.blineignore`) to respect during file collection. May be repeated.
-- **Use when:** Agents or projects use custom ignore files (Bline-style) and want CLI / tx / MCP search (and replace/tidy) to honor the same layered ignores as the pure-library API.
+- **What it does:** Specifies additional gitignore-style ignore files (e.g. `.agentignore`, `.cursorignore`) to respect during file collection. May be repeated.
+- **Use when:** LLM agents or projects use tool-specific ignore files and want CLI / tx / MCP search (and replace/tidy) to honor the same layered ignores as the pure-library API.
 - **Parity:** Matches `SearchOptions.custom_ignore_filenames`.
 
 <!-- ref:global-flag:files-from -->
@@ -1162,7 +1162,7 @@ The operations below are the building blocks inside `operations`.
 
 - **What it does:** Searches a file for a pattern inside a transaction and includes match results in the JSON output without writing anything.
 - **Use when:** An agent needs to locate patterns before replacing them in the same plan, enabling locate-then-edit in a single call.
-- **Optional fields:** `literal`, `regex`, `case_insensitive`, `multiline`, `invert_match`, `context`/`before_context`/`after_context`, `globs`, `exclude_patterns`, `custom_ignore_filenames` (for .blineignore layering), `max_results`, `assert_count`. These provide full parity with the top-level `search` command and library `SearchOptions`.
+- **Optional fields:** `literal`, `regex`, `case_insensitive`, `multiline`, `invert_match`, `context`/`before_context`/`after_context`, `globs`, `exclude_patterns`, `custom_ignore_filenames` (for agent/tool ignore layering), `max_results`, `assert_count`. These provide full parity with the top-level `search` command and library `SearchOptions`.
 - **Related:** top level `search`
 
 <!-- ref:tx-op:read -->
@@ -1201,7 +1201,7 @@ The operations below are the building blocks inside `operations`.
 
 - **What it does:** Rewrites a function signature using tree-sitter. Structured fields `visibility`, `parameters`, and `return_type` map to [`FunctionSigEdit`](https://docs.rs/patchloom); optional `new_signature` replaces the whole signature span. Field `old` (alias `name`) is the function name. Library: `api::ast_rewrite_signature`. MCP: `ast_rewrite_signature`.
 - **Body gap:** High-level paths accept a logical `new_signature` without trailing whitespace and preserve the original gap before `{` (or insert a conventional space if the original was already glued). Trait/extern forms ending in `;` do not get a spurious space. See #1503 / `splice_function_signature`.
-- **Use when:** Changing parameter lists, visibility, or return types without a brittle line scan (agent hosts such as Bline).
+- **Use when:** Changing parameter lists, visibility, or return types without a brittle line scan (LLM agent hosts and embedders).
 - **Failure behavior:** Missing function name exits 3 (`no_matches`) with the function name in the error; JSON plans report `error_kind: "no_matches"`.
 - **Related:** `ast.replace`, `ast.rename`
 
@@ -1271,11 +1271,11 @@ The operations below are the building blocks inside `operations`.
 ## Library API
 
 - **What it does:** Use patchloom as a Rust library (`default-features = false`, enable `ast`/`mcp` as needed). High level entry points in `patchloom::api` (search, replace_text, etc), plus `execute_plan`, `make_plan`, `PathGuard` for containment, and full plan types for tx. All public types are `Send + Sync`.
-- **Use when:** Embedding in agents (e.g. bline), custom tools, or tests without CLI spawn overhead. See `cargo doc --no-default-features --features ast --open`.
+- **Use when:** Embedding in LLM coding agents, custom tools, or tests without CLI spawn overhead. See `cargo doc --no-default-features --features ast --open`.
 - **Notable:** `search_directory(root, pattern, opts)` for parallel content search with globs/context (library equivalent of CLI search). Error paths and guards documented in api.rs.
 - **Related:** README "As a library", `src/api.rs`, `src/lib.rs` docs, examples/README.md entry for search_directory.
 
-### Embedder surfaces (Bline-oriented)
+### Embedder surfaces (LLM agent hosts)
 
 | Need | API |
 |------|-----|

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -164,7 +164,7 @@ pub struct EditResult {
     /// Whether the content changed.
     pub changed: bool,
     /// Action/kind of the edit (e.g. "append", "create", "replace", "rename", "doc.set").
-    /// Helps consumers (like Bline) distinguish cross-file or op type without parsing path.
+    /// Helps agent hosts distinguish cross-file or op type without parsing path.
     pub action: &'static str,
     /// For cross-file operations (e.g. `file_rename`, `md_move_section` with `to`),
     /// the destination path if different from `path`.

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -84,7 +84,7 @@ pub fn search_file(
 
 /// Options for full directory search (for library consumers).
 ///
-/// Supports customization for advanced ignore behavior (e.g. blineignore)
+/// Supports customization for advanced ignore behavior (e.g. agent/tool ignore files)
 /// via `exclude_patterns` and `custom_ignore_filenames`. The underlying
 /// `ignore::WalkBuilder` is used when the "files" feature is enabled, so
 /// standard .gitignore is respected by default.
@@ -111,11 +111,11 @@ pub struct SearchOptions {
     pub globs: Vec<String>,
     /// Max number of results (0 for unlimited).
     pub max_results: usize,
-    /// Additional gitignore-style patterns to *exclude* (e.g. from a .blineignore).
+    /// Additional gitignore-style patterns to *exclude* (e.g. from a custom ignore file).
     /// These are applied in addition to any .gitignore respected by the walker.
     pub exclude_patterns: Vec<String>,
     /// Custom ignore filenames to respect in addition to .gitignore / .ignore
-    /// (e.g. `vec![".blineignore".to_string()]`).
+    /// (e.g. `vec![".agentignore".to_string()]`).
     pub custom_ignore_filenames: Vec<String>,
 }
 
@@ -167,14 +167,15 @@ pub fn build_context_lines(
 /// Respects globs and custom ignores (via `SearchOptions`) if "files" feature enabled.
 /// Uses parallel processing when available.
 /// This provides the full power of the CLI search for library use (see #773, #796).
-/// See `SearchOptions` for `exclude_patterns` and `custom_ignore_filenames` (blineignore etc.).
+/// See `SearchOptions` for `exclude_patterns` and `custom_ignore_filenames`
+/// (agent/tool ignore files, etc.).
 ///
 /// For callers that already have a list of files (custom walker), see [`search_one_file`].
 ///
-/// Example for custom ignore (bline style):
+/// Example for custom ignore files used by LLM agents:
 /// ```ignore
 /// let opts = SearchOptions {
-///     custom_ignore_filenames: vec![".blineignore".into()],
+///     custom_ignore_filenames: vec![".agentignore".into()],
 ///     exclude_patterns: vec!["*.tmp".into()],
 ///     ..Default::default()
 /// };

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1748,15 +1748,15 @@ fn search_directory_exclude_patterns_and_custom_ignore() {
     let dir = TempDir::new().unwrap();
     std::fs::write(dir.path().join("keep.txt"), "keep this\n").unwrap();
     std::fs::write(dir.path().join("ignore.txt"), "ignore me\n").unwrap();
-    std::fs::write(dir.path().join("bline.txt"), "bline secret\n").unwrap();
+    std::fs::write(dir.path().join("hidden.txt"), "hidden secret\n").unwrap();
 
-    // Create a custom ignore file (blineignore style)
-    std::fs::write(dir.path().join(".blineignore"), "bline.txt\n").unwrap();
+    // Create a custom agent/tool ignore file
+    std::fs::write(dir.path().join(".agentignore"), "hidden.txt\n").unwrap();
 
     let opts = SearchOptions {
         regex: true,
         exclude_patterns: vec!["*ignore*".to_string()],
-        custom_ignore_filenames: vec![".blineignore".to_string()],
+        custom_ignore_filenames: vec![".agentignore".to_string()],
         ..Default::default()
     };
     let results = search_directory(dir.path(), "keep|me|secret", &opts).unwrap();
@@ -1767,18 +1767,18 @@ fn search_directory_exclude_patterns_and_custom_ignore() {
 
 #[test]
 #[cfg(any(feature = "cli", feature = "files"))]
-fn search_parity_blineignore_across_api_cli_and_plan() {
+fn search_parity_custom_ignore_across_api_cli_and_plan() {
     // Cross-surface parity test for #821: same inputs via api, CLI collect, and tx plan Search
     // produce equivalent rich results (counts/paths) when using custom ignore + exclude + globs + max.
     let dir = TempDir::new().unwrap();
     let root = dir.path();
     std::fs::write(root.join("keep.rs"), "keep foo here\n").unwrap();
     std::fs::write(root.join("skip.rs"), "skip foo\n").unwrap();
-    std::fs::write(root.join("bline.txt"), "bline foo secret\n").unwrap();
+    std::fs::write(root.join("hidden.txt"), "hidden foo secret\n").unwrap();
     std::fs::write(root.join("other.txt"), "other foo\n").unwrap();
     std::fs::create_dir_all(root.join("target")).unwrap();
     std::fs::write(root.join("target/bad.rs"), "bad foo\n").unwrap();
-    std::fs::write(root.join(".blineignore"), "bline.txt\ntarget/\n").unwrap();
+    std::fs::write(root.join(".agentignore"), "hidden.txt\ntarget/\n").unwrap();
     std::fs::write(root.join(".gitignore"), "").unwrap();
 
     let pattern = "foo";
@@ -1786,7 +1786,7 @@ fn search_parity_blineignore_across_api_cli_and_plan() {
         literal: true,
         globs: vec!["*.rs".to_string()],
         exclude_patterns: vec!["*skip*".to_string()],
-        custom_ignore_filenames: vec![".blineignore".to_string()],
+        custom_ignore_filenames: vec![".agentignore".to_string()],
         max_results: 10,
         ..Default::default()
     };
@@ -1840,7 +1840,7 @@ fn search_parity_blineignore_across_api_cli_and_plan() {
             "literal": true,
             "globs": ["*.rs"],
             "exclude_patterns": ["*skip*"],
-            "custom_ignore_filenames": [".blineignore"],
+            "custom_ignore_filenames": [".agentignore"],
             "max_results": 10
         }}]
     }}"#,
@@ -1861,7 +1861,7 @@ fn search_parity_blineignore_across_api_cli_and_plan() {
     assert!(plan_total > 0, "plan should have recorded matches");
     // Ensure no leaked bad files in api results
     assert!(
-        !api_paths.iter().any(|p| p.contains("bline")
+        !api_paths.iter().any(|p| p.contains("hidden")
             || p.contains("skip")
             || p.contains("target")
             || p.contains("bad")),
@@ -4585,7 +4585,7 @@ fn restore_path_from_latest_backup_after_apply() {
     assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
 }
 
-// ── #1658–#1666 Bline embedder API batch ──────────────────────────────────
+// ── #1658–#1666 LLM agent embedder API batch ──────────────────────────────
 
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
 #[test]

--- a/src/ast/symbol_extract.rs
+++ b/src/ast/symbol_extract.rs
@@ -104,7 +104,7 @@ fn node_signature(node: tree_sitter_lib::Node, source: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// Language-specific extractors (matching bline's patterns)
+// Language-specific extractors (agent-oriented symbol shapes)
 // ---------------------------------------------------------------------------
 
 fn extract_rust(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind, String)> {

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -67,11 +67,11 @@ pub struct GlobalFlags {
     #[cfg_attr(feature = "cli", arg(long, global = true, action = clap::ArgAction::Append))]
     pub glob: Vec<String>,
 
-    /// Exclude paths matching these glob patterns (in addition to .gitignore and custom ignore files). May be repeated. Enables layered excludes (e.g. .blineignore use cases) for search, replace, tidy etc.
+    /// Exclude paths matching these glob patterns (in addition to .gitignore and custom ignore files). May be repeated. Enables layered excludes for search, replace, tidy etc.
     #[cfg_attr(feature = "cli", arg(long, global = true, action = clap::ArgAction::Append))]
     pub exclude: Vec<String>,
 
-    /// Additional gitignore-style ignore filenames to respect (e.g. `.blineignore`). May be repeated. These are processed in addition to .gitignore.
+    /// Additional gitignore-style ignore filenames to respect (e.g. `.agentignore`). May be repeated. These are processed in addition to .gitignore.
     #[cfg_attr(feature = "cli", arg(long, global = true, action = clap::ArgAction::Append, value_name = "FILENAME"))]
     pub ignore_file: Vec<String>,
 

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -197,7 +197,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for Bline parity: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .blineignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Canonical multi-root field is paths (array); singular path is accepted as an alias for one root (same as paths:[path]). Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".blineignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
+        description = "Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for LLM agents: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .agentignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Canonical multi-root field is paths (array); singular path is accepted as an alias for one root (same as paths:[path]). Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".agentignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
     )]
     async fn search_files(
         &self,
@@ -231,7 +231,7 @@ impl PatchloomService {
                 svc.check_path(path)?;
             }
             // Validate custom ignore filenames too (new in #821 for layered ignores).
-            // Treat them as paths relative to cwd for containment (even if just names like ".blineignore").
+            // Treat them as paths relative to cwd for containment (even if just names like ".agentignore").
             for f in &p.custom_ignore_filenames {
                 svc.check_path(f)?;
             }

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -170,7 +170,7 @@ pub(crate) struct SearchParams {
     /// Exclude glob patterns (in addition to ignore files).
     #[serde(default)]
     pub exclude_patterns: Vec<String>,
-    /// Custom ignore filenames (e.g. .blineignore).
+    /// Custom ignore filenames (e.g. .agentignore).
     #[serde(default)]
     pub custom_ignore_filenames: Vec<String>,
     /// Max detailed results (0 = unlimited).

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -58,7 +58,7 @@ mod basic {
         assert_eq!(
             descriptions.get("search_files"),
             Some(
-                &"Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for Bline parity: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .blineignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Canonical multi-root field is paths (array); singular path is accepted as an alias for one root (same as paths:[path]). Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".blineignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
+                &"Search text files for a pattern (regex by default, use literal=true for exact match). Supports advanced layered ignores for LLM agents: globs (include), exclude_patterns, custom_ignore_filenames (e.g. .agentignore), max_results. Other options: files_with_matches, count, case_insensitive, multiline, invert_match, assert_count, before/after_context. Canonical multi-root field is paths (array); singular path is accepted as an alias for one root (same as paths:[path]). Example: {\"pattern\": \"TODO\", \"paths\": [\"src/\"], \"literal\": true, \"custom_ignore_filenames\": [\".agentignore\"], \"exclude_patterns\": [\"target/**\"], \"max_results\": 20}"
             ),
             "search_files description drifted"
         );
@@ -222,14 +222,14 @@ mod basic {
     }
 
     #[test]
-    fn mcp_search_params_accept_new_bline_ignore_fields() {
+    fn mcp_search_params_accept_custom_ignore_fields() {
         // Ensures schemars/serde accept the new fields added for #821 parity.
         let json = r#"{
             "pattern": "TODO",
             "paths": ["src/"],
             "globs": ["*.rs"],
             "exclude_patterns": ["target/**"],
-            "custom_ignore_filenames": [".blineignore"],
+            "custom_ignore_filenames": [".agentignore"],
             "max_results": 10,
             "literal": true
         }"#;

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -11,7 +11,7 @@ EXAMPLES:
   patchloom search 'fn main' src/ --count
   patchloom search 'error|warn' --regex src/ -C 2
   patchloom search 'password' . --glob '*.yaml'
-  patchloom search 'TODO' . --ignore-file .blineignore --exclude 'target/**' --max-results 50")]
+  patchloom search 'TODO' . --ignore-file .agentignore --exclude 'target/**' --max-results 50")]
 pub struct SearchArgs {
     /// Pattern to search for.
     pub pattern: String,

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -14,10 +14,11 @@
 //! |--------|----------|---------|
 //! | `Reject` | MCP server or untrusted agent output (default for safety) | CLI tools exposed over network |
 //! | `AllowIfContained` | Trusted library use, absolute paths inside workspace only | Standard agent in project dir |
-//! | `AllowAdditionalRoots(...)` or builder | Agents needing /tmp (incl. macOS symlinks), build artifacts, scratch dirs while keeping guard for sensitive paths | Bline `--yolo` or experiment mode |
+//! | `AllowAdditionalRoots(...)` or builder | Agents needing /tmp (incl. macOS symlinks), build artifacts, scratch dirs while keeping guard for sensitive paths | Host experiment mode / temp-file agents |
 //!
 //! **Threat model note**: MCP uses untrusted LLM-generated paths, so strict `Reject`.
-//! Direct library embedding (e.g. Bline) can use relaxed policies because the host controls the agent.
+//! Direct library embedding (LLM agent hosts that control the agent process) can use
+//! relaxed policies because the host owns path policy.
 //! Even with extra roots, escapes *out of* allowed roots are still blocked.
 //!
 //! # Example
@@ -781,7 +782,7 @@ mod tests {
             .unwrap();
 
         // Use a unique name under the conventional /tmp to simulate real usage
-        // (Bline yolo flush tests, agent-generated paths, etc.).
+        // (host experiment-mode paths, agent-generated paths, etc.).
         let tmp_path = format!("/tmp/patchloom_781_test_{}.txt", std::process::id());
         let _ = std::fs::remove_file(&tmp_path);
         std::fs::write(&tmp_path, "data for 781").unwrap();

--- a/src/files.rs
+++ b/src/files.rs
@@ -171,7 +171,7 @@ pub(crate) fn collect_file_paths_opts(
     if include_hidden {
         builder.hidden(false);
     }
-    // Support advanced layered ignores (e.g. .blineignore) for parity with library
+    // Support advanced layered ignores (e.g. .agentignore) for parity with library
     // `collect_file_paths_with_ignores` and `api::SearchOptions` (#821).
     for name in &global.ignore_file {
         builder.add_custom_ignore_filename(name);
@@ -504,7 +504,7 @@ fn apply_exclude_globs(
     Ok(())
 }
 
-/// Collect files while respecting .gitignore + custom ignore files (e.g. .blineignore)
+/// Collect files while respecting .gitignore + custom ignore files (e.g. .agentignore)
 /// + additional exclude globs.
 ///
 /// This is the reusable primitive for library consumers
@@ -930,18 +930,18 @@ mod tests {
         fs::write(root.join("src/main.rs"), "fn main() {}\n").unwrap();
         fs::write(root.join("target/debug"), "binary").unwrap(); // will be excluded by pattern
         fs::write(root.join("README.md"), "# hi\n").unwrap();
-        fs::write(root.join("Cargo.toml"), "[package]\n").unwrap(); // should survive .blineignore + exclude
-        fs::write(root.join(".blineignore"), "target/\n*.md\n").unwrap();
+        fs::write(root.join("Cargo.toml"), "[package]\n").unwrap(); // should survive .agentignore + exclude
+        fs::write(root.join(".agentignore"), "target/\n*.md\n").unwrap();
 
         let mut global = GlobalFlags::test_default();
         global.cwd = Some(root.to_string_lossy().into_owned());
-        global.ignore_file = vec![".blineignore".to_string()];
+        global.ignore_file = vec![".agentignore".to_string()];
         global.exclude = vec!["*.rs".to_string()]; // further exclude rs on top
 
         let paths =
             collect_file_paths_opts(&[".".to_string()], &global, false, Some(root)).unwrap();
 
-        // .blineignore skips target/ and *.md; then exclude *.rs skips the rs files.
+        // .agentignore skips target/ and *.md; then exclude *.rs skips the rs files.
         // Only nothing should remain? Wait, adjust: actually with exclude *.rs and ignore md/target, expect empty or adjust expectation.
         // Simpler assertion: the ignore_file was honored (no target, no md), and additional exclude removed rs.
         let rels: Vec<_> = paths

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //!
 //! With "files" feature you also get `api::search_directory`, `api::execute_plan`,
 //! `api::file_append`/`file_prepend`, and full plan execution for library use.
-//! For advanced search ignore (e.g. .blineignore on top of .gitignore) + custom walkers:
+//! For advanced search ignore (e.g. `.agentignore` on top of `.gitignore`) + custom walkers:
 //! Use `SearchOptions::exclude_patterns` and `custom_ignore_filenames` with `search_directory`/`search_file`,
 //! or collect paths with `files::collect_file_paths_with_ignores` (or your own `WalkBuilder`) then
 //! pair with the low-level `api::search_one_file` inside `par_process_files` + `format_search_results` / `build_context_lines`.
@@ -71,7 +71,7 @@
 //! # Ok::<(), anyhow::Error>(())
 //! ```
 //!
-//! For AST signature edits (bline #1459 / #821 follow-through, #1493):
+//! For AST signature edits (library embedder surface, #1459 / #821 / #1493):
 //!
 //! - In-memory: `api::ast_rewrite_signature_in_content` or
 //!   `ast::rewrite::rewrite_function_signature` with `FunctionSigEdit`
@@ -142,7 +142,7 @@
 //! (including idempotent `removed: 0` no-ops) (#811, #1439, #1459, #1674).
 //! See `api::PlanReport`, `api::execute_plan`, and embedding docs. CLI/MCP retain (code, json) for compatibility.
 //!
-//! For library users needing relaxed containment (e.g. agents like Bline using --yolo or temp files):
+//! For library users needing relaxed containment (e.g. LLM agents using temp files or host experiment mode):
 //! ```rust,no_run
 //! use patchloom::containment::PathGuard;
 //! let guard = PathGuard::builder(std::env::current_dir().unwrap())

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -223,7 +223,7 @@ fn parse_all_operation_variants() {
             {"op": "search", "path": "f.txt", "pattern": "hello"},
             {"op": "search", "path": "f.txt", "pattern": "he.*o", "regex": true, "case_insensitive": true, "multiline": true},
             {"op": "search", "path": "f.txt", "pattern": "TODO", "invert_match": true, "assert_count": 5},
-            {"op": "search", "path": ".", "pattern": "foo", "literal": true, "exclude_patterns": ["target/**"], "custom_ignore_filenames": [".blineignore"], "max_results": 10},
+            {"op": "search", "path": ".", "pattern": "foo", "literal": true, "exclude_patterns": ["target/**"], "custom_ignore_filenames": [".agentignore"], "max_results": 10},
             {"op": "ast.rename", "path": "f.rs", "old": "Foo", "new": "Bar"},
             {"op": "ast.replace", "path": "f.rs", "symbol": "main", "old": "a", "new": "b"},
             {"op": "ast.insert", "path": "f.rs", "content": "fn new() {}", "after": "main"},


### PR DESCRIPTION
## Summary

- Remove Bline-specific product framing from docs, crate/API comments, MCP `search` tool description, CLI examples, and tests.
- Use generic **LLM agent / embedder** wording.
- Use `.agentignore` as the sample custom-ignore filename (any name still works; this is not a rename of a required file).

Behavior is unchanged. This is product framing only so 0.13.0 and public docs do not read as Bline-only.

## Test plan

- [x] `rg -ni bline` clean in repo (excluding target)
- [x] `cargo test --lib --all-features custom_ignore`
- [x] `collect_file_paths_opts_respects_ignore_file_and_exclude`
- [x] `mcp_search_params_accept_custom_ignore_fields` / `mcp_lists_expected_tools`
- [ ] CI green