### PR TITLE
fix: force rename hardlinks and TxOutput serde defaults

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -5,7 +5,7 @@
 
 **Decision rule: if you are about to make 3+ tool calls for file edits, use `patchloom batch` instead.** One call replaces N round-trips. For agent sandboxes that shell out to the CLI, pass `--contain` (with `--cwd`) so operation targets and meta-input files cannot escape the workspace.
 
-**Apply write safety:** all Apply paths share one writer. Symlinks are resolved so the link entry is not replaced (#1230). On Unix, files with multiple hard links (`nlink > 1`) are updated in place so sibling paths stay in sync (#1733); single-link files use temp+rename.
+**Apply write safety:** all Apply paths share one writer. Symlinks are resolved so the link entry is not replaced (#1230). On Unix, files with multiple hard links (`nlink > 1`) are updated in place so sibling paths stay in sync (#1733); single-link files use temp+rename. CLI `rename` and plan `file.rename` (including force overwrite) use `fs::rename` so multi-hardlinked sources keep their shared inode (#1739, #1746).
 
 ## Tool selection guide
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -86,7 +86,8 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
         "**Apply write safety:** all Apply paths share one writer. Symlinks are resolved so \
          the link entry is not replaced (#1230). On Unix, files with multiple hard links \
          (`nlink > 1`) are updated in place so sibling paths stay in sync (#1733); single-link \
-         files use temp+rename.\n\n",
+         files use temp+rename. CLI `rename` and plan `file.rename` (including force overwrite) \
+         use `fs::rename` so multi-hardlinked sources keep their shared inode (#1739, #1746).\n\n",
     );
 
     // When to use

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -406,6 +406,47 @@ mod tests {
         );
     }
 
+    /// `--force` overwrite must also keep multi-hardlinked source inodes
+    /// (CLI direct rename uses fs::rename which replaces dest).
+    #[cfg(unix)]
+    #[test]
+    fn rename_force_preserves_hardlinks() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        let dest = dir.path().join("existing.txt");
+        fs::write(&a, "source body\n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+        fs::write(&dest, "old dest\n").unwrap();
+        let before_ino = fs::metadata(&a).unwrap().ino();
+        assert_eq!(fs::metadata(&a).unwrap().nlink(), 2);
+
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let args = RenameArgs {
+            from: a.to_string_lossy().into_owned(),
+            to: dest.to_string_lossy().into_owned(),
+            force: true,
+            write: Default::default(),
+        };
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(!a.exists());
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "source body\n");
+        assert_eq!(
+            fs::read_to_string(&b).unwrap(),
+            "source body\n",
+            "sibling hardlink must still share the moved inode"
+        );
+        assert_eq!(fs::metadata(&dest).unwrap().ino(), before_ino);
+        assert_eq!(fs::metadata(&b).unwrap().ino(), before_ino);
+        assert!(
+            fs::metadata(&dest).unwrap().nlink() > 1,
+            "nlink must stay > 1 after force rename"
+        );
+    }
+
     #[test]
     fn rename_fails_if_dst_exists() {
         let dir = TempDir::new().unwrap();

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -476,6 +476,53 @@ mod tests {
         assert!(fs::metadata(&c).unwrap().nlink() > 1);
     }
 
+    /// Force-overwrite rename must still keep multi-hardlinked source inodes
+    /// (fs::rename replaces dest; must not fall back to create+delete).
+    #[cfg(unix)]
+    #[test]
+    fn execute_file_rename_force_preserves_hardlinks() {
+        use std::os::unix::fs::MetadataExt;
+        let dir = TempDir::new().unwrap();
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        let dest = dir.path().join("existing.txt");
+        fs::write(&a, "source body\n").unwrap();
+        fs::hard_link(&a, &b).unwrap();
+        fs::write(&dest, "old dest\n").unwrap();
+        let before_ino = fs::metadata(&a).unwrap().ino();
+        assert_eq!(fs::metadata(&a).unwrap().nlink(), 2);
+
+        let global = GlobalFlags::test_default();
+        let op = Operation::FileRename {
+            from: "a.txt".to_string(),
+            to: "existing.txt".to_string(),
+            force: true,
+        };
+        let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
+        assert_eq!(
+            result.exec_result.renames.len(),
+            1,
+            "force rename must be recorded for hardlink-preserving commit, got {:?}",
+            result.exec_result.renames
+        );
+        result.commit().unwrap();
+
+        assert!(!a.exists());
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "source body\n");
+        assert_eq!(
+            fs::read_to_string(&b).unwrap(),
+            "source body\n",
+            "hardlink sibling of source must still share the moved inode"
+        );
+        assert_eq!(fs::metadata(&dest).unwrap().ino(), before_ino);
+        assert_eq!(fs::metadata(&b).unwrap().ino(), before_ino);
+        assert!(
+            fs::metadata(&dest).unwrap().nlink() > 1,
+            "nlink must stay > 1 after force rename, got {}",
+            fs::metadata(&dest).unwrap().nlink()
+        );
+    }
+
     /// Double rename then replace in one plan (a->c->d) must keep hardlinks.
     #[cfg(unix)]
     #[test]

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -230,16 +230,23 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 let _ = read_file_content(tx.pending, tx.existed_before, &dst_path)?;
             }
 
