### PR TITLE
fix: post-write backup root, min_fuzzy validation, embedder docs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -37,13 +37,16 @@
 - `require_change`: error when the pattern matches zero times (fail closed).
 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
 - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
+- `min_fuzzy_score`: reject fuzzy matches below this floor (0.0..=1.0); exact/anchored unaffected (#1687).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
 **Library embedder undo / post-write (Rust hosts, not CLI-only):**
-- After `ApplyMode::Apply`, hosts can run validators then restore one path without shelling out to `undo`:
+- After `ApplyMode::Apply`, `EditResult.backup_session` is the session id for that write (#1686).
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
-- `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`
+- `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)
+- `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`
+- Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)
 **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674).
 
 Use patchloom when:

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1283,11 +1283,14 @@ The operations below are the building blocks inside `operations`.
 | Non-`anyhow` error kinds | `classify_error(&dyn Error)` / `classify_error_ref` (#1659); `EditErrorKind::FormatFailed` for post-write hooks |
 | Shell token rename | `ReplaceOptions.command_position` / `ContentEdit::Replace` (#1666) |
 | Scoped symbol replace (literal/regex) | `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (#1658) |
-| Project symbol discovery + multi-file rename | `find_files_with_symbol` then `ast_rename_batch` (#1664) |
+| Project symbol discovery + multi-file rename | `find_files_with_symbol` then `ast_rename_batch` (#1664); one-shot `ast_rename_project` (#1689) |
 | Match honesty (fuzzy confidence) | `EditResult` / `ContentEditsResult` `match_mode` / `match_score` (#1662); CLI/MCP JSON (#1669); plan/tx `TxChange` + aggregate mode/score/`match_count` from engine meta (#1674) |
+| Reject weak fuzzy matches | `ReplaceOptions.min_fuzzy_score` / plan `min_fuzzy_score` / MCP `min_fuzzy_score` (#1687); range `0.0..=1.0` |
+| Apply session id for surgical undo | `EditResult.backup_session` after Apply (#1686); pair with `restore_path_from_session` |
+| Nested monorepo backup listing | `backup::list_sessions_under` + `ListSessionsOptions` (#1688) |
 | In-memory multi-op with real diff headers | `apply_content_edits_with_label` (#1665) |
 | Surgical undo one path | `backup::restore_path_from_session(root, ts, path)` (#1660) |
-| Post-Apply format/lint + optional revert | `run_post_write_validation` / `PostWriteHooks` (#1663) |
+| Post-Apply format/lint + optional revert | `run_post_write_validation` / `PostWriteHooks` (#1663); also `ReplaceOptions.post_write`, `WritePolicyOptions.post_write`, `AstRenameBatchOptions.post_write` (#1690). Revert uses the file parent as backup root even when hooks cwd differs |
 | Signature rewrite complete in one write | `ast_rewrite_signature` body-gap invariant (#1661) |
 
 ### Shell command-position for embedders

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -182,11 +182,11 @@ fn post_write_from_edits(
     let mut hooks = None;
     let mut cwd = None;
     for e in edits {
-        if let ContentEdit::Replace { options, .. } = e {
-            if options.post_write.is_some() {
-                hooks = options.post_write.as_ref();
-                cwd = options.post_write_cwd.as_deref();
-            }
+        if let ContentEdit::Replace { options, .. } = e
+            && options.post_write.is_some()
+        {
+            hooks = options.post_write.as_ref();
+            cwd = options.post_write_cwd.as_deref();
         }
     }
     (hooks, cwd)

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -19,7 +19,9 @@ use std::path::Path;
 use crate::containment::PathGuard;
 
 #[cfg(any(feature = "cli", feature = "files"))]
-use super::{ApplyMode, EditResult, build_edit_result, write_if_apply};
+use super::{
+    ApplyMode, EditResult, PostWriteHooks, build_edit_result, maybe_post_write, write_if_apply,
+};
 
 #[cfg(any(feature = "cli", feature = "files"))]
 use crate::write::WritePolicy;
@@ -163,11 +165,31 @@ pub fn apply_content_edits_to_file(
         "content.edits",
         None,
     );
-    result.backup_session = backup_session;
+    result.backup_session = backup_session.clone();
     result.match_count = batch.match_count;
     result.match_mode = batch.match_mode;
     result.match_score = batch.match_score;
+    // Honor post_write from the last Replace edit that set hooks (#1690).
+    let (hooks, hooks_cwd) = post_write_from_edits(edits);
+    maybe_post_write(applied, path, hooks, hooks_cwd, backup_session.as_deref())?;
     Ok(result)
+}
+
+/// Last replace-side post_write wins (agent hosts set hooks once on the batch).
+fn post_write_from_edits(
+    edits: &[ContentEdit],
+) -> (Option<&PostWriteHooks>, Option<&std::path::Path>) {
+    let mut hooks = None;
+    let mut cwd = None;
+    for e in edits {
+        if let ContentEdit::Replace { options, .. } = e {
+            if options.post_write.is_some() {
+                hooks = options.post_write.as_ref();
+                cwd = options.post_write_cwd.as_deref();
+            }
+        }
+    }
+    (hooks, cwd)
 }
 
 /// Returns (new content, replace match_count, match_mode, match_score).

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -176,6 +176,7 @@ pub fn apply_content_edits_to_file(
 }
 
 /// Last replace-side post_write wins (agent hosts set hooks once on the batch).
+#[cfg(any(feature = "cli", feature = "files"))]
 fn post_write_from_edits(
     edits: &[ContentEdit],
 ) -> (Option<&PostWriteHooks>, Option<&std::path::Path>) {

--- a/src/api/post_write.rs
+++ b/src/api/post_write.rs
@@ -52,6 +52,10 @@ pub fn run_post_write_validation(
 /// Like [`run_post_write_validation`], but reverts via a specific backup session
 /// when `backup_session` is `Some` (#1686 / #1690). Falls back to latest-session
 /// restore when `None`.
+///
+/// `project_root` is the shell cwd for format/lint commands. Backup restore uses
+/// the **file parent** (where library Apply stores sessions), not `project_root`,
+/// so hosts can set `post_write_cwd` to a workspace root without breaking Revert.
 pub fn run_post_write_validation_with_session(
     project_root: &Path,
     path: &Path,
@@ -59,6 +63,9 @@ pub fn run_post_write_validation_with_session(
     backup_session: Option<&str>,
 ) -> anyhow::Result<()> {
     let timeout = hooks.timeout_secs.unwrap_or(30);
+    // Library Apply backs up under the file's parent (`write_if_apply`), which
+    // may differ from the host's hooks cwd (often the workspace root).
+    let backup_root = path.parent().unwrap_or(project_root);
     for (label, cmd) in [
         ("format", hooks.format_cmd.as_deref()),
         ("lint", hooks.lint_cmd.as_deref()),
@@ -71,9 +78,9 @@ pub fn run_post_write_validation_with_session(
                 // Surface restore failure: silent Ok(false)/Err left the file
                 // mutated while the host only saw the format error.
                 let restore = if let Some(ts) = backup_session {
-                    crate::backup::restore_path_from_session(project_root, ts, path)
+                    crate::backup::restore_path_from_session(backup_root, ts, path)
                 } else {
-                    restore_path_from_latest_backup(project_root, path)
+                    restore_path_from_latest_backup(backup_root, path)
                 };
                 match restore {
                     Ok(true) => {}

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -427,14 +427,14 @@ pub fn replace_in_content(
             msg: "empty search pattern".into(),
         }));
     }
-    if let Some(min) = opts.min_fuzzy_score {
-        if !(0.0..=1.0).contains(&min) || min.is_nan() {
-            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                msg: format!(
-                    "min_fuzzy_score must be in 0.0..=1.0 (got {min}); leave None for no floor"
-                ),
-            }));
-        }
+    if let Some(min) = opts.min_fuzzy_score
+        && (!(0.0..=1.0).contains(&min) || min.is_nan())
+    {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!(
+                "min_fuzzy_score must be in 0.0..=1.0 (got {min}); leave None for no floor"
+            ),
+        }));
     }
     if opts.range.is_some() && !opts.whole_line {
         return Err(anyhow::Error::new(crate::exit::InvalidInputError {

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -427,6 +427,15 @@ pub fn replace_in_content(
             msg: "empty search pattern".into(),
         }));
     }
+    if let Some(min) = opts.min_fuzzy_score {
+        if !(0.0..=1.0).contains(&min) || min.is_nan() {
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!(
+                    "min_fuzzy_score must be in 0.0..=1.0 (got {min}); leave None for no floor"
+                ),
+            }));
+        }
+    }
     if opts.range.is_some() && !opts.whole_line {
         return Err(anyhow::Error::new(crate::exit::InvalidInputError {
             msg: "range requires whole_line to be true".into(),

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -5152,22 +5152,29 @@ fn min_fuzzy_score_rejects_weak_fuzzy_allows_exact() {
         natural > 0.85,
         "similarity path requires >0.85, got {natural}"
     );
-
-    let strict = ReplaceOptions {
-        fuzzy: true,
-        min_fuzzy_score: Some(natural + 0.01),
-        ..Default::default()
-    };
-    let err = replace_in_content(content, misspelled, "REPLACED", &strict).unwrap_err();
-    assert_eq!(
-        edit_error_kind(&err),
-        Some(EditErrorKind::NoMatch),
-        "weak fuzzy must be NoMatch: {err}"
-    );
-    assert!(
-        err.to_string().contains("min_fuzzy_score"),
-        "message should name the floor: {err}"
-    );
+    // Strict floor just above natural, clamped to the valid 0.0..=1.0 range.
+    // When natural is already 1.0, any valid floor allows equality (score < min is false).
+    let strict_floor = (natural + 1e-4).clamp(0.0, 1.0);
+    if (strict_floor - natural).abs() < 1e-12 {
+        // Natural is effectively 1.0; only out-of-range floors would reject, which is InvalidInput.
+        // Covered by min_fuzzy_score_rejects_out_of_range.
+    } else {
+        let strict = ReplaceOptions {
+            fuzzy: true,
+            min_fuzzy_score: Some(strict_floor),
+            ..Default::default()
+        };
+        let err = replace_in_content(content, misspelled, "REPLACED", &strict).unwrap_err();
+        assert_eq!(
+            edit_error_kind(&err),
+            Some(EditErrorKind::NoMatch),
+            "weak fuzzy must be NoMatch: {err}"
+        );
+        assert!(
+            err.to_string().contains("min_fuzzy_score"),
+            "message should name the floor: {err}"
+        );
+    }
 
     // Floor at or below natural score allows the same fuzzy match.
     let loose = ReplaceOptions {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -5366,6 +5366,62 @@ fn post_write_hooks_on_replace_apply_and_preview() {
     );
 }
 
+/// #1690 regression: hooks cwd may be workspace root while backup lives under
+/// the file parent; Revert must still restore.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn post_write_revert_uses_file_parent_backup_root() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("pkg");
+    fs::create_dir_all(&nested).unwrap();
+    let file = nested.join("x.txt");
+    fs::write(&file, "v1\n").unwrap();
+
+    // Hooks run at workspace root; backup session is under nested/.
+    let fail_opts = ReplaceOptions {
+        post_write: Some(PostWriteHooks {
+            format_cmd: Some("false".into()),
+            on_failure: PostWriteOnFailure::Revert,
+            ..Default::default()
+        }),
+        post_write_cwd: Some(dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let err = replace_text(&file, "v1", "v2", &fail_opts, ApplyMode::Apply, None).unwrap_err();
+    assert_eq!(
+        edit_error_kind(&err),
+        Some(EditErrorKind::FormatFailed),
+        "{err}"
+    );
+    assert!(
+        !err.to_string().contains("also failed to revert"),
+        "session restore must find backup under file parent: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "v1\n",
+        "content restored despite hooks cwd != backup root"
+    );
+}
+
+/// #1687: out-of-range min_fuzzy_score is InvalidInput.
+#[test]
+fn min_fuzzy_score_rejects_out_of_range() {
+    for bad in [f64::NAN, -0.1, 1.5, 2.0] {
+        let opts = ReplaceOptions {
+            fuzzy: true,
+            min_fuzzy_score: Some(bad),
+            ..Default::default()
+        };
+        let err = replace_in_content("hello world\n", "helo", "hi", &opts).unwrap_err();
+        assert_eq!(
+            edit_error_kind(&err),
+            Some(EditErrorKind::InvalidInput),
+            "bad={bad} err={err}"
+        );
+    }
+}
+
 /// #1690: tidy honors WritePolicyOptions.post_write.
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -328,9 +328,17 @@ pub fn list_sessions_under(
     roots.push(project_root.to_path_buf());
 
     if opts.ancestors {
+        // Cap ancestor walk so hosts cannot accidentally walk to filesystem root
+        // on deep absolute paths (same budget as descendant max_depth default).
+        let ancestor_cap = opts.max_depth.unwrap_or(8).max(1);
         let mut cur = project_root.parent();
+        let mut walked = 0usize;
         while let Some(p) = cur {
+            if walked >= ancestor_cap {
+                break;
+            }
             roots.push(p.to_path_buf());
+            walked += 1;
             cur = p.parent();
         }
     }
@@ -1237,6 +1245,51 @@ mod tests {
         assert!(!ok, "basename-only match would restore the wrong path");
         assert_eq!(std::fs::read_to_string(&file_a).unwrap(), "A2");
         assert_eq!(std::fs::read_to_string(&file_b).unwrap(), "B");
+    }
+
+    /// #1688: ancestors walk is capped by max_depth (does not climb to FS root).
+    #[test]
+    fn list_sessions_under_ancestors_respects_max_depth() {
+        let deep = tempfile::TempDir::new().unwrap();
+        let nested = deep.path().join("a").join("b").join("c").join("d");
+        std::fs::create_dir_all(&nested).unwrap();
+        // Session only at the temp root (two levels above nested with cap=2).
+        let file = deep.path().join("top.txt");
+        std::fs::write(&file, "x").unwrap();
+        let mut session = BackupSession::new(deep.path()).unwrap();
+        session.save_before_write(&file).unwrap();
+        session.finalize().unwrap();
+
+        // From nested, max_depth=2 walks a/b then a (not deep root unless shallow enough).
+        let found = list_sessions_under(
+            &nested,
+            &ListSessionsOptions {
+                ancestors: true,
+                descendants: false,
+                max_depth: Some(2),
+            },
+        )
+        .unwrap();
+        // nested is deep/a/b/c/d → parents: c, b (cap 2). top session is at deep root.
+        assert!(
+            found.is_empty(),
+            "cap 2 from nested/d must not reach temp root: {found:?}"
+        );
+
+        let found_far = list_sessions_under(
+            &nested,
+            &ListSessionsOptions {
+                ancestors: true,
+                descendants: false,
+                max_depth: Some(8),
+            },
+        )
+        .unwrap();
+        // May include sibling host temp sessions above deep; require our root.
+        assert!(
+            found_far.iter().any(|l| l.project_root == deep.path()),
+            "cap 8 should reach temp root: {found_far:?}"
+        );
     }
 
     /// #1688: list_sessions_under walks nested crate roots and skips heavy dirs.

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -114,13 +114,16 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `require_change`: error when the pattern matches zero times (fail closed).\n\
              - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).\n\
              - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
+             - `min_fuzzy_score`: reject fuzzy matches below this floor (0.0..=1.0); exact/anchored unaffected (#1687).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
              \"command_position\":true,\"require_change\":true}`\n\n\
              **Library embedder undo / post-write (Rust hosts, not CLI-only):**\n\
-             - After `ApplyMode::Apply`, hosts can run validators then restore one path without shelling out to `undo`:\n\
+             - After `ApplyMode::Apply`, `EditResult.backup_session` is the session id for that write (#1686).\n\
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
-             - `api::run_post_write_validation(project_root, path, &PostWriteHooks { format_cmd, lint_cmd, on_failure: Revert|KeepWithError, .. })` (#1663) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
+             - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)\n\
+             - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
+             - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)\n\
              **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674).\n\n",
         );
     }

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -96,6 +96,17 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         anyhow::bail!("execute_replace_op called with non-Replace operation")
     };
     let regex_mode = *regex_mode;
+    if let Some(min) = min_fuzzy_score {
+        if !(0.0..=1.0).contains(min) || min.is_nan() {
+            return Err(crate::exit::InvalidInputError {
+                msg: format!(
+                    "min_fuzzy_score must be in 0.0..=1.0 (got {min}); leave None for no floor"
+                )
+                .into(),
+            }
+            .into());
+        }
+    }
     let word_boundary = matches!(
         op,
         Operation::Replace {

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -96,16 +96,15 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         anyhow::bail!("execute_replace_op called with non-Replace operation")
     };
     let regex_mode = *regex_mode;
-    if let Some(min) = min_fuzzy_score {
-        if !(0.0..=1.0).contains(min) || min.is_nan() {
-            return Err(crate::exit::InvalidInputError {
-                msg: format!(
-                    "min_fuzzy_score must be in 0.0..=1.0 (got {min}); leave None for no floor"
-                )
-                .into(),
-            }
-            .into());
+    if let Some(min) = min_fuzzy_score
+        && (!(0.0..=1.0).contains(min) || min.is_nan())
+    {
+        return Err(crate::exit::InvalidInputError {
+            msg: format!(
+                "min_fuzzy_score must be in 0.0..=1.0 (got {min}); leave None for no floor"
+            ),
         }
+        .into());
     }
     let word_boundary = matches!(
         op,


### PR DESCRIPTION
## Summary

MPI cycle after #1692 agent-host APIs. Hardens correctness and docs for embedders.

- **Bug:** post-write Revert used `post_write_cwd` as the backup root; library Apply stores sessions under the file parent, so restore failed when hooks cwd was the workspace root. Restore now uses the file parent.
- **Validation:** `min_fuzzy_score` must be in `0.0..=1.0` (library + tx/plan path).
- **Completeness:** `apply_content_edits_to_file` honors post_write from the last Replace edit.
- **Perf:** `list_sessions_under` ancestor walks are capped by `max_depth`.
- **Docs:** embedder reference table, agent-rules / PATCHLOOM.md.

## Test plan

- [x] `make check-fast` green
- [x] Regression: post_write_revert_uses_file_parent_backup_root
- [x] min_fuzzy out-of-range InvalidInput; floor reject still works
- [x] list_sessions_under ancestor depth cap

## Gate notes

- Open release PR #1691 (0.14.0): not merged (needs explicit approval)
- Dist issues #632–#634, #960–#963 left as large packaging backlog