### PR TITLE
fix: multi-doc set error hint and insert_after_section coverage

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -322,6 +322,8 @@ dependencies[name=react].version # predicate filter
 
 **Write ops and predicates:** `doc set` / `doc ensure` / `doc delete` / `doc move` are **single-path only** (keys and indexes such as `items.0.val`). Wildcards and predicates (`items[id=b].val`, `items[*].enabled`) belong on `doc update` (multi-match write) or `doc delete-where` (array filter). If you pass a predicate to `doc set`, the error points you at `doc update` or an index path.
 
+**Multi-document YAML:** Files with multiple `---` documents parse as a **top-level array** (one element per document). Address a field with a document index first, e.g. `0.metadata.name` or `[0].metadata.name`, not a bare key at the stream root. Writes keep the multi-doc form (still `---` separators, not a single YAML sequence).
+
 **Markdown insert placement:** `md_insert_after_heading` inserts **under the heading line** (before existing body). To add a sibling `##` section after the full section body, use `md_insert_after_section`.
 
 ## Exit codes

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -682,6 +682,8 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 **Comment preservation:** All `doc` write operations preserve inline comments, section comments, and formatting in YAML and TOML files. The parser edits the concrete syntax tree (CST) directly, so only the changed values are rewritten while surrounding comments and whitespace stay intact. This includes operations that change array length (`append`, `prepend`, `delete-where`), which use text-level splicing to preserve comments on the affected file.
 
+**Multi-document YAML:** Streams with more than one `---` document are modeled as a JSON array (one element per document). Use a document index in the selector (`0.metadata.name`, `[1].spec.ports[0].port`). A bare top-level key on a multi-doc file fails with an actionable type error that points at the index form. Successful writes re-serialize with `---` separators (not as a single YAML sequence), so `kubectl apply -f` style multi-doc files stay valid.
+
 **JSON write summary:** Every doc write success payload under `--json` / `--jsonl` includes `changed` (bool). `doc delete` and `doc delete-where` also include `removed` (usize). Agents should not treat exit 0 alone as "something was deleted"; check `removed` / `changed` for idempotent no-ops. The same fields appear on MCP `doc_delete` / `doc_delete_where` and on `execute_plan` / `tx` reports (plus a `mutations` array with per-op `path`, `op`, `changed`, `removed` for multi-step plans).
 
 <!-- ref:doc-action:get -->

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -465,6 +465,10 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
          (`items[id=b].val`, `items[*].enabled`) belong on `doc update` (multi-match write) or \
          `doc delete-where` (array filter). If you pass a predicate to `doc set`, the error points \
          you at `doc update` or an index path.\n\n\
+         **Multi-document YAML:** Files with multiple `---` documents parse as a **top-level array** \
+         (one element per document). Address a field with a document index first, e.g. `0.metadata.name` \
+         or `[0].metadata.name`, not a bare key at the stream root. Writes keep the multi-doc form \
+         (still `---` separators, not a single YAML sequence).\n\n\
          **Markdown insert placement:** `md_insert_after_heading` inserts **under the heading line** \
          (before existing body). To add a sibling `##` section after the full section body, use \
          `md_insert_after_section`.\n\n",
@@ -713,6 +717,17 @@ mod tests {
         let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
         assert!(out.contains("--whole-line"));
         assert!(out.contains("--collapse-blanks"));
+    }
+
+    #[test]
+    fn workflow_documents_multi_document_yaml_index() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(
+            out.contains("Multi-document YAML")
+                && out.contains("0.metadata.name")
+                && out.contains("top-level array"),
+            "agents need multi-doc index guidance"
+        );
     }
 
     #[test]

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -304,6 +304,20 @@ mod basic {
     }
 
     #[test]
+    fn parse_line_md_insert_after_section() {
+        let op = parse_line(
+            "md.insert_after_section README.md \"## Config\" \"## FAQ\"",
+            1,
+        )
+        .unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdInsertAfterSection { path, heading, content }
+            if path == "README.md" && heading == "## Config" && content == "## FAQ"
+        ));
+    }
+
+    #[test]
     fn parse_line_md_insert_before_heading() {
         let op = parse_line(
             "md.insert_before_heading README.md \"## Rules\" \"Preamble\"",

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -150,12 +150,23 @@ pub fn set_at_path(
                 }
                 return Ok(());
             }
+            // Capture type before mut borrow for the error path (multi-doc array root).
+            let parent_kind = value_type_name(parent);
             parent
                 .as_object_mut()
                 .ok_or_else(|| {
-                    anyhow::Error::new(crate::exit::TypeErrorError {
-                        msg: "parent is not an object".into(),
-                    })
+                    // Multi-document YAML is modeled as a top-level array; agents
+                    // often try `doc set multi.yaml key val` without a doc index.
+                    let msg = if parent_kind == "array" {
+                        format!(
+                            "parent is an array, not an object (for multi-document YAML or \
+                             top-level arrays, address a document/element with an index first, \
+                             e.g. 0.{k} or [0].{k})"
+                        )
+                    } else {
+                        format!("parent is not an object (found {parent_kind})")
+                    };
+                    anyhow::Error::new(crate::exit::TypeErrorError { msg })
                 })?
                 .insert(k.clone(), value);
         }
