### PR TITLE
fix: add replace --min-fuzzy-score CLI flag for plan/MCP parity

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -200,6 +200,7 @@ patchloom replace 'TODO' --whole-line --range 10:200 --new '' notes.md --apply
 # Rewrite shell invocable tokens only (not uv pip / pipenv):
 patchloom replace pip --new uv install.sh --command-position --require-change --apply
 patchloom replace 'fn proccess_data' --new 'fn process_data' src/ --fuzzy --apply
+patchloom replace 'fn proccess_data' --new 'fn process_data' src/ --fuzzy --min-fuzzy-score 0.80 --apply
 ```
 
 ### Edit a CI workflow

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -606,6 +606,13 @@ These are meaningful command-specific modes that change how a top-level command 
 - **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` in library results and CLI/MCP JSON (#1669). Multi-file CLI replace, plan/tx, and content_edits all roll up worst-case confidence (`fuzzy` > `anchored` > `exact`) so mixed batches never under-report fuzzy.
 - **Prefer instead:** Exact replace when the target string is known.
 
+<!-- ref:replace-mode:min-fuzzy-score -->
+### `replace --min-fuzzy-score` / library `ReplaceOptions.min_fuzzy_score` / plan `min_fuzzy_score`
+
+- **What it does:** When a fuzzy match is found, reject it if its similarity score is below this floor (`0.0..=1.0`). Exact and anchored matches are unaffected. Available on CLI (`--min-fuzzy-score`), plan/MCP (`min_fuzzy_score`), and `ReplaceOptions` (#1687).
+- **Use when:** Agent hosts want fuzzy recovery for small typos but must refuse weak similarity hits (typical floor: `0.80`).
+- **Prefer instead:** Exact replace when the target string is known; bare `--fuzzy` when any fuzzy hit is acceptable.
+
 <!-- ref:create-mode:stdin -->
 ### `create --stdin`
 
@@ -1286,7 +1293,7 @@ The operations below are the building blocks inside `operations`.
 | Scoped symbol replace (literal/regex) | `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (#1658) |
 | Project symbol discovery + multi-file rename | `find_files_with_symbol` then `ast_rename_batch` (#1664); one-shot `ast_rename_project` (#1689) |
 | Match honesty (fuzzy confidence) | `EditResult` / `ContentEditsResult` `match_mode` / `match_score` (#1662); CLI/MCP JSON (#1669); plan/tx `TxChange` + aggregate mode/score/`match_count` from engine meta (#1674) |
-| Reject weak fuzzy matches | `ReplaceOptions.min_fuzzy_score` / plan `min_fuzzy_score` / MCP `min_fuzzy_score` (#1687); range `0.0..=1.0` |
+| Reject weak fuzzy matches | CLI `--min-fuzzy-score` / `ReplaceOptions.min_fuzzy_score` / plan `min_fuzzy_score` / MCP `min_fuzzy_score` (#1687); range `0.0..=1.0` |
 | Apply session id for surgical undo | `EditResult.backup_session` after Apply (#1686); pair with `restore_path_from_session` |
 | Nested monorepo backup listing | `backup::list_sessions_under` + `ListSessionsOptions` (#1688) |
 | In-memory multi-op with real diff headers | `apply_content_edits_with_label` (#1665) |

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -333,6 +333,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              # Rewrite shell invocable tokens only (not uv pip / pipenv):\n\
              patchloom replace pip --new uv install.sh --command-position --require-change --apply\n\
              patchloom replace 'fn proccess_data' --new 'fn process_data' src/ --fuzzy --apply\n\
+             patchloom replace 'fn proccess_data' --new 'fn process_data' src/ --fuzzy --min-fuzzy-score 0.80 --apply\n\
              ```\n\n",
         );
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -106,6 +106,11 @@ pub struct ReplaceArgs {
     /// `--before-context` / `--after-context` is set). Literal only.
     #[arg(long)]
     pub fuzzy: bool,
+    // ref:replace-mode:min-fuzzy-score
+    /// Reject fuzzy matches below this score (0.0..=1.0). Exact and anchored
+    /// matches are unaffected. Plan/MCP field name: `min_fuzzy_score` (#1687).
+    #[arg(long, value_name = "SCORE")]
+    pub min_fuzzy_score: Option<f64>,
     #[command(flatten)]
     pub write: crate::cli::global::WriteFlags,
 }
@@ -726,7 +731,7 @@ fn run_context_replace(
                 require_change: args.require_change && file_paths.len() == 1,
                 command_position: args.command_position,
                 fuzzy: args.fuzzy,
-                min_fuzzy_score: None,
+                min_fuzzy_score: args.min_fuzzy_score,
             }
         })
         .collect();
