### PR TITLE
test: embedder-grade fuzzy identifier typo coverage

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -5440,6 +5440,132 @@ fn fuzzy_identifier_typo_keeps_line_syntax() {
     );
 }
 
+/// Embedder default path: fuzzy + unique + require_change (Bline edit_file shape).
+#[test]
+fn fuzzy_embedder_options_identifier_typo_safe() {
+    let content = "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        unique: true,
+        require_change: true,
+        min_fuzzy_score: Some(0.80),
+        ..Default::default()
+    };
+    let r = replace_in_content(
+        content,
+        "CONFIGURATION_VALUE_PRIMRY",
+        "CONFIGURATION_VALUE_SECONDARY",
+        &opts,
+    )
+    .expect("embedder-style fuzzy typo must succeed");
+    assert!(r.changed);
+    assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
+    assert!(r.match_score.is_some_and(|s| s >= 0.80));
+    assert!(
+        r.new_content
+            .contains("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
+        "{}",
+        r.new_content
+    );
+    // Second occurrence still original (single fuzzy site).
+    assert!(
+        r.new_content.contains("CONFIGURATION_VALUE_PRIMARY"),
+        "second site left for single fuzzy replace: {}",
+        r.new_content
+    );
+    assert!(
+        !r.new_content
+            .lines()
+            .any(|l| l == "CONFIGURATION_VALUE_SECONDARY"),
+        "must not replace a whole line with bare new identifier"
+    );
+}
+
+/// Multi-language identifier typos under replace_in_content.
+#[test]
+fn fuzzy_identifier_typo_matrix_replace_in_content() {
+    let cases: &[(&str, &str, &str, &str)] = &[
+        (
+            "def load_configuration_value():\n    return 1\n",
+            "load_configration_value",
+            "load_settings_value",
+            "def load_settings_value():",
+        ),
+        (
+            "const getUserProfile = () => null;\n",
+            "getUserProfle",
+            "getUserAccount",
+            "const getUserAccount = () => null;",
+        ),
+        (
+            "fn process_request(x: i32) {}\n",
+            "process_requets",
+            "handle_request",
+            "fn handle_request(x: i32) {}",
+        ),
+        (
+            "    obj.fetchUserDetails(id);\n",
+            "fetchUserDetials",
+            "fetchUserInfo",
+            "    obj.fetchUserInfo(id);",
+        ),
+    ];
+    for (content, typo, new, must_contain) in cases {
+        let r = replace_in_content(
+            content,
+            typo,
+            new,
+            &ReplaceOptions {
+                fuzzy: true,
+                require_change: true,
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|e| panic!("typo {typo:?} failed: {e}"));
+        assert!(
+            r.new_content.contains(must_contain),
+            "typo={typo:?} want {must_contain:?} got {}",
+            r.new_content
+        );
+        assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
+    }
+}
+
+/// Disk Apply path used by hosts (replace_text), same safety contract.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn fuzzy_identifier_typo_disk_apply_preserves_syntax() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("cfg.rs");
+    fs::write(
+        &file,
+        "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+    )
+    .unwrap();
+    let r = replace_text(
+        &file,
+        "CONFIGURATION_VALUE_PRIMRY",
+        "CONFIGURATION_VALUE_SECONDARY",
+        &ReplaceOptions {
+            fuzzy: true,
+            unique: true,
+            require_change: true,
+            ..Default::default()
+        },
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(r.applied);
+    assert!(r.backup_session.is_some());
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.starts_with("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
+        "disk: {on_disk}"
+    );
+    assert!(on_disk.contains("CONFIGURATION_VALUE_PRIMARY"));
+}
+
 /// #1687: out-of-range min_fuzzy_score is InvalidInput.
 #[test]
 fn min_fuzzy_score_rejects_out_of_range() {

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -1205,6 +1205,112 @@ mod tests {
         );
     }
 
+    /// Embedder-style identifier typos across real source shapes (#1694 contract).
+    #[test]
+    fn resolve_token_typo_matrix_preserves_non_identifier_syntax() {
+        // (content, typo_target, expected_matched_token, must_not_be_in_match)
+        let cases: &[(&str, &str, &str, &[&str])] = &[
+            // Rust const + use site (Bline #1694 repro shape).
+            (
+                "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+                "CONFIGURATION_VALUE_PRIMRY",
+                "CONFIGURATION_VALUE_PRIMARY",
+                &["const", "i32", "fn"],
+            ),
+            // Rust function name typo (token, not full signature).
+            (
+                "fn process_request(data: &str) -> Result<()> {\n    Ok(())\n}\n",
+                "process_requets",
+                "process_request",
+                &["fn", "Result", "data"],
+            ),
+            // Python def.
+            (
+                "def load_configuration_value():\n    return 1\n",
+                "load_configration_value",
+                "load_configuration_value",
+                &["def", "return"],
+            ),
+            // JS/TS const + call.
+            (
+                "const getUserProfile = () => null;\nexport { getUserProfile };\n",
+                "getUserProfle",
+                "getUserProfile",
+                &["const", "export"],
+            ),
+            // YAML-ish key in a line with punctuation (identifier extraction).
+            (
+                "server_port_primary: 8080\n",
+                "server_port_primry",
+                "server_port_primary",
+                &[":", "8080"],
+            ),
+            // camelCase method.
+            (
+                "    obj.fetchUserDetails(id);\n",
+                "fetchUserDetials",
+                "fetchUserDetails",
+                &["obj", "id"],
+            ),
+        ];
+
+        for (content, typo, expected, forbidden) in cases {
+            let r = resolve_with_fallback(content, typo, None, None)
+                .unwrap_or_else(|e| panic!("token typo {typo:?} should match in {content:?}: {e}"));
+            assert_eq!(r.strategy, MatchStrategy::Similarity, "typo={typo:?}");
+            assert_eq!(
+                r.matched_text, *expected,
+                "typo={typo:?} content={content:?}"
+            );
+            assert!(
+                content[r.start_offset..].starts_with(expected),
+                "offset wrong for {typo:?}"
+            );
+            for bad in *forbidden {
+                assert!(
+                    !r.matched_text.contains(bad),
+                    "span leaked {bad:?} for typo={typo:?} match={:?}",
+                    r.matched_text
+                );
+            }
+            // Token-like targets must never expand to multi-word spans.
+            assert!(
+                !r.matched_text.contains(' '),
+                "token match must not contain spaces: {:?}",
+                r.matched_text
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_token_typo_picks_first_best_occurrence() {
+        let content = "FOO_PRIMARY=1\nFOO_PRIMARY=2\n";
+        let r = resolve_with_fallback(content, "FOO_PRIMRY", None, None).unwrap();
+        assert_eq!(r.matched_text, "FOO_PRIMARY");
+        // First line occurrence (offset 0).
+        assert_eq!(r.start_offset, 0);
+    }
+
+    #[test]
+    fn resolve_token_unrelated_is_no_match() {
+        let content = "const ALPHA: i32 = 1;\nconst BETA: i32 = 2;\n";
+        let err =
+            resolve_with_fallback(content, "ZZZZ_COMPLETELY_UNRELATED", None, None).unwrap_err();
+        assert_eq!(err.kind, EditErrorKind::NoMatch);
+    }
+
+    #[test]
+    fn is_token_like_target_classification() {
+        assert!(is_token_like_target("CONFIGURATION_VALUE_PRIMRY"));
+        assert!(is_token_like_target("getUserProfile"));
+        assert!(is_token_like_target("kebab-case-name"));
+        assert!(!is_token_like_target("fn process_data() {}"));
+        assert!(!is_token_like_target("const FOO: i32 = 1;"));
+        assert!(!is_token_like_target("server.port"));
+        assert!(!is_token_like_target(""));
+        assert!(!is_token_like_target("   "));
+    }
+
     #[test]
     fn resolve_with_fallback_structured_error() {
         let content = "fn alpha() {}\nfn beta() {}\n";

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -1162,6 +1162,62 @@ mod tests {
         assert_eq!(meta.match_count, 1);
     }
 
+    /// Plan/tx path: identifier typo must not nuke surrounding syntax (#1694).
+    #[test]
+    fn replace_fuzzy_identifier_typo_preserves_syntax() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("cfg.rs");
+        std::fs::write(
+            &file,
+            "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+        )
+        .unwrap();
+
+        let op = Operation::Replace {
+            path: Some("cfg.rs".into()),
+            glob: None,
+            regex: false,
+            old: "CONFIGURATION_VALUE_PRIMRY".into(),
+            new_text: Some("CONFIGURATION_VALUE_SECONDARY".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            before_context: None,
+            after_context: None,
+            unique: true,
+            require_change: true,
+            command_position: false,
+            fuzzy: true,
+            min_fuzzy_score: Some(0.80),
+        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        let count = execute_replace_op(&op, &mut tx).unwrap();
+        drop(tx);
+        assert_eq!(count, 1);
+        let out = &f.pending[&file].1;
+        assert!(
+            out.starts_with("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
+            "tx fuzzy must keep syntax: {out}"
+        );
+        assert!(
+            out.contains("CONFIGURATION_VALUE_PRIMARY"),
+            "second occurrence left: {out}"
+        );
+        assert!(
+            !out.lines().any(|l| l == "CONFIGURATION_VALUE_SECONDARY"),
+            "must not bare-line replace: {out}"
+        );
+        let meta = f.replace_match_meta.get(&file).expect("fuzzy meta");
+        assert_eq!(meta.mode, crate::api::MatchMode::Fuzzy);
+    }
+
     #[test]
     fn replace_exact_records_match_mode_exact() {
         let dir = TempDir::new().unwrap();

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1833,3 +1833,90 @@ fn test_replace_missing_path_is_not_found() {
     assert_eq!(parsed["ok"], false);
     assert_eq!(parsed["error_kind"], "not_found");
 }
+
+// ---------------------------------------------------------------------------
+// Fuzzy identifier typo safety for embedders (#1694 contract)
+// ---------------------------------------------------------------------------
+
+/// CLI repro from #1694: bare identifier typo must not replace the whole line.
+#[test]
+fn test_replace_fuzzy_identifier_typo_preserves_syntax() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.rs");
+    fs::write(
+        &file,
+        "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "replace",
+            "CONFIGURATION_VALUE_PRIMRY",
+            "--new",
+            "CONFIGURATION_VALUE_SECONDARY",
+            "--fuzzy",
+            "--apply",
+        ])
+        .arg(&file)
+        .assert()
+        .code(0);
+
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.starts_with("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
+        "CLI fuzzy must keep const/type: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("CONFIGURATION_VALUE_PRIMARY"),
+        "second site left: {on_disk}"
+    );
+    assert!(
+        !on_disk
+            .lines()
+            .any(|l| l.trim() == "CONFIGURATION_VALUE_SECONDARY"),
+        "must not bare-line replace: {on_disk}"
+    );
+}
+
+/// CLI JSON reports fuzzy mode for identifier typo without span corruption.
+#[test]
+fn test_replace_fuzzy_identifier_typo_json_match_mode() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.rs");
+    fs::write(&file, "fn process_request(x: i32) {}\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "process_requets",
+            "--new",
+            "handle_request",
+            "--fuzzy",
+            "--apply",
+        ])
+        .arg(&file)
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    // Aggregate or per-file match_mode should be fuzzy when present.
+    let mode = parsed["match_mode"]
+        .as_str()
+        .or_else(|| parsed["files"][0]["match_mode"].as_str())
+        .unwrap_or("");
+    assert!(
+        mode == "fuzzy" || parsed["ok"] == true,
+        "expected fuzzy success payload: {parsed}"
+    );
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert_eq!(on_disk, "fn handle_request(x: i32) {}\n");
+}


### PR DESCRIPTION
## Summary

Expands tests for the embedder fuzzy path that 0.13 missed: bare **identifier typos** in real source (not multi-word line snippets).

Assertions check **syntax preservation** (`const`, `fn`, types, punctuation), not only `changed == true`.

### Coverage

| Layer | What |
|-------|------|
| `resolve_with_fallback` | Rust/Python/JS/YAML-ish/camelCase matrix; first occurrence; unrelated NoMatch; `is_token_like` classification |
| `replace_in_content` | Bline-like `fuzzy+unique+require_change+min_fuzzy_score`; multi-language matrix |
| `replace_text` Apply | Disk write + backup_session still safe |
| tx `replace_op` | Plan/MCP path same contract |
| CLI integration | Exact #1694 repro; function-name typo JSON path |

## Test plan

- [x] `cargo test --lib` filters for new tests
- [x] `cargo test --test integration test_replace_fuzzy_identifier`
- [x] clippy `-D warnings`