### PR TITLE
feat: similar_targets on CLI replace no-match JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ sections below are managed by release-please.
 
 ### Features
 
-* Bline embedder API surfaces ([#1658](https://github.com/patchloom/patchloom/issues/1658)–[#1666](https://github.com/patchloom/patchloom/issues/1666)) ([#1667](https://github.com/patchloom/patchloom/issues/1667)) ([e413ec7](https://github.com/patchloom/patchloom/commit/e413ec784aa1383084481d44f961d3c2eb119f85)), closes [#1659](https://github.com/patchloom/patchloom/issues/1659) [#1660](https://github.com/patchloom/patchloom/issues/1660) [#1661](https://github.com/patchloom/patchloom/issues/1661) [#1662](https://github.com/patchloom/patchloom/issues/1662) [#1663](https://github.com/patchloom/patchloom/issues/1663) [#1664](https://github.com/patchloom/patchloom/issues/1664) [#1665](https://github.com/patchloom/patchloom/issues/1665)
+* LLM agent embedder API surfaces ([#1658](https://github.com/patchloom/patchloom/issues/1658)–[#1666](https://github.com/patchloom/patchloom/issues/1666)) ([#1667](https://github.com/patchloom/patchloom/issues/1667)) ([e413ec7](https://github.com/patchloom/patchloom/commit/e413ec784aa1383084481d44f961d3c2eb119f85)), closes [#1659](https://github.com/patchloom/patchloom/issues/1659) [#1660](https://github.com/patchloom/patchloom/issues/1660) [#1661](https://github.com/patchloom/patchloom/issues/1661) [#1662](https://github.com/patchloom/patchloom/issues/1662) [#1663](https://github.com/patchloom/patchloom/issues/1663) [#1664](https://github.com/patchloom/patchloom/issues/1664) [#1665](https://github.com/patchloom/patchloom/issues/1665)
 * match honesty for tx/batch_replace + agent-rules undo docs ([#1676](https://github.com/patchloom/patchloom/issues/1676)) ([9ef792a](https://github.com/patchloom/patchloom/commit/9ef792a663a9d5441cd7e5398fa4a8af9640bd9a))
 * match_mode rollup on multi-op content edits ([#1673](https://github.com/patchloom/patchloom/issues/1673)) ([ebbd458](https://github.com/patchloom/patchloom/commit/ebbd45825522908ebad04e27661035a1689ad35b))
 * plan/tx fuzzy replace and match_mode JSON ([#1668](https://github.com/patchloom/patchloom/issues/1668) [#1669](https://github.com/patchloom/patchloom/issues/1669)) ([#1671](https://github.com/patchloom/patchloom/issues/1671)) ([8b3dde5](https://github.com/patchloom/patchloom/commit/8b3dde5e45faf67e87b0fbb661af05fd1d65b268))
@@ -24,7 +24,7 @@ sections below are managed by release-please.
 
 ### Bug Fixes
 
-* Bline API follow-ups (fuzzy disk, FormatFailed, max_files) ([#1670](https://github.com/patchloom/patchloom/issues/1670)) ([64d046d](https://github.com/patchloom/patchloom/commit/64d046df99fc12d418095b60610b46c882a46eb0))
+* agent embedder API follow-ups (fuzzy disk, FormatFailed, max_files) ([#1670](https://github.com/patchloom/patchloom/issues/1670)) ([64d046d](https://github.com/patchloom/patchloom/commit/64d046df99fc12d418095b60610b46c882a46eb0))
 * CLI fuzzy match_mode from tx meta + docs ([#1677](https://github.com/patchloom/patchloom/issues/1677)) ([12df1c3](https://github.com/patchloom/patchloom/commit/12df1c335aadece3ea43f1bad9df88a06973ada8))
 * EditResult match_mode and match_count from tx ([#1679](https://github.com/patchloom/patchloom/issues/1679)) ([03deb12](https://github.com/patchloom/patchloom/commit/03deb120512bbd0e4194eff3c73256226061921f))
 * fuzzy/context replace parity for globs and directories ([#1672](https://github.com/patchloom/patchloom/issues/1672)) ([e14840c](https://github.com/patchloom/patchloom/commit/e14840cc9ffc734456bfd47ee33a4bb00328bfae))

--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -44,7 +44,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`
-**Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) (#1669, #1674).
+**Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674).
 
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -121,7 +121,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
              - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
-             **Match honesty in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) (#1669, #1674).\n\n",
+             **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674).\n\n",
         );
     }
     if show_cli {

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -502,7 +502,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. Optional fuzzy enables similarity fallback; JSON reports match_mode (exact/fuzzy/anchored) per change and aggregate (#1674). IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
+        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. Optional fuzzy enables similarity fallback; JSON reports match_mode (exact/fuzzy/anchored), match_count per change and aggregate (#1674). IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
     )]
     async fn batch_replace(
         &self,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -142,6 +142,10 @@ struct ReplaceOutput {
     match_mode: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     match_score: Option<f64>,
+    /// Did-you-mean candidates on soft no-match (literal patterns only).
+    /// Agents should prefer this over scraping the English error string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    similar_targets: Option<Vec<String>>,
 }
 
 /// Result of processing a single file.
@@ -158,6 +162,48 @@ struct FileReplacement {
 
 fn match_mode_str(mode: crate::api::MatchMode) -> &'static str {
     crate::tx::match_mode_label(mode)
+}
+
+/// Best-effort "did you mean?" candidates for a soft no-match (literal only).
+///
+/// Samples up to a few readable files under the replace path args so agents
+/// can branch on structured `similar_targets` without scraping English.
+fn similar_targets_for_no_match(
+    args: &ReplaceArgs,
+    global: &GlobalFlags,
+    cwd: &std::path::Path,
+) -> Option<Vec<String>> {
+    if args.regex {
+        return None;
+    }
+    let mut files: Vec<std::path::PathBuf> = Vec::new();
+    for p in &args.paths {
+        let abs = cwd.join(p);
+        if abs.is_file() {
+            files.push(abs);
+        } else if abs.is_dir()
+            && let Ok(mut walked) = crate::files::collect_file_paths_opts(
+                std::slice::from_ref(p),
+                global,
+                false,
+                Some(cwd),
+            )
+        {
+            walked.truncate(5);
+            files.extend(walked);
+        }
+    }
+    files.truncate(5);
+    for f in files {
+        let Ok(content) = std::fs::read_to_string(&f) else {
+            continue;
+        };
+        let similar = crate::fallback::find_similar_targets(&content, &args.old, 3);
+        if !similar.is_empty() {
+            return Some(similar);
+        }
+    }
+    None
 }
 
 /// Parse `--range` argument into (start, optional_end). Reuses the line-range
@@ -381,6 +427,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     error_kind: Some("ambiguous"),
                     match_mode: None,
                     match_score: None,
+                    similar_targets: None,
                 };
                 global.emit_json(&output)?;
                 if !global.quiet {
@@ -415,6 +462,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 error_kind: None,
                 match_mode: Some("exact"),
                 match_score: None,
+                similar_targets: None,
             };
             global.emit_json(&output)?;
             if !global.quiet && !global.json && !global.jsonl {
@@ -436,6 +484,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 error_kind: None,
                 match_mode: None,
                 match_score: None,
+                similar_targets: None,
             };
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
@@ -448,6 +497,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             global.emit_error_json_kind(Some("not_found"), &msg)?;
             return Ok(exit::FAILURE);
         }
+        let similar = similar_targets_for_no_match(&args, global, &cwd);
         let output = ReplaceOutput {
             ok: false,
             match_count: 0,
@@ -458,11 +508,15 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             error_kind: Some("no_matches"),
             match_mode: None,
             match_score: None,
+            similar_targets: similar.clone(),
         };
         global.emit_json(&output)?;
         if !global.quiet && !global.json && !global.jsonl {
             let path_desc = global.path_scope_description(&args.paths);
             eprintln!("no matches for '{}' in {path_desc}", args.old);
+            if let Some(ref s) = similar {
+                eprintln!("did you mean: {}?", s.join(", "));
+            }
             if !args.regex && crate::files::has_regex_metacharacters(&args.old) {
                 eprintln!("hint: pattern contains regex characters, try --regex");
             }
@@ -523,6 +577,7 @@ fn replace_output(
         error_kind: None,
         match_mode: agg_mode,
         match_score: agg_score,
+        similar_targets: None,
     };
 
     finalize_report(
@@ -626,6 +681,7 @@ fn run_context_replace(
             },
             match_mode: None,
             match_score: None,
+            similar_targets: None,
         };
         global.emit_json(&empty)?;
         if args.if_exists {
@@ -691,6 +747,7 @@ fn run_context_replace(
             },
             match_mode: None,
             match_score: None,
+            similar_targets: None,
         };
         global.emit_json(&empty)?;
         if args.if_exists {

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1714,6 +1714,35 @@ fn test_replace_cli_json_error_kind_no_matches() {
 }
 
 #[test]
+fn test_replace_cli_json_no_matches_includes_similar_targets() {
+    // Agents branch on structured similar_targets (not English scrape).
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    fs::write(&file, "process_request\nprocess_response\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["replace", "process_requst", "--new", "x", "a.txt"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("valid JSON");
+    assert_eq!(v["error_kind"], "no_matches");
+    let similar = v["similar_targets"]
+        .as_array()
+        .expect("similar_targets array on literal no-match");
+    assert!(
+        similar
+            .iter()
+            .any(|s| s.as_str() == Some("process_request")),
+        "expected process_request suggestion: {v}"
+    );
+}
+
+#[test]
 fn test_replace_cli_json_error_kind_ambiguous() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("a.txt");


### PR DESCRIPTION
## Summary

MPI cycle 2026-07-13 session 4 (post-0.13.0):

- **Observability:** CLI `replace --json` soft no-match payload includes
  optional `similar_targets` (did-you-mean) for literal patterns, sampled
  from path args / a few walked files.
- Text mode also prints `did you mean: ...` when suggestions exist.
- Docs: agent-rules / PATCHLOOM.md; MCP `batch_replace` description mentions
  `match_count`; CHANGELOG 0.13.0 soft-rewrite of product framing.

## Test plan

- [x] `make check-fast`
- [x] `test_replace_cli_json_no_matches_includes_similar_targets`
- [ ] CI green

## Gate notes

- Dist issues #632–#634, #960–#963 remain external packaging backlog.