### PR TITLE
ci: add manual Scoop bucket republish workflow

### DIFF
--- a/.github/workflows/publish-scoop.yml
+++ b/.github/workflows/publish-scoop.yml
@@ -1,0 +1,101 @@
+# Manually (or on demand) rewrite patchloom/scoop-bucket from a published
+# GitHub Release. The automatic path is publish-scoop-bucket in release.yml;
+# this workflow exists to re-sync after a missed push or to verify the PAT.
+name: Publish Scoop bucket
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >
+          Semver without tag prefix (e.g. 0.13.0). Leave empty to use the
+          latest GitHub Release tag (strip patchloom-v / v prefix).
+        required: false
+        type: string
+        default: ""
+
+concurrency:
+  group: publish-scoop-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Update scoop-bucket
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    env:
+      GITHUB_USER: "axo bot"
+      GITHUB_EMAIL: "admin+bot@axo.dev"
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout patchloom
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          path: patchloom
+
+      - name: Checkout scoop-bucket
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: patchloom/scoop-bucket
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          persist-credentials: true
+          path: scoop-bucket
+
+      - name: Resolve version and download SHA256 files
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION#v}"
+            version="${version#patchloom-v}"
+            tag="patchloom-v${version}"
+          else
+            tag=$(gh release view --repo patchloom/patchloom --json tagName --jq .tag_name)
+            version="${tag#patchloom-v}"
+            version="${version#v}"
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "Resolved version=${version} tag=${tag}"
+          mkdir -p artifacts
+          for asset in \
+            patchloom-x86_64-pc-windows-msvc.zip.sha256 \
+            patchloom-aarch64-pc-windows-msvc.zip.sha256
+          do
+            gh release download "${tag}" \
+              --repo patchloom/patchloom \
+              --pattern "${asset}" \
+              --dir artifacts
+          done
+          ls -la artifacts
+
+      - name: Update and push Scoop manifest
+        working-directory: scoop-bucket
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          python3 ../patchloom/scripts/update-scoop-manifest.py \
+            --version "${VERSION}" \
+            --artifacts-dir ../artifacts \
+            --output bucket/patchloom.json
+          git config user.name "${GITHUB_USER}"
+          git config user.email "${GITHUB_EMAIL}"
+          git add bucket/patchloom.json
+          if git diff --cached --quiet; then
+            echo "Scoop manifest already at ${VERSION}; nothing to commit"
+            exit 0
+          fi
+          git commit -m "patchloom ${VERSION}"
+          git push

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz git-clean clean
+.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -63,6 +63,9 @@ verify-release-notes: ## Verify RELEASE_NOTES.md if present (for curated release
 	else \
 		echo "No RELEASE_NOTES.md present (generated changelog will be used)"; \
 	fi
+
+scoop-manifest-test: ## Unit tests for scripts/update-scoop-manifest.py (Scoop release publish)
+	python3 scripts/test_update_scoop_manifest.py
 
 git-clean: ## Remove known temp files that pollute `git status` (e.g. .lycheecache). Addresses #736.
 	@rm -f .lycheecache

--- a/REPO-SETUP.md
+++ b/REPO-SETUP.md
@@ -10,7 +10,7 @@ This file captures the recommended day 1 policy setup for `patchloom/patchloom`,
 | CI | Have at least one required CI workflow | use a single `CI` workflow at the start, and point it at the repo's self-hosted runner once that runner exists |
 | Release workflow | Commit `dist-workspace.toml`, `.github/workflows/release.yml`, and `.github/workflows/publish-crates.yml` together | keep cargo-dist config and release automation in sync, keep release jobs on GitHub-hosted runners at first, and skip crates.io and Homebrew publishing while the repo is private |
 | Homebrew tap repo | create `patchloom/homebrew-tap` before the first stable release | the release workflow pushes formula updates there |
-| Scoop bucket repo | create `patchloom/scoop-bucket` with `bucket/patchloom.json` | `publish-scoop-bucket` in `release.yml` rewrites version + hashes on each release (uses `HOMEBREW_TAP_TOKEN` to push) |
+| Scoop bucket repo | create `patchloom/scoop-bucket` with `bucket/patchloom.json` | `publish-scoop-bucket` in `release.yml` rewrites version + hashes on each release; `publish-scoop.yml` is a manual re-sync (`workflow_dispatch`) |
 | npm publish | set `NPM_TOKEN` (granular, Bypass 2FA, all packages) on the project repo | cargo-dist builds `*-npm-package.tar.gz`; `publish-npm` job in `release.yml` |
 | Release secrets | add `HOMEBREW_TAP_TOKEN` and `CARGO_REGISTRY_TOKEN` | `HOMEBREW_TAP_TOKEN` must push to both `homebrew-tap` and `scoop-bucket` (classic PAT `public_repo` is enough for public org repos) |
 | Security reporting | commit `SECURITY.md` now, then enable GitHub private vulnerability reporting after the repo becomes public | private Free org repos do not expose GitHub private vulnerability reporting yet |


### PR DESCRIPTION
## Summary

Finishes Scoop private-bucket **release wiring**:

1. **Automatic** (already on main from #1703): `publish-scoop-bucket` in `release.yml` on each public release.
2. **Manual** (this PR): `.github/workflows/publish-scoop.yml` with `workflow_dispatch` to re-sync `patchloom/scoop-bucket` from any published release (or latest). Use to verify `HOMEBREW_TAP_TOKEN` can push the bucket without cutting a new version.

Also adds `make scoop-manifest-test`.

Does **not** close #962 yet: Windows `scoop install` smoke is still unchecked (needs a Windows host).

## How to verify the PAT after merge

```bash
gh workflow run publish-scoop.yml --repo patchloom/patchloom
# optional: -f version=0.13.0
gh run list --workflow=publish-scoop.yml --limit 1
```

Expect success and either a no-op ("already at version") or a commit on scoop-bucket.

## Test plan

- [x] `make scoop-manifest-test`
- [x] YAML parse + actionlint clean for publish-scoop.yml
- [ ] CI green
- [ ] After merge: manual `workflow_dispatch` once (proves token)

Ref #962