### PR TITLE
fix: preserve hardlinks on plan/tx file.rename

### DIFF
--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -404,6 +404,41 @@ mod tests {
         assert_eq!(content, "moved content\n");
     }
 
+    /// Plan/tx `file.rename` must keep multi-hardlinked inodes (#1739).
+    #[cfg(unix)]
+    #[test]
+    fn execute_file_rename_preserves_hardlinks() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "shared\n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+        let before_ino = fs::metadata(&a).unwrap().ino();
+        assert_eq!(fs::metadata(&a).unwrap().nlink(), 2);
+
+        let global = GlobalFlags::test_default();
+        let op = Operation::FileRename {
+            from: "a.txt".to_string(),
+            to: "c.txt".to_string(),
+            force: false,
+        };
+        let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
+        result.commit().unwrap();
+
+        assert!(!a.exists());
+        let c = dir.path().join("c.txt");
+        assert_eq!(fs::read_to_string(&c).unwrap(), "shared\n");
+        assert_eq!(fs::read_to_string(&b).unwrap(), "shared\n");
+        assert_eq!(fs::metadata(&c).unwrap().ino(), before_ino);
+        assert_eq!(fs::metadata(&b).unwrap().ino(), before_ino);
+        assert!(
+            fs::metadata(&c).unwrap().nlink() > 1,
+            "nlink must stay > 1 after tx rename, got {}",
+            fs::metadata(&c).unwrap().nlink()
+        );
+    }
+
     #[test]
     fn execute_single_create_empty_file() {
         let dir = TempDir::new().unwrap();

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -68,6 +68,11 @@ pub(crate) fn restore_after_failed_commit(cwd: &Path, timestamp: &str) -> bool {
 /// Apply pending changes to disk: backup originals, write modified files,
 /// delete removed files, finalize backup session.
 ///
+/// Pure renames (`file.rename` staged as create-dest + delete-src with
+/// identical content) are applied with `fs::rename` so multi-hardlinked
+/// inodes stay shared (#1739). Other mutations keep the create/write +
+/// delete path.
+///
 /// If any write fails, restores all already-written files from the backup
 /// session before returning [`CommitError`].
 /// Finalize backup then write. Returns the backup session timestamp when a
@@ -106,9 +111,28 @@ pub(crate) fn commit_changes(
         .finalize()
         .map_err(|e| commit_error(format!("finalizing backup session: {e}")))?;
 
+    let rename_pairs = detect_pure_renames(changes, deletions, existed_before);
+    let renamed_from: HashSet<&Path> = rename_pairs.iter().map(|(f, _)| f.as_path()).collect();
+    let renamed_to: HashSet<&Path> = rename_pairs.iter().map(|(_, t)| t.as_path()).collect();
+
     let noop_policy = WritePolicy::default();
     let write_result = (|| -> anyhow::Result<()> {
+        // Apply pure renames first via fs::rename (preserves hardlinks #1739).
+        for (from, to) in &rename_pairs {
+            if let Some(parent) = to.parent()
+                && !parent.as_os_str().is_empty()
+                && !parent.exists()
+            {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("creating directory {}", parent.display()))?;
+            }
+            rename_or_copy(from, to)?;
+        }
+
         for (path, _, new_content) in changes {
+            if renamed_from.contains(path.as_path()) || renamed_to.contains(path.as_path()) {
+                continue;
+            }
             if deletions.contains(path) {
                 std::fs::remove_file(path)
                     .with_context(|| format!("deleting {}", path.display()))?;
@@ -128,6 +152,9 @@ pub(crate) fn commit_changes(
             }
         }
         for path in deletions {
+            if renamed_from.contains(path.as_path()) {
+                continue;
+            }
             if path.exists() {
                 std::fs::remove_file(path)
                     .with_context(|| format!("deleting {}", path.display()))?;
@@ -150,4 +177,140 @@ pub(crate) fn commit_changes(
     }
 
     Ok(backup_session)
+}
+
+/// Detect pure renames staged as create-dest + delete-src with identical
+/// content (how `file.rename` is represented in pending). Pairing is
+/// deterministic by path order so identical-content concurrent renames
+/// remain stable.
+fn detect_pure_renames(
+    changes: &[(PathBuf, String, String)],
+    deletions: &HashSet<PathBuf>,
+    existed_before: &HashSet<PathBuf>,
+) -> Vec<(PathBuf, PathBuf)> {
+    use std::collections::HashMap;
+
+    // Sources: deleted paths whose staged final content is empty (or which
+    // appear only as deletions) with a known original body.
+    let mut sources_by_content: HashMap<&str, Vec<&PathBuf>> = HashMap::new();
+    for (path, original, new_content) in changes {
+        if !deletions.contains(path) {
+            continue;
+        }
+        // Empty final content is the FileRename / delete staging shape.
+        if !new_content.is_empty() {
+            continue;
+        }
+        sources_by_content
+            .entry(original.as_str())
+            .or_default()
+            .push(path);
+    }
+    for paths in sources_by_content.values_mut() {
+        paths.sort();
+    }
+
+    let mut pairs = Vec::new();
+    let mut used_from: HashSet<&Path> = HashSet::new();
+
+    // Destinations: new paths (not existed_before) not themselves deleted.
+    let mut dests: Vec<(&PathBuf, &str)> = changes
+        .iter()
+        .filter(|(path, _, _)| !deletions.contains(path) && !existed_before.contains(path))
+        .map(|(path, _, new_content)| (path, new_content.as_str()))
+        .collect();
+    dests.sort_by(|a, b| a.0.cmp(b.0));
+
+    for (to, content) in dests {
+        let Some(sources) = sources_by_content.get_mut(content) else {
+            continue;
+        };
+        while let Some(from) = sources.pop() {
+            if used_from.contains(from.as_path()) {
+                continue;
+            }
+            // Avoid renaming a path onto itself.
+            if from == to {
+                continue;
+            }
+            used_from.insert(from.as_path());
+            pairs.push((from.clone(), to.clone()));
+            break;
+        }
+    }
+    pairs
+}
+
+/// Rename a file, falling back to copy+delete across devices.
+fn rename_or_copy(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    match std::fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if is_cross_device(&e) => {
+            std::fs::copy(src, dst).with_context(|| {
+                format!("cross-device copy {} -> {}", src.display(), dst.display())
+            })?;
+            std::fs::remove_file(src).with_context(|| {
+                format!("removing source after cross-device copy: {}", src.display())
+            })?;
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn is_cross_device(e: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        e.raw_os_error() == Some(libc::EXDEV)
+    }
+    #[cfg(windows)]
+    {
+        // ERROR_NOT_SAME_DEVICE
+        e.raw_os_error() == Some(17)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = e;
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn detect_pure_renames_pairs_create_and_delete() {
+        let from = PathBuf::from("/tmp/ws/a.txt");
+        let to = PathBuf::from("/tmp/ws/c.txt");
+        let changes = vec![
+            (to.clone(), String::new(), "shared\n".to_string()),
+            (from.clone(), "shared\n".to_string(), String::new()),
+        ];
+        let mut deletions = HashSet::new();
+        deletions.insert(from.clone());
+        let existed = HashSet::new();
+        let pairs = detect_pure_renames(&changes, &deletions, &existed);
+        assert_eq!(pairs, vec![(from, to)]);
+    }
+
+    #[test]
+    fn detect_pure_renames_skips_modified_dest() {
+        let from = PathBuf::from("/tmp/ws/a.txt");
+        let to = PathBuf::from("/tmp/ws/c.txt");
+        let changes = vec![
+            (to.clone(), "old\n".to_string(), "shared\n".to_string()),
+            (from.clone(), "shared\n".to_string(), String::new()),
+        ];
+        let mut deletions = HashSet::new();
+        deletions.insert(from);
+        let mut existed = HashSet::new();
+        existed.insert(to);
+        let pairs = detect_pure_renames(&changes, &deletions, &existed);
+        assert!(
+            pairs.is_empty(),
+            "force-overwrite dest is not a pure rename"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Plan/tx `file.rename` staged as create-destination + delete-source, which **split multi-hardlinked inodes**. CLI `rename --apply` already used `fs::rename` (#1740); this closes the engine path.

`commit_changes` now detects pure renames (new path + deleted path with the same original content) and applies them with `fs::rename` (cross-device: copy+delete). Force-overwrite and content-mutating paths are unchanged.

## Test plan

- [x] Unit: `detect_pure_renames_*`
- [x] Unit: `execute_file_rename_preserves_hardlinks` (Unix)
- [x] Dogfood: `tx` rename of hardlinked pair keeps shared inode + nlink=2
- [ ] CI green

Closes #1739