### PR TITLE
feat: batch replace flags, doc predicate errors, md insert-after-section

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -16,6 +16,7 @@
 | Compare two structured files | `doc_diff` |
 | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |
 | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |
+| Insert a sibling section after a full section body | `md_insert_after_section` |
 | Move a heading section (same file or cross-file) | `md_move_section` |
 | Remove duplicate headings | `md_dedupe_headings` |
 | Lint markdown for structural issues | `md_lint` |
@@ -108,6 +109,7 @@ patchloom batch --apply <<'EOF'
 doc.set config.json version "2.0.0"
 doc.set config.yaml app.version "2.0.0"
 replace README.md "1.0.0" "2.0.0"
+replace src/main.rs "proccess" "process" --fuzzy --min-fuzzy-score 0.80
 file.create hello.txt "Hello, World!"
 file.rename old.txt new.txt
 md.upsert_bullet CHANGELOG.md "## Changes" "- Bumped to 2.0.0"
@@ -115,6 +117,7 @@ EOF
 ```
 
 One line per operation. Double-quote values with spaces. Escapes in quotes: only `\"` and `\\` (literal `\n` is not a newline; use `tx`/MCP JSON for multi-line content).
+Batch `replace` accepts optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.
 
 On Windows (where heredocs are not available), write operations to a file and pass it:
 
@@ -317,6 +320,10 @@ jobs[0].steps[*].name           # index + wildcard
 dependencies[name=react].version # predicate filter
 ```
 
+**Write ops and predicates:** `doc set` / `doc ensure` / `doc delete` / `doc move` are **single-path only** (keys and indexes such as `items.0.val`). Wildcards and predicates (`items[id=b].val`, `items[*].enabled`) belong on `doc update` (multi-match write) or `doc delete-where` (array filter). If you pass a predicate to `doc set`, the error points you at `doc update` or an index path.
+
+**Markdown insert placement:** `md_insert_after_heading` inserts **under the heading line** (before existing body). To add a sibling `##` section after the full section body, use `md_insert_after_section`.
+
 ## Exit codes
 
 | Code | Meaning |
@@ -356,8 +363,9 @@ dependencies[name=react].version # predicate filter
 - `md.replace_section`: Replace the body of a markdown section identified by heading.
 - `md.upsert_bullet`: Insert or update a bullet point under a markdown heading.
 - `md.table_append`: Append a row to a markdown table under a heading.
-- `md.insert_after_heading`: Insert content immediately after a markdown heading.
-- `md.insert_before_heading`: Insert content immediately before a markdown heading.
+- `md.insert_after_heading`: Insert content immediately after a markdown heading line (before any existing body). For a sibling section after the full body, use md.insert_after_section.
+- `md.insert_after_section`: Insert content after the full section body (sibling placement). Use when adding a new ## section after this section's content. Prefer md.insert_after_heading for content under the heading line.
+- `md.insert_before_heading`: Insert content immediately before a markdown heading line.
 - `md.move_section`: Move a heading section to a new position (same-file reorder or cross-file move). Exactly one of before or after is required.
 - `patch.apply`: Apply a unified diff patch to one or more files. Supports three-way merge on stale context.
 - `doc.prepend`: Prepend a value to the beginning of an array at a selector path.

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -99,7 +99,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 ## By the numbers
 
 - **2,800+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
-- **23 commands** including MCP server with 55 structured tool calls
+- **23 commands** including MCP server with 56 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -90,7 +90,7 @@ the registry when that would lose multi-file, batch, or read UX.
 
 Custom tools are inventoried in `CUSTOM_MCP_TOOLS_CORE` (always registered)
 and `CUSTOM_MCP_TOOLS_AST` (only when the `ast` feature is enabled). Default
-builds expose **55** tools (registry + custom). Builds without `ast` omit the
+builds expose **56** tools (registry + custom). Builds without `ast` omit the
 AST tools so `list_tools` stays honest about what is callable.
 
 | Tool | Description |
@@ -115,7 +115,8 @@ AST tools so `list_tools` stays honest about what is callable.
 | `md_upsert_bullet` | Add a bullet under a markdown heading |
 | `md_table_append` | Append a row to a markdown table |
 | `md_replace_section` | Replace a markdown section by heading |
-| `md_insert_after_heading` | Insert content after a markdown heading |
+| `md_insert_after_heading` | Insert content immediately after a heading line (before body) |
+| `md_insert_after_section` | Insert content after the full section body (sibling section) |
 | `md_insert_before_heading` | Insert content before a markdown heading |
 | `md_move_section` | Move a heading section (same file reorder or cross-file) |
 | `md_dedupe_headings` | Remove duplicate markdown headings in a file |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -315,7 +315,7 @@ These are the main entry points. If you are deciding between commands, start her
 ## `batch`
 
 - **What it does:** Executes multiple operations from a simple line-oriented format. Each line is one operation with positional arguments (e.g., `doc.set config.json version "2.0.0"`). Internally builds a tx plan and delegates to the tx engine.
-- **Use when:** Editing multiple files and the JSON tx plan format is too verbose. The line format covers 27 operations (doc.set, doc.delete, doc.merge, doc.ensure, doc.append, doc.prepend, doc.update, doc.move, doc.delete_where, replace, file.append, file.prepend, file.create, file.delete, file.rename, md.upsert_bullet, md.table_append, md.replace_section, md.insert_after_heading, md.insert_before_heading, md.move_section, md.dedupe_headings, md.lint_agents, tidy.fix, ast.rename, ast.replace, ast.rewrite_signature) with minimal syntax. For AI agents, this is faster to generate than a full JSON plan.
+- **Use when:** Editing multiple files and the JSON tx plan format is too verbose. The line format covers 28 operations (doc.set, doc.delete, doc.merge, doc.ensure, doc.append, doc.prepend, doc.update, doc.move, doc.delete_where, replace with optional flags, file.append, file.prepend, file.create, file.delete, file.rename, md.upsert_bullet, md.table_append, md.replace_section, md.insert_after_heading, md.insert_after_section, md.insert_before_heading, md.move_section, md.dedupe_headings, md.lint_agents, tidy.fix, ast.rename, ast.replace, ast.rewrite_signature) with minimal syntax. For AI agents, this is faster to generate than a full JSON plan.
 - **Paths:** A relative ops file path is resolved under `--cwd` (same as `tx` plan files). Paths *inside* ops lines are also resolved against `--cwd`.
 - **Quoting:** Double-quoted tokens allow only `\"` and `\\`. Sequences like `\n` are **literal** (not newlines). Prefer `tx` / MCP JSON for multi-line content, or put real newlines outside one-line quoted strings.
 - **Failure behavior:** Line parse failures (unknown op, bad arity, bad quotes) exit `4` (`PARSE_ERROR`) with `error_kind: "parse_error"` under `--json`/`--jsonl`. Too many operations (over the hard cap) exits `1` with `invalid_input`. Runtime op failures use the shared tx exit codes. Preview with changes uses the same `status: "changes_detected"` / exit `2` contract as `tx`.
