### PR TITLE
fix: report missing --files-from paths in replace JSON skipped

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -165,6 +165,38 @@ struct ReplaceOutput {
     /// Agents should prefer this over scraping the English error string.
     #[serde(skip_serializing_if = "Option::is_none")]
     similar_targets: Option<Vec<String>>,
+    /// Paths from `--files-from` that were missing or unreadable and soft-skipped.
+    /// Present under `--json` even when `--quiet` suppresses stderr (#1756).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skipped: Option<Vec<String>>,
+}
+
+/// List `--files-from` entries that do not exist on disk (for agent JSON).
+///
+/// Skips when the list is stdin (`-`): that source can only be read once, and
+/// `collect_file_paths_opts` already consumes it for the walk.
+fn files_from_skipped_missing(
+    global: &GlobalFlags,
+    cwd: &std::path::Path,
+) -> anyhow::Result<Option<Vec<String>>> {
+    if global.files_from.as_deref() == Some("-") {
+        return Ok(None);
+    }
+    let Some(files) = global.read_files_from()? else {
+        return Ok(None);
+    };
+    let mut missing = Vec::new();
+    for f in files {
+        let p = cwd.join(&f);
+        if !p.exists() {
+            missing.push(f);
+        }
+    }
+    if missing.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(missing))
+    }
 }
 
 /// Result of processing a single file.
@@ -422,11 +454,12 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // outside the workspace while computing matches (precomputed write-path
     // guard remains defense-in-depth).
     global.check_paths_contained(&cwd, &args.paths)?;
+    let skipped = files_from_skipped_missing(global, &cwd)?;
 
     // Context / pure fuzzy: route through the tx engine where the
     // context_filtered_offset and fallback chain live (#1668).
     if args.fuzzy || args.before_context.is_some() || args.after_context.is_some() {
-        return run_context_replace(args, global, &cwd);
+        return run_context_replace(args, global, &cwd, skipped);
     }
 
     // Phase 1: Parallel file scan to identify files with matches (includes identity).
@@ -457,6 +490,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     match_score: None,
                     matched_text: None,
                     similar_targets: None,
+                    skipped: skipped.clone(),
                 };
                 global.emit_json(&output)?;
                 if !global.quiet {
@@ -494,6 +528,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 match_score: None,
                 matched_text: None,
                 similar_targets: None,
+                skipped: skipped.clone(),
             };
             global.emit_json(&output)?;
             if !global.quiet && !global.json && !global.jsonl {
@@ -518,6 +553,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 match_score: None,
                 matched_text: None,
                 similar_targets: None,
+                skipped: skipped.clone(),
             };
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
@@ -559,6 +595,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             match_score: None,
             matched_text: None,
             similar_targets: similar.clone(),
+            skipped: skipped.clone(),
         };
         global.emit_json(&output)?;
         if !global.quiet && !global.json && !global.jsonl {
@@ -599,7 +636,15 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // Phase 3: Render output based on mode (check/apply/diff/confirm).
     // Custom JSON schema (match counts); mode/exit via write_mode helpers.
-    replace_output(global, result, &files, total_matches, file_count, &cwd)
+    replace_output(
+        global,
+        result,
+        &files,
+        total_matches,
+        file_count,
+        &cwd,
+        skipped,
+    )
 }
 
 /// Handle output rendering and commit/check/preview for replace via the engine.
