### PR TITLE
fix: report nth out of range instead of false no-match

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -5,7 +5,8 @@ use crate::cli::global::GlobalFlags;
 use crate::diff::render_diffs_colored;
 use crate::exit;
 use crate::ops::replace::{
-    compile_replace_regex, replace_content, replace_whole_lines, replacement_text,
+    compile_replace_regex, count_content_matches, replace_content, replace_whole_lines,
+    replacement_text,
 };
 use crate::tx::engine::WriteSource;
 use clap::Args;
@@ -617,6 +618,37 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 );
             }
             return Ok(exit::SUCCESS);
+        }
+        // --nth past the last match returns applied count 0 (looks like no-match).
+        // Re-count so agents see "nth out of range" instead of "no matches for pattern".
+        if let Some(n) = args.nth {
+            let compiled_re = compile_replace_regex(
+                &args.old,
+                args.regex,
+                args.case_insensitive,
+                args.multiline,
+                args.word_boundary,
+            )?;
+            let cwd = global.resolve_cwd()?;
+            let file_paths =
+                crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+            for path in &file_paths {
+                let Ok(content) = std::fs::read_to_string(path) else {
+                    continue;
+                };
+                let total = count_content_matches(&content, &args.old, compiled_re.as_ref());
+                if total > 0 && n > total {
+                    let display = crate::files::relative_display(path, &cwd)
+                        .to_string_lossy()
+                        .into_owned();
+                    let msg = format!(
+                        "nth {n} is out of range in {display}: pattern matches {total} time{}",
+                        if total == 1 { "" } else { "s" }
+                    );
+                    global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+                    return Ok(exit::FAILURE);
+                }
+            }
         }
         if args.if_exists {
             let output = ReplaceOutput {

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -200,6 +200,28 @@ fn expand_regex_replacement(caps: &regex::Captures<'_>, replacement: &str) -> St
     expanded
 }
 
+/// Count non-overlapping matches of `from` / `compiled_re` in `content`.
+///
+/// Used for agent-honest errors when `--nth` is past the last match (the
+/// replace path returns applied count 0, which is otherwise indistinguishable
+/// from a true no-match).
+pub fn count_content_matches(content: &str, from: &str, compiled_re: Option<&Regex>) -> usize {
+    match compiled_re {
+        Some(re) => {
+            let content_len = content.len();
+            re.find_iter(content)
+                .filter(|m| !(m.start() == content_len && m.end() == content_len))
+                .count()
+        }
+        None => {
+            if from.is_empty() {
+                return 0;
+            }
+            content.match_indices(from).count()
+        }
+    }
+}
+
 pub fn replace_content<'a>(
     content: &'a str,
     from: &str,

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -285,6 +285,24 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             );
             record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count, None);
             Ok(match_count)
+        } else if let Some((n, total)) = (*nth).and_then(|n| {
+            // nth past last match: applied count is 0 but pattern may still match.
+            // Do not report soft no_matches (agents confuse this with missing pattern).
+            let total =
+                crate::ops::replace::count_content_matches(content, old, compiled_re.as_ref());
+            if total > 0 && n > total {
+                Some((n, total))
+            } else {
+                None
+            }
+        }) {
+            Err(crate::exit::InvalidInputError {
+                msg: format!(
+                    "nth {n} is out of range in {p}: pattern matches {total} time{}",
+                    if total == 1 { "" } else { "s" }
+                ),
+            }
+            .into())
         } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some()) {
             // Tier 3: fuzzy and/or context fallback when exact match fails (#1668).
             match crate::fallback::resolve_with_fallback_skip_exact(
@@ -571,6 +589,26 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     replaced.into_owned(),
                 );
                 record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count, None);
+            } else if let Some((n, total)) = (*nth).and_then(|n| {
+                let total =
+                    crate::ops::replace::count_content_matches(&content, old, compiled_re.as_ref());
+                if total > 0 && n > total {
+                    Some((n, total))
+                } else {
+                    None
+                }
+            }) {
+                let rel = file_path
+                    .strip_prefix(tx.cwd)
+                    .unwrap_or(&file_path)
+                    .display();
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!(
+                        "nth {n} is out of range in {rel}: pattern matches {total} time{}",
+                        if total == 1 { "" } else { "s" }
+                    ),
+                }
+                .into());
             } else if !regex_mode && (*fuzzy || before_context.is_some() || after_context.is_some())
             {
                 // Fuzzy/context fallback for glob paths (parity with #1668 path arm).

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -768,6 +768,8 @@ fn test_replace_nth_no_match_when_out_of_range() {
     let file = dir.path().join("test.txt");
     fs::write(&file, "foo bar\n").unwrap();
 
+    // nth past last match is invalid_input (not "no matches for pattern"), so
+    // agents can distinguish out-of-range nth from a missing pattern.
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("replace")
@@ -779,10 +781,43 @@ fn test_replace_nth_no_match_when_out_of_range() {
         .arg("--apply")
         .arg(file.to_str().unwrap())
         .assert()
-        .code(3); // NO_MATCHES
+        .code(1)
+        .stderr(predicates::str::contains("nth 5 is out of range"))
+        .stderr(predicates::str::contains("matches 1 time"));
 
     // File unchanged.
     assert_eq!(fs::read_to_string(&file).unwrap(), "foo bar\n");
+}
+
+#[test]
+fn test_replace_nth_out_of_range_json() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "a\na\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "replace",
+            "a",
+            "--new",
+            "X",
+            "--nth",
+            "5",
+            file.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "invalid_input");
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("nth 5 is out of range") && err.contains("matches 2 times"),
+        "got: {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `--nth` past the last match used to look like a soft no-match (`error_kind: no_matches`, "no matches for pattern").
- Agents cannot tell "pattern missing" from "nth too high".
- Re-count matches and return `invalid_input` with an explicit out-of-range message.

Found by fixrealloop.

## Test plan

- [x] `test_replace_nth_no_match_when_out_of_range` / `test_replace_nth_out_of_range_json`
- [x] `make check-fast`
- [ ] CI green