@@ -814,16 +814,23 @@ Use these when markdown structure matters more than raw text matching.
 <!-- ref:md-action:insert-after-heading -->
 ### `md insert-after-heading`
 
-- **What it does:** Inserts content immediately after a heading.
-- **Use when:** You want to add a note, release entry, or status line while preserving the existing section body.
-- **Prefer instead:** Use `md replace-section` when the whole section should be regenerated.
+- **What it does:** Inserts content **immediately after the heading line** (before any existing body such as tables or paragraphs). It does **not** insert after the full section body.
+- **Use when:** You want to add a note, intro, or status line under a heading while keeping the rest of the section body after the insert (for example intro text before an existing table).
+- **Prefer instead:** Use `md insert-after-section` when adding a **sibling** `##` section after this section's body. Use `md replace-section` when the whole section should be regenerated.
+
+<!-- ref:md-action:insert-after-section -->
+### `md insert-after-section`
+
+- **What it does:** Inserts content after the **full section body** (after the last line of the section, before the next same-or-higher heading). Sibling placement for new sections.
+- **Use when:** You want to add a new `## FAQ` (or similar) after `## Config` including Config's existing body.
+- **Prefer instead:** Use `md insert-after-heading` only for content under the heading line, not for a new sibling section.
 
 <!-- ref:md-action:insert-before-heading -->
 ### `md insert-before-heading`
 
-- **What it does:** Inserts content immediately before a heading.
+- **What it does:** Inserts content immediately before a heading line.
 - **Use when:** You want to add a preface or a new section boundary before an existing heading.
-- **Prefer instead:** Use `md insert-after-heading` when the addition belongs inside the section that starts at the heading.
+- **Prefer instead:** Use `md insert-after-section` when the addition belongs after the previous section's body.
 
 <!-- ref:md-action:upsert-bullet -->
 ### `md upsert-bullet`
@@ -1077,14 +1084,21 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:md.insert_after_heading -->
 ### `md.insert_after_heading`
 
-- **What it does:** Inserts markdown content after a heading inside a transaction.
-- **Use when:** A release note or docs annotation must be added atomically with code or config changes.
-- **Related:** top level `md insert-after-heading`
+- **What it does:** Inserts markdown content immediately after a heading line (before existing body) inside a transaction.
+- **Use when:** A release note or docs annotation under a heading must be added atomically with code or config changes.
+- **Related:** top level `md insert-after-heading`; sibling sections: `md.insert_after_section`
+
+<!-- ref:tx-op:md.insert_after_section -->
+### `md.insert_after_section`
+
+- **What it does:** Inserts markdown content after the full section body (sibling placement) inside a transaction.
+- **Use when:** Adding a new section after an existing section's content as part of a multi-op plan.
+- **Related:** top level `md insert-after-section`
 
 <!-- ref:tx-op:md.insert_before_heading -->
 ### `md.insert_before_heading`
 
-- **What it does:** Inserts markdown content before a heading inside a transaction.
+- **What it does:** Inserts markdown content before a heading line inside a transaction.
 - **Use when:** Docs structure must change as one step in a broader plan.
 - **Related:** top level `md insert-before-heading`
 

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -57,6 +57,9 @@ fn md_write(
         Operation::MdInsertAfterHeading {
             heading, content, ..
         } => ops::md::insert_after_heading_in(&original, &heading, &content),
+        Operation::MdInsertAfterSection {
+            heading, content, ..
+        } => ops::md::insert_after_section_in(&original, &heading, &content),
         Operation::MdInsertBeforeHeading {
             heading, content, ..
         } => ops::md::insert_before_heading_in(&original, &heading, &content),
@@ -172,6 +175,22 @@ pub fn md_insert_after_heading(
         content: insertion.into(),
     };
     md_write(op, path, mode, guard, "md.insert_after_heading")
+}
+
+/// Insert content after the full section body (sibling placement). #1726
+pub fn md_insert_after_section(
+    path: &Path,
+    heading: &str,
+    insertion: &str,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    let op = Operation::MdInsertAfterSection {
+        path: path.to_string_lossy().into(),
+        heading: heading.into(),
+        content: insertion.into(),
+    };
+    md_write(op, path, mode, guard, "md.insert_after_section")
 }
 
 /// Move a markdown section to a position relative to another heading.

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -94,6 +94,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Compare two structured files | `doc_diff` |\n\
              | Edit markdown section, bullet, or table | `md_replace_section`, `md_upsert_bullet`, `md_table_append` |\n\
              | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |\n\
+             | Insert a sibling section after a full section body | `md_insert_after_section` |\n\
              | Move a heading section (same file or cross-file) | `md_move_section` |\n\
              | Remove duplicate headings | `md_dedupe_headings` |\n\
              | Lint markdown for structural issues | `md_lint` |\n\
@@ -204,13 +205,17 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  doc.set config.json version \"2.0.0\"\n\
                  doc.set config.yaml app.version \"2.0.0\"\n\
                  replace README.md \"1.0.0\" \"2.0.0\"\n\
+                 replace src/main.rs \"proccess\" \"process\" --fuzzy --min-fuzzy-score 0.80\n\
                  file.create hello.txt \"Hello, World!\"\n\
                  file.rename old.txt new.txt\n\
                  md.upsert_bullet CHANGELOG.md \"## Changes\" \"- Bumped to 2.0.0\"\n\
                  EOF\n\
                  ```\n\n\
                  One line per operation. Double-quote values with spaces. Escapes in quotes: only `\\\"` and `\\\\` \
-                 (literal `\\n` is not a newline; use `tx`/MCP JSON for multi-line content).\n\n",
+                 (literal `\\n` is not a newline; use `tx`/MCP JSON for multi-line content).\n\
+                 Batch `replace` accepts optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, \
+                 `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, \
+                 `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.\n\n",
             );
         }
 