@@ -612,6 +657,7 @@ fn replace_output(
     total_matches: usize,
     file_count: usize,
     cwd: &std::path::Path,
+    skipped: Option<Vec<String>>,
 ) -> anyhow::Result<u8> {
     use crate::cmd::write_mode::{FinalizeCallbacks, finalize_report};
 
@@ -633,6 +679,7 @@ fn replace_output(
             None
         },
         similar_targets: None,
+        skipped: skipped.clone(),
     };
 
     finalize_report(
@@ -701,6 +748,7 @@ fn run_context_replace(
     args: ReplaceArgs,
     global: &GlobalFlags,
     cwd: &std::path::Path,
+    skipped: Option<Vec<String>>,
 ) -> anyhow::Result<u8> {
     use crate::plan::Operation;
 
@@ -739,6 +787,7 @@ fn run_context_replace(
             match_score: None,
             matched_text: None,
             similar_targets: None,
+            skipped: skipped.clone(),
         };
         global.emit_json(&empty)?;
         if args.if_exists {
@@ -815,6 +864,7 @@ fn run_context_replace(
             match_score: None,
             matched_text: None,
             similar_targets: None,
+            skipped: skipped.clone(),
         };
         global.emit_json(&empty)?;
         if args.if_exists {
@@ -894,7 +944,15 @@ fn run_context_replace(
     let total_matches = files.len();
     let file_count = total_matches;
     // Same mode/exit owner as default replace path (no hand-rolled matrix).
-    replace_output(global, result, &files, total_matches, file_count, &cwd)
+    replace_output(
+        global,
+        result,
+        &files,
+        total_matches,
+        file_count,
+        &cwd,
+        skipped,
+    )
 }
 
 #[path = "replace_tests.rs"]

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -171,34 +171,6 @@ struct ReplaceOutput {
     skipped: Option<Vec<String>>,
 }
 
-/// List `--files-from` entries that do not exist on disk (for agent JSON).
-///
-/// Skips when the list is stdin (`-`): that source can only be read once, and
-/// `collect_file_paths_opts` already consumes it for the walk.
-fn files_from_skipped_missing(
-    global: &GlobalFlags,
-    cwd: &std::path::Path,
-) -> anyhow::Result<Option<Vec<String>>> {
-    if global.files_from.as_deref() == Some("-") {
-        return Ok(None);
-    }
-    let Some(files) = global.read_files_from()? else {
-        return Ok(None);
-    };
-    let mut missing = Vec::new();
-    for f in files {
-        let p = cwd.join(&f);
-        if !p.exists() {
-            missing.push(f);
-        }
-    }
-    if missing.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(missing))
-    }
-}
-
 /// Result of processing a single file.
 struct FileReplacement {
     path: String,
@@ -454,7 +426,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // outside the workspace while computing matches (precomputed write-path
     // guard remains defense-in-depth).
     global.check_paths_contained(&cwd, &args.paths)?;
-    let skipped = files_from_skipped_missing(global, &cwd)?;
+    let skipped = crate::files::files_from_missing_entries(global, &cwd)?;
 
     // Context / pure fuzzy: route through the tx engine where the
     // context_filtered_offset and fallback chain live (#1668).

--- a/src/files.rs
+++ b/src/files.rs
@@ -106,6 +106,35 @@ pub(crate) fn all_scan_targets_missing(
     Ok(all_explicit_paths_missing(paths, root))
 }
 
+/// `--files-from` list entries that do not exist under `cwd` (agent JSON).
+///
+/// Returns `None` when files-from is unset, is stdin (`-`, single-read), or
+/// every listed path exists. Used so soft-skips are visible under `--json`
+/// even when `--quiet` suppresses stderr (#1756).
+#[cfg(feature = "cli")]
+pub(crate) fn files_from_missing_entries(
+    global: &crate::cli::global::GlobalFlags,
+    cwd: &Path,
+) -> anyhow::Result<Option<Vec<String>>> {
+    if global.files_from.as_deref() == Some("-") {
+        return Ok(None);
+    }
+    let Some(files) = global.read_files_from()? else {
+        return Ok(None);
+    };
+    let mut missing = Vec::new();
+    for f in files {
+        if !cwd.join(&f).exists() {
+            missing.push(f);
+        }
+    }
+    if missing.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(missing))
+    }
+}
+
 /// Collect file paths from either `--files-from`, or by walking `paths` with
 /// `ignore::WalkBuilder` (respects `.gitignore`).  When `root` is `Some`,
 /// paths are joined with it before walking.  Tidy commands set

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2191,3 +2191,46 @@ fn test_replace_word_boundary_fuzzy_does_not_partial_match() {
         assert_eq!(on_disk, "process_data process_data_extra\n");
     }
 }
+
+/// #1756: --files-from missing paths must appear in JSON under --quiet.
+#[test]
+fn test_replace_files_from_missing_reported_in_json() {
+    let dir = TempDir::new().unwrap();
+    let list = dir.path().join("list.txt");
+    let a = dir.path().join("a.txt");
+    fs::write(&a, "hello\n").unwrap();
+    fs::write(&list, "a.txt\nmissing.txt\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--quiet", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "--files-from",
+            "list.txt",
+            "replace",
+            "hello",
+            "--new",
+            "hi",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["match_count"], 1);
+    let skipped = v["skipped"]
+        .as_array()
+        .expect("skipped array for missing files-from entry");
+    assert!(
+        skipped.iter().any(|s| s.as_str() == Some("missing.txt")),
+        "expected missing.txt in skipped: {v}"
+    );
+    assert_eq!(fs::read_to_string(&a).unwrap(), "hi\n");
+}


### PR DESCRIPTION
## Summary

- Soft-missing `--files-from` entries are silent under `--json --quiet` (only stderr when not quiet).
- CLI replace JSON now includes `skipped: ["missing.txt", …]` for list entries that do not exist.

Closes #1756

## Test plan

- [x] `make check-fast`
- [x] Integration: files-from with one good + one missing path sets `skipped` under `--json --quiet`