@@ -683,6 +694,24 @@ mod tests {
         assert!(
             msg.contains("doc update") && msg.contains("wildcard/predicate"),
             "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn set_at_path_array_root_key_hints_document_index() {
+        // Multi-doc YAML / top-level array: key at root needs 0.key / [0].key.
+        let mut root = json!([{"a": 1}, {"b": 2}]);
+        let err = set_at_path(&mut root, &segs("a"), json!(9)).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("array")
+                && (msg.contains("0.a") || msg.contains("[0].a"))
+                && msg.contains("index"),
+            "got: {msg}"
+        );
+        assert!(
+            !msg.eq("parent is not an object"),
+            "bare message is not agent-actionable: {msg}"
         );
     }
 

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -726,6 +726,40 @@ mod edge_cases {
     }
 
     #[test]
+    fn insert_after_section_last_section_appends() {
+        let content = "## First\n\nA\n\n## Last\n\nBody of last\n";
+        let result = insert_after_section_in(content, "## Last", "## Trailer\n\nEnd.\n").unwrap();
+        assert!(
+            result.ends_with("## Trailer\n\nEnd.\n")
+                || result.contains("Body of last\n\n## Trailer\n\nEnd.\n"),
+            "trailer must follow last section body:\n{result}"
+        );
+        assert!(
+            result.find("Body of last").unwrap() < result.find("## Trailer").unwrap(),
+            "body stays under Last:\n{result}"
+        );
+    }
+
+    #[test]
+    fn insert_after_section_includes_nested_lower_headings() {
+        // Nested ### stays under Parent; sibling ## is after the new section.
+        let content = "## Parent\n\nintro\n\n### Nested\n\nnested body\n\n## Sibling\n\nsib\n";
+        let result = insert_after_section_in(content, "## Parent", "## AfterParent\nx\n").unwrap();
+        let nested = result.find("### Nested").unwrap();
+        let after = result.find("## AfterParent").unwrap();
+        let sibling = result.find("## Sibling").unwrap();
+        assert!(
+            nested < after && after < sibling,
+            "nested body stays under Parent, AfterParent before Sibling:\n{result}"
+        );
+    }
+
+    #[test]
+    fn insert_after_section_missing_heading_returns_none() {
+        assert!(insert_after_section_in("# Title\n\nBody\n", "## Missing", "x\n").is_none());
+    }
+
+    #[test]
     fn dedupe_headings_no_duplicates() {
         let content = "# A\n## B\n# C\n";
         let (result, removed) = dedupe_headings_in(content);

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -91,6 +91,40 @@ fn test_batch_apply_modifies_files() {
     );
 }
 
+/// Batch `md.insert_after_section` places a sibling after the full body (#1726).
+#[test]
+fn test_batch_md_insert_after_section() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("readme.md"),
+        "## Config\n\nSettings.\n\n## Usage\n\nRun it.\n",
+    )
+    .unwrap();
+
+    let ops = dir.path().join("ops.txt");
+    fs::write(
+        &ops,
+        "md.insert_after_section readme.md \"## Config\" \"## FAQ\"\n",
+    )
+    .unwrap();
+
+    patchloom_in(dir.path())
+        .arg("batch")
+        .arg(&ops)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(dir.path().join("readme.md")).unwrap();
+    let settings = content.find("Settings.").unwrap();
+    let faq = content.find("## FAQ").unwrap();
+    let usage = content.find("## Usage").unwrap();
+    assert!(
+        settings < faq && faq < usage,
+        "batch insert_after_section must keep Config body before FAQ:\n{content}"
+    );
+}
+
 /// Batch replace optional flags (#1724).
 #[test]
 fn test_batch_replace_fuzzy_min_score() {

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2705,3 +2705,31 @@ fn test_doc_set_predicate_errors_with_update_hint() {
         "expected actionable error, got: {combined}"
     );
 }
