### PR TITLE
fix: reject --verify without ast feature instead of silent no-op

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -350,6 +350,22 @@ pub(crate) fn run_parsed_plan(
         return Ok(exit::PARSE_ERROR);
     }
 
+    // Symbol verify needs AST. Without the feature, reject so agents do not
+    // believe --verify / plan.verify ran when it was compiled out.
+    #[cfg(not(feature = "ast"))]
+    {
+        let plan_has_verify = plan.verify.as_ref().is_some_and(|v| !v.is_empty());
+        if !verify.is_empty() || plan_has_verify {
+            let msg = "symbol verification (`--verify` / plan `verify`) requires the `ast` feature (rebuild with default features or --features ast)";
+            if structured {
+                let ok = emit_error_json("invalid_input", msg, None, compact);
+                return Ok(exit_after_emit(ok, exit::FAILURE));
+            }
+            eprintln!("tx: {msg}");
+            return Ok(exit::FAILURE);
+        }
+    }
+
     crate::verbose!(
         "tx: parsed plan with {} operations, strict={:?}",
         plan.operations.len(),

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -1488,4 +1488,31 @@ mod integrity {
             "restored file should have original content"
         );
     }
+
+    /// Without the `ast` feature, `--verify` must fail closed (not silent no-op).
+    #[test]
+    #[cfg(not(feature = "ast"))]
+    fn verify_without_ast_feature_is_invalid_input() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let txt = dir.path().join("a.txt");
+        fs::write(&txt, "hello\n").unwrap();
+        let plan_file = dir.path().join("plan.json");
+        fs::write(
+            &plan_file,
+            r#"{"operations":[{"op":"replace","path":"a.txt","old":"hello","new":"hi"}]}"#,
+        )
+        .unwrap();
+        let args = TxArgs {
+            plan: plan_file.to_str().unwrap().to_string(),
+            plan_format: None,
+            no_strict: false,
+            verify: vec!["unique_names".into()],
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_default();
+        global.apply = true;
+        global.json = true;
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
+    }
 }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -505,28 +505,27 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
     // 3. Apply filter (currently supports `has_symbol(NAME)`).
     if let Some(ref filter) = fe.filter {
         let filter = filter.trim();
-        if let Some(sym_name) = filter
+        let Some(sym_name) = filter
             .strip_prefix("has_symbol(")
             .and_then(|s| s.strip_suffix(')'))
-        {
-            let sym_name = sym_name.trim();
-            #[cfg(feature = "ast")]
-            {
-                matched.retain(|p| {
-                    let syms = crate::ast::symbols::extract_symbols_from_file(p, None);
-                    syms.iter().any(|s| s.name == sym_name)
-                });
-            }
-            #[cfg(not(feature = "ast"))]
-            {
-                let _ = sym_name;
-                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: "for_each filter `has_symbol(...)` requires the `ast` feature".into(),
-                }));
-            }
-        } else {
+        else {
             return Err(anyhow::Error::new(crate::exit::InvalidInputError {
                 msg: format!("for_each: unsupported filter expression: {filter}"),
+            }));
+        };
+        let sym_name = sym_name.trim();
+        #[cfg(feature = "ast")]
+        {
+            matched.retain(|p| {
+                let syms = crate::ast::symbols::extract_symbols_from_file(p, None);
+                syms.iter().any(|s| s.name == sym_name)
+            });
+        }
+        #[cfg(not(feature = "ast"))]
+        {
+            let _ = sym_name;
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: "for_each filter `has_symbol(...)` requires the `ast` feature".into(),
             }));
         }
     }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -10,6 +10,7 @@ use crate::plan::{self, Plan};
 use crate::tx::execute::execute_and_collect;
 use crate::tx::output::{TxOutput, build_error_output, build_full_tx_output};
 use crate::tx::validate::validate_plan_operations;
+#[cfg(feature = "ast")]
 use crate::tx::verify;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -19,6 +19,7 @@ mod output;
 mod replace_op;
 mod search_op;
 mod validate;
+#[cfg(feature = "ast")]
 pub(crate) mod verify;
 
 // Operation handler modules (extracted from the former monofile execute module).


### PR DESCRIPTION
## Summary

Without the `ast` feature, CLI `--verify` and plan `verify` were accepted but silently ignored (code compiled out). Agents could believe symbol verification ran when it did not.

- Fail closed with `error_kind: invalid_input` when verify is requested without `ast`
- Gate `tx::verify` module on `ast` (clears dead_code under mcp+cli+files without ast)
- Clippy: restructure for_each `has_symbol` filter for no-ast builds

## Test plan

- [x] `cargo test --lib --no-default-features --features 'cli,files,mcp' verify_without_ast`
- [x] Live: no-ast binary rejects `--verify unique_names`
- [x] Default features: `--verify` still works
- [x] `make check-fast`