-            // Record pure renames so commit can use fs::rename and preserve
-            // hardlinks even when a later op edits the dest (#1739 follow-up:
+            // Record renames so commit can use fs::rename and preserve hardlinks
+            // even when a later op edits the dest (#1739 follow-up:
             // rename-then-replace). Also chain renames where the source is only
             // a prior rename dest in this plan (a->c then c->d; c is not on disk
             // yet during staging). file.create-then-rename stays content-staged
             // (source neither on disk nor a rename dest).
-            if !*force && !case_only && !dst_path.exists() {
+            //
+            // Force overwrite (dest already exists) must also record the pair:
+            // commit's rename_or_copy replaces the dest entry while keeping the
+            // source inode (and its hardlink siblings). Skipping the record falls
+            // back to create-dest + delete-src and splits hardlinks (#1746).
+            if !case_only {
                 let src_on_disk = src_path.exists() && src_path.is_file();
                 let src_is_rename_dest = tx.renames.iter().any(|(_, to)| to == &src_path);
-                if src_on_disk || src_is_rename_dest {
+                // Non-force with an on-disk dest is rejected earlier. Force may
+                // overwrite; non-force only records when dest is not on disk.
+                if (src_on_disk || src_is_rename_dest) && (*force || !dst_path.exists()) {
                     tx.renames.push((src_path.clone(), dst_path.clone()));
                 }
             }

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -35,31 +35,31 @@ pub struct TxOutput {
     /// Aggregate of [`TxDocMutation::changed`] when `mutations` is non-empty.
     /// Mirrors CLI doc write JSON so agents can treat exit 0 + `removed: 0`
     /// as an idempotent no-op without re-reading the file.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub changed: Option<bool>,
     /// Sum of [`TxDocMutation::removed`] when `mutations` is non-empty.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub removed: Option<usize>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error_kind: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub backup_session: Option<String>,
     /// Aggregate replace match honesty when every replace-backed change agrees
     /// (or worst-case: fuzzy > anchored > exact). See #1674.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub match_mode: Option<String>,
     /// Similarity score when aggregate [`Self::match_mode`] is fuzzy.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub match_score: Option<f64>,
     /// Sum of per-path replace match counts when any replace meta was recorded.
     /// Lets MCP/CLI agents read honesty without a second content pass.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub match_count: Option<usize>,
     /// First fuzzy/anchored matched span when a single change path is present.
     /// Compare to requested `old` after fuzzy apply (#1736).
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", default)]
     pub matched_text: Option<String>,
 }
 
@@ -808,5 +808,20 @@ mod tests {
         assert!(!json.contains("\"searches\""));
         assert!(!json.contains("\"lints\""));
         assert!(!json.contains("\"error\""));
+    }
+
+    /// Hosts may deserialize older plan/tx JSON that never had match honesty
+    /// fields. Missing keys must default to None (parity with TxChange).
+    #[test]
+    fn tx_output_deserializes_minimal_json_without_match_fields() {
+        let json = r#"{"ok":true,"status":"success","files_changed":0,"files_created":0,"files_deleted":0,"changes":[]}"#;
+        let parsed: TxOutput = serde_json::from_str(json).expect("minimal TxOutput JSON");
+        assert!(parsed.ok);
+        assert!(parsed.match_mode.is_none());
+        assert!(parsed.match_score.is_none());
+        assert!(parsed.match_count.is_none());
+        assert!(parsed.matched_text.is_none());
+        assert!(parsed.backup_session.is_none());
+        assert!(parsed.error_kind.is_none());
     }
 }


### PR DESCRIPTION
## Summary

MPI rotation findings after hardlink/matched_text work:

1. **Force `file.rename` split hardlinks** — plan/tx only recorded renames when `!force && !dest.exists()`. Force overwrite used create-dest + delete-src and broke multi-hardlinked sources. Record force pairs so commit uses `fs::rename` (same as non-force and CLI).
2. **TxOutput deserialize** — optional fields lacked `#[serde(default)]` (unlike `TxChange`). Minimal older JSON failed host deserialize.

## Test plan

- [x] `make check-fast`
- [x] `make check-patchloom-md`
- [x] `execute_file_rename_force_preserves_hardlinks`
- [x] `rename_force_preserves_hardlinks`
- [x] `tx_output_deserializes_minimal_json_without_match_fields`