### PR TITLE
fix: agent-honest JSON, context anchors, batch suggestions

### DIFF
--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -148,15 +148,31 @@ fn print_symbol_compact(sym: &SymbolDef, indent: usize) {
     }
 }
 
+/// Emit symbols in agent-honest structured form.
+///
+/// `--json` prints a single pretty-printed JSON array (one `json.loads` for
+/// the whole stdout). `--jsonl` prints one compact object per line.
+/// Per-symbol `emit_json` was wrong for multi-symbol files: pretty multi-docs
+/// are not a single parseable JSON value (fixrealloop 2026-07-15).
 pub(super) fn print_symbols_json(
     path: &str,
     symbols: &[&SymbolDef],
     global: &GlobalFlags,
 ) -> anyhow::Result<()> {
-    for sym in symbols {
-        let obj = symbol_to_json(sym, path);
-        global.emit_json(&obj)?;
-    }
+    let items: Vec<serde_json::Value> = symbols
+        .iter()
+        .map(|sym| symbol_to_json(sym, path))
+        .collect();
+    global.emit_json_items(&items)?;
+    Ok(())
+}
+
+/// Emit a pre-built list of symbol JSON objects (multi-file list path).
+pub(super) fn print_symbol_items_json(
+    items: &[serde_json::Value],
+    global: &GlobalFlags,
+) -> anyhow::Result<()> {
+    global.emit_json_items(items)?;
     Ok(())
 }
 

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -2,8 +2,9 @@
 
 use super::common::{
     collect_source_files, display_path, filter_symbols, get_git_file_content, lang_from_str,
-    parse_kind_filter, print_symbols_compact, print_symbols_human, print_symbols_json,
-    resolve_lang, resolve_target_paths, setup_multi_file, setup_single_file,
+    parse_kind_filter, print_symbol_items_json, print_symbols_compact, print_symbols_human,
+    print_symbols_json, resolve_lang, resolve_target_paths, setup_multi_file, setup_single_file,
+    symbol_to_json,
 };
 use crate::ast::symbols::{self, SymbolDef};
 use crate::cli::global::GlobalFlags;
@@ -45,6 +46,10 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
     );
 
     let mut any_output = false;
