### PR TITLE
fix: fail-closed min_fuzzy floor; document embedder-smoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make audit` | Run `cargo audit` for known vulnerabilities (optional locally; also in CI) |
 | `make deny` | Run `cargo deny check` for licenses/bans/sources (`deny.toml`; required in CI) |
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
+| `make embedder-smoke` | Pre-release host contracts (fuzzy token span, nested undo list, plan `key` alias). Not part of `check`; run before tagging a release |
 | `make fuzz` | Run fuzz tests (11 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse, containment_check, fallback_resolve, ast_parse, md_heading, replace_regex). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |
 | `make bench-mcp` | Run MCP benchmarks: per-call latency vs CLI process spawn (not part of `check`) |
@@ -39,6 +40,8 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make clean` | Remove build artifacts and temp files |
 
 Always run `make check` before committing. It is the full CI gate.
+
+Before tagging a release, also run `make embedder-smoke` (host-facing contracts that unit tests historically missed).
 
 ## Git hygiene
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ This is a quick-reference subset. For the complete list, see [AGENTS.md](./AGENT
 | `make clippy` | Run clippy with `-D warnings` |
 | `make check` | Full CI gate (run before every commit) |
 | `make check-fast` | Fast check (skips PATCHLOOM.md sync only; still checks README test count) |
+| `make embedder-smoke` | Pre-release host contracts (fuzzy token span, nested undo, plan key alias); not part of `check` |
 | `make audit` | Run `cargo audit` for known vulnerabilities (also in CI) |
 | `make deny` | Run `cargo deny check` for licenses/bans/sources (`deny.toml`; also in CI) |
 | `make update-readme` | Update README.md rounded test count |

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -317,11 +317,11 @@ fn replace_write(
                     let score = anchor.score.or(default_score);
                     if match_mode == MatchMode::Fuzzy
                         && let Some(min) = min_fuzzy_score
-                        && score.is_some_and(|s| s < min)
+                        && crate::fallback::fuzzy_fails_min_floor(score, min)
                     {
                         let actual = score
                             .map(|s| format!("{s:.3}"))
-                            .unwrap_or_else(|| "?".into());
+                            .unwrap_or_else(|| "none".into());
                         return Err(anyhow::Error::new(crate::exit::NoMatchError {
                             msg: format!(
                                 "fuzzy match score {actual} below min_fuzzy_score {min} for {old:?}"
@@ -568,11 +568,11 @@ pub fn replace_in_content(
                 let score = anchor.score.or(default_score);
                 if mode == super::MatchMode::Fuzzy
                     && let Some(min) = opts.min_fuzzy_score
-                    && score.is_some_and(|s| s < min)
+                    && crate::fallback::fuzzy_fails_min_floor(score, min)
                 {
                     let actual = score
                         .map(|s| format!("{s:.3}"))
-                        .unwrap_or_else(|| "?".into());
+                        .unwrap_or_else(|| "none".into());
                     return Err(crate::fallback::EditError::new(
                         crate::fallback::EditErrorKind::NoMatch,
                         format!(

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -675,6 +675,18 @@ pub fn resolve_with_fallback(
     })
 }
 
+/// Whether a fuzzy match should be rejected by `min_fuzzy_score` (#1687).
+///
+/// Fail closed when score is missing: hosts that set a floor must not apply
+/// unscored fuzzy matches (anchor/legacy paths without a score cannot prove
+/// they clear the floor).
+pub(crate) fn fuzzy_fails_min_floor(score: Option<f64>, min: f64) -> bool {
+    match score {
+        Some(s) => s < min,
+        None => true,
+    }
+}
+
 /// True when `target` is a single identifier-like token (no whitespace).
 ///
 /// Multi-word / snippet targets keep whole-line similarity. Token-like targets
@@ -1310,6 +1322,14 @@ mod tests {
         assert!(!is_token_like_target("server.port"));
         assert!(!is_token_like_target(""));
         assert!(!is_token_like_target("   "));
+    }
+
+    #[test]
+    fn fuzzy_fails_min_floor_fail_closed_without_score() {
+        assert!(fuzzy_fails_min_floor(None, 0.8));
+        assert!(fuzzy_fails_min_floor(Some(0.5), 0.8));
+        assert!(!fuzzy_fails_min_floor(Some(0.9), 0.8));
+        assert!(!fuzzy_fails_min_floor(Some(0.8), 0.8));
     }
 
     /// Kebab-case targets use line similarity (not broken token path).

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -252,11 +252,11 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     // Reject weak fuzzy matches when host set a floor (#1687).
                     if mode == MatchMode::Fuzzy
                         && let Some(min) = min_fuzzy_score
-                        && score.is_some_and(|s| s < *min)
+                        && crate::fallback::fuzzy_fails_min_floor(score, *min)
                     {
                         let actual = score
                             .map(|s| format!("{s:.3}"))
-                            .unwrap_or_else(|| "?".into());
+                            .unwrap_or_else(|| "none".into());
                         tx.replace_hint = Some(format!(
                             "fuzzy match score {actual} below min_fuzzy_score {min} for {:?}",
                             crate::fallback::truncate_str(old, 60),
@@ -474,7 +474,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         let score = anchor.score.or(default_score);
                         if mode == MatchMode::Fuzzy
                             && let Some(min) = min_fuzzy_score
-                            && score.is_some_and(|s| s < *min)
+                            && crate::fallback::fuzzy_fails_min_floor(score, *min)
                         {
                             // Skip this file; keep scanning (require_change after loop).
                             continue;

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -35,6 +35,40 @@ async fn test_mcp_doc_set_round_trip() {
 
 /// #1696: registry MCP accepts LLM-prior `key` as alias for `selector`.
 #[tokio::test]
+async fn test_mcp_doc_delete_accepts_key_alias() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("config.json"),
+        r#"{"server":{"port":8080,"host":"localhost"}}"#,
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_delete",
+        serde_json::json!({
+            "path": "config.json",
+            "key": "server.port"
+        }),
+    )
+    .await;
+    assert!(!is_error, "doc_delete with key alias must succeed: {val}");
+    let content = fs::read_to_string(dir.path().join("config.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert!(
+        v["server"].get("port").is_none(),
+        "port should be deleted: {content}"
+    );
+    assert_eq!(v["server"]["host"], "localhost");
+    client.cancel().await.unwrap();
+}
+
+/// #1696: registry MCP accepts LLM-prior `key` as alias for `selector`.
+#[tokio::test]
 async fn test_mcp_doc_set_accepts_key_alias() {
     if !has_mcp_support() {
         return;


### PR DESCRIPTION
## Summary

MPI cycle findings:

1. **min_fuzzy_score fail-closed:** if a Fuzzy match has no score, reject when a floor is set (hosts must not apply unscored fuzzy). Shared helper used by library replace and tx replace_op.
2. **Docs:** AGENTS.md + CONTRIBUTING document `make embedder-smoke` for pre-tag host contracts.
3. **MCP:** `doc_delete` accepts `key` alias (parity with `doc_set` / #1696).

## Test plan

- [x] `make check-fast`
- [x] `make embedder-smoke`
- [x] unit: `fuzzy_fails_min_floor_*`
- [x] existing min_fuzzy tests still pass