### PR TITLE
test: multi-doc CLI apply lock and md clap field help

### DIFF
--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -26,7 +26,9 @@ pub struct MdArgs {
 pub enum MdAction {
     /// Replace a heading section.
     ReplaceSection {
+        /// Markdown file to edit.
         file: String,
+        /// Heading of the section to replace (e.g. `## Unreleased`).
         #[arg(long)]
         heading: String,
         /// Read replacement content from stdin.
@@ -91,20 +93,31 @@ pub enum MdAction {
     },
     /// Add a bullet under a heading if not already present.
     UpsertBullet {
+        /// Markdown file to edit.
         file: String,
+        /// Heading under which to upsert the bullet (e.g. `## Rules`).
         #[arg(long)]
         heading: String,
+        /// Bullet text (leading `- ` is optional).
         #[arg(long, allow_hyphen_values = true)]
         bullet: String,
     },
     /// Remove duplicate headings.
-    DedupeHeadings { file: String },
+    DedupeHeadings {
+        /// Markdown file to scan for duplicate headings.
+        file: String,
+    },
     /// Lint common AGENTS.md problems.
     #[command(name = "lint-agents", alias = "lint")]
-    LintAgents { file: String },
+    LintAgents {
+        /// AGENTS.md (or similar) file to lint.
+        file: String,
+    },
     /// Append a row to a markdown table under a heading.
     TableAppend {
+        /// Markdown file containing the table.
         file: String,
+        /// Heading above the target table (e.g. `## API`).
         #[arg(long)]
         heading: String,
         /// Table row: `| col1 | col2 |` or compact `col1|col2` / `col1 | col2`.

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -42,12 +42,16 @@ pub enum MdAction {
     /// Does not insert after the full section body. For a sibling section after
     /// the section ends, use `insert-after-section` (#1726).
     InsertAfterHeading {
+        /// Markdown file to edit.
         file: String,
+        /// Heading line to insert under (e.g. `## Config`).
         #[arg(long)]
         heading: String,
         // ref:md-mode:stdin
+        /// Read insertion content from stdin instead of `--content`.
         #[arg(long)]
         stdin: bool,
+        /// Content to insert (omit when using `--stdin`).
         #[arg(long)]
         content: Option<String>,
     },
@@ -57,23 +61,31 @@ pub enum MdAction {
     /// `insert-after-heading` only for content under the heading (e.g. intro
     /// before a table). #1726
     InsertAfterSection {
+        /// Markdown file to edit.
         file: String,
+        /// Heading whose section body ends just before the insertion point.
         #[arg(long)]
         heading: String,
         // ref:md-mode:stdin
+        /// Read insertion content from stdin instead of `--content`.
         #[arg(long)]
         stdin: bool,
+        /// Content to insert (omit when using `--stdin`).
         #[arg(long)]
         content: Option<String>,
     },
     /// Insert content immediately before a heading line.
     InsertBeforeHeading {
+        /// Markdown file to edit.
         file: String,
+        /// Heading line to insert before (e.g. `## Config`).
         #[arg(long)]
         heading: String,
         // ref:md-mode:stdin
+        /// Read insertion content from stdin instead of `--content`.
         #[arg(long)]
         stdin: bool,
+        /// Content to insert (omit when using `--stdin`).
         #[arg(long)]
         content: Option<String>,
     },

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2733,3 +2733,50 @@ fn test_doc_set_multi_document_bare_key_hints_index() {
     // File must be unchanged.
     assert_eq!(fs::read_to_string(&file).unwrap(), "a: 1\n---\nb: 2\n");
 }
+
+/// CLI `doc set --apply` on multi-doc YAML must keep `---` separators on disk
+/// (not collapse to a single YAML sequence). Unit tests cover the serializer;
+/// this locks the full CLI write path (#1719).
+#[test]
+fn test_doc_set_multi_document_apply_preserves_separators() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("k8s.yaml");
+    let original = "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: demo\ndata:\n  key: value\n---\napiVersion: v1\nkind: Service\nmetadata:\n  name: demo-svc\nspec:\n  ports:\n    - port: 80\n";
+    fs::write(&file, original).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "set"])
+        .arg(&file)
+        .args(["0.data.key", "newval", "--apply"])
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    assert!(
+        result.contains("---"),
+        "CLI apply must preserve multi-doc stream separators, got:\n{result}"
+    );
+    assert!(
+        !result.trim_start().starts_with("- "),
+        "must not serialize multi-doc as a YAML sequence, got:\n{result}"
+    );
+    assert!(
+        result.contains("key: newval") || result.contains("key: \"newval\""),
+        "updated value missing:\n{result}"
+    );
+    assert!(
+        result.contains("kind: Service") && result.contains("demo-svc"),
+        "second document must be preserved:\n{result}"
+    );
+
+    // Second document still addressable by index after write.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "get"])
+        .arg(&file)
+        .arg("1.metadata.name")
+        .assert()
+        .code(0)
+        .stdout(predicates::str::contains("demo-svc"));
+}

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -185,6 +185,35 @@ fn test_md_insert_after_section_sibling() {
     );
 }
 
+/// Default (preview) mode for insert-after-section: exit 2, no disk mutation.
+#[test]
+fn test_md_insert_after_section_preview_exits_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("readme.md");
+    let original = "## Config\n\nSettings.\n\n## Usage\n\nRun it.\n";
+    fs::write(&file, original).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "md",
+            "insert-after-section",
+            "--heading",
+            "## Config",
+            "--content",
+            "## FAQ\n\nCommon Q.\n",
+        ])
+        .arg(&file)
+        .assert()
+        .code(2);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        original,
+        "preview must not mutate the file"
+    );
+}
+
 #[test]
 fn test_md_insert_after_section_not_found() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

MPI cycle after v0.14.0 (session branch `fix/improve-mpi-20260714-s3`).

- **QA:** Integration lock for multi-document YAML `doc set --apply` preserving `---` separators on disk (unit tests covered the serializer only). Preview exit 2 + no mutation for `md insert-after-section`.
- **New Contributor / End User:** clap field docs for all `md` subcommand args so `--help` is not blank for file/heading/content/stdin/bullet/row.

## Test plan

- [x] `cargo test --test integration multi_document_apply_preserves`
- [x] `cargo test --test integration insert_after_section_preview`
- [x] `make check-fast`

## Gate

Open accepted backlog remains dist B-path only: #960 winget, #961 Chocolatey, #632-#634 directories (external).