### PR TITLE
fix: fuzzy token span, nested undo list, MCP key alias

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -5411,6 +5411,35 @@ fn post_write_revert_uses_file_parent_backup_root() {
     );
 }
 
+/// #1694: fuzzy identifier typo keeps surrounding syntax (not whole-line replace).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn fuzzy_identifier_typo_keeps_line_syntax() {
+    let content = "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n";
+    let r = replace_in_content(
+        content,
+        "CONFIGURATION_VALUE_PRIMRY",
+        "CONFIGURATION_VALUE_SECONDARY",
+        &ReplaceOptions {
+            fuzzy: true,
+            ..Default::default()
+        },
+    )
+    .expect("fuzzy typo should apply");
+    assert!(r.changed);
+    assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
+    assert!(
+        r.new_content
+            .starts_with("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
+        "must keep const/type/value: {}",
+        r.new_content
+    );
+    assert!(
+        !r.new_content.starts_with("CONFIGURATION_VALUE_SECONDARY\n"),
+        "must not replace whole first line with bare new text"
+    );
+}
+
 /// #1687: out-of-range min_fuzzy_score is InvalidInput.
 #[test]
 fn min_fuzzy_score_rejects_out_of_range() {

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -331,6 +331,43 @@ pub(super) fn inject_strict_into_schema(mut schema: serde_json::Value) -> serde_
     schema
 }
 
+/// LLM-prior field aliases accepted by plan serde and hand-written MCP params.
+///
+/// Remap **before** the registry allowlist so schemars-derived schemas (which do
+/// not expose `#[serde(alias)]`) still accept the same priors (#1696 / #1435).
+/// Only applied when the **canonical** name is a property of this tool's schema
+/// (so `doc.move`'s real `from`/`to` fields are not remapped to replace's old/new).
+const FIELD_ALIASES: &[(&str, &str)] = &[
+    ("key", "selector"),
+    ("from", "old"),
+    ("to", "new"),
+    ("ops", "operations"),
+];
+
+/// Rename known alias keys to canonical names when the schema allows the canonical.
+fn apply_field_aliases(
+    args: &mut serde_json::Map<String, serde_json::Value>,
+    allowed_fields: &std::collections::HashSet<String>,
+) -> Result<(), McpError> {
+    for &(alias, canonical) in FIELD_ALIASES {
+        if !args.contains_key(alias) || !allowed_fields.contains(canonical) {
+            continue;
+        }
+        if args.contains_key(canonical) {
+            return Err(McpError::invalid_params(
+                format!(
+                    "conflicting fields {alias:?} and {canonical:?}; use canonical {canonical:?} only"
+                ),
+                None,
+            ));
+        }
+        if let Some(val) = args.remove(alias) {
+            args.insert(canonical.to_string(), val);
+        }
+    }
+    Ok(())
+}
+
 /// Generic handler for auto-generated MCP tools.
 ///
 /// Runs field validations from the registry entry, injects the `op` discriminator,
