### PR TITLE
fix: preserve hardlinks in atomic_write when nlink > 1

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -5,6 +5,8 @@
 
 **Decision rule: if you are about to make 3+ tool calls for file edits, use `patchloom batch` instead.** One call replaces N round-trips. For agent sandboxes that shell out to the CLI, pass `--contain` (with `--cwd`) so operation targets and meta-input files cannot escape the workspace.
 
+**Apply write safety:** all Apply paths share one writer. Symlinks are resolved so the link entry is not replaced (#1230). On Unix, files with multiple hard links (`nlink > 1`) are updated in place so sibling paths stay in sync (#1733); single-link files use temp+rename.
+
 ## Tool selection guide
 
 | Task pattern | Tool to use |

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -39,6 +39,17 @@ Every write command supports four modes:
 
 These modes are mutually exclusive. Patchloom is safe by default: nothing is written unless you pass `--apply` or confirm an interactive prompt.
 
+## Write safety on disk
+
+Apply writers share a single `atomic_write` path:
+
+- **Normal files** (`nlink == 1`): write a same-directory temp file, then rename over the target so readers never see a half-written file.
+- **Symlinks** (#1230): resolve and write the target; the symlink directory entry is not replaced by a regular file.
+- **Hardlinks** (`nlink > 1` on Unix, #1733): stage full content on a same-dir temp, then rewrite the **existing** inode in place so every hardlink path stays in sync. Temp+rename would break siblings (they would keep the old inode). Windows and other platforms without this check keep rename semantics.
+- **New files**: create via temp + exclusive persist (no pre-existing inode to preserve).
+
+Library embedders, CLI `--apply`, MCP tools, and `tx`/`batch` all use this path.
+
 ## Write policy
 
 A write policy controls transformations applied to all content before it reaches disk:

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -81,6 +81,14 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
         );
     }
 
+    // Shared Apply write semantics (CLI + MCP + library).
+    out.push_str(
+        "**Apply write safety:** all Apply paths share one writer. Symlinks are resolved so \
+         the link entry is not replaced (#1230). On Unix, files with multiple hard links \
+         (`nlink > 1`) are updated in place so sibling paths stay in sync (#1733); single-link \
+         files use temp+rename.\n\n",
+    );
+
     // When to use
     if show_mcp {
         out.push_str(
@@ -727,6 +735,15 @@ mod tests {
                 && out.contains("0.metadata.name")
                 && out.contains("top-level array"),
             "agents need multi-doc index guidance"
+        );
+    }
+
+    #[test]
+    fn workflow_documents_hardlink_preserving_apply() {
+        let out = generate_agent_rules(&args(AgentMode::All, AgentPlatform::All));
+        assert!(
+            out.contains("hard links") && out.contains("nlink") && out.contains("temp+rename"),
+            "agents need hardlink-preserving Apply guidance (#1733)"
         );
     }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -668,9 +668,16 @@ pub(crate) fn atomic_create_new(
 
 /// Atomically write `content` to `path` after applying `policy`.
 ///
-/// A temporary file is created in the same directory as `path`, written to, then
-/// renamed over `path`. This guarantees the target file is never in a
-/// partially-written state (assuming the same filesystem).
+/// Default path (single hard link or new file): a temporary file is created in
+/// the same directory as `path`, written to, then renamed over `path`. The
+/// target is never left half-written for normal files.
+///
+/// When the resolved target is a regular file with **more than one hard link**
+/// (`nlink > 1` on Unix), rename would break siblings (they would keep the old
+/// inode). In that case the full payload is staged to a same-dir temp first,
+/// then written into the **existing** inode so all hardlink paths stay in sync
+/// (#1733). Symlinks are resolved first (#1230); the hardlink rule applies to
+/// the resolved path.
 pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow::Result<()> {
     let final_content = apply_policy(content, policy);
 
@@ -687,7 +694,24 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
     };
 
     // Capture the original file's permissions before overwriting.
-    let original_perms = std::fs::metadata(write_path).ok().map(|m| m.permissions());
+    let original_meta = std::fs::metadata(write_path).ok();
+    let original_perms = original_meta.as_ref().map(|m| m.permissions());
+
+    // Preserve hardlinks on Unix when the resolved target is multi-linked (#1733).
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if let Some(ref meta) = original_meta
+            && meta.is_file()
+            && meta.nlink() > 1
+        {
+            return write_preserving_hardlinks(
+                write_path,
+                final_content.as_bytes(),
+                original_perms,
+            );
+        }
+    }
 
     let parent = write_path
         .parent()
@@ -709,6 +733,56 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
     tmp.persist(write_path)
         .with_context(|| format!("failed to persist tempfile to {}", write_path.display()))?;
 
+    Ok(())
+}
+
+/// Stage full content on a same-dir temp, then rewrite the existing inode in
+/// place so all hardlink paths observe the new bytes (`nlink` stays > 1).
+///
+/// Used only when `metadata(path).nlink() > 1`. Single-link files keep the
+/// rename path in [`atomic_write`].
+#[cfg(unix)]
+fn write_preserving_hardlinks(
+    path: &Path,
+    bytes: &[u8],
+    original_perms: Option<std::fs::Permissions>,
+) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    let parent = path
+        .parent()
+        .context("cannot determine parent directory of target path")?;
+
+    // Stage complete payload first so we do not begin truncating the shared
+    // inode until the full content exists on disk (best-effort durability).
+    let mut tmp = NamedTempFile::new_in(parent)
+        .with_context(|| format!("failed to create tempfile in {}", parent.display()))?;
+    tmp.write_all(bytes)
+        .with_context(|| format!("failed to write to tempfile {}", tmp.path().display()))?;
+    // Best-effort; some filesystems/OS combinations do not support sync_all.
+    let _ = tmp.as_file().sync_all();
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .with_context(|| {
+            format!(
+                "failed to open hardlinked path for write {}",
+                path.display()
+            )
+        })?;
+    file.write_all(bytes)
+        .with_context(|| format!("failed to write hardlinked path {}", path.display()))?;
+    let _ = file.sync_all();
+    drop(file);
+
+    if let Some(perms) = original_perms {
+        std::fs::set_permissions(path, perms)
+            .with_context(|| format!("failed to restore permissions on {}", path.display()))?;
+    }
+
+    // NamedTempFile Drop removes the staging file.
     Ok(())
 }
 

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -881,6 +881,138 @@ mod symlink_handling {
     }
 }
 
