### PR TITLE
fix: treat empty JSON as {} for doc parse/set

### DIFF
--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -415,8 +415,18 @@ fn try_preserve_yaml_array(
 
 pub fn parse_doc(content: &str, format: &FileFormat) -> anyhow::Result<serde_json::Value> {
     match format {
-        FileFormat::Json => serde_json::from_str(content)
-            .map_err(|e| anyhow::Error::new(crate::exit::ParseErrorError { msg: e.to_string() })),
+        // Empty / whitespace-only files: treat as empty object so `doc set`
+        // can bootstrap a new document (YAML/TOML already accept empty input;
+        // serde_json rejects EOF — fixrealloop 2026-07-15).
+        FileFormat::Json => {
+            if content.trim().is_empty() {
+                Ok(serde_json::json!({}))
+            } else {
+                serde_json::from_str(content).map_err(|e| {
+                    anyhow::Error::new(crate::exit::ParseErrorError { msg: e.to_string() })
+                })
+            }
+        }
         FileFormat::Yaml => {
             if is_multi_document_yaml(content) {
                 parse_multi_document_yaml(content).map_err(|e| {

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -54,6 +54,15 @@ mod basic {
     }
 
     #[test]
+    fn parse_empty_json_is_empty_object() {
+        assert_eq!(parse_doc("", &FileFormat::Json).unwrap(), json!({}));
+        assert_eq!(
+            parse_doc("   \n\t  ", &FileFormat::Json).unwrap(),
+            json!({})
+        );
+    }
+
+    #[test]
     fn parse_and_serialize_yaml_roundtrip() {
         let input = "a: 1\n";
         let val = parse_doc(input, &crate::ops::doc::FileFormat::Yaml).unwrap();

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2815,3 +2815,27 @@ fn test_doc_set_multi_document_apply_preserves_separators() {
         .code(0)
         .stdout(predicates::str::contains("demo-svc"));
 }
+
+/// Empty JSON file should bootstrap like empty YAML/TOML for doc set.
+#[test]
+fn test_doc_set_empty_json_file() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.json");
+    fs::write(&file, "").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["doc", "set", "empty.json", "a", "1", "--apply"])
+        .assert()
+        .code(0)
+        .stdout(
+            predicates::str::contains(r#""ok":true"#)
+                .or(predicates::str::contains(r#""ok": true"#)),
+        );
+
+    let content = fs::read_to_string(&file).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(v, serde_json::json!({"a": 1}));
+}


### PR DESCRIPTION
## Summary

Empty YAML and TOML files already accept `doc set` (bootstrap a new document). Empty JSON failed with `parse_error` / EOF, so agents could not initialize a new `.json` file via `doc set` after `create` with empty content (or a zero-byte placeholder).

`parse_doc` now treats empty / whitespace-only JSON as `{}`, matching the YAML/TOML bootstrap behavior.

Found by fixrealloop doc set scenarios.

## Test plan

- [x] Unit: `parse_empty_json_is_empty_object`
- [x] Integration: `test_doc_set_empty_json_file`
- [x] `make check-fast`
- [ ] CI green