### PR TITLE
fix: MCP replace honesty from engine match meta

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -44,7 +44,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`
-**Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`) and optional `match_score` so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) (#1669, #1674).
+**Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) (#1669, #1674).
 
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)
@@ -260,7 +260,7 @@ Plan/MCP `replace` accepts library flags (default false):
 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
 - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
-Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) on replace-backed changes plus a worst-case aggregate (`fuzzy` > `anchored` > `exact`) when any replace matched (#1674).
+Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674).
 
 ## AST-aware operations
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -218,10 +218,11 @@ Returns:
   "files_deleted": 0,
   "changes": [
     { "path": "CHANGELOG.md", "action": "modified" },
-    { "path": "README.md", "action": "modified", "match_mode": "exact" },
+    { "path": "README.md", "action": "modified", "match_mode": "exact", "match_count": 1 },
     { "path": "package.json", "action": "modified" }
   ],
-  "match_mode": "exact"
+  "match_mode": "exact",
+  "match_count": 1
 }
 ```
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1284,7 +1284,7 @@ The operations below are the building blocks inside `operations`.
 | Shell token rename | `ReplaceOptions.command_position` / `ContentEdit::Replace` (#1666) |
 | Scoped symbol replace (literal/regex) | `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (#1658) |
 | Project symbol discovery + multi-file rename | `find_files_with_symbol` then `ast_rename_batch` (#1664) |
-| Match honesty (fuzzy confidence) | `EditResult` / `ContentEditsResult` `match_mode` / `match_score` (#1662); CLI/MCP JSON (#1669); plan/tx `TxChange` + aggregate (#1674) |
+| Match honesty (fuzzy confidence) | `EditResult` / `ContentEditsResult` `match_mode` / `match_score` (#1662); CLI/MCP JSON (#1669); plan/tx `TxChange` + aggregate mode/score/`match_count` from engine meta (#1674) |
 | In-memory multi-op with real diff headers | `apply_content_edits_with_label` (#1665) |
 | Surgical undo one path | `backup::restore_path_from_session(root, ts, path)` (#1660) |
 | Post-Apply format/lint + optional revert | `run_post_write_validation` / `PostWriteHooks` (#1663) |

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -121,7 +121,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
              - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
-             **Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`) and optional `match_score` so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) (#1669, #1674).\n\n",
+             **Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) (#1669, #1674).\n\n",
         );
     }
     if show_cli {
@@ -398,7 +398,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\
-                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) on replace-backed changes plus a worst-case aggregate (`fuzzy` > `anchored` > `exact`) when any replace matched (#1674).\n\n");
+                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674).\n\n");
         }
     }
 

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -371,35 +371,9 @@ impl PatchloomService {
                 Vec::new()
             };
 
-            // Capture match honesty before Apply mutates the file (#1669).
-            let match_meta = {
-                let abs = svc.cwd().join(&p.path);
-                std::fs::read_to_string(&abs).ok().and_then(|content| {
-                    let opts = crate::api::ReplaceOptions {
-                        regex: p.regex,
-                        nth: p.nth,
-                        case_insensitive: p.case_insensitive,
-                        multiline: p.multiline,
-                        insert_before: p.insert_before.clone(),
-                        insert_after: p.insert_after.clone(),
-                        whole_line: p.whole_line,
-                        range: None,
-                        if_exists: true,
-                        word_boundary: p.word_boundary,
-                        unique: p.unique,
-                        fuzzy: p.fuzzy,
-                        before_context: p.before_context.clone(),
-                        after_context: p.after_context.clone(),
-                        require_change: false,
-                        command_position: p.command_position,
-                    };
-                    let to = p.new_text.as_deref().unwrap_or("");
-                    crate::api::replace_in_content(&content, &p.old, to, &opts)
-                        .ok()
-                        .map(|r| (r.match_mode, r.match_score, r.match_count))
-                })
-            };
-
+            // Match honesty comes from engine TxOutput (replace_match_meta), not a
+            // second replace_in_content pass. Re-deriving with range:None could
+            // overwrite correct engine mode after ranged/fuzzy applies.
             let replace_op = Operation::Replace {
                 glob: None,
                 path: Some(p.path),
@@ -423,30 +397,6 @@ impl PatchloomService {
                 fuzzy: p.fuzzy,
             };
             let mut tool_result = svc.run_one_op(replace_op, Some(p.strict))?;
-
-            // Inject match_mode / match_score into structured JSON content (#1669).
-            if let Some((mode, score, count)) = match_meta {
-                for block in &mut tool_result.content {
-                    if let ContentBlock::Text(text_content) = block {
-                        let text = &mut text_content.text;
-                        if let Ok(mut v) = serde_json::from_str::<serde_json::Value>(text) {
-                            if let Some(m) = mode {
-                                v["match_mode"] = serde_json::json!(crate::tx::match_mode_label(m));
-                            }
-                            if let Some(s) = score {
-                                v["match_score"] = serde_json::json!(s);
-                            }
-                            if count > 0 {
-                                v["match_count"] = serde_json::json!(count);
-                            }
-                            if let Ok(s) = serde_json::to_string(&v) {
-                                *text = s;
-                            }
-                            break;
-                        }
-                    }
-                }
-            }
 
             // Append validation warnings to the response.
             if !validation_warnings.is_empty() {

--- a/src/json_emit.rs
+++ b/src/json_emit.rs
@@ -236,6 +236,7 @@ mod tests {
             backup_session: None,
             match_mode: None,
             match_score: None,
+            match_count: None,
         };
         let emit = serialize_structured(&report, true);
         assert!(!emit.primary_ok);

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -48,6 +48,10 @@ pub struct TxOutput {
     /// Similarity score when aggregate [`Self::match_mode`] is fuzzy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub match_score: Option<f64>,
+    /// Sum of per-path replace match counts when any replace meta was recorded.
+    /// Lets MCP/CLI agents read honesty without a second content pass.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_count: Option<usize>,
 }
 
 /// One doc delete / delete-where outcome inside a plan/tx report (#1439).
@@ -72,6 +76,10 @@ pub struct TxChange {
     /// Similarity score when [`Self::match_mode`] is fuzzy.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub match_score: Option<f64>,
+    /// Number of replace matches for this path (from engine meta). Omitted for
+    /// non-replace changes. Prefer this over re-deriving after Apply.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub match_count: Option<usize>,
 }
 
 /// A search match in the tx output.
@@ -172,10 +180,14 @@ pub(crate) use crate::api::merge_match_modes;
 fn match_meta_for_path(
     path: &Path,
     meta: &HashMap<PathBuf, ReplaceMatchMeta>,
-) -> (Option<String>, Option<f64>) {
+) -> (Option<String>, Option<f64>, Option<usize>) {
     match meta.get(path) {
-        Some(m) => (Some(match_mode_label(m.mode).to_string()), m.score),
-        None => (None, None),
+        Some(m) => (
+            Some(match_mode_label(m.mode).to_string()),
+            m.score,
+            Some(m.match_count),
+        ),
+        None => (None, None, None),
     }
 }
 
@@ -194,6 +206,8 @@ pub(crate) fn build_tx_output_with_meta(
     let mut modified = 0usize;
     let mut agg_mode: Option<crate::api::MatchMode> = None;
     let mut agg_score: Option<f64> = None;
+    let mut agg_count: usize = 0;
+    let mut any_replace_meta = false;
 
     let display_path = |p: &Path| -> String {
         crate::files::relative_display(p, cwd)
@@ -203,12 +217,14 @@ pub(crate) fn build_tx_output_with_meta(
 
     for (path, _original, _) in changes {
         let path_str = display_path(path);
-        let (match_mode, match_score) = match_meta_for_path(path, replace_match_meta);
+        let (match_mode, match_score, match_count) = match_meta_for_path(path, replace_match_meta);
         if let Some(m) = replace_match_meta.get(path) {
+            any_replace_meta = true;
             agg_mode = Some(merge_match_modes(agg_mode, m.mode));
             if matches!(m.mode, crate::api::MatchMode::Fuzzy) {
                 agg_score = m.score.or(agg_score);
             }
+            agg_count = agg_count.saturating_add(m.match_count);
         }
         if deletions.contains(path) {
             tx_changes.push(TxChange {
@@ -216,6 +232,7 @@ pub(crate) fn build_tx_output_with_meta(
                 action: "deleted".to_string(),
                 match_mode,
                 match_score,
+                match_count,
             });
             deleted_count += 1;
         } else if !existed_before.contains(path) {
@@ -224,6 +241,7 @@ pub(crate) fn build_tx_output_with_meta(
                 action: "created".to_string(),
                 match_mode,
                 match_score,
+                match_count,
             });
             created += 1;
         } else {
@@ -232,6 +250,7 @@ pub(crate) fn build_tx_output_with_meta(
                 action: "modified".to_string(),
                 match_mode,
                 match_score,
+                match_count,
             });
             modified += 1;
         }
@@ -239,12 +258,17 @@ pub(crate) fn build_tx_output_with_meta(
     // Deletions not captured in changes (empty files).
     for path in deletions {
         if !changes.iter().any(|(c, _, _)| c == path) {
-            let (match_mode, match_score) = match_meta_for_path(path, replace_match_meta);
+            let (match_mode, match_score, match_count) =
+                match_meta_for_path(path, replace_match_meta);
+            if replace_match_meta.contains_key(path) {
+                any_replace_meta = true;
+            }
             tx_changes.push(TxChange {
                 path: display_path(path),
                 action: "deleted".to_string(),
                 match_mode,
                 match_score,
+                match_count,
             });
             deleted_count += 1;
         }
@@ -280,6 +304,11 @@ pub(crate) fn build_tx_output_with_meta(
         backup_session: None,
         match_mode: top_mode,
         match_score: top_score,
+        match_count: if any_replace_meta {
+            Some(agg_count)
+        } else {
+            None
+        },
     }
 }
 
@@ -354,6 +383,7 @@ pub(crate) fn build_error_output(
         backup_session: backup_session.map(str::to_string),
         match_mode: None,
         match_score: None,
+        match_count: None,
     }
 }
 
@@ -491,6 +521,7 @@ mod tests {
             backup_session: None,
             match_mode: None,
             match_score: None,
+            match_count: None,
         }
     }
 
@@ -513,6 +544,7 @@ mod tests {
             backup_session: None,
             match_mode: None,
             match_score: None,
+            match_count: None,
         }
     }
 
@@ -701,11 +733,14 @@ mod tests {
         );
         assert_eq!(out.match_mode.as_deref(), Some("fuzzy"));
         assert_eq!(out.match_score, Some(0.91));
+        assert_eq!(out.match_count, Some(1));
         assert_eq!(out.changes.len(), 1);
         assert_eq!(out.changes[0].match_mode.as_deref(), Some("fuzzy"));
         assert_eq!(out.changes[0].match_score, Some(0.91));
+        assert_eq!(out.changes[0].match_count, Some(1));
         let json = serde_json::to_string(&out).unwrap();
         assert!(json.contains("\"match_mode\":\"fuzzy\""), "{json}");
+        assert!(json.contains("\"match_count\":1"), "{json}");
     }
 
     // ---- TxOutput serde round-trip ----

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1864,7 +1864,10 @@ async fn test_mcp_batch_replace_fuzzy_reports_match_mode() {
     assert_eq!(changes.len(), 2, "two files changed: {val}");
     for ch in changes {
         assert_eq!(ch["match_mode"], "fuzzy", "per-file fuzzy match_mode: {ch}");
-        assert_eq!(ch["match_count"], 1, "per-file match_count from engine: {ch}");
+        assert_eq!(
+            ch["match_count"], 1,
+            "per-file match_count from engine: {ch}"
+        );
     }
     assert_eq!(
         val["match_count"], 2,
@@ -1884,7 +1887,6 @@ async fn test_mcp_batch_replace_fuzzy_reports_match_mode() {
     );
     client.cancel().await.unwrap();
 }
-
 
 #[tokio::test]
 async fn test_mcp_replace_text_fuzzy_reports_engine_match_mode() {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1864,7 +1864,12 @@ async fn test_mcp_batch_replace_fuzzy_reports_match_mode() {
     assert_eq!(changes.len(), 2, "two files changed: {val}");
     for ch in changes {
         assert_eq!(ch["match_mode"], "fuzzy", "per-file fuzzy match_mode: {ch}");
+        assert_eq!(ch["match_count"], 1, "per-file match_count from engine: {ch}");
     }
+    assert_eq!(
+        val["match_count"], 2,
+        "top-level match_count sum from engine: {val}"
+    );
     assert!(
         fs::read_to_string(dir.path().join("a.rs"))
             .unwrap()
@@ -1876,6 +1881,53 @@ async fn test_mcp_batch_replace_fuzzy_reports_match_mode() {
             .unwrap()
             .contains("handle_data"),
         "b.rs rewritten"
+    );
+    client.cancel().await.unwrap();
+}
+
+
+#[tokio::test]
+async fn test_mcp_replace_text_fuzzy_reports_engine_match_mode() {
+    // Honesty must come from replace_op meta via TxOutput, not a pre-apply
+    // replace_in_content re-derive (which hard-coded range: None).
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn process_data() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "lib.rs",
+            "old": "fn proccess_data() {}",
+            "new": "fn handle_data() {}",
+            "fuzzy": true,
+            "require_change": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "replace_text fuzzy should succeed: {val}");
+    assert_eq!(val["ok"], true, "replace_text ok: {val}");
+    assert_eq!(
+        val["match_mode"], "fuzzy",
+        "engine match_mode on replace_text: {val}"
+    );
+    assert_eq!(
+        val["match_count"], 1,
+        "engine match_count on replace_text: {val}"
+    );
+    let changes = val["changes"].as_array().expect("changes");
+    assert_eq!(changes.len(), 1);
+    assert_eq!(changes[0]["match_mode"], "fuzzy");
+    assert_eq!(changes[0]["match_count"], 1);
+    assert!(
+        fs::read_to_string(dir.path().join("lib.rs"))
+            .unwrap()
+            .contains("handle_data"),
+        "file rewritten"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
## Summary

MPI cycle 2026-07-13 session 2:

- **Bug:** MCP `replace_text` re-derived match honesty with `replace_in_content` before apply (`range` forced to `None`), then overwrote engine JSON. Ranged/fuzzy results could lie.
- **Fix:** Trust plan/tx `TxOutput` from `replace_match_meta`. Surface `match_count` on each `TxChange` and a top-level sum.
- **Tests:** MCP `replace_text` / `batch_replace` fuzzy honesty + match_count; quickstart smoke JSON updated.

## Test plan

- [x] `make check-fast`
- [x] `test_mcp_replace_text_fuzzy_reports_engine_match_mode`
- [x] `test_mcp_batch_replace_fuzzy_reports_match_mode`
- [x] `test_smoke_quickstart_transaction_snippet`
- [ ] CI green

## Gate notes

- Release PR #1657 still open (needs explicit user OK).
- Dist issues #632–#634, #960–#963 remain external packaging backlog.