### PR TITLE
docs: clarify npm install is not live until NPM_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,6 @@ MCP mode wins overall (228.5s vs 233.8s native) because structured tool calls sk
 # Homebrew (macOS/Linux)
 brew install patchloom/tap/patchloom
 
-# npm / npx (downloads the platform binary; requires Node.js)
-npm install -g patchloom
-# or: npx patchloom --version
-
 # crates.io (requires Rust 1.95+, includes MCP server)
 cargo install patchloom
 ```
@@ -179,6 +175,9 @@ cargo install patchloom
 scoop bucket add patchloom https://github.com/patchloom/scoop-bucket
 scoop install patchloom/patchloom
 ```
+
+npm (`npx patchloom` / `npm install -g patchloom`) is wired in the release
+pipeline and will publish once `NPM_TOKEN` is configured (tracked in #963).
 
 Pre-built binaries for Linux, macOS, and Windows are on the
 [Releases](https://github.com/patchloom/patchloom/releases/latest) page.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -10,7 +10,13 @@ This installs patchloom with all commands, including the MCP server.
 
 ## From npm / npx
 
+> **Status:** cargo-dist is configured to publish the unscoped `patchloom`
+> package on each GitHub Release once the repo `NPM_TOKEN` secret is set
+> (see issue #963). Until the first publish lands, prefer Homebrew, Scoop,
+> crates.io, or the install scripts below.
+
 ```bash
+# After the package is on npmjs.com:
 # One-shot (downloads the platform binary on first run)
 npx patchloom --version
 


### PR DESCRIPTION
## Summary

After #1701, install docs showed `npm install -g patchloom` / `npx` as current install paths. The package is not on npmjs.com yet (`NPM_TOKEN` still missing, tracked in #963), so those commands fail for users.

This PR keeps the npm pipeline docs accurate without advertising a broken install channel.

## Test plan

- [x] No unpublished npmjs.com package URL (lychee 403 fixed in #1701)
- [x] Scoop/Homebrew/crates.io remain primary install instructions
- [ ] Links CI green

Ref #963