### PR TITLE
fix: always put no_matches diagnostics in replace/search JSON error

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -531,14 +531,21 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::FAILURE);
         }
         let similar = similar_targets_for_no_match(&args, global, &cwd);
+        let path_desc = global.path_scope_description(&args.paths);
         // Agents reading `error` (tx parity) should not need to scrape stderr.
-        let error_msg = similar.as_ref().map(|s| {
-            format!(
+        // Always set a message (even without similar_targets) so pure misses are
+        // not error_kind-only empty bodies.
+        let error_msg = match &similar {
+            Some(s) if !s.is_empty() => format!(
                 "no matches for '{}' (did you mean: {}?)",
                 crate::fallback::truncate_str(&args.old, 60),
                 s.join(", ")
-            )
-        });
+            ),
+            _ => format!(
+                "no matches for '{}' in {path_desc}",
+                crate::fallback::truncate_str(&args.old, 60)
+            ),
+        };
         let output = ReplaceOutput {
             ok: false,
             match_count: 0,
@@ -547,7 +554,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             diff: None,
             identity: None,
             error_kind: Some("no_matches"),
-            error: error_msg,
+            error: Some(error_msg),
             match_mode: None,
             match_score: None,
             matched_text: None,
@@ -555,7 +562,6 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         };
         global.emit_json(&output)?;
         if !global.quiet && !global.json && !global.jsonl {
-            let path_desc = global.path_scope_description(&args.paths);
             eprintln!("no matches for '{}' in {path_desc}", args.old);
             if let Some(ref s) = similar {
                 eprintln!("did you mean: {}?", s.join(", "));

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -75,6 +75,9 @@ struct SearchOutput {
     /// CLI replace / tx JSON. Omitted on success.
     #[serde(skip_serializing_if = "Option::is_none")]
     error_kind: Option<&'static str>,
+    /// Human/agent diagnostic on soft no-match (path scope). Omitted on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -188,6 +191,7 @@ pub(crate) fn format_results(
             matches: results.matches,
             files,
             error_kind: None,
+            error: None,
         };
         out = serde_json::to_string_pretty(&payload)?;
         out.push('\n');
@@ -387,6 +391,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             global.emit_error_json_kind(Some("not_found"), &msg)?;
             return Ok(exit::FAILURE);
         }
+        let path_desc = global.path_scope_description(&args.paths);
         let payload = SearchOutput {
             ok: false,
             match_count: 0,
@@ -394,10 +399,13 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             matches: vec![],
             files: vec![],
             error_kind: Some("no_matches"),
+            error: Some(format!(
+                "no matches for '{}' in {path_desc}",
+                crate::fallback::truncate_str(&args.pattern, 60)
+            )),
         };
         global.emit_json(&payload)?;
         if !global.quiet && !global.json && !global.jsonl {
-            let path_desc = global.path_scope_description(&args.paths);
             eprintln!("no matches for '{}' in {path_desc}", args.pattern);
             if args.literal && crate::files::has_regex_metacharacters(&args.pattern) {
                 eprintln!(

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1757,6 +1757,11 @@ fn test_replace_cli_json_error_kind_no_matches() {
         v["error_kind"], "no_matches",
         "CLI replace no-match JSON should set error_kind: {v}"
     );
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("no matches") && err.contains("missing"),
+        "pure no-match JSON must include error message: {v}"
+    );
 }
 
 #[test]

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -258,6 +258,11 @@ fn test_search_json_no_match_emits_valid_json() {
         parsed["error_kind"], "no_matches",
         "search --json no-match should set error_kind: {parsed}"
     );
+    let err = parsed["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("no matches") && err.contains("zzz_no_match_zzz"),
+        "search no-match JSON must include error message: {parsed}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- CLI replace pure soft no-match (no similar_targets) now sets JSON `error` with path-scoped prose, not only `error_kind`.
- CLI search soft no-match sets JSON `error` the same way (tx/agent parity with replace).

## Test plan

- [x] `make check-fast`
- [x] replace pure no-match JSON has `error` containing pattern
- [x] search pure no-match JSON has `error` containing pattern