### PR TITLE
feat: agent-host APIs (backup session, fuzzy floor, nested list, project rename, post-write)

### DIFF
--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -15,7 +15,8 @@ use crate::plan::Operation;
 use crate::write::WritePolicy;
 
 use super::{
-    ApplyMode, ContentEditResult, EditResult, ensure_contained, make_diff, write_if_apply,
+    ApplyMode, ContentEditResult, EditResult, PostWriteHooks, ensure_contained, make_diff,
+    maybe_post_write, write_if_apply,
 };
 
 /// Rewrite a function signature on disk (PathGuard + ApplyMode like other writers).
@@ -147,7 +148,7 @@ pub fn ast_rename(
         .into());
     }
     let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &renamed.content, mode, &policy, guard)?;
+    let (applied, backup_session) = write_if_apply(path, &renamed.content, mode, &policy, guard)?;
     let mut result = super::build_edit_result(
         &path_str,
         original,
@@ -156,6 +157,7 @@ pub fn ast_rename(
         "ast.rename",
         None,
     );
+    result.backup_session = backup_session;
     result.match_count = renamed.replacements;
     Ok(result)
 }
@@ -211,7 +213,7 @@ pub fn ast_replace_in_symbol(
         .into());
     }
     let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &replaced.content, mode, &policy, guard)?;