+/// Hardlink-preserving writes (#1733): multi-linked files keep a shared inode.
+#[cfg(unix)]
+mod hardlink_handling {
+    use super::*;
+    use std::os::unix::fs::MetadataExt;
+
+    #[test]
+    fn atomic_write_preserves_hardlinks() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "shared\n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+
+        let before_ino = fs::metadata(&a).unwrap().ino();
+        assert_eq!(fs::metadata(&a).unwrap().nlink(), 2);
+        assert_eq!(fs::metadata(&b).unwrap().ino(), before_ino);
+
+        let policy = WritePolicy::default();
+        atomic_write(&a, "changed\n", &policy).unwrap();
+
+        assert_eq!(fs::read_to_string(&a).unwrap(), "changed\n");
+        assert_eq!(
+            fs::read_to_string(&b).unwrap(),
+            "changed\n",
+            "sibling hardlink must see the new content"
+        );
+        let after_a = fs::metadata(&a).unwrap();
+        let after_b = fs::metadata(&b).unwrap();
+        assert_eq!(after_a.ino(), before_ino, "inode must be preserved");
+        assert_eq!(
+            after_b.ino(),
+            before_ino,
+            "siblings must share the same inode"
+        );
+        assert!(
+            after_a.nlink() > 1,
+            "nlink must stay > 1 after write, got {}",
+            after_a.nlink()
+        );
+    }
+
+    #[test]
+    fn atomic_write_single_link_still_uses_rename_path() {
+        // Single-link files should not take the hardlink-preserving branch.
+        // After rename, the path still has nlink == 1 and the new content.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("solo.txt");
+        fs::write(&path, "before\n").unwrap();
+        assert_eq!(fs::metadata(&path).unwrap().nlink(), 1);
+
+        let policy = WritePolicy::default();
+        atomic_write(&path, "after\n", &policy).unwrap();
+
+        assert_eq!(fs::read_to_string(&path).unwrap(), "after\n");
+        assert_eq!(
+            fs::metadata(&path).unwrap().nlink(),
+            1,
+            "single-link file must remain nlink == 1"
+        );
+    }
+
+    #[test]
+    fn atomic_write_through_symlink_to_hardlinked_target() {
+        // Compose #1230 + #1733: symlink → multi-hardlinked regular file.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real.txt");
+        let sibling = dir.path().join("sibling.txt");
+        fs::write(&target, "shared\n").unwrap();
+        fs::hard_link(&target, &sibling).unwrap();
+
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let before_ino = fs::metadata(&target).unwrap().ino();
+        let policy = WritePolicy::default();
+        atomic_write(&link, "via-link\n", &policy).unwrap();
+
+        assert!(link.is_symlink(), "symlink entry must remain a symlink");
+        assert_eq!(fs::read_to_string(&target).unwrap(), "via-link\n");
+        assert_eq!(
+            fs::read_to_string(&sibling).unwrap(),
+            "via-link\n",
+            "hardlink sibling of symlink target must update"
+        );
+        assert_eq!(fs::metadata(&target).unwrap().ino(), before_ino);
+        assert_eq!(fs::metadata(&sibling).unwrap().ino(), before_ino);
+        assert!(fs::metadata(&target).unwrap().nlink() > 1);
+    }
+
+    #[test]
+    fn atomic_write_preserves_hardlink_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "shared\n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+        std::fs::set_permissions(&a, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        let policy = WritePolicy::default();
+        atomic_write(&a, "changed\n", &policy).unwrap();
+
+        let mode = fs::metadata(&a).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o640,
+            "permissions must be restored on the shared inode"
+        );
+        assert_eq!(fs::read_to_string(&b).unwrap(), "changed\n");
+    }
+
+    #[test]
+    fn atomic_write_hardlinks_applies_write_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "line  \n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+
+        let policy = WritePolicy {
+            trim_trailing_whitespace: true,
+            ensure_final_newline: true,
+            ..WritePolicy::default()
+        };
+        atomic_write(&a, "line  ", &policy).unwrap();
+
+        assert_eq!(fs::read_to_string(&a).unwrap(), "line\n");
+        assert_eq!(fs::read_to_string(&b).unwrap(), "line\n");
+        assert!(fs::metadata(&a).unwrap().nlink() > 1);
+    }
+}
+
 mod error_handling {
     use super::*;
 

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2734,6 +2734,41 @@ fn test_doc_set_multi_document_bare_key_hints_index() {
     assert_eq!(fs::read_to_string(&file).unwrap(), "a: 1\n---\nb: 2\n");
 }
 
+/// doc set Apply shares `atomic_write`; hardlinked siblings must stay in sync (#1733).
+#[cfg(unix)]
+#[test]
+fn test_doc_set_apply_preserves_hardlinks() {
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("cfg.json");
+    let b = dir.path().join("cfg-copy.json");
+    fs::write(&a, r#"{"name":"demo"}"#).unwrap();
+    fs::hard_link(&a, &b).unwrap();
+    let before_ino = fs::metadata(&a).unwrap().ino();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "set"])
+        .arg(&a)
+        .args(["name", "updated", "--apply"])
+        .assert()
+        .code(0);
+
+    let a_content = fs::read_to_string(&a).unwrap();
+    let b_content = fs::read_to_string(&b).unwrap();
+    assert!(
+        a_content.contains("updated"),
+        "doc set must update primary path: {a_content}"
+    );
+    assert_eq!(
+        a_content, b_content,
+        "hardlink sibling must match after doc set --apply"
+    );
+    assert_eq!(fs::metadata(&a).unwrap().ino(), before_ino);
+    assert!(fs::metadata(&a).unwrap().nlink() > 1);
+}
+
 /// CLI `doc set --apply` on multi-doc YAML must keep `---` separators on disk
 /// (not collapse to a single YAML sequence). Unit tests cover the serializer;
 /// this locks the full CLI write path (#1719).

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1217,10 +1217,56 @@ fn test_replace_follows_symlink_within_cwd() {
         .assert()
         .code(0);
 
-    // atomic_write replaces the symlink with a regular file (rename semantics).
-    // Reading the link path should show the replacement.
-    let content = fs::read_to_string(&link).unwrap();
-    assert_eq!(content, "goodbye world\n");
+    // #1230: atomic_write resolves the symlink and updates the target; the
+    // link path remains a symlink.
+    assert!(
+        link.is_symlink(),
+        "replace --apply through a symlink must preserve the symlink entry"
+    );
+    assert_eq!(fs::read_to_string(&real_file).unwrap(), "goodbye world\n");
+    assert_eq!(fs::read_to_string(&link).unwrap(), "goodbye world\n");
+}
+
+/// CLI Apply through one path of a hardlinked pair must update both (#1733).
+#[cfg(unix)]
+#[test]
+fn test_replace_apply_preserves_hardlinks() {
+    use std::os::unix::fs::MetadataExt;
+
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.txt");
+    let b = dir.path().join("b.txt");
+    fs::write(&a, "shared line\n").unwrap();
+    fs::hard_link(&a, &b).unwrap();
+    let before_ino = fs::metadata(&a).unwrap().ino();
+    assert_eq!(fs::metadata(&a).unwrap().nlink(), 2);
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("shared line")
+        .arg("--new")
+        .arg("changed line")
+        .arg("--apply")
+        .arg(&a)
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read_to_string(&a).unwrap(), "changed line\n");
+    assert_eq!(
+        fs::read_to_string(&b).unwrap(),
+        "changed line\n",
+        "sibling hardlink must see the same content after replace --apply"
+    );
+    let meta_a = fs::metadata(&a).unwrap();
+    let meta_b = fs::metadata(&b).unwrap();
+    assert_eq!(meta_a.ino(), before_ino, "inode must be preserved");
+    assert_eq!(meta_b.ino(), before_ino);
+    assert!(
+        meta_a.nlink() > 1,
+        "nlink must stay > 1, got {}",
+        meta_a.nlink()
+    );
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

Implements [#1733](https://github.com/patchloom/patchloom/issues/1733): when the resolved Apply target is a regular file with `nlink > 1` (Unix), `atomic_write` no longer renames a temp over the path (which orphaned sibling hardlinks on the old inode).

### Behavior
| Case | Path |
|------|------|
| `nlink > 1` (Unix) | Stage full content to same-dir temp, then open/truncate/write the **existing** inode |
| `nlink == 1` or new file | Unchanged temp + rename |
| Symlink | Resolve first (#1230), then apply hardlink rule on the target |
| Non-Unix | Rename path only (no portable `nlink` special case) |

### Tests
- Unit: hardlinked pair same inode + content; single-link still nlink=1; symlink→hardlink compose; permissions; write policy
- Integration: `replace --apply` and `doc set --apply` on hardlinked pairs
- Also corrected symlink integration assertion (link entry preserved)

### Docs
- concepts: "Write safety on disk"
- agent-rules / PATCHLOOM.md Apply note

Closes #1733

## Test plan
- [x] `cargo test --lib hardlink --all-features`
- [x] `cargo test --test integration preserves_hardlinks --all-features`
- [x] `make check-fast`
- [x] `make check-patchloom-md`