### PR TITLE
ci: update Scoop bucket on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -633,6 +633,70 @@ jobs:
           done
           git push
 
+  # Push updated Scoop manifest to patchloom/scoop-bucket (version + hashes).
+  # The committed JSON is the install source of truth; checkver/autoupdate in
+  # the manifest is only a client-side fallback if the bucket lags.
+  # Uses HOMEBREW_TAP_TOKEN (classic PAT with public_repo) — same token must
+  # be able to push to patchloom/scoop-bucket.
+  publish-scoop-bucket:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    timeout-minutes: 15
+    env:
+      PLAN: ${{ needs.plan.outputs.val }}
+      GITHUB_USER: "axo bot"
+      GITHUB_EMAIL: "admin+bot@axo.dev"
+    # always() prevents transitive skip from release-please chain.
+    # Do not publish outside the repo while the repository is private.
+    if: ${{ always() && !cancelled() && needs.host.result == 'success' && !github.event.repository.private && (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Checkout patchloom (manifest generator)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          path: patchloom
+      - name: Checkout scoop-bucket
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: "patchloom/scoop-bucket"
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          persist-credentials: true
+          path: scoop-bucket
+      - name: Fetch release artifacts (sha256 files)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: artifacts-*
+          path: artifacts/
+          merge-multiple: true
+      - name: Update and push Scoop manifest
+        working-directory: scoop-bucket
+        run: |
+          set -euo pipefail
+          version=$(echo "$PLAN" | jq -r '.releases[0].app_version // empty')
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "PLAN had no releases[0].app_version" >&2
+            exit 1
+          fi
+          python3 ../patchloom/scripts/update-scoop-manifest.py \
+            --version "$version" \
+            --artifacts-dir ../artifacts \
+            --output bucket/patchloom.json
+          git config user.name "${GITHUB_USER}"
+          git config user.email "${GITHUB_EMAIL}"
+          git add bucket/patchloom.json
+          if git diff --cached --quiet; then
+            echo "Scoop manifest already at ${version}; nothing to commit"
+            exit 0
+          fi
+          git commit -m "patchloom ${version}"
+          git push
+
   # Publish cargo-dist generated npm installer package (downloads prebuilt
   # binaries from GitHub Releases at install time). Requires NPM_TOKEN secret.
   publish-npm:
@@ -698,12 +762,13 @@ jobs:
       - plan
       - host
       - publish-homebrew-formula
+      - publish-scoop-bucket
       - publish-npm
       - custom-publish-crates
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') && (needs.custom-publish-crates.result == 'skipped' || needs.custom-publish-crates.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-scoop-bucket.result == 'skipped' || needs.publish-scoop-bucket.result == 'success') && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') && (needs.custom-publish-crates.result == 'skipped' || needs.custom-publish-crates.result == 'success') }}
     runs-on: "ubuntu-22.04"
     timeout-minutes: 10
     env:

--- a/REPO-SETUP.md
+++ b/REPO-SETUP.md
@@ -10,9 +10,9 @@ This file captures the recommended day 1 policy setup for `patchloom/patchloom`,
 | CI | Have at least one required CI workflow | use a single `CI` workflow at the start, and point it at the repo's self-hosted runner once that runner exists |
 | Release workflow | Commit `dist-workspace.toml`, `.github/workflows/release.yml`, and `.github/workflows/publish-crates.yml` together | keep cargo-dist config and release automation in sync, keep release jobs on GitHub-hosted runners at first, and skip crates.io and Homebrew publishing while the repo is private |
 | Homebrew tap repo | create `patchloom/homebrew-tap` before the first stable release | the release workflow pushes formula updates there |
-| Scoop bucket repo | create `patchloom/scoop-bucket` with `bucket/patchloom.json` | manifest uses Scoop `checkver`/`autoupdate` against `patchloom-v*` tags |
+| Scoop bucket repo | create `patchloom/scoop-bucket` with `bucket/patchloom.json` | `publish-scoop-bucket` in `release.yml` rewrites version + hashes on each release (uses `HOMEBREW_TAP_TOKEN` to push) |
 | npm publish | set `NPM_TOKEN` (granular, Bypass 2FA, all packages) on the project repo | cargo-dist builds `*-npm-package.tar.gz`; `publish-npm` job in `release.yml` |
