### PR TITLE
fix: agent JSON honesty for search skipped and fuzzy refuse meta

### DIFF
--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -297,7 +297,7 @@ impl PatchloomService {
                 return no_results("No matches found.");
             }
 
-            let output = crate::cmd::search::format_results(results, &search_args, &global)
+            let output = crate::cmd::search::format_results(results, &search_args, &global, None)
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
             exit_code_to_result(exit::SUCCESS, &output, "No results.")
         })

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -349,6 +349,45 @@ fn make_file_results(replacements: &[FileReplacement]) -> Vec<ReplaceFileResult>
         .collect()
 }
 
+/// Candidate honesty from soft refuses (no write): fuzzy fail-closed (#1758)
+/// or floor reject with recorded meta. Single-path meta surfaces mode/score/span.
+fn aggregate_refuse_match_meta(
+    meta: &std::collections::HashMap<std::path::PathBuf, crate::tx::ReplaceMatchMeta>,
+) -> (Option<&'static str>, Option<f64>, Option<String>) {
+    use crate::api::{MatchMode, merge_match_modes};
+
+    if meta.is_empty() {
+        return (None, None, None);
+    }
+    let mut agg: Option<MatchMode> = None;
+    let mut score: Option<f64> = None;
+    let mut matched: Option<String> = None;
+    for m in meta.values() {
+        agg = Some(merge_match_modes(agg, m.mode));
+        if m.mode == MatchMode::Fuzzy
+            && let Some(s) = m.score
+        {
+            score = Some(score.map_or(s, |prev| prev.min(s)));
+        }
+        if matched.is_none() {
+            matched = m.matched_text.clone();
+        }
+    }
+    let mode = match agg {
+        Some(MatchMode::Fuzzy) => Some("fuzzy"),
+        Some(MatchMode::Anchored) => Some("anchored"),
+        Some(MatchMode::Exact) => Some("exact"),
+        None => None,
+    };
+    let score = if matches!(agg, Some(MatchMode::Fuzzy)) {
+        score
+    } else {
+        None
+    };
+    let matched = if meta.len() == 1 { matched } else { None };
+    (mode, score, matched)
+}
+
 /// Top-level match honesty for multi-file CLI replace (#1669 / #1674).
 ///
 /// Uses the same worst-case rollup as plan/tx and content_edits
@@ -827,6 +866,9 @@ fn run_context_replace(
             .as_deref()
             .filter(|h| !h.is_empty())
             .map(str::to_string);
+        // Soft refuse (#1758) records candidate honesty without a write.
+        let (refuse_mode, refuse_score, refuse_matched) =
+            aggregate_refuse_match_meta(&result.exec_result.replace_match_meta);
         let empty = ReplaceOutput {
             ok: args.if_exists,
             match_count: 0,
@@ -840,9 +882,9 @@ fn run_context_replace(
                 Some("no_matches")
             },
             error: if args.if_exists { None } else { hint.clone() },
-            match_mode: None,
-            match_score: None,
-            matched_text: None,
+            match_mode: refuse_mode,
+            match_score: refuse_score,
+            matched_text: refuse_matched,
             similar_targets: None,
             skipped: skipped.clone(),
         };

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -78,6 +78,9 @@ struct SearchOutput {
     /// Human/agent diagnostic on soft no-match (path scope). Omitted on success.
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    /// Paths from `--files-from` that were missing (agent JSON; #1756).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skipped: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -158,6 +161,7 @@ pub(crate) fn format_results(
     results: SearchResults,
     args: &SearchArgs,
     global: &GlobalFlags,
+    skipped: Option<Vec<String>>,
 ) -> anyhow::Result<String> {
     use std::fmt::Write;
     let mut out = String::new();
@@ -192,6 +196,7 @@ pub(crate) fn format_results(
             files,
             error_kind: None,
             error: None,
+            skipped,
         };
         out = serde_json::to_string_pretty(&payload)?;
         out.push('\n');
@@ -333,6 +338,8 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     let results = collect_matches(&args, global)?;
+    let cwd = global.resolve_cwd()?;
+    let skipped = crate::files::files_from_missing_entries(global, &cwd)?;
 
     // --assert-count mode: succeed only if total count equals N.
     // JSON matches MCP search_files: ok == matched; mismatch sets
@@ -403,6 +410,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 "no matches for '{}' in {path_desc}",
                 crate::fallback::truncate_str(&args.pattern, 60)
             )),
