### PR TITLE
fix: set truncated when search --max-results caps matches

### DIFF
--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -71,6 +71,11 @@ struct SearchOutput {
     files: Vec<SearchFileEntry>,
     match_count: usize,
     file_count: usize,
+    /// True when `matches` was capped by `--max-results` while `match_count`
+    /// is the full total. Agents must not treat `matches.len()` as complete
+    /// coverage when this is set (fixrealloop 2026-07-16).
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    truncated: bool,
     /// Machine-readable failure kind for agents (`no_matches`), aligned with
     /// CLI replace / tx JSON. Omitted on success.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -188,12 +193,16 @@ pub(crate) fn format_results(
         } else {
             Vec::new()
         };
+        let match_count: usize = results.file_match_counts.values().sum();
+        // match_count is always full; matches may be capped by --max-results.
+        let truncated = args.max_results > 0 && results.matches.len() < match_count;
         let payload = SearchOutput {
             ok: true,
-            match_count: results.file_match_counts.values().sum(),
+            match_count,
             file_count: results.file_match_counts.len(),
             matches: results.matches,
             files,
+            truncated,
             error_kind: None,
             error: None,
             skipped,
@@ -405,6 +414,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             file_count: 0,
             matches: vec![],
             files: vec![],
+            truncated: false,
             error_kind: Some("no_matches"),
             error: Some(format!(
                 "no matches for '{}' in {path_desc}",

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -141,6 +141,10 @@ pub struct TxSearchResult {
     pub pattern: String,
     pub match_count: usize,
     pub matches: Vec<TxSearchMatch>,
+    /// True when `matches` was capped by `max_results` while `match_count` is
+    /// the full total (same honesty as CLI `search --json` truncated).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
 }
 
 /// A file read result in the tx output.

--- a/src/tx/search_op.rs
+++ b/src/tx/search_op.rs
@@ -234,6 +234,7 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
     }
 
     // Cap after assertion check. Append order matches walk order.
+    let truncated = *max_results > 0 && all_matches.len() > *max_results;
     if *max_results > 0 {
         all_matches.truncate(*max_results);
     }
@@ -243,6 +244,7 @@ pub(crate) fn execute_search_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
         pattern: pattern.clone(),
         match_count: total_match_count,
         matches: all_matches,
+        truncated,
     });
     Ok(())
 }
@@ -524,6 +526,10 @@ mod tests {
         assert_eq!(f.searches[0].match_count, 5);
         // matches vec is truncated to max_results
         assert_eq!(f.searches[0].matches.len(), 2);
+        assert!(
+            f.searches[0].truncated,
+            "agents must see truncated when matches are capped"
+        );
     }
 
     #[test]

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1294,3 +1294,51 @@ fn test_search_files_from_missing_reported_in_json() {
         "expected missing.txt in skipped: {v}"
     );
 }
+
+/// --max-results caps the matches array while match_count stays full.
+/// Agents need truncated=true so they do not treat matches as complete.
+#[test]
+fn test_search_max_results_json_sets_truncated() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("many.txt");
+    fs::write(&file, "hit\nhit\nhit\nhit\nhit\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["search", "hit", "many.txt", "--max-results", "2"])
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["match_count"], 5, "full count: {v}");
+    assert_eq!(v["matches"].as_array().unwrap().len(), 2, "{v}");
+    assert_eq!(v["truncated"], true, "must flag truncation: {v}");
+}
+
+#[test]
+fn test_search_json_omits_truncated_when_complete() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("few.txt");
+    fs::write(&file, "hit\nhit\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["search", "hit", "few.txt"])
+        .output()
+        .unwrap();
+
+    assert_eq!(out.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["match_count"], 2);
+    assert_eq!(v["matches"].as_array().unwrap().len(), 2);
+    assert!(
+        v.get("truncated").is_none() || v["truncated"] == false,
+        "no truncation flag when complete: {v}"
+    );
+}


### PR DESCRIPTION
## Summary

- `search --json` with `--max-results` kept full `match_count` but capped `matches` with no flag, so agents could treat the array as complete coverage
- Add `truncated: true` when the matches array was capped (omitted when false)
- Same field on tx `TxSearchResult` for plan/execute_plan honesty
- MCP search reuses `format_results`, so it inherits the flag

Found by fixrealloop (max-results honesty).

## Test plan

- [x] Unit: `search_max_results_cap` asserts `truncated`
- [x] Integration: `test_search_max_results_json_sets_truncated`
- [x] Integration: `test_search_json_omits_truncated_when_complete`
- [ ] CI green