### PR TITLE
ci: do not cancel Scoop install smoke on main

### DIFF
--- a/.github/workflows/test-scoop.yml
+++ b/.github/workflows/test-scoop.yml
@@ -18,8 +18,11 @@ on:
       - "scripts/test_update_scoop_manifest.py"
 
 concurrency:
-  group: test-scoop-${{ github.ref }}
-  cancel-in-progress: true
+  # Per-ref group so PRs still cancel superseded runs. Never cancel on main:
+  # a cancelled suite sticks on the commit and makes the default-branch
+  # statusCheckRollup FAILURE even when a later Scoop smoke succeeds.
+  group: test-scoop-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Main tip looked red even though CI and a later Scoop smoke succeeded. Cause: `Test Scoop install` used `cancel-in-progress: true` on `test-scoop-${{ github.ref }}`. A push-triggered run was cancelled by a later `workflow_dispatch` on the same ref; GitHub attaches the cancelled suite to the commit and `statusCheckRollup` becomes FAILURE.

## Change

- Keep cancelling superseded runs on PR branches
- Never cancel in-progress Scoop smoke on `main`
- Slightly clearer concurrency group key (`workflow` + `ref`)

## Test plan

- [x] Diff reviewed
- [ ] PR CI green
- [ ] After merge, main rollup no longer stuck red solely from cancelled Scoop (new tip supersedes old suite)