@@ -780,7 +785,7 @@ fn run_context_replace(
         after_context: args.after_context.clone(),
         require_change: false,
         command_position: args.command_position,
-        min_fuzzy_score: None,
+        min_fuzzy_score: args.min_fuzzy_score,
         post_write: None,
         post_write_cwd: None,
     };

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -24,6 +24,7 @@ fn make_args(old: &str, new: &str, paths: Vec<String>) -> ReplaceArgs {
         require_change: false,
         command_position: false,
         fuzzy: false,
+        min_fuzzy_score: None,
         write: Default::default(),
     }
 }
@@ -76,6 +77,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -112,6 +114,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -218,6 +221,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -279,6 +283,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -341,6 +346,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -384,6 +390,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -420,6 +427,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -455,6 +463,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -492,6 +501,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -533,6 +543,7 @@ mod basic {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -577,6 +588,7 @@ mod edge_cases {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -612,6 +624,7 @@ mod edge_cases {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let global = GlobalFlags {
@@ -672,6 +685,7 @@ mod edge_cases {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -752,6 +766,7 @@ mod edge_cases {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -797,6 +812,7 @@ mod edge_cases {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let replacements = collect_replacements(&args, &GlobalFlags::test_default()).unwrap();
@@ -856,6 +872,7 @@ mod error_handling {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -889,6 +906,7 @@ mod error_handling {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -922,6 +940,7 @@ mod error_handling {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -955,6 +974,7 @@ mod error_handling {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -996,6 +1016,7 @@ mod error_handling {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1041,6 +1062,7 @@ mod error_handling {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let code = run(args, &GlobalFlags::test_default()).unwrap();
@@ -1087,6 +1109,7 @@ mod context_replace {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1139,6 +1162,7 @@ mod context_replace {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1185,6 +1209,7 @@ mod context_replace {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
 
@@ -1219,6 +1244,7 @@ mod context_replace {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
 
@@ -1257,6 +1283,7 @@ mod context_replace {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1300,6 +1327,7 @@ mod context_replace {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1344,6 +1372,7 @@ mod context_replace {
             require_change: false,
             command_position: false,
             fuzzy: false,
+            min_fuzzy_score: None,
             write: Default::default(),
         };
         let mut global = GlobalFlags::test_default();
@@ -1383,6 +1412,7 @@ fn fuzzy_cli_json_reports_match_mode() {
     let content = fs::read_to_string(&file).unwrap();
     let opts = crate::api::ReplaceOptions {
         fuzzy: true,
+        min_fuzzy_score: None,
         require_change: true,
         ..Default::default()
     };

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1880,6 +1880,63 @@ fn test_replace_fuzzy_identifier_typo_preserves_syntax() {
     );
 }
 
+/// CLI `--min-fuzzy-score` rejects weak fuzzy hits (plan/MCP parity; fixrealloop R4).
+#[test]
+fn test_replace_cli_min_fuzzy_score_rejects_weak_match() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("typo.txt");
+    fs::write(&file, "hello wrold foo\n").unwrap();
+
+    // Score for "hello world" vs "hello wrold" is ~0.93; floor 0.99 must miss.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "replace",
+            "hello world",
+            "--new",
+            "hello earth",
+            "--fuzzy",
+            "--min-fuzzy-score",
+            "0.99",
+            "--apply",
+        ])
+        .arg(&file)
+        .assert()
+        .code(3);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "hello wrold foo\n",
+        "high floor must leave content unchanged"
+    );
+
+    // Lower floor accepts the same fuzzy hit.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "replace",
+            "hello world",
+            "--new",
+            "hello earth",
+            "--fuzzy",
+            "--min-fuzzy-score",
+            "0.5",
+            "--apply",
+        ])
+        .arg(&file)
+        .assert()
+        .code(0);
+    // Fuzzy may replace a larger token span than the query string alone.
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.contains("hello earth"),
+        "low floor must apply fuzzy replacement: {on_disk}"
+    );
+    assert!(
+        !on_disk.contains("wrold"),
+        "typo token must be gone: {on_disk}"
+    );
+}
+
 /// CLI JSON reports fuzzy mode for identifier typo without span corruption.
 #[test]
 fn test_replace_fuzzy_identifier_typo_json_match_mode() {


### PR DESCRIPTION
## Summary

CLI `replace` now accepts `--min-fuzzy-score`, matching plan/MCP/library `min_fuzzy_score` (#1687).

Before this change, agent-rules and schema documented the floor, but `patchloom replace --fuzzy --min-fuzzy-score 0.80` failed with clap "unexpected argument". The CLI path hard-coded `min_fuzzy_score: None` when building the tx op.

## Test plan

- [x] Integration: high floor (0.99) exits 3 and leaves file; low floor (0.5) applies
- [x] Unit/lib replace suite green
- [x] agent_rules tests green
- [x] Runtime release binary probe
- [x] clippy `-D warnings`

Closes #1720
