### PR TITLE
fix: preserve hardlinks for tx rename-then-edit plans

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -129,6 +129,7 @@ fn commit_and_finalize(
         &result.deletions,
         &result.existed_before,
         ctx.cwd,
+        &result.renames,
     ) {
         Ok(session) => session,
         Err(err) => {

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -1358,7 +1358,7 @@ mod integrity {
         let existed_before: HashSet<_> = [f1.clone()].into();
 
         let _guard = RestoreFailGuard::engage();
-        let err = crate::tx::commit_changes(&changes, &deletions, &existed_before, dir.path())
+        let err = crate::tx::commit_changes(&changes, &deletions, &existed_before, dir.path(), &[])
             .unwrap_err();
 
         assert!(!err.rollback_ok, "restore should be reported as failed");
@@ -1384,7 +1384,7 @@ mod integrity {
         let deletions = HashSet::new();
         let existed_before: HashSet<_> = [f1.clone()].into();
 
-        let err = crate::tx::commit_changes(&changes, &deletions, &existed_before, dir.path())
+        let err = crate::tx::commit_changes(&changes, &deletions, &existed_before, dir.path(), &[])
             .unwrap_err();
         assert!(err.rollback_ok, "rollback should succeed");
         assert!(

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -143,6 +143,7 @@ impl ExecutionResult {
             &self.exec_result.deletions,
             &self.exec_result.existed_before,
             &self.cwd,
+            &self.exec_result.renames,
         )
         .map_err(|e| anyhow::anyhow!("{}", e.message))
     }
@@ -231,6 +232,7 @@ pub fn execute_precomputed(
         replace_no_matches: false,
         replace_hint: None,
         replace_match_meta: HashMap::new(),
+        renames: Vec::new(),
     };
 
     Ok(ExecutionResult {
@@ -437,6 +439,41 @@ mod tests {
             "nlink must stay > 1 after tx rename, got {}",
             fs::metadata(&c).unwrap().nlink()
         );
+    }
+
+    /// Rename then replace in one plan must still share the hardlink inode.
+    #[cfg(unix)]
+    #[test]
+    fn execute_rename_then_replace_preserves_hardlinks() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "hello world\n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+        let before_ino = fs::metadata(&a).unwrap().ino();
+
+        let global = GlobalFlags::test_default();
+        let plan = crate::plan::parse_plan(
+            r#"{"ops":[
+              {"op":"file.rename","from":"a.txt","to":"c.txt"},
+              {"op":"replace","path":"c.txt","old":"hello","new":"hi"}
+            ]}"#,
+        )
+        .unwrap();
+        let result =
+            execute_operations(plan.operations, test_options(dir.path(), &global)).unwrap();
+        result.commit().unwrap();
+
+        let c = dir.path().join("c.txt");
+        assert_eq!(fs::read_to_string(&c).unwrap(), "hi world\n");
+        assert_eq!(
+            fs::read_to_string(&b).unwrap(),
+            "hi world\n",
+            "hardlink sibling must see the replace"
+        );
+        assert_eq!(fs::metadata(&c).unwrap().ino(), before_ino);
+        assert!(fs::metadata(&c).unwrap().nlink() > 1);
     }
 
     #[test]

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -230,6 +230,18 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 let _ = read_file_content(tx.pending, tx.existed_before, &dst_path)?;
             }
 
+            // Record pure on-disk renames so commit can use fs::rename and
+            // preserve hardlinks even when a later op edits the dest (#1739
+            // follow-up: rename-then-replace in one plan).
+            if !*force
+                && !case_only
+                && src_path.exists()
+                && src_path.is_file()
+                && !dst_path.exists()
+            {
+                tx.renames.push((src_path.clone(), dst_path.clone()));
+            }
+
             // Write content to destination.
             update_file_content(
                 tx.pending,

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -229,6 +229,8 @@ pub(crate) struct TxState<'a> {
     pub(crate) replace_hint: Option<String>,
     /// Per-path replace match honesty (#1674). Accumulated across ops.
     pub(crate) replace_match_meta: &'a mut HashMap<PathBuf, super::output::ReplaceMatchMeta>,
+    /// Explicit `file.rename` pairs `(from, to)` for hardlink-preserving commit.
+    pub(crate) renames: &'a mut Vec<(PathBuf, PathBuf)>,
     pub(crate) cwd: &'a Path,
     pub(crate) quiet: bool,
     pub(crate) structured: bool,
@@ -253,6 +255,7 @@ pub(crate) struct TxStateFixture {
     pub mutations: Vec<TxDocMutation>,
     pub write_targets: HashSet<PathBuf>,
     pub replace_match_meta: HashMap<PathBuf, crate::tx::output::ReplaceMatchMeta>,
+    pub renames: Vec<(PathBuf, PathBuf)>,
 }
 
 #[cfg(test)]
@@ -269,6 +272,7 @@ impl TxStateFixture {
             mutations: Vec::new(),
             write_targets: HashSet::new(),
             replace_match_meta: HashMap::new(),
+            renames: Vec::new(),
         }
     }
 
@@ -285,6 +289,7 @@ impl TxStateFixture {
             write_targets: &mut self.write_targets,
             replace_hint: None,
             replace_match_meta: &mut self.replace_match_meta,
+            renames: &mut self.renames,
             cwd,
             quiet: true,
             structured: false,
@@ -516,6 +521,7 @@ pub(crate) fn execute_and_collect(
     let mut doc_cache: HashMap<PathBuf, CachedDoc> = HashMap::new();
     let mut replace_hint: Option<String> = None;
     let mut replace_match_meta: HashMap<PathBuf, super::output::ReplaceMatchMeta> = HashMap::new();
+    let mut renames: Vec<(PathBuf, PathBuf)> = Vec::new();
 
     // Upfront PathGuard on declared paths (same contract as execute_plan_inner /
     // execute_plan_direct). CLI `tx` and `batch` call this function directly and
@@ -570,6 +576,7 @@ pub(crate) fn execute_and_collect(
             write_targets: &mut write_targets,
             replace_hint: None,
             replace_match_meta: &mut replace_match_meta,
+            renames: &mut renames,
             cwd,
             quiet,
             structured,
@@ -698,5 +705,6 @@ pub(crate) fn execute_and_collect(
         replace_no_matches,
         replace_hint,
         replace_match_meta,
+        renames,
     })
 }

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -82,6 +82,7 @@ pub(crate) fn commit_changes(
     deletions: &HashSet<PathBuf>,
     existed_before: &HashSet<PathBuf>,
     cwd: &Path,
+    renames: &[(PathBuf, PathBuf)],
 ) -> Result<Option<String>, CommitError> {
     let mut backup = crate::backup::BackupSession::new(cwd)
         .map_err(|e| commit_error(format!("starting backup session: {e}")))?;
@@ -111,13 +112,25 @@ pub(crate) fn commit_changes(
         .finalize()
         .map_err(|e| commit_error(format!("finalizing backup session: {e}")))?;
 
-    let rename_pairs = detect_pure_renames(changes, deletions, existed_before);
+    // Prefer explicit file.rename records (covers rename-then-edit). Fall back
+    // to content-based pure-rename detection for any remaining pairs.
+    let mut rename_pairs: Vec<(PathBuf, PathBuf)> = renames.to_vec();
+    let mut covered_from: HashSet<PathBuf> = renames.iter().map(|(f, _)| f.clone()).collect();
+    let mut covered_to: HashSet<PathBuf> = renames.iter().map(|(_, t)| t.clone()).collect();
+    for (from, to) in detect_pure_renames(changes, deletions, existed_before) {
+        if covered_from.contains(&from) || covered_to.contains(&to) {
+            continue;
+        }
+        covered_from.insert(from.clone());
+        covered_to.insert(to.clone());
+        rename_pairs.push((from, to));
+    }
     let renamed_from: HashSet<&Path> = rename_pairs.iter().map(|(f, _)| f.as_path()).collect();
     let renamed_to: HashSet<&Path> = rename_pairs.iter().map(|(_, t)| t.as_path()).collect();
 
     let noop_policy = WritePolicy::default();
     let write_result = (|| -> anyhow::Result<()> {
-        // Apply pure renames first via fs::rename (preserves hardlinks #1739).
+        // Apply renames first via fs::rename (preserves hardlinks #1739).
         for (from, to) in &rename_pairs {
             if let Some(parent) = to.parent()
                 && !parent.as_os_str().is_empty()
@@ -130,12 +143,17 @@ pub(crate) fn commit_changes(
         }
 
         for (path, _, new_content) in changes {
-            if renamed_from.contains(path.as_path()) || renamed_to.contains(path.as_path()) {
+            if renamed_from.contains(path.as_path()) {
+                // Source already moved by rename_or_copy.
                 continue;
             }
             if deletions.contains(path) {
                 std::fs::remove_file(path)
                     .with_context(|| format!("deleting {}", path.display()))?;
+            } else if renamed_to.contains(path.as_path()) {
+                // Dest exists after rename; rewrite final content in place so
+                // multi-hardlinked siblings stay in sync (nlink > 1 path).
+                atomic_write(path, new_content, &noop_policy)?;
             } else {
                 if let Some(parent) = path.parent()
                     && !parent.as_os_str().is_empty()

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -200,6 +200,7 @@ pub fn execute_plan_direct(
         &result.deletions,
         &result.existed_before,
         &effective_cwd,
+        &result.renames,
     ) {
         Ok(session) => session,
         Err(err) => {

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -147,6 +147,9 @@ pub(crate) struct TxExecResult {
     pub(crate) replace_hint: Option<String>,
     /// Per-path replace match honesty recorded during plan execution (#1674).
     pub(crate) replace_match_meta: HashMap<PathBuf, ReplaceMatchMeta>,
+    /// Explicit `file.rename` pairs `(from, to)` for hardlink-preserving
+    /// commit via `fs::rename` (including rename-then-edit in one plan).
+    pub(crate) renames: Vec<(PathBuf, PathBuf)>,
 }
 
 /// Per-path replace match honesty recorded during plan execution.


### PR DESCRIPTION
## Summary

A single plan that renames a hardlinked file and then replaces text on the new path was still **splitting hardlinks**: pure-rename detection only matched when dest content still equaled source content, so rename-then-edit fell back to create-dest + delete-src.

This records explicit `file.rename` pairs and commits them with `fs::rename` first, then applies further content edits via hardlink-preserving `atomic_write`.

## Test plan

- [x] `execute_file_rename_preserves_hardlinks`
- [x] `execute_rename_then_replace_preserves_hardlinks` (new)
- [x] `cargo test --lib --all-features tx::`
- [ ] CI green