### PR TITLE
fix: unique_names verify catches cross-file symbol collisions

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -435,7 +435,7 @@ pub(crate) fn run_parsed_plan(
     // 3c. Take pre-execution symbol snapshot for verification.
     #[cfg(feature = "ast")]
     let verify_before = if !verify_checks.is_empty() {
-        let affected = crate::tx::verify::affected_file_paths(&plan, &cwd);
+        let affected = crate::tx::verify::scan_paths_for_checks(&plan, &cwd, &verify_checks);
         verify_checks
             .iter()
             .map(|check| {
@@ -480,7 +480,7 @@ pub(crate) fn run_parsed_plan(
     // 4b. Post-execution verification against pending content.
     #[cfg(feature = "ast")]
     if !verify_before.is_empty() {
-        let affected = crate::tx::verify::affected_file_paths(&plan, &cwd);
+        let affected = crate::tx::verify::scan_paths_for_checks(&plan, &cwd, &verify_checks);
         let mut any_failed = false;
         let mut messages = Vec::new();
         for (check, before_snap) in &verify_before {

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -130,7 +130,7 @@ pub fn execute_plan_direct(
     #[cfg(feature = "ast")]
     let verify_before = if let Some(ref checks) = plan.verify {
         if !checks.is_empty() {
-            let affected = verify::affected_file_paths(&plan, &effective_cwd);
+            let affected = verify::scan_paths_for_checks(&plan, &effective_cwd, checks);
             checks
                 .iter()
                 .map(|check| {
@@ -177,7 +177,8 @@ pub fn execute_plan_direct(
     // Post-execution verification against pending content.
     #[cfg(feature = "ast")]
     if !verify_before.is_empty() {
-        let affected = verify::affected_file_paths(&plan, &effective_cwd);
+        let checks: Vec<_> = verify_before.iter().map(|(c, _)| c.clone()).collect();
+        let affected = verify::scan_paths_for_checks(&plan, &effective_cwd, &checks);
         let mut messages = Vec::new();
         let mut any_failed = false;
         for (check, before_snap) in &verify_before {

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -1,5 +1,8 @@
 //! Pre/post-operation symbol count verification for structural safety.
 //!
+//! size-waiver: accepted single-domain bulk (policy #1408). Symbol snapshot,
+//! unique_names/no_orphans, and count checks co-located; do not split for LOC.
+//!
 //! When `--verify` is used, the tx engine captures a symbol snapshot before
 //! executing operations and compares it against a post-execution snapshot.
 //! Mismatches trigger rollback with a descriptive error.
@@ -95,6 +98,39 @@ pub(crate) fn affected_file_paths(plan: &crate::plan::Plan, cwd: &Path) -> Vec<P
                     walk_and_match(cwd, cwd, &matcher, &mut paths);
                 }
             }
+        }
+    }
+    paths.into_iter().collect()
+}
+
+/// Paths to snapshot for a set of verify checks.
+///
+/// Named checks (`unique_names`, `no_orphans`) need a project-wide view so a
+/// single-file rename cannot create a silent cross-file name collision
+/// (runtime fixrealloop 2026-07-15). Symbol-count checks stay on declared
+/// operation paths only for performance.
+#[cfg(feature = "ast")]
+pub(crate) fn scan_paths_for_checks(
+    plan: &crate::plan::Plan,
+    cwd: &Path,
+    checks: &[VerifyCheck],
+) -> Vec<PathBuf> {
+    let needs_project = checks.iter().any(|c| {
+        matches!(
+            c,
+            VerifyCheck::Named { check }
+                if check == "unique_names" || check == "no_orphans"
+        )
+    });
+    // `mut` needed when `cli` extends the set for unique_names/no_orphans.
+    #[allow(unused_mut)]
+    let mut paths: HashSet<PathBuf> = affected_file_paths(plan, cwd).into_iter().collect();
+    if needs_project {
+        #[cfg(feature = "cli")]
+        if let Ok(files) =
+            crate::cmd::ast::collect_source_files(cwd, &crate::cli::global::GlobalFlags::default())
+        {
+            paths.extend(files);
         }
     }
     paths.into_iter().collect()
@@ -419,10 +455,14 @@ pub(crate) fn compare_snapshots(
     }
 }
 
-/// Check that no file has duplicate symbol names.
+/// Check that symbol names are unique within each file and across the snapshot.
+///
+/// Cross-file uniqueness matters for renames: `foo` → `bar` in one file must
+/// fail when another scanned file already defines `bar`.
 #[cfg(feature = "ast")]
 fn check_unique_names(snapshot: &SymbolSnapshot, cwd: &Path) -> VerifyResult {
     let mut duplicates = Vec::new();
+    // Per-file duplicates.
     for (path, syms) in &snapshot.files {
         let mut seen = HashMap::new();
         for sym in syms {
@@ -435,6 +475,29 @@ fn check_unique_names(snapshot: &SymbolSnapshot, cwd: &Path) -> VerifyResult {
             }
         }
     }
+    // Cross-file: same name in two or more files (count each file once).
+    let mut by_name: HashMap<&str, Vec<&Path>> = HashMap::new();
+    for (path, syms) in &snapshot.files {
+        let mut names_in_file = HashSet::new();
+        for sym in syms {
+            if names_in_file.insert(sym.name.as_str()) {
+                by_name.entry(sym.name.as_str()).or_default().push(path);
+            }
+        }
+    }
+    for (name, paths) in &by_name {
+        if paths.len() > 1 {
+            let mut displays: Vec<String> = paths
+                .iter()
+                .map(|p| p.strip_prefix(cwd).unwrap_or(p).display().to_string())
+                .collect();
+            displays.sort();
+            duplicates.push(format!(
+                "  '{name}' appears in multiple files: {}",
+                displays.join(", ")
+            ));
+        }
+    }
 
     if duplicates.is_empty() {
         VerifyResult {
@@ -442,6 +505,8 @@ fn check_unique_names(snapshot: &SymbolSnapshot, cwd: &Path) -> VerifyResult {
             message: "verify unique_names: no duplicates found \u{2713}".to_string(),
         }
     } else {
+        // Stable order for agent-facing diagnostics.
+        duplicates.sort();
         VerifyResult {
             passed: false,
             message: format!(
@@ -850,6 +915,37 @@ fn not_a_test() {}
         let result = check_unique_names(&snapshot, Path::new("/tmp"));
         assert!(!result.passed);
         assert!(result.message.contains("'foo' appears 2 times"));
+    }
+
+    #[test]
+    #[cfg(feature = "ast")]
+    fn unique_names_cross_file_duplicates() {
+        let snapshot = SymbolSnapshot {
+            files: HashMap::from([
+                (
+                    PathBuf::from("/tmp/a.rs"),
+                    vec![SnappedSymbol {
+                        name: "bar".into(),
+                        kind: symbols::SymbolKind::Function,
+                    }],
+                ),
+                (
+                    PathBuf::from("/tmp/b.rs"),
+                    vec![SnappedSymbol {
+                        name: "bar".into(),
+                        kind: symbols::SymbolKind::Function,
+                    }],
+                ),
+            ]),
+            total: 2,
+        };
+        let result = check_unique_names(&snapshot, Path::new("/tmp"));
+        assert!(!result.passed, "{}", result.message);
+        assert!(
+            result.message.contains("multiple files") && result.message.contains("'bar'"),
+            "cross-file collision must be reported: {}",
+            result.message
+        );
     }
 
     #[test]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8348,3 +8348,54 @@ fn test_tx_replace_partial_floor_reports_refused() {
         "refused must name candidate: {json}"
     );
 }
+
+/// unique_names must reject renames that collide with symbols in other files.
+#[test]
+fn test_tx_verify_unique_names_cross_file() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), "fn foo() {}\n").unwrap();
+    fs::write(dir.path().join("b.rs"), "fn bar() {}\n").unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.rename",
+            "path": "a.rs",
+            "old": "foo",
+            "new": "bar"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .arg("--verify")
+        .arg("unique_names")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(6),
+        "cross-file unique_names collision should exit 6: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "verification_failed", "{json}");
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("multiple files") && err.contains("bar"),
+        "error should name cross-file collision: {err}"
+    );
+    // Changes must not apply.
+    assert_eq!(
+        fs::read_to_string(dir.path().join("a.rs")).unwrap(),
+        "fn foo() {}\n",
+        "rename must roll back on verification failure"
+    );
+}


### PR DESCRIPTION
## Summary

Runtime scenario: `ast.rename` foo→bar in one file while another file already defines `bar`, with `--verify unique_names`.

**Before:** exit 0, "no duplicates found", both files left with `fn bar`.

**After:** exit 6, `verification_failed`, lists multi-file collision, rename rolled back.

- Project-wide source scan for `unique_names` / `no_orphans`
- Cross-file uniqueness in `check_unique_names`
- Unit + integration regression tests

## Test plan

- [x] Unit: `unique_names_cross_file_duplicates`
- [x] Integration: `test_tx_verify_unique_names_cross_file`
- [x] Live repro: rename collision fails closed
- [x] `make check-fast`