### PR TITLE
chore: toml_edit 0.25.13 and harden Chocolatey CI

### DIFF
--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -31,6 +31,11 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 20
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -803,6 +803,11 @@ jobs:
       PLAN: ${{ needs.plan.outputs.val }}
     if: ${{ always() && !cancelled() && needs.host.result == 'success' && !github.event.repository.private && (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,9 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2572,9 +2572,9 @@ dependencies = [
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tower"

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ flowchart LR
 
 | Component | Status |
 |---|---|
-| CLI | Published on [crates.io](https://crates.io/crates/patchloom), [Homebrew](https://github.com/patchloom/homebrew-tap), [Scoop](https://github.com/patchloom/scoop-bucket), [Chocolatey](https://community.chocolatey.org/packages) (`choco install patchloom` after first listing), and [npm](https://www.npmjs.com/package/patchloom) (`npx patchloom`) |
+| CLI | Published on [crates.io](https://crates.io/crates/patchloom), [Homebrew](https://github.com/patchloom/homebrew-tap), [Scoop](https://github.com/patchloom/scoop-bucket), [Chocolatey](https://community.chocolatey.org/packages/patchloom) (`choco install patchloom`; first version under moderation), and [npm](https://www.npmjs.com/package/patchloom) (`npx patchloom`) |
 | Editor extension | Published on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom) and [Open VSX](https://open-vsx.org/extension/patchloom/patchloom) |
 
 ## Full command reference


### PR DESCRIPTION
## Summary

MPI 2026-07-14 cycle follow-up after Chocolatey packaging landed:

- Bump `toml_edit` 0.25.12 → 0.25.13 (and `toml_writer` 1.1.1 → 1.1.2)
- Add `step-security/harden-runner` to Chocolatey publish paths (`release.yml` + `publish-chocolatey.yml`), matching Scoop/crates publish hygiene
- README: link the live [packages/patchloom](https://community.chocolatey.org/packages/patchloom) page (first version still under community moderation)

## Gate notes

- Release PR #1691 (0.14.0): still needs explicit user yes
- Dist B-path: #961 Chocolatey moderation pending; #960 winget moderator; #632–#634 MCP directories external

## Test plan

- [x] `cargo outdated --root-deps-only` clean after bump
- [x] `python3 scripts/test_update_chocolatey_package.py`
- [x] `cargo check --lib --all-features`
- [ ] CI green