### PR TITLE
fix: dedupe CLI and plan verify checks

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -410,14 +410,19 @@ pub(crate) fn run_parsed_plan(
         return Ok(exit::PARSE_ERROR);
     }
 
-    // Merge --verify CLI args with plan's verify field.
+    // Merge --verify CLI args with plan's verify field (dedupe: CLI + plan often
+    // both pass unique_names and would double-run the same check).
     #[cfg(feature = "ast")]
     let verify_checks = {
         use crate::plan::VerifyCheck;
         let mut checks: Vec<VerifyCheck> = plan.verify.clone().unwrap_or_default();
         for raw in verify {
             match VerifyCheck::parse(raw) {
-                Ok(c) => checks.push(c),
+                Ok(c) => {
+                    if !checks.contains(&c) {
+                        checks.push(c);
+                    }
+                }
                 Err(e) => {
                     let msg = format!("invalid --verify spec '{raw}': {e}");
                     if structured {

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -89,7 +89,7 @@ pub struct ForEach {
 }
 
 /// A single verification check parsed from `--verify` or plan `verify` field.
-#[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(untagged)]
 pub enum VerifyCheck {
     /// `{"kind": "function", "attr": "test"}` or `{"kind": "function"}`

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8399,3 +8399,45 @@ fn test_tx_verify_unique_names_cross_file() {
         "rename must roll back on verification failure"
     );
 }
+
+/// CLI `--verify unique_names` plus plan `verify: [{check: unique_names}]` must
+/// not run the check twice (duplicate error lines confuse agents).
+#[test]
+fn test_tx_verify_cli_and_plan_unique_names_deduped() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), "fn foo() {}\n").unwrap();
+    fs::write(dir.path().join("b.rs"), "fn bar() {}\n").unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "verify": [{"check": "unique_names"}],
+        "operations": [{
+            "op": "ast.rename",
+            "path": "a.rs",
+            "old": "foo",
+            "new": "bar"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .arg("--verify")
+        .arg("unique_names")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(6));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let err = json["error"].as_str().unwrap_or("");
+    let count = err.matches("duplicate symbols found").count();
+    assert_eq!(
+        count, 1,
+        "unique_names must appear once when CLI and plan both request it: {err}"
+    );
+}


### PR DESCRIPTION
## Summary

- Merging CLI `--verify` with plan `verify` used to push duplicates.
- Agents that set both (common when the plan embeds checks and the CLI re-asserts them) saw the same `unique_names` failure twice.
- Deduplicate on merge (`PartialEq` on `VerifyCheck`).

Found by fixrealloop.

## Test plan

- [x] `test_tx_verify_cli_and_plan_unique_names_deduped`
- [x] `make check-fast`
- [ ] CI green