### PR TITLE
fix: skip MCP exact pre-validation when fuzzy or context set

### DIFF
--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -345,10 +345,18 @@ impl PatchloomService {
             .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
 
             // Tier 2: pre-validate structured file edits and collect warnings.
-            // Skip when case_insensitive or word_boundary is set: validate_edit_nth
-            // uses literal `content.contains(from)` which is case-sensitive and
-            // ignores word boundaries, producing false "pattern not found" errors.
-            let validation_warnings = if !p.regex && !p.case_insensitive && !p.word_boundary {
+            // Skip when case_insensitive, word_boundary, fuzzy, or context anchors
+            // are set: validate_edit_nth uses literal `content.contains(from)`,
+            // which is case-sensitive and exact-only. Fuzzy typo recovery and
+            // context anchors would get false "pattern not found" warnings while
+            // the engine still applies successfully (#1751).
+            let validation_warnings = if !p.regex
+                && !p.case_insensitive
+                && !p.word_boundary
+                && !p.fuzzy
+                && p.before_context.is_none()
+                && p.after_context.is_none()
+            {
                 let abs = svc.cwd().join(&p.path);
                 if let Ok(content) = std::fs::read_to_string(&abs) {
                     let to_str = p.new_text.as_deref().unwrap_or("");

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -3947,6 +3947,43 @@ async fn test_mcp_replace_case_insensitive_no_false_warnings() {
     client.cancel().await.unwrap();
 }
 
+/// Fuzzy typo recovery must not attach false "pattern not found" warnings
+/// from exact-only validate_edit_nth (#1751).
+#[tokio::test]
+async fn test_mcp_replace_fuzzy_no_false_pattern_warnings() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("code.rs"),
+        "fn process_request(data: &str) -> Result<()> {\n    Ok(())\n}\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "code.rs",
+            "old": "fn process_requets(data: &str) -> Result<()> {",
+            "new": "fn process_request(data: &str) -> Result<()> {",
+            "fuzzy": true
+        }),
+    )
+    .await;
+    assert!(!is_error, "fuzzy replace should succeed: {val}");
+    assert_eq!(val["ok"], true, "replace ok field: {val}");
+
+    let response_text = format!("{val}");
+    assert!(
+        !response_text.contains("not found"),
+        "fuzzy typo old must not produce false 'pattern not found' warning: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_md_dedupe_headings() {
     if !has_mcp_support() {


### PR DESCRIPTION
## Summary

MCP `replace_text` pre-validation calls `validate_edit_nth` with exact `content.contains(old)`. That already skips for `case_insensitive` / `word_boundary`, but not for **fuzzy** or **context anchors**.

Agents using fuzzy typo recovery would get **false "pattern not found" warnings** while the engine still applied successfully. Same class as the existing case-insensitive fix.

## Test plan

- [x] `make check-fast`
- [x] `test_mcp_replace_fuzzy_no_false_pattern_warnings`