### PR TITLE
fix: fail closed when replace context does not disambiguate

### DIFF
--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -252,6 +252,7 @@ fn replace_write(
         // Context disambiguation: when multiple exact matches and context is
         // provided, select the match nearest to the context instead of
         // replacing all (mirrors tx engine logic in replace_op.rs).
+        // Fail closed when context does not select a unique match.
         if count > 1
             && nth.is_none()
             && !whole_line
@@ -286,6 +287,13 @@ fn replace_write(
                 result.backup_session = backup_session;
                 return Ok(result);
             }
+            return Err(anyhow::Error::new(crate::exit::AmbiguousError {
+                msg: format!(
+                    "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth or stronger before/after-context)",
+                    crate::fallback::truncate_str(&old, 60),
+                    count
+                ),
+            }));
         }
 
         let new_content = new_content.into_owned();
@@ -560,37 +568,46 @@ pub fn replace_in_content(
     // Context disambiguation (#1315): when multiple exact matches and context
     // is provided, select the match nearest to the context instead of
     // replacing all (mirrors replace_write and tx engine logic).
+    // Fail closed when context does not select a unique match.
     if count > 1
         && opts.nth.is_none()
         && !opts.whole_line
         && !is_regex
         && (opts.before_context.is_some() || opts.after_context.is_some())
-        && let Some(target_offset) = ops::replace::context_filtered_offset(
+    {
+        if let Some(target_offset) = ops::replace::context_filtered_offset(
             content,
             from,
             opts.before_context.as_deref(),
             opts.after_context.as_deref(),
-        )
-    {
-        let ctx_content = format!(
-            "{}{}{}",
-            &content[..target_offset],
-            replacement,
-            &content[target_offset + from.len()..],
-        );
-        let diff = super::make_diff("<content>", content, &ctx_content);
-        return Ok(ContentEditResult {
-            original: content.to_string(),
-            new_content: ctx_content,
-            diff,
-            changed: true,
-            match_count: 1,
-            match_mode: Some(MatchMode::Anchored),
-            match_score: None,
-            // Exact span at the context-picked offset (equals `from`; hosts
-            // still get a non-null matched_text on Anchored like fuzzy #1736).
-            matched_text: Some(from.to_string()),
-        });
+        ) {
+            let ctx_content = format!(
+                "{}{}{}",
+                &content[..target_offset],
+                replacement,
+                &content[target_offset + from.len()..],
+            );
+            let diff = super::make_diff("<content>", content, &ctx_content);
+            return Ok(ContentEditResult {
+                original: content.to_string(),
+                new_content: ctx_content,
+                diff,
+                changed: true,
+                match_count: 1,
+                match_mode: Some(MatchMode::Anchored),
+                match_score: None,
+                // Exact span at the context-picked offset (equals `from`; hosts
+                // still get a non-null matched_text on Anchored like fuzzy #1736).
+                matched_text: Some(from.to_string()),
+            });
+        }
+        return Err(anyhow::Error::new(crate::exit::AmbiguousError {
+            msg: format!(
+                "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth or stronger before/after-context)",
+                crate::fallback::truncate_str(from, 60),
+                count
+            ),
+        }));
     }
 
     let new_content = new_content.into_owned();

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -235,33 +235,45 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         if match_count > 0 {
             // When there are multiple exact matches and context is provided
             // (but no nth), use context to disambiguate instead of replacing all.
+            // If context does not select a unique match, fail closed as ambiguous
+            // (do not fall through to replace-all; fixrealloop 2026-07-15).
             if match_count > 1
                 && nth.is_none()
                 && !*whole_line
                 && !regex_mode
                 && (before_context.is_some() || after_context.is_some())
-                && let Some(target_offset) = context_filtered_offset(
+            {
+                if let Some(target_offset) = context_filtered_offset(
                     content,
                     old,
                     before_context.as_deref(),
                     after_context.as_deref(),
-                )
-            {
-                let new_content = format!(
-                    "{}{}{}",
-                    &content[..target_offset],
-                    replacement,
-                    &content[target_offset + old.len()..],
-                );
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &file_path,
-                    new_content,
-                );
-                record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
-                return Ok(1);
+                ) {
+                    let new_content = format!(
+                        "{}{}{}",
+                        &content[..target_offset],
+                        replacement,
+                        &content[target_offset + old.len()..],
+                    );
+                    update_file_content(
+                        tx.pending,
+                        tx.deletions,
+                        tx.write_targets,
+                        &file_path,
+                        new_content,
+                    );
+                    record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
+                    return Ok(1);
+                }
+                return Err(crate::exit::AmbiguousError {
+                    msg: format!(
+                        "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth or stronger before/after-context)",
+                        crate::fallback::truncate_str(old, 60),
+                        match_count,
+                        p
+                    ),
+                }
+                .into());
             }
             let owned = replaced.into_owned();
             update_file_content(
@@ -512,29 +524,43 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     && !*whole_line
                     && !regex_mode
                     && (before_context.is_some() || after_context.is_some())
-                    && let Some(target_offset) = context_filtered_offset(
+                {
+                    if let Some(target_offset) = context_filtered_offset(
                         &content,
                         old,
                         before_context.as_deref(),
                         after_context.as_deref(),
-                    )
-                {
-                    let new_content = format!(
-                        "{}{}{}",
-                        &content[..target_offset],
-                        replacement,
-                        &content[target_offset + old.len()..],
-                    );
-                    update_file_content(
-                        tx.pending,
-                        tx.deletions,
-                        tx.write_targets,
-                        &file_path,
-                        new_content,
-                    );
-                    record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
-                    total_matches += 1;
-                    continue;
+                    ) {
+                        let new_content = format!(
+                            "{}{}{}",
+                            &content[..target_offset],
+                            replacement,
+                            &content[target_offset + old.len()..],
+                        );
+                        update_file_content(
+                            tx.pending,
+                            tx.deletions,
+                            tx.write_targets,
+                            &file_path,
+                            new_content,
+                        );
+                        record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
+                        total_matches += 1;
+                        continue;
+                    }
+                    let rel = file_path
+                        .strip_prefix(tx.cwd)
+                        .unwrap_or(&file_path)
+                        .display();
+                    return Err(crate::exit::AmbiguousError {
+                        msg: format!(
+                            "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth or stronger before/after-context)",
+                            crate::fallback::truncate_str(old, 60),
+                            match_count,
+                            rel
+                        ),
+                    }
+                    .into());
                 }
                 total_matches += match_count;
                 update_file_content(
@@ -1029,6 +1055,54 @@ mod tests {
             result.contains("[cache]\nhost = localhost"),
             "cache section should be unchanged: {result}"
         );
+    }
+
+    /// Context that scores no match must not fall through to replace-all.
+    #[test]
+    fn replace_context_fail_closed_when_no_score() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("a.txt");
+        std::fs::write(&file, "alpha foo\nbeta foo\n").unwrap();
+        let op = Operation::Replace {
+            path: Some("a.txt".into()),
+            glob: None,
+            regex: false,
+            old: "foo".into(),
+            new_text: Some("X".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            whole_line: false,
+            word_boundary: false,
+            range: None,
+            // "zzz" is nowhere near either match → score 0 → None.
+            before_context: Some("zzz".into()),
+            after_context: None,
+            if_exists: false,
+            unique: false,
+            require_change: false,
+            command_position: false,
+            fuzzy: false,
+            min_fuzzy_score: None,
+            allow_absent_old: false,
+        };
+        let mut f = TxStateFixture::new();
+        let mut tx = f.state(dir.path());
+        let err = execute_replace_op(&op, &mut tx).unwrap_err();
+        drop(tx);
+        let msg = err.to_string();
+        assert!(
+            msg.contains("context did not select") || msg.contains("ambiguous"),
+            "want fail-closed ambiguous, got: {msg}"
+        );
+        if let Some((_, content)) = f.pending.get(&file) {
+            assert_eq!(
+                content, "alpha foo\nbeta foo\n",
+                "must not rewrite either match when context fails: {content:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2432,3 +2432,41 @@ fn test_replace_multi_fuzzy_floor_reports_refused() {
         "refused must name candidate: {v}"
     );
 }
+
+/// Context that fails to score must not replace-all multi-match.
+#[test]
+fn test_replace_context_fail_closed_not_replace_all() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    fs::write(&file, "alpha foo\nbeta foo\n").unwrap();
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "foo",
+            "--new",
+            "X",
+            "--before-context",
+            "zzz",
+            "--apply",
+        ])
+        .arg(&file)
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(5), "want ambiguous exit 5");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "ambiguous", "{v}");
+    assert!(
+        v["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("context did not select"),
+        "{v}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "alpha foo\nbeta foo\n",
+        "must not rewrite when context fails"
+    );
+}


### PR DESCRIPTION
## Summary

Runtime scenario: multi-match `replace` with weak/non-matching `--before-context` rewrote **all** occurrences because `context_filtered_offset` returned `None` and the engine fell through to replace-all.

**After:** exit 5, `error_kind: ambiguous`, file unchanged. Message notes context failed to select a unique occurrence.

Sibling paths updated: tx path + glob, library `replace_text` + `replace_in_content`.

## Test plan

- [x] Unit: `replace_context_fail_closed_when_no_score`
- [x] Integration: `test_replace_context_fail_closed_not_replace_all`
- [x] Existing context disambiguation tests still pass
- [x] `make check-fast`