@@ -454,7 +459,15 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
          scripts.test                    # simple selector path\n\
          jobs[0].steps[*].name           # index + wildcard\n\
          dependencies[name=react].version # predicate filter\n\
-         ```\n\n",
+         ```\n\n\
+         **Write ops and predicates:** `doc set` / `doc ensure` / `doc delete` / `doc move` are \
+         **single-path only** (keys and indexes such as `items.0.val`). Wildcards and predicates \
+         (`items[id=b].val`, `items[*].enabled`) belong on `doc update` (multi-match write) or \
+         `doc delete-where` (array filter). If you pass a predicate to `doc set`, the error points \
+         you at `doc update` or an index path.\n\n\
+         **Markdown insert placement:** `md_insert_after_heading` inserts **under the heading line** \
+         (before existing body). To add a sibling `##` section after the full section body, use \
+         `md_insert_after_section`.\n\n",
     );
 
     // Exit codes (CLI only — MCP tools return results as JSON, not exit codes)

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -21,7 +21,9 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
 /// doc.update <path> <selector> <value>
 /// doc.move <path> <from> <to>
 /// doc.delete_where <path> <selector> <predicate>
-/// replace <path> <from> <to>
+/// replace <path> <from> <to> [--fuzzy] [--min-fuzzy-score N] [-i] …
+///   Optional flags (phase 1, #1724): --fuzzy, --min-fuzzy-score, --word-boundary/-w,
+///   --command-position, --require-change, -i/--case-insensitive, --if-exists
 /// file.create <path> <content>
 /// file.delete <path>
 /// file.rename <from> <to>
@@ -31,6 +33,7 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
 /// md.table_append <path> <heading> <row>
 /// md.replace_section <path> <heading> <content>
 /// md.insert_after_heading <path> <heading> <content>
+/// md.insert_after_section <path> <heading> <content>
 /// md.insert_before_heading <path> <heading> <content>
 /// md.move_section <path> <heading> before|after <target_heading>
 /// md.move_section <path> <heading> <to> before|after <target_heading>
@@ -47,10 +50,10 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
 #[derive(Debug, Args)]
 #[command(after_help = r#"OPERATIONS:
   doc.set, doc.delete, doc.merge, doc.ensure, doc.append, doc.prepend,
-  doc.update, doc.move, doc.delete_where, replace, file.create,
+  doc.update, doc.move, doc.delete_where, replace (optional flags: --fuzzy, …), file.create,
   file.delete, file.rename, file.append, file.prepend, md.upsert_bullet,
   md.table_append, md.replace_section, md.insert_after_heading,
-  md.insert_before_heading, md.move_section, md.dedupe_headings,
+  md.insert_after_section, md.insert_before_heading, md.move_section, md.dedupe_headings,
   md.lint_agents, tidy.fix, ast.rename, ast.replace, ast.rewrite_signature
 
 EXAMPLES:
@@ -58,6 +61,7 @@ EXAMPLES:
   patchloom batch --apply <<'EOF'
   doc.set package.json version "3.0.0"
   replace README.md "v1.0" "v3.0"
+  replace src/main.rs "proccess" "process" --fuzzy --min-fuzzy-score 0.80
   EOF"#)]
 pub struct BatchArgs {
     /// Read operations from a file, or stdin if omitted.
@@ -160,32 +164,7 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
         }
 
         // -- replace -----------------------------------------------------------
-        "replace" => {
-            require_args(op, args, 3, line_num)?;
-            Ok(Operation::Replace {
-                glob: None,
-                path: Some(args[0].clone()),
-                regex: false,
-                old: args[1].clone(),
-                new_text: Some(args[2].clone()),
-                nth: None,
-                insert_before: None,
-                insert_after: None,
-                case_insensitive: false,
-                multiline: false,
-                if_exists: false,
-                whole_line: false,
-                range: None,
-                word_boundary: false,
-                before_context: None,
-                after_context: None,
-                unique: false,
-                require_change: false,
-                command_position: false,
-                fuzzy: false,
-                min_fuzzy_score: None,
-            })
-        }
+        "replace" => parse_replace_line(args, line_num),
 
         // -- file operations ---------------------------------------------------
         "file.append" => {
@@ -230,6 +209,7 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
         "md.table_append" => md_phc!(op, args, line_num, MdTableAppend, row),
         "md.replace_section" => md_phc!(op, args, line_num, MdReplaceSection, content),
         "md.insert_after_heading" => md_phc!(op, args, line_num, MdInsertAfterHeading, content),
+        "md.insert_after_section" => md_phc!(op, args, line_num, MdInsertAfterSection, content),
         "md.insert_before_heading" => md_phc!(op, args, line_num, MdInsertBeforeHeading, content),
 
         "md.move_section" => {
@@ -360,6 +340,7 @@ const KNOWN_BATCH_OPS: &[&str] = &[
     "md.table_append",
     "md.replace_section",
     "md.insert_after_heading",
+    "md.insert_after_section",
     "md.insert_before_heading",
     "md.move_section",
     "md.dedupe_headings",
@@ -448,6 +429,200 @@ fn require_args(op: &str, args: &[String], expected: usize, line_num: usize) -> 
         }));
     }
     Ok(())
