### PR TITLE
fix: put error_kind and replace_hint on tx no_matches JSON

### DIFF
--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -159,12 +159,13 @@ pub fn execute_plan_direct(
     };
 
     if result.replace_no_matches {
-        let output = build_error_output(
+        // Prefer structured no_matches report so replace_hint / error_kind
+        // match CLI --json tx (build_full_tx_output), not an empty error body.
+        return Ok(build_full_tx_output(
             "no_matches",
-            result.replace_hint.as_deref().unwrap_or(""),
-            None,
-        );
-        return Ok(output);
+            &mut result,
+            &effective_cwd,
+        ));
     }
 
     if result.no_effective_changes {

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -383,6 +383,18 @@ pub(crate) fn build_full_tx_output(
     output.searches = std::mem::take(&mut result.tx_searches);
     output.lints = std::mem::take(&mut result.tx_lints);
     attach_mutations(&mut output, std::mem::take(&mut result.tx_mutations));
+    // Soft no-match replaces still set status=no_matches with ok=true (exit 3).
+    // Surface error_kind + replace_hint so agents see floor / did-you-mean
+    // diagnostics that path/glob arms already computed (#1753).
+    if status == "no_matches" {
+        output.error_kind = Some("no_matches".to_string());
+        let detail = result
+            .replace_hint
+            .as_deref()
+            .filter(|h| !h.is_empty())
+            .unwrap_or("no matches");
+        output.error = Some(detail.to_string());
+    }
     output
 }
 
@@ -914,6 +926,40 @@ mod tests {
         assert!(!json.contains("\"searches\""));
         assert!(!json.contains("\"lints\""));
         assert!(!json.contains("\"error\""));
+    }
+
+    /// Soft no_matches reports must carry error_kind + replace_hint for agents.
+    #[test]
+    fn build_full_tx_output_no_matches_includes_hint() {
+        use std::collections::HashMap;
+        let cwd = Path::new("/project");
+        let mut result = TxExecResult {
+            changes: vec![],
+            deletions: HashSet::new(),
+            existed_before: HashSet::new(),
+            pending: HashMap::new(),
+            tx_reads: vec![],
+            tx_searches: vec![],
+            tx_lints: vec![],
+            tx_mutations: vec![],
+            no_effective_changes: true,
+            replace_no_matches: true,
+            replace_hint: Some(
+                "fuzzy match score 0.900 below min_fuzzy_score 1 for \"proccess\"".into(),
+            ),
+            replace_match_meta: HashMap::new(),
+            renames: vec![],
+        };
+        let out = build_full_tx_output("no_matches", &mut result, cwd);
+        assert_eq!(out.status, "no_matches");
+        assert_eq!(out.error_kind.as_deref(), Some("no_matches"));
+        assert!(
+            out.error
+                .as_deref()
+                .is_some_and(|e| e.contains("min_fuzzy_score")),
+            "hint must appear in error: {:?}",
+            out.error
+        );
     }
 
     /// Hosts may deserialize older plan/tx JSON that never had match honesty

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -3027,6 +3027,14 @@ fn test_tx_json_check_replace_no_match_exits_3_with_no_matches_payload() {
     let v: serde_json::Value =
         serde_json::from_str(stdout.trim()).expect("tx --json should emit JSON on no-match");
     assert_eq!(v["status"], "no_matches", "status should be no_matches");
+    assert_eq!(
+        v["error_kind"], "no_matches",
+        "agents need error_kind on soft no_matches: {stdout}"
+    );
+    assert!(
+        v["error"].as_str().is_some_and(|e| !e.is_empty()),
+        "agents need non-empty error (hint or default): {stdout}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`tx --json` / MCP soft replace no-match returned:

```json
{"ok":true,"status":"no_matches","files_changed":0,"files_created":0,"files_deleted":0,"changes":[]}
```

No `error_kind`, no `error`, and **`replace_hint` was discarded**. Agents using fuzzy floor / did-you-mean never saw those diagnostics on the structured path (path/glob arms already set `replace_hint` in memory).

## Fix

- `build_full_tx_output("no_matches", …)` sets `error_kind` + `error` from `replace_hint` (default `"no matches"`)
- Library `plan_exec` uses the same shape

## Test plan

- [x] `make check-fast`
- [x] unit: `build_full_tx_output_no_matches_includes_hint`
- [x] integration: `test_tx_json_check_replace_no_match` asserts error_kind + non-empty error