### PR TITLE
fix: chain multi-hop file.rename in one plan

### DIFF
--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -476,6 +476,54 @@ mod tests {
         assert!(fs::metadata(&c).unwrap().nlink() > 1);
     }
 
+    /// Double rename then replace in one plan (a->c->d) must keep hardlinks.
+    #[cfg(unix)]
+    #[test]
+    fn execute_rename_chain_then_replace_preserves_hardlinks() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        fs::write(&a, "hello\n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+        let before_ino = fs::metadata(&a).unwrap().ino();
+
+        let global = GlobalFlags::test_default();
+        let plan = crate::plan::parse_plan(
+            r#"{"ops":[
+              {"op":"file.rename","from":"a.txt","to":"c.txt"},
+              {"op":"file.rename","from":"c.txt","to":"d.txt"},
+              {"op":"replace","path":"d.txt","old":"hello","new":"hi"}
+            ]}"#,
+        )
+        .unwrap();
+        let result =
+            execute_operations(plan.operations, test_options(dir.path(), &global)).unwrap();
+        assert_eq!(
+            result.exec_result.renames.len(),
+            2,
+            "both renames must be recorded for chaining, got {:?}",
+            result.exec_result.renames
+        );
+        result.commit().unwrap();
+
+        let d = dir.path().join("d.txt");
+        assert!(!dir.path().join("a.txt").exists());
+        assert!(!dir.path().join("c.txt").exists());
+        assert_eq!(fs::read_to_string(&d).unwrap(), "hi\n");
+        assert_eq!(
+            fs::read_to_string(&b).unwrap(),
+            "hi\n",
+            "hardlink sibling must see chained rename+replace"
+        );
+        assert_eq!(fs::metadata(&d).unwrap().ino(), before_ino);
+        assert!(
+            fs::metadata(&d).unwrap().nlink() > 1,
+            "nlink must stay > 1, got {}",
+            fs::metadata(&d).unwrap().nlink()
+        );
+    }
+
     #[test]
     fn execute_single_create_empty_file() {
         let dir = TempDir::new().unwrap();

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -230,16 +230,18 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 let _ = read_file_content(tx.pending, tx.existed_before, &dst_path)?;
             }
 
-            // Record pure on-disk renames so commit can use fs::rename and
-            // preserve hardlinks even when a later op edits the dest (#1739
-            // follow-up: rename-then-replace in one plan).
-            if !*force
-                && !case_only
-                && src_path.exists()
-                && src_path.is_file()
-                && !dst_path.exists()
-            {
-                tx.renames.push((src_path.clone(), dst_path.clone()));
+            // Record pure renames so commit can use fs::rename and preserve
+            // hardlinks even when a later op edits the dest (#1739 follow-up:
+            // rename-then-replace). Also chain renames where the source is only
+            // a prior rename dest in this plan (a->c then c->d; c is not on disk
+            // yet during staging). file.create-then-rename stays content-staged
+            // (source neither on disk nor a rename dest).
+            if !*force && !case_only && !dst_path.exists() {
+                let src_on_disk = src_path.exists() && src_path.is_file();
+                let src_is_rename_dest = tx.renames.iter().any(|(_, to)| to == &src_path);
+                if src_on_disk || src_is_rename_dest {
+                    tx.renames.push((src_path.clone(), dst_path.clone()));
+                }
             }
 
             // Write content to destination.


### PR DESCRIPTION
## Summary

A plan with two renames then a replace on a hardlinked file:

```json
{"ops":[
  {"op":"file.rename","from":"a.txt","to":"c.txt"},
  {"op":"file.rename","from":"c.txt","to":"d.txt"},
  {"op":"replace","path":"d.txt","old":"hello","new":"hi"}
]}
```

left the hardlink sibling on the old content. The second rename was not recorded because `c.txt` exists only as a staged rename dest (not on disk yet), so commit only `fs::rename`d `a->c` and content-created `d`.

Now renames chain when the source is already a prior rename destination. Applies hops in order, then hardlink-preserving writes.

## Test plan

- [x] `execute_rename_chain_then_replace_preserves_hardlinks`
- [x] prior rename/hardlink unit tests
- [ ] CI green