### PR TITLE
fix: report matched_text for fuzzy replace and document semantic check

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -43,6 +43,12 @@
 - `min_fuzzy_score`: reject fuzzy matches below this floor (0.0..=1.0); exact/anchored unaffected (#1687).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
+**Fuzzy success is not semantic success (#1736):**
+- `min_fuzzy_score` only rejects *weak* similarity. Scores above the floor can still rewrite a *different* live identifier than the `old` string you requested.
+- After any fuzzy apply, read JSON `matched_text` (and re-read the file if needed). If `matched_text` is not the intended typo (for example `old=compute_cheksum` fuzzy-hits `compute_checksum` at score ~0.99), **undo** and use `ast_rename` / exact replace instead.
+- Prefer `ast_rename` / `ast_rename_project` for code identifiers. Fuzzy is a last resort for typos in non-AST text (prose, comments), not a general rename tool.
+- Do not treat `ok` + `match_score >= min_fuzzy_score` alone as "correct target." Distinct from closed whole-line bug #1694.
+
 **Library embedder undo / post-write (Rust hosts, not CLI-only):**
 - After `ApplyMode::Apply`, `EditResult.backup_session` is the session id for that write (#1686).
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
@@ -51,8 +57,8 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - CLI: `patchloom undo --list` walks nested `.patchloom/backups` under the cwd (#1695). Bare CLI undo is dry-run (exit 2); restore needs the write apply flag (see CLI agent-rules).
 - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`
 - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)
-- Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts (#1687, #1694)
-**Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674).
+- Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts; always check `matched_text` (#1687, #1694, #1736)
+**Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, optional `matched_text` (actual span for fuzzy/anchored; may differ from `old`), and replace `match_count` (plan/tx also on each change + sum) so agents can verify fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674, #1736).
 
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)
@@ -193,6 +199,8 @@ patchloom search --count "old_function_name" src/
 patchloom replace "old_function_name" --new "new_function_name" src/ --apply
 ```
 
+Bad: `replace --fuzzy` with a misspelled `old` that is **not** in the file (e.g. `compute_cheksum` → may rewrite live `compute_checksum` even with `--min-fuzzy-score 0.95`). After fuzzy JSON, check `matched_text` (#1736).
+
 ### Delete lines matching a pattern
 
 ```bash
@@ -273,7 +281,7 @@ Plan/MCP `replace` accepts library flags (default false):
 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
 - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
-Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674).
+Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`), optional `matched_text` for fuzzy/anchored spans, and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674, #1736).
 
 ## AST-aware operations
 
@@ -351,7 +359,7 @@ dependencies[name=react].version # predicate filter
 
 ## Operations (from schema registry)
 
-- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches), command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip), and fuzzy (similarity fallback when exact match fails).
+- `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches), command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip), and fuzzy (similarity fallback when exact match fails). Fuzzy + min_fuzzy_score only reject weak scores; high scores can still rewrite a different live identifier than old—check matched_text and prefer ast.rename for identifiers (#1736).
 - `file.append`: Append content to an existing file.
 - `file.prepend`: Prepend content to an existing file.
 - `file.create`: Create a new file with specified content.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -603,14 +603,16 @@ These are meaningful command-specific modes that change how a top-level command 
 ### `replace --fuzzy` / library `ReplaceOptions.fuzzy` / plan `fuzzy`
 
 - **What it does:** When the exact pattern has zero matches, try similarity/anchor fallback (same chain as before/after context). Plan ops and MCP `replace_text` accept `fuzzy: true`. Pure fuzzy (no context) works on disk library, single-path tx, **glob** plan ops, and CLI (including directory roots expanded like ordinary replace).
-- **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` in library results and CLI/MCP JSON (#1669). Multi-file CLI replace, plan/tx, and content_edits all roll up worst-case confidence (`fuzzy` > `anchored` > `exact`) so mixed batches never under-report fuzzy.
-- **Prefer instead:** Exact replace when the target string is known.
+- **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` / `matched_text` in library results and CLI/MCP JSON (#1669, #1736). Multi-file CLI replace, plan/tx, and content_edits all roll up worst-case confidence (`fuzzy` > `anchored` > `exact`) so mixed batches never under-report fuzzy.
+- **Agent rule:** Fuzzy success is not semantic success. A high score can rewrite a *different* live identifier than `old` (example: `old=compute_cheksum` may match `compute_checksum` at score ~0.99). After fuzzy apply, check `matched_text` against the intended span; prefer `ast rename` for identifiers. Distinct from whole-line span fix #1694.
+- **Prefer instead:** Exact replace when the target string is known; `ast rename` for code identifiers.
 
 <!-- ref:replace-mode:min-fuzzy-score -->
 ### `replace --min-fuzzy-score` / library `ReplaceOptions.min_fuzzy_score` / plan `min_fuzzy_score`
 
 - **What it does:** When a fuzzy match is found, reject it if its similarity score is below this floor (`0.0..=1.0`). Exact and anchored matches are unaffected. Available on CLI (`--min-fuzzy-score`), plan/MCP (`min_fuzzy_score`), and `ReplaceOptions` (#1687).
 - **Use when:** Agent hosts want fuzzy recovery for small typos but must refuse weak similarity hits (typical floor: `0.80`).
+- **Does not mean:** `score >= min_fuzzy_score` proves the matched span is the intended target. Always inspect `matched_text` (#1736).
 - **Prefer instead:** Exact replace when the target string is known; bare `--fuzzy` when any fuzzy hit is acceptable.
 
 <!-- ref:create-mode:stdin -->

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -105,6 +105,8 @@ pub fn ast_rewrite_signature_in_content(
         match_count: if changed { 1 } else { 0 },
         match_mode: None,
         match_score: None,
+
+        matched_text: None,
     })
 }
 

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -68,6 +68,8 @@ pub struct ContentEditsResult {
     pub match_mode: Option<MatchMode>,
     /// Similarity score from the first fuzzy replace op in the batch, if any.
     pub match_score: Option<f64>,
+    /// Matched span from the first fuzzy/anchored replace in the batch (#1736).
+    pub matched_text: Option<String>,
 }
 
 /// Apply ordered edits to an in-memory buffer.
@@ -101,17 +103,21 @@ pub fn apply_content_edits_with_label(
     let mut match_count = 0usize;
     let mut match_mode: Option<MatchMode> = None;
     let mut match_score: Option<f64> = None;
+    let mut matched_text: Option<String> = None;
 
     for (i, edit) in edits.iter().enumerate() {
-        let (next, n, mode, score) = apply_one(&current, edit)
+        let one = apply_one(&current, edit)
             .with_context(|| format!("content edit {} of {} failed", i + 1, edits.len()))?;
-        current = next;
-        match_count = match_count.saturating_add(n);
+        current = one.content;
+        match_count = match_count.saturating_add(one.match_count);
         ops_applied += 1;
-        if let Some(m) = mode {
+        if let Some(m) = one.match_mode {
             match_mode = Some(super::merge_match_modes(match_mode, m));
             if m == MatchMode::Fuzzy && match_score.is_none() {
-                match_score = score;
+                match_score = one.match_score;
+            }
+            if matched_text.is_none() {
+                matched_text = one.matched_text;
             }
         }
     }
@@ -128,6 +134,7 @@ pub fn apply_content_edits_with_label(
         match_count,
         match_mode,
         match_score,
+        matched_text,
     })
 }
 
@@ -169,6 +176,7 @@ pub fn apply_content_edits_to_file(
     result.match_count = batch.match_count;
     result.match_mode = batch.match_mode;
     result.match_score = batch.match_score;
+    result.matched_text = batch.matched_text;
     // Honor post_write from the last Replace edit that set hooks (#1690).
     let (hooks, hooks_cwd) = post_write_from_edits(edits);
     maybe_post_write(applied, path, hooks, hooks_cwd, backup_session.as_deref())?;
@@ -193,20 +201,27 @@ fn post_write_from_edits(
     (hooks, cwd)
 }
 
-/// Returns (new content, replace match_count, match_mode, match_score).
-fn apply_one(
-    content: &str,
-    edit: &ContentEdit,
-) -> anyhow::Result<(String, usize, Option<MatchMode>, Option<f64>)> {
+/// Intermediate apply_one result (keeps the match-honesty fields together).
+struct OneEdit {
+    content: String,
+    match_count: usize,
+    match_mode: Option<MatchMode>,
+    match_score: Option<f64>,
+    matched_text: Option<String>,
+}
+
+/// Apply a single content edit; returns the new buffer plus replace honesty.
+fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<OneEdit> {
     match edit {
         ContentEdit::Replace { old, new, options } => {
             let result: ContentEditResult = replace_in_content(content, old, new, options)?;
-            Ok((
-                result.new_content,
-                result.match_count,
-                result.match_mode,
-                result.match_score,
-            ))
+            Ok(OneEdit {
+                content: result.new_content,
+                match_count: result.match_count,
+                match_mode: result.match_mode,
+                match_score: result.match_score,
+                matched_text: result.matched_text,
+            })
         }
         ContentEdit::InsertBefore {
             anchor,
@@ -226,7 +241,13 @@ fn apply_one(
                     out.push_str(&content[..idx]);
                     out.push_str(insert);
                     out.push_str(&content[idx..]);
-                    Ok((out, 0, None, None))
+                    Ok(OneEdit {
+                        content: out,
+                        match_count: 0,
+                        match_mode: None,
+                        match_score: None,
+                        matched_text: None,
+                    })
                 }
                 None => Err(EditError::new(
                     EditErrorKind::NoMatch,
@@ -252,7 +273,13 @@ fn apply_one(
                     out.push_str(&content[..end]);
                     out.push_str(insert);
                     out.push_str(&content[end..]);
-                    Ok((out, 0, None, None))
+                    Ok(OneEdit {
+                        content: out,
+                        match_count: 0,
+                        match_mode: None,
+                        match_score: None,
+                        matched_text: None,
+                    })
                 }
                 None => Err(EditError::new(
                     EditErrorKind::NoMatch,
@@ -261,12 +288,20 @@ fn apply_one(
                 .into()),
             }
         }
-        ContentEdit::Append { content: inject } => {
-            Ok((append_content(content, inject), 0, None, None))
-        }
-        ContentEdit::Prepend { content: inject } => {
-            Ok((prepend_content(content, inject), 0, None, None))
-        }
+        ContentEdit::Append { content: inject } => Ok(OneEdit {
+            content: append_content(content, inject),
+            match_count: 0,
+            match_mode: None,
+            match_score: None,
+            matched_text: None,
+        }),
+        ContentEdit::Prepend { content: inject } => Ok(OneEdit {
+            content: prepend_content(content, inject),
+            match_count: 0,
+            match_mode: None,
+            match_score: None,
+            matched_text: None,
+        }),
     }
 }
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -186,6 +186,12 @@ pub struct EditResult {
     pub match_mode: Option<MatchMode>,
     /// Similarity score when [`MatchMode::Fuzzy`] was used; otherwise `None`.
     pub match_score: Option<f64>,
+    /// Text actually matched for fuzzy/anchored replace (may differ from `old`).
+    ///
+    /// Agents must not treat `match_mode == Fuzzy` + high `match_score` alone as
+    /// "correct target": compare this field to the requested pattern and prefer
+    /// `ast_rename` for identifier renames (#1736).
+    pub matched_text: Option<String>,
     /// Backup session timestamp created for this Apply (if any).
     ///
     /// Set when a write produced a backup session (see `BackupSession::finalize`).
@@ -219,6 +225,9 @@ pub struct ContentEditResult {
     pub match_mode: Option<MatchMode>,
     /// Similarity score when fuzzy matching was used.
     pub match_score: Option<f64>,
+    /// Text actually matched for fuzzy/anchored replace (may differ from `from`).
+    /// See #1736: hosts should verify this against the requested pattern.
+    pub matched_text: Option<String>,
 }
 
 /// Controls whether an operation writes to disk.
@@ -537,6 +546,7 @@ pub(crate) fn build_edit_result(
         removed: 0,
         match_mode: None,
         match_score: None,
+        matched_text: None,
         backup_session: None,
     }
 }
@@ -639,7 +649,7 @@ fn execution_result_to_edit_result(
         .exec_result
         .changes
         .first()
-        .and_then(|(abs_path, _, _)| result.exec_result.replace_match_meta.get(abs_path).copied());
+        .and_then(|(abs_path, _, _)| result.exec_result.replace_match_meta.get(abs_path).cloned());
     let (path_str, original, new_content) =
         if let Some((abs_path, orig, new)) = result.exec_result.changes.first() {
             let rel = crate::files::relative_display(abs_path, cwd);
@@ -674,11 +684,12 @@ fn execution_result_to_edit_result(
     let mut edit = build_edit_result(&path_str, original, new_content, applied, action, dest_path);
     edit.removed = removed;
     edit.backup_session = backup_session;
-    // Thread replace honesty from the engine (#1674 / #1662).
+    // Thread replace honesty from the engine (#1674 / #1662 / #1736).
     if let Some(meta) = replace_meta {
         edit.match_mode = Some(meta.mode);
         edit.match_score = meta.score;
         edit.match_count = meta.match_count;
+        edit.matched_text = meta.matched_text;
     } else if has_changes && action == "replace" {
         // Legacy fallback if meta was not recorded (should be rare).
         edit.match_mode = Some(MatchMode::Exact);

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -77,6 +77,7 @@ pub fn replace_text(
         result.match_count = content_result.match_count;
         result.match_mode = content_result.match_mode;
         result.match_score = content_result.match_score;
+        result.matched_text = content_result.matched_text;
         result.backup_session = backup_session.clone();
         super::maybe_post_write(
             applied,
@@ -350,6 +351,7 @@ fn replace_write(
                     result.match_count = 1;
                     result.match_mode = Some(match_mode);
                     result.match_score = score;
+                    result.matched_text = Some(anchor.matched_text.clone());
                     result.backup_session = backup_session;
                     return Ok(result);
                 }
@@ -542,6 +544,8 @@ pub fn replace_in_content(
             match_count: 1,
             match_mode: Some(MatchMode::Anchored),
             match_score: None,
+
+            matched_text: None,
         });
     }
 
@@ -604,6 +608,7 @@ pub fn replace_in_content(
                     match_count: 1,
                     match_mode: Some(mode),
                     match_score: score,
+                    matched_text: Some(anchor.matched_text.clone()),
                 });
             }
             Err(edit_error) => {
@@ -616,6 +621,8 @@ pub fn replace_in_content(
                         match_count: 0,
                         match_mode: None,
                         match_score: None,
+
+                        matched_text: None,
                     });
                 }
                 let similar = fallback::find_similar_targets(content, from, 3);
@@ -668,6 +675,8 @@ fn finalize_content_replace(
             match_count: 0,
             match_mode: None,
             match_score: None,
+
+            matched_text: None,
         });
     }
 
@@ -703,5 +712,7 @@ fn finalize_content_replace(
             None
         },
         match_score: None,
+
+        matched_text: None,
     })
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -5632,3 +5632,44 @@ fn tidy_post_write_hooks_on_apply() {
     assert!(r.changed);
     assert_eq!(fs::read_to_string(&file).unwrap(), "line\n");
 }
+
+/// #1736: fuzzy near-collision must expose matched_text so hosts can refuse.
+#[test]
+fn replace_in_content_fuzzy_near_collision_reports_matched_text() {
+    let content = concat!(
+        "def compute_checksum(payload: bytes) -> str:\n",
+        "    return payload.hex()\n",
+        "\n",
+        "def compute_checksum_fast(payload: bytes) -> str:\n",
+        "    return payload[:8].hex()\n",
+    );
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        min_fuzzy_score: Some(0.95),
+        ..ReplaceOptions::default()
+    };
+    let r = replace_in_content(content, "compute_cheksum", "compute_digest", &opts)
+        .expect("fuzzy should land on a near identifier");
+    assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
+    assert!(
+        r.match_score.is_some_and(|s| s >= 0.95),
+        "{:?}",
+        r.match_score
+    );
+    let matched = r
+        .matched_text
+        .as_deref()
+        .expect("matched_text required for fuzzy");
+    assert_ne!(
+        matched, "compute_cheksum",
+        "requested old is absent; matched_text must be the live span"
+    );
+    assert!(
+        matched.contains("compute_checksum"),
+        "expected live identifier in matched_text, got {matched:?}"
+    );
+    assert!(
+        r.new_content.contains("compute_digest"),
+        "replacement should apply to the matched span"
+    );
+}

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -126,6 +126,16 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - `min_fuzzy_score`: reject fuzzy matches below this floor (0.0..=1.0); exact/anchored unaffected (#1687).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
              \"command_position\":true,\"require_change\":true}`\n\n\
+             **Fuzzy success is not semantic success (#1736):**\n\
+             - `min_fuzzy_score` only rejects *weak* similarity. Scores above the floor can still \
+rewrite a *different* live identifier than the `old` string you requested.\n\
+             - After any fuzzy apply, read JSON `matched_text` (and re-read the file if needed). \
+If `matched_text` is not the intended typo (for example `old=compute_cheksum` fuzzy-hits \
+`compute_checksum` at score ~0.99), **undo** and use `ast_rename` / exact replace instead.\n\
+             - Prefer `ast_rename` / `ast_rename_project` for code identifiers. Fuzzy is a last \
+resort for typos in non-AST text (prose, comments), not a general rename tool.\n\
+             - Do not treat `ok` + `match_score >= min_fuzzy_score` alone as \"correct target.\" \
+Distinct from closed whole-line bug #1694.\n\n\
              **Library embedder undo / post-write (Rust hosts, not CLI-only):**\n\
              - After `ApplyMode::Apply`, `EditResult.backup_session` is the session id for that write (#1686).\n\
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
@@ -134,8 +144,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              - CLI: `patchloom undo --list` walks nested `.patchloom/backups` under the cwd (#1695). Bare CLI undo is dry-run (exit 2); restore needs the write apply flag (see CLI agent-rules).\n\
              - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
              - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)\n\
-             - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts (#1687, #1694)\n\
-             **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, and replace `match_count` (plan/tx also on each change + sum) so agents can verify low-confidence fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674).\n\n",
+             - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts; always check `matched_text` (#1687, #1694, #1736)\n\
+             **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, optional `matched_text` (actual span for fuzzy/anchored; may differ from `old`), and replace `match_count` (plan/tx also on each change + sum) so agents can verify fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674, #1736).\n\n",
         );
     }
     if show_cli {
@@ -333,7 +343,10 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              # Fallback: text-based workflow when AST mode is unavailable\n\
              patchloom search --count \"old_function_name\" src/\n\
              patchloom replace \"old_function_name\" --new \"new_function_name\" src/ --apply\n\
-             ```\n\n",
+             ```\n\n\
+             Bad: `replace --fuzzy` with a misspelled `old` that is **not** in the file \
+             (e.g. `compute_cheksum` → may rewrite live `compute_checksum` even with \
+             `--min-fuzzy-score 0.95`). After fuzzy JSON, check `matched_text` (#1736).\n\n",
         );
 
         out.push_str(
@@ -421,7 +434,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
                  - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\
-                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`) and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674).\n\n");
+                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`), optional `matched_text` for fuzzy/anchored spans, and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674, #1736).\n\n");
         }
     }
 
@@ -801,8 +814,20 @@ mod tests {
                 && mcp.contains("fuzzy")
                 && mcp.contains("restore_path_from_session")
                 && mcp.contains("run_post_write_validation")
-                && mcp.contains("match_mode"),
-            "MCP-only agent-rules must document replace_text flags, library undo helpers, and match_mode"
+                && mcp.contains("match_mode")
+                && mcp.contains("matched_text")
+                && mcp.contains("Fuzzy success is not semantic success")
+                && mcp.contains("compute_cheksum"),
+            "MCP-only agent-rules must document replace_text flags, matched_text, and fuzzy semantic check (#1736)"
+        );
+    }
+
+    #[test]
+    fn workflow_documents_fuzzy_near_collision_negative_example() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(
+            out.contains("compute_cheksum") && out.contains("matched_text"),
+            "CLI rename workflow must warn about fuzzy near-identifier collisions (#1736)"
         );
     }
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -125,6 +125,9 @@ struct ReplaceFileResult {
     /// Similarity score when match_mode is fuzzy.
     #[serde(skip_serializing_if = "Option::is_none")]
     match_score: Option<f64>,
+    /// Text actually matched for fuzzy/anchored (may differ from `--old`). #1736
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matched_text: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -147,6 +150,9 @@ struct ReplaceOutput {
     match_mode: Option<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     match_score: Option<f64>,
+    /// First-file fuzzy/anchored matched span when `file_count == 1` (#1736).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matched_text: Option<String>,
     /// Did-you-mean candidates on soft no-match (literal patterns only).
     /// Agents should prefer this over scraping the English error string.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -163,6 +169,7 @@ struct FileReplacement {
     match_count: usize,
     match_mode: Option<&'static str>,
     match_score: Option<f64>,
+    matched_text: Option<String>,
 }
 
 fn match_mode_str(mode: crate::api::MatchMode) -> &'static str {
@@ -297,6 +304,7 @@ fn collect_replacements(
                     match_count: count,
                     match_mode: Some("exact"),
                     match_score: None,
+                    matched_text: None,
                 })
             } else {
                 None
@@ -317,6 +325,7 @@ fn make_file_results(replacements: &[FileReplacement]) -> Vec<ReplaceFileResult>
             match_count: r.match_count,
             match_mode: r.match_mode,
             match_score: r.match_score,
+            matched_text: r.matched_text.clone(),
         })
         .collect()
 }
@@ -426,12 +435,14 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         match_count: r.match_count,
                         match_mode: r.match_mode,
                         match_score: r.match_score,
+                        matched_text: r.matched_text.clone(),
                     }],
                     diff: None,
                     identity: None,
                     error_kind: Some("ambiguous"),
                     match_mode: None,
                     match_score: None,
+                    matched_text: None,
                     similar_targets: None,
                 };
                 global.emit_json(&output)?;
@@ -467,6 +478,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 error_kind: None,
                 match_mode: Some("exact"),
                 match_score: None,
+                matched_text: None,
                 similar_targets: None,
             };
             global.emit_json(&output)?;
@@ -489,6 +501,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 error_kind: None,
                 match_mode: None,
                 match_score: None,
+                matched_text: None,
                 similar_targets: None,
             };
             global.emit_json(&output)?;
@@ -513,6 +526,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             error_kind: Some("no_matches"),
             match_mode: None,
             match_score: None,
+            matched_text: None,
             similar_targets: similar.clone(),
         };
         global.emit_json(&output)?;
@@ -582,6 +596,11 @@ fn replace_output(
         error_kind: None,
         match_mode: agg_mode,
         match_score: agg_score,
+        matched_text: if files.len() == 1 {
+            files[0].matched_text.clone()
+        } else {
+            None
+        },
         similar_targets: None,
     };
 
@@ -686,6 +705,7 @@ fn run_context_replace(
             },
             match_mode: None,
             match_score: None,
+            matched_text: None,
             similar_targets: None,
         };
         global.emit_json(&empty)?;
@@ -753,6 +773,7 @@ fn run_context_replace(
             },
             match_mode: None,
             match_score: None,
+            matched_text: None,
             similar_targets: None,
         };
         global.emit_json(&empty)?;
@@ -795,20 +816,26 @@ fn run_context_replace(
         .changes
         .iter()
         .map(|(p, original, _new)| {
-            let (mode, score, count) = if let Some(m) = result.exec_result.replace_match_meta.get(p)
-            {
-                (Some(match_mode_str(m.mode)), m.score, m.match_count.max(1))
-            } else {
-                match crate::api::replace_in_content(original, &args.old, to, &lib_opts) {
-                    Ok(r) => (
-                        r.match_mode.map(match_mode_str),
-                        r.match_score,
-                        r.match_count.max(1),
-                    ),
-                    // Do not invent "exact" when re-derive fails (#1674 honesty).
-                    Err(_) => (None, None, 1),
-                }
-            };
+            let (mode, score, count, matched_text) =
+                if let Some(m) = result.exec_result.replace_match_meta.get(p) {
+                    (
+                        Some(match_mode_str(m.mode)),
+                        m.score,
+                        m.match_count.max(1),
+                        m.matched_text.clone(),
+                    )
+                } else {
+                    match crate::api::replace_in_content(original, &args.old, to, &lib_opts) {
+                        Ok(r) => (
+                            r.match_mode.map(match_mode_str),
+                            r.match_score,
+                            r.match_count.max(1),
+                            r.matched_text,
+                        ),
+                        // Do not invent "exact" when re-derive fails (#1674 honesty).
+                        Err(_) => (None, None, 1, None),
+                    }
+                };
             ReplaceFileResult {
                 path: crate::files::relative_display(p, &cwd)
                     .to_string_lossy()
@@ -816,6 +843,7 @@ fn run_context_replace(
                 match_count: count,
                 match_mode: mode,
                 match_score: score,
+                matched_text,
             }
         })
         .collect();

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -1523,12 +1523,14 @@ fn multi_file_match_mode_worst_case_rollup() {
             match_count: 1,
             match_mode: Some("exact"),
             match_score: None,
+            matched_text: None,
         },
         ReplaceFileResult {
             path: "b.txt".into(),
             match_count: 1,
             match_mode: Some("fuzzy"),
             match_score: Some(0.9),
+            matched_text: None,
         },
     ];
     let (mode, score) = aggregate_match_meta(&files);
@@ -1541,12 +1543,14 @@ fn multi_file_match_mode_worst_case_rollup() {
             match_count: 1,
             match_mode: Some("exact"),
             match_score: None,
+            matched_text: None,
         },
         ReplaceFileResult {
             path: "b.txt".into(),
             match_count: 1,
             match_mode: Some("anchored"),
             match_score: None,
+            matched_text: None,
         },
     ];
     let (mode, score) = aggregate_match_meta(&mixed_anchored);

--- a/src/json_emit.rs
+++ b/src/json_emit.rs
@@ -237,6 +237,7 @@ mod tests {
             match_mode: None,
             match_score: None,
             match_count: None,
+            matched_text: None,
         };
         let emit = serialize_structured(&report, true);
         assert!(!emit.primary_ok);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -183,7 +183,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     // --- Weak tier ---
     OpMeta {
         name: "replace",
-        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches), command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip), and fuzzy (similarity fallback when exact match fails).",
+        description: "Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches), command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip), and fuzzy (similarity fallback when exact match fails). Fuzzy + min_fuzzy_score only reject weak scores; high scores can still rewrite a different live identifier than old—check matched_text and prefer ast.rename for identifiers (#1736).",
         tier: Tier::Weak,
         examples: &[
             (

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -52,6 +52,10 @@ pub struct TxOutput {
     /// Lets MCP/CLI agents read honesty without a second content pass.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub match_count: Option<usize>,
+    /// First fuzzy/anchored matched span when a single change path is present.
+    /// Compare to requested `old` after fuzzy apply (#1736).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub matched_text: Option<String>,
 }
 
 /// One doc delete / delete-where outcome inside a plan/tx report (#1439).
@@ -80,6 +84,9 @@ pub struct TxChange {
     /// non-replace changes. Prefer this over re-deriving after Apply.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub match_count: Option<usize>,
+    /// Text actually matched for fuzzy/anchored replace on this path (#1736).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub matched_text: Option<String>,
 }
 
 /// A search match in the tx output.
@@ -143,11 +150,13 @@ pub(crate) struct TxExecResult {
 }
 
 /// Per-path replace match honesty recorded during plan execution.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) struct ReplaceMatchMeta {
     pub mode: crate::api::MatchMode,
     pub score: Option<f64>,
     pub match_count: usize,
+    /// Fuzzy/anchored span text actually matched (may differ from plan `old`). #1736
+    pub matched_text: Option<String>,
 }
 
 /// Apply mutation summaries onto a [`TxOutput`] (aggregates + list).
@@ -180,14 +189,15 @@ pub(crate) use crate::api::merge_match_modes;
 fn match_meta_for_path(
     path: &Path,
     meta: &HashMap<PathBuf, ReplaceMatchMeta>,
-) -> (Option<String>, Option<f64>, Option<usize>) {
+) -> (Option<String>, Option<f64>, Option<usize>, Option<String>) {
     match meta.get(path) {
         Some(m) => (
             Some(match_mode_label(m.mode).to_string()),
             m.score,
             Some(m.match_count),
+            m.matched_text.clone(),
         ),
-        None => (None, None, None),
+        None => (None, None, None, None),
     }
 }
 
@@ -208,6 +218,7 @@ pub(crate) fn build_tx_output_with_meta(
     let mut agg_score: Option<f64> = None;
     let mut agg_count: usize = 0;
     let mut any_replace_meta = false;
+    let mut top_matched_text: Option<String> = None;
 
     let display_path = |p: &Path| -> String {
         crate::files::relative_display(p, cwd)
@@ -217,7 +228,8 @@ pub(crate) fn build_tx_output_with_meta(
 
     for (path, _original, _) in changes {
         let path_str = display_path(path);
-        let (match_mode, match_score, match_count) = match_meta_for_path(path, replace_match_meta);
+        let (match_mode, match_score, match_count, matched_text) =
+            match_meta_for_path(path, replace_match_meta);
         if let Some(m) = replace_match_meta.get(path) {
             any_replace_meta = true;
             agg_mode = Some(merge_match_modes(agg_mode, m.mode));
@@ -225,6 +237,9 @@ pub(crate) fn build_tx_output_with_meta(
                 agg_score = m.score.or(agg_score);
             }
             agg_count = agg_count.saturating_add(m.match_count);
+            if top_matched_text.is_none() {
+                top_matched_text = m.matched_text.clone();
+            }
         }
         if deletions.contains(path) {
             tx_changes.push(TxChange {
@@ -233,6 +248,7 @@ pub(crate) fn build_tx_output_with_meta(
                 match_mode,
                 match_score,
                 match_count,
+                matched_text,
             });
             deleted_count += 1;
         } else if !existed_before.contains(path) {
@@ -242,6 +258,7 @@ pub(crate) fn build_tx_output_with_meta(
                 match_mode,
                 match_score,
                 match_count,
+                matched_text,
             });
             created += 1;
         } else {
@@ -251,6 +268,7 @@ pub(crate) fn build_tx_output_with_meta(
                 match_mode,
                 match_score,
                 match_count,
+                matched_text,
             });
             modified += 1;
         }
@@ -258,7 +276,7 @@ pub(crate) fn build_tx_output_with_meta(
     // Deletions not captured in changes (empty files).
     for path in deletions {
         if !changes.iter().any(|(c, _, _)| c == path) {
-            let (match_mode, match_score, match_count) =
+            let (match_mode, match_score, match_count, matched_text) =
                 match_meta_for_path(path, replace_match_meta);
             if replace_match_meta.contains_key(path) {
                 any_replace_meta = true;
@@ -269,6 +287,7 @@ pub(crate) fn build_tx_output_with_meta(
                 match_mode,
                 match_score,
                 match_count,
+                matched_text,
             });
             deleted_count += 1;
         }
@@ -306,6 +325,13 @@ pub(crate) fn build_tx_output_with_meta(
         match_score: top_score,
         match_count: if any_replace_meta {
             Some(agg_count)
+        } else {
+            None
+        },
+        // Surface only when a single replace path is present so multi-file
+        // rollups do not pick an arbitrary sibling span.
+        matched_text: if changes.len() == 1 {
+            top_matched_text
         } else {
             None
         },
@@ -384,6 +410,7 @@ pub(crate) fn build_error_output(
         match_mode: None,
         match_score: None,
         match_count: None,
+        matched_text: None,
     }
 }
 
@@ -522,6 +549,7 @@ mod tests {
             match_mode: None,
             match_score: None,
             match_count: None,
+            matched_text: None,
         }
     }
 
@@ -545,6 +573,7 @@ mod tests {
             match_mode: None,
             match_score: None,
             match_count: None,
+            matched_text: None,
         }
     }
 
@@ -720,6 +749,7 @@ mod tests {
                 mode: crate::api::MatchMode::Fuzzy,
                 score: Some(0.91),
                 match_count: 1,
+                matched_text: Some("proccess".into()),
             },
         );
         let out = build_tx_output_with_meta(
@@ -738,9 +768,12 @@ mod tests {
         assert_eq!(out.changes[0].match_mode.as_deref(), Some("fuzzy"));
         assert_eq!(out.changes[0].match_score, Some(0.91));
         assert_eq!(out.changes[0].match_count, Some(1));
+        assert_eq!(out.matched_text.as_deref(), Some("proccess"));
+        assert_eq!(out.changes[0].matched_text.as_deref(), Some("proccess"));
         let json = serde_json::to_string(&out).unwrap();
         assert!(json.contains("\"match_mode\":\"fuzzy\""), "{json}");
         assert!(json.contains("\"match_count\":1"), "{json}");
+        assert!(json.contains("\"matched_text\":\"proccess\""), "{json}");
     }
 
     // ---- TxOutput serde round-trip ----

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -16,13 +16,14 @@ use ignore::WalkBuilder;
 use std::collections::HashSet;
 use std::path::Path;
 
-/// Record replace match honesty for a path (worst-case merge if re-visited) (#1674).
+/// Record replace match honesty for a path (worst-case merge if re-visited) (#1674 / #1736).
 fn record_replace_match(
     tx: &mut TxState<'_>,
     path: &Path,
     mode: MatchMode,
     score: Option<f64>,
     match_count: usize,
+    matched_text: Option<String>,
 ) {
     use crate::tx::output::ReplaceMatchMeta;
     let entry = tx.replace_match_meta.entry(path.to_path_buf());
@@ -32,20 +33,24 @@ fn record_replace_match(
                 mode,
                 score,
                 match_count,
+                matched_text,
             });
         }
         std::collections::hash_map::Entry::Occupied(mut e) => {
-            let prev = *e.get();
+            let prev = e.get().clone();
             let merged = merge_match_modes(Some(prev.mode), mode);
             let merged_score = if matches!(merged, MatchMode::Fuzzy) {
                 score.or(prev.score)
             } else {
                 None
             };
+            // Prefer the first non-exact span so multi-op plans keep the fuzzy text.
+            let merged_text = prev.matched_text.or(matched_text);
             e.insert(ReplaceMatchMeta {
                 mode: merged,
                 score: merged_score,
                 match_count: prev.match_count.saturating_add(match_count),
+                matched_text: merged_text,
             });
         }
     }
@@ -224,7 +229,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     &file_path,
                     new_content,
                 );
-                record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1);
+                record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
                 return Ok(1);
             }
             let owned = replaced.into_owned();
@@ -235,7 +240,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 &file_path,
                 owned,
             );
-            record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count);
+            record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count, None);
             Ok(match_count)
         } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some()) {
             // Tier 3: fuzzy and/or context fallback when exact match fails (#1668).
@@ -283,7 +288,14 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         &file_path,
                         new_content,
                     );
-                    record_replace_match(tx, &file_path, mode, score, 1);
+                    record_replace_match(
+                        tx,
+                        &file_path,
+                        mode,
+                        score,
+                        1,
+                        Some(anchor.matched_text.clone()),
+                    );
                     tx.replace_hint = Some(format!(
                         "fallback matched via {:?} strategy in {}",
                         anchor.strategy, p,
@@ -446,7 +458,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         &file_path,
                         new_content,
                     );
-                    record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1);
+                    record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
                     total_matches += 1;
                     continue;
                 }
@@ -458,7 +470,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     &file_path,
                     replaced.into_owned(),
                 );
-                record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count);
+                record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count, None);
             } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some())
             {
                 // Fuzzy/context fallback for glob paths (parity with #1668 path arm).
@@ -499,7 +511,14 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             &file_path,
                             new_content,
                         );
-                        record_replace_match(tx, &file_path, mode, score, 1);
+                        record_replace_match(
+                            tx,
+                            &file_path,
+                            mode,
+                            score,
+                            1,
+                            Some(anchor.matched_text.clone()),
+                        );
                         total_matches += 1;
                     }
                     Err(_) => {

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2024,3 +2024,54 @@ fn test_replace_fuzzy_identifier_typo_json_match_mode() {
     let on_disk = fs::read_to_string(&file).unwrap();
     assert_eq!(on_disk, "fn handle_request(x: i32) {}\n");
 }
+
+/// #1736: CLI fuzzy JSON must report matched_text for agent verification.
+#[test]
+fn test_replace_fuzzy_json_reports_matched_text() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("app.py");
+    fs::write(
+        &file,
+        "def compute_checksum(payload: bytes) -> str:\n    return payload.hex()\n",
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "compute_cheksum",
+            "--new",
+            "compute_digest",
+            "--fuzzy",
+            "--min-fuzzy-score",
+            "0.95",
+            "--apply",
+        ])
+        .arg(&file)
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["match_mode"], "fuzzy");
+    let matched = v["matched_text"]
+        .as_str()
+        .expect("top-level matched_text for single-file fuzzy");
+    assert_ne!(matched, "compute_cheksum");
+    assert!(
+        matched.contains("compute_checksum"),
+        "matched_text should be live identifier: {matched}"
+    );
+    let file_matched = v["files"][0]["matched_text"]
+        .as_str()
+        .expect("per-file matched_text");
+    assert_eq!(file_matched, matched);
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(content.contains("compute_digest"), "file: {content}");
+}


### PR DESCRIPTION
## Summary

Closes #1736 (bline dogfood): agents treated `ok` + `match_score >= min_fuzzy_score` as proof the intended typo was fixed. High scores can still rewrite a *different* live identifier (`compute_cheksum` → `compute_checksum` at ~0.99).

### Product
- Emit **`matched_text`** (actual fuzzy/anchored span) on:
  - library `EditResult` / `ContentEditResult` / `ContentEditsResult`
  - plan/tx `TxChange` + top-level `TxOutput` (single-file only)
  - CLI `replace --json` (per-file + top-level when one file)
- MCP/`execute_plan` inherit tx JSON automatically.

### Docs
- agent-rules: **Fuzzy success is not semantic success** + verify `matched_text` + prefer `ast_rename`
- schema `replace` description + reference `--fuzzy` / `--min-fuzzy-score`
- CLI rename workflow negative example

### Tests
- Library near-collision unit test
- CLI JSON integration test
- agent-rules string locks
- tx output meta includes `matched_text`

### Non-goals
- Changing default floor or fuzzy algorithm
- Fail-closed flag that would break intentional typo recovery (`matched_text != old` is normal for fuzzy)

Closes #1736

## Test plan
- [x] `cargo test --lib replace_in_content_fuzzy_near_collision`
- [x] `cargo test --test integration test_replace_fuzzy_json_reports_matched_text`
- [x] `make check-fast`
- [x] `make check-patchloom-md`