### PR TITLE
test: tighten AI findings on fuzzy assert and MCP tests

### DIFF
--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -156,6 +156,42 @@ async fn test_mcp_read_round_trip() {
     client.cancel().await.unwrap();
 }
 
+/// Boundary: same line count without a trailing newline (str::lines() omits a final empty line).
+#[tokio::test]
+async fn test_mcp_read_round_trip_without_trailing_newline() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("data_no_trailing_newline.txt"),
+        "line1\nline2\nline3",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "read_file",
+        serde_json::json!({"path": "data_no_trailing_newline.txt"}),
+    )
+    .await;
+    assert!(!is_error, "read should succeed");
+    let content = val["reads"][0]["content"]
+        .as_str()
+        .expect("reads[0].content should be a string");
+    assert_eq!(
+        content, "line1\nline2\nline3",
+        "read should return exact file content without trailing newline"
+    );
+    assert_eq!(
+        val["reads"][0]["total_lines"], 3,
+        "should have 3 lines without trailing newline"
+    );
+    assert_eq!(val["reads"][0]["path"], "data_no_trailing_newline.txt");
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_doc_set_nonexistent_file_returns_error() {
     if !has_mcp_support() {
@@ -772,7 +808,6 @@ async fn test_mcp_patch_round_trip() {
     client.cancel().await.unwrap();
 }
 
-#[cfg(feature = "mcp")]
 #[tokio::test]
 async fn test_mcp_apply_patch_on_stale_merge() {
     if !has_mcp_support() {
@@ -803,7 +838,6 @@ async fn test_mcp_apply_patch_on_stale_merge() {
     client.cancel().await.unwrap();
 }
 
-#[cfg(feature = "mcp")]
 #[tokio::test]
 async fn test_mcp_apply_patch_merge_conflict_rejected_without_allow_conflicts() {
     if !has_mcp_support() {
@@ -846,7 +880,6 @@ async fn test_mcp_apply_patch_merge_conflict_rejected_without_allow_conflicts() 
     client.cancel().await.unwrap();
 }
 
-#[cfg(feature = "mcp")]
 #[tokio::test]
 async fn test_mcp_apply_patch_merge_conflict_with_allow_conflicts() {
     if !has_mcp_support() {
@@ -889,7 +922,6 @@ async fn test_mcp_apply_patch_merge_conflict_with_allow_conflicts() {
     client.cancel().await.unwrap();
 }
 
-#[cfg(feature = "mcp")]
 #[tokio::test]
 async fn test_mcp_md_insert_after_heading_round_trip() {
     if !has_mcp_support() {
@@ -928,7 +960,6 @@ async fn test_mcp_md_insert_after_heading_round_trip() {
     client.cancel().await.unwrap();
 }
 
-#[cfg(feature = "mcp")]
 #[tokio::test]
 async fn test_mcp_md_insert_before_heading_round_trip() {
     if !has_mcp_support() {

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1913,10 +1913,11 @@ fn test_replace_fuzzy_identifier_typo_json_match_mode() {
         .as_str()
         .or_else(|| parsed["files"][0]["match_mode"].as_str())
         .unwrap_or("");
-    assert!(
-        mode == "fuzzy" || parsed["ok"] == true,
-        "expected fuzzy success payload: {parsed}"
+    assert_eq!(
+        mode, "fuzzy",
+        "expected fuzzy match_mode in success payload: {parsed}"
     );
+    assert_eq!(parsed["ok"], true, "expected ok in payload: {parsed}");
     let on_disk = fs::read_to_string(&file).unwrap();
     assert_eq!(on_disk, "fn handle_request(x: i32) {}\n");
 }


### PR DESCRIPTION
## Summary

Address GitHub AI Code Quality findings from https://github.com/patchloom/patchloom/security/quality/ai-findings

- **Real:** `test_replace_fuzzy_identifier_typo_json_match_mode` asserted `mode == "fuzzy" || ok`, which always passes on success. Now requires `match_mode == "fuzzy"` and `ok == true` separately.
- **Cosmetic:** five MCP integration tests had `#[cfg(feature = "mcp")]` while the rest of the file only uses the runtime `has_mcp_support()` guard. Removed the cfg so the file is consistent.
- **Noise reduction:** added `test_mcp_read_round_trip_without_trailing_newline` so line-count boundary behavior is explicit (the original `total_lines=3` with trailing newline remains correct for Rust `str::lines()`).

## Test plan

- [x] `cargo test --test integration --all-features fuzzy_identifier_typo_json_match_mode`
- [x] `cargo test --test integration --all-features test_mcp_read_round_trip`
- [x] `cargo test --test integration --all-features test_mcp_apply_patch_on_stale`
- [x] `cargo test --test integration --all-features test_mcp_md_insert_after`