### PR TITLE
fix: preserve --- separators when writing multi-document YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3400%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3500%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -459,7 +459,7 @@ flowchart LR
 
 ## Status
 
-3400+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3500+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -92,6 +92,12 @@ pub fn serialize_value_preserving(
             Ok(doc.to_string())
         }
         FileFormat::Yaml => {
+            // Multi-document streams must stay multi-document on write. Falling
+            // through to single-doc serialize turns `---` docs into a YAML
+            // sequence (`- item:`), which breaks kubectl/kustomize manifests.
+            if is_multi_document_yaml(original_content) {
+                return serialize_multi_document_yaml(original_content, old_value, new_value);
+            }
             if let Some(result) = try_preserve_yaml(original_content, old_value, new_value)? {
                 return Ok(result);
             }
@@ -504,6 +510,136 @@ fn parse_multi_document_yaml(content: &str) -> anyhow::Result<serde_json::Value>
     // ---  separators and the YAML deserializer always yields at least one doc.
     debug_assert!(!docs.is_empty(), "multi-doc YAML produced zero documents");
     Ok(serde_json::Value::Array(docs))
+}
+
+/// Whether a single line (without trailing newline) is a YAML document marker.
+fn is_yaml_document_separator_line(line: &str) -> bool {
+    line.strip_prefix("---").is_some_and(is_after_yaml_marker)
+}
+
+/// Split multi-document YAML into document body strings.
+///
+/// Returns `(had_leading_marker, bodies)`. Bodies exclude the `---` separator
+/// lines. Caller should only invoke when [`is_multi_document_yaml`] is true.
+pub(crate) fn split_multi_document_yaml(content: &str) -> (bool, Vec<String>) {
+    let mut bodies: Vec<String> = Vec::new();
+    let mut current = String::new();
+    let mut leading_marker = false;
+    let mut first_line = true;
+    let mut saw_body = false;
+
+    for line in content.split_inclusive('\n') {
+        let without_nl = line.trim_end_matches(['\n', '\r']);
+        if is_yaml_document_separator_line(without_nl) {
+            if first_line && !saw_body {
+                // Leading stream marker (optional preamble), not a boundary.
+                leading_marker = true;
+                first_line = false;
+                continue;
+            }
+            bodies.push(std::mem::take(&mut current));
+            first_line = false;
+            continue;
+        }
+        first_line = false;
+        saw_body = true;
+        current.push_str(line);
+    }
+    bodies.push(current);
+    (leading_marker, bodies)
+}
+
+/// Reassemble multi-document YAML from body strings.
+fn join_multi_document_yaml(leading_marker: bool, docs: &[String]) -> String {
+    let mut out = String::new();
+    if leading_marker {
+        out.push_str("---\n");
+    }
+    for (i, doc) in docs.iter().enumerate() {
+        if i > 0 {
+            if !out.ends_with('\n') {
+                out.push('\n');
+            }
+            out.push_str("---\n");
+        }
+        let body = doc.trim_end_matches(['\n', '\r']);
+        if !body.is_empty() {
+            out.push_str(body);
+            out.push('\n');
+        }
+    }
+    if out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+/// Serialize one document body (single-doc preserve path, no multi-doc re-entry).
+fn serialize_single_yaml_document(
+    original_body: &str,
+    old_value: &serde_json::Value,
+    new_value: &serde_json::Value,
+) -> anyhow::Result<String> {
+    if old_value == new_value && !original_body.is_empty() {
+        return Ok(original_body.to_string());
+    }
+    if !original_body.trim().is_empty()
+        && let Some(result) = try_preserve_yaml(original_body, old_value, new_value)?
+    {
+        return Ok(result);
+    }
+    let body = serialize_value(new_value, &FileFormat::Yaml)?;
+    if original_body.is_empty() {
+        Ok(body)
+    } else {
+        Ok(preserve::hoist_comments(original_body, &body))
+    }
+}
+
+/// Write multi-document YAML while keeping `---` document separators.
+///
+/// Parse models multi-doc streams as a JSON array. Naively serializing that
+/// array emits a single sequence document (`- kind: ...`), which is not a
+/// multi-document stream and breaks tools that expect `---` separators
+/// (e.g. `kubectl apply -f`).
+fn serialize_multi_document_yaml(
+    original_content: &str,
+    old_value: &serde_json::Value,
+    new_value: &serde_json::Value,
+) -> anyhow::Result<String> {
+    if old_value == new_value {
+        return Ok(original_content.to_string());
+    }
+
+    let (leading_marker, bodies) = split_multi_document_yaml(original_content);
+
+    let Some(new_docs) = new_value.as_array() else {
+        // Unexpected: multi-doc parse always yields an array. Fall back.
+        let body = serialize_value(new_value, &FileFormat::Yaml)?;
+        return Ok(preserve::hoist_comments(original_content, &body));
+    };
+
+    let old_docs = old_value.as_array();
+    let mut out_docs: Vec<String> = Vec::with_capacity(new_docs.len());
+
+    for (i, new_doc) in new_docs.iter().enumerate() {
+        let orig_body = bodies.get(i).map(String::as_str).unwrap_or("");
+        let old_doc = old_docs.and_then(|arr| arr.get(i));
+        match old_doc {
+            Some(old_doc) if old_doc == new_doc && !orig_body.is_empty() => {
+                out_docs.push(orig_body.to_string());
+            }
+            Some(old_doc) => {
+                out_docs.push(serialize_single_yaml_document(orig_body, old_doc, new_doc)?);
+            }
+            None => {
+                // Appended document: no original body to preserve.
+                out_docs.push(serialize_value(new_doc, &FileFormat::Yaml)?);
+            }
+        }
+    }
+
+    Ok(join_multi_document_yaml(leading_marker, &out_docs))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -1,3 +1,9 @@
+//! Document format ops (JSON/YAML/TOML): detect, parse, serialize, preserve.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). Format detect,
+//! multi-document YAML parse/write (#1718), and CST-preserving serialize
+//! entrypoints are one document surface; do not split for LOC alone.
+
 use crate::selector;
 use serde::Deserialize;
 use std::path::Path;

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -868,6 +868,86 @@ mod error_handling {
     }
 
     #[test]
+    fn yaml_multi_document_set_preserves_separators() {
+        // Writing multi-doc YAML must keep --- separators (not collapse to a
+        // single sequence document). kubectl apply -f requires multi-doc form.
+        let yaml = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  key: value\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: demo-svc\nspec:\n  ports:\n    - port: 80\n";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new[0]["data"]["key"] = json!("newval");
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+
+        assert!(
+            is_multi_document_yaml(&result),
+            "write must preserve multi-doc stream, got:\n{result}"
+        );
+        assert!(
+            !result.trim_start().starts_with("- "),
+            "must not serialize multi-doc as a YAML sequence, got:\n{result}"
+        );
+        assert!(
+            result.contains("key: newval") || result.contains("key: \"newval\""),
+            "updated value missing:\n{result}"
+        );
+        assert!(
+            result.contains("kind: Service"),
+            "second document must be preserved:\n{result}"
+        );
+
+        // Round-trip: still addressable by document index.
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed[0]["data"]["key"], json!("newval"));
+        assert_eq!(reparsed[1]["kind"], json!("Service"));
+        assert_eq!(reparsed[1]["spec"]["ports"][0]["port"], json!(80));
+    }
+
+    #[test]
+    fn yaml_multi_document_set_second_doc_preserves_first() {
+        let yaml = "---\nname: alpha\nversion: 1\n---\nname: beta\nversion: 2\n";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new[1]["version"] = json!(99);
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+
+        assert!(is_multi_document_yaml(&result), "got:\n{result}");
+        assert!(
+            result.starts_with("---"),
+            "leading marker preserved:\n{result}"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed[0]["name"], json!("alpha"));
+        assert_eq!(reparsed[0]["version"], json!(1));
+        assert_eq!(reparsed[1]["name"], json!("beta"));
+        assert_eq!(reparsed[1]["version"], json!(99));
+    }
+
+    #[test]
+    fn yaml_multi_document_unchanged_returns_original() {
+        let yaml = "first: 1\n---\nsecond: 2\n";
+        let val = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let result = serialize_value_preserving(yaml, &val, &val, &FileFormat::Yaml).unwrap();
+        assert_eq!(result, yaml);
+    }
+
+    #[test]
+    fn split_multi_document_yaml_without_leading_marker() {
+        let (leading, bodies) = split_multi_document_yaml("first: 1\n---\nsecond: 2\n");
+        assert!(!leading);
+        assert_eq!(bodies.len(), 2);
+        assert!(bodies[0].contains("first: 1"));
+        assert!(bodies[1].contains("second: 2"));
+    }
+
+    #[test]
+    fn split_multi_document_yaml_with_leading_marker() {
+        let (leading, bodies) = split_multi_document_yaml("---\na: 1\n---\nb: 2\n");
+        assert!(leading);
+        assert_eq!(bodies.len(), 2);
+        assert!(bodies[0].contains("a: 1"));
+        assert!(bodies[1].contains("b: 2"));
+    }
+
+    #[test]
     fn mutation_append_to_non_array() {
         let mut root = json!({"items": "not-array"});
         let result = apply_doc_mutation(


### PR DESCRIPTION
## Summary

Multi-document YAML writes no longer collapse `---` streams into a single sequence document.

Parse already modeled multi-doc as a JSON array so selectors like `0.data.key` work. On write, `serialize_value_preserving` serialized that array with `serde_yaml_ng`, producing:

```yaml
- apiVersion: v1
  kind: ConfigMap
  ...
- apiVersion: v1
  kind: Service
  ...
```

instead of a multi-document stream. That breaks `kubectl apply -f` and similar tools.

**Fix:** detect multi-doc original content, serialize each document (preserve path per body when possible), rejoin with `---`.

## Test plan

- [x] Unit: `yaml_multi_document_set_preserves_separators` (k8s-style)
- [x] Unit: `yaml_multi_document_set_second_doc_preserves_first`
- [x] Unit: unchanged multi-doc returns original text
- [x] Unit: split helper leading / non-leading marker
- [x] Runtime: release binary `doc set` on two-resource manifest keeps `---` and updates both docs
- [x] `cargo test --lib ops::doc::` (276 ok)
- [x] clippy `-D warnings`

Closes #1718
