### PR TITLE
fix: report refused fuzzy paths on multi-file partial apply

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -58,7 +58,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`
 - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)
 - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts; always check `matched_text` (#1687, #1694, #1736)
-**Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, optional `matched_text` (actual span for fuzzy/anchored; may differ from `old`), and replace `match_count` (plan/tx also on each change + sum) so agents can verify fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) and the **minimum** fuzzy `match_score` across paths/ops (lowest confidence). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674, #1736, #1747).
+**Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, optional `matched_text` (actual span for fuzzy/anchored; may differ from `old`), and replace `match_count` (plan/tx also on each change + sum) so agents can verify fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) and the **minimum** fuzzy `match_score` across paths/ops (lowest confidence). When some paths write and others soft-refuse, overall ok/success may still be true: check `refused[]` (path, match_mode, match_score, matched_text, reason=`exact_old_absent` or `below_min_fuzzy_score`) so partial apply is not mistaken for full coverage. Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674, #1736, #1747).
 
 Use patchloom when:
 - Editing JSON, YAML, or TOML (parser-backed, preserves comments, output is always valid)
@@ -281,7 +281,7 @@ Plan/MCP `replace` accepts library flags (default false):
 - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).
 - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).
 Example: `{"op":"replace","path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
-Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`), optional `matched_text` for fuzzy/anchored spans, and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674, #1736).
+Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`), optional `matched_text` for fuzzy/anchored spans, and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674, #1736). Partial soft-refuses list `refused[]` with reason (`exact_old_absent` / `below_min_fuzzy_score`); do not treat ok/success alone as full multi-path coverage.
 
 ## AST-aware operations
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -91,8 +91,8 @@ use crate::write::{EolMode, WritePolicy, atomic_write};
 
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use crate::tx::{
-    TxChange, TxDocMutation, TxLintResult, TxOutput as PlanReport, TxReadResult, TxSearchMatch,
-    TxSearchResult,
+    TxChange, TxDocMutation, TxLintResult, TxOutput as PlanReport, TxReadResult, TxRefused,
+    TxSearchMatch, TxSearchResult,
 };
 
 mod doc;

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -143,7 +143,7 @@ resort for typos in non-AST text (prose, comments), not a general rename tool.\n
              - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
              - Project rename: `api::ast_rename_project(root, old, new, &opts, guard)` (#1689)\n\
              - Fuzzy tip: bare-identifier typos use token span matching; prefer `min_fuzzy_score` (e.g. 0.80) for agent hosts; always check `matched_text` (#1687, #1694, #1736)\n\
-             **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, optional `matched_text` (actual span for fuzzy/anchored; may differ from `old`), and replace `match_count` (plan/tx also on each change + sum) so agents can verify fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) and the **minimum** fuzzy `match_score` across paths/ops (lowest confidence). Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674, #1736, #1747).\n\n",
+             **Match reporting in JSON:** CLI `replace --json`, MCP `replace_text` / `batch_replace` / `execute_plan`, and library `EditResult` report `match_mode` (`exact`/`fuzzy`/`anchored`), optional `match_score`, optional `matched_text` (actual span for fuzzy/anchored; may differ from `old`), and replace `match_count` (plan/tx also on each change + sum) so agents can verify fuzzy sites. Multi-file / multi-op aggregates use worst-case rollup (`fuzzy` > `anchored` > `exact`) and the **minimum** fuzzy `match_score` across paths/ops (lowest confidence). When some paths write and others soft-refuse, overall ok/success may still be true: check `refused[]` (path, match_mode, match_score, matched_text, reason=`exact_old_absent` or `below_min_fuzzy_score`) so partial apply is not mistaken for full coverage. Soft no-match CLI JSON may include `similar_targets` (did-you-mean) for literal patterns (#1669, #1674, #1736, #1747).\n\n",
         );
     }
     if show_cli {
@@ -432,7 +432,7 @@ resort for typos in non-AST text (prose, comments), not a general rename tool.\n
                  - `fuzzy`: similarity fallback when exact match fails (also with before_context/after_context).\n\
                  Example: `{\"op\":\"replace\",\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
                  \"command_position\":true,\"require_change\":true}`\n\
-                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`), optional `matched_text` for fuzzy/anchored spans, and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674, #1736).\n\n");
+                 Successful plan/tx and `batch_replace` JSON includes `match_mode` (`exact`/`fuzzy`/`anchored`), optional `matched_text` for fuzzy/anchored spans, and `match_count` on replace-backed changes plus worst-case aggregate mode and sum of counts when any replace matched (#1674, #1736). Partial soft-refuses list `refused[]` with reason (`exact_old_absent` / `below_min_fuzzy_score`); do not treat ok/success alone as full multi-path coverage.\n\n");
         }
     }
 
@@ -815,8 +815,10 @@ mod tests {
                 && mcp.contains("match_mode")
                 && mcp.contains("matched_text")
                 && mcp.contains("allow_absent_old")
-                && mcp.contains("fail closed"),
-            "MCP-only agent-rules must document replace_text flags and fuzzy fail-closed (#1758)"
+                && mcp.contains("fail closed")
+                && mcp.contains("refused[]")
+                && mcp.contains("below_min_fuzzy_score"),
+            "MCP-only agent-rules must document replace_text flags, fuzzy fail-closed, and refused[]"
         );
     }
 

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -121,8 +121,28 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if global.json {
-        if !multi && outputs.len() == 1 {
+        if !multi && outputs.len() == 1 && errors.is_empty() {
             global.emit_json(&outputs[0])?;
+        } else if multi && !errors.is_empty() {
+            // Partial multi-path: bare success array hides failed paths from agents
+            // that only parse stdout. Envelope with skipped[] + error_kind.
+            #[derive(Serialize)]
+            struct PartialReadReport {
+                ok: bool,
+                files: Vec<ReadOutput>,
+                skipped: Vec<String>,
+                error_kind: &'static str,
+                error: String,
+            }
+            // Errors are "{path}: {io}"; keep full diagnostic string.
+            let report = PartialReadReport {
+                ok: false,
+                files: outputs,
+                skipped: errors.clone(),
+                error_kind: "not_found",
+                error: format!("partial read failure: {} path(s) failed", errors.len()),
+            };
+            global.emit_json(&report)?;
         } else {
             global.emit_json(&outputs)?;
         }

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -1,3 +1,6 @@
+//! size-waiver: accepted single-domain bulk (policy #1408). CLI replace scan,
+//! context/fuzzy routing, and agent JSON honesty for matches/refuses is one unit.
+
 use crate::cli::global::GlobalFlags;
 use crate::diff::render_diffs_colored;
 use crate::exit;
@@ -176,6 +179,25 @@ struct ReplaceOutput {
     /// Present under `--json` even when `--quiet` suppresses stderr (#1756).
     #[serde(skip_serializing_if = "Option::is_none")]
     skipped: Option<Vec<String>>,
+    /// Files where fuzzy/similarity found a candidate but did not write
+    /// (exact old absent without `allow_absent_old`). Present on partial multi-file
+    /// success so agents do not treat overall ok as full coverage.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refused: Option<Vec<RefuseFileResult>>,
+}
+
+/// Per-file soft refuse honesty (fuzzy fail-closed without a write).
+#[derive(Debug, Clone, Serialize)]
+struct RefuseFileResult {
+    path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    match_mode: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    match_score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matched_text: Option<String>,
+    /// Machine-readable reason (`exact_old_absent`).
+    reason: &'static str,
 }
 
 /// Result of processing a single file.
@@ -349,6 +371,39 @@ fn make_file_results(replacements: &[FileReplacement]) -> Vec<ReplaceFileResult>
         .collect()
 }
 
+/// Files with recorded match meta but no write (fuzzy refuse / floor skip).
+fn collect_refused_files(
+    cwd: &std::path::Path,
+    changes: &[(std::path::PathBuf, String, String)],
+    meta: &std::collections::HashMap<std::path::PathBuf, crate::tx::ReplaceMatchMeta>,
+) -> Option<Vec<RefuseFileResult>> {
+    let mut out = Vec::new();
+    for (path, m) in meta {
+        if changes.iter().any(|(c, _, _)| c == path) {
+            continue;
+        }
+        // Only surface candidates that were found but not applied (count 0).
+        if m.match_count != 0 || m.matched_text.is_none() {
+            continue;
+        }
+        let reason = if m.mode == crate::api::MatchMode::Fuzzy {
+            "exact_old_absent"
+        } else {
+            "no_write"
+        };
+        out.push(RefuseFileResult {
+            path: crate::files::relative_display(path, cwd)
+                .to_string_lossy()
+                .into_owned(),
+            match_mode: Some(match_mode_str(m.mode)),
+            match_score: m.score,
+            matched_text: m.matched_text.clone(),
+            reason,
+        });
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
 /// Candidate honesty from soft refuses (no write): fuzzy fail-closed (#1758)
 /// or floor reject with recorded meta. Single-path meta surfaces mode/score/span.
 fn aggregate_refuse_match_meta(
@@ -509,6 +564,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     matched_text: None,
                     similar_targets: None,
                     skipped: skipped.clone(),
+                    refused: None,
                 };
                 global.emit_json(&output)?;
                 if !global.quiet {
@@ -547,6 +603,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 matched_text: None,
                 similar_targets: None,
                 skipped: skipped.clone(),
+                refused: None,
             };
             global.emit_json(&output)?;
             if !global.quiet && !global.json && !global.jsonl {
@@ -572,6 +629,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 matched_text: None,
                 similar_targets: None,
                 skipped: skipped.clone(),
+                refused: None,
             };
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
@@ -614,6 +672,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             matched_text: None,
             similar_targets: similar.clone(),
             skipped: skipped.clone(),
+            refused: None,
         };
         global.emit_json(&output)?;
         if !global.quiet && !global.json && !global.jsonl {
@@ -679,6 +738,11 @@ fn replace_output(
 ) -> anyhow::Result<u8> {
     use crate::cmd::write_mode::{FinalizeCallbacks, finalize_report};
 
+    let refused = collect_refused_files(
+        cwd,
+        &result.exec_result.changes,
+        &result.exec_result.replace_match_meta,
+    );
     let (agg_mode, agg_score) = aggregate_match_meta(files);
     let build_output = |diff: Option<String>| ReplaceOutput {
         ok: true,
@@ -698,6 +762,7 @@ fn replace_output(
         },
         similar_targets: None,
         skipped: skipped.clone(),
+        refused: refused.clone(),
     };
 
     finalize_report(
@@ -713,6 +778,18 @@ fn replace_output(
                     println!("{total_matches} match(es) in {file_count} file(s)");
                     for f in files {
                         println!("  {}: {} match(es)", f.path, f.match_count);
+                    }
+                }
+                if !g.quiet
+                    && !g.json
+                    && !g.jsonl
+                    && let Some(ref refused) = refused
+                {
+                    for r in refused {
+                        eprintln!(
+                            "refused {}: {} (use --allow-absent-old to apply fuzzy candidate)",
+                            r.path, r.reason
+                        );
                     }
                 }
                 Ok(())
@@ -733,6 +810,18 @@ fn replace_output(
                         }
                     }
                 }
+                if !g.quiet
+                    && !g.json
+                    && !g.jsonl
+                    && let Some(ref refused) = refused
+                {
+                    for r in refused {
+                        eprintln!(
+                            "refused {}: {} (use --allow-absent-old to apply fuzzy candidate)",
+                            r.path, r.reason
+                        );
+                    }
+                }
                 Ok(())
             },
             on_preview: |g: &GlobalFlags,
@@ -743,6 +832,18 @@ fn replace_output(
                     g.emit_json(&build_output(diff_text))?;
                 } else if !g.emit_json_items(files)? && !diffs.is_empty() {
                     print!("{}", render_diffs_colored(diffs, g.should_color()));
+                }
+                if !g.quiet
+                    && !g.json
+                    && !g.jsonl
+                    && let Some(ref refused) = refused
+                {
+                    for r in refused {
+                        eprintln!(
+                            "refused {}: {} (use --allow-absent-old to apply fuzzy candidate)",
+                            r.path, r.reason
+                        );
+                    }
                 }
                 Ok(())
             },
@@ -806,6 +907,7 @@ fn run_context_replace(
             matched_text: None,
             similar_targets: None,
             skipped: skipped.clone(),
+            refused: None,
         };
         global.emit_json(&empty)?;
         if args.if_exists {
@@ -869,6 +971,11 @@ fn run_context_replace(
         // Soft refuse (#1758) records candidate honesty without a write.
         let (refuse_mode, refuse_score, refuse_matched) =
             aggregate_refuse_match_meta(&result.exec_result.replace_match_meta);
+        let refused = collect_refused_files(
+            &cwd,
+            &result.exec_result.changes,
+            &result.exec_result.replace_match_meta,
+        );
         let empty = ReplaceOutput {
             ok: args.if_exists,
             match_count: 0,
@@ -887,6 +994,7 @@ fn run_context_replace(
             matched_text: refuse_matched,
             similar_targets: None,
             skipped: skipped.clone(),
+            refused,
         };
         global.emit_json(&empty)?;
         if args.if_exists {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -386,11 +386,13 @@ fn collect_refused_files(
         if m.match_count != 0 || m.matched_text.is_none() {
             continue;
         }
-        let reason = if m.mode == crate::api::MatchMode::Fuzzy {
-            "exact_old_absent"
-        } else {
-            "no_write"
-        };
+        let reason = m
+            .refuse_reason
+            .unwrap_or(if m.mode == crate::api::MatchMode::Fuzzy {
+                "exact_old_absent"
+            } else {
+                "no_write"
+            });
         out.push(RefuseFileResult {
             path: crate::files::relative_display(path, cwd)
                 .to_string_lossy()

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -187,6 +187,9 @@ struct TidyCheckOutput {
     ok: bool,
     issue_count: usize,
     issues: Vec<TidyIssue>,
+    /// Paths from `--files-from` that were missing (agent honesty).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skipped: Option<Vec<String>>,
 }
 
 /// Render issues to stdout.
@@ -194,12 +197,17 @@ struct TidyCheckOutput {
 /// Structured modes propagate serialize errors (`?`) instead of discarding
 /// them (`let _ =` / `if let Ok`), so `--json`/`--jsonl` never looks empty
 /// while the exit code still reports issues (#1651 class).
-pub(super) fn render_issues(issues: &[TidyIssue], global: &GlobalFlags) -> anyhow::Result<()> {
+pub(super) fn render_issues(
+    issues: &[TidyIssue],
+    global: &GlobalFlags,
+    skipped: Option<Vec<String>>,
+) -> anyhow::Result<()> {
     if global.json {
         let output = TidyCheckOutput {
             ok: issues.is_empty(),
             issue_count: issues.len(),
             issues: issues.to_vec(),
+            skipped,
         };
         global.emit_json(&output)?;
     } else if global.jsonl {
@@ -229,9 +237,10 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(exit::FAILURE);
     }
+    let skipped = crate::files::files_from_missing_entries(global, &cwd)?;
     let issues = collect_issues(paths, global)?;
     if !global.quiet || global.json || global.jsonl {
-        render_issues(&issues, global)?;
+        render_issues(&issues, global, skipped)?;
     }
     if issues.is_empty() {
         Ok(exit::SUCCESS)

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -23,6 +23,9 @@ struct TidyFixOutput {
     files: Vec<TidyFixFileResult>,
     #[serde(skip_serializing_if = "Option::is_none")]
     diff: Option<String>,
+    /// Paths from `--files-from` that were missing (agent honesty; #1756 class).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skipped: Option<Vec<String>>,
 }
 
 /// Convert `EolMode` to the string format expected by `Operation::TidyFix`.
@@ -43,6 +46,7 @@ pub(super) fn tidy_fix_output(
     result: ExecutionResult,
     dirty_rel_paths: &[String],
     cwd: &Path,
+    skipped: Option<Vec<String>>,
 ) -> anyhow::Result<u8> {
     use crate::cmd::write_mode::{FinalizeCallbacks, finalize_report};
 
@@ -59,7 +63,7 @@ pub(super) fn tidy_fix_output(
         true,
         FinalizeCallbacks {
             on_check: |g: &GlobalFlags, _has: bool, _diffs: &[crate::diff::FileDiff]| {
-                emit_tidy_fix_output(g, &fix_files, None)?;
+                emit_tidy_fix_output(g, &fix_files, None, skipped.clone())?;
                 if !g.quiet && !g.json && !g.jsonl {
                     for p in dirty_rel_paths {
                         println!("{p}");
@@ -71,14 +75,14 @@ pub(super) fn tidy_fix_output(
                        _has: bool,
                        _diffs: &[crate::diff::FileDiff],
                        diff_text: Option<String>| {
-                emit_tidy_fix_output(g, &fix_files, diff_text)?;
+                emit_tidy_fix_output(g, &fix_files, diff_text, skipped.clone())?;
                 Ok(())
             },
             on_preview: |g: &GlobalFlags,
                          _has: bool,
                          diffs: &[crate::diff::FileDiff],
                          diff_text: Option<String>| {
-                emit_tidy_fix_output(g, &fix_files, diff_text)?;
+                emit_tidy_fix_output(g, &fix_files, diff_text, skipped.clone())?;
                 if !g.json && !g.jsonl && !g.quiet && !diffs.is_empty() {
                     print!("{}", render_diffs_colored(diffs, g.should_color()));
                 }
@@ -103,6 +107,7 @@ fn emit_tidy_fix_output(
     global: &GlobalFlags,
     fix_files: &[TidyFixFileResult],
     diff_text: Option<String>,
+    skipped: Option<Vec<String>>,
 ) -> anyhow::Result<()> {
     if global.json {
         let output = TidyFixOutput {
@@ -110,6 +115,7 @@ fn emit_tidy_fix_output(
             files_changed: fix_files.len(),
             files: fix_files.to_vec(),
             diff: diff_text,
+            skipped,
         };
         global.emit_json(&output)?;
     } else if global.jsonl {
@@ -180,6 +186,7 @@ pub(super) fn run_fix(
 
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, &paths)?;
+    let skipped = crate::files::files_from_missing_entries(global, &cwd)?;
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
     let fix_file_paths = crate::collect_file_paths_opts(&paths, global, true, Some(&cwd))?;
     let glob_roots = crate::collect_glob_roots_from_global(&paths, global, Some(&cwd))?;
@@ -243,7 +250,7 @@ pub(super) fn run_fix(
             global.emit_error_json_kind(Some("not_found"), &msg)?;
             return Ok(exit::FAILURE);
         }
-        emit_tidy_fix_output(global, &[], None)?;
+        emit_tidy_fix_output(global, &[], None, skipped)?;
         return Ok(exit::SUCCESS);
     }
 
@@ -271,5 +278,5 @@ pub(super) fn run_fix(
     // write-policy fields use the effective check-parity defaults above.
     let (cwd, result) = crate::cmd::output::stage_for_write(WriteSource::Operations(ops), global)?;
 
-    tidy_fix_output(global, result, &dirty_rel_paths, &cwd)
+    tidy_fix_output(global, result, &dirty_rel_paths, &cwd, skipped)
 }

--- a/src/cmd/tidy/tests.rs
+++ b/src/cmd/tidy/tests.rs
@@ -472,7 +472,7 @@ fn check_render_issues_json_ok() {
         json: true,
         ..GlobalFlags::default()
     };
-    render_issues(&issues, &global).expect("json emit must succeed for TidyIssue");
+    render_issues(&issues, &global, None).expect("json emit must succeed for TidyIssue");
 }
 
 #[test]
@@ -486,7 +486,7 @@ fn check_render_issues_jsonl_ok() {
         jsonl: true,
         ..GlobalFlags::default()
     };
-    render_issues(&issues, &global).expect("jsonl emit must succeed for TidyIssue");
+    render_issues(&issues, &global, None).expect("jsonl emit must succeed for TidyIssue");
 }
 
 /// Regression: `tidy check --quiet --json` must still emit JSON output.

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -49,6 +49,50 @@ fn print_diffs(changes: &[(PathBuf, String, String)], cwd: &Path, color: bool) {
     print!("{}", format_diff_result_colored(&result, color));
 }
 
+/// Human-mode soft-refuse + no_matches diagnostics (parity with CLI replace).
+/// Uses `!quiet`, not `show_status()`, so scripts/piped stderr still see them.
+fn print_human_replace_honesty(result: &TxExecResult, cwd: &Path, quiet: bool) {
+    if quiet {
+        return;
+    }
+    // Full soft no-match: print engine hint (floor / exact_old_absent / did-you-mean).
+    if result.replace_no_matches
+        && let Some(hint) = result.replace_hint.as_deref().filter(|h| !h.is_empty())
+    {
+        eprintln!("{hint}");
+    }
+    // Partial multi-op: list soft-refused paths from meta.
+    let mut refused: Vec<_> = result
+        .replace_match_meta
+        .iter()
+        .filter(|(path, m)| {
+            m.match_count == 0
+                && m.matched_text.is_some()
+                && !result.changes.iter().any(|(c, _, _)| c == *path)
+                && !result.deletions.contains(*path)
+        })
+        .map(|(path, m)| {
+            let rel = crate::files::relative_display(path, cwd)
+                .to_string_lossy()
+                .into_owned();
+            let reason = m
+                .refuse_reason
+                .unwrap_or(if m.mode == crate::api::MatchMode::Fuzzy {
+                    "exact_old_absent"
+                } else {
+                    "no_write"
+                });
+            (rel, reason)
+        })
+        .collect();
+    refused.sort_by(|a, b| a.0.cmp(&b.0));
+    for (path, reason) in refused {
+        eprintln!(
+            "refused {path}: {reason} (use allow_absent_old / --allow-absent-old for exact_old_absent)"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Direct execution (MCP / in-process callers)
 // ---------------------------------------------------------------------------
@@ -191,13 +235,16 @@ fn commit_and_finalize(
             let ok = emit_output_json(&output, ctx.compact);
             return Ok(exit_after_emit(ok, exit::NO_MATCHES));
         }
+        print_human_replace_honesty(result, ctx.cwd, global.quiet);
         return Ok(exit::NO_MATCHES);
     }
     if ctx.structured {
         let output = build_full_tx_output("success", result, ctx.cwd);
         let ok = emit_output_json(&output, ctx.compact);
         return Ok(exit_after_emit(ok, exit::SUCCESS));
-    } else if global.show_status() {
+    }
+    print_human_replace_honesty(result, ctx.cwd, global.quiet);
+    if global.show_status() {
         let extra_deletions = result
             .deletions
             .iter()
@@ -463,6 +510,7 @@ pub(crate) fn run_parsed_plan(
                     let ok = emit_output_json(&output, compact);
                     return Ok(exit_after_emit(ok, exit::NO_MATCHES));
                 }
+                print_human_replace_honesty(&result, &cwd, global.quiet);
                 return Ok(exit::NO_MATCHES);
             }
             if structured {
@@ -482,6 +530,7 @@ pub(crate) fn run_parsed_plan(
                 result.changes.len() + pending_deletions
             );
         }
+        print_human_replace_honesty(&result, &cwd, global.quiet);
         return Ok(exit::CHANGES_DETECTED);
     }
 
@@ -504,6 +553,7 @@ pub(crate) fn run_parsed_plan(
             let ok = emit_output_json(&output, compact);
             return Ok(exit_after_emit(ok, exit::NO_MATCHES));
         }
+        print_human_replace_honesty(&result, &cwd, global.quiet);
         return Ok(exit::NO_MATCHES);
     }
 
@@ -537,6 +587,7 @@ pub(crate) fn run_parsed_plan(
     } else if !result.changes.is_empty() {
         print_diffs(&result.changes, &cwd, global.should_color());
     }
+    print_human_replace_honesty(&result, &cwd, global.quiet);
     if !result.no_effective_changes && global.show_status() {
         let extra_deletions = result
             .deletions

--- a/src/json_emit.rs
+++ b/src/json_emit.rs
@@ -238,6 +238,7 @@ mod tests {
             match_score: None,
             match_count: None,
             matched_text: None,
+            refused: vec![],
         };
         let emit = serialize_structured(&report, true);
         assert!(!emit.primary_ok);

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -36,8 +36,8 @@ pub(crate) use output::{
     format_error_with_backup_hint, match_mode_label,
 };
 pub use output::{
-    TxChange, TxDocMutation, TxLintResult, TxOutput, TxReadResult, TxSearchMatch, TxSearchResult,
-    exit_code_from_tx_output,
+    TxChange, TxDocMutation, TxLintResult, TxOutput, TxReadResult, TxRefused, TxSearchMatch,
+    TxSearchResult, exit_code_from_tx_output,
 };
 
 // validate.rs (test-only re-exports for src/cmd/tx.rs tests)

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -65,6 +65,26 @@ pub struct TxOutput {
     /// Compare to requested `old` after fuzzy apply (#1736).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub matched_text: Option<String>,
+    /// Soft-refuse paths where fuzzy found a candidate but did not write
+    /// (exact old absent without `allow_absent_old`). Present on partial
+    /// multi-op success so agents do not treat overall ok as full coverage
+    /// (parity with CLI `replace` `refused[]`).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub refused: Vec<TxRefused>,
+}
+
+/// One soft-refuse path in a plan/tx report (fuzzy fail-closed without a write).
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TxRefused {
+    pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub match_mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub match_score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub matched_text: Option<String>,
+    /// Machine-readable reason (`exact_old_absent` or `no_write`).
+    pub reason: String,
 }
 
 /// One doc delete / delete-where outcome inside a plan/tx report (#1439).
@@ -325,7 +345,7 @@ pub(crate) fn build_tx_output_with_meta(
     // Soft full refuses (fuzzy fail-closed #1758) store honesty without a write.
     // Fold only when there is no write surface: otherwise refuse meta would poison
     // success aggregates (e.g. exact multi-file apply + one soft refuse → match_mode
-    // "fuzzy"). Partial refuses are reported via CLI `refused[]` instead.
+    // "fuzzy"). Partial refuses are listed in `refused[]` instead.
     if changes.is_empty() && deletions.is_empty() {
         for m in replace_match_meta.values() {
             any_replace_meta = true;
@@ -341,6 +361,31 @@ pub(crate) fn build_tx_output_with_meta(
             }
         }
     }
+
+    // Paths with recorded meta but no write (fuzzy refuse / floor skip).
+    let mut refused = Vec::new();
+    for (path, m) in replace_match_meta {
+        if changes.iter().any(|(c, _, _)| c == path) || deletions.contains(path) {
+            continue;
+        }
+        // Only surface candidates that were found but not applied (count 0).
+        if m.match_count != 0 || m.matched_text.is_none() {
+            continue;
+        }
+        let reason = if m.mode == crate::api::MatchMode::Fuzzy {
+            "exact_old_absent"
+        } else {
+            "no_write"
+        };
+        refused.push(TxRefused {
+            path: display_path(path),
+            match_mode: Some(match_mode_label(m.mode).to_string()),
+            match_score: m.score,
+            matched_text: m.matched_text.clone(),
+            reason: reason.to_string(),
+        });
+    }
+    refused.sort_by(|a, b| a.path.cmp(&b.path));
 
     let (top_mode, top_score) = match agg_mode {
         Some(m) => (
@@ -386,6 +431,7 @@ pub(crate) fn build_tx_output_with_meta(
         } else {
             None
         },
+        refused,
     }
 }
 
@@ -474,6 +520,7 @@ pub(crate) fn build_error_output(
         match_score: None,
         match_count: None,
         matched_text: None,
+        refused: Vec::new(),
     }
 }
 
@@ -613,6 +660,7 @@ mod tests {
             match_score: None,
             match_count: None,
             matched_text: None,
+            refused: Vec::new(),
         }
     }
 
@@ -637,6 +685,7 @@ mod tests {
             match_score: None,
             match_count: None,
             matched_text: None,
+            refused: Vec::new(),
         }
     }
 
@@ -1075,6 +1124,11 @@ mod tests {
         assert_eq!(out.match_mode.as_deref(), Some("exact"));
         assert!(out.match_score.is_none());
         assert_eq!(out.match_count, Some(1));
+        assert_eq!(out.refused.len(), 1);
+        assert_eq!(out.refused[0].path, "b.txt");
+        assert_eq!(out.refused[0].match_mode.as_deref(), Some("fuzzy"));
+        assert_eq!(out.refused[0].reason, "exact_old_absent");
+        assert_eq!(out.refused[0].matched_text.as_deref(), Some("helo world"));
     }
 
     /// Hosts may deserialize older plan/tx JSON that never had match honesty

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -322,23 +322,23 @@ pub(crate) fn build_tx_output_with_meta(
         }
     }
 
-    // Soft refuses (fuzzy fail-closed #1758, floor reject with recorded
-    // candidate) store honesty in replace_match_meta without a write. Fold
-    // those paths so no_matches JSON still exposes match_mode/score/matched_text.
-    for (path, m) in replace_match_meta {
-        if changes.iter().any(|(c, _, _)| c == path) || deletions.contains(path) {
-            continue;
-        }
-        any_replace_meta = true;
-        agg_mode = Some(merge_match_modes(agg_mode, m.mode));
-        if matches!(m.mode, crate::api::MatchMode::Fuzzy)
-            && let Some(s) = m.score
-        {
-            agg_score = Some(agg_score.map_or(s, |prev| prev.min(s)));
-        }
-        agg_count = agg_count.saturating_add(m.match_count);
-        if top_matched_text.is_none() {
-            top_matched_text = m.matched_text.clone();
+    // Soft full refuses (fuzzy fail-closed #1758) store honesty without a write.
+    // Fold only when there is no write surface: otherwise refuse meta would poison
+    // success aggregates (e.g. exact multi-file apply + one soft refuse → match_mode
+    // "fuzzy"). Partial refuses are reported via CLI `refused[]` instead.
+    if changes.is_empty() && deletions.is_empty() {
+        for m in replace_match_meta.values() {
+            any_replace_meta = true;
+            agg_mode = Some(merge_match_modes(agg_mode, m.mode));
+            if matches!(m.mode, crate::api::MatchMode::Fuzzy)
+                && let Some(s) = m.score
+            {
+                agg_score = Some(agg_score.map_or(s, |prev| prev.min(s)));
+            }
+            agg_count = agg_count.saturating_add(m.match_count);
+            if top_matched_text.is_none() {
+                top_matched_text = m.matched_text.clone();
+            }
         }
     }
 
@@ -1023,6 +1023,58 @@ mod tests {
         assert_eq!(out.match_score, Some(0.987));
         assert_eq!(out.matched_text.as_deref(), Some("compute_checksum"));
         assert_eq!(out.match_count, Some(0));
+    }
+
+    /// Partial apply + soft refuse must not report aggregate match_mode=fuzzy.
+    #[test]
+    fn build_full_tx_output_partial_success_ignores_refuse_meta_in_aggregate() {
+        use std::collections::HashMap;
+        let cwd = Path::new("/project");
+        let changed = PathBuf::from("/project/a.txt");
+        let refused = PathBuf::from("/project/b.txt");
+        let mut meta = HashMap::new();
+        meta.insert(
+            changed.clone(),
+            ReplaceMatchMeta {
+                mode: crate::api::MatchMode::Exact,
+                score: None,
+                match_count: 1,
+                matched_text: None,
+            },
+        );
+        meta.insert(
+            refused,
+            ReplaceMatchMeta {
+                mode: crate::api::MatchMode::Fuzzy,
+                score: Some(0.97),
+                match_count: 0,
+                matched_text: Some("helo world".into()),
+            },
+        );
+        let mut result = TxExecResult {
+            changes: vec![(changed, "hello world\n".into(), "hi\n".into())],
+            deletions: HashSet::new(),
+            existed_before: {
+                let mut s = HashSet::new();
+                s.insert(PathBuf::from("/project/a.txt"));
+                s
+            },
+            pending: HashMap::new(),
+            tx_reads: vec![],
+            tx_searches: vec![],
+            tx_lints: vec![],
+            tx_mutations: vec![],
+            no_effective_changes: false,
+            replace_no_matches: false,
+            replace_hint: Some("exact old absent".into()),
+            replace_match_meta: meta,
+            renames: vec![],
+        };
+        let out = build_full_tx_output("success", &mut result, cwd);
+        assert_eq!(out.status, "success");
+        assert_eq!(out.match_mode.as_deref(), Some("exact"));
+        assert!(out.match_score.is_none());
+        assert_eq!(out.match_count, Some(1));
     }
 
     /// Hosts may deserialize older plan/tx JSON that never had match honesty

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -193,6 +193,9 @@ pub(crate) struct ReplaceMatchMeta {
     pub match_count: usize,
     /// Fuzzy/anchored span text actually matched (may differ from plan `old`). #1736
     pub matched_text: Option<String>,
+    /// Soft-no-write reason when `match_count` is 0 (`exact_old_absent`,
+    /// `below_min_fuzzy_score`). Used for CLI/tx `refused[]` honesty.
+    pub refuse_reason: Option<&'static str>,
 }
 
 /// Apply mutation summaries onto a [`TxOutput`] (aggregates + list).
@@ -372,11 +375,13 @@ pub(crate) fn build_tx_output_with_meta(
         if m.match_count != 0 || m.matched_text.is_none() {
             continue;
         }
-        let reason = if m.mode == crate::api::MatchMode::Fuzzy {
-            "exact_old_absent"
-        } else {
-            "no_write"
-        };
+        let reason = m
+            .refuse_reason
+            .unwrap_or(if m.mode == crate::api::MatchMode::Fuzzy {
+                "exact_old_absent"
+            } else {
+                "no_write"
+            });
         refused.push(TxRefused {
             path: display_path(path),
             match_mode: Some(match_mode_label(m.mode).to_string()),
@@ -862,6 +867,7 @@ mod tests {
                 score: Some(0.91),
                 match_count: 1,
                 matched_text: Some("proccess".into()),
+                refuse_reason: None,
             },
         );
         let out = build_tx_output_with_meta(
@@ -907,6 +913,7 @@ mod tests {
                 score: Some(0.95),
                 match_count: 1,
                 matched_text: Some("aaa".into()),
+                refuse_reason: None,
             },
         );
         meta.insert(
@@ -916,6 +923,7 @@ mod tests {
                 score: Some(0.80),
                 match_count: 1,
                 matched_text: Some("bbb".into()),
+                refuse_reason: None,
             },
         );
         let out = build_tx_output_with_meta(
@@ -960,6 +968,7 @@ mod tests {
                 score: Some(0.88),
                 match_count: 1,
                 matched_text: Some("live_span".into()),
+                refuse_reason: None,
             },
         );
         let out = build_tx_output_with_meta(
@@ -1049,6 +1058,7 @@ mod tests {
                 score: Some(0.987),
                 match_count: 0,
                 matched_text: Some("compute_checksum".into()),
+                refuse_reason: None,
             },
         );
         let mut result = TxExecResult {
@@ -1089,6 +1099,7 @@ mod tests {
                 score: None,
                 match_count: 1,
                 matched_text: None,
+                refuse_reason: None,
             },
         );
         meta.insert(
@@ -1098,6 +1109,7 @@ mod tests {
                 score: Some(0.97),
                 match_count: 0,
                 matched_text: Some("helo world".into()),
+                refuse_reason: Some("exact_old_absent"),
             },
         );
         let mut result = TxExecResult {

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -25,6 +25,19 @@ fn record_replace_match(
     match_count: usize,
     matched_text: Option<String>,
 ) {
+    record_replace_match_with_reason(tx, path, mode, score, match_count, matched_text, None);
+}
+
+/// Like [`record_replace_match`], with optional soft-refuse reason for `refused[]`.
+fn record_replace_match_with_reason(
+    tx: &mut TxState<'_>,
+    path: &Path,
+    mode: MatchMode,
+    score: Option<f64>,
+    match_count: usize,
+    matched_text: Option<String>,
+    refuse_reason: Option<&'static str>,
+) {
     use crate::tx::output::ReplaceMatchMeta;
     let entry = tx.replace_match_meta.entry(path.to_path_buf());
     match entry {
@@ -34,6 +47,7 @@ fn record_replace_match(
                 score,
                 match_count,
                 matched_text,
+                refuse_reason,
             });
         }
         std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -53,11 +67,19 @@ fn record_replace_match(
             };
             // Prefer the first non-exact span so multi-op plans keep the fuzzy text.
             let merged_text = prev.matched_text.or(matched_text);
+            // Keep first refuse reason when both soft-refuse the path.
+            let merged_reason = prev.refuse_reason.or(refuse_reason);
             e.insert(ReplaceMatchMeta {
                 mode: merged,
                 score: merged_score,
                 match_count: prev.match_count.saturating_add(match_count),
                 matched_text: merged_text,
+                // Successful write clears soft-refuse reason.
+                refuse_reason: if prev.match_count.saturating_add(match_count) > 0 {
+                    None
+                } else {
+                    merged_reason
+                },
             });
         }
     }
@@ -279,6 +301,16 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             crate::fallback::truncate_str(old, 60),
                         ));
                         // Soft zero: still honor require_change below (#1748).
+                        // Record candidate so multi-op partial success can list refused[].
+                        record_replace_match_with_reason(
+                            tx,
+                            &file_path,
+                            mode,
+                            score,
+                            0,
+                            Some(anchor.matched_text.clone()),
+                            Some("below_min_fuzzy_score"),
+                        );
                     } else if crate::fallback::should_refuse_fuzzy_absent_old(
                         *fuzzy,
                         mode == MatchMode::Fuzzy,
@@ -292,13 +324,14 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             score,
                         ));
                         // Surface candidate honesty without counting a write match.
-                        record_replace_match(
+                        record_replace_match_with_reason(
                             tx,
                             &file_path,
                             mode,
                             score,
                             0,
                             Some(anchor.matched_text.clone()),
+                            Some("exact_old_absent"),
                         );
                     } else {
                         let to_text = if let Some(ib) = insert_before {
@@ -542,6 +575,15 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                                 "fuzzy match score {actual} below min_fuzzy_score {min} for {:?}",
                                 crate::fallback::truncate_str(old, 60),
                             ));
+                            record_replace_match_with_reason(
+                                tx,
+                                &file_path,
+                                mode,
+                                score,
+                                0,
+                                Some(anchor.matched_text.clone()),
+                                Some("below_min_fuzzy_score"),
+                            );
                             // Skip this file; keep scanning (require_change after loop).
                             continue;
                         }
@@ -557,13 +599,14 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                                     &anchor.matched_text,
                                     score,
                                 ));
-                            record_replace_match(
+                            record_replace_match_with_reason(
                                 tx,
                                 &file_path,
                                 mode,
                                 score,
                                 0,
                                 Some(anchor.matched_text.clone()),
+                                Some("exact_old_absent"),
                             );
                             continue;
                         }

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -196,7 +196,7 @@ fn test_read_multiple_files_json() {
 }
 
 #[test]
-fn test_read_multiple_files_json_partial_failure_keeps_array() {
+fn test_read_multiple_files_json_partial_failure_reports_skipped() {
     let dir = TempDir::new().unwrap();
     let existing = dir.path().join("exists.txt");
     fs::write(&existing, "hello\n").unwrap();
@@ -210,13 +210,26 @@ fn test_read_multiple_files_json_partial_failure_keeps_array() {
         .output()
         .unwrap();
 
-    // Partial failure returns FAILURE exit code (#1166), but still outputs JSON.
+    // Partial failure: FAILURE exit + envelope so agents see skipped paths
+    // (not a bare success array that hides misses).
     assert_eq!(output.status.code(), Some(1));
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert!(json.is_array());
-    assert_eq!(json.as_array().unwrap().len(), 1);
-    assert_eq!(json[0]["path"], existing.to_str().unwrap());
-    assert_eq!(json[0]["content"], "hello\n");
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(json["error_kind"], "not_found", "{json}");
+    assert!(json["files"].is_array(), "{json}");
+    assert_eq!(json["files"].as_array().unwrap().len(), 1);
+    assert_eq!(json["files"][0]["path"], existing.to_str().unwrap());
+    assert_eq!(json["files"][0]["content"], "hello\n");
+    let skipped = json["skipped"]
+        .as_array()
+        .expect("partial multi-read must list skipped");
+    assert_eq!(skipped.len(), 1, "{json}");
+    assert!(
+        skipped[0]
+            .as_str()
+            .is_some_and(|s| s.contains("no-such-file-json-array-shape")),
+        "skipped should name missing path: {json}"
+    );
 }
 
 #[test]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2377,3 +2377,58 @@ fn test_replace_multi_fuzzy_partial_reports_refused() {
         "refused must name candidate: {v}"
     );
 }
+
+/// Multi-file floor: exact hits must not hide below-min_fuzzy_score on other paths.
+#[test]
+fn test_replace_multi_fuzzy_floor_reports_refused() {
+    let dir = TempDir::new().unwrap();
+    let exact = dir.path().join("exact.txt");
+    let typo = dir.path().join("typo.txt");
+    fs::write(&exact, "hello world\n").unwrap();
+    fs::write(&typo, "helo world\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "hello world",
+            "--new",
+            "hi",
+            "--fuzzy",
+            "--min-fuzzy-score",
+            "0.99",
+            "--apply",
+        ])
+        .arg(&exact)
+        .arg(&typo)
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "partial exact apply should succeed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["file_count"], 1);
+    assert_eq!(fs::read_to_string(&exact).unwrap(), "hi\n");
+    assert_eq!(
+        fs::read_to_string(&typo).unwrap(),
+        "helo world\n",
+        "floor reject must not rewrite"
+    );
+    let refused = v["refused"]
+        .as_array()
+        .expect("partial multi-file floor must report refused paths");
+    assert_eq!(refused.len(), 1, "one refused path: {v}");
+    assert_eq!(refused[0]["reason"], "below_min_fuzzy_score");
+    assert_eq!(refused[0]["match_mode"], "fuzzy");
+    assert!(
+        refused[0]["matched_text"]
+            .as_str()
+            .is_some_and(|t| t.contains("helo")),
+        "refused must name candidate: {v}"
+    );
+}

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2324,3 +2324,56 @@ fn test_replace_fuzzy_absent_old_fails_closed() {
     assert!(on_disk.contains("compute_digest"), "{on_disk}");
     assert!(!on_disk.contains("compute_checksum"), "{on_disk}");
 }
+
+/// Multi-file fuzzy: exact hits must not hide refuse on other paths.
+#[test]
+fn test_replace_multi_fuzzy_partial_reports_refused() {
+    let dir = TempDir::new().unwrap();
+    let exact = dir.path().join("exact.txt");
+    let typo = dir.path().join("typo.txt");
+    fs::write(&exact, "hello world\n").unwrap();
+    fs::write(&typo, "helo world\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "hello world",
+            "--new",
+            "hi",
+            "--fuzzy",
+            "--apply",
+        ])
+        .arg(&exact)
+        .arg(&typo)
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "partial exact apply should succeed: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["file_count"], 1);
+    assert_eq!(fs::read_to_string(&exact).unwrap(), "hi\n");
+    assert_eq!(
+        fs::read_to_string(&typo).unwrap(),
+        "helo world\n",
+        "typo file must not rewrite without allow_absent_old"
+    );
+    let refused = v["refused"]
+        .as_array()
+        .expect("partial multi-file fuzzy must report refused paths");
+    assert_eq!(refused.len(), 1, "one refused path: {v}");
+    assert_eq!(refused[0]["reason"], "exact_old_absent");
+    assert_eq!(refused[0]["match_mode"], "fuzzy");
+    assert!(
+        refused[0]["matched_text"]
+            .as_str()
+            .is_some_and(|t| t.contains("helo")),
+        "refused must name candidate: {v}"
+    );
+}

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -639,3 +639,37 @@ fn test_tidy_fix_format_failure_json_error_kind() {
     // Tidy write still applied before format failure.
     assert_eq!(fs::read_to_string(&file).unwrap(), "x\n");
 }
+
+/// --files-from missing entries must appear in tidy fix JSON skipped[] (agent honesty).
+#[test]
+fn test_tidy_fix_files_from_missing_reports_skipped() {
+    let dir = TempDir::new().unwrap();
+    let existing = dir.path().join("a.txt");
+    // Dirty so fix reports a change; also covers clean+skipped path.
+    fs::write(&existing, "x  ").unwrap();
+    let list = dir.path().join("list.txt");
+    fs::write(&list, "a.txt\nmissing.txt\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["--files-from", "list.txt", "tidy", "fix", "--apply"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], true, "{parsed}");
+    assert_eq!(parsed["files_changed"], 1, "{parsed}");
+    let skipped = parsed["skipped"]
+        .as_array()
+        .expect("tidy fix must report files-from missing in skipped");
+    assert_eq!(skipped.len(), 1, "{parsed}");
+    assert_eq!(skipped[0], "missing.txt");
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8274,3 +8274,77 @@ fn test_tx_replace_partial_fuzzy_reports_refused() {
         "refused must name candidate: {json}"
     );
 }
+
+/// Multi-op floor: exact apply must not hide below-min_fuzzy_score on siblings.
+#[test]
+fn test_tx_replace_partial_floor_reports_refused() {
+    let dir = TempDir::new().unwrap();
+    let exact = dir.path().join("exact.txt");
+    let typo = dir.path().join("typo.txt");
+    fs::write(&exact, "hello world\n").unwrap();
+    fs::write(&typo, "helo world\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "replace",
+                "path": "exact.txt",
+                "old": "hello world",
+                "new": "hi",
+                "fuzzy": true,
+                "min_fuzzy_score": 0.99
+            },
+            {
+                "op": "replace",
+                "path": "typo.txt",
+                "old": "hello world",
+                "new": "hi",
+                "fuzzy": true,
+                "min_fuzzy_score": 0.99
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "partial exact apply should succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(json["files_changed"], 1, "{json}");
+    assert_eq!(json["match_mode"], "exact", "{json}");
+    assert_eq!(fs::read_to_string(&exact).unwrap(), "hi\n");
+    assert_eq!(
+        fs::read_to_string(&typo).unwrap(),
+        "helo world\n",
+        "floor reject must not rewrite"
+    );
+    let refused = json["refused"]
+        .as_array()
+        .expect("partial multi-op floor must report refused paths");
+    assert_eq!(refused.len(), 1, "one refused path: {json}");
+    assert_eq!(refused[0]["path"], "typo.txt");
+    assert_eq!(refused[0]["reason"], "below_min_fuzzy_score");
+    assert_eq!(refused[0]["match_mode"], "fuzzy");
+    assert!(
+        refused[0]["matched_text"]
+            .as_str()
+            .is_some_and(|t| t.contains("helo")),
+        "refused must name candidate: {json}"
+    );
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8199,3 +8199,78 @@ fn test_tx_replace_fuzzy_pure_in_plan() {
         "plan pure fuzzy must rewrite: {on_disk}"
     );
 }
+
+/// Multi-op fuzzy: exact apply must not hide refuse on other replace ops.
+#[test]
+fn test_tx_replace_partial_fuzzy_reports_refused() {
+    let dir = TempDir::new().unwrap();
+    let exact = dir.path().join("exact.txt");
+    let typo = dir.path().join("typo.txt");
+    fs::write(&exact, "hello world\n").unwrap();
+    fs::write(&typo, "helo world\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "replace",
+                "path": "exact.txt",
+                "old": "hello world",
+                "new": "hi",
+                "fuzzy": true
+            },
+            {
+                "op": "replace",
+                "path": "typo.txt",
+                "old": "hello world",
+                "new": "hi",
+                "fuzzy": true
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "partial exact apply should succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(json["files_changed"], 1, "{json}");
+    assert_eq!(
+        json["match_mode"], "exact",
+        "must not poison with refuse meta: {json}"
+    );
+    assert_eq!(fs::read_to_string(&exact).unwrap(), "hi\n");
+    assert_eq!(
+        fs::read_to_string(&typo).unwrap(),
+        "helo world\n",
+        "typo file must not rewrite without allow_absent_old"
+    );
+    let refused = json["refused"]
+        .as_array()
+        .expect("partial multi-op fuzzy must report refused paths");
+    assert_eq!(refused.len(), 1, "one refused path: {json}");
+    assert_eq!(refused[0]["path"], "typo.txt");
+    assert_eq!(refused[0]["reason"], "exact_old_absent");
+    assert_eq!(refused[0]["match_mode"], "fuzzy");
+    assert!(
+        refused[0]["matched_text"]
+            .as_str()
+            .is_some_and(|t| t.contains("helo")),
+        "refused must name candidate: {json}"
+    );
+}


### PR DESCRIPTION
## Summary

Agent honesty for multi-file / multi-op soft refuses and partial skips:

1. **CLI `replace`**: multi-path partial apply reports `refused[]` when fuzzy finds a candidate but does not write.
2. **`tx` / plan / MCP / batch**: same `refused[]` on `TxOutput` / `PlanReport`.
3. **Aggregate fix**: refuse meta no longer poisons top-level `match_mode` when exact writes applied.
4. **Floor rejects**: below `min_fuzzy_score` records meta with reason `below_min_fuzzy_score`.
5. **Human tx**: soft-refuse and no_matches hints print when not `--quiet`.
6. **agent-rules / PATCHLOOM.md**: document `refused[]`.
7. **Multi-file `read` partial**: JSON envelope with `files[]` + `skipped[]` + `error_kind` (not bare success array).
8. **`tidy` fix/check**: `--files-from` missing paths in `skipped[]` (parity with replace/search).

Reasons: `exact_old_absent`, `below_min_fuzzy_score` (fallback `no_write`).

## Test plan

- [x] Unit + integration for refuse / floor / aggregate
- [x] Integration: multi-read partial skipped envelope
- [x] Integration: tidy files-from skipped
- [x] `make check-fast`