### PR TITLE
feat: mark edit/tx result types non_exhaustive for 0.15.0

### DIFF
--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -48,7 +48,11 @@ pub enum ContentEdit {
 }
 
 /// Result of applying a sequence of [`ContentEdit`]s to a buffer.
+///
+/// Marked `non_exhaustive` so new honesty fields can land in minor releases
+/// without breaking external struct literals.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ContentEditsResult {
     /// Original buffer before any edits.
     pub original: String,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -149,7 +149,11 @@ pub enum MatchMode {
 }
 
 /// The result of an editing operation.
+///
+/// Marked `non_exhaustive` so new honesty fields (for example `matched_text`)
+/// can land in minor releases without breaking external struct literals.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct EditResult {
     /// Path to the affected file (as provided by the caller).
     pub path: String,
@@ -204,7 +208,11 @@ pub struct EditResult {
 ///
 /// Returned by [`replace::replace_in_content`] for callers that work on
 /// in-memory buffers rather than files on disk.
+///
+/// Marked `non_exhaustive` so new honesty fields can land in minor releases
+/// without breaking external struct literals.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct ContentEditResult {
     /// The original content before the edit.
     pub original: String,

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -8,7 +8,12 @@ use std::path::{Path, PathBuf};
 /// Library users can deserialize the JSON string returned by `execute_plan`
 /// into this type for typed access instead of string parsing.
 /// See #805 and the embedding docs.
+///
+/// Marked `non_exhaustive` so new honesty fields can land in minor releases
+/// without breaking external struct literals. Serde deserialization is
+/// unaffected (`#[serde(default)]` on optional fields).
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct TxOutput {
     pub ok: bool,
     pub status: String,
@@ -69,7 +74,11 @@ pub struct TxDocMutation {
 }
 
 /// A single file change in a plan/tx report.
+///
+/// Marked `non_exhaustive` so new honesty fields can land in minor releases
+/// without breaking external struct literals.
 #[derive(Serialize, Deserialize, Debug, Clone)]
+#[non_exhaustive]
 pub struct TxChange {
     pub path: String,
     pub action: String,


### PR DESCRIPTION
## Summary

Unblock release-please by fixing the cargo-semver-checks failure on #1735.

- #1735 proposed **0.14.1** (patch)
- cargo-semver-checks reports **constructible_struct_adds_field** for public `matched_text` on `EditResult`, `ContentEditResult`, `ContentEditsResult`, `TxOutput`, and `TxChange` (#1736)
- That is a major-level API change under cargo-semver-checks; with `bump-minor-pre-major`, the correct next version is **0.15.0**

This PR marks those host-facing result types `#[non_exhaustive]` so future honesty fields can land without another constructible-field break. Same-crate construction is unchanged; Serde deserialize is unaffected.

## After merge

release-please should resync #1735 to **0.15.0**. Local check:

```
Cargo.toml version 0.15.0 → cargo semver-checks check-release --all-features
# Summary: no semver update required
```

## Test plan

- [x] `make check-fast` (fmt, clippy, unit, feature matrix, integration, pty)
- [x] `cargo semver-checks check-release` with simulated 0.15.0 vs 0.14.0 baseline (pass)
- [x] `matched_text` and `tx::output` unit tests pass

Ref #1735