@@ -342,21 +379,40 @@ pub(super) fn handle_simple_op(
     allowed_fields: &std::collections::HashSet<String>,
 ) -> Result<CallToolResult, McpError> {
     let args_obj = args
-        .as_object()
+        .as_object_mut()
         .ok_or_else(|| McpError::invalid_params("expected JSON object", None))?;
 
+    // Remap LLM-prior aliases first so allowlist sees only canonical names (#1696).
+    apply_field_aliases(args_obj, allowed_fields)?;
+
     // Reject unknown fields (replaces deny_unknown_fields from hand-written params).
-    let unknown: Vec<&str> = args_obj
+    let unknown: Vec<String> = args_obj
         .keys()
         .filter(|k| !allowed_fields.contains(k.as_str()))
-        .map(|k| k.as_str())
+        .cloned()
         .collect();
     if !unknown.is_empty() {
-        return Err(McpError::invalid_params(
-            format!("unknown field(s): {}", unknown.join(", ")),
-            None,
-        ));
+        let hint = unknown
+            .iter()
+            .filter_map(|u| {
+                FIELD_ALIASES
+                    .iter()
+                    .find(|(a, _)| *a == u.as_str())
+                    .map(|(_, c)| format!("{u} (did you mean {c}?)"))
+            })
+            .collect::<Vec<_>>();
+        let msg = if hint.is_empty() {
+            format!("unknown field(s): {}", unknown.join(", "))
+        } else {
+            // Alias present but this op's schema has no canonical (should be rare).
+            format!("unknown field(s): {}", hint.join(", "))
+        };
+        return Err(McpError::invalid_params(msg, None));
     }
+
+    let args_obj = args
+        .as_object()
+        .ok_or_else(|| McpError::invalid_params("expected JSON object", None))?;
 
     // Run field validations.
     for v in meta.validations {
@@ -426,4 +482,69 @@ pub(super) fn handle_simple_op(
     }
 
     service.run_one_op(op, strict)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn field_aliases_remap_key_to_selector() {
+        let allowed: HashSet<String> = ["path", "selector", "value", "strict"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let mut args = serde_json::json!({
+            "path": "c.json",
+            "key": "server.port",
+            "value": 9,
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        apply_field_aliases(&mut args, &allowed).unwrap();
+        assert_eq!(
+            args.get("selector").and_then(|v| v.as_str()),
+            Some("server.port")
+        );
+        assert!(!args.contains_key("key"));
+    }
+
+    #[test]
+    fn field_aliases_conflict_when_both_present() {
+        // Only selector is in real schema; include both keys in the args map.
+        let allowed: HashSet<String> = ["selector"].into_iter().map(str::to_string).collect();
+        let mut args = serde_json::json!({
+            "key": "a",
+            "selector": "b",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        let err = apply_field_aliases(&mut args, &allowed).unwrap_err();
+        assert!(err.to_string().contains("conflicting"), "err={err}");
+    }
+
+    #[test]
+    fn field_aliases_skip_from_when_canonical_not_in_schema() {
+        // doc.move has real `from`/`to` properties; do not remap to old/new.
+        let allowed: HashSet<String> = ["path", "from", "to"]
+            .into_iter()
+            .map(str::to_string)
+            .collect();
+        let mut args = serde_json::json!({
+            "path": "c.json",
+            "from": "a.b",
+            "to": "c.d",
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+        apply_field_aliases(&mut args, &allowed).unwrap();
+        assert_eq!(args.get("from").and_then(|v| v.as_str()), Some("a.b"));
+        assert_eq!(args.get("to").and_then(|v| v.as_str()), Some("c.d"));
+        assert!(!args.contains_key("old"));
+        assert!(!args.contains_key("new"));
+    }
 }

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -9,9 +9,13 @@ use serde::Serialize;
 EXAMPLES:
   patchloom undo --list
   patchloom undo --apply
-  patchloom undo --session 20240101_120000 --apply")]
+  patchloom undo --session 20240101_120000 --apply
+
+NOTE:
+  --list walks nested .patchloom/backups roots under the cwd (monorepo
+  crates) so sessions from library Apply under crates/foo/ are visible.")]
 pub struct UndoArgs {
-    /// List available backup sessions instead of restoring.
+    /// List available backup sessions (including nested monorepo roots).
     #[arg(long)]
     pub list: bool,
 
@@ -25,6 +29,15 @@ pub struct UndoArgs {
 }
 
 #[derive(Debug, Serialize)]
+struct UndoListEntry {
+    timestamp: String,
+    /// Backup project root relative to cwd when possible (#1695).
+    project_root: String,
+    file_count: usize,
+    entries: Vec<backup::ManifestEntry>,
+}
+
+#[derive(Debug, Serialize)]
 struct UndoPreviewEntry {
     path: String,
     action: String,
@@ -35,6 +48,7 @@ struct UndoPreviewOutput {
     ok: bool,
     status: &'static str,
     session: String,
+    project_root: String,
     file_count: usize,
     entries: Vec<UndoPreviewEntry>,
 }
@@ -49,7 +63,7 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
 
     if args.list {
-        let sessions = backup::list_sessions(&cwd)?;
+        let sessions = collect_sessions(&cwd)?;
         if sessions.is_empty() {
             // Match other CLI exit-3 paths: agents branch on error_kind without
             // scraping stderr (empty array alone was inconsistent with undo apply).
@@ -57,17 +71,23 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::NO_MATCHES);
         }
 
-        if !global.emit_json_items(&sessions)? && !global.quiet {
-            for s in &sessions {
+        let list_items: Vec<UndoListEntry> = sessions
+            .iter()
+            .map(|(root, manifest)| UndoListEntry {
+                timestamp: manifest.timestamp.clone(),
+                project_root: display_root(&cwd, root),
+                file_count: manifest.entries.len(),
+                entries: manifest.entries.clone(),
+            })
+            .collect();
+
+        if !global.emit_json_items(&list_items)? && !global.quiet {
+            for (root, s) in &sessions {
                 let file_count = s.entries.len();
-                let actions: Vec<String> = s
-                    .entries
-                    .iter()
-                    .map(|e| format!("  {} ({})", e.path, action_label(&e.action)))
-                    .collect();
-                println!("{} ({file_count} file(s))", s.timestamp);
-                for a in &actions {
-                    println!("{a}");
+                let root_disp = display_root(&cwd, root);
+                println!("{} ({file_count} file(s)) root={root_disp}", s.timestamp);
+                for e in &s.entries {
+                    println!("  {} ({})", e.path, action_label(&e.action));
                 }
                 println!();
             }
@@ -75,33 +95,16 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::SUCCESS);
     }
 
-    // Determine which session to restore.
-    let timestamp = if let Some(ref ts) = args.session {
-        ts.clone()
-    } else {
-        // Use the most recent session.
-        let sessions = backup::list_sessions(&cwd)?;
-        if sessions.is_empty() {
+    // Resolve session across nested backup roots (#1695).
+    let (backup_root, timestamp, session) = match resolve_session(&cwd, args.session.as_deref())? {
+        Some(v) => v,
+        None => {
             global.emit_error_json_kind(Some("no_matches"), "no backup sessions found")?;
             return Ok(exit::NO_MATCHES);
         }
-        sessions[0].timestamp.clone()
     };
 
     if !args.apply {
-        // Dry-run: show what would be restored.
-        let sessions = backup::list_sessions(&cwd)?;
-        let session = sessions
-            .iter()
-            .find(|s| s.timestamp == timestamp)
-            .ok_or_else(|| {
-                anyhow::Error::new(crate::exit::NoMatchError {
-                    msg: format!(
-                        "session {timestamp} not in session list (use `patchloom undo --list` to see available sessions)"
-                    ),
-                })
-            })?;
-
         let entries: Vec<UndoPreviewEntry> = session
             .entries
             .iter()
@@ -120,14 +123,16 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             ok: true,
             status: "changes_detected",
             session: timestamp.clone(),
+            project_root: display_root(&cwd, &backup_root),
             file_count: entries.len(),
             entries,
         };
         if !global.emit_json(&output)? && !global.quiet {
             println!(
-                "Would restore session {} ({} file(s)):",
+                "Would restore session {} ({} file(s)) root={}:",
                 timestamp,
-                session.entries.len()
+                session.entries.len(),
+                output.project_root
             );
             for entry in &output.entries {
                 println!("  {} -> {}", entry.path, entry.action);
@@ -139,17 +144,22 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::CHANGES_DETECTED);
     }
 
-    // Apply restore.
-    crate::verbose!("undo: restoring session {}", timestamp);
-    let restored = backup::restore_session(&cwd, &timestamp)?;
+    // Apply restore from the root that owns the session (#1695).
+    crate::verbose!(
+        "undo: restoring session {} under {}",
+        timestamp,
+        backup_root.display()
+    );
+    let restored = backup::restore_session(&backup_root, &timestamp)?;
     // Remove the consumed session so subsequent `undo` calls advance to
     // the next-oldest session instead of replaying the same one.
-    backup::remove_session(&cwd, &timestamp)?;
+    backup::remove_session(&backup_root, &timestamp)?;
     crate::verbose!("undo: restored {} file(s)", restored);
     if !global.emit_json(&serde_json::json!({
         "ok": true,
         "status": "restored",
         "session": timestamp,
+        "project_root": display_root(&cwd, &backup_root),
         "file_count": restored,
     }))? && !global.quiet
     {
@@ -157,6 +167,66 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     Ok(exit::SUCCESS)
+}
+
+/// Sessions under `cwd` and nested monorepo roots, newest first (#1695).
+fn collect_sessions(
+    cwd: &std::path::Path,
+) -> anyhow::Result<Vec<(std::path::PathBuf, backup::Manifest)>> {
+    let listings = backup::list_sessions_under(
+        cwd,
+        &backup::ListSessionsOptions {
+            descendants: true,
+            ancestors: false,
+            max_depth: Some(8),
+        },
+    )?;
+    let mut all = Vec::new();
+    for listing in listings {
+        for session in listing.sessions {
+            all.push((listing.project_root.clone(), session));
+        }
+    }
+    all.sort_by(|a, b| b.1.timestamp.cmp(&a.1.timestamp));
+    Ok(all)
+}
+
+fn resolve_session(
+    cwd: &std::path::Path,
+    wanted: Option<&str>,
+) -> anyhow::Result<Option<(std::path::PathBuf, String, backup::Manifest)>> {
+    let sessions = collect_sessions(cwd)?;
+    if let Some(ts) = wanted {
+        for (root, manifest) in &sessions {
+            if manifest.timestamp == ts {
+                return Ok(Some((root.clone(), ts.to_string(), manifest.clone())));
+            }
+        }
+        // Named session missing (whether or not any other sessions exist).
+        // Match restore_session wording; generic anyhow → exit 1.
+        return Err(anyhow::anyhow!(
+            "no backup session found for {ts} (use `patchloom undo --list` to see available sessions)"
+        ));
+    }
+    if sessions.is_empty() {
+        return Ok(None);
+    }
+    let (root, manifest) = sessions.into_iter().next().expect("non-empty");
+    let ts = manifest.timestamp.clone();
+    Ok(Some((root, ts, manifest)))
+}
+
+fn display_root(cwd: &std::path::Path, root: &std::path::Path) -> String {
+    root.strip_prefix(cwd)
+        .map(|p| {
+            let s = p.to_string_lossy();
+            if s.is_empty() {
+                ".".to_string()
+            } else {
+                s.into_owned()
+            }
+        })
+        .unwrap_or_else(|_| root.to_string_lossy().into_owned())
 }
 
 fn action_label(action: &backup::FileAction) -> &'static str {
@@ -210,6 +280,52 @@ mod tests {
         };
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);
+    }
+
+    /// #1695: nested crate backups appear when listing from workspace root.
+    #[test]
+    fn list_finds_nested_monorepo_sessions() {
+        let workspace = TempDir::new().unwrap();
+        let crate_dir = workspace.path().join("crates").join("foo");
+        std::fs::create_dir_all(&crate_dir).unwrap();
+        let ts = create_backup(&crate_dir, "lib.txt", "old");
+
+        // Workspace-root only listing would miss nested roots.
+        assert!(
+            backup::list_sessions(workspace.path()).unwrap().is_empty(),
+            "control: flat list_sessions misses nested"
+        );
+
+        let mut global = GlobalFlags::test_default();
+        global.quiet = true;
+        global.cwd = Some(workspace.path().to_string_lossy().to_string());
+        let code = run(
+            UndoArgs {
+                list: true,
+                session: None,
+                apply: false,
+            },
+            &global,
+        )
+        .unwrap();
+        assert_eq!(code, exit::SUCCESS);
+
+        // Restore by session id from workspace cwd.
+        std::fs::write(crate_dir.join("lib.txt"), "new").unwrap();
+        let code = run(
+            UndoArgs {
+                list: false,
+                session: Some(ts.clone()),
+                apply: true,
+            },
+            &global,
+        )
+        .unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(
+            std::fs::read_to_string(crate_dir.join("lib.txt")).unwrap(),
+            "old"
+        );
     }
 
     #[test]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -640,38 +640,22 @@ pub fn resolve_with_fallback(
         return Ok(result);
     }
 
-    // Step 3: Similarity-based matching (find the most similar line block).
+    // Step 3: Similarity-based matching (#1694).
+    //
+    // Single-token targets (identifiers / typos) must match **tokens**, not whole
+    // lines. Jaro-Winkler on a full source line vs a short identifier scores high
+    // because of shared prefixes, then the apply path replaces the entire line and
+    // deletes surrounding syntax (`const`, types, etc.).
     let target_lines: Vec<&str> = target.lines().collect();
     if target_lines.len() == 1 {
-        // Single-line target: find the most similar single line.
-        let mut best_score = 0.0f64;
-        let mut best_match = String::new();
-        let mut best_offset = 0usize;
-        let mut offset = 0usize;
-        for line in content.lines() {
-            let score = strsim::jaro_winkler(line.trim(), target.trim());
-            if score > best_score {
-                best_score = score;
-                best_match = line.to_string();
-                best_offset = offset;
+        let target_trim = target.trim();
+        if is_token_like_target(target_trim) {
+            if let Some(hit) = best_token_similarity(content, target_trim) {
+                return Ok(hit);
             }
-            // Advance past the line content and the actual line ending,
-            // which may be \r\n (2 bytes) or \n (1 byte).
-            offset += line.len();
-            if content.as_bytes().get(offset) == Some(&b'\r') {
-                offset += 1;
-            }
-            if content.as_bytes().get(offset) == Some(&b'\n') {
-                offset += 1;
-            }
-        }
-        if best_score > 0.85 {
-            return Ok(AnchorMatchResult {
-                matched_text: best_match,
-                start_offset: best_offset,
-                strategy: MatchStrategy::Similarity,
-                score: Some(best_score),
-            });
+            // Do not fall through to whole-line similarity for token-like targets.
+        } else if let Some(hit) = best_line_similarity(content, target_trim) {
+            return Ok(hit);
         }
     }
 
@@ -691,24 +675,134 @@ pub fn resolve_with_fallback(
     })
 }
 
+/// True when `target` is a single identifier-like token (no whitespace).
+///
+/// Multi-word / snippet targets keep whole-line similarity. Token-like targets
+/// use identifier-level matching so fuzzy typo recovery does not expand the
+/// replace span to an entire source line (#1694).
+fn is_token_like_target(target: &str) -> bool {
+    if target.is_empty() || target.chars().any(|c| c.is_whitespace()) {
+        return false;
+    }
+    // At least one alphanumeric so we do not treat pure punctuation as a token.
+    target.chars().any(|c| c.is_alphanumeric())
+        && target
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+}
+
+/// Best identifier similarity hit, if score > 0.85.
+fn best_token_similarity(content: &str, target: &str) -> Option<AnchorMatchResult> {
+    let mut best_score = 0.0f64;
+    let mut best_match = String::new();
+    let mut best_offset = 0usize;
+    let mut offset = 0usize;
+    for line in content.lines() {
+        for (ident, col) in extract_identifiers_with_offsets(line) {
+            if ident == target {
+                continue;
+            }
+            let score = strsim::jaro_winkler(&ident, target);
+            if score > best_score {
+                best_score = score;
+                best_match = ident;
+                best_offset = offset + col;
+            }
+        }
+        offset = advance_line_offset(content, offset, line);
+    }
+    if best_score > 0.85 {
+        Some(AnchorMatchResult {
+            matched_text: best_match,
+            start_offset: best_offset,
+            strategy: MatchStrategy::Similarity,
+            score: Some(best_score),
+        })
+    } else {
+        None
+    }
+}
+
+/// Whole-line similarity for multi-word / snippet targets.
+///
+/// Refuses a match when the line is much longer than the target (ratio > 2)
+/// so accidental line expansion stays rare even for long snippets (#1694).
+fn best_line_similarity(content: &str, target: &str) -> Option<AnchorMatchResult> {
+    let mut best_score = 0.0f64;
+    let mut best_match = String::new();
+    let mut best_offset = 0usize;
+    let mut offset = 0usize;
+    for line in content.lines() {
+        let score = strsim::jaro_winkler(line.trim(), target);
+        if score > best_score {
+            best_score = score;
+            best_match = line.to_string();
+            best_offset = offset;
+        }
+        offset = advance_line_offset(content, offset, line);
+    }
+    if best_score <= 0.85 {
+        return None;
+    }
+    let line_len = best_match.trim().len();
+    let target_len = target.len().max(1);
+    if line_len > target_len.saturating_mul(2) && line_len > target_len + 16 {
+        // Too expansive: treat as no similarity match (suggestions still help).
+        return None;
+    }
+    Some(AnchorMatchResult {
+        matched_text: best_match,
+        start_offset: best_offset,
+        strategy: MatchStrategy::Similarity,
+        score: Some(best_score),
+    })
+}
+
+fn advance_line_offset(content: &str, mut offset: usize, line: &str) -> usize {
+    // Advance past the line content and the actual line ending (\r\n or \n).
+    offset += line.len();
+    if content.as_bytes().get(offset) == Some(&b'\r') {
+        offset += 1;
+    }
+    if content.as_bytes().get(offset) == Some(&b'\n') {
+        offset += 1;
+    }
+    offset
+}
+
 /// Extract identifier-like tokens from a line of code.
 fn extract_identifiers(line: &str) -> Vec<String> {
+    extract_identifiers_with_offsets(line)
+        .into_iter()
+        .map(|(s, _)| s)
+        .collect()
+}
+
+/// Identifier tokens with byte offsets into `line` (#1694).
+fn extract_identifiers_with_offsets(line: &str) -> Vec<(String, usize)> {
     let mut identifiers = Vec::new();
     let mut current = String::new();
+    let mut start = 0usize;
+    let mut i = 0usize;
 
     for ch in line.chars() {
+        let clen = ch.len_utf8();
         if ch.is_alphanumeric() || ch == '_' {
+            if current.is_empty() {
+                start = i;
+            }
             current.push(ch);
         } else {
             if current.len() >= 3 {
-                identifiers.push(std::mem::take(&mut current));
+                identifiers.push((std::mem::take(&mut current), start));
             } else {
                 current.clear();
             }
         }
+        i += clen;
     }
     if current.len() >= 3 {
-        identifiers.push(current);
+        identifiers.push((current, start));
     }
 
     identifiers
@@ -1069,6 +1163,46 @@ mod tests {
         );
         let r = result.expect("similarity fallback should succeed");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
+        // Multi-word snippet → whole-line match (not a bare identifier).
+        assert!(
+            r.matched_text.contains("process_request"),
+            "snippet match: {:?}",
+            r.matched_text
+        );
+    }
+
+    /// #1694: single-token fuzzy must not expand to the whole source line.
+    #[test]
+    fn resolve_token_typo_does_not_match_whole_line() {
+        let content = "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n";
+        let r = resolve_with_fallback(content, "CONFIGURATION_VALUE_PRIMRY", None, None)
+            .expect("token typo should fuzzy-match the identifier");
+        assert_eq!(r.strategy, MatchStrategy::Similarity);
+        assert_eq!(
+            r.matched_text, "CONFIGURATION_VALUE_PRIMARY",
+            "must match the identifier token only, not the whole line"
+        );
+        assert!(
+            content[r.start_offset..].starts_with("CONFIGURATION_VALUE_PRIMARY"),
+            "offset must point at the token"
+        );
+        // Surrounding syntax must still be outside the match span.
+        assert!(!r.matched_text.contains("const"));
+        assert!(!r.matched_text.contains("i32"));
+    }
+
+    /// #1694: intentional full-line target still uses line similarity.
+    #[test]
+    fn resolve_full_line_snippet_still_matches_line() {
+        let content = "const FOO: i32 = 1;\n";
+        let r = resolve_with_fallback(content, "const FO: i32 = 1;", None, None)
+            .expect("near-full-line snippet should match the line");
+        assert_eq!(r.strategy, MatchStrategy::Similarity);
+        assert!(
+            r.matched_text.contains("const") && r.matched_text.contains("FOO"),
+            "line match: {:?}",
+            r.matched_text
+        );
     }
 
     #[test]

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -33,6 +33,42 @@ async fn test_mcp_doc_set_round_trip() {
     client.cancel().await.unwrap();
 }
 
+/// #1696: registry MCP accepts LLM-prior `key` as alias for `selector`.
+#[tokio::test]
+async fn test_mcp_doc_set_accepts_key_alias() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("config.json"),
+        r#"{"server":{"port":8080}}"#,
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_set",
+        serde_json::json!({
+            "path": "config.json",
+            "key": "server.port",
+            "value": 9090
+        }),
+    )
+    .await;
+    assert!(!is_error, "doc_set with key alias must not reject: {val}");
+    assert_eq!(val["ok"], true, "doc_set key alias ok: {val}");
+
+    let content = fs::read_to_string(dir.path().join("config.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(
+        v["server"]["port"], 9090,
+        "key alias did not apply: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_replace_round_trip() {
     if !has_mcp_support() {


### PR DESCRIPTION
## Summary

Implements open issues #1694–#1696.

### #1694 — Fuzzy whole-line span (P0)
Single-token fuzzy targets (identifier typos) now match **tokens** via the same identifier extraction as suggestions. Whole-line Jaro-Winkler is reserved for multi-word snippets. Fixes:

```text
# before: whole first line replaced by bare `new`
CONFIGURATION_VALUE_SECONDARY
fn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }

# after: token only
const CONFIGURATION_VALUE_SECONDARY: i32 = 1;
fn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }
```

### #1695 — Nested undo list
`undo --list` and session resolve use `list_sessions_under` so monorepo `crates/foo/.patchloom/backups` sessions appear from the workspace root.

### #1696 — Registry MCP `key` alias
Before the schema allowlist, remap known LLM priors when the canonical field is on the tool schema (`key`→`selector`, and `from`/`to`→`old`/`new` only when those canonicals exist so `doc.move` is unchanged).

## Test plan

- [x] `make check-fast`
- [x] Unit: token typo does not match whole line; line snippets still work
- [x] Unit: nested undo list + restore by session
- [x] Unit: field alias remap / conflict / doc.move safety
- [x] Integration: MCP `doc_set` with `key` succeeds

Closes #1694
Closes #1695
Closes #1696