+}
+
+/// Parse batch `replace path old new [--flags…]` (#1724).
+///
+/// First three non-flag tokens are path/old/new. Remaining tokens are optional
+/// CLI-style flags shared with `patchloom replace`.
+fn parse_replace_line(args: &[String], line_num: usize) -> anyhow::Result<Operation> {
+    if args.len() < 3 {
+        return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!(
+                "line {line_num}: 'replace' requires at least 3 arguments (path old new), got {}",
+                args.len()
+            ),
+        }));
+    }
+
+    let mut path = None;
+    let mut old = None;
+    let mut new_text = None;
+    let mut case_insensitive = false;
+    let mut if_exists = false;
+    let mut word_boundary = false;
+    let mut require_change = false;
+    let mut command_position = false;
+    let mut fuzzy = false;
+    let mut min_fuzzy_score = None;
+    let mut i = 0usize;
+
+    while i < args.len() {
+        let tok = args[i].as_str();
+        // Known flags only. Unknown dash-leading tokens remain positionals so
+        // `replace f.md "- old" "- new"` still works (review #1724).
+        let is_flag = matches!(
+            tok,
+            "--fuzzy"
+                | "--if-exists"
+                | "--require-change"
+                | "--command-position"
+                | "--word-boundary"
+                | "-w"
+                | "-i"
+                | "--case-insensitive"
+                | "--min-fuzzy-score"
+        ) || tok.starts_with("--min-fuzzy-score=");
+
+        if is_flag {
+            match tok {
+                "--fuzzy" => fuzzy = true,
+                "--if-exists" => if_exists = true,
+                "--require-change" => require_change = true,
+                "--command-position" => command_position = true,
+                "--word-boundary" | "-w" => word_boundary = true,
+                "-i" | "--case-insensitive" => case_insensitive = true,
+                flag if flag == "--min-fuzzy-score" || flag.starts_with("--min-fuzzy-score=") => {
+                    let raw = if let Some(v) = flag.strip_prefix("--min-fuzzy-score=") {
+                        v.to_string()
+                    } else {
+                        i += 1;
+                        args.get(i).cloned().ok_or_else(|| {
+                            anyhow::Error::new(crate::exit::ParseErrorError {
+                                msg: format!(
+                                    "line {line_num}: --min-fuzzy-score requires a value (0.0..=1.0)"
+                                ),
+                            })
+                        })?
+                    };
+                    let score: f64 = raw.parse().map_err(|_| {
+                        anyhow::Error::new(crate::exit::ParseErrorError {
+                            msg: format!(
+                                "line {line_num}: invalid --min-fuzzy-score value '{raw}' (expected number)"
+                            ),
+                        })
+                    })?;
+                    if !(0.0..=1.0).contains(&score) {
+                        return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                            msg: format!(
+                                "line {line_num}: --min-fuzzy-score must be in 0.0..=1.0 (got {score})"
+                            ),
+                        }));
+                    }
+                    min_fuzzy_score = Some(score);
+                }
+                other => {
+                    return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                        msg: format!(
+                            "line {line_num}: unknown replace flag '{other}' \
+                             (supported: --fuzzy, --min-fuzzy-score, --word-boundary/-w, \
+                             --command-position, --require-change, -i/--case-insensitive, --if-exists); \
+                             advanced flags (regex, context, nth) need `tx` plan JSON"
+                        ),
+                    }));
+                }
+            }
+            i += 1;
+            continue;
+        }
+
+        if tok.starts_with('-')
+            && path.is_some()
+            && old.is_some()
+            && new_text.is_some()
+            && tok != "-"
+        {
+            // After positionals are filled, unknown dash tokens are flag typos.
+            return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                msg: format!(
+                    "line {line_num}: unknown replace flag '{tok}' \
+                     (supported: --fuzzy, --min-fuzzy-score, --word-boundary/-w, \
+                     --command-position, --require-change, -i/--case-insensitive, --if-exists); \
+                     advanced flags (regex, context, nth) need `tx` plan JSON"
+                ),
+            }));
+        }
+
+        // Positional: path, old, new (in order). May start with '-' (bullet text, flags as values).
+        if path.is_none() {
+            path = Some(args[i].clone());
+        } else if old.is_none() {
+            old = Some(args[i].clone());
+        } else if new_text.is_none() {
+            new_text = Some(args[i].clone());
+        } else {
+            return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                msg: format!(
+                    "line {line_num}: unexpected argument '{}' after replace path/old/new \
+                     (use flags like --fuzzy, or `tx` for full replace options)",
+                    args[i]
+                ),
+            }));
+        }
+        i += 1;
+    }
+
+    let path = path.ok_or_else(|| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("line {line_num}: 'replace' requires a path argument"),
+        })
+    })?;
+    let old = old.ok_or_else(|| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("line {line_num}: 'replace' requires an old pattern argument"),
+        })
+    })?;
+    let new_text = new_text.ok_or_else(|| {
+        anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("line {line_num}: 'replace' requires a new text argument"),
+        })
+    })?;
+
+    if command_position
+        && let Some(msg) = crate::ops::shell_token::command_position_combo_error(
+            crate::ops::shell_token::CommandPositionIncompat {
+                regex: false,
+                case_insensitive,
+                word_boundary,
+                whole_line: false,
+                multiline: false,
+                nth: false,
+                insert_before: false,
+                insert_after: false,
+                before_context: false,
+                after_context: false,
+                fuzzy,
+            },
+        )
+    {
+        return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("line {line_num}: {msg}"),
+        }));
+    }
+
+    Ok(Operation::Replace {
+        glob: None,
+        path: Some(path),
+        regex: false,
+        old,
+        new_text: Some(new_text),
+        nth: None,
+        insert_before: None,
+        insert_after: None,
+        case_insensitive,
+        multiline: false,
+        if_exists,
+        whole_line: false,
+        range: None,
+        word_boundary,
+        before_context: None,
+        after_context: None,
+        unique: false,
+        require_change,
+        command_position,
+        fuzzy,
+        min_fuzzy_score,
+    })
 }
 
 /// Parse a string as a JSON value. Delegates to `doc::parse_value` which

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -90,9 +90,121 @@ mod basic {
         let op = parse_line(r#"replace src/main.rs "old text" "new text""#, 1).unwrap();
         assert!(matches!(
             op,
-            Operation::Replace { path: Some(p), old, new_text: Some(t), .. }
+            Operation::Replace { path: Some(p), old, new_text: Some(t), fuzzy: false, min_fuzzy_score: None, .. }
             if p == "src/main.rs" && old == "old text" && t == "new text"
         ));
+    }
+
+    #[test]
+    fn parse_line_replace_with_fuzzy_flags() {
+        let op = parse_line(
+            r#"replace a.txt "hello world" "hello earth" --fuzzy --min-fuzzy-score 0.80 -i"#,
+            1,
+        )
+        .unwrap();
+        match op {
+            Operation::Replace {
+                path: Some(p),
+                old,
+                new_text: Some(t),
+                fuzzy,
+                min_fuzzy_score,
+                case_insensitive,
+                ..
+            } => {
+                assert_eq!(p, "a.txt");
+                assert_eq!(old, "hello world");
+                assert_eq!(t, "hello earth");
+                assert!(fuzzy);
+                assert_eq!(min_fuzzy_score, Some(0.80));
+                assert!(case_insensitive);
+            }
+            _ => panic!("expected Replace"),
+        }
+    }
+
+    #[test]
+    fn parse_line_replace_flags_before_positionals() {
+        let op = parse_line(
+            r#"replace --fuzzy --word-boundary f.rs old_name new_name"#,
+            1,
+        )
+        .unwrap();
+        match op {
+            Operation::Replace {
+                path: Some(p),
+                fuzzy,
+                word_boundary,
+                old,
+                new_text: Some(t),
+                ..
+            } => {
+                assert_eq!(p, "f.rs");
+                assert!(fuzzy);
+                assert!(word_boundary);
+                assert_eq!(old, "old_name");
+                assert_eq!(t, "new_name");
+            }
+            _ => panic!("expected Replace"),
+        }
+    }
+
+    #[test]
+    fn parse_line_replace_unknown_flag_errors() {
+        let err = parse_line(r#"replace f.txt old new --regex"#, 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown replace flag") && msg.contains("--regex"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_line_replace_unexpected_positional_errors() {
+        let err = parse_line(r#"replace f.txt old new extra"#, 1).unwrap_err();
+        assert!(
+            err.to_string().contains("unexpected argument"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_line_replace_dash_prefixed_values_are_positionals() {
+        // Bullet renames and flag-like strings must not be misread as flags.
+        let op = parse_line(r#"replace f.md "- old bullet" "- new bullet" --fuzzy"#, 1).unwrap();
+        match op {
+            Operation::Replace {
+                old,
+                new_text: Some(t),
+                fuzzy,
+                ..
+            } => {
+                assert_eq!(old, "- old bullet");
+                assert_eq!(t, "- new bullet");
+                assert!(fuzzy);
+            }
+            _ => panic!("expected Replace"),
+        }
+    }
+
+    #[test]
+    fn parse_line_replace_min_fuzzy_score_equals_form() {
+        let op = parse_line(
+            r#"replace a.txt "hello world" "hello earth" --fuzzy --min-fuzzy-score=0.75"#,
+            1,
+        )
+        .unwrap();
+        match op {
+            Operation::Replace {
+                fuzzy,
+                min_fuzzy_score: Some(s),
+                ..
+            } => {
+                assert!(fuzzy);
+                assert!((s - 0.75).abs() < f64::EPSILON);
+            }
+            _ => panic!("expected Replace with min_fuzzy_score"),
+        }
     }
 
     #[test]
@@ -389,9 +501,9 @@ mod error_handling {
 
     #[test]
     fn known_batch_ops_inventory_stable() {
-        // docs/reference and clap after_help list 27 batch ops; keep the
+        // docs/reference and clap after_help list 28 batch ops; keep the
         // suggestion table in lockstep so bare-name hints stay accurate.
-        assert_eq!(KNOWN_BATCH_OPS.len(), 27);
+        assert_eq!(KNOWN_BATCH_OPS.len(), 28);
         let mut sorted = KNOWN_BATCH_OPS.to_vec();
         sorted.sort_unstable();
         sorted.dedup();
@@ -501,11 +613,12 @@ mod error_handling {
             r#"doc.update f.json sel "v" extra"#,
             r#"doc.move f.json from to extra"#,
             r#"doc.delete_where f.json sel "k=v" extra"#,
-            r#"replace f.txt old new extra"#,
+            // replace allows optional flags; bare extra positional tested separately
             r##"md.upsert_bullet f.md "# H" "- b" extra"##,
             r##"md.table_append f.md "# H" "| r |" extra"##,
             r##"md.replace_section f.md "# H" body extra"##,
             r##"md.insert_after_heading f.md "# H" text extra"##,
+            r##"md.insert_after_section f.md "# H" text extra"##,
             r##"md.insert_before_heading f.md "# H" text extra"##,
         ];
         for line in &three_arg_ops {

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -149,7 +149,10 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             format!("Replace section \"{heading}\" in {path}")
         }
         Operation::MdInsertAfterHeading { path, heading, .. } => {
-            format!("Insert content after \"{heading}\" in {path}")
+            format!("Insert content after heading line \"{heading}\" in {path}")
+        }
+        Operation::MdInsertAfterSection { path, heading, .. } => {
+            format!("Insert content after section body \"{heading}\" in {path}")
         }
         Operation::MdInsertBeforeHeading { path, heading, .. } => {
             format!("Insert content before \"{heading}\" in {path}")

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -218,7 +218,19 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         tool_name: "md_insert_after_heading",
         op_name: "md.insert_after_heading",
         extra: Some(
-            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+            "Inserts immediately under the heading line (before existing body). For a sibling ## section after the full body, use md_insert_after_section. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
+        has_strict: false,
+        validations: &[
+            FieldValidation::Path("path"),
+            FieldValidation::ContentSize("content"),
+        ],
+    },
+    McpToolMeta {
+        tool_name: "md_insert_after_section",
+        op_name: "md.insert_after_section",
+        extra: Some(
+            "Inserts after the full section body (sibling placement). Prefer md_insert_after_heading for content under the heading. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: false,
         validations: &[

--- a/src/cmd/mcp/surface.rs
+++ b/src/cmd/mcp/surface.rs
@@ -284,7 +284,7 @@ mod tests {
         // Core tools always; AST tools only with `ast` (matches list_tools registration).
         let registry_n = MCP_TOOL_REGISTRY.len();
         let custom_n = custom_mcp_tools().count();
-        let expected_total = if cfg!(feature = "ast") { 55 } else { 35 };
+        let expected_total = if cfg!(feature = "ast") { 56 } else { 36 };
         assert_eq!(
             registry_n + custom_n,
             expected_total,

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -99,6 +99,7 @@ mod basic {
             "md_table_append",
             "md_replace_section",
             "md_insert_after_heading",
+            "md_insert_after_section",
             "md_insert_before_heading",
             "md_dedupe_headings",
             "move_file",
@@ -155,6 +156,10 @@ mod basic {
         assert!(
             names.contains(&"md_insert_after_heading"),
             "missing md_insert_after_heading tool"
+        );
+        assert!(
+            names.contains(&"md_insert_after_section"),
+            "missing md_insert_after_section tool"
         );
         assert!(
             names.contains(&"md_insert_before_heading"),

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -25,7 +25,7 @@ fn server_instructions() -> String {
          doc_merge, doc_query, doc_update, doc_ensure, doc_move, doc_append, doc_prepend, \
          doc_delete_where, doc_diff\n\
          - Markdown ops (by heading): md_replace_section, md_upsert_bullet, \
-         md_table_append, md_insert_after_heading, md_insert_before_heading, \
+         md_table_append, md_insert_after_heading, md_insert_after_section, md_insert_before_heading, \
          md_move_section, md_dedupe_headings, md_lint\n\
          - Text ops: replace_text, batch_replace, search_files, apply_patch\n\
          - File ops: create_file, read_file, delete_file, move_file, append_file, \

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -37,7 +37,10 @@ pub enum MdAction {
         #[arg(long)]
         content: Option<String>,
     },
-    /// Insert content after a heading.
+    /// Insert content immediately after a heading line (before existing body).
+    ///
+    /// Does not insert after the full section body. For a sibling section after
+    /// the section ends, use `insert-after-section` (#1726).
     InsertAfterHeading {
         file: String,
         #[arg(long)]
@@ -48,7 +51,22 @@ pub enum MdAction {
         #[arg(long)]
         content: Option<String>,
     },
-    /// Insert content before a heading.
+    /// Insert content after the full section body (sibling placement).
+    ///
+    /// Use when adding a new `##` section after this section's content. Prefer
+    /// `insert-after-heading` only for content under the heading (e.g. intro
+    /// before a table). #1726
+    InsertAfterSection {
+        file: String,
+        #[arg(long)]
+        heading: String,
+        // ref:md-mode:stdin
+        #[arg(long)]
+        stdin: bool,
+        #[arg(long)]
+        content: Option<String>,
+    },
+    /// Insert content immediately before a heading line.
     InsertBeforeHeading {
         file: String,
         #[arg(long)]
@@ -227,6 +245,34 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 return Ok(exit::FAILURE);
             };
             let op = Operation::MdInsertAfterHeading {
+                path: file.clone(),
+                heading: heading.clone(),
+                content: insertion,
+            };
+            execute_md_op(
+                op,
+                global,
+                &file,
+                &format!("would modify {file}"),
+                &format!("modified {file}"),
+            )
+        }
+
+        MdAction::InsertAfterSection {
+            file,
+            heading,
+            stdin,
+            content,
+        } => {
+            crate::verbose!(
+                "md: insert-after-section file={}, heading={:?}",
+                file,
+                heading
+            );
+            let Some(insertion) = read_content(stdin, &content, global)? else {
+                return Ok(exit::FAILURE);
+            };
+            let op = Operation::MdInsertAfterSection {
                 path: file.clone(),
                 heading: heading.clone(),
                 content: insertion,

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -1,3 +1,9 @@
+//! Document tree navigation: set/delete/move/update_matching and predicates.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). Selector write
+//! navigation and multi-match update share one unit; agent-facing predicate
+//! error strings (#1725) live here; do not split for LOC alone.
+
 use crate::selector;
 
 fn value_type_name(v: &serde_json::Value) -> &'static str {

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -87,7 +87,7 @@ pub fn navigate_mut<'a>(
             })?,
             _ => {
                 return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: "wildcard/predicate not supported in write navigation".into(),
+                    msg: write_nav_predicate_msg("write navigation (doc.set/ensure/delete/move)"),
                 }));
             }
         };
@@ -169,11 +169,36 @@ pub fn set_at_path(
         }
         _ => {
             return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                msg: "cannot set at wildcard/predicate".into(),
+                msg: write_nav_predicate_msg("doc.set/doc.ensure"),
             }));
         }
     }
     Ok(())
+}
+
+/// Agent-facing message when a single-path write op receives a predicate/wildcard
+/// selector (#1725). Points at the right multi-match alternative and index form.
+fn write_nav_predicate_msg(op_context: &str) -> String {
+    // Match exact op labels, not substrings of compound messages like
+    // "doc.set/ensure/delete/move".
+    let alt = if op_context == "doc.delete"
+        || op_context.starts_with("doc.delete ")
+        || op_context.starts_with("doc.move")
+    {
+        if op_context.starts_with("doc.move") {
+            "Use a concrete index/key path (e.g. items.0.val), not wildcards or predicates"
+        } else {
+            "Use: doc delete-where <file> <array-selector> --predicate key=value for filtered \
+             array deletes, or a concrete index path such as items.0"
+        }
+    } else {
+        "Use: doc update <file> 'items[id=b].val' <value> for multi-match writes, \
+         or a concrete index path such as items.0.val"
+    };
+    format!(
+        "selector uses wildcard/predicate, which is not valid for {op_context} \
+         (single path only). {alt}"
+    )
 }
 
 /// Delete the value at the given selector path. Returns `true` if
@@ -223,7 +248,7 @@ pub fn delete_at_selector(
             }
         }
         _ => Err(anyhow::Error::new(crate::exit::InvalidInputError {
-            msg: "cannot delete at wildcard/predicate".into(),
+            msg: write_nav_predicate_msg("doc.delete"),
         })),
     }
 }
@@ -407,7 +432,7 @@ pub fn move_at_path(
             }
             _ => {
                 return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: "cannot move from wildcard/predicate".into(),
+                    msg: write_nav_predicate_msg("doc.move (from)"),
                 }));
             }
         }
@@ -465,7 +490,7 @@ pub fn move_at_path(
             }
             _ => {
                 return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: "cannot move to wildcard/predicate".into(),
+                    msg: write_nav_predicate_msg("doc.move (to)"),
                 }));
             }
         }
