### PR TITLE
fix: fuzzy token-like alignment and embedder smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz git-clean clean
+.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -118,6 +118,9 @@ agent-test: build ## Run agent integration tests (requires LLM API key). Use MOD
 		([ -d .venv ] || python3 -m venv .venv) && \
 		.venv/bin/pip install -q -r requirements.txt && \
 		.venv/bin/pytest -v --timeout 240 $(if $(MODEL),--model $(MODEL),) --ignore=test_bench.py
+
+embedder-smoke: build ## Pre-release host contracts (fuzzy token span, nested undo list, plan key alias)
+	bash scripts/embedder-smoke.sh target/debug/patchloom
 
 bench-cli: build ## Run CLI benchmarks vs native tools (requires hyperfine)
 	cd benches/cli && bash run.sh

--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -45,8 +45,10 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)
+- CLI: `patchloom undo --list` also walks nested `.patchloom/backups` under the cwd (#1695)
 - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`
 - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)
+- Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts (#1687, #1694)
 **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674).
 
 Use patchloom when:

--- a/scripts/embedder-smoke.sh
+++ b/scripts/embedder-smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Pre-release embedder smoke: contracts hosts actually hit (not full CI).
+# Usage: scripts/embedder-smoke.sh [path-to-patchloom-binary]
+set -euo pipefail
+
+BIN="${1:-target/debug/patchloom}"
+if [[ ! -x "$BIN" ]]; then
+  echo "error: binary not executable: $BIN (run make build first)" >&2
+  exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "OK: $*"; }
+
+# --- #1694: bare identifier typo must not nuke surrounding syntax ---
+printf 'const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n' \
+  >"$tmpdir/f.rs"
+"$BIN" replace CONFIGURATION_VALUE_PRIMRY \
+  --new CONFIGURATION_VALUE_SECONDARY --fuzzy --apply "$tmpdir/f.rs" >/dev/null
+got=$(cat "$tmpdir/f.rs")
+echo "$got" | grep -q 'const CONFIGURATION_VALUE_SECONDARY: i32 = 1;' \
+  || fail "fuzzy typo lost const/type syntax: $got"
+echo "$got" | grep -qx 'CONFIGURATION_VALUE_SECONDARY' \
+  && fail "fuzzy typo bare-line replaced: $got"
+pass "fuzzy identifier typo preserves syntax (#1694)"
+
+# --- #1695: nested monorepo undo --list sees crate-local sessions ---
+mkdir -p "$tmpdir/ws/crates/foo"
+printf 'old\n' >"$tmpdir/ws/crates/foo/lib.txt"
+"$BIN" --cwd "$tmpdir/ws/crates/foo" replace old --new new --apply lib.txt >/dev/null
+list_out=$("$BIN" --cwd "$tmpdir/ws" undo --list 2>/dev/null || true)
+echo "$list_out" | grep -qE '[0-9]{10,}' \
+  || fail "undo --list from workspace missed nested session: $list_out"
+pass "undo --list finds nested monorepo sessions (#1695)"
+
+# --- plan accepts key alias (registry MCP covered by unit/integration) ---
+printf '{"server":{"port":8080}}\n' >"$tmpdir/ws/config.json"
+cat >"$tmpdir/ws/plan.json" <<'JSON'
+{"ops":[{"op":"doc.set","path":"config.json","key":"server.port","value":9090}]}
+JSON
+"$BIN" --cwd "$tmpdir/ws" tx plan.json --apply >/dev/null
+grep -q '9090' "$tmpdir/ws/config.json" || fail "plan key alias did not apply"
+pass "plan doc.set accepts key alias (#1696/#1435)"
+
+echo "embedder-smoke: all checks passed"

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -5531,6 +5531,32 @@ fn fuzzy_identifier_typo_matrix_replace_in_content() {
     }
 }
 
+/// unique must still fire on exact multi-match even when fuzzy is enabled.
+#[test]
+fn fuzzy_does_not_bypass_unique_on_exact_multi_match() {
+    let content = "foo bar foo\n";
+    let err = replace_in_content(
+        content,
+        "foo",
+        "baz",
+        &ReplaceOptions {
+            fuzzy: true,
+            unique: true,
+            ..Default::default()
+        },
+    )
+    .unwrap_err();
+    assert_eq!(
+        edit_error_kind(&err),
+        Some(EditErrorKind::AmbiguousTarget),
+        "exact multi-match must stay unique-ambiguous with fuzzy on: {err}"
+    );
+    assert!(
+        err.to_string().contains("ambiguous"),
+        "message should name ambiguity: {err}"
+    );
+}
+
 /// Disk Apply path used by hosts (replace_text), same safety contract.
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -122,8 +122,10 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
              - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)\n\
+             - CLI: `patchloom undo --list` also walks nested `.patchloom/backups` under the cwd (#1695)\n\
              - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
              - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)\n\
+             - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts (#1687, #1694)\n\
              **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674).\n\n",
         );
     }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -684,11 +684,11 @@ fn is_token_like_target(target: &str) -> bool {
     if target.is_empty() || target.chars().any(|c| c.is_whitespace()) {
         return false;
     }
-    // At least one alphanumeric so we do not treat pure punctuation as a token.
+    // Match extract_identifiers: alphanumeric + underscore only. Hyphens would
+    // mark the target as "token-like" while extraction splits on `-`, so a
+    // kebab-case typo never matched a full token and skipped line fallback.
     target.chars().any(|c| c.is_alphanumeric())
-        && target
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+        && target.chars().all(|c| c.is_alphanumeric() || c == '_')
 }
 
 /// Best identifier similarity hit, if score > 0.85.
@@ -1303,12 +1303,28 @@ mod tests {
     fn is_token_like_target_classification() {
         assert!(is_token_like_target("CONFIGURATION_VALUE_PRIMRY"));
         assert!(is_token_like_target("getUserProfile"));
-        assert!(is_token_like_target("kebab-case-name"));
+        // Hyphenated names are not identifier tokens (extraction splits on `-`).
+        assert!(!is_token_like_target("kebab-case-name"));
         assert!(!is_token_like_target("fn process_data() {}"));
         assert!(!is_token_like_target("const FOO: i32 = 1;"));
         assert!(!is_token_like_target("server.port"));
         assert!(!is_token_like_target(""));
         assert!(!is_token_like_target("   "));
+    }
+
+    /// Kebab-case targets use line similarity (not broken token path).
+    #[test]
+    fn resolve_kebab_case_uses_line_similarity_not_broken_token_path() {
+        let content = "font-weight-primary: bold;\n";
+        // Near-full-line typo; must still resolve (line path), not dead-end as token.
+        let r = resolve_with_fallback(content, "font-weight-primry: bold;", None, None)
+            .expect("kebab line snippet should match via line similarity");
+        assert_eq!(r.strategy, MatchStrategy::Similarity);
+        assert!(
+            r.matched_text.contains("font-weight-primary"),
+            "{:?}",
+            r.matched_text
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

MPI cycle after embedder fuzzy coverage work.

### Fixes
- **Hyphen inconsistency:** `is_token_like_target` allowed `-` but identifier extraction splits on hyphens, so kebab-case typos neither token-matched nor fell back to line similarity cleanly. Align token-like with `extract_identifiers` (alphanumeric + `_` only).
- **unique + fuzzy:** lock that exact multi-match still returns `AmbiguousTarget` when `fuzzy: true`.

### Release hygiene
- `make embedder-smoke` runs host contracts that 0.13 missed (fuzzy token span, nested `undo --list`, plan `key` alias). Not part of `make check` (keeps the gate fast); run before tagging.

### Docs
- agent-rules / PATCHLOOM.md: nested CLI undo, fuzzy tip for hosts.

## Test plan

- [x] `make check-fast`
- [x] `make embedder-smoke`
- [x] unit: kebab line path, unique multi, token-like classification