+    let (applied, backup_session) = write_if_apply(path, &replaced.content, mode, &policy, guard)?;
     let mut result = super::build_edit_result(
         &path_str,
         original,
@@ -220,6 +222,7 @@ pub fn ast_replace_in_symbol(
         "ast.replace_in_symbol",
         None,
     );
+    result.backup_session = backup_session;
     result.match_count = replaced.replacements;
     result.match_mode = Some(super::MatchMode::Exact);
     Ok(result)
@@ -315,6 +318,55 @@ pub fn find_files_with_symbol(
     Ok(out)
 }
 
+/// Options for [`ast_rename_project`] (#1689).
+#[derive(Debug, Clone, Default)]
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub struct AstRenameProjectOptions {
+    pub search: SymbolSearchOptions,
+    pub rename: AstRenameBatchOptions,
+}
+
+/// Result of [`ast_rename_project`]: discovery set plus per-file rename outcomes.
+#[derive(Debug)]
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub struct AstRenameProjectReport {
+    /// Paths discovery considered (even when rename is a no-op).
+    pub paths_considered: Vec<PathBuf>,
+    /// Per-file rename results (same order as batch processing).
+    pub results: Vec<AstRenameFileResult>,
+}
+
+/// Discover files containing `old_name` under `root` then batch-rename (#1689).
+///
+/// Preferred one-shot for agent hosts: “rename OldType project-wide” without a
+/// separate path list from the model.
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+pub fn ast_rename_project(
+    root: &Path,
+    old_name: &str,
+    new_name: &str,
+    opts: &AstRenameProjectOptions,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<AstRenameProjectReport> {
+    let paths = find_files_with_symbol(root, old_name, &opts.search)?;
+    if paths.is_empty() {
+        return Err(EditError::new(
+            EditErrorKind::NoMatch,
+            format!(
+                "no files under {} contain identifier {old_name:?}",
+                root.display()
+            ),
+        )
+        .into());
+    }
+    let path_refs: Vec<&Path> = paths.iter().map(PathBuf::as_path).collect();
+    let results = ast_rename_batch(&path_refs, old_name, new_name, &opts.rename, guard)?;
+    Ok(AstRenameProjectReport {
+        paths_considered: paths,
+        results,
+    })
+}
+
 /// Word-boundary check for an identifier (ASCII-aware; good enough for discovery).
 #[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
 fn content_has_identifier(content: &str, name: &str) -> bool {
@@ -357,6 +409,10 @@ pub struct AstRenameBatchOptions {
     /// Independent of [`Self::continue_on_no_match`] (which only covers
     /// `NoMatch`).
     pub fail_fast: bool,
+    /// Optional post-Apply format/lint hooks run per successful write (#1690).
+    pub post_write: Option<PostWriteHooks>,
+    /// Working directory for [`Self::post_write`] shell commands.
+    pub post_write_cwd: Option<std::path::PathBuf>,
 }
 
 impl Default for AstRenameBatchOptions {
@@ -365,6 +421,8 @@ impl Default for AstRenameBatchOptions {
             mode: ApplyMode::Preview,
             continue_on_no_match: true,
             fail_fast: false,
+            post_write: None,
+            post_write_cwd: None,
         }
     }
 }
@@ -412,10 +470,32 @@ pub fn ast_rename_batch(
     let mut out = Vec::with_capacity(unique_paths.len());
     for path in unique_paths {
         match ast_rename(path, old, new, opts.mode, guard) {
-            Ok(r) => out.push(AstRenameFileResult {
-                path: path.to_path_buf(),
-                result: Ok(r),
-            }),
+            Ok(r) => {
+                // Post-Apply format/lint hooks when configured (#1690).
+                if let Err(e) = maybe_post_write(
+                    r.applied,
+                    path,
+                    opts.post_write.as_ref(),
+                    opts.post_write_cwd.as_deref(),
+                    r.backup_session.as_deref(),
+                ) {
+                    let edit_err = e.downcast::<EditError>().unwrap_or_else(|e| {
+                        EditError::new(EditErrorKind::FormatFailed, e.to_string())
+                    });
+                    out.push(AstRenameFileResult {
+                        path: path.to_path_buf(),
+                        result: Err(edit_err),
+                    });
+                    if opts.fail_fast {
+                        break;
+                    }
+                    continue;
+                }
+                out.push(AstRenameFileResult {
+                    path: path.to_path_buf(),
+                    result: Ok(r),
+                });
+            }
             Err(e) => {
                 let edit_err = e.downcast::<EditError>().unwrap_or_else(|e| {
                     EditError::new(EditErrorKind::OperationFailed, e.to_string())

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -26,6 +26,8 @@ use crate::write::WritePolicy;
 
 /// A single ordered edit on an in-memory buffer.
 #[derive(Debug, Clone)]
+// ReplaceOptions carries post_write hooks (#1690); boxing would break callers.
+#[allow(clippy::large_enum_variant)]
 pub enum ContentEdit {
     /// Text replacement (reuses [`ReplaceOptions`]).
     Replace {
@@ -151,7 +153,7 @@ pub fn apply_content_edits_to_file(
     // Prefer real path labels in multi-op preview (#1665 / #1500).
     let batch = apply_content_edits_with_label(&original, edits, Some(path_str.as_str()))?;
     let policy = WritePolicy::default();
-    let applied = write_if_apply(path, &batch.modified, mode, &policy, guard)?;
+    let (applied, backup_session) = write_if_apply(path, &batch.modified, mode, &policy, guard)?;
     // build_edit_result uses path for headers (#1500) and stays field-complete.
     let mut result = build_edit_result(
         &path_str,
@@ -161,6 +163,7 @@ pub fn apply_content_edits_to_file(
         "content.edits",
         None,
     );
+    result.backup_session = backup_session;
     result.match_count = batch.match_count;
     result.match_mode = batch.match_mode;
     result.match_score = batch.match_score;
@@ -516,6 +519,7 @@ mod tests {
             new: "fn handle_data() {}".into(),
             options: ReplaceOptions {
                 fuzzy: true,
+                min_fuzzy_score: None,
                 require_change: true,
                 ..Default::default()
             },

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -81,14 +81,15 @@ fn doc_write(
     let policy = WritePolicy::default();
     // Do not write (or report applied) when the mutation is a no-op.
     let content_changed = original != new_content;
-    let applied = if content_changed {
+    let (applied, backup_session) = if content_changed {
         super::write_if_apply(path, &new_content, mode, &policy, guard)?
     } else {
-        false
+        (false, None)
     };
     let mut edit =
         super::build_edit_result(&path_str, original, new_content, applied, action, None);
     edit.removed = removed;
+    edit.backup_session = backup_session;
     Ok(edit)
 }
 

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -61,10 +61,14 @@ fn file_write(
                 }));
             }
             let policy = crate::write::WritePolicy::default();
-            let applied = super::write_if_apply(path, &content, mode, &policy, guard)?;
-            Ok(super::build_edit_result(
-                &path_str, original, content, applied, action, None,
-            ))
+            let (applied, backup_session) =
+                super::write_if_apply(path, &content, mode, &policy, guard)?;
+            {
+                let mut __e =
+                    super::build_edit_result(&path_str, original, content, applied, action, None);
+                __e.backup_session = backup_session;
+                Ok(__e)
+            }
         }
         Operation::FileDelete { .. } => {
             let path_str = path.to_string_lossy();
@@ -77,22 +81,32 @@ fn file_write(
             }
             let original = std::fs::read_to_string(path)
                 .with_context(|| format!("failed to read {}", path.display()))?;
-            let applied = if mode == ApplyMode::Apply {
-                super::ensure_contained(guard, path)?;
-                std::fs::remove_file(path)
-                    .with_context(|| format!("failed to delete {}", path.display()))?;
-                true
+            let (applied, backup_session) = if mode == ApplyMode::Apply {
+                super::apply_mutation(
+                    path,
+                    mode,
+                    guard,
+                    |backup| backup.save_before_delete(path),
+                    || {
+                        std::fs::remove_file(path)
+                            .with_context(|| format!("failed to delete {}", path.display()))
+                    },
+                )?
             } else {
-                false
+                (false, None)
             };
-            Ok(super::build_edit_result(
-                &path_str,
-                original,
-                String::new(),
-                applied,
-                action,
-                None,
-            ))
+            {
+                let mut __e = super::build_edit_result(
+                    &path_str,
+                    original,
+                    String::new(),
+                    applied,
+                    action,
+                    None,
+                );
+                __e.backup_session = backup_session;
+                Ok(__e)
+            }
         }
         Operation::FileAppend { ref content, .. } | Operation::FilePrepend { ref content, .. } => {
             let is_append = matches!(op, Operation::FileAppend { .. });
@@ -118,10 +132,14 @@ fn file_write(
                 crate::ops::file::prepend_content(&original, &content)
             };
             let policy = crate::write::WritePolicy::default();
-            let applied = super::write_if_apply(path, &combined, mode, &policy, guard)?;
-            Ok(super::build_edit_result(
-                &path_str, original, combined, applied, action, None,
-            ))
+            let (applied, backup_session) =
+                super::write_if_apply(path, &combined, mode, &policy, guard)?;
+            {
+                let mut __e =
+                    super::build_edit_result(&path_str, original, combined, applied, action, None);
+                __e.backup_session = backup_session;
+                Ok(__e)
+            }
         }
         _ => bail!("unsupported file operation"),
     }
@@ -162,7 +180,7 @@ fn file_write_cross(
         }
         let original = std::fs::read_to_string(src)
             .with_context(|| format!("failed to read {}", src.display()))?;
-        let applied = super::apply_cross_file_mutation(
+        let (applied, backup_session) = super::apply_cross_file_mutation(
             src,
             Some(dst),
             mode,
@@ -180,14 +198,18 @@ fn file_write_cross(
                 })
             },
         )?;
-        Ok(super::build_edit_result(
-            &src.to_string_lossy(),
-            original.clone(),
-            original,
-            applied,
-            action,
-            dest_path,
-        ))
+        {
+            let mut __e = super::build_edit_result(
+                &src.to_string_lossy(),
+                original.clone(),
+                original,
+                applied,
+                action,
+                dest_path,
+            );
+            __e.backup_session = backup_session;
+            Ok(__e)
+        }
     } else {
         bail!("unsupported cross-file operation")
     }

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -73,15 +73,18 @@ fn md_write(
             return match ops::md::table_append_in(&original, body_start, body_end, &row) {
                 Ok(new_content) => {
                     let policy = WritePolicy::default();
-                    let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;
-                    Ok(super::build_edit_result(
+                    let (applied, backup_session) =
+                        super::write_if_apply(path, &new_content, mode, &policy, guard)?;
+                    let mut edit = super::build_edit_result(
                         &path_str,
                         original,
                         new_content,
                         applied,
                         action,
                         None,
-                    ))
+                    );
+                    edit.backup_session = backup_session;
+                    Ok(edit)
                 }
                 Err(e) => Err(anyhow::Error::new(crate::exit::InvalidInputError {
                     msg: format!("{e} under heading {heading:?} in {path_str}"),
@@ -97,15 +100,12 @@ fn md_write(
     })?;
 
     let policy = WritePolicy::default();
-    let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;
-    Ok(super::build_edit_result(
-        &path_str,
-        original,
-        new_content,
-        applied,
-        action,
-        None,
-    ))
+    let (applied, backup_session) =
+        super::write_if_apply(path, &new_content, mode, &policy, guard)?;
+    let mut edit =
+        super::build_edit_result(&path_str, original, new_content, applied, action, None);
+    edit.backup_session = backup_session;
+    Ok(edit)
 }
 
 /// Replace the body of a markdown section identified by heading.
@@ -220,7 +220,7 @@ pub fn md_move_section(
         let _ = super::write_if_apply(dest_path, &new_dest, mode, &policy, guard)?;
     }
     // Use generalized cross helper for source (centralized per #839).
-    let applied = super::apply_cross_file_mutation(
+    let (applied, backup_session) = super::apply_cross_file_mutation(
         path,
         None,
         mode,
@@ -229,9 +229,10 @@ pub fn md_move_section(
         || crate::write::atomic_write(path, &new_source, &policy),
     )?;
     let dest = to.map(|p| p.to_string_lossy().to_string());
-    Ok(super::build_edit_result(
-        &path_str, original, new_source, applied, "md.move", dest,
-    ))
+    let mut edit =
+        super::build_edit_result(&path_str, original, new_source, applied, "md.move", dest);
+    edit.backup_session = backup_session;
+    Ok(edit)
 }
 
 /// Remove duplicate headings at the same level in a markdown file.
@@ -251,11 +252,12 @@ pub fn md_dedupe_headings(
     let (new_content, removed) = ops::md::dedupe_headings_in(&original);
 
     let policy = crate::write::WritePolicy::default();
-    let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;
-    Ok((
-        super::build_edit_result(&path_str, original, new_content, applied, "md.dedupe", None),
-        removed,
-    ))
+    let (applied, backup_session) =
+        super::write_if_apply(path, &new_content, mode, &policy, guard)?;
+    let mut edit =
+        super::build_edit_result(&path_str, original, new_content, applied, "md.dedupe", None);
+    edit.backup_session = backup_session;
+    Ok((edit, removed))
 }
 
 /// A lint issue found in a markdown file.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -186,6 +186,12 @@ pub struct EditResult {
     pub match_mode: Option<MatchMode>,
     /// Similarity score when [`MatchMode::Fuzzy`] was used; otherwise `None`.
     pub match_score: Option<f64>,
+    /// Backup session timestamp created for this Apply (if any).
+    ///
+    /// Set when a write produced a backup session (see `BackupSession::finalize`).
+    /// `None` for Preview/Check, no-ops, or when nothing was backed up.
+    /// Use with [`crate::backup::restore_path_from_session`] for surgical undo (#1686).
+    pub backup_session: Option<String>,
 }
 
 /// Result of an in-memory content edit (no file path, no applied flag).
@@ -293,6 +299,17 @@ pub struct ReplaceOptions {
     /// longer tokens (`pip` vs `pipenv`) or as arguments (`uv pip`). Opt-in;
     /// not the same as `word_boundary`. See #1494.
     pub command_position: bool,
+    /// When fuzzy applies, reject if similarity is below this floor (e.g. `0.80`).
+    /// `None` = no floor (default). Exact and anchored matches are unaffected (#1687).
+    pub min_fuzzy_score: Option<f64>,
+    /// Optional post-Apply format/lint hooks (#1690 / #1663).
+    ///
+    /// When set, runs after a successful disk write. Prefer pairing with
+    /// [`EditResult::backup_session`] for targeted revert.
+    pub post_write: Option<PostWriteHooks>,
+    /// Working directory for [`Self::post_write`] shell commands.
+    /// Defaults to the written file's parent when unset.
+    pub post_write_cwd: Option<std::path::PathBuf>,
 }
 
 // Re-export structured edit errors for embedders (#1492, #1659).
@@ -312,6 +329,10 @@ pub struct WritePolicyOptions {
     pub trim_trailing_whitespace: bool,
     /// Collapse consecutive blank lines into a single blank line.
     pub collapse_blanks: bool,
+    /// Optional post-Apply format/lint hooks for high-level writers (#1690).
+    pub post_write: Option<PostWriteHooks>,
+    /// Cwd for [`Self::post_write`] shell commands (default: file parent).
+    pub post_write_cwd: Option<std::path::PathBuf>,
 }
 
 // ---------------------------------------------------------------------------
@@ -389,15 +410,16 @@ fn make_diff(path: &str, old: &str, new: &str) -> String {
 /// Generalized helper for Apply-mode mutations that need backup + guard.
 ///
 /// Used by write_if_apply and special file ops (create/delete/rename cross-file).
-fn apply_mutation(
+/// Returns `(applied, backup_session)`.
+pub(crate) fn apply_mutation(
     path: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
     prepare_backup: impl FnOnce(&mut BackupSession) -> anyhow::Result<()>,
     perform_mutation: impl FnOnce() -> anyhow::Result<()>,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<(bool, Option<String>)> {
     if mode != ApplyMode::Apply {
-        return Ok(false);
+        return Ok((false, None));
     }
     ensure_contained(guard, path)?;
     // Use the project root (parent of the file) as backup root.
@@ -406,14 +428,15 @@ fn apply_mutation(
     let mut backup = BackupSession::new(cwd)?;
     prepare_backup(&mut backup)?;
     perform_mutation()?;
-    backup.finalize()?;
-    Ok(true)
+    let session = backup.finalize()?;
+    Ok((true, session))
 }
 
 /// Generalized cross-file mutation helper (for rename and md cross-file moves).
 ///
 /// Handles guard checks and backup for src (and optional dst).
 /// Centralizes the cross-file guard and backup logic.
+/// Returns `(applied, backup_session)`.
 fn apply_cross_file_mutation(
     src: &Path,
     dst: Option<&Path>,
@@ -421,9 +444,9 @@ fn apply_cross_file_mutation(
     guard: Option<&PathGuard>,
     prepare_backup: impl FnOnce(&mut BackupSession) -> anyhow::Result<()>,
     perform_mutation: impl FnOnce() -> anyhow::Result<()>,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<(bool, Option<String>)> {
     if mode != ApplyMode::Apply {
-        return Ok(false);
+        return Ok((false, None));
     }
     ensure_contained(guard, src)?;
     if let Some(d) = dst {
@@ -433,17 +456,18 @@ fn apply_cross_file_mutation(
     let mut backup = BackupSession::new(cwd)?;
     prepare_backup(&mut backup)?;
     perform_mutation()?;
-    backup.finalize()?;
-    Ok(true)
+    let session = backup.finalize()?;
+    Ok((true, session))
 }
 
-fn write_if_apply(
+/// Write content on Apply. Returns `(applied, backup_session)`.
+pub(crate) fn write_if_apply(
     path: &Path,
     new_content: &str,
     mode: ApplyMode,
     policy: &WritePolicy,
     guard: Option<&PathGuard>,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<(bool, Option<String>)> {
     apply_mutation(
         path,
         mode,
@@ -451,6 +475,28 @@ fn write_if_apply(
         |backup| backup.save_before_write(path),
         || atomic_write(path, new_content, policy),
     )
+}
+
+/// Run optional post-write hooks after a successful Apply (#1690).
+pub(crate) fn maybe_post_write(
+    applied: bool,
+    path: &Path,
+    hooks: Option<&PostWriteHooks>,
+    hooks_cwd: Option<&Path>,
+    backup_session: Option<&str>,
+) -> anyhow::Result<()> {
+    if !applied {
+        return Ok(());
+    }
+    let Some(hooks) = hooks else {
+        return Ok(());
+    };
+    let root = hooks_cwd.unwrap_or_else(|| path.parent().unwrap_or_else(|| Path::new(".")));
+    if let Some(ts) = backup_session {
+        run_post_write_validation_with_session(root, path, hooks, Some(ts))
+    } else {
+        run_post_write_validation(root, path, hooks)
+    }
 }
 
 /// Private helper to centralize the guard check and eliminate duplicated
@@ -491,6 +537,7 @@ pub(crate) fn build_edit_result(
         removed: 0,
         match_mode: None,
         match_score: None,
+        backup_session: None,
     }
 }
 
@@ -616,16 +663,17 @@ fn execution_result_to_edit_result(
             (String::new(), String::new(), String::new())
         };
 
-    // Commit for Apply mode.
-    let applied = if mode == ApplyMode::Apply && has_changes {
-        result.commit()?;
-        true
+    // Commit for Apply mode; capture backup session for embedder undo (#1686).
+    let (applied, backup_session) = if mode == ApplyMode::Apply && has_changes {
+        let session = result.commit()?;
+        (true, session)
     } else {
-        false
+        (false, None)
     };
 
     let mut edit = build_edit_result(&path_str, original, new_content, applied, action, dest_path);
     edit.removed = removed;
+    edit.backup_session = backup_session;
     // Thread replace honesty from the engine (#1674 / #1662).
     if let Some(meta) = replace_meta {
         edit.match_mode = Some(meta.mode);

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -81,15 +81,14 @@ fn patch_write(
         })?;
 
         let policy = crate::write::WritePolicy::default();
-        let applied = super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
-        Ok(super::build_edit_result(
-            &pf.path,
-            original,
-            new_content,
-            applied,
-            "patch",
-            None,
-        ))
+        let (applied, backup_session) =
+            super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
+        {
+            let mut __e =
+                super::build_edit_result(&pf.path, original, new_content, applied, "patch", None);
+            __e.backup_session = backup_session;
+            Ok(__e)
+        }
     } else {
         anyhow::bail!("expected PatchApply operation")
     }
@@ -131,15 +130,12 @@ pub fn apply_patch_file(
         })?;
 
         let policy = crate::write::WritePolicy::default();
-        let applied = super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
-        results.push(super::build_edit_result(
-            &pf.path,
-            original,
-            new_content,
-            applied,
-            "patch",
-            None,
-        ));
+        let (applied, backup_session) =
+            super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
+        let mut edit =
+            super::build_edit_result(&pf.path, original, new_content, applied, "patch", None);
+        edit.backup_session = backup_session;
+        results.push(edit);
     }
     Ok(results)
 }

--- a/src/api/post_write.rs
+++ b/src/api/post_write.rs
@@ -46,6 +46,18 @@ pub fn run_post_write_validation(
     path: &Path,
     hooks: &PostWriteHooks,
 ) -> anyhow::Result<()> {
+    run_post_write_validation_with_session(project_root, path, hooks, None)
+}
+
+/// Like [`run_post_write_validation`], but reverts via a specific backup session
+/// when `backup_session` is `Some` (#1686 / #1690). Falls back to latest-session
+/// restore when `None`.
+pub fn run_post_write_validation_with_session(
+    project_root: &Path,
+    path: &Path,
+    hooks: &PostWriteHooks,
+    backup_session: Option<&str>,
+) -> anyhow::Result<()> {
     let timeout = hooks.timeout_secs.unwrap_or(30);
     for (label, cmd) in [
         ("format", hooks.format_cmd.as_deref()),
@@ -58,7 +70,12 @@ pub fn run_post_write_validation(
             if hooks.on_failure == PostWriteOnFailure::Revert {
                 // Surface restore failure: silent Ok(false)/Err left the file
                 // mutated while the host only saw the format error.
-                match restore_path_from_latest_backup(project_root, path) {
+                let restore = if let Some(ts) = backup_session {
+                    crate::backup::restore_path_from_session(project_root, ts, path)
+                } else {
+                    restore_path_from_latest_backup(project_root, path)
+                };
+                match restore {
                     Ok(true) => {}
                     Ok(false) => {
                         return Err(FormatFailedError {

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -63,7 +63,7 @@ pub fn replace_text(
         })?;
         let content_result = replace_in_content(&original, from, to, opts)?;
         let policy = crate::write::WritePolicy::default();
-        let applied =
+        let (applied, backup_session) =
             super::write_if_apply(path, &content_result.new_content, mode, &policy, guard)?;
         let path_str = path.to_string_lossy();
         let mut result = super::build_edit_result(
@@ -77,6 +77,14 @@ pub fn replace_text(
         result.match_count = content_result.match_count;
         result.match_mode = content_result.match_mode;
         result.match_score = content_result.match_score;
+        result.backup_session = backup_session.clone();
+        super::maybe_post_write(
+            applied,
+            path,
+            opts.post_write.as_ref(),
+            opts.post_write_cwd.as_deref(),
+            backup_session.as_deref(),
+        )?;
         return Ok(result);
     }
 
@@ -102,6 +110,7 @@ pub fn replace_text(
         require_change: false,
         command_position: opts.command_position,
         fuzzy: false,
+        min_fuzzy_score: opts.min_fuzzy_score,
     };
     let mut result = replace_write(op, path, mode, guard, opts.fuzzy)?;
     // if_exists intentionally softens zero-match (Ok unchanged). require_change
@@ -126,6 +135,14 @@ pub fn replace_text(
             result.match_count = 1;
         }
     }
+    // Post-Apply format/lint hooks (#1690).
+    super::maybe_post_write(
+        result.applied,
+        path,
+        opts.post_write.as_ref(),
+        opts.post_write_cwd.as_deref(),
+        result.backup_session.as_deref(),
+    )?;
     Ok(result)
 }
 
@@ -170,6 +187,7 @@ fn replace_write(
         unique,
         before_context,
         after_context,
+        min_fuzzy_score,
         ..
     } = op
     {
@@ -250,7 +268,8 @@ fn replace_write(
                     &original[target_offset + old.len()..],
                 );
                 let policy = crate::write::WritePolicy::default();
-                let applied = super::write_if_apply(path, &ctx_content, mode, &policy, guard)?;
+                let (applied, backup_session) =
+                    super::write_if_apply(path, &ctx_content, mode, &policy, guard)?;
                 let mut result = super::build_edit_result(
                     &path_str,
                     original,
@@ -261,6 +280,7 @@ fn replace_write(
                 );
                 result.match_count = 1;
                 result.match_mode = Some(MatchMode::Anchored);
+                result.backup_session = backup_session;
                 return Ok(result);
             }
         }
@@ -292,6 +312,22 @@ fn replace_write(
                 after_context.as_deref(),
             ) {
                 Ok(anchor) => {
+                    let (match_mode, default_score) =
+                        super::match_mode_from_strategy(anchor.strategy);
+                    let score = anchor.score.or(default_score);
+                    if match_mode == MatchMode::Fuzzy
+                        && let Some(min) = min_fuzzy_score
+                        && score.is_some_and(|s| s < min)
+                    {
+                        let actual = score
+                            .map(|s| format!("{s:.3}"))
+                            .unwrap_or_else(|| "?".into());
+                        return Err(anyhow::Error::new(crate::exit::NoMatchError {
+                            msg: format!(
+                                "fuzzy match score {actual} below min_fuzzy_score {min} for {old:?}"
+                            ),
+                        }));
+                    }
                     let to_text = if let Some(ib) = &insert_before {
                         format!("{}{}", ib, anchor.matched_text)
                     } else if let Some(ia) = &insert_after {
@@ -306,14 +342,15 @@ fn replace_write(
                         &original[anchor.start_offset + anchor.matched_text.len()..],
                     );
                     let policy = crate::write::WritePolicy::default();
-                    let applied = super::write_if_apply(path, &fb_content, mode, &policy, guard)?;
+                    let (applied, backup_session) =
+                        super::write_if_apply(path, &fb_content, mode, &policy, guard)?;
                     let mut result = super::build_edit_result(
                         &path_str, original, fb_content, applied, "replace", None,
                     );
                     result.match_count = 1;
-                    let (mode, default_score) = super::match_mode_from_strategy(anchor.strategy);
-                    result.match_mode = Some(mode);
-                    result.match_score = anchor.score.or(default_score);
+                    result.match_mode = Some(match_mode);
+                    result.match_score = score;
+                    result.backup_session = backup_session;
                     return Ok(result);
                 }
                 Err(edit_error) => {
@@ -352,13 +389,15 @@ fn replace_write(
         }
 
         let policy = crate::write::WritePolicy::default();
-        let applied = super::write_if_apply(path, &new_content, mode, &policy, guard)?;
+        let (applied, backup_session) =
+            super::write_if_apply(path, &new_content, mode, &policy, guard)?;
         let mut result =
             super::build_edit_result(&path_str, original, new_content, applied, "replace", None);
         result.match_count = count;
         if count > 0 {
             result.match_mode = Some(MatchMode::Exact);
         }
+        result.backup_session = backup_session;
         Ok(result)
     } else {
         bail!("expected Replace operation")
@@ -516,6 +555,24 @@ pub fn replace_in_content(
             opts.after_context.as_deref(),
         ) {
             Ok(anchor) => {
+                let (mode, default_score) = super::match_mode_from_strategy(anchor.strategy);
+                let score = anchor.score.or(default_score);
+                if mode == super::MatchMode::Fuzzy
+                    && let Some(min) = opts.min_fuzzy_score
+                    && score.is_some_and(|s| s < min)
+                {
+                    let actual = score
+                        .map(|s| format!("{s:.3}"))
+                        .unwrap_or_else(|| "?".into());
+                    return Err(crate::fallback::EditError::new(
+                        crate::fallback::EditErrorKind::NoMatch,
+                        format!(
+                            "fuzzy match score {actual} below min_fuzzy_score {min} for {:?}",
+                            from
+                        ),
+                    )
+                    .into());
+                }
                 let to_text = if let Some(ib) = &opts.insert_before {
                     format!("{}{}", ib, anchor.matched_text)
                 } else if let Some(ia) = &opts.insert_after {
@@ -530,7 +587,6 @@ pub fn replace_in_content(
                     &content[anchor.start_offset + anchor.matched_text.len()..]
                 );
                 let diff = super::make_diff("<content>", content, &fuzzy_content);
-                let (mode, default_score) = super::match_mode_from_strategy(anchor.strategy);
                 return Ok(ContentEditResult {
                     original: content.to_string(),
                     new_content: fuzzy_content,
@@ -538,7 +594,7 @@ pub fn replace_in_content(
                     changed: true,
                     match_count: 1,
                     match_mode: Some(mode),
-                    match_score: anchor.score.or(default_score),
+                    match_score: score,
                 });
             }
             Err(edit_error) => {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -867,6 +867,7 @@ fn make_write_policy_maps_options() {
         normalize_eol: Some(EolMode::Lf),
         trim_trailing_whitespace: true,
         collapse_blanks: true,
+        ..Default::default()
     };
     let policy = make_write_policy(&opts);
     assert!(policy.ensure_final_newline);
@@ -2479,6 +2480,7 @@ fn adapter_unchanged_returns_no_diff() {
         require_change: false,
         command_position: false,
         fuzzy: false,
+        min_fuzzy_score: None,
     };
 
     let result =
@@ -2880,6 +2882,7 @@ fn replace_in_content_fuzzy_resolves_typo() {
     let content = "fn setup() {}\nfn process_data(x: i32) {}\nfn cleanup() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         ..Default::default()
     };
     let result = replace::replace_in_content(
@@ -2909,6 +2912,7 @@ fn replace_in_content_fuzzy_exact_match_preferred() {
     let content = "fn hello() {}\nfn world() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         ..Default::default()
     };
     let result =
@@ -2924,6 +2928,7 @@ fn replace_in_content_fuzzy_no_match_returns_error_with_hints() {
     let content = "fn alpha() {}\nfn beta() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         ..Default::default()
     };
     let err = replace::replace_in_content(
@@ -2946,6 +2951,7 @@ fn replace_in_content_fuzzy_with_if_exists_suppresses_error() {
     let content = "fn alpha() {}\nfn beta() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         if_exists: true,
         ..Default::default()
     };
@@ -2982,6 +2988,7 @@ fn replace_in_content_fuzzy_not_applied_in_regex_mode() {
     let content = "fn process_data() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         regex: true,
         ..Default::default()
     };
@@ -3001,6 +3008,7 @@ fn replace_in_content_fuzzy_with_unique() {
     let content = "fn setup() {}\nfn process_data(x: i32) {}\nfn cleanup() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         unique: true,
         ..Default::default()
     };
@@ -3022,6 +3030,7 @@ fn replace_in_content_fuzzy_with_insert_before() {
     let content = "fn process_data() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         insert_before: Some("// TODO: refactor\n".to_string()),
         ..Default::default()
     };
@@ -3050,6 +3059,7 @@ fn replace_in_content_fuzzy_with_insert_after() {
     let content = "fn process_data() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         insert_after: Some("\n// end".to_string()),
         ..Default::default()
     };
@@ -3068,6 +3078,7 @@ fn replace_in_content_fuzzy_uses_before_context() {
     let content = "fn alpha() {}\nfn proccess_data() {}\nfn beta() {}\nfn proccess_data() {}\nfn gamma() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         before_context: Some("fn beta()".to_string()),
         ..Default::default()
     };
@@ -3089,6 +3100,7 @@ fn replace_in_content_fuzzy_uses_after_context() {
     let content = "fn alpha() {}\nfn proccess_data() {}\nfn beta() {}\nfn proccess_data() {}\nfn gamma() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         after_context: Some("fn beta()".to_string()),
         ..Default::default()
     };
@@ -3449,6 +3461,7 @@ fn replace_in_content_unicode_fuzzy() {
     let content = "fn процесс_данных() {}\n";
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         ..Default::default()
     };
     let result = replace::replace_in_content(
@@ -3622,6 +3635,7 @@ fn replace_text_fuzzy_with_context_any_path() {
 
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         before_context: Some("fn setup()".to_string()),
         ..Default::default()
     };
@@ -3651,6 +3665,7 @@ fn replace_text_fuzzy_with_if_exists_any_path() {
 
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         if_exists: true,
         before_context: Some("fn alpha()".to_string()),
         ..Default::default()
@@ -4121,6 +4136,7 @@ fn replace_in_content_command_position_rejects_word_boundary_and_fuzzy() {
             ReplaceOptions {
                 command_position: true,
                 fuzzy: true,
+                min_fuzzy_score: None,
                 ..Default::default()
             },
         ),
@@ -4346,6 +4362,7 @@ fn ast_rename_batch_two_files_success() {
         mode: ApplyMode::Apply,
         continue_on_no_match: true,
         fail_fast: false,
+        ..Default::default()
     };
     let results = ast_rename_batch(&[&a, &b], "foo", "bar", &opts, None).unwrap();
     assert_eq!(results.len(), 2);
@@ -4437,6 +4454,7 @@ fn ast_rename_batch_fail_fast_stops_after_hard_error() {
         mode: ApplyMode::Apply,
         continue_on_no_match: true,
         fail_fast: true,
+        ..Default::default()
     };
     // Process good first (ok), then outside (guard), then after must not run.
     let results = ast_rename_batch(
@@ -4479,6 +4497,7 @@ fn ast_rename_batch_continue_on_no_match_false_stops() {
         mode: ApplyMode::Apply,
         continue_on_no_match: false,
         fail_fast: false,
+        ..Default::default()
     };
     let results = ast_rename_batch(&[&miss, &after], "foo", "bar", &opts, None).unwrap();
     assert_eq!(
@@ -4547,6 +4566,7 @@ fn ast_rename_batch_guard_rejects_outside() {
         mode: ApplyMode::Apply,
         continue_on_no_match: false,
         fail_fast: false,
+        ..Default::default()
     };
     let results = ast_rename_batch(&[&outside], "foo", "bar", &opts, Some(&guard)).unwrap();
     assert_eq!(results.len(), 1);
@@ -4767,6 +4787,7 @@ fn match_mode_exact_fuzzy_and_anchored() {
         "fn process_data() {}",
         &ReplaceOptions {
             fuzzy: true,
+            min_fuzzy_score: None,
             ..Default::default()
         },
     )
@@ -4810,6 +4831,7 @@ fn replace_text_pure_fuzzy_without_context() {
     fs::write(&file, "fn process_data() {}\n").unwrap();
     let opts = ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         require_change: true,
         ..Default::default()
     };
@@ -5053,4 +5075,316 @@ fn replace_text_exact_disk_multi_match_count() {
     assert!(r.changed);
     assert_eq!(r.match_count, 3, "multi exact match_count: {:?}", r);
     assert_eq!(r.match_mode, Some(MatchMode::Exact));
+}
+
+// ---------------------------------------------------------------------------
+// Agent-host APIs #1686–#1690
+// ---------------------------------------------------------------------------
+
+/// #1686: Apply replace reports backup_session; restore_path_from_session works.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn edit_result_backup_session_enables_surgical_restore() {
+    use crate::backup::restore_path_from_session;
+
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("note.txt");
+    fs::write(&file, "hello world\n").unwrap();
+
+    let r = replace_text(
+        &file,
+        "world",
+        "patchloom",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(r.applied);
+    assert!(r.changed);
+    let session = r
+        .backup_session
+        .as_deref()
+        .expect("Apply must report backup_session (#1686)");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello patchloom\n");
+
+    // Preview must not create a session.
+    let preview = replace_text(
+        &file,
+        "patchloom",
+        "again",
+        &ReplaceOptions::default(),
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(preview.backup_session.is_none());
+
+    let cwd = file.parent().unwrap();
+    assert!(
+        restore_path_from_session(cwd, session, &file).unwrap(),
+        "restore via reported session"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello world\n");
+}
+
+/// #1687: min_fuzzy_score rejects low-confidence fuzzy; exact still wins.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn min_fuzzy_score_rejects_weak_fuzzy_allows_exact() {
+    let content = "fn process_request(data: &str) -> Result<()> {\n    Ok(())\n}\n";
+    let misspelled = "fn process_requets(data: &str) -> Result<()> {";
+
+    // First measure the natural fuzzy score, then set a floor just above it.
+    let probe = replace_in_content(
+        content,
+        misspelled,
+        "REPLACED",
+        &ReplaceOptions {
+            fuzzy: true,
+            ..Default::default()
+        },
+    )
+    .expect("unfloored fuzzy should match");
+    assert_eq!(probe.match_mode, Some(MatchMode::Fuzzy));
+    let natural = probe.match_score.expect("fuzzy score");
+    assert!(
+        natural > 0.85,
+        "similarity path requires >0.85, got {natural}"
+    );
+
+    let strict = ReplaceOptions {
+        fuzzy: true,
+        min_fuzzy_score: Some(natural + 0.01),
+        ..Default::default()
+    };
+    let err = replace_in_content(content, misspelled, "REPLACED", &strict).unwrap_err();
+    assert_eq!(
+        edit_error_kind(&err),
+        Some(EditErrorKind::NoMatch),
+        "weak fuzzy must be NoMatch: {err}"
+    );
+    assert!(
+        err.to_string().contains("min_fuzzy_score"),
+        "message should name the floor: {err}"
+    );
+
+    // Floor at or below natural score allows the same fuzzy match.
+    let loose = ReplaceOptions {
+        fuzzy: true,
+        min_fuzzy_score: Some(natural),
+        ..Default::default()
+    };
+    let ok = replace_in_content(content, misspelled, "REPLACED {", &loose).unwrap();
+    assert!(ok.changed);
+    assert_eq!(ok.match_mode, Some(MatchMode::Fuzzy));
+    assert!(ok.match_score.is_some_and(|s| s >= natural - 1e-9));
+
+    // Exact match is unaffected by a high floor.
+    let exact_opts = ReplaceOptions {
+        fuzzy: true,
+        min_fuzzy_score: Some(1.0),
+        ..Default::default()
+    };
+    let exact = replace_in_content("alpha beta gamma\n", "beta", "BETA", &exact_opts).unwrap();
+    assert!(exact.changed);
+    assert_eq!(exact.match_mode, Some(MatchMode::Exact));
+    assert!(exact.new_content.contains("BETA"));
+}
+
+/// #1688: nested monorepo backups found by list_sessions_under.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn list_sessions_under_finds_nested_backup_roots() {
+    use crate::backup::{ListSessionsOptions, list_sessions, list_sessions_under};
+
+    let workspace = TempDir::new().unwrap();
+    let crate_dir = workspace.path().join("crates").join("foo");
+    fs::create_dir_all(&crate_dir).unwrap();
+    let file = crate_dir.join("lib.txt");
+    fs::write(&file, "old\n").unwrap();
+
+    let r = replace_text(
+        &file,
+        "old",
+        "new",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(r.backup_session.is_some());
+
+    // Workspace-root list is empty (session lives under file parent).
+    let root_sessions = list_sessions(workspace.path()).unwrap();
+    assert!(
+        root_sessions.is_empty(),
+        "workspace list_sessions should miss nested root: {root_sessions:?}"
+    );
+
+    let listings = list_sessions_under(
+        workspace.path(),
+        &ListSessionsOptions {
+            descendants: true,
+            max_depth: Some(8),
+            ancestors: false,
+        },
+    )
+    .unwrap();
+    assert!(
+        !listings.is_empty(),
+        "list_sessions_under must find nested sessions"
+    );
+    let found = listings.iter().any(|l| {
+        l.sessions
+            .iter()
+            .any(|s| Some(&s.timestamp) == r.backup_session.as_ref())
+    });
+    assert!(
+        found,
+        "reported session must appear in nested listing: {listings:?}"
+    );
+}
+
+/// #1689: ast_rename_project discovers + renames without a path list.
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_project_discovers_and_renames() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.rs");
+    let b = dir.path().join("b.rs");
+    let empty = dir.path().join("empty.rs");
+    fs::write(&a, "struct OldType {}\n").unwrap();
+    fs::write(&b, "fn use_it(x: OldType) {}\n").unwrap();
+    fs::write(&empty, "fn other() {}\n").unwrap();
+
+    let report = ast_rename_project(
+        dir.path(),
+        "OldType",
+        "NewType",
+        &AstRenameProjectOptions {
+            search: SymbolSearchOptions::default(),
+            rename: AstRenameBatchOptions {
+                mode: ApplyMode::Apply,
+                ..Default::default()
+            },
+        },
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        report.paths_considered.len(),
+        2,
+        "{:?}",
+        report.paths_considered
+    );
+    assert!(
+        report.results.iter().all(|r| r.result.is_ok()),
+        "rename results: {:?}",
+        report.results
+    );
+    assert!(fs::read_to_string(&a).unwrap().contains("NewType"));
+    assert!(fs::read_to_string(&b).unwrap().contains("NewType"));
+    assert!(!fs::read_to_string(&empty).unwrap().contains("NewType"));
+
+    let err = ast_rename_project(
+        dir.path(),
+        "DoesNotExistAnywhere",
+        "X",
+        &AstRenameProjectOptions::default(),
+        None,
+    )
+    .unwrap_err();
+    assert_eq!(edit_error_kind(&err), Some(EditErrorKind::NoMatch));
+}
+
+/// #1690: post_write hooks on replace Apply; Preview skips hooks; fail reverts.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn post_write_hooks_on_replace_apply_and_preview() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("x.txt");
+    fs::write(&file, "before\n").unwrap();
+
+    // Preview must not run hooks (failing command would error).
+    let preview_opts = ReplaceOptions {
+        post_write: Some(PostWriteHooks {
+            format_cmd: Some("false".into()),
+            on_failure: PostWriteOnFailure::KeepWithError,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let preview = replace_text(
+        &file,
+        "before",
+        "after",
+        &preview_opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .unwrap();
+    assert!(!preview.applied);
+    assert_eq!(fs::read_to_string(&file).unwrap(), "before\n");
+
+    // Apply + success hook.
+    let ok_opts = ReplaceOptions {
+        post_write: Some(PostWriteHooks {
+            format_cmd: Some("true".into()),
+            on_failure: PostWriteOnFailure::KeepWithError,
+            ..Default::default()
+        }),
+        post_write_cwd: Some(dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let ok = replace_text(&file, "before", "after", &ok_opts, ApplyMode::Apply, None).unwrap();
+    assert!(ok.applied);
+    assert!(ok.backup_session.is_some());
+    assert_eq!(fs::read_to_string(&file).unwrap(), "after\n");
+
+    // Apply + failing hook with Revert restores prior content.
+    fs::write(&file, "v1\n").unwrap();
+    let fail_opts = ReplaceOptions {
+        post_write: Some(PostWriteHooks {
+            format_cmd: Some("false".into()),
+            on_failure: PostWriteOnFailure::Revert,
+            ..Default::default()
+        }),
+        post_write_cwd: Some(dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let err = replace_text(&file, "v1", "v2", &fail_opts, ApplyMode::Apply, None).unwrap_err();
+    assert_eq!(
+        edit_error_kind(&err),
+        Some(EditErrorKind::FormatFailed),
+        "{err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "v1\n",
+        "Revert must restore pre-edit content"
+    );
+}
+
+/// #1690: tidy honors WritePolicyOptions.post_write.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn tidy_post_write_hooks_on_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("messy.txt");
+    fs::write(&file, "line  \n").unwrap();
+
+    let opts = WritePolicyOptions {
+        trim_trailing_whitespace: true,
+        post_write: Some(PostWriteHooks {
+            format_cmd: Some("true".into()),
+            ..Default::default()
+        }),
+        post_write_cwd: Some(dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let r = tidy(&file, &opts, ApplyMode::Apply, None).unwrap();
+    assert!(r.applied);
+    assert!(r.changed);
+    assert_eq!(fs::read_to_string(&file).unwrap(), "line\n");
 }

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -69,7 +69,16 @@ pub fn tidy_with_indent(
         indent: indent_opts.indent.clone(),
         lines: indent_opts.lines.clone(),
     };
-    tidy_write(op, path, mode, guard)
+    let result = tidy_write(op, path, mode, guard)?;
+    // Optional post-Apply format/lint hooks from WritePolicyOptions (#1690).
+    super::maybe_post_write(
+        result.applied,
+        path,
+        policy_opts.post_write.as_ref(),
+        policy_opts.post_write_cwd.as_deref(),
+        result.backup_session.as_deref(),
+    )?;
+    Ok(result)
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -138,15 +147,14 @@ fn tidy_write(
         }
 
         let noop_policy = crate::write::WritePolicy::default();
-        let applied = super::write_if_apply(path, &new_content, mode, &noop_policy, guard)?;
-        Ok(super::build_edit_result(
-            &path_str,
-            original,
-            new_content,
-            applied,
-            "tidy",
-            None,
-        ))
+        let (applied, backup_session) =
+            super::write_if_apply(path, &new_content, mode, &noop_policy, guard)?;
+        {
+            let mut __e =
+                super::build_edit_result(&path_str, original, new_content, applied, "tidy", None);
+            __e.backup_session = backup_session;
+            Ok(__e)
+        }
     } else {
         anyhow::bail!("expected TidyFix operation")
     }

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -40,7 +40,7 @@ pub enum FileAction {
 }
 
 /// The manifest for a backup session.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Manifest {
     pub timestamp: String,
     pub entries: Vec<ManifestEntry>,
@@ -282,6 +282,134 @@ pub fn list_sessions(project_root: &Path) -> anyhow::Result<Vec<Manifest>> {
     }
 
     Ok(sessions)
+}
+
+/// Options for [`list_sessions_under`] (#1688).
+#[derive(Debug, Clone)]
+pub struct ListSessionsOptions {
+    /// Also search ancestor directories of `project_root` for `.patchloom/backups`.
+    pub ancestors: bool,
+    /// Also search descendants for nested `.patchloom/backups` (default true).
+    pub descendants: bool,
+    /// Max directory depth for descendant walks (default 8).
+    pub max_depth: Option<usize>,
+}
+
+impl Default for ListSessionsOptions {
+    fn default() -> Self {
+        Self {
+            ancestors: false,
+            descendants: true,
+            max_depth: Some(8),
+        }
+    }
+}
+
+/// One backup root plus its sessions (newest first), for nested monorepo layouts (#1688).
+#[derive(Debug, Clone)]
+pub struct SessionListing {
+    /// Directory that contains `.patchloom/backups` (the project root for that tree).
+    pub project_root: PathBuf,
+    /// Sessions under that root, newest first.
+    pub sessions: Vec<Manifest>,
+}
+
+/// List backup sessions under `project_root`, optionally walking nested crates.
+///
+/// Library Apply stores sessions under each file's parent tree, so monorepo
+/// edits may create `crates/foo/.patchloom/backups/` while the workspace root
+/// only has its own backups. Agent hosts use this helper instead of
+/// reimplementing nested discovery.
+pub fn list_sessions_under(
+    project_root: &Path,
+    opts: &ListSessionsOptions,
+) -> anyhow::Result<Vec<SessionListing>> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+    roots.push(project_root.to_path_buf());
+
+    if opts.ancestors {
+        let mut cur = project_root.parent();
+        while let Some(p) = cur {
+            roots.push(p.to_path_buf());
+            cur = p.parent();
+        }
+    }
+
+    if opts.descendants {
+        let max_depth = opts.max_depth.unwrap_or(8);
+        collect_descendant_backup_roots(project_root, max_depth, 0, &mut roots)?;
+    }
+
+    // Dedupe while preserving order.
+    let mut seen = std::collections::HashSet::new();
+    let mut unique_roots = Vec::new();
+    for r in roots {
+        if seen.insert(r.clone()) {
+            unique_roots.push(r);
+        }
+    }
+
+    let mut out = Vec::new();
+    for root in unique_roots {
+        let sessions = list_sessions(&root)?;
+        if !sessions.is_empty() {
+            out.push(SessionListing {
+                project_root: root,
+                sessions,
+            });
+        }
+    }
+
+    // Global newest-first by first session timestamp when present.
+    out.sort_by(|a, b| {
+        let ta = a
+            .sessions
+            .first()
+            .map(|s| s.timestamp.as_str())
+            .unwrap_or("");
+        let tb = b
+            .sessions
+            .first()
+            .map(|s| s.timestamp.as_str())
+            .unwrap_or("");
+        tb.cmp(ta)
+    });
+    Ok(out)
+}
+
+fn collect_descendant_backup_roots(
+    dir: &Path,
+    max_depth: usize,
+    depth: usize,
+    out: &mut Vec<PathBuf>,
+) -> anyhow::Result<()> {
+    if depth >= max_depth {
+        return Ok(());
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Ok(());
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Skip heavy / VCS / backup dirs themselves.
+        if matches!(
+            name.as_ref(),
+            ".git" | "target" | "node_modules" | ".patchloom" | "dist" | "build" | ".venv"
+        ) {
+            continue;
+        }
+        let backup = path.join(BACKUP_DIR);
+        if backup.is_dir() {
+            out.push(path.clone());
+        }
+        collect_descendant_backup_roots(&path, max_depth, depth + 1, out)?;
+    }
+    Ok(())
 }
 
 /// Restore a single path from the most recent backup session that contains it.
@@ -1109,5 +1237,49 @@ mod tests {
         assert!(!ok, "basename-only match would restore the wrong path");
         assert_eq!(std::fs::read_to_string(&file_a).unwrap(), "A2");
         assert_eq!(std::fs::read_to_string(&file_b).unwrap(), "B");
+    }
+
+    /// #1688: list_sessions_under walks nested crate roots and skips heavy dirs.
+    #[test]
+    fn list_sessions_under_nested_and_depth_cap() {
+        let workspace = tempfile::TempDir::new().unwrap();
+        let nested = workspace.path().join("crates").join("pkg");
+        std::fs::create_dir_all(&nested).unwrap();
+        let file = nested.join("f.txt");
+        std::fs::write(&file, "x").unwrap();
+
+        let mut session = BackupSession::new(&nested).unwrap();
+        session.save_before_write(&file).unwrap();
+        let ts = session.finalize().unwrap().expect("session");
+
+        // Direct workspace list misses nested.
+        assert!(list_sessions(workspace.path()).unwrap().is_empty());
+
+        let listings = list_sessions_under(
+            workspace.path(),
+            &ListSessionsOptions {
+                descendants: true,
+                max_depth: Some(8),
+                ancestors: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(listings.len(), 1);
+        assert_eq!(listings[0].sessions[0].timestamp, ts);
+
+        // Depth 1 from workspace only sees `crates/`, not `crates/pkg`.
+        let shallow = list_sessions_under(
+            workspace.path(),
+            &ListSessionsOptions {
+                descendants: true,
+                max_depth: Some(1),
+                ancestors: false,
+            },
+        )
+        .unwrap();
+        assert!(
+            shallow.is_empty(),
+            "max_depth=1 should not reach crates/pkg: {shallow:?}"
+        );
     }
 }

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -183,6 +183,7 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
                 require_change: false,
                 command_position: false,
                 fuzzy: false,
+                min_fuzzy_score: None,
             })
         }
 

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -446,6 +446,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Replace "v1" with "v2" in README.md (literal)"#);
@@ -474,6 +475,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -605,6 +607,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert_eq!(
@@ -637,6 +640,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Insert "// added" after "use crate" in lib.rs"#);
@@ -665,6 +669,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("whole-line"), "{desc}");
@@ -779,6 +784,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -811,6 +817,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -842,6 +849,7 @@ mod tests {
             require_change: true,
             command_position: true,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert!(
@@ -874,6 +882,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains(", multiline"), "missing multiline: {desc}");
@@ -903,6 +912,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("**/*.rs"), "{desc}");
@@ -931,6 +941,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let desc = describe_operation(&op);
         assert!(desc.contains("(delete)"), "{desc}");

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -395,6 +395,7 @@ impl PatchloomService {
                 require_change: p.require_change,
                 command_position: p.command_position,
                 fuzzy: p.fuzzy,
+                min_fuzzy_score: p.min_fuzzy_score,
             };
             let mut tool_result = svc.run_one_op(replace_op, Some(p.strict))?;
 
@@ -545,6 +546,7 @@ impl PatchloomService {
                     require_change: p.require_change,
                     command_position: p.command_position,
                     fuzzy: p.fuzzy,
+                    min_fuzzy_score: p.min_fuzzy_score,
                 })
                 .collect();
             svc.run_ops(ops, Some(p.strict))

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -70,6 +70,9 @@ pub(crate) struct ReplaceParams {
     /// When exact match fails, try fuzzy/similarity fallback (#1668).
     #[serde(default)]
     pub fuzzy: bool,
+    /// Reject fuzzy matches below this similarity floor (#1687). `None` = no floor.
+    #[serde(default)]
+    pub min_fuzzy_score: Option<f64>,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,
@@ -264,6 +267,9 @@ pub(crate) struct BatchReplaceParams {
     /// When exact match fails, try fuzzy/similarity fallback (#1668).
     #[serde(default)]
     pub fuzzy: bool,
+    /// Reject fuzzy matches below this similarity floor (#1687). `None` = no floor.
+    #[serde(default)]
+    pub min_fuzzy_score: Option<f64>,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]
     pub strict: bool,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -726,6 +726,7 @@ fn run_context_replace(
                 require_change: args.require_change && file_paths.len() == 1,
                 command_position: args.command_position,
                 fuzzy: args.fuzzy,
+                min_fuzzy_score: None,
             }
         })
         .collect();
@@ -779,6 +780,9 @@ fn run_context_replace(
         after_context: args.after_context.clone(),
         require_change: false,
         command_position: args.command_position,
+        min_fuzzy_score: None,
+        post_write: None,
+        post_write_cwd: None,
     };
     let to = args.new.as_deref().unwrap_or("");
     let files: Vec<ReplaceFileResult> = result

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -124,14 +124,17 @@ fn commit_and_finalize(
         result.deletions.len(),
         ctx.strict
     );
-    if let Err(err) = crate::tx::commit_changes(
+    let _apply_backup_session = match crate::tx::commit_changes(
         &result.changes,
         &result.deletions,
         &result.existed_before,
         ctx.cwd,
     ) {
-        return handle_commit_error(err, ctx.structured, ctx.compact);
-    }
+        Ok(session) => session,
+        Err(err) => {
+            return handle_commit_error(err, ctx.structured, ctx.compact);
+        }
+    };
 
     if let Err(e) = run_format_command(global, ctx.cwd) {
         // The commit already succeeded; files are written but unformatted.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,14 @@
 //! CLI `--command-position`. Post-Apply validate/revert: use
 //! `api::run_post_write_validation` (#1663) or
 //! `backup::restore_path_from_session` / `restore_path_from_latest_backup` (#1660).
+//! After Apply, `EditResult.backup_session` names the session created for that
+//! write so hosts can call `restore_path_from_session` without re-listing
+//! backups (#1686). Nested monorepos: `backup::list_sessions_under` walks
+//! descendant `.patchloom/backups` roots (#1688). Fuzzy policy:
+//! `ReplaceOptions.min_fuzzy_score` rejects weak similarity matches (#1687).
+//! Project-wide rename: `api::ast_rename_project` (#1689). Post-Apply hooks:
+//! `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` / batch
+//! `AstRenameBatchOptions.post_write` (#1690).
 //!
 //! Match honesty for agents (#1662 / #1669 / #1674): `EditResult` /
 //! `ContentEditResult` / `ContentEditsResult` expose `match_mode`

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -67,6 +67,9 @@ pub enum Operation {
         /// Also enabled implicitly when before_context/after_context is set.
         #[serde(default)]
         fuzzy: bool,
+        /// Reject fuzzy matches below this score when set (#1687).
+        #[serde(default)]
+        min_fuzzy_score: Option<f64>,
     },
     #[serde(rename = "doc.set")]
     DocSet {

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -353,6 +353,7 @@ mod basic {
                     require_change: false,
                     command_position: false,
                     fuzzy: false,
+                    min_fuzzy_score: None,
                 },
             ),
             (

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -132,9 +132,11 @@ impl ExecutionResult {
     }
 
     /// Commit the staged changes to disk with backup.
-    pub fn commit(self) -> anyhow::Result<()> {
+    ///
+    /// Returns the backup session timestamp when a session was created.
+    pub fn commit(self) -> anyhow::Result<Option<String>> {
         if !self.has_changes {
-            return Ok(());
+            return Ok(None);
         }
         super::commit_changes(
             &self.exec_result.changes,

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -199,6 +199,7 @@ fn op_needs_doc_flush_for_replace() {
         require_change: false,
         command_position: false,
         fuzzy: false,
+        min_fuzzy_score: None,
     };
     assert!(op_needs_doc_flush(&op));
 }

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -70,12 +70,14 @@ pub(crate) fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
 ///
 /// If any write fails, restores all already-written files from the backup
 /// session before returning [`CommitError`].
+/// Finalize backup then write. Returns the backup session timestamp when a
+/// session was created (`None` if nothing was backed up).
 pub(crate) fn commit_changes(
     changes: &[(PathBuf, String, String)],
     deletions: &HashSet<PathBuf>,
     existed_before: &HashSet<PathBuf>,
     cwd: &Path,
-) -> Result<(), CommitError> {
+) -> Result<Option<String>, CommitError> {
     let mut backup = crate::backup::BackupSession::new(cwd)
         .map_err(|e| commit_error(format!("starting backup session: {e}")))?;
     for (path, _, _) in changes {
@@ -147,5 +149,5 @@ pub(crate) fn commit_changes(
         });
     }
 
-    Ok(())
+    Ok(backup_session)
 }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -195,20 +195,24 @@ pub fn execute_plan_direct(
     }
 
     // Apply: back up originals, write files.
-    if let Err(err) = commit_changes(
+    let apply_backup_session = match commit_changes(
         &result.changes,
         &result.deletions,
         &result.existed_before,
         &effective_cwd,
     ) {
-        let error_kind = if err.rollback_ok {
-            "rollback"
-        } else {
-            "rollback_failed"
-        };
-        let output = build_error_output(error_kind, &err.message, err.backup_session.as_deref());
-        return Ok(output);
-    }
+        Ok(session) => session,
+        Err(err) => {
+            let error_kind = if err.rollback_ok {
+                "rollback"
+            } else {
+                "rollback_failed"
+            };
+            let output =
+                build_error_output(error_kind, &err.message, err.backup_session.as_deref());
+            return Ok(output);
+        }
+    };
 
     // Snapshot non-tx files before format/validate steps so we can restore
     // collateral changes on strict rollback (#1111.7).
@@ -237,7 +241,10 @@ pub fn execute_plan_direct(
         return Ok(build_error_output(err.kind, &err.message, None));
     }
 
-    let output = build_full_tx_output("success", &mut result, &effective_cwd);
+    let mut output = build_full_tx_output("success", &mut result, &effective_cwd);
+    if output.backup_session.is_none() {
+        output.backup_session = apply_backup_session;
+    }
     Ok(output)
 }
 
@@ -368,6 +375,7 @@ mod tests {
                 require_change: false,
                 command_position: false,
                 fuzzy: false,
+                min_fuzzy_score: None,
             }],
             write_policy: None,
             strict: None,
@@ -725,6 +733,7 @@ mod tests {
                     require_change: true,
                     command_position: false,
                     fuzzy: true,
+                    min_fuzzy_score: None,
                 },
                 crate::plan::Operation::Replace {
                     glob: None,
@@ -747,6 +756,7 @@ mod tests {
                     require_change: true,
                     command_position: false,
                     fuzzy: false,
+                    min_fuzzy_score: None,
                 },
             ],
             write_policy: None,

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -89,6 +89,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         require_change,
         command_position,
         fuzzy,
+        min_fuzzy_score,
         ..
     } = op
     else {
@@ -235,6 +236,23 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 after_context.as_deref(),
             ) {
                 Ok(anchor) => {
+                    let (mode, default_score) =
+                        crate::api::match_mode_from_strategy(anchor.strategy);
+                    let score = anchor.score.or(default_score);
+                    // Reject weak fuzzy matches when host set a floor (#1687).
+                    if mode == MatchMode::Fuzzy
+                        && let Some(min) = min_fuzzy_score
+                        && score.is_some_and(|s| s < *min)
+                    {
+                        let actual = score
+                            .map(|s| format!("{s:.3}"))
+                            .unwrap_or_else(|| "?".into());
+                        tx.replace_hint = Some(format!(
+                            "fuzzy match score {actual} below min_fuzzy_score {min} for {:?}",
+                            crate::fallback::truncate_str(old, 60),
+                        ));
+                        return Ok(0);
+                    }
                     let to_text = if let Some(ib) = insert_before {
                         format!("{}{}", ib, anchor.matched_text)
                     } else if let Some(ia) = insert_after {
@@ -255,9 +273,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         &file_path,
                         new_content,
                     );
-                    let (mode, default_score) =
-                        crate::api::match_mode_from_strategy(anchor.strategy);
-                    record_replace_match(tx, &file_path, mode, anchor.score.or(default_score), 1);
+                    record_replace_match(tx, &file_path, mode, score, 1);
                     tx.replace_hint = Some(format!(
                         "fallback matched via {:?} strategy in {}",
                         anchor.strategy, p,
@@ -443,6 +459,16 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     after_context.as_deref(),
                 ) {
                     Ok(anchor) => {
+                        let (mode, default_score) =
+                            crate::api::match_mode_from_strategy(anchor.strategy);
+                        let score = anchor.score.or(default_score);
+                        if mode == MatchMode::Fuzzy
+                            && let Some(min) = min_fuzzy_score
+                            && score.is_some_and(|s| s < *min)
+                        {
+                            // Skip this file; keep scanning (require_change after loop).
+                            continue;
+                        }
                         let to_text = if let Some(ib) = insert_before {
                             format!("{}{}", ib, anchor.matched_text)
                         } else if let Some(ia) = insert_after {
@@ -463,15 +489,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             &file_path,
                             new_content,
                         );
-                        let (mode, default_score) =
-                            crate::api::match_mode_from_strategy(anchor.strategy);
-                        record_replace_match(
-                            tx,
-                            &file_path,
-                            mode,
-                            anchor.score.or(default_score),
-                            1,
-                        );
+                        record_replace_match(tx, &file_path, mode, score, 1);
                         total_matches += 1;
                     }
                     Err(_) => {
@@ -529,6 +547,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -566,6 +585,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -601,6 +621,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -638,6 +659,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -673,6 +695,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -717,6 +740,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -757,6 +781,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -809,6 +834,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -858,6 +884,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -903,6 +930,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -946,6 +974,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
 
         let mut f = TxStateFixture::new();
@@ -982,6 +1011,7 @@ mod tests {
             require_change: true,
             command_position: true,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
@@ -1017,11 +1047,64 @@ mod tests {
             require_change: true,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
         let err = execute_replace_op(&op, &mut tx).unwrap_err();
         assert!(err.to_string().contains("no matches"), "{err}");
+    }
+
+    #[test]
+    fn replace_min_fuzzy_score_rejects_weak_match() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("src.rs");
+        std::fs::write(
+            &file,
+            "fn process_request(data: &str) -> Result<()> {\n    Ok(())\n}\n",
+        )
+        .unwrap();
+
+        // Floor above any real similarity score so the match is always rejected.
+        let op = Operation::Replace {
+            path: Some("src.rs".into()),
+            glob: None,
+            regex: false,
+            old: "fn process_requets(data: &str) -> Result<()> {".into(),
+            new_text: Some("REPLACED".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            unique: false,
+            require_change: false,
+            command_position: false,
+            fuzzy: true,
+            min_fuzzy_score: Some(1.0),
+        };
+        let mut f = TxStateFixture::new();
+        let hint = {
+            let mut tx = f.state(dir.path());
+            let count = execute_replace_op(&op, &mut tx).unwrap();
+            assert_eq!(count, 0, "score floor must reject weak fuzzy");
+            tx.replace_hint.clone()
+        };
+        assert!(
+            f.write_targets.is_empty(),
+            "rejected fuzzy must not stage a write"
+        );
+        assert!(
+            hint.as_deref()
+                .is_some_and(|h| h.contains("min_fuzzy_score")),
+            "hint: {hint:?}"
+        );
     }
 
     #[test]
@@ -1051,6 +1134,7 @@ mod tests {
             require_change: true,
             command_position: false,
             fuzzy: true,
+            min_fuzzy_score: None,
         };
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
@@ -1095,6 +1179,7 @@ mod tests {
             require_change: true,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());
@@ -1133,6 +1218,7 @@ mod tests {
             require_change: true,
             command_position: false,
             fuzzy: true,
+            min_fuzzy_score: None,
         };
         let mut f = TxStateFixture::new();
         let mut tx = f.state(dir.path());

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -155,6 +155,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         }
     }
 
@@ -213,6 +214,7 @@ mod tests {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
         };
         let err = validate_operation(&op).unwrap_err();
         assert!(

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -533,6 +533,7 @@ mod tests {
                 require_change: false,
                 command_position: false,
                 fuzzy: false,
+                min_fuzzy_score: None,
             }],
             write_policy: None,
             format: None,


### PR DESCRIPTION
## Summary

Library and plan/MCP surfaces that agent hosts need after Apply, without reimplementing backup discovery, fuzzy policy, or post-write wiring.

- **#1686** `EditResult.backup_session` on successful Apply writes (tx/plan already had session on output)
- **#1687** `ReplaceOptions.min_fuzzy_score` / plan / MCP reject weak fuzzy matches; exact and anchored unchanged
- **#1688** `backup::list_sessions_under` walks nested `.patchloom/backups` roots with depth caps
- **#1689** `api::ast_rename_project` composes `find_files_with_symbol` + `ast_rename_batch`
- **#1690** `post_write` hooks on `ReplaceOptions`, `WritePolicyOptions` (tidy), and `AstRenameBatchOptions`, with session-aware revert

## Test plan

- [x] `make check-fast` green locally
- [x] Unit: backup_session + restore_path_from_session
- [x] Unit: min_fuzzy reject/allow + exact wins; tx replace_op floor
- [x] Unit: list_sessions_under nested + depth cap
- [x] Unit: ast_rename_project multi-file + zero discovery NoMatch
- [x] Unit: post_write Preview skip, Apply success, Revert restore; tidy hooks

Closes #1686
Closes #1687
Closes #1688
Closes #1689
Closes #1690