@@ -500,7 +525,7 @@ pub fn move_at_path(
             }
             _ => {
                 return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: "cannot remove from wildcard/predicate selector".into(),
+                    msg: write_nav_predicate_msg("doc.move (remove source)"),
                 }));
             }
         }
@@ -642,6 +667,17 @@ mod tests {
         let mut root = json!({"a": {}});
         let val = navigate_mut(&mut root, &segs("a.b"), true).unwrap();
         assert!(val.is_object(), "should create intermediate object");
+    }
+
+    #[test]
+    fn set_at_path_predicate_errors_with_update_hint() {
+        let mut root = json!({"items":[{"id":"a","val":1}]});
+        let err = set_at_path(&mut root, &segs("items[id=a].val"), json!(9)).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("doc update") && msg.contains("wildcard/predicate"),
+            "got: {msg}"
+        );
     }
 
     #[test]

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -467,6 +467,33 @@ pub fn insert_after_heading_in(content: &str, heading: &str, insertion: &str) ->
     Some(out)
 }
 
+/// Insert content after the **full section body** (after the last line of the
+/// section, before the next same-or-higher heading). Use this to add a sibling
+/// section; prefer [`insert_after_heading_in`] to insert under the heading line
+/// (e.g. intro text before an existing table). See #1726.
+pub fn insert_after_section_in(content: &str, heading: &str, insertion: &str) -> Option<String> {
+    let eol = crate::write::detect_eol(content);
+    let (_, body_end) = find_section(content, heading)?;
+    let mut out = String::with_capacity(content.len() + insertion.len() + 4);
+    out.push_str(&content[..body_end]);
+    if !insertion.is_empty() {
+        // Ensure a blank line before a new sibling section when the prior body
+        // does not already end with a blank line.
+        if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") {
+            if !out.ends_with('\n') {
+                out.push_str(eol);
+            }
+            out.push_str(eol);
+        }
+        out.push_str(insertion);
+        if !insertion.ends_with('\n') {
+            out.push_str(eol);
+        }
+    }
+    out.push_str(&content[body_end..]);
+    Some(out)
+}
+
 pub fn insert_before_heading_in(content: &str, heading: &str, insertion: &str) -> Option<String> {
     let eol = crate::write::detect_eol(content);
     let headings = parse_headings(content);

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -701,6 +701,31 @@ mod edge_cases {
     }
 
     #[test]
+    fn insert_after_section_places_sibling_after_body() {
+        // #1726: sibling section after full body keeps Config body under Config.
+        let content = "## Config\n\nSettings.\n\n## Usage\n\nRun it.\n";
+        let result =
+            insert_after_section_in(content, "## Config", "## FAQ\n\nCommon Q.\n").unwrap();
+        let config = result.find("## Config").unwrap();
+        let settings = result.find("Settings.").unwrap();
+        let faq = result.find("## FAQ").unwrap();
+        let common = result.find("Common Q.").unwrap();
+        let usage = result.find("## Usage").unwrap();
+        assert!(
+            config < settings && settings < faq && faq < common && common < usage,
+            "expected Config body then FAQ sibling then Usage:\n{result}"
+        );
+        // Contrast: insert_after_heading would put FAQ before Settings.
+        let under = insert_after_heading_in(content, "## Config", "## FAQ\n\nCommon Q.\n").unwrap();
+        let u_faq = under.find("## FAQ").unwrap();
+        let u_settings = under.find("Settings.").unwrap();
+        assert!(
+            u_faq < u_settings,
+            "heading insert puts FAQ under Config heading:\n{under}"
+        );
+    }
+
+    #[test]
     fn dedupe_headings_no_duplicates() {
         let content = "# A\n## B\n# C\n";
         let (result, removed) = dedupe_headings_in(content);

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -307,6 +307,7 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<String> {
         | Operation::DocDeleteWhere { path, .. }
         | Operation::MdReplaceSection { path, .. }
         | Operation::MdInsertAfterHeading { path, .. }
+        | Operation::MdInsertAfterSection { path, .. }
         | Operation::MdInsertBeforeHeading { path, .. }
         | Operation::MdUpsertBullet { path, .. }
         | Operation::MdTableAppend { path, .. }

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -168,6 +168,13 @@ pub enum Operation {
         heading: String,
         content: String,
     },
+    /// Insert after the full section body (sibling placement). #1726
+    #[serde(rename = "md.insert_after_section")]
+    MdInsertAfterSection {
+        path: String,
+        heading: String,
+        content: String,
+    },
     #[serde(rename = "md.insert_before_heading")]
     MdInsertBeforeHeading {
         path: String,
@@ -525,6 +532,7 @@ impl Operation {
             Operation::DocDeleteWhere { .. } => "doc.delete_where",
             Operation::MdReplaceSection { .. } => "md.replace_section",
             Operation::MdInsertAfterHeading { .. } => "md.insert_after_heading",
+            Operation::MdInsertAfterSection { .. } => "md.insert_after_section",
             Operation::MdInsertBeforeHeading { .. } => "md.insert_before_heading",
             Operation::MdUpsertBullet { .. } => "md.upsert_bullet",
             Operation::MdTableAppend { .. } => "md.table_append",
@@ -576,6 +584,7 @@ impl Operation {
             Operation::Replace { .. }
                 | Operation::MdReplaceSection { .. }
                 | Operation::MdInsertAfterHeading { .. }
+                | Operation::MdInsertAfterSection { .. }
                 | Operation::MdInsertBeforeHeading { .. }
                 | Operation::MdUpsertBullet { .. }
                 | Operation::MdTableAppend { .. }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -334,13 +334,22 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "md.insert_after_heading",
-        description: "Insert content immediately after a markdown heading.",
+        description: "Insert content immediately after a markdown heading line (before any existing body). For a sibling section after the full body, use md.insert_after_section.",
         tier: Tier::Medium,
         examples: &[],
     },
     OpMeta {
+        name: "md.insert_after_section",
+        description: "Insert content after the full section body (sibling placement). Use when adding a new ## section after this section's content. Prefer md.insert_after_heading for content under the heading line.",
+        tier: Tier::Medium,
+        examples: &[(
+            "Add FAQ after Config section body",
+            r###"{"op":"md.insert_after_section","path":"README.md","heading":"## Config","content":"## FAQ\n\nCommon questions.\n"}"###,
+        )],
+    },
+    OpMeta {
         name: "md.insert_before_heading",
-        description: "Insert content immediately before a markdown heading.",
+        description: "Insert content immediately before a markdown heading line.",
         tier: Tier::Medium,
         examples: &[],
     },

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -487,6 +487,14 @@ mod basic {
                 },
             ),
             (
+                "md.insert_after_section",
+                Operation::MdInsertAfterSection {
+                    path: "f".into(),
+                    heading: "h".into(),
+                    content: "c".into(),
+                },
+            ),
+            (
                 "md.insert_before_heading",
                 Operation::MdInsertBeforeHeading {
                     path: "f".into(),

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -431,6 +431,7 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
         // execute_md_op extracted to tx/md_op.rs (#1359).
         Operation::MdReplaceSection { .. }
         | Operation::MdInsertAfterHeading { .. }
+        | Operation::MdInsertAfterSection { .. }
         | Operation::MdInsertBeforeHeading { .. }
         | Operation::MdUpsertBullet { .. }
         | Operation::MdTableAppend { .. }

--- a/src/tx/md_op.rs
+++ b/src/tx/md_op.rs
@@ -1,8 +1,8 @@
 use super::execute::{TxState, read_file_content, update_file_content};
 use super::output::TxLintResult;
 use crate::ops::md::{
-    dedupe_headings_in, insert_after_heading_in, insert_before_heading_in, move_section_in,
-    replace_section_in, upsert_bullet_in,
+    dedupe_headings_in, insert_after_heading_in, insert_after_section_in, insert_before_heading_in,
+    move_section_in, replace_section_in, upsert_bullet_in,
 };
 use crate::plan::Operation;
 
@@ -57,6 +57,21 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
                 heading,
                 content,
                 insert_after_heading_in,
+                "heading",
+            )?;
+        }
+
+        Operation::MdInsertAfterSection {
+            path,
+            heading,
+            content,
+        } => {
+            apply_md_heading_op(
+                tx,
+                path,
+                heading,
+                content,
+                insert_after_section_in,
                 "heading",
             )?;
         }

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -48,6 +48,7 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
         | Operation::DocDeleteWhere { .. }
         | Operation::MdReplaceSection { .. }
         | Operation::MdInsertAfterHeading { .. }
+        | Operation::MdInsertAfterSection { .. }
         | Operation::MdInsertBeforeHeading { .. }
         | Operation::MdUpsertBullet { .. }
         | Operation::MdTableAppend { .. }

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -91,6 +91,53 @@ fn test_batch_apply_modifies_files() {
     );
 }
 
+/// Batch replace optional flags (#1724).
+#[test]
+fn test_batch_replace_fuzzy_min_score() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hello wrold\n").unwrap();
+    fs::write(dir.path().join("b.txt"), "hello wrold\n").unwrap();
+
+    let ops_high = dir.path().join("ops_high.txt");
+    fs::write(
+        &ops_high,
+        "replace a.txt \"hello world\" \"hello earth\" --fuzzy --min-fuzzy-score 0.99\n",
+    )
+    .unwrap();
+    // High floor rejects this typo (~0.93 score); file must stay unchanged.
+    let high = patchloom_in(dir.path())
+        .arg("batch")
+        .arg(&ops_high)
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_ne!(
+        high.status.code(),
+        Some(0),
+        "high min-fuzzy-score should not succeed; stderr={}",
+        String::from_utf8_lossy(&high.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("a.txt")).unwrap(),
+        "hello wrold\n"
+    );
+
+    let ops_low = dir.path().join("ops_low.txt");
+    fs::write(
+        &ops_low,
+        "replace b.txt \"hello world\" \"hello earth\" --fuzzy --min-fuzzy-score 0.5\n",
+    )
+    .unwrap();
+    patchloom_in(dir.path())
+        .arg("batch")
+        .arg(&ops_low)
+        .arg("--apply")
+        .assert()
+        .code(0);
+    let b = fs::read_to_string(dir.path().join("b.txt")).unwrap();
+    assert!(b.contains("earth"), "low floor should apply fuzzy: {b}");
+}
+
 #[test]
 fn test_batch_empty_input_succeeds() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2681,3 +2681,27 @@ fn test_doc_set_format_failure_json_error_kind() {
         "doc set must still write before format failure"
     );
 }
+
+/// Predicate selectors on doc set point agents at doc update (#1725).
+#[test]
+fn test_doc_set_predicate_errors_with_update_hint() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"items":[{"id":"a","val":1}]}"#).unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "set"])
+        .arg(&file)
+        .args(["items[id=a].val", "9", "--apply"])
+        .output()
+        .unwrap();
+    assert_ne!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("doc update") && combined.contains("wildcard/predicate"),
+        "expected actionable error, got: {combined}"
+    );
+}

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -152,6 +152,39 @@ fn test_md_insert_after_heading() {
     );
 }
 
