### PR TITLE
docs: clarify undo is dry-run until --apply

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -45,7 +45,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)
-- CLI undo is **dry-run by default**: `patchloom undo` previews and exits 2; restore with `patchloom undo --apply` (optional `--session <ts>`). `undo --list` walks nested `.patchloom/backups` under the cwd (#1695).
+- CLI: `patchloom undo --list` walks nested `.patchloom/backups` under the cwd (#1695). Bare CLI undo is dry-run (exit 2); restore needs the write apply flag (see CLI agent-rules).
 - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`
 - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)
 - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts (#1687, #1694)

--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -45,7 +45,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)
-- CLI: `patchloom undo --list` also walks nested `.patchloom/backups` under the cwd (#1695)
+- CLI undo is **dry-run by default**: `patchloom undo` previews and exits 2; restore with `patchloom undo --apply` (optional `--session <ts>`). `undo --list` walks nested `.patchloom/backups` under the cwd (#1695).
 - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`
 - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)
 - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts (#1687, #1694)
@@ -56,6 +56,8 @@ Use patchloom when:
 - Editing markdown sections, bullets, or tables by heading
 - Batching edits across multiple files in one call
 - You need atomic rollback if any edit fails
+
+**CLI undo (dry-run by default):** `patchloom undo` only previews the most recent backup and exits 2. Restore with `patchloom undo --apply` (optional `--session <timestamp>`). List sessions with `patchloom undo --list`. There is no `--latest` flag.
 
 ## MCP mode
 
@@ -320,7 +322,7 @@ dependencies[name=react].version # predicate filter
 |------|---------|
 | 0 | Success (operation completed, or no changes needed) |
 | 1 | Failure (error during execution, CLI usage/invalid args/unknown flags/subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |
-| 2 | Changes detected (`--check` / write preview, or CLI/MCP/plan/tx `search` `assert_count` mismatch; `error_kind: changes_detected` for assert_count) |
+| 2 | Changes detected (`--check` / write preview including `undo` without `--apply`, or CLI/MCP/plan/tx `search` `assert_count` mismatch; `error_kind: changes_detected` for assert_count). For undo, re-run with `--apply` to restore. |
 | 3 | No matches (search/replace pattern miss, undo with no sessions, missing AST symbol for extract/insert/reorder/wrap/move, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |
 | 4 | Parse error (malformed input file or plan, invalid AST search pattern/query, or AST validate parse failure; `error_kind: parse_error`) |
 | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -349,13 +349,14 @@ Patchloom can be used as a Rust library (disable default `cli` feature for small
 <!-- ref:command:undo -->
 ## `undo`
 
-- **What it does:** Restores files from a backup created by a previous `--apply` operation. Before any `--apply` write, patchloom saves the original content of affected files to `.patchloom/backups/<timestamp>/`. In dry-run mode, `undo` reports what would be restored and exits with code `2` (`CHANGES_DETECTED`). `--json` or `--jsonl` emit that preview as structured output.
+- **What it does:** Previews or restores files from a backup created by a previous write `--apply`. Before any `--apply` write, patchloom saves originals under `.patchloom/backups/<timestamp>/`. **Default is dry-run** (same singularity as other write commands): bare `patchloom undo` prints what would be restored, exits `2` (`CHANGES_DETECTED`), and does not change files. Pass `--apply` to restore (exit `0`). There is no `--latest`; without `--session`, the most recent backup is used. Dry-run JSON includes `status: "changes_detected"` and a `hint` field reminding agents to pass `--apply`.
 - **Use when:** An `--apply` operation produced an undesirable result and you want to revert. Especially useful when the working tree was not committed before applying changes.
 - **Notable flags:**
   - `--list` shows available backup sessions. `--json` emits the full session list as one array, while `--jsonl` emits one session object per line.
   - `--session <timestamp>` targets a specific session (defaults to most recent).
-  - `--apply` actually restores files (dry-run by default, showing what would change).
+  - `--apply` actually restores files (required for a real restore; omitted = preview only).
 - **Failure behavior:** No backup sessions (`--list` empty, or restore with no sessions) exits `3` (`NO_MATCHES`). With `--json`/`--jsonl`, the error envelope includes `error_kind: "no_matches"` so agents can branch without scraping stderr.
+- **Agent trap:** Do not treat exit `2` from bare `undo` as a completed restore. Re-run with `--apply`.
 - **Prefer instead:** Use `git checkout` or `git stash` when working in a committed git repo.
 - **Related:** `tx`, `replace`, `tidy`
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -122,7 +122,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
              - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)\n\
-             - CLI undo is **dry-run by default**: `patchloom undo` previews and exits 2; restore with `patchloom undo --apply` (optional `--session <ts>`). `undo --list` walks nested `.patchloom/backups` under the cwd (#1695).\n\
+             - CLI: `patchloom undo --list` walks nested `.patchloom/backups` under the cwd (#1695). Bare CLI undo is dry-run (exit 2); restore needs the write apply flag (see CLI agent-rules).\n\
              - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
              - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)\n\
              - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts (#1687, #1694)\n\

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -122,7 +122,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
              - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)\n\
-             - CLI: `patchloom undo --list` also walks nested `.patchloom/backups` under the cwd (#1695)\n\
+             - CLI undo is **dry-run by default**: `patchloom undo` previews and exits 2; restore with `patchloom undo --apply` (optional `--session <ts>`). `undo --list` walks nested `.patchloom/backups` under the cwd (#1695).\n\
              - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
              - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)\n\
              - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts (#1687, #1694)\n\
@@ -135,7 +135,11 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)\n\
              - Editing markdown sections, bullets, or tables by heading\n\
              - Batching edits across multiple files in one call\n\
-             - You need atomic rollback if any edit fails\n\n",
+             - You need atomic rollback if any edit fails\n\n\
+             **CLI undo (dry-run by default):** `patchloom undo` only previews the most recent \
+             backup and exits 2. Restore with `patchloom undo --apply` (optional \
+             `--session <timestamp>`). List sessions with `patchloom undo --list`. There is no \
+             `--latest` flag.\n\n",
         );
         if !show_mcp {
             out.push_str(
@@ -460,7 +464,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              |------|---------|\n\
              | 0 | Success (operation completed, or no changes needed) |\n\
              | 1 | Failure (error during execution, CLI usage/invalid args/unknown flags/subcommands), or tx `rollback_failed` when mid-commit rollback could not fully restore files |\n\
-             | 2 | Changes detected (`--check` / write preview, or CLI/MCP/plan/tx `search` `assert_count` mismatch; `error_kind: changes_detected` for assert_count) |\n\
+             | 2 | Changes detected (`--check` / write preview including `undo` without `--apply`, or CLI/MCP/plan/tx `search` `assert_count` mismatch; `error_kind: changes_detected` for assert_count). For undo, re-run with `--apply` to restore. |\n\
              | 3 | No matches (search/replace pattern miss, undo with no sessions, missing AST symbol for extract/insert/reorder/wrap/move, or tx/plan AST/md/doc target not found; `error_kind: no_matches`) |\n\
              | 4 | Parse error (malformed input file or plan, invalid AST search pattern/query, or AST validate parse failure; `error_kind: parse_error`) |\n\
              | 5 | Ambiguous (CLI/tx `unique` multi-match, or stale/missing patch context; `error_kind: ambiguous` in CLI/tx JSON) |\n\
@@ -695,6 +699,20 @@ mod tests {
         let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
         assert!(out.contains("--whole-line"));
         assert!(out.contains("--collapse-blanks"));
+    }
+
+    #[test]
+    fn workflow_documents_undo_dry_run_and_apply() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(
+            out.contains("undo --apply") && out.contains("dry-run by default"),
+            "CLI agent-rules must state undo is dry-run unless --apply"
+        );
+        // Exit table should point agents at --apply for undo preview exit 2.
+        assert!(
+            out.contains("For undo, re-run with `--apply`"),
+            "exit code 2 row must mention undo --apply"
+        );
     }
 
     #[test]

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -5,13 +5,28 @@ use clap::Args;
 use serde::Serialize;
 
 #[derive(Debug, Args)]
+#[command(
+    about = "Preview or restore files from a backup created by --apply",
+    long_about = "\
+Preview or restore files from a backup session under `.patchloom/backups/`.
+
+**Dry-run by default (same write singularity as replace/tx):** running \
+`patchloom undo` only shows what would be restored and exits 2 \
+(`CHANGES_DETECTED`). Pass `--apply` to actually restore. There is no \
+`--latest` flag; without `--session`, the most recent backup is used.
+
+Backups are created only when a write command was run with `--apply`."
+)]
 #[command(after_help = "\
 EXAMPLES:
   patchloom undo --list
-  patchloom undo --apply
+  patchloom undo              # dry-run preview (exit 2); does NOT restore
+  patchloom undo --apply      # restore most recent session
   patchloom undo --session 20240101_120000 --apply
 
 NOTE:
+  Default is preview only. Agents that want a real restore must pass
+  `--apply` (exit 0). Preview is exit 2 with status changes_detected.
   --list walks nested .patchloom/backups roots under the cwd (monorepo
   crates) so sessions from library Apply under crates/foo/ are visible.")]
 pub struct UndoArgs {
@@ -19,11 +34,12 @@ pub struct UndoArgs {
     #[arg(long)]
     pub list: bool,
 
-    /// Restore a specific backup session by timestamp.
+    /// Restore a specific backup session by timestamp (default: most recent).
     #[arg(long)]
     pub session: Option<String>,
 
-    /// Actually restore files (default: dry-run showing what would change).
+    /// Actually restore files. Without this flag, undo only previews
+    /// (exit 2) and does not change the working tree.
     #[arg(long)]
     pub apply: bool,
 }
@@ -47,11 +63,15 @@ struct UndoPreviewEntry {
 struct UndoPreviewOutput {
     ok: bool,
     status: &'static str,
+    /// Always set on dry-run so agents do not treat exit 2 as a completed restore.
+    hint: &'static str,
     session: String,
     project_root: String,
     file_count: usize,
     entries: Vec<UndoPreviewEntry>,
 }
+
+const UNDO_DRY_RUN_HINT: &str = "pass --apply to restore files (default is dry-run preview; exit 2 means changes would be made)";
 
 pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!(
@@ -122,6 +142,7 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let output = UndoPreviewOutput {
             ok: true,
             status: "changes_detected",
+            hint: UNDO_DRY_RUN_HINT,
             session: timestamp.clone(),
             project_root: display_root(&cwd, &backup_root),
             file_count: entries.len(),
@@ -137,9 +158,9 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             for entry in &output.entries {
                 println!("  {} -> {}", entry.path, entry.action);
             }
-        }
-        if global.show_status() {
-            eprintln!("\nhint: use --apply to actually restore these files");
+            // Always print when not quiet: agents often capture piped stderr
+            // and miss TTY-only show_status() hints (fixrealloop confusion).
+            eprintln!("hint: {UNDO_DRY_RUN_HINT}");
         }
         return Ok(exit::CHANGES_DETECTED);
     }
@@ -343,6 +364,38 @@ mod tests {
         };
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::CHANGES_DETECTED);
+        // File must remain modified: dry-run never restores without --apply.
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("b.txt")).unwrap(),
+            "modified"
+        );
+    }
+
+    #[test]
+    fn dry_run_hint_tells_agents_to_pass_apply() {
+        assert!(
+            UNDO_DRY_RUN_HINT.contains("--apply"),
+            "hint must name --apply: {UNDO_DRY_RUN_HINT}"
+        );
+        assert!(
+            UNDO_DRY_RUN_HINT.contains("dry-run") || UNDO_DRY_RUN_HINT.contains("preview"),
+            "hint must say dry-run/preview: {UNDO_DRY_RUN_HINT}"
+        );
+        let preview = UndoPreviewOutput {
+            ok: true,
+            status: "changes_detected",
+            hint: UNDO_DRY_RUN_HINT,
+            session: "t".into(),
+            project_root: ".".into(),
+            file_count: 1,
+            entries: vec![],
+        };
+        let v = serde_json::to_value(&preview).unwrap();
+        assert_eq!(v["status"], "changes_detected");
+        assert!(
+            v["hint"].as_str().unwrap().contains("--apply"),
+            "JSON preview must include hint: {v}"
+        );
     }
 
     #[test]

--- a/tests/integration/reference_docs_tests.rs
+++ b/tests/integration/reference_docs_tests.rs
@@ -86,7 +86,13 @@ fn test_reference_doc_describes_status_and_undo_contracts() {
     assert!(
         reference.contains("This command is git-backed, so it must run inside a git repository.")
     );
-    assert!(reference.contains("In dry-run mode, `undo` reports what would be restored and exits with code `2` (`CHANGES_DETECTED`)."));
+    // Undo dry-run singularity (fixrealloop agent trap): bare undo previews only.
+    assert!(
+        reference.contains("**Default is dry-run**")
+            && reference.contains("exits `2` (`CHANGES_DETECTED`)")
+            && reference.contains("Pass `--apply` to restore"),
+        "reference must document undo dry-run exit 2 and --apply restore"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Yes, the fixrealloop \"undo did not restore\" line was **instruction confusion**, not a product restore bug.

Bare `patchloom undo` is dry-run (exit 2), same as other write commands without `--apply`. Agents and harnesses still often expect restore on bare `undo` (or invent `--latest`).

Clarify in:

- CLI about/examples/NOTE (no `--latest`; need `--apply`)
- Dry-run JSON `hint` field + stderr hint when not quiet (not TTY-only)
- agent-rules / PATCHLOOM.md + exit code 2 row
- reference `undo` section + agent trap

## Test plan

- [x] `cargo test --lib dry_run_hint workflow_documents_undo --all-features`
- [x] dry-run leaves file modified; `--apply` restores
- [ ] CI green