### PR TITLE
fix: honor if_exists on min_fuzzy_score floor reject

### DIFF
--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -320,6 +320,17 @@ fn replace_write(
                         && let Some(min) = min_fuzzy_score
                         && crate::fallback::fuzzy_fails_min_floor(score, min)
                     {
+                        // Floor reject is a soft miss: honor if_exists like resolve Err.
+                        if if_exists {
+                            return Ok(super::build_edit_result(
+                                &path_str,
+                                original.clone(),
+                                original,
+                                false,
+                                "replace",
+                                None,
+                            ));
+                        }
                         let actual = score
                             .map(|s| format!("{s:.3}"))
                             .unwrap_or_else(|| "none".into());
@@ -575,6 +586,20 @@ pub fn replace_in_content(
                     && let Some(min) = opts.min_fuzzy_score
                     && crate::fallback::fuzzy_fails_min_floor(score, min)
                 {
+                    // Floor reject is a soft miss: honor if_exists like resolve Err
+                    // (#1750). Without if_exists, still hard NoMatch.
+                    if opts.if_exists {
+                        return Ok(ContentEditResult {
+                            original: content.to_string(),
+                            new_content: content.to_string(),
+                            diff: String::new(),
+                            changed: false,
+                            match_count: 0,
+                            match_mode: None,
+                            match_score: None,
+                            matched_text: None,
+                        });
+                    }
                     let actual = score
                         .map(|s| format!("{s:.3}"))
                         .unwrap_or_else(|| "none".into());

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2966,6 +2966,54 @@ fn replace_in_content_fuzzy_with_if_exists_suppresses_error() {
     assert_eq!(result.match_count, 0);
 }
 
+/// Floor reject must honor if_exists (soft miss), same as resolve failure (#1750).
+#[test]
+fn replace_in_content_min_fuzzy_floor_honors_if_exists() {
+    let content = "fn process_request(data: &str) -> Result<()> {\n    Ok(())\n}\n";
+    let misspelled = "fn process_requets(data: &str) -> Result<()> {";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        min_fuzzy_score: Some(1.0),
+        if_exists: true,
+        ..Default::default()
+    };
+    let result = replace::replace_in_content(content, misspelled, "REPLACED", &opts)
+        .expect("if_exists must soften min_fuzzy_score floor reject");
+    assert!(!result.changed);
+    assert_eq!(result.match_count, 0);
+    assert!(result.match_mode.is_none());
+}
+
+/// Disk path: floor reject + if_exists must not error (#1750).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_min_fuzzy_floor_honors_if_exists() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("src.rs");
+    fs::write(
+        &file,
+        "fn process_request(data: &str) -> Result<()> {\n    Ok(())\n}\n",
+    )
+    .unwrap();
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        min_fuzzy_score: Some(1.0),
+        if_exists: true,
+        ..Default::default()
+    };
+    let result = replace_text(
+        &file,
+        "fn process_requets(data: &str) -> Result<()> {",
+        "REPLACED",
+        &opts,
+        ApplyMode::Preview,
+        None,
+    )
+    .expect("if_exists must soften floor reject on disk path");
+    assert!(!result.changed);
+    assert_eq!(result.match_count, 0);
+}
+
 #[test]
 fn replace_in_content_fuzzy_disabled_by_default() {
     // Default ReplaceOptions has fuzzy: false, so a near-miss should fail.


### PR DESCRIPTION
## Summary

Library `replace_text` / `replace_in_content` treated a fuzzy hit rejected by `min_fuzzy_score` as a hard `NoMatch`, even when `if_exists: true`.

Exact miss and fuzzy-resolve failure already soft-succeed under `if_exists`. Floor reject is the same soft miss: no write, no error.

**Real use:** agents that enable optional typo recovery (`fuzzy` + floor + `if_exists`) would fail the call on a weak score instead of skipping.

## Test plan

- [x] `make check-fast`
- [x] `replace_in_content_min_fuzzy_floor_honors_if_exists`
- [x] `replace_text_min_fuzzy_floor_honors_if_exists`
- [x] existing `min_fuzzy_score_rejects_weak_fuzzy_allows_exact` still hard-fails without `if_exists`