+/// Sibling section placement keeps body under original heading (#1726).
+#[test]
+fn test_md_insert_after_section_sibling() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("readme.md");
+    fs::write(&file, "## Config\n\nSettings.\n\n## Usage\n\nRun it.\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "md",
+            "insert-after-section",
+            "--heading",
+            "## Config",
+            "--content",
+            "## FAQ\n\nCommon Q.\n",
+            "--apply",
+        ])
+        .arg(&file)
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    let config = content.find("## Config").unwrap();
+    let settings = content.find("Settings.").unwrap();
+    let faq = content.find("## FAQ").unwrap();
+    let usage = content.find("## Usage").unwrap();
+    assert!(
+        config < settings && settings < faq && faq < usage,
+        "Config body must stay before FAQ sibling:\n{content}"
+    );
+}
+
 #[test]
 fn test_md_upsert_bullet_adds_new() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -801,7 +801,7 @@ fn test_smoke_readme_command_examples() {
         "launch announcement CLI command count drifted"
     );
     assert!(
-        launch.contains("55 structured tool calls"),
+        launch.contains("56 structured tool calls"),
         "launch announcement MCP tool count drifted"
     );
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
## Summary

Implements the three agent-parity enhancements from fixrealloop Round 5 research:

| Issue | Change |
|-------|--------|
| #1724 | Batch `replace path old new` accepts optional CLI flags (`--fuzzy`, `--min-fuzzy-score`, `-i`, `--word-boundary`, `--command-position`, `--require-change`, `--if-exists`). Known flags only; dash-prefixed values stay positionals. |
| #1725 | Single-path write ops (`set`/`ensure`/`delete`/`move`) emit actionable errors pointing to `doc update` or `doc delete-where` / index paths. |
| #1726 | Docs clarify heading-line vs section-body insert; new `md.insert_after_section` (CLI, plan, batch, MCP, API) for sibling sections. |

## Test plan

- [x] Unit: batch replace flags (including dash-prefixed values, `=score` form)
- [x] Unit: `set_at_path` predicate error hint
- [x] Unit: `insert_after_section` vs under-heading placement
- [x] Integration: batch fuzzy min-score, md insert-after-section sibling, doc set predicate JSON error
- [x] Lib suite green (2419+)
- [x] clippy `-D warnings`
- [x] Reviewer pass; fixed dash-positional bug + related nits

Closes #1724
Closes #1725
Closes #1726