+
+/// Multi-document YAML is an array root; bare keys must hint document index.
+#[test]
+fn test_doc_set_multi_document_bare_key_hints_index() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("multi.yaml");
+    fs::write(&file, "a: 1\n---\nb: 2\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "set"])
+        .arg(&file)
+        .args(["a", "9", "--apply"])
+        .output()
+        .unwrap();
+    assert_ne!(out.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("array")
+            && (combined.contains("0.a") || combined.contains("[0].a"))
+            && combined.contains("index"),
+        "expected multi-doc index hint, got: {combined}"
+    );
+    // File must be unchanged.
+    assert_eq!(fs::read_to_string(&file).unwrap(), "a: 1\n---\nb: 2\n");
+}

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -961,6 +961,46 @@ async fn test_mcp_md_insert_after_heading_round_trip() {
 }
 
 #[tokio::test]
+async fn test_mcp_md_insert_after_section_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("doc.md"),
+        "## Config\n\nSettings.\n\n## Usage\n\nRun it.\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "md_insert_after_section",
+        serde_json::json!({
+            "path": "doc.md",
+            "heading": "## Config",
+            "content": "## FAQ\n\nCommon Q.\n"
+        }),
+    )
+    .await;
+    assert!(!is_error, "md insert_after_section should succeed: {val}");
+    assert_eq!(val["ok"], true, "md insert_after_section ok: {val}");
+    assert_eq!(
+        val["files_changed"], 1,
+        "md insert_after_section files_changed: {val}"
+    );
+    let content = fs::read_to_string(dir.path().join("doc.md")).unwrap();
+    let settings = content.find("Settings.").expect("Settings present");
+    let faq = content.find("## FAQ").expect("FAQ present");
+    let usage = content.find("## Usage").expect("Usage present");
+    assert!(
+        settings < faq && faq < usage,
+        "MCP insert_after_section keeps Config body before FAQ:\n{content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_md_insert_before_heading_round_trip() {
     if !has_mcp_support() {
         return;

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -186,6 +186,28 @@ fn test_md_insert_after_section_sibling() {
 }
 
 #[test]
+fn test_md_insert_after_section_not_found() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(&file, "# Title\n\nContent.\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("md")
+        .arg("insert-after-section")
+        .arg(file.to_str().unwrap())
+        .arg("--heading")
+        .arg("## Missing")
+        .arg("--content")
+        .arg("x")
+        .arg("--apply")
+        .assert()
+        .code(3)
+        .stdout(predicates::str::contains("no_matches"));
+}
+
+#[test]
 fn test_md_upsert_bullet_adds_new() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("notes.md");

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2601,6 +2601,42 @@ fn test_tx_md_insert_after_heading_in_plan() {
 }
 
 #[test]
+fn test_tx_md_insert_after_section_in_plan() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(&file, "## Config\n\nSettings.\n\n## Usage\n\nRun it.\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "md.insert_after_section",
+            "path": portable_path_str(&file),
+            "heading": "## Config",
+            "content": "## FAQ\n\nCommon Q.\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    let settings = result.find("Settings.").unwrap();
+    let faq = result.find("## FAQ").unwrap();
+    let usage = result.find("## Usage").unwrap();
+    assert!(
+        settings < faq && faq < usage,
+        "tx insert_after_section must keep body under Config:\n{result}"
+    );
+}
+
+#[test]
 fn test_tx_md_replace_section_nonexistent_file_rolls_back() {
     let dir = TempDir::new().unwrap();
 


### PR DESCRIPTION
## Summary

MPI cycle (2026-07-14 s2) after #1727 landed.

- **Agent UX:** `doc set` on multi-document YAML (array root) no longer says bare `parent is not an object`. Errors now point at document-index selectors (`0.key` / `[0].key`).
- **Docs:** agent-rules, PATCHLOOM.md, and reference document multi-doc index addressing and separator-preserving writes.
- **Tests:** lock `md.insert_after_section` across CLI not-found, batch, tx, MCP, and ops edge cases (last section, nested lower headings); batch parse unit test; multi-doc bare-key integration test.

Ref #1726 (coverage follow-up for insert-after-section surfaces).

## Test plan

- [x] `make check` (full gate)
- [x] unit: `set_at_path_array_root_key_hints_document_index`, insert_after_section edge cases, batch parse
- [x] integration: md/batch/tx/MCP insert_after_section + multi-doc bare key