### PR TITLE
fix: CLI replace error hints and word_boundary+fuzzy boundary honesty

### DIFF
--- a/fuzz/fuzz_targets/fuzz_fallback_resolve.rs
+++ b/fuzz/fuzz_targets/fuzz_fallback_resolve.rs
@@ -5,5 +5,5 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: (&str, &str, Option<&str>, Option<&str>)| {
     let (content, target, before, after) = data;
     // resolve_with_fallback must never panic on arbitrary inputs.
-    let _ = patchloom::fallback::resolve_with_fallback(content, target, before, after);
+    let _ = patchloom::fallback::resolve_with_fallback(content, target, before, after, false);
 });

--- a/fuzz/fuzz_targets/fuzz_fallback_resolve.rs
+++ b/fuzz/fuzz_targets/fuzz_fallback_resolve.rs
@@ -5,5 +5,5 @@ use libfuzzer_sys::fuzz_target;
 fuzz_target!(|data: (&str, &str, Option<&str>, Option<&str>)| {
     let (content, target, before, after) = data;
     // resolve_with_fallback must never panic on arbitrary inputs.
-    let _ = patchloom::fallback::resolve_with_fallback(content, target, before, after, false);
+    let _ = patchloom::fallback::resolve_with_fallback(content, target, before, after);
 });

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -306,7 +306,7 @@ fn replace_write(
         if count == 0 && !is_regex && (fuzzy || before_context.is_some() || after_context.is_some())
         {
             use crate::fallback;
-            match fallback::resolve_with_fallback(
+            match fallback::resolve_with_fallback_skip_exact(
                 &original,
                 &old,
                 before_context.as_deref(),
@@ -576,7 +576,7 @@ pub fn replace_in_content(
         && (opts.fuzzy || opts.before_context.is_some() || opts.after_context.is_some())
     {
         use crate::fallback;
-        match fallback::resolve_with_fallback(
+        match fallback::resolve_with_fallback_skip_exact(
             content,
             from,
             opts.before_context.as_deref(),

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -311,6 +311,9 @@ fn replace_write(
                 &old,
                 before_context.as_deref(),
                 after_context.as_deref(),
+                // Primary path already applied word_boundary exact; bare find
+                // would re-accept substrings rejected by \b (#1755).
+                word_boundary,
             ) {
                 Ok(anchor) => {
                     let (match_mode, default_score) =
@@ -578,6 +581,9 @@ pub fn replace_in_content(
             from,
             opts.before_context.as_deref(),
             opts.after_context.as_deref(),
+            // Primary path already applied word_boundary exact; bare find
+            // would re-accept substrings rejected by \b (#1755).
+            opts.word_boundary,
         ) {
             Ok(anchor) => {
                 let (mode, default_score) = super::match_mode_from_strategy(anchor.strategy);

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -149,6 +149,10 @@ struct ReplaceOutput {
     /// aligned with tx JSON `error_kind`. Omitted on success.
     #[serde(skip_serializing_if = "Option::is_none")]
     error_kind: Option<&'static str>,
+    /// Human/agent diagnostic on failure (floor reject, did-you-mean prose).
+    /// Mirrors tx JSON `error` for soft no-matches (#1754).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
     /// Aggregate match strategy when all files share one mode (#1669).
     #[serde(skip_serializing_if = "Option::is_none")]
     match_mode: Option<&'static str>,
@@ -448,6 +452,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     diff: None,
                     identity: None,
                     error_kind: Some("ambiguous"),
+                    error: None,
                     match_mode: None,
                     match_score: None,
                     matched_text: None,
@@ -484,6 +489,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 diff: None,
                 identity: Some(true),
                 error_kind: None,
+                error: None,
                 match_mode: Some("exact"),
                 match_score: None,
                 matched_text: None,
@@ -507,6 +513,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 diff: None,
                 identity: None,
                 error_kind: None,
+                error: None,
                 match_mode: None,
                 match_score: None,
                 matched_text: None,
@@ -524,6 +531,14 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::FAILURE);
         }
         let similar = similar_targets_for_no_match(&args, global, &cwd);
+        // Agents reading `error` (tx parity) should not need to scrape stderr.
+        let error_msg = similar.as_ref().map(|s| {
+            format!(
+                "no matches for '{}' (did you mean: {}?)",
+                crate::fallback::truncate_str(&args.old, 60),
+                s.join(", ")
+            )
+        });
         let output = ReplaceOutput {
             ok: false,
             match_count: 0,
@@ -532,6 +547,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             diff: None,
             identity: None,
             error_kind: Some("no_matches"),
+            error: error_msg,
             match_mode: None,
             match_score: None,
             matched_text: None,
@@ -602,6 +618,7 @@ fn replace_output(
         diff,
         identity: None,
         error_kind: None,
+        error: None,
         match_mode: agg_mode,
         match_score: agg_score,
         matched_text: if files.len() == 1 {
@@ -711,6 +728,7 @@ fn run_context_replace(
             } else {
                 Some("no_matches")
             },
+            error: None,
             match_mode: None,
             match_score: None,
             matched_text: None,
@@ -767,6 +785,13 @@ fn run_context_replace(
     let (cwd, result) = crate::cmd::output::stage_for_write(WriteSource::Operations(ops), global)?;
 
     if !result.has_changes {
+        // Engine already computed floor / resolve / did-you-mean into replace_hint.
+        let hint = result
+            .exec_result
+            .replace_hint
+            .as_deref()
+            .filter(|h| !h.is_empty())
+            .map(str::to_string);
         let empty = ReplaceOutput {
             ok: args.if_exists,
             match_count: 0,
@@ -779,6 +804,7 @@ fn run_context_replace(
             } else {
                 Some("no_matches")
             },
+            error: if args.if_exists { None } else { hint.clone() },
             match_mode: None,
             match_score: None,
             matched_text: None,
@@ -790,6 +816,10 @@ fn run_context_replace(
         }
         if !global.quiet && !global.json && !global.jsonl {
             eprintln!("no matches for '{}' in context-based replace", args.old);
+            // Engine floor / did-you-mean prose (also in JSON `error`).
+            if let Some(ref h) = hint {
+                eprintln!("{h}");
+            }
         }
         return Ok(exit::NO_MATCHES);
     }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -32,8 +32,7 @@
 //!     "fn process_data(x: i32) {}",
 //!     Some("fn setup() {}"),
 //!     Some("fn cleanup() {}"),
-//!     false,
-//! ).expect("anchor match should succeed");
+//!).expect("anchor match should succeed");
 //! assert_eq!(result.strategy, MatchStrategy::Anchor);
 //! assert!(result.matched_text.contains("proccess_data"));
 //! ```
@@ -621,11 +620,25 @@ impl std::fmt::Display for MatchStrategy {
 ///
 /// Returns the first successful match or a structured error with diagnosis.
 ///
+/// Stable 4-arg surface. Callers that already enforced a stricter exact path
+/// (for example `--word-boundary`) should use [`resolve_with_fallback_skip_exact`]
+/// so bare `find` does not re-accept a substring the primary path rejected.
+pub fn resolve_with_fallback(
+    content: &str,
+    target: &str,
+    before_context: Option<&str>,
+    after_context: Option<&str>,
+) -> Result<AnchorMatchResult, EditError> {
+    resolve_with_fallback_skip_exact(content, target, before_context, after_context, false)
+}
+
+/// Like [`resolve_with_fallback`], with control over the bare Exact tier.
+///
 /// When `skip_exact` is true, bare `find` Exact matching is skipped. Callers that
 /// already ran a stricter exact path (for example `--word-boundary`) must set
-/// this so fallback does not re-accept a substring that word boundaries rejected.
-/// Similarity and anchor strategies still run (whole-token typo recovery).
-pub fn resolve_with_fallback(
+/// this so fallback does not re-accept a substring that word boundaries rejected
+/// (#1755). Similarity and anchor strategies still run (whole-token typo recovery).
+pub fn resolve_with_fallback_skip_exact(
     content: &str,
     target: &str,
     before_context: Option<&str>,
@@ -1148,7 +1161,7 @@ mod tests {
     #[test]
     fn resolve_with_fallback_exact_match() {
         let content = "fn hello() {}\n";
-        let result = resolve_with_fallback(content, "fn hello()", None, None, false).unwrap();
+        let result = resolve_with_fallback(content, "fn hello()", None, None).unwrap();
         assert_eq!(result.strategy, MatchStrategy::Exact);
     }
 
@@ -1158,13 +1171,13 @@ mod tests {
     fn resolve_with_fallback_skip_exact_rejects_substring() {
         let content = "process_data process_data_extra\n";
         // Without skip_exact, bare find would match "process_dat" inside process_data.
-        let bare = resolve_with_fallback(content, "process_dat", None, None, false).unwrap();
+        let bare = resolve_with_fallback(content, "process_dat", None, None).unwrap();
         assert_eq!(bare.strategy, MatchStrategy::Exact);
         assert_eq!(bare.matched_text, "process_dat");
 
         // With skip_exact, Exact is skipped; token similarity may recover the
         // full identifier (process_data) or miss — but never the bare substring.
-        match resolve_with_fallback(content, "process_dat", None, None, true) {
+        match resolve_with_fallback_skip_exact(content, "process_dat", None, None, true) {
             Ok(hit) => {
                 assert_ne!(
                     hit.strategy,
@@ -1186,14 +1199,9 @@ mod tests {
     #[test]
     fn resolve_with_fallback_similarity_crlf_offset() {
         let content = "fn alpha() {}\r\nfn process_requets(data: &str) {}\r\nfn gamma() {}\r\n";
-        let result = resolve_with_fallback(
-            content,
-            "fn process_requests(data: &str) {}",
-            None,
-            None,
-            false,
-        )
-        .unwrap();
+        let result =
+            resolve_with_fallback(content, "fn process_requests(data: &str) {}", None, None)
+                .unwrap();
         assert_eq!(result.strategy, MatchStrategy::Similarity);
         // "fn alpha() {}\r\n" is 15 bytes, so the match starts at offset 15.
         assert_eq!(result.start_offset, 15);
@@ -1216,7 +1224,6 @@ mod tests {
             "fn process_requets(data: &str) -> Result<()> {",
             None,
             None,
-            false,
         );
         let r = result.expect("similarity fallback should succeed");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
@@ -1232,7 +1239,7 @@ mod tests {
     #[test]
     fn resolve_token_typo_does_not_match_whole_line() {
         let content = "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n";
-        let r = resolve_with_fallback(content, "CONFIGURATION_VALUE_PRIMRY", None, None, false)
+        let r = resolve_with_fallback(content, "CONFIGURATION_VALUE_PRIMRY", None, None)
             .expect("token typo should fuzzy-match the identifier");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
         assert_eq!(
@@ -1252,7 +1259,7 @@ mod tests {
     #[test]
     fn resolve_full_line_snippet_still_matches_line() {
         let content = "const FOO: i32 = 1;\n";
-        let r = resolve_with_fallback(content, "const FO: i32 = 1;", None, None, false)
+        let r = resolve_with_fallback(content, "const FO: i32 = 1;", None, None)
             .expect("near-full-line snippet should match the line");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
         assert!(
@@ -1312,7 +1319,7 @@ mod tests {
         ];
 
         for (content, typo, expected, forbidden) in cases {
-            let r = resolve_with_fallback(content, typo, None, None, false)
+            let r = resolve_with_fallback(content, typo, None, None)
                 .unwrap_or_else(|e| panic!("token typo {typo:?} should match in {content:?}: {e}"));
             assert_eq!(r.strategy, MatchStrategy::Similarity, "typo={typo:?}");
             assert_eq!(
@@ -1342,7 +1349,7 @@ mod tests {
     #[test]
     fn resolve_token_typo_picks_first_best_occurrence() {
         let content = "FOO_PRIMARY=1\nFOO_PRIMARY=2\n";
-        let r = resolve_with_fallback(content, "FOO_PRIMRY", None, None, false).unwrap();
+        let r = resolve_with_fallback(content, "FOO_PRIMRY", None, None).unwrap();
         assert_eq!(r.matched_text, "FOO_PRIMARY");
         // First line occurrence (offset 0).
         assert_eq!(r.start_offset, 0);
@@ -1351,8 +1358,8 @@ mod tests {
     #[test]
     fn resolve_token_unrelated_is_no_match() {
         let content = "const ALPHA: i32 = 1;\nconst BETA: i32 = 2;\n";
-        let err = resolve_with_fallback(content, "ZZZZ_COMPLETELY_UNRELATED", None, None, false)
-            .unwrap_err();
+        let err =
+            resolve_with_fallback(content, "ZZZZ_COMPLETELY_UNRELATED", None, None).unwrap_err();
         assert_eq!(err.kind, EditErrorKind::NoMatch);
     }
 
@@ -1382,7 +1389,7 @@ mod tests {
     fn resolve_kebab_case_uses_line_similarity_not_broken_token_path() {
         let content = "font-weight-primary: bold;\n";
         // Near-full-line typo; must still resolve (line path), not dead-end as token.
-        let r = resolve_with_fallback(content, "font-weight-primry: bold;", None, None, false)
+        let r = resolve_with_fallback(content, "font-weight-primry: bold;", None, None)
             .expect("kebab line snippet should match via line similarity");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
         assert!(
@@ -1395,8 +1402,7 @@ mod tests {
     #[test]
     fn resolve_with_fallback_structured_error() {
         let content = "fn alpha() {}\nfn beta() {}\n";
-        let result =
-            resolve_with_fallback(content, "fn completely_unrelated_xyz()", None, None, false);
+        let result = resolve_with_fallback(content, "fn completely_unrelated_xyz()", None, None);
         let err = result.unwrap_err();
         assert_eq!(err.kind, EditErrorKind::NoMatch);
         assert!(err.message.contains("target not found"));
@@ -1412,7 +1418,6 @@ mod tests {
             "fn process_data(x: i32) {}",
             Some("fn setup() {}"),
             Some("fn cleanup() {}"),
-            false,
         );
         let r = result.expect("anchor fallback should succeed");
         assert_eq!(r.strategy, MatchStrategy::Anchor);
@@ -1512,8 +1517,7 @@ mod tests {
     fn resolve_fallback_multi_line_no_similarity() {
         // Multi-line targets skip the similarity path and go to error.
         let content = "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n";
-        let result =
-            resolve_with_fallback(content, "fn alphax() {}\nfn betax() {}", None, None, false);
+        let result = resolve_with_fallback(content, "fn alphax() {}\nfn betax() {}", None, None);
         assert!(
             result.is_err(),
             "multi-line targets without context should not match via similarity"
@@ -1532,7 +1536,6 @@ mod tests {
             "fn process_data(x: i32) {\n    x + 1\n}",
             Some("fn header() {}"),
             Some("fn footer() {}"),
-            false,
         );
         let r = result.expect("multi-line anchor should succeed");
         assert_eq!(r.strategy, MatchStrategy::Anchor);
@@ -1652,7 +1655,7 @@ mod tests {
 
     #[test]
     fn resolve_with_fallback_empty_content() {
-        let result = resolve_with_fallback("", "fn hello()", None, None, false);
+        let result = resolve_with_fallback("", "fn hello()", None, None);
         let err = result.unwrap_err();
         assert_eq!(err.kind, EditErrorKind::NoMatch);
     }

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -32,6 +32,7 @@
 //!     "fn process_data(x: i32) {}",
 //!     Some("fn setup() {}"),
 //!     Some("fn cleanup() {}"),
+//!     false,
 //! ).expect("anchor match should succeed");
 //! assert_eq!(result.strategy, MatchStrategy::Anchor);
 //! assert!(result.matched_text.contains("proccess_data"));
@@ -619,14 +620,20 @@ impl std::fmt::Display for MatchStrategy {
 /// Run the full fallback chain: exact -> anchor -> similarity -> structured error.
 ///
 /// Returns the first successful match or a structured error with diagnosis.
+///
+/// When `skip_exact` is true, bare `find` Exact matching is skipped. Callers that
+/// already ran a stricter exact path (for example `--word-boundary`) must set
+/// this so fallback does not re-accept a substring that word boundaries rejected.
+/// Similarity and anchor strategies still run (whole-token typo recovery).
 pub fn resolve_with_fallback(
     content: &str,
     target: &str,
     before_context: Option<&str>,
     after_context: Option<&str>,
+    skip_exact: bool,
 ) -> Result<AnchorMatchResult, EditError> {
-    // Step 1: Exact match.
-    if let Some(pos) = content.find(target) {
+    // Step 1: Exact match (unless caller already enforced a stricter exact path).
+    if !skip_exact && let Some(pos) = content.find(target) {
         return Ok(AnchorMatchResult {
             matched_text: target.to_string(),
             start_offset: pos,
@@ -637,7 +644,11 @@ pub fn resolve_with_fallback(
 
     // Step 2: Anchor-based matching.
     if let Some(result) = anchor_match(content, target, before_context, after_context) {
-        return Ok(result);
+        // anchor_match may still surface Exact via its own find; reject that when
+        // the caller asked to skip bare exact (word_boundary).
+        if !(skip_exact && result.strategy == MatchStrategy::Exact) {
+            return Ok(result);
+        }
     }
 
     // Step 3: Similarity-based matching (#1694).
@@ -1137,8 +1148,36 @@ mod tests {
     #[test]
     fn resolve_with_fallback_exact_match() {
         let content = "fn hello() {}\n";
-        let result = resolve_with_fallback(content, "fn hello()", None, None).unwrap();
+        let result = resolve_with_fallback(content, "fn hello()", None, None, false).unwrap();
         assert_eq!(result.strategy, MatchStrategy::Exact);
+    }
+
+    /// #1755: skip_exact must not re-accept a bare substring after a stricter
+    /// primary path (e.g. word_boundary) already rejected it.
+    #[test]
+    fn resolve_with_fallback_skip_exact_rejects_substring() {
+        let content = "process_data process_data_extra\n";
+        // Without skip_exact, bare find would match "process_dat" inside process_data.
+        let bare = resolve_with_fallback(content, "process_dat", None, None, false).unwrap();
+        assert_eq!(bare.strategy, MatchStrategy::Exact);
+        assert_eq!(bare.matched_text, "process_dat");
+
+        // With skip_exact, Exact is skipped; token similarity may recover the
+        // full identifier (process_data) or miss — but never the bare substring.
+        match resolve_with_fallback(content, "process_dat", None, None, true) {
+            Ok(hit) => {
+                assert_ne!(
+                    hit.strategy,
+                    MatchStrategy::Exact,
+                    "skip_exact must not return Exact"
+                );
+                assert_ne!(
+                    hit.matched_text, "process_dat",
+                    "must not re-accept word_boundary-rejected substring"
+                );
+            }
+            Err(e) => assert_eq!(e.kind, EditErrorKind::NoMatch),
+        }
     }
 
     /// Regression: similarity matching on CRLF content must compute
@@ -1147,9 +1186,14 @@ mod tests {
     #[test]
     fn resolve_with_fallback_similarity_crlf_offset() {
         let content = "fn alpha() {}\r\nfn process_requets(data: &str) {}\r\nfn gamma() {}\r\n";
-        let result =
-            resolve_with_fallback(content, "fn process_requests(data: &str) {}", None, None)
-                .unwrap();
+        let result = resolve_with_fallback(
+            content,
+            "fn process_requests(data: &str) {}",
+            None,
+            None,
+            false,
+        )
+        .unwrap();
         assert_eq!(result.strategy, MatchStrategy::Similarity);
         // "fn alpha() {}\r\n" is 15 bytes, so the match starts at offset 15.
         assert_eq!(result.start_offset, 15);
@@ -1172,6 +1216,7 @@ mod tests {
             "fn process_requets(data: &str) -> Result<()> {",
             None,
             None,
+            false,
         );
         let r = result.expect("similarity fallback should succeed");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
@@ -1187,7 +1232,7 @@ mod tests {
     #[test]
     fn resolve_token_typo_does_not_match_whole_line() {
         let content = "const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n";
-        let r = resolve_with_fallback(content, "CONFIGURATION_VALUE_PRIMRY", None, None)
+        let r = resolve_with_fallback(content, "CONFIGURATION_VALUE_PRIMRY", None, None, false)
             .expect("token typo should fuzzy-match the identifier");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
         assert_eq!(
@@ -1207,7 +1252,7 @@ mod tests {
     #[test]
     fn resolve_full_line_snippet_still_matches_line() {
         let content = "const FOO: i32 = 1;\n";
-        let r = resolve_with_fallback(content, "const FO: i32 = 1;", None, None)
+        let r = resolve_with_fallback(content, "const FO: i32 = 1;", None, None, false)
             .expect("near-full-line snippet should match the line");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
         assert!(
@@ -1267,7 +1312,7 @@ mod tests {
         ];
 
         for (content, typo, expected, forbidden) in cases {
-            let r = resolve_with_fallback(content, typo, None, None)
+            let r = resolve_with_fallback(content, typo, None, None, false)
                 .unwrap_or_else(|e| panic!("token typo {typo:?} should match in {content:?}: {e}"));
             assert_eq!(r.strategy, MatchStrategy::Similarity, "typo={typo:?}");
             assert_eq!(
@@ -1297,7 +1342,7 @@ mod tests {
     #[test]
     fn resolve_token_typo_picks_first_best_occurrence() {
         let content = "FOO_PRIMARY=1\nFOO_PRIMARY=2\n";
-        let r = resolve_with_fallback(content, "FOO_PRIMRY", None, None).unwrap();
+        let r = resolve_with_fallback(content, "FOO_PRIMRY", None, None, false).unwrap();
         assert_eq!(r.matched_text, "FOO_PRIMARY");
         // First line occurrence (offset 0).
         assert_eq!(r.start_offset, 0);
@@ -1306,8 +1351,8 @@ mod tests {
     #[test]
     fn resolve_token_unrelated_is_no_match() {
         let content = "const ALPHA: i32 = 1;\nconst BETA: i32 = 2;\n";
-        let err =
-            resolve_with_fallback(content, "ZZZZ_COMPLETELY_UNRELATED", None, None).unwrap_err();
+        let err = resolve_with_fallback(content, "ZZZZ_COMPLETELY_UNRELATED", None, None, false)
+            .unwrap_err();
         assert_eq!(err.kind, EditErrorKind::NoMatch);
     }
 
@@ -1337,7 +1382,7 @@ mod tests {
     fn resolve_kebab_case_uses_line_similarity_not_broken_token_path() {
         let content = "font-weight-primary: bold;\n";
         // Near-full-line typo; must still resolve (line path), not dead-end as token.
-        let r = resolve_with_fallback(content, "font-weight-primry: bold;", None, None)
+        let r = resolve_with_fallback(content, "font-weight-primry: bold;", None, None, false)
             .expect("kebab line snippet should match via line similarity");
         assert_eq!(r.strategy, MatchStrategy::Similarity);
         assert!(
@@ -1350,7 +1395,8 @@ mod tests {
     #[test]
     fn resolve_with_fallback_structured_error() {
         let content = "fn alpha() {}\nfn beta() {}\n";
-        let result = resolve_with_fallback(content, "fn completely_unrelated_xyz()", None, None);
+        let result =
+            resolve_with_fallback(content, "fn completely_unrelated_xyz()", None, None, false);
         let err = result.unwrap_err();
         assert_eq!(err.kind, EditErrorKind::NoMatch);
         assert!(err.message.contains("target not found"));
@@ -1366,6 +1412,7 @@ mod tests {
             "fn process_data(x: i32) {}",
             Some("fn setup() {}"),
             Some("fn cleanup() {}"),
+            false,
         );
         let r = result.expect("anchor fallback should succeed");
         assert_eq!(r.strategy, MatchStrategy::Anchor);
@@ -1465,7 +1512,8 @@ mod tests {
     fn resolve_fallback_multi_line_no_similarity() {
         // Multi-line targets skip the similarity path and go to error.
         let content = "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n";
-        let result = resolve_with_fallback(content, "fn alphax() {}\nfn betax() {}", None, None);
+        let result =
+            resolve_with_fallback(content, "fn alphax() {}\nfn betax() {}", None, None, false);
         assert!(
             result.is_err(),
             "multi-line targets without context should not match via similarity"
@@ -1484,6 +1532,7 @@ mod tests {
             "fn process_data(x: i32) {\n    x + 1\n}",
             Some("fn header() {}"),
             Some("fn footer() {}"),
+            false,
         );
         let r = result.expect("multi-line anchor should succeed");
         assert_eq!(r.strategy, MatchStrategy::Anchor);
@@ -1603,7 +1652,7 @@ mod tests {
 
     #[test]
     fn resolve_with_fallback_empty_content() {
-        let result = resolve_with_fallback("", "fn hello()", None, None);
+        let result = resolve_with_fallback("", "fn hello()", None, None, false);
         let err = result.unwrap_err();
         assert_eq!(err.kind, EditErrorKind::NoMatch);
     }

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -251,7 +251,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             Ok(match_count)
         } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some()) {
             // Tier 3: fuzzy and/or context fallback when exact match fails (#1668).
-            match crate::fallback::resolve_with_fallback(
+            match crate::fallback::resolve_with_fallback_skip_exact(
                 content,
                 old,
                 before_context.as_deref(),
@@ -492,7 +492,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some())
             {
                 // Fuzzy/context fallback for glob paths (parity with #1668 path arm).
-                match crate::fallback::resolve_with_fallback(
+                match crate::fallback::resolve_with_fallback_skip_exact(
                     &content,
                     old,
                     before_context.as_deref(),

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -256,6 +256,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 old,
                 before_context.as_deref(),
                 after_context.as_deref(),
+                // Primary path already applied word_boundary exact; bare find
+                // would re-accept substrings rejected by \b (#1755).
+                word_boundary,
             ) {
                 Ok(anchor) => {
                     let (mode, default_score) =
@@ -494,6 +497,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     old,
                     before_context.as_deref(),
                     after_context.as_deref(),
+                    // Primary path already applied word_boundary exact; bare find
+                    // would re-accept substrings rejected by \b (#1755).
+                    word_boundary,
                 ) {
                     Ok(anchor) => {
                         let (mode, default_score) =

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2113,3 +2113,76 @@ fn test_replace_fuzzy_json_reports_matched_text() {
     let content = fs::read_to_string(&file).unwrap();
     assert!(content.contains("compute_digest"), "file: {content}");
 }
+
+/// #1755: --fuzzy must not undo --word-boundary by bare Exact fallback.
+#[test]
+fn test_replace_word_boundary_fuzzy_does_not_partial_match() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("ids.txt");
+    fs::write(&file, "process_data process_data_extra\n").unwrap();
+
+    // word_boundary alone: miss (process_dat is a prefix, not a whole word).
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "replace",
+            "process_dat",
+            "--new",
+            "X",
+            "--word-boundary",
+            "--apply",
+        ])
+        .arg(&file)
+        .assert()
+        .code(3);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "process_data process_data_extra\n"
+    );
+
+    // word_boundary + fuzzy: must not re-accept the bare substring via Exact.
+    // Token similarity may rewrite the full identifier process_data, which is
+    // correct whole-word recovery; partial "process_dat" -> "X" + "a" is not.
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "process_dat",
+            "--new",
+            "X",
+            "--word-boundary",
+            "--fuzzy",
+            "--apply",
+        ])
+        .arg(&file)
+        .output()
+        .unwrap();
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        !on_disk.starts_with("Xa"),
+        "must not partial-match inside process_data: {on_disk}"
+    );
+    if out.status.code() == Some(0) {
+        let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+        let mode = v["match_mode"].as_str().unwrap_or("");
+        assert_ne!(mode, "exact", "skip_exact must block bare Exact: {v}");
+        let matched = v["matched_text"].as_str().unwrap_or("");
+        assert_ne!(matched, "process_dat", "must not match bare substring: {v}");
+        // Whole-token recovery rewrites process_data -> X (process_data_extra may remain).
+        assert!(
+            on_disk.starts_with("X "),
+            "fuzzy whole-token recovery expected: {on_disk}"
+        );
+        assert_eq!(matched, "process_data", "should match full identifier: {v}");
+    } else {
+        assert_eq!(
+            out.status.code(),
+            Some(3),
+            "soft miss ok if similarity does not fire: status={} stderr={}",
+            out.status.code().unwrap_or(255),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert_eq!(on_disk, "process_data process_data_extra\n");
+    }
+}

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1786,6 +1786,11 @@ fn test_replace_cli_json_no_matches_includes_similar_targets() {
             .any(|s| s.as_str() == Some("process_request")),
         "expected process_request suggestion: {v}"
     );
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("did you mean") && err.contains("process_request"),
+        "exact no-match JSON error must carry did-you-mean prose: {v}"
+    );
 }
 
 #[test]
@@ -1953,6 +1958,39 @@ fn test_replace_cli_min_fuzzy_score_rejects_weak_match() {
         fs::read_to_string(&file).unwrap(),
         "hello wrold foo\n",
         "high floor must leave content unchanged"
+    );
+
+    // Soft floor reject under --json must surface engine replace_hint in `error`
+    // so agents do not only get error_kind=no_matches with an empty body (#1754).
+    let json_out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "hello world",
+            "--new",
+            "hello earth",
+            "--fuzzy",
+            "--min-fuzzy-score",
+            "0.99",
+        ])
+        .arg(&file)
+        .output()
+        .unwrap();
+    assert_eq!(
+        json_out.status.code(),
+        Some(3),
+        "stderr={}",
+        String::from_utf8_lossy(&json_out.stderr)
+    );
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&json_out.stdout)).expect("valid JSON");
+    assert_eq!(v["ok"], false);
+    assert_eq!(v["error_kind"], "no_matches");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("min_fuzzy_score") || err.contains("below"),
+        "CLI fuzzy floor no-match JSON must include floor hint in error: {v}"
     );
 
     // Lower floor accepts the same fuzzy hit.


### PR DESCRIPTION
## Summary

- Soft no-match on context/fuzzy CLI replace now puts engine `replace_hint` (floor rejects, did-you-mean) into JSON `error`, matching tx/MCP agent envelopes. Exact no-match also fills `error` from `similar_targets`.
- `--word-boundary --fuzzy` no longer re-accepts bare substrings via fallback Exact (`content.find`): `skip_exact` when primary already enforced word boundaries. Whole-token fuzzy recovery still works.

## Test plan

- [x] `make check-fast`
- [x] Integration: floor reject JSON `error` contains `min_fuzzy_score`
- [x] Integration: exact no-match JSON `error` contains did-you-mean
- [x] Integration: word_boundary+fuzzy does not produce `Xa` from `process_data`