-| Release secrets | add `HOMEBREW_TAP_TOKEN` and `CARGO_REGISTRY_TOKEN` | needed before the first public release |
+| Release secrets | add `HOMEBREW_TAP_TOKEN` and `CARGO_REGISTRY_TOKEN` | `HOMEBREW_TAP_TOKEN` must push to both `homebrew-tap` and `scoop-bucket` (classic PAT `public_repo` is enough for public org repos) |
 | Security reporting | commit `SECURITY.md` now, then enable GitHub private vulnerability reporting after the repo becomes public | private Free org repos do not expose GitHub private vulnerability reporting yet |
 | Branch protection | Protect `main` once the repo is public or on a plan that supports private branch protection | required before accepting outside patches |
 | Public repo metadata | commit `LICENSE`, `README.md`, `CONTRIBUTING.md`, and issue templates in the bootstrap | keep the repo legible from day one |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,8 +34,14 @@ scoop bucket add patchloom https://github.com/patchloom/scoop-bucket
 scoop install patchloom/patchloom
 ```
 
-The Scoop manifest uses `checkver` / `autoupdate` against GitHub Releases
-(`patchloom-v*` tags), so `scoop update patchloom` picks up new versions.
+Each GitHub Release updates `bucket/patchloom.json` in
+[patchloom/scoop-bucket](https://github.com/patchloom/scoop-bucket) with the
+new version and SHA256 hashes (same idea as the Homebrew tap). Then:
+
+```powershell
+scoop update
+scoop update patchloom
+```
 
 ## From crates.io
 

--- a/scripts/test_update_scoop_manifest.py
+++ b/scripts/test_update_scoop_manifest.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Tests for scripts/update-scoop-manifest.py"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "update-scoop-manifest.py"
+
+
+class UpdateScoopManifestTests(unittest.TestCase):
+    def test_write_from_hashes(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out = Path(td) / "patchloom.json"
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--version",
+                    "0.13.0",
+                    "--hash-x64",
+                    "b194104e93904c82a9ffd30b5a6f9125b1ca41848b24c63353ec4bd775c332f1",
+                    "--hash-arm64",
+                    "1e96356a395d74c86eac9e1ef63617bd2e87f755cb6cd158e97cabc0f1a8dc5d",
+                    "--output",
+                    str(out),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("wrote", r.stdout)
+            data = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(data["version"], "0.13.0")
+            self.assertEqual(data["bin"], "patchloom.exe")
+            self.assertIn("patchloom-v0.13.0", data["architecture"]["64bit"]["url"])
+            self.assertIn(
+                "patchloom-x86_64-pc-windows-msvc.zip",
+                data["architecture"]["64bit"]["url"],
+            )
+            self.assertEqual(
+                data["architecture"]["64bit"]["hash"],
+                "b194104e93904c82a9ffd30b5a6f9125b1ca41848b24c63353ec4bd775c332f1",
+            )
+            self.assertIn("patchloom-v$version", data["autoupdate"]["architecture"]["64bit"]["url"])
+
+    def test_artifacts_dir_and_check(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            art = root / "artifacts" / "nested"
+            art.mkdir(parents=True)
+            (art / "patchloom-x86_64-pc-windows-msvc.zip.sha256").write_text(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+                "*patchloom-x86_64-pc-windows-msvc.zip\n",
+                encoding="utf-8",
+            )
+            (art / "patchloom-aarch64-pc-windows-msvc.zip.sha256").write_text(
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb "
+                "*patchloom-aarch64-pc-windows-msvc.zip\n",
+                encoding="utf-8",
+            )
+            out = root / "bucket" / "patchloom.json"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--version",
+                    "patchloom-v1.2.3",
+                    "--artifacts-dir",
+                    str(root / "artifacts"),
+                    "--output",
+                    str(out),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            data = json.loads(out.read_text(encoding="utf-8"))
+            self.assertEqual(data["version"], "1.2.3")
+            self.assertEqual(
+                data["architecture"]["64bit"]["hash"],
+                "a" * 64,
+            )
+            self.assertEqual(
+                data["architecture"]["arm64"]["hash"],
+                "b" * 64,
+            )
+            # --check must pass for same content
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--version",
+                    "1.2.3",
+                    "--hash-x64",
+                    "a" * 64,
+                    "--hash-arm64",
+                    "b" * 64,
+                    "--output",
+                    str(out),
+                    "--check",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(r.returncode, 0, r.stderr)
+
+    def test_missing_hash_file_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            out = root / "out.json"
+            r = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--version",
+                    "0.1.0",
+                    "--artifacts-dir",
+                    str(root),
+                    "--output",
+                    str(out),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(r.returncode, 0)
+            self.assertIn("missing", r.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/update-scoop-manifest.py
+++ b/scripts/update-scoop-manifest.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Generate or update the Scoop bucket manifest for patchloom.
+
+Release CI runs this after GitHub Release assets exist so patchloom/scoop-bucket
+always pins the new version + SHA256. Client-side Scoop checkver/autoupdate is
+kept as a fallback only; the committed JSON is the source of truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# cargo-dist tag format for this project
+TAG_PREFIX = "patchloom-v"
+
+X64_ZIP = "patchloom-x86_64-pc-windows-msvc.zip"
+ARM64_ZIP = "patchloom-aarch64-pc-windows-msvc.zip"
+
+HASH_RE = re.compile(r"^([a-fA-F0-9]{64})\b")
+
+
+def parse_hash_file(path: Path) -> str:
+    text = path.read_text(encoding="utf-8").strip()
+    if not text:
+        raise SystemExit(f"empty hash file: {path}")
+    m = HASH_RE.match(text.splitlines()[0].strip())
+    if not m:
+        raise SystemExit(f"could not parse SHA256 from {path}: {text!r}")
+    return m.group(1).lower()
+
+
+def find_hash(artifacts_dir: Path, zip_name: str) -> str:
+    """Locate zip.sha256 under a recursive artifacts download tree."""
+    candidates = list(artifacts_dir.rglob(f"{zip_name}.sha256"))
+    if not candidates:
+        # also accept bare sha256 next to zip
+        candidates = list(artifacts_dir.rglob(zip_name))
+        raise SystemExit(
+            f"missing {zip_name}.sha256 under {artifacts_dir} "
+            f"(found {len(list(artifacts_dir.rglob('*')))} files)"
+        )
+    if len(candidates) > 1:
+        # prefer shallowest
+        candidates.sort(key=lambda p: len(p.parts))
+    return parse_hash_file(candidates[0])
+
+
+def build_manifest(version: str, hash_x64: str, hash_arm64: str) -> dict:
+    tag = f"{TAG_PREFIX}{version}"
+    base = f"https://github.com/patchloom/patchloom/releases/download/{tag}"
+    return {
+        "version": version,
+        "description": (
+            "Structured file editing CLI for AI agents: search, replace, "
+            "patch, doc, md, AST, and MCP."
+        ),
+        "homepage": "https://github.com/patchloom/patchloom",
+        "license": "MIT|Apache-2.0",
+        "architecture": {
+            "64bit": {
+                "url": f"{base}/{X64_ZIP}",
+                "hash": hash_x64.lower(),
+            },
+            "arm64": {
+                "url": f"{base}/{ARM64_ZIP}",
+                "hash": hash_arm64.lower(),
+            },
+        },
+        "bin": "patchloom.exe",
+        # Fallback if the bucket JSON lags; release CI should keep version current.
+        "checkver": {
+            "url": "https://api.github.com/repos/patchloom/patchloom/releases/latest",
+            "jsonpath": "$.tag_name",
+            "regex": r"patchloom-v([\d.]+)",
+        },
+        "autoupdate": {
+            "architecture": {
+                "64bit": {
+                    "url": (
+                        "https://github.com/patchloom/patchloom/releases/download/"
+                        "patchloom-v$version/" + X64_ZIP
+                    ),
+                    "hash": {
+                        "url": "$url.sha256",
+                        "regex": r"^([a-fA-F0-9]{64})",
+                    },
+                },
+                "arm64": {
+                    "url": (
+                        "https://github.com/patchloom/patchloom/releases/download/"
+                        "patchloom-v$version/" + ARM64_ZIP
+                    ),
+                    "hash": {
+                        "url": "$url.sha256",
+                        "regex": r"^([a-fA-F0-9]{64})",
+                    },
+                },
+            }
+        },
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--version", required=True, help="Semver without tag prefix, e.g. 0.13.0")
+    p.add_argument(
+        "--artifacts-dir",
+        type=Path,
+        help="Directory with cargo-dist artifacts (searched for *.zip.sha256)",
+    )
+    p.add_argument("--hash-x64", help="SHA256 of the x86_64 Windows zip")
+    p.add_argument("--hash-arm64", help="SHA256 of the aarch64 Windows zip")
+    p.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to write bucket/patchloom.json",
+    )
+    p.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 0 only if existing --output matches generated content",
+    )
+    args = p.parse_args()
+
+    version = args.version.lstrip("v")
+    if version.startswith(TAG_PREFIX):
+        version = version[len(TAG_PREFIX) :]
+
+    if args.artifacts_dir:
+        hash_x64 = find_hash(args.artifacts_dir, X64_ZIP)
+        hash_arm64 = find_hash(args.artifacts_dir, ARM64_ZIP)
+    elif args.hash_x64 and args.hash_arm64:
+        hash_x64 = args.hash_x64
+        hash_arm64 = args.hash_arm64
+    else:
+        p.error("provide --artifacts-dir or both --hash-x64 and --hash-arm64")
+
+    manifest = build_manifest(version, hash_x64, hash_arm64)
+    text = json.dumps(manifest, indent=4) + "\n"
+
+    if args.check:
+        if not args.output.is_file():
+            print(f"missing {args.output}", file=sys.stderr)
+            return 1
+        existing = args.output.read_text(encoding="utf-8")
+        if existing != text:
+            print(f"{args.output} is stale for version {version}", file=sys.stderr)
+            return 1
+        print(f"ok: {args.output} matches {version}")
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(text, encoding="utf-8")
+    print(f"wrote {args.output} for version {version}")
+    print(f"  64bit  {hash_x64}")
+    print(f"  arm64  {hash_arm64}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Wires **Scoop** the same way Homebrew is wired: on each public release, CI updates [patchloom/scoop-bucket](https://github.com/patchloom/scoop-bucket) so `bucket/patchloom.json` always pins the new version, zip URLs, and SHA256 hashes.

This is the real publish path. Client-side Scoop `checkver`/`autoupdate` stays in the JSON only as a fallback if the bucket ever lags.

## Changes

- `publish-scoop-bucket` job in `release.yml` (after `host`, before announce)
  - checks out `patchloom/scoop-bucket` with `HOMEBREW_TAP_TOKEN`
  - downloads cargo-dist artifacts
  - runs `scripts/update-scoop-manifest.py`
  - commits and pushes when the manifest changes
- Generator script + unit tests (`scripts/test_update_scoop_manifest.py`)
- Docs: installation.md + REPO-SETUP (token must push to both homebrew-tap and scoop-bucket)

Also updated the scoop-bucket README on that repo to document release CI ownership.

## Token requirement

`HOMEBREW_TAP_TOKEN` must be able to push to **both**:

- `patchloom/homebrew-tap`
- `patchloom/scoop-bucket`

A classic PAT with `public_repo` for public org repos is enough (same setup as Homebrew).

## Test plan

- [x] `python3 scripts/test_update_scoop_manifest.py` passes
- [x] Generator reproduces 0.13.0 URLs/hashes used by the live bucket
- [x] release.yml YAML parses; actionlint has no new errors on the Scoop job
- [ ] CI green on this PR
- [ ] Next release (e.g. 0.14.0 after #1691): confirm `publish-scoop-bucket` commits to scoop-bucket

Ref #962