### PR TITLE
fix: worst-case fuzzy score min and matched_text meta gate

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -603,7 +603,7 @@ These are meaningful command-specific modes that change how a top-level command 
 ### `replace --fuzzy` / library `ReplaceOptions.fuzzy` / plan `fuzzy`
 
 - **What it does:** When the exact pattern has zero matches, try similarity/anchor fallback (same chain as before/after context). Plan ops and MCP `replace_text` accept `fuzzy: true`. Pure fuzzy (no context) works on disk library, single-path tx, **glob** plan ops, and CLI (including directory roots expanded like ordinary replace).
-- **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` / `matched_text` in library results and CLI/MCP JSON (#1669, #1736). Multi-file CLI replace, plan/tx, and content_edits all roll up worst-case confidence (`fuzzy` > `anchored` > `exact`) so mixed batches never under-report fuzzy.
+- **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` / `matched_text` in library results and CLI/MCP JSON (#1669, #1736). Multi-file CLI replace, plan/tx, and content_edits all roll up worst-case confidence (`fuzzy` > `anchored` > `exact`) so mixed batches never under-report fuzzy. Aggregate `match_score` is the **minimum** fuzzy score across paths/ops (lowest confidence), not the first fuzzy hit.
 - **Agent rule:** Fuzzy success is not semantic success. A high score can rewrite a *different* live identifier than `old` (example: `old=compute_cheksum` may match `compute_checksum` at score ~0.99). After fuzzy apply, check `matched_text` against the intended span; prefer `ast rename` for identifiers. Distinct from whole-line span fix #1694.
 - **Prefer instead:** Exact replace when the target string is known; `ast rename` for code identifiers.
 

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -70,7 +70,8 @@ pub struct ContentEditsResult {
     /// Worst-case match strategy across replace ops (`Fuzzy` > `Anchored` > `Exact`).
     /// `None` when no replace ops ran or none matched.
     pub match_mode: Option<MatchMode>,
-    /// Similarity score from the first fuzzy replace op in the batch, if any.
+    /// Lowest fuzzy similarity score across replace ops in the batch (worst-case
+    /// confidence when several fuzzy ops ran).
     pub match_score: Option<f64>,
     /// Matched span from the first fuzzy/anchored replace in the batch (#1736).
     pub matched_text: Option<String>,
@@ -117,8 +118,11 @@ pub fn apply_content_edits_with_label(
         ops_applied += 1;
         if let Some(m) = one.match_mode {
             match_mode = Some(super::merge_match_modes(match_mode, m));
-            if m == MatchMode::Fuzzy && match_score.is_none() {
-                match_score = one.match_score;
+            // Worst-case confidence: lowest fuzzy score across ops.
+            if m == MatchMode::Fuzzy
+                && let Some(s) = one.match_score
+            {
+                match_score = Some(match_score.map_or(s, |prev| prev.min(s)));
             }
             if matched_text.is_none() {
                 matched_text = one.matched_text;

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -355,8 +355,12 @@ fn aggregate_match_meta(files: &[ReplaceFileResult]) -> (Option<&'static str>, O
             _ => continue,
         };
         agg = Some(merge_match_modes(agg, mode));
-        if mode == MatchMode::Fuzzy && score.is_none() {
-            score = f.match_score;
+        // Worst-case confidence: lowest fuzzy score across files (parity with
+        // plan/tx aggregate and content_edits).
+        if mode == MatchMode::Fuzzy
+            && let Some(s) = f.match_score
+        {
+            score = Some(score.map_or(s, |prev| prev.min(s)));
         }
     }
     match agg {

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -1537,6 +1537,31 @@ fn multi_file_match_mode_worst_case_rollup() {
     assert_eq!(mode, Some("fuzzy"), "worst-case must be fuzzy");
     assert_eq!(score, Some(0.9));
 
+    // Multiple fuzzy files: aggregate score is the minimum (worst confidence).
+    let multi_fuzzy = [
+        ReplaceFileResult {
+            path: "a.txt".into(),
+            match_count: 1,
+            match_mode: Some("fuzzy"),
+            match_score: Some(0.95),
+            matched_text: None,
+        },
+        ReplaceFileResult {
+            path: "b.txt".into(),
+            match_count: 1,
+            match_mode: Some("fuzzy"),
+            match_score: Some(0.72),
+            matched_text: None,
+        },
+    ];
+    let (mode, score) = aggregate_match_meta(&multi_fuzzy);
+    assert_eq!(mode, Some("fuzzy"));
+    assert_eq!(
+        score,
+        Some(0.72),
+        "multi-file fuzzy aggregate score must be the minimum"
+    );
+
     let mixed_anchored = [
         ReplaceFileResult {
             path: "a.txt".into(),

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -245,8 +245,11 @@ pub(crate) fn build_tx_output_with_meta(
         if let Some(m) = replace_match_meta.get(path) {
             any_replace_meta = true;
             agg_mode = Some(merge_match_modes(agg_mode, m.mode));
-            if matches!(m.mode, crate::api::MatchMode::Fuzzy) {
-                agg_score = m.score.or(agg_score);
+            if matches!(m.mode, crate::api::MatchMode::Fuzzy)
+                && let Some(s) = m.score
+            {
+                // Worst-case confidence: keep the lowest fuzzy score across paths.
+                agg_score = Some(agg_score.map_or(s, |prev| prev.min(s)));
             }
             agg_count = agg_count.saturating_add(m.match_count);
             if top_matched_text.is_none() {
@@ -290,8 +293,18 @@ pub(crate) fn build_tx_output_with_meta(
         if !changes.iter().any(|(c, _, _)| c == path) {
             let (match_mode, match_score, match_count, matched_text) =
                 match_meta_for_path(path, replace_match_meta);
-            if replace_match_meta.contains_key(path) {
+            if let Some(m) = replace_match_meta.get(path) {
                 any_replace_meta = true;
+                agg_mode = Some(merge_match_modes(agg_mode, m.mode));
+                if matches!(m.mode, crate::api::MatchMode::Fuzzy)
+                    && let Some(s) = m.score
+                {
+                    agg_score = Some(agg_score.map_or(s, |prev| prev.min(s)));
+                }
+                agg_count = agg_count.saturating_add(m.match_count);
+                if top_matched_text.is_none() {
+                    top_matched_text = m.matched_text.clone();
+                }
             }
             tx_changes.push(TxChange {
                 path: display_path(path),
@@ -341,8 +354,10 @@ pub(crate) fn build_tx_output_with_meta(
             None
         },
         // Surface only when a single replace path is present so multi-file
-        // rollups do not pick an arbitrary sibling span.
-        matched_text: if changes.len() == 1 {
+        // rollups do not pick an arbitrary sibling span. Gate on replace meta
+        // count (not write `changes.len()`), so a lone replace among other
+        // ops or a deletion-only replace path still reports the span.
+        matched_text: if replace_match_meta.len() == 1 {
             top_matched_text
         } else {
             None
@@ -786,6 +801,97 @@ mod tests {
         assert!(json.contains("\"match_mode\":\"fuzzy\""), "{json}");
         assert!(json.contains("\"match_count\":1"), "{json}");
         assert!(json.contains("\"matched_text\":\"proccess\""), "{json}");
+    }
+
+    /// Multi-path fuzzy aggregate must report the minimum score (worst case).
+    #[test]
+    fn build_tx_output_fuzzy_agg_score_is_minimum() {
+        let cwd = Path::new("/project");
+        let a = PathBuf::from("/project/a.txt");
+        let b = PathBuf::from("/project/b.txt");
+        let existed = HashSet::from([a.clone(), b.clone()]);
+        let changes = vec![
+            (a.clone(), "old".into(), "new".into()),
+            (b.clone(), "old".into(), "new".into()),
+        ];
+        let mut meta = HashMap::new();
+        meta.insert(
+            a,
+            ReplaceMatchMeta {
+                mode: crate::api::MatchMode::Fuzzy,
+                score: Some(0.95),
+                match_count: 1,
+                matched_text: Some("aaa".into()),
+            },
+        );
+        meta.insert(
+            b,
+            ReplaceMatchMeta {
+                mode: crate::api::MatchMode::Fuzzy,
+                score: Some(0.80),
+                match_count: 1,
+                matched_text: Some("bbb".into()),
+            },
+        );
+        let out = build_tx_output_with_meta(
+            "success",
+            true,
+            &changes,
+            &HashSet::new(),
+            &existed,
+            cwd,
+            &meta,
+        );
+        assert_eq!(out.match_mode.as_deref(), Some("fuzzy"));
+        assert_eq!(
+            out.match_score,
+            Some(0.80),
+            "worst-case aggregate score must be the min fuzzy score"
+        );
+        assert!(
+            out.matched_text.is_none(),
+            "multi-replace paths must not surface a single arbitrary matched_text"
+        );
+        assert_eq!(out.match_count, Some(2));
+    }
+
+    /// Top-level matched_text when only one replace path exists, even if other
+    /// non-replace changes are present (gate on replace meta, not changes.len).
+    #[test]
+    fn build_tx_output_matched_text_when_single_replace_among_other_changes() {
+        let cwd = Path::new("/project");
+        let replaced = PathBuf::from("/project/a.txt");
+        let other = PathBuf::from("/project/b.txt");
+        let existed = HashSet::from([replaced.clone(), other.clone()]);
+        let changes = vec![
+            (replaced.clone(), "old".into(), "new".into()),
+            (other, "x".into(), "y".into()),
+        ];
+        let mut meta = HashMap::new();
+        meta.insert(
+            replaced,
+            ReplaceMatchMeta {
+                mode: crate::api::MatchMode::Fuzzy,
+                score: Some(0.88),
+                match_count: 1,
+                matched_text: Some("live_span".into()),
+            },
+        );
+        let out = build_tx_output_with_meta(
+            "success",
+            true,
+            &changes,
+            &HashSet::new(),
+            &existed,
+            cwd,
+            &meta,
+        );
+        assert_eq!(
+            out.matched_text.as_deref(),
+            Some("live_span"),
+            "single replace path must surface matched_text even when other files changed"
+        );
+        assert_eq!(out.match_score, Some(0.88));
     }
 
     // ---- TxOutput serde round-trip ----


### PR DESCRIPTION
## Summary

GitHub AI Code Quality findings on `src/tx/output.rs` (2 items):

1. **Aggregate fuzzy score** used first-wins instead of **minimum** (worst confidence when multi-path fuzzy disagrees).
2. **Top-level `matched_text`** gated on `changes.len() == 1` instead of `replace_match_meta.len() == 1`, so a lone replace among other file changes (or deletion-only meta) could hide the span.

Also aligned CLI multi-file replace and `content_edits` score rollup to min for parity, and documented the rule in the reference.

## Test plan

- [x] `make check-fast`
- [x] `build_tx_output_fuzzy_agg_score_is_minimum`
- [x] `build_tx_output_matched_text_when_single_replace_among_other_changes`
- [x] `multi_file_match_mode_worst_case_rollup` (min of 0.95 / 0.72)