### PR TITLE
fix: match_mode worst-case rollup parity across surfaces

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -44,7 +44,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`
-**Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`) and optional `match_score` so agents can verify low-confidence fuzzy sites (#1669, #1674).
+**Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`) and optional `match_score` so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) (#1669, #1674).
 
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)
@@ -260,7 +260,7 @@ Plan/MCP `replace` accepts library flags (default false):
 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
 - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
-Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) on replace-backed changes plus an aggregate `match_mode` when any replace matched (#1674).
+Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) on replace-backed changes plus a worst-case aggregate (`fuzzy` > `anchored` > `exact`) when any replace matched (#1674).
 
 ## AST-aware operations
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -602,7 +602,7 @@ These are meaningful command-specific modes that change how a top-level command 
 ### `replace --fuzzy` / library `ReplaceOptions.fuzzy` / plan `fuzzy`
 
 - **What it does:** When the exact pattern has zero matches, try similarity/anchor fallback (same chain as before/after context). Plan ops and MCP `replace_text` accept `fuzzy: true`. Pure fuzzy (no context) works on disk library, single-path tx, **glob** plan ops, and CLI (including directory roots expanded like ordinary replace).
-- **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` in library results and CLI/MCP JSON (#1669).
+- **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` in library results and CLI/MCP JSON (#1669). Multi-file CLI replace, plan/tx, and content_edits all roll up worst-case confidence (`fuzzy` > `anchored` > `exact`) so mixed batches never under-report fuzzy.
 - **Prefer instead:** Exact replace when the target string is known.
 
 <!-- ref:create-mode:stdin -->

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -105,7 +105,7 @@ pub fn apply_content_edits_with_label(
         match_count = match_count.saturating_add(n);
         ops_applied += 1;
         if let Some(m) = mode {
-            match_mode = Some(merge_match_mode(match_mode, m));
+            match_mode = Some(super::merge_match_modes(match_mode, m));
             if m == MatchMode::Fuzzy && match_score.is_none() {
                 match_score = score;
             }
@@ -125,14 +125,6 @@ pub fn apply_content_edits_with_label(
         match_mode,
         match_score,
     })
-}
-
-fn merge_match_mode(prev: Option<MatchMode>, next: MatchMode) -> MatchMode {
-    match (prev, next) {
-        (Some(MatchMode::Fuzzy), _) | (_, MatchMode::Fuzzy) => MatchMode::Fuzzy,
-        (Some(MatchMode::Anchored), _) | (_, MatchMode::Anchored) => MatchMode::Anchored,
-        _ => MatchMode::Exact,
-    }
 }
 
 /// Read a file, apply multi-op content edits, and write according to `mode`.
@@ -532,5 +524,50 @@ mod tests {
         assert!(r.changed);
         assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
         assert!(r.match_score.is_some_and(|s| s > 0.85));
+    }
+
+    #[test]
+    fn content_edit_match_mode_rollup_anchored_over_exact() {
+        // Exact first, then context-anchored: worst-case is Anchored (#1673).
+        let edits = [
+            ContentEdit::Replace {
+                old: "alpha".into(),
+                new: "ALPHA".into(),
+                options: ReplaceOptions::default(),
+            },
+            ContentEdit::Replace {
+                old: "TODO: fix".into(),
+                new: "TODO: done".into(),
+                options: ReplaceOptions {
+                    before_context: Some("gamma".into()),
+                    ..Default::default()
+                },
+            },
+        ];
+        let r = apply_content_edits("alpha\nTODO: fix\nbeta\ngamma\nTODO: fix\n", &edits).unwrap();
+        assert!(r.changed);
+        assert_eq!(r.match_mode, Some(MatchMode::Anchored));
+        assert_eq!(r.match_count, 2);
+        assert!(r.modified.starts_with("ALPHA\n"));
+        assert!(r.modified.contains("gamma\nTODO: done"));
+        // Context-anchored replace must not touch the first TODO: fix
+        assert!(
+            r.modified.contains("ALPHA\nTODO: fix\nbeta"),
+            "first TODO must remain: {}",
+            r.modified
+        );
+    }
+
+    #[test]
+    fn merge_match_modes_precedence_table() {
+        use super::super::merge_match_modes;
+        use MatchMode::*;
+        assert_eq!(merge_match_modes(None, Exact), Exact);
+        assert_eq!(merge_match_modes(Some(Exact), Anchored), Anchored);
+        assert_eq!(merge_match_modes(Some(Anchored), Exact), Anchored);
+        assert_eq!(merge_match_modes(Some(Exact), Fuzzy), Fuzzy);
+        assert_eq!(merge_match_modes(Some(Anchored), Fuzzy), Fuzzy);
+        assert_eq!(merge_match_modes(Some(Fuzzy), Anchored), Fuzzy);
+        assert_eq!(merge_match_modes(Some(Fuzzy), Exact), Fuzzy);
     }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -506,6 +506,18 @@ pub(crate) fn match_mode_from_strategy(
     }
 }
 
+/// Worst-case match honesty rollup: fuzzy > anchored > exact (#1673 / #1674).
+///
+/// Shared by multi-op content edits, plan/tx aggregates, and replace_op path
+/// re-visits so every surface reports the same confidence ordering.
+pub(crate) fn merge_match_modes(prev: Option<MatchMode>, next: MatchMode) -> MatchMode {
+    match (prev, next) {
+        (Some(MatchMode::Fuzzy), _) | (_, MatchMode::Fuzzy) => MatchMode::Fuzzy,
+        (Some(MatchMode::Anchored), _) | (_, MatchMode::Anchored) => MatchMode::Anchored,
+        _ => MatchMode::Exact,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // TX engine adapter (requires tx module: cli or files feature)
 // ---------------------------------------------------------------------------

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -121,7 +121,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
              - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
-             **Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`) and optional `match_score` so agents can verify low-confidence fuzzy sites (#1669, #1674).\n\n",
+             **Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`) and optional `match_score` so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) (#1669, #1674).\n\n",
         );
     }
     if show_cli {
@@ -398,7 +398,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\
-                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) on replace-backed changes plus an aggregate `match_mode` when any replace matched (#1674).\n\n");
+                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) on replace-backed changes plus a worst-case aggregate (`fuzzy` > `anchored` > `exact`) when any replace matched (#1674).\n\n");
         }
     }
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -270,22 +270,36 @@ fn make_file_results(replacements: &[FileReplacement]) -> Vec<ReplaceFileResult>
         .collect()
 }
 
-/// Prefer a single top-level match_mode when every file agrees (#1669).
+/// Top-level match honesty for multi-file CLI replace (#1669 / #1674).
+///
+/// Uses the same worst-case rollup as plan/tx and content_edits
+/// (`fuzzy` > `anchored` > `exact`) so agents see a single conservative
+/// confidence when files disagree.
 fn aggregate_match_meta(files: &[ReplaceFileResult]) -> (Option<&'static str>, Option<f64>) {
-    let modes: Vec<_> = files.iter().filter_map(|f| f.match_mode).collect();
-    if modes.is_empty() {
-        return (None, None);
-    }
-    let first = modes[0];
-    if modes.iter().all(|m| *m == first) {
-        let score = if first == "fuzzy" {
-            files.iter().find_map(|f| f.match_score)
-        } else {
-            None
+    use crate::api::{MatchMode, merge_match_modes};
+
+    let mut agg: Option<MatchMode> = None;
+    let mut score: Option<f64> = None;
+    for f in files {
+        let Some(label) = f.match_mode else {
+            continue;
         };
-        (Some(first), score)
-    } else {
-        (None, None)
+        let mode = match label {
+            "fuzzy" => MatchMode::Fuzzy,
+            "anchored" => MatchMode::Anchored,
+            "exact" => MatchMode::Exact,
+            _ => continue,
+        };
+        agg = Some(merge_match_modes(agg, mode));
+        if mode == MatchMode::Fuzzy && score.is_none() {
+            score = f.match_score;
+        }
+    }
+    match agg {
+        Some(MatchMode::Fuzzy) => (Some("fuzzy"), score),
+        Some(MatchMode::Anchored) => (Some("anchored"), None),
+        Some(MatchMode::Exact) => (Some("exact"), None),
+        None => (None, None),
     }
 }
 

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -1454,3 +1454,72 @@ fn fuzzy_cli_expands_directory_roots() {
         "sibling file outside root must not change"
     );
 }
+
+#[test]
+fn multi_file_fuzzy_cli_json_reports_worst_case_match_mode() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.txt");
+    let b = dir.path().join("b.txt");
+    fs::write(&a, "hello world\n").unwrap();
+    fs::write(&b, "helo world\n").unwrap();
+
+    let mut args = make_args(
+        "hello world",
+        "hi world",
+        vec![
+            a.to_string_lossy().into_owned(),
+            b.to_string_lossy().into_owned(),
+        ],
+    );
+    args.fuzzy = true;
+    let global = GlobalFlags {
+        apply: true,
+        json: true,
+        cwd: Some(dir.path().to_string_lossy().into_owned()),
+        ..GlobalFlags::test_default()
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(code, exit::SUCCESS);
+    assert_eq!(fs::read_to_string(&a).unwrap(), "hi world\n");
+    assert_eq!(fs::read_to_string(&b).unwrap(), "hi world\n");
+}
+
+#[test]
+fn multi_file_match_mode_worst_case_rollup() {
+    // Child module of replace can call private aggregate_match_meta.
+    let files = [
+        ReplaceFileResult {
+            path: "a.txt".into(),
+            match_count: 1,
+            match_mode: Some("exact"),
+            match_score: None,
+        },
+        ReplaceFileResult {
+            path: "b.txt".into(),
+            match_count: 1,
+            match_mode: Some("fuzzy"),
+            match_score: Some(0.9),
+        },
+    ];
+    let (mode, score) = aggregate_match_meta(&files);
+    assert_eq!(mode, Some("fuzzy"), "worst-case must be fuzzy");
+    assert_eq!(score, Some(0.9));
+
+    let mixed_anchored = [
+        ReplaceFileResult {
+            path: "a.txt".into(),
+            match_count: 1,
+            match_mode: Some("exact"),
+            match_score: None,
+        },
+        ReplaceFileResult {
+            path: "b.txt".into(),
+            match_count: 1,
+            match_mode: Some("anchored"),
+            match_score: None,
+        },
+    ];
+    let (mode, score) = aggregate_match_meta(&mixed_anchored);
+    assert_eq!(mode, Some("anchored"));
+    assert!(score.is_none());
+}

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -164,20 +164,10 @@ pub(crate) fn match_mode_label(mode: crate::api::MatchMode) -> &'static str {
 }
 
 /// Worst-case rollup: fuzzy > anchored > exact (#1674 / #1673).
-pub(crate) fn merge_match_modes(
-    prev: Option<crate::api::MatchMode>,
-    next: crate::api::MatchMode,
-) -> crate::api::MatchMode {
-    match (prev, next) {
-        (Some(crate::api::MatchMode::Fuzzy), _) | (_, crate::api::MatchMode::Fuzzy) => {
-            crate::api::MatchMode::Fuzzy
-        }
-        (Some(crate::api::MatchMode::Anchored), _) | (_, crate::api::MatchMode::Anchored) => {
-            crate::api::MatchMode::Anchored
-        }
-        _ => crate::api::MatchMode::Exact,
-    }
-}
+///
+/// Thin re-export of [`crate::api::merge_match_modes`] so `tx::replace_op`
+/// and callers keep a stable import path.
+pub(crate) use crate::api::merge_match_modes;
 
 fn match_meta_for_path(
     path: &Path,


### PR DESCRIPTION
## Summary

MPI cycle 2026-07-13 on match honesty:

- **Shared helper:** `api::merge_match_modes` (fuzzy > anchored > exact) used by content_edits and tx; remove duplicate logic.
- **CLI fix:** multi-file `replace --json` top-level `match_mode` no longer drops when files disagree; uses the same worst-case rollup as plan/tx.
- **Tests:** precedence table, content_edits Anchored-over-Exact multi-op, multi-file CLI unit + e2e.
- **Docs:** agent-rules / PATCHLOOM.md / reference note worst-case aggregates.

## Test plan

- [x] `make check-fast`
- [x] `content_edit_*` / `merge_match_modes_precedence` / `multi_file_*` unit tests
- [ ] CI green

## Gate notes

- Release PR #1657 still open (needs explicit user OK to merge).
- Open distribution issues #632–#634, #960–#963 left as external packaging backlog.