### PR TITLE
test: harden hardlink path and matched_text contracts

### DIFF
--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -586,6 +586,14 @@ mod tests {
         assert!(r.changed);
         assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
         assert!(r.match_score.is_some_and(|s| s > 0.85));
+        let matched = r
+            .matched_text
+            .as_deref()
+            .expect("content_edits fuzzy must surface matched_text");
+        assert!(
+            matched.contains("process_data"),
+            "matched_text should be live span: {matched:?}"
+        );
     }
 
     #[test]
@@ -610,6 +618,12 @@ mod tests {
         assert!(r.changed);
         assert_eq!(r.match_mode, Some(MatchMode::Anchored));
         assert_eq!(r.match_count, 2);
+        // Exact first leaves matched_text None; first non-null is the anchored span.
+        assert_eq!(
+            r.matched_text.as_deref(),
+            Some("TODO: fix"),
+            "batch should report first anchored/fuzzy matched_text (#1736)"
+        );
         assert!(r.modified.starts_with("ALPHA\n"));
         assert!(r.modified.contains("gamma\nTODO: done"));
         // Context-anchored replace must not touch the first TODO: fix

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -544,8 +544,9 @@ pub fn replace_in_content(
             match_count: 1,
             match_mode: Some(MatchMode::Anchored),
             match_score: None,
-
-            matched_text: None,
+            // Exact span at the context-picked offset (equals `from`; hosts
+            // still get a non-null matched_text on Anchored like fuzzy #1736).
+            matched_text: Some(from.to_string()),
         });
     }
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4815,6 +4815,11 @@ fn match_mode_exact_fuzzy_and_anchored() {
     assert!(r.changed);
     assert_eq!(r.match_mode, Some(MatchMode::Anchored));
     assert_eq!(r.match_count, 1);
+    assert_eq!(
+        r.matched_text.as_deref(),
+        Some("TODO: fix"),
+        "anchored multi-match path must report matched_text (#1736 parity)"
+    );
     assert!(r.new_content.contains("beta\nTODO: done"));
     assert!(r.new_content.contains("alpha\nTODO: fix"));
 }
@@ -4860,6 +4865,16 @@ fn replace_text_pure_fuzzy_without_context() {
         "score: {:?}",
         result.match_score
     );
+    // #1736: library hosts on the disk path need matched_text, not only mode/score.
+    let matched = result
+        .matched_text
+        .as_deref()
+        .expect("disk pure fuzzy must report matched_text");
+    assert!(
+        matched.contains("process_data"),
+        "matched_text should be the live span, got {matched:?}"
+    );
+    assert_ne!(matched, "fn proccess_data() {}");
 }
 
 #[test]

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -305,7 +305,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with new=\"\" to delete lines). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"README.md\", \"old\": \"1.0.0\", \"new\": \"2.0.0\"}"
+        description = "Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary, fuzzy, min_fuzzy_score. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with new=\"\" to delete lines). Fuzzy + min_fuzzy_score only reject weak scores; high scores can still rewrite a different live identifier than old—check JSON matched_text and prefer ast_rename for identifiers (#1736). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"README.md\", \"old\": \"1.0.0\", \"new\": \"2.0.0\"}"
     )]
     async fn replace_text(
         &self,
@@ -503,7 +503,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. Optional fuzzy enables similarity fallback; JSON reports match_mode (exact/fuzzy/anchored), match_count per change and aggregate (#1674). IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
+        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. Optional fuzzy enables similarity fallback; JSON reports match_mode (exact/fuzzy/anchored), optional match_score, optional matched_text (actual fuzzy/anchored span; may differ from old—check before treating fuzzy as semantic success, #1736), match_count per change and aggregate (#1674). IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
     )]
     async fn batch_replace(
         &self,

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -125,9 +125,14 @@ mod basic {
         assert_eq!(
             descriptions.get("replace_text"),
             Some(
-                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with new=\"\" to delete lines). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"README.md\", \"old\": \"1.0.0\", \"new\": \"2.0.0\"}"
+                &"Replace text in a file. Literal by default; set regex=true for regex. Options: nth, insert_before, insert_after, case_insensitive, multiline, if_exists, whole_line, range, word_boundary, fuzzy, min_fuzzy_score. Set word_boundary=true to match only whole words (prevents 'SetupFile' matching inside 'BenchSetupFile'). Set whole_line=true to replace entire lines containing a match (use with new=\"\" to delete lines). Fuzzy + min_fuzzy_score only reject weak scores; high scores can still rewrite a different live identifier than old—check JSON matched_text and prefer ast_rename for identifiers (#1736). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity. Example: {\"path\": \"README.md\", \"old\": \"1.0.0\", \"new\": \"2.0.0\"}"
             ),
             "replace_text description drifted"
+        );
+        let batch_desc = descriptions.get("batch_replace").copied().unwrap_or("");
+        assert!(
+            batch_desc.contains("matched_text") && batch_desc.contains("match_mode"),
+            "batch_replace must document matched_text + match_mode: {batch_desc}"
         );
         assert!(
             names.contains(&"fix_whitespace"),

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -104,11 +104,15 @@ pub struct ReplaceArgs {
     // ref:replace-mode:fuzzy
     /// When exact match fails, try fuzzy/similarity fallback (and when
     /// `--before-context` / `--after-context` is set). Literal only.
+    /// With `--json`, check `matched_text`: a high score can still rewrite a
+    /// different live identifier than `--old` (#1736).
     #[arg(long)]
     pub fuzzy: bool,
     // ref:replace-mode:min-fuzzy-score
     /// Reject fuzzy matches below this score (0.0..=1.0). Exact and anchored
-    /// matches are unaffected. Plan/MCP field name: `min_fuzzy_score` (#1687).
+    /// matches are unaffected. Does not prove the matched span is the intended
+    /// target; inspect JSON `matched_text`. Plan/MCP field name: `min_fuzzy_score`
+    /// (#1687, #1736).
     #[arg(long, value_name = "SCORE")]
     pub min_fuzzy_score: Option<f64>,
     #[command(flatten)]

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -1019,6 +1019,35 @@ mod hardlink_handling {
         assert_eq!(fs::read_to_string(&b).unwrap(), "line\n");
         assert!(fs::metadata(&a).unwrap().nlink() > 1);
     }
+
+    #[test]
+    fn atomic_write_hardlink_readonly_errors_with_path() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "shared\n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+        fs::set_permissions(&a, fs::Permissions::from_mode(0o444)).unwrap();
+        // Root (common in Docker) can still write mode-444 files. Skip when
+        // permissions do not actually block writing. Probe without truncate so
+        // we never clobber content if the open succeeds.
+        if fs::OpenOptions::new().write(true).open(&a).is_ok() {
+            let _ = fs::set_permissions(&a, fs::Permissions::from_mode(0o644));
+            return;
+        }
+
+        let policy = WritePolicy::default();
+        let err = atomic_write(&a, "changed\n", &policy).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("hardlinked") && msg.contains("a.txt"),
+            "readonly hardlink error must name the path and hardlink path: {msg}"
+        );
+        // Sibling must still hold original content (failed open before truncate).
+        let _ = fs::set_permissions(&a, fs::Permissions::from_mode(0o644));
+        assert_eq!(fs::read_to_string(&b).unwrap(), "shared\n");
+    }
 }
 
 mod error_handling {

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -926,11 +926,14 @@ mod hardlink_handling {
     #[test]
     fn atomic_write_single_link_still_uses_rename_path() {
         // Single-link files should not take the hardlink-preserving branch.
-        // After rename, the path still has nlink == 1 and the new content.
+        // Rename (temp+persist) replaces the directory entry with a new inode;
+        // open+truncate would keep the same inode. nlink alone does not prove
+        // which branch ran (both leave nlink == 1).
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("solo.txt");
         fs::write(&path, "before\n").unwrap();
         assert_eq!(fs::metadata(&path).unwrap().nlink(), 1);
+        let before_ino = fs::metadata(&path).unwrap().ino();
 
         let policy = WritePolicy::default();
         atomic_write(&path, "after\n", &policy).unwrap();
@@ -940,6 +943,11 @@ mod hardlink_handling {
             fs::metadata(&path).unwrap().nlink(),
             1,
             "single-link file must remain nlink == 1"
+        );
+        assert_ne!(
+            fs::metadata(&path).unwrap().ino(),
+            before_ino,
+            "rename path must install a new inode (open+write would preserve ino)"
         );
     }
 


### PR DESCRIPTION
## Summary

MPI cycle on post-#1737 main, focused on hardlink (#1733/#1734) and fuzzy `matched_text` (#1736/#1737) surfaces.

- Prove single-link `atomic_write` uses rename via inode change (nlink alone cannot distinguish open+write).
- Assert `matched_text` on disk pure-fuzzy `replace_text`, content_edits fuzzy/anchored rollups, and anchored multi-match content path.
- Report `matched_text` on context-disambiguated Anchored content replaces (was always `None`).
- Unit test readonly multi-linked file open failure (path in error, sibling content intact).
- MCP `replace_text` / `batch_replace` tool descriptions and CLI `--fuzzy` / `--min-fuzzy-score` help mention `matched_text` for agent semantic checks.

## Test plan

- [x] `make check-fast`
- [x] Targeted unit tests: hardlink_handling, pure_fuzzy, content_edits match_mode, MCP tool list

Ref #1736
Ref #1733