### PR TITLE
fix: accept compact md table-append rows

### DIFF
--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 #[command(after_help = "\
 EXAMPLES:
   patchloom md table-append README.md --heading '## API' --row '| /users | List users |'
+  patchloom md table-append README.md --heading '## API' --row '/users|List users'
   patchloom md upsert-bullet AGENTS.md --heading '## Rules' --bullet '- Run make check'
   patchloom md replace-section CHANGELOG.md --heading '## Unreleased' --content '- New feature' --apply")]
 pub struct MdArgs {
@@ -76,7 +77,7 @@ pub enum MdAction {
         file: String,
         #[arg(long)]
         heading: String,
-        /// The row to append, in markdown table format (e.g., "| col1 | col2 | col3 |").
+        /// Table row: `| col1 | col2 |` or compact `col1|col2` / `col1 | col2`.
         #[arg(long)]
         row: String,
     },

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -642,10 +642,42 @@ impl std::fmt::Display for TableAppendError {
         match self {
             Self::NoTable => write!(f, "no markdown table found"),
             Self::ColumnMismatch { expected, actual } => {
-                write!(f, "row has {actual} column(s), table has {expected}")
+                write!(
+                    f,
+                    "row has {actual} column(s), table has {expected} \
+                     (use markdown row form `| a | b |` or compact `a|b`)"
+                )
             }
         }
     }
+}
+
+/// Normalize agent-friendly row inputs into a full markdown table row.
+///
+/// Accepts canonical `| a | b |` and compact forms agents often pass
+/// (`a|b`, `a | b`). Empty input stays empty.
+pub(crate) fn normalize_md_table_row(row: &str) -> String {
+    let t = row.trim();
+    if t.is_empty() {
+        return String::new();
+    }
+    if is_table_row(t) {
+        return t.to_string();
+    }
+    // Compact pipe-separated cells without requiring outer pipes.
+    let cells: Vec<&str> = t.trim_matches('|').split('|').map(str::trim).collect();
+    if cells.is_empty() || cells.iter().all(|c| c.is_empty()) {
+        return String::new();
+    }
+    format!("| {} |", cells.join(" | "))
+}
+
+fn table_column_count(row: &str) -> usize {
+    let t = row.trim();
+    if !is_table_row(t) {
+        return 0;
+    }
+    t.matches('|').count().saturating_sub(1)
 }
 
 pub fn table_append_in(
@@ -692,6 +724,9 @@ pub fn table_append_in(
 
     let insert_pos = last_data_end.ok_or(TableAppendError::NoTable)?;
 
+    // Agents often pass compact `a|b` without outer pipes; normalize first.
+    let row = normalize_md_table_row(row);
+
     // Validate that the new row has the same column count as the existing
     // table to prevent silent corruption of markdown tables (#1172).
     let expected_cols = {
@@ -699,14 +734,10 @@ pub fn table_append_in(
         section
             .lines()
             .find(|l| is_separator_row(l))
-            .map(|sep| sep.trim().matches('|').count().saturating_sub(1))
+            .map(table_column_count)
     };
     if let Some(expected) = expected_cols {
-        let actual = if is_table_row(row) {
-            row.trim().matches('|').count().saturating_sub(1)
-        } else {
-            0
-        };
+        let actual = table_column_count(&row);
         if actual != expected {
             return Err(TableAppendError::ColumnMismatch { expected, actual });
         }
@@ -720,7 +751,7 @@ pub fn table_append_in(
     if insert_pos > 0 && content.as_bytes().get(insert_pos - 1) != Some(&b'\n') {
         out.push_str(eol);
     }
-    out.push_str(row);
+    out.push_str(&row);
     if !row.ends_with('\n') {
         out.push_str(eol);
     }

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -204,6 +204,44 @@ mod basic {
     }
 
     #[test]
+    fn table_append_compact_row_without_outer_pipes() {
+        // Agents often pass `a|b` instead of `| a | b |` (fixrealloop).
+        let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n";
+        let (start, end) = find_section(content, "API").unwrap();
+        let result = table_append_in(content, start, end, "b|2").unwrap();
+        assert!(
+            result.contains("| a | 1 |\n| b | 2 |\n"),
+            "compact row should normalize: {result}"
+        );
+    }
+
+    #[test]
+    fn table_append_compact_row_spaced_cells() {
+        let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n";
+        let (start, end) = find_section(content, "API").unwrap();
+        let result = table_append_in(content, start, end, "b | 2").unwrap();
+        assert!(result.contains("| b | 2 |\n"), "got: {result}");
+    }
+
+    #[test]
+    fn normalize_md_table_row_canonical_unchanged() {
+        assert_eq!(normalize_md_table_row("| a | b |"), "| a | b |");
+    }
+
+    #[test]
+    fn table_append_column_mismatch_mentions_formats() {
+        let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n";
+        let (start, end) = find_section(content, "API").unwrap();
+        let err = table_append_in(content, start, end, "only-one").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("column"), "{msg}");
+        assert!(
+            msg.contains("compact") || msg.contains("| a | b |"),
+            "error should hint formats: {msg}"
+        );
+    }
+
+    #[test]
     fn table_append_for_tx_basic() {
         let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n";
         let result = table_append_for_tx(content, "API", "| b | 2 |")
@@ -1479,14 +1517,22 @@ body text
 
     #[test]
     fn table_append_not_table_row_returns_column_mismatch() {
-        // Row without pipe wrapping should fail with ColumnMismatch,
-        // not with NoTable (there IS a table, the row is just malformed).
+        // Compact two-cell rows are normalized (fixrealloop). A single cell
+        // with no pipes is still a column mismatch for a 2-column table.
         let content = "# T\n| A | B |\n|---|---|\n| 1 | 2 |\n";
         let (start, end) = find_section(content, "T").unwrap();
-        let err = table_append_in(content, start, end, "x | y").unwrap_err();
+        let ok = table_append_in(content, start, end, "x | y").expect("compact two cells");
+        assert!(ok.contains("| x | y |\n"), "got: {ok}");
+        let err = table_append_in(content, start, end, "only-one-cell").unwrap_err();
         assert!(
-            matches!(err, TableAppendError::ColumnMismatch { .. }),
-            "expected ColumnMismatch for unwrapped row, got: {err:?}"
+            matches!(
+                err,
+                TableAppendError::ColumnMismatch {
+                    expected: 2,
+                    actual: 1
+                }
+            ),
+            "expected ColumnMismatch for single cell, got: {err:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixrealloop found that `md table-append --row '9|8'` failed with
`row has 0 column(s), table has 2` because column counting only accepted
full markdown rows (`| 9 | 8 |`).

- Normalize compact `a|b` / `a | b` to `| a | b |` before append
- Keep `| a | b |` unchanged
- Clearer ColumnMismatch message with format hints
- Unit tests for compact success and single-cell mismatch

## Test plan

- [x] `cargo test --lib table_append --all-features`
- [x] CLI: `md table-append … --row '9|8' --apply` appends `| 9 | 8 |`
- [x] CLI: `--row only` still ColumnMismatch with format hint
- [ ] CI green