+            skipped: skipped.clone(),
         };
         global.emit_json(&payload)?;
         if !global.quiet && !global.json && !global.jsonl {
@@ -420,7 +428,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if global.json || global.jsonl || !global.quiet {
-        let output = format_results(results, &args, global)?;
+        let output = format_results(results, &args, global, skipped)?;
         print!("{output}");
     }
 
@@ -556,7 +564,7 @@ mod tests {
         let mut args = make_args("Hello", vec![dir.path().to_string_lossy().into_owned()]);
         args.files_with_matches = true;
         let results = collect_matches(&args, &GlobalFlags::test_default()).unwrap();
-        let output = format_results(results, &args, &GlobalFlags::test_default()).unwrap();
+        let output = format_results(results, &args, &GlobalFlags::test_default(), None).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines.len(), 1);
         assert!(lines[0].ends_with("hello.txt"));
@@ -574,7 +582,7 @@ mod tests {
         let mut args = make_args("Hello", vec![dir.path().to_string_lossy().into_owned()]);
         args.count = true;
         let results = collect_matches(&args, &GlobalFlags::test_default()).unwrap();
-        let output = format_results(results, &args, &GlobalFlags::test_default()).unwrap();
+        let output = format_results(results, &args, &GlobalFlags::test_default(), None).unwrap();
         let lines: Vec<&str> = output.lines().collect();
         assert_eq!(lines.len(), 1);
         assert!(lines[0].ends_with(":2"));
@@ -768,7 +776,7 @@ mod tests {
         let mut global = GlobalFlags::test_default();
         global.json = true;
         let results = collect_matches(&args, &global).unwrap();
-        let output = format_results(results, &args, &global).unwrap();
+        let output = format_results(results, &args, &global, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert_eq!(v["ok"], serde_json::json!(true));
         // "Hello" appears in two lines of hello.txt, one file.
@@ -806,7 +814,7 @@ mod tests {
         let mut global = GlobalFlags::test_default();
         global.json = true;
         let results = collect_matches(&args, &global).unwrap();
-        let output = format_results(results, &args, &global).unwrap();
+        let output = format_results(results, &args, &global, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert_eq!(v["ok"], serde_json::json!(true));
         assert_eq!(v["file_count"], serde_json::json!(1));
@@ -826,7 +834,7 @@ mod tests {
         let mut global = GlobalFlags::test_default();
         global.json = true;
         let results = collect_matches(&args, &global).unwrap();
-        let output = format_results(results, &args, &global).unwrap();
+        let output = format_results(results, &args, &global, None).unwrap();
         let v: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert_eq!(v["ok"], serde_json::json!(true));
         // files array must contain the per-file counts.
@@ -932,8 +940,13 @@ mod tests {
         let mut args = make_args("match", vec![file.to_string_lossy().into_owned()]);
         args.context = Some(1);
         let global = GlobalFlags::test_default();
-        let output =
-            format_results(collect_matches(&args, &global).unwrap(), &args, &global).unwrap();
+        let output = format_results(
+            collect_matches(&args, &global).unwrap(),
+            &args,
+            &global,
+            None,
+        )
+        .unwrap();
         // "line3" should appear exactly once, not twice.
         let count = output.matches("line3").count();
         assert_eq!(count, 1, "line3 should appear once, got: {output}");
@@ -950,8 +963,13 @@ mod tests {
         let mut args = make_args("match", vec![file.to_string_lossy().into_owned()]);
         args.context = Some(1);
         let global = GlobalFlags::test_default();
-        let output =
-            format_results(collect_matches(&args, &global).unwrap(), &args, &global).unwrap();
+        let output = format_results(
+            collect_matches(&args, &global).unwrap(),
+            &args,
+            &global,
+            None,
+        )
+        .unwrap();
         // "match_b" should appear exactly once (as a match line).
         let count = output.matches("match_b").count();
         assert_eq!(

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -31,13 +31,13 @@ mod tidy_op;
 // Re-export all pub and pub(crate) items so `crate::tx::*` paths continue to work.
 
 // output.rs
+pub(crate) use output::{
+    ReplaceMatchMeta, TxExecResult, build_error_output, build_full_tx_output,
+    format_error_with_backup_hint, match_mode_label,
+};
 pub use output::{
     TxChange, TxDocMutation, TxLintResult, TxOutput, TxReadResult, TxSearchMatch, TxSearchResult,
     exit_code_from_tx_output,
-};
-pub(crate) use output::{
-    TxExecResult, build_error_output, build_full_tx_output, format_error_with_backup_hint,
-    match_mode_label,
 };
 
 // validate.rs (test-only re-exports for src/cmd/tx.rs tests)

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -1,3 +1,7 @@
+//! size-waiver: accepted single-domain bulk (policy #1408). Tx JSON output
+//! assembly and match honesty aggregation for plan/CLI/MCP is one unit; do not
+//! split for LOC alone.
+
 use crate::exit;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
@@ -315,6 +319,26 @@ pub(crate) fn build_tx_output_with_meta(
                 matched_text,
             });
             deleted_count += 1;
+        }
+    }
+
+    // Soft refuses (fuzzy fail-closed #1758, floor reject with recorded
+    // candidate) store honesty in replace_match_meta without a write. Fold
+    // those paths so no_matches JSON still exposes match_mode/score/matched_text.
+    for (path, m) in replace_match_meta {
+        if changes.iter().any(|(c, _, _)| c == path) || deletions.contains(path) {
+            continue;
+        }
+        any_replace_meta = true;
+        agg_mode = Some(merge_match_modes(agg_mode, m.mode));
+        if matches!(m.mode, crate::api::MatchMode::Fuzzy)
+            && let Some(s) = m.score
+        {
+            agg_score = Some(agg_score.map_or(s, |prev| prev.min(s)));
+        }
+        agg_count = agg_count.saturating_add(m.match_count);
+        if top_matched_text.is_none() {
+            top_matched_text = m.matched_text.clone();
         }
     }
 
@@ -960,6 +984,45 @@ mod tests {
             "hint must appear in error: {:?}",
             out.error
         );
+    }
+
+    /// Soft refuse (#1758) records replace_match_meta without a write; no_matches
+    /// JSON must still expose match_mode / match_score / matched_text.
+    #[test]
+    fn build_full_tx_output_no_matches_includes_refuse_match_meta() {
+        use std::collections::HashMap;
+        let cwd = Path::new("/project");
+        let mut meta = HashMap::new();
+        meta.insert(
+            PathBuf::from("/project/app.py"),
+            ReplaceMatchMeta {
+                mode: crate::api::MatchMode::Fuzzy,
+                score: Some(0.987),
+                match_count: 0,
+                matched_text: Some("compute_checksum".into()),
+            },
+        );
+        let mut result = TxExecResult {
+            changes: vec![],
+            deletions: HashSet::new(),
+            existed_before: HashSet::new(),
+            pending: HashMap::new(),
+            tx_reads: vec![],
+            tx_searches: vec![],
+            tx_lints: vec![],
+            tx_mutations: vec![],
+            no_effective_changes: true,
+            replace_no_matches: true,
+            replace_hint: Some("exact old absent; best fuzzy candidate".into()),
+            replace_match_meta: meta,
+            renames: vec![],
+        };
+        let out = build_full_tx_output("no_matches", &mut result, cwd);
+        assert_eq!(out.status, "no_matches");
+        assert_eq!(out.match_mode.as_deref(), Some("fuzzy"));
+        assert_eq!(out.match_score, Some(0.987));
+        assert_eq!(out.matched_text.as_deref(), Some("compute_checksum"));
+        assert_eq!(out.match_count, Some(0));
     }
 
     /// Hosts may deserialize older plan/tx JSON that never had match honesty

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2283,6 +2283,19 @@ fn test_replace_fuzzy_absent_old_fails_closed() {
         err.contains("exact old absent") && err.contains("compute_checksum"),
         "JSON error must explain refuse: {v}"
     );
+    // Structured candidate honesty for agents (not only English error).
+    assert_eq!(
+        v["match_mode"], "fuzzy",
+        "refuse must report fuzzy mode: {v}"
+    );
+    assert!(
+        v["match_score"].as_f64().is_some_and(|s| s >= 0.95),
+        "refuse must report score: {v}"
+    );
+    assert_eq!(
+        v["matched_text"], "compute_checksum",
+        "refuse must report live candidate: {v}"
+    );
     assert!(
         fs::read_to_string(&file)
             .unwrap()

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1260,3 +1260,37 @@ fn test_search_files_from_all_missing_is_not_found() {
     assert_eq!(parsed["ok"], false);
     assert_eq!(parsed["error_kind"], "not_found");
 }
+
+/// #1756: search --files-from missing paths under --json --quiet.
+#[test]
+fn test_search_files_from_missing_reported_in_json() {
+    let dir = TempDir::new().unwrap();
+    let list = dir.path().join("list.txt");
+    let a = dir.path().join("a.txt");
+    fs::write(&a, "hello\n").unwrap();
+    fs::write(&list, "a.txt\nmissing.txt\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--quiet", "--cwd"])
+        .arg(dir.path())
+        .args(["--files-from", "list.txt", "search", "hello"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true);
+    assert!(v["match_count"].as_u64().unwrap_or(0) >= 1);
+    let skipped = v["skipped"]
+        .as_array()
+        .expect("skipped array for missing files-from entry");
+    assert!(
+        skipped.iter().any(|s| s.as_str() == Some("missing.txt")),
+        "expected missing.txt in skipped: {v}"
+    );
+}


### PR DESCRIPTION
## Summary

- **Search:** `--files-from` missing entries are reported as `skipped` in JSON even with `--quiet` (parity with replace after #1757).
- **Fuzzy refuse (#1758 follow-up):** when fail-closed refuses a write, soft `no_matches` JSON now includes structured `match_mode`, `match_score`, and `matched_text` for the best candidate (CLI replace and tx/plan), not only English in `error`.

## Test plan

- [x] `make check-fast`
- [x] Integration: search files-from missing → `skipped`
- [x] Integration: fuzzy absent-old refuse → structured match fields
- [x] Unit: tx soft no_matches folds refuse match meta