+    // Structured multi-file output must be one array (or one JSONL stream), not
+    // one pretty document per file/symbol (fixrealloop 2026-07-15).
+    let mut structured_items: Vec<serde_json::Value> = Vec::new();
+    let structured = global.json || global.jsonl;
 
     if target.is_file() {
         let lang = resolve_lang(lang_hint, &target);
@@ -64,7 +69,7 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
         let filtered = filter_symbols(&symbols, &kind_filter);
         if !filtered.is_empty() {
             any_output = true;
-            if global.json || global.jsonl {
+            if structured {
                 print_symbols_json(&args.path, &filtered, global)?;
             } else if args.compact {
                 print_symbols_compact(&args.path, &filtered);
@@ -100,13 +105,18 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
                 continue;
             }
             any_output = true;
-            if global.json || global.jsonl {
-                print_symbols_json(&result.display, &filtered, global)?;
+            if structured {
+                for sym in &filtered {
+                    structured_items.push(symbol_to_json(sym, &result.display));
+                }
             } else if args.compact {
                 print_symbols_compact(&result.display, &filtered);
             } else {
                 print_symbols_human(&result.display, &filtered);
             }
+        }
+        if structured && !structured_items.is_empty() {
+            print_symbol_items_json(&structured_items, global)?;
         }
     } else {
         let msg = format!("path not found: {}", args.path);
@@ -219,17 +229,20 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
             Some(ValidateFileResult { display, result })
         });
 
+    let structured = global.json || global.jsonl;
+    let mut structured_items: Vec<serde_json::Value> = Vec::new();
     for vr in &results {
         if !vr.result.valid {
             all_valid = false;
         }
-        if !global.emit_json(&serde_json::json!({
-            "file": vr.display,
-            "valid": vr.result.valid,
-            "language": vr.result.language,
-            "errors": vr.result.errors,
-        }))? && !global.quiet
-        {
+        if structured {
+            structured_items.push(serde_json::json!({
+                "file": vr.display,
+                "valid": vr.result.valid,
+                "language": vr.result.language,
+                "errors": vr.result.errors,
+            }));
+        } else if !global.quiet {
             if !vr.result.valid {
                 eprintln!("{}: INVALID ({})", vr.display, vr.result.language);
                 for err in &vr.result.errors {
@@ -239,6 +252,10 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
                 eprintln!("{}: OK ({})", vr.display, vr.result.language);
             }
         }
+    }
+    // One array for --json (agent-parseable); one line per file for --jsonl.
+    if structured {
+        global.emit_json_items(&structured_items)?;
     }
 
     if all_valid {
@@ -318,16 +335,20 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
             Some(SearchFileResult { display, matches })
         });
 
+    let structured = global.json || global.jsonl;
+    let mut structured_items: Vec<serde_json::Value> = Vec::new();
     'outer: for result in &file_results {
         for m in &result.matches {
             total_matches += 1;
-            if !global.emit_json(&serde_json::json!({
-                "file": result.display,
-                "line": m.line,
-                "column": m.column,
-                "text": m.text,
-                "captures": m.captures,
-            }))? {
+            if structured {
+                structured_items.push(serde_json::json!({
+                    "file": result.display,
+                    "line": m.line,
+                    "column": m.column,
+                    "text": m.text,
+                    "captures": m.captures,
+                }));
+            } else {
                 println!(
                     "{}:{}:{}: {}",
                     result.display,
@@ -352,6 +373,9 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
         global.emit_error_json_kind(Some("no_matches"), &msg)?;
         Ok(exit::NO_MATCHES)
     } else {
+        if structured {
+            global.emit_json_items(&structured_items)?;
+        }
         Ok(exit::SUCCESS)
     }
 }
@@ -443,6 +467,8 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
     crate::verbose!("ast deps: scanning {} files", paths.len());
 
     let mut any_output = false;
+    let structured = global.json || global.jsonl;
+    let mut structured_items: Vec<serde_json::Value> = Vec::new();
 
     if args.reverse {
         // For reverse deps, scan all files and find which ones import
@@ -487,14 +513,14 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
 
         for hit in &hits {
             any_output = true;
-            if global.json || global.jsonl {
+            if structured {
                 for imp in &hit.matching {
-                    global.emit_json(&serde_json::json!({
+                    structured_items.push(serde_json::json!({
                         "file": hit.display,
                         "imports": imp.path,
                         "line": imp.line,
                         "raw": imp.raw,
-                    }))?;
+                    }));
                 }
             } else {
                 for imp in &hit.matching {
@@ -522,10 +548,12 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
 
         for result in &results {
             any_output = true;
-            if !global.emit_json(&serde_json::json!({
-                "file": result.display,
-                "imports": result.imports,
-            }))? {
+            if structured {
+                structured_items.push(serde_json::json!({
+                    "file": result.display,
+                    "imports": result.imports,
+                }));
+            } else {
                 println!("{}", result.display);
                 println!("  imports:");
                 for imp in &result.imports {
@@ -537,6 +565,9 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
     }
 
     if any_output {
+        if structured {
+            global.emit_json_items(&structured_items)?;
+        }
         Ok(exit::SUCCESS)
     } else {
         let msg = format!("no imports found in {}", args.path);

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -372,7 +372,7 @@ fn suggest_batch_op(op: &str) -> Option<String> {
     // from `file.create` / `doc.set`. Prefer the real bare name over JW neighbors
     // like `file.rename` (fixrealloop 2026-07-15).
     if let Some((_, leaf)) = op.split_once('.')
-        && KNOWN_BATCH_OPS.iter().any(|k| *k == leaf)
+        && KNOWN_BATCH_OPS.contains(&leaf)
     {
         return Some(leaf.to_string());
     }

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -368,6 +368,15 @@ fn batch_unsupported_hint(op: &str) -> Option<&'static str> {
 
 /// Suggest close batch op names for typos and bare names (`create` → `file.create`).
 fn suggest_batch_op(op: &str) -> Option<String> {
+    // Wrong namespace for a bare op: agents invent `file.replace` / `doc.replace`
+    // from `file.create` / `doc.set`. Prefer the real bare name over JW neighbors
+    // like `file.rename` (fixrealloop 2026-07-15).
+    if let Some((_, leaf)) = op.split_once('.')
+        && KNOWN_BATCH_OPS.iter().any(|k| *k == leaf)
+    {
+        return Some(leaf.to_string());
+    }
+
     // Bare leaf name: `create` matches `file.create`, `append` matches both file/doc.
     let mut suffix: Vec<&str> = KNOWN_BATCH_OPS
         .iter()

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -556,6 +556,18 @@ mod error_handling {
         );
     }
 
+    /// Agents invent `file.replace` from `file.create` / `file.delete`.
+    /// Suggest bare `replace`, not JW neighbors like `file.rename`.
+    #[test]
+    fn parse_line_suggests_replace_for_file_replace() {
+        let err = parse_line(r#"file.replace path.txt old new"#, 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did you mean") && msg.contains("replace") && !msg.contains("file.rename"),
+            "expected bare replace suggestion, got: {msg}"
+        );
+    }
+
     // Batch intentionally does not support read, search, and patch.apply.
     // These are tx-only operations. The tests below document this as deliberate
     // and lock the redirect hint in the error message.

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -49,6 +49,16 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Str
     }
 
     let selected = select_lines(&content, lines.expect("checked is_none above"));
+    // Empty selection for an explicit --lines range is not success: agents treat
+    // ok:true + empty content as "file is empty", not "range past EOF"
+    // (fixrealloop 2026-07-15).
+    if selected.start_line == 0 {
+        let n = selected.total_lines;
+        return Err(format!(
+            "{path}: line range outside file ({n} line{})",
+            if n == 1 { "" } else { "s" }
+        ));
+    }
 
     Ok(ReadOutput {
         ok: true,
@@ -114,8 +124,14 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if errors.len() == args.files.len() {
-        // Prefer not_found when every path failed (typical: missing files).
         let msg = errors.join("\n");
+        // Prefer no_matches when every path failed only because --lines is past EOF.
+        let all_range_outside = errors.iter().all(|e| e.contains("line range outside file"));
+        if all_range_outside {
+            global.emit_error_json_kind(Some("no_matches"), &msg)?;
+            return Ok(exit::NO_MATCHES);
+        }
+        // Prefer not_found when every path failed (typical: missing files).
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(exit::FAILURE);
     }
@@ -315,9 +331,30 @@ mod tests {
         let file = dir.path().join("empty.txt");
         fs::write(&file, "").unwrap();
         let lines = Some((1, Some(5)));
-        let result = read_one_file(file.to_str().unwrap(), lines).unwrap();
-        assert_eq!(result.content, "");
-        assert_eq!(result.total_lines, 0);
+        let result = read_one_file(file.to_str().unwrap(), lines);
+        assert!(
+            result.is_err(),
+            "empty file with --lines must not look like success: {result:?}"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("line range outside file"),
+            "expected outside-file error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn read_one_file_line_range_beyond_eof_errors() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let file = dir.path().join("short.txt");
+        fs::write(&file, "line1\nline2\nline3\n").unwrap();
+        let result = read_one_file(file.to_str().unwrap(), Some((5, Some(10))));
+        assert!(result.is_err(), "expected error, got Ok: {result:?}");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("line range outside file") && err.contains("3 lines"),
+            "got: {err}"
+        );
     }
 
     #[test]

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -301,20 +301,44 @@ pub fn replace_content<'a>(
     }
 }
 
+/// Score how well a content fragment matches a context fragment.
+///
+/// Uses Jaro-Winkler (full-string similarity) and substring containment.
+/// Agents often pass short anchors (`alpha`, `[cache]`) that appear inside
+/// longer lines; pure JW of the whole line vs the short token can fall under
+/// 0.8 even when the anchor is clearly present (fixrealloop 2026-07-15).
+fn context_fragment_score(content_fragment: &str, ctx_fragment: &str) -> f64 {
+    let a = content_fragment.trim();
+    let b = ctx_fragment.trim();
+    if b.is_empty() {
+        return 0.0;
+    }
+    let jw = strsim::jaro_winkler(a, b);
+    // Containment for short anchors inside longer lines (min 2 chars avoids
+    // matching single-character noise like "a" / "x" everywhere).
+    if b.len() >= 2 && a.contains(b) {
+        jw.max(1.0)
+    } else {
+        jw
+    }
+}
+
 /// Filter multiple exact matches by `before_context` / `after_context`.
 ///
 /// When the `old` text occurs more than once in `content` and no `nth` is
 /// specified, this function uses context lines to pick the right occurrence.
 /// It compares up to 3 lines of context (nearest to the match first) using
-/// Jaro-Winkler similarity (threshold >= 0.8). The occurrence with the
-/// highest aggregate score wins. Returns the byte offset of the winning
-/// match, or `None` if no context is provided, only one match exists, or
-/// all scores are zero.
+/// Jaro-Winkler similarity and substring containment (threshold >= 0.8). The
+/// occurrence with the highest aggregate score wins. Returns the byte offset
+/// of the winning match, or `None` if no context is provided, only one match
+/// exists, or all scores are zero.
 ///
 /// For `before_context`, the last N lines are compared against the N lines
-/// preceding the match. For `after_context`, the first N lines are compared
-/// against the N lines following the match. Tie-breaking: first occurrence
-/// (lowest byte offset) wins on equal scores.
+/// preceding the match, and (for single-line `old`) the same-line prefix
+/// before the match is also scored against the nearest context fragment.
+/// For `after_context`, the first N lines following the match are compared,
+/// plus the same-line suffix after a single-line match.
+/// Tie-breaking: first occurrence (lowest byte offset) wins on equal scores.
 pub fn context_filtered_offset(
     content: &str,
     old: &str,
@@ -354,6 +378,8 @@ pub fn context_filtered_offset(
     };
 
     const MAX_CONTEXT_LINES: usize = 3;
+    let old_line_count = old.lines().count().max(1);
+    let single_line_old = old_line_count == 1 && !old.contains('\n');
 
     let mut best: Option<(usize, f64)> = None;
     for &match_off in &offsets {
@@ -367,10 +393,25 @@ pub fn context_filtered_offset(
             let start = ctx_lines.len().saturating_sub(MAX_CONTEXT_LINES);
             let ctx_tail = &ctx_lines[start..];
             for (i, ctx_line) in ctx_tail.iter().rev().enumerate() {
+                // Nearest before-context fragment also scores the same-line
+                // prefix (agents pass anchors that sit on the match line).
+                if i == 0 && single_line_old && match_line < lines.len() {
+                    let line = lines[match_line];
+                    let col = match_off
+                        .saturating_sub(line_starts[match_line])
+                        .min(line.len());
+                    if line.is_char_boundary(col) {
+                        checks += 1;
+                        let sim = context_fragment_score(&line[..col], ctx_line);
+                        if sim >= 0.8 {
+                            score += sim;
+                        }
+                    }
+                }
                 let content_idx = match_line.checked_sub(i + 1);
                 if let Some(ci) = content_idx {
                     checks += 1;
-                    let sim = strsim::jaro_winkler(lines[ci].trim(), ctx_line.trim());
+                    let sim = context_fragment_score(lines[ci], ctx_line);
                     if sim >= 0.8 {
                         score += sim;
                     }
@@ -381,13 +422,27 @@ pub fn context_filtered_offset(
         if let Some(after) = after_context {
             let ctx_lines: Vec<&str> = after.lines().collect();
             let n = ctx_lines.len().min(MAX_CONTEXT_LINES);
-            let old_lines = old.lines().count();
-            let end_line = match_line + old_lines;
+            let end_line = match_line + old_line_count;
             for (i, ctx_line) in ctx_lines[..n].iter().enumerate() {
+                // Same-line suffix for nearest after-context fragment.
+                if i == 0 && single_line_old && match_line < lines.len() {
+                    let line = lines[match_line];
+                    let match_end = match_off.saturating_add(old.len());
+                    let col = match_end
+                        .saturating_sub(line_starts[match_line])
+                        .min(line.len());
+                    if line.is_char_boundary(col) {
+                        checks += 1;
+                        let sim = context_fragment_score(&line[col..], ctx_line);
+                        if sim >= 0.8 {
+                            score += sim;
+                        }
+                    }
+                }
                 let content_idx = end_line + i;
                 if content_idx < lines.len() {
                     checks += 1;
-                    let sim = strsim::jaro_winkler(lines[content_idx].trim(), ctx_line.trim());
+                    let sim = context_fragment_score(lines[content_idx], ctx_line);
                     if sim >= 0.8 {
                         score += sim;
                     }

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -773,6 +773,34 @@ mod context_filter_tests {
         assert_eq!(offset, Some(11)); // "[database]\n" is 11 bytes
     }
 
+    /// Short anchors inside longer previous lines must score (JW alone is <0.8).
+    #[test]
+    fn before_context_short_anchor_inside_long_line() {
+        let content = "prefix alpha foo more\nother foo\n";
+        let offset = context_filtered_offset(content, "foo", Some("alpha"), None);
+        assert_eq!(
+            offset,
+            Some(content.find("foo").unwrap()),
+            "should pick the foo after alpha on the same/prior fragment"
+        );
+    }
+
+    /// Same-line prefix: `--before-context alpha` on `alpha foo` / `beta foo`.
+    #[test]
+    fn before_context_same_line_prefix() {
+        let content = "alpha foo\nbeta foo\n";
+        let offset = context_filtered_offset(content, "foo", Some("alpha"), None);
+        assert_eq!(offset, Some("alpha ".len()));
+    }
+
+    /// Same-line suffix for after-context.
+    #[test]
+    fn after_context_same_line_suffix() {
+        let content = "foo alpha\nfoo beta\n";
+        let offset = context_filtered_offset(content, "foo", None, Some("alpha"));
+        assert_eq!(offset, Some(0));
+    }
+
     #[test]
     fn before_context_picks_correct_occurrence() {
         let content =

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -41,6 +41,66 @@ fn test_ast_list_basic() {
         .stdout(predicates::str::contains("Bar"));
 }
 
+/// `--json` for multi-symbol list must be one parseable JSON array, not
+/// pretty multi-documents (agents use `json.loads` on full stdout).
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_list_json_is_single_array() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, "pub fn foo() {}\nstruct Bar;\nfn baz() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["ast", "list", "lib.rs", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("ast list --json must be single JSON document: {e}\n{text}"));
+    let arr = val
+        .as_array()
+        .unwrap_or_else(|| panic!("ast list --json must be a JSON array, got: {val}"));
+    assert!(
+        arr.len() >= 3,
+        "expected at least 3 symbols, got {}",
+        arr.len()
+    );
+    let names: Vec<&str> = arr
+        .iter()
+        .filter_map(|v| v.get("name").and_then(|n| n.as_str()))
+        .collect();
+    assert!(names.contains(&"foo"), "missing foo in {names:?}");
+    assert!(names.contains(&"Bar"), "missing Bar in {names:?}");
+    assert!(names.contains(&"baz"), "missing baz in {names:?}");
+}
+
+/// Directory `ast list --json` must still be one array (not one array per file).
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_list_dir_json_is_single_array() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), "fn a() {}\n").unwrap();
+    fs::write(dir.path().join("b.rs"), "fn b() {}\nfn c() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["ast", "list", ".", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("dir list --json must be single JSON: {e}\n{text}"));
+    let arr = val.as_array().expect("dir list --json must be array");
+    assert!(
+        arr.len() >= 3,
+        "expected symbols from both files, got {}",
+        arr.len()
+    );
+}
+
 #[test]
 #[cfg(feature = "ast")]
 fn test_ast_read_basic() {
@@ -103,12 +163,21 @@ fn test_ast_search_basic() {
     let f = dir.path().join("s.rs");
     fs::write(&f, "fn f() { let y = 42; }\n").unwrap();
     // simple structural query for function item
-    patchloom_in(dir.path())
+    let out = patchloom_in(dir.path())
         .args(["ast", "search", "(function_item) @fn", "s.rs", "--json"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("fn f()"))
-        .stdout(predicates::str::contains("let y = 42"));
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("ast search --json must be single JSON: {e}\n{text}"));
+    let arr = v.as_array().expect("ast search --json must be array");
+    assert!(!arr.is_empty());
+    let joined = text;
+    assert!(joined.contains("fn f()"), "{joined}");
+    assert!(joined.contains("let y = 42"), "{joined}");
 }
 
 #[test]
@@ -287,8 +356,33 @@ fn test_ast_validate_json_exit_code_on_invalid_file() {
         .stdout
         .clone();
     let text = String::from_utf8(out).unwrap();
+    // Multi-result commands emit a JSON array (even for a single file).
     let v: serde_json::Value = serde_json::from_str(text.trim()).unwrap();
-    assert_eq!(v["valid"], serde_json::json!(false));
+    let arr = v.as_array().expect("validate --json must be array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["valid"], serde_json::json!(false));
+}
+
+/// Multi-file validate --json must be one array, not multi-document JSON.
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_validate_multi_file_json_is_single_array() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ok.rs"), "fn ok() {}\n").unwrap();
+    fs::write(dir.path().join("also.rs"), "fn also() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["ast", "validate", ".", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let v: serde_json::Value = serde_json::from_str(text.trim())
+        .unwrap_or_else(|e| panic!("validate multi --json must be single JSON: {e}\n{text}"));
+    let arr = v.as_array().expect("validate --json must be array");
+    assert!(arr.len() >= 2, "expected both files, got {}", arr.len());
+    assert!(arr.iter().all(|e| e["valid"] == true));
 }
 
 #[test]

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -145,7 +145,7 @@ fn test_read_json_output() {
 }
 
 #[test]
-fn test_read_json_lines_start_past_eof_clamps_metadata() {
+fn test_read_json_lines_start_past_eof_is_no_matches() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("short.txt");
     fs::write(&file, "a\nb\n").unwrap();
@@ -160,12 +160,18 @@ fn test_read_json_lines_start_past_eof_clamps_metadata() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    // Past-EOF must not look like ok:true empty content (agent honesty).
+    assert_eq!(output.status.code(), Some(3));
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["content"].as_str().unwrap(), "");
-    assert_eq!(json["total_lines"], 2);
-    assert_eq!(json["start_line"], 0);
-    assert_eq!(json["end_line"], 0);
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "no_matches");
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("line range outside file"),
+        "got: {json}"
+    );
 }
 
 #[test]

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -87,6 +87,40 @@ fn test_read_json_invalid_lines_returns_error_object() {
     );
 }
 
+/// --lines past EOF must not return ok:true with empty content (agents treat that
+/// as a successful empty read).
+#[test]
+fn test_read_lines_beyond_eof_json_no_matches() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("short.txt");
+    fs::write(&file, "a\nb\nc\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("read")
+        .arg(file.to_str().unwrap())
+        .arg("--lines")
+        .arg("5-10")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "expected NO_MATCHES, stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "no_matches");
+    let error = json["error"].as_str().unwrap();
+    assert!(
+        error.contains("line range outside file"),
+        "got error: {error}"
+    );
+}
+
 #[test]
 fn test_read_json_output() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

- **ast multi-result `--json`**: `list` / `search` / `validate` / `deps` now emit one JSON array (or JSONL lines) via `emit_json_items`, so agents can `json.loads` full stdout.
- **replace context anchors**: short and same-line `--before-context` / `--after-context` tokens score correctly (substring containment + same-line prefix/suffix); still fail-closed when nothing scores.
- **batch did-you-mean**: invented `file.replace` suggests bare `replace` instead of JW neighbors like `file.rename`.
- **read `--lines` past EOF**: return `error_kind: no_matches` and exit 3 instead of `ok: true` with empty content (agents treated that as a successful empty read).

Found by fixrealloop runtime probes.

## Test plan

- [x] `make check-fast`
- [x] Unit/integration for each fix
- [ ] CI green