### PR TITLE
fix: multi-file --nth out-of-range fails closed for all paths

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -585,6 +585,44 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
     }
 
+    // --nth past the last match in ANY scanned file is fail-closed, even when
+    // another file can apply nth successfully. Silent skip of under-matched
+    // files hid agent mistakes in multi-path replaces (fixrealloop 2026-07-15).
+    if let Some(n) = args.nth {
+        let compiled_re = compile_replace_regex(
+            &args.old,
+            args.regex,
+            args.case_insensitive,
+            args.multiline,
+            args.word_boundary,
+        )?;
+        let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+        let range = parse_range_arg(args.range.as_deref())?;
+        for path in &file_paths {
+            let Ok(content) = std::fs::read_to_string(path) else {
+                continue;
+            };
+            let total = count_nth_candidates(
+                &content,
+                &args.old,
+                compiled_re.as_ref(),
+                args.whole_line,
+                range,
+            );
+            if total > 0 && n > total {
+                let display = crate::files::relative_display(path, &cwd)
+                    .to_string_lossy()
+                    .into_owned();
+                let msg = format!(
+                    "nth {n} is out of range in {display}: pattern matches {total} time{}",
+                    if total == 1 { "" } else { "s" }
+                );
+                global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+                return Ok(exit::FAILURE);
+            }
+        }
+    }
+
     // Drop files where the replacement produces identical content (e.g.
     // replacing "X" with "X"). Match count was non-zero, but there is no
     // actual change to write, diff, or report.
@@ -618,44 +656,6 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 );
             }
             return Ok(exit::SUCCESS);
-        }
-        // --nth past the last match returns applied count 0 (looks like no-match).
-        // Re-count so agents see "nth out of range" instead of "no matches for pattern".
-        if let Some(n) = args.nth {
-            let compiled_re = compile_replace_regex(
-                &args.old,
-                args.regex,
-                args.case_insensitive,
-                args.multiline,
-                args.word_boundary,
-            )?;
-            let cwd = global.resolve_cwd()?;
-            let file_paths =
-                crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
-            let range = parse_range_arg(args.range.as_deref())?;
-            for path in &file_paths {
-                let Ok(content) = std::fs::read_to_string(path) else {
-                    continue;
-                };
-                let total = count_nth_candidates(
-                    &content,
-                    &args.old,
-                    compiled_re.as_ref(),
-                    args.whole_line,
-                    range,
-                );
-                if total > 0 && n > total {
-                    let display = crate::files::relative_display(path, &cwd)
-                        .to_string_lossy()
-                        .into_owned();
-                    let msg = format!(
-                        "nth {n} is out of range in {display}: pattern matches {total} time{}",
-                        if total == 1 { "" } else { "s" }
-                    );
-                    global.emit_error_json_kind(Some("invalid_input"), &msg)?;
-                    return Ok(exit::FAILURE);
-                }
-            }
         }
         if args.if_exists {
             let output = ReplaceOutput {

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2577,3 +2577,45 @@ fn test_replace_context_fail_closed_not_replace_all() {
         "must not rewrite when context fails"
     );
 }
+
+/// Multi-file --nth: fail closed when any file has matches but fewer than nth,
+/// even if another file could apply successfully.
+#[test]
+fn test_replace_multi_file_nth_out_of_range_fail_closed() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("m1.txt"), "a\n").unwrap();
+    fs::write(dir.path().join("m2.txt"), "a\na\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace", "a", "--new", "X", "--nth", "2", "m1.txt", "m2.txt",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input");
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("nth 2 is out of range") && err.contains("m1.txt"),
+        "must name the under-matched file: {err}"
+    );
+    // Neither file should change.
+    assert_eq!(
+        fs::read_to_string(dir.path().join("m1.txt")).unwrap(),
+        "a\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("m2.txt")).unwrap(),
+        "a\na\n"
+    );
+}


### PR DESCRIPTION
## Summary

With multi-path `replace --nth N`, a file that had enough matches could be rewritten while a sibling file with fewer than N matches was silently skipped. Agents assumed every path was updated.

Run the nth out-of-range scan on **all** targets before any write and fail with `invalid_input` naming the under-matched file (same diagnosis as single-file nth OOR).

Found by fixrealloop multi-path replace scenarios.

## Test plan

- [x] Integration: `test_replace_multi_file_nth_out_of_range_fail_closed`
- [x] `make check-fast`
- [ ] CI green