### PR TITLE
fix: surface soft replace no-match in multi-op refused[]

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -69,7 +69,9 @@ pub struct ReplaceArgs {
     #[arg(long, short = 'w')]
     pub word_boundary: bool,
     // ref:replace-mode:range
-    /// Restrict matching to a line range (e.g. '10:50' or '10-50'). 1-based, inclusive.
+    /// Restrict matching to a line range (e.g. '10:50' or '10-50'). 1-based,
+    /// inclusive. Requires `--whole-line` (substring replace within a range is
+    /// not supported).
     #[arg(long, short = 'R')]
     pub range: Option<String>,
     // ref:replace-mode:before-context

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -65,10 +65,10 @@ pub struct TxOutput {
     /// Compare to requested `old` after fuzzy apply (#1736).
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub matched_text: Option<String>,
-    /// Soft-refuse paths where fuzzy found a candidate but did not write
-    /// (exact old absent without `allow_absent_old`). Present on partial
-    /// multi-op success so agents do not treat overall ok as full coverage
-    /// (parity with CLI `replace` `refused[]`).
+    /// Soft-refuse / soft-skip replace paths that did not write. Includes
+    /// fuzzy fail-closed (`exact_old_absent`) and exact soft no-match
+    /// (`no_matches`) so multi-op success does not hide a silent miss
+    /// (fixrealloop 2026-07-16). Parity with CLI `replace` `refused[]`.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub refused: Vec<TxRefused>,
 }
@@ -198,7 +198,8 @@ pub(crate) struct ReplaceMatchMeta {
     /// Fuzzy/anchored span text actually matched (may differ from plan `old`). #1736
     pub matched_text: Option<String>,
     /// Soft-no-write reason when `match_count` is 0 (`exact_old_absent`,
-    /// `below_min_fuzzy_score`). Used for CLI/tx `refused[]` honesty.
+    /// `below_min_fuzzy_score`, `no_matches`). Used for CLI/tx `refused[]`
+    /// honesty.
     pub refuse_reason: Option<&'static str>,
 }
 
@@ -369,14 +370,21 @@ pub(crate) fn build_tx_output_with_meta(
         }
     }
 
-    // Paths with recorded meta but no write (fuzzy refuse / floor skip).
+    // Paths with recorded meta but no write (fuzzy refuse / floor skip /
+    // exact soft no-match). Multi-op success must still list these so agents
+    // do not treat overall ok as "every replace applied".
     let mut refused = Vec::new();
     for (path, m) in replace_match_meta {
         if changes.iter().any(|(c, _, _)| c == path) || deletions.contains(path) {
             continue;
         }
-        // Only surface candidates that were found but not applied (count 0).
-        if m.match_count != 0 || m.matched_text.is_none() {
+        // Only surface zero-match soft skips (writes already listed in changes).
+        if m.match_count != 0 {
+            continue;
+        }
+        // Fuzzy/anchored candidates carry matched_text; exact soft no-match
+        // carries refuse_reason "no_matches" without a candidate span.
+        if m.matched_text.is_none() && m.refuse_reason != Some("no_matches") {
             continue;
         }
         let reason = m
@@ -1145,6 +1153,55 @@ mod tests {
         assert_eq!(out.refused[0].match_mode.as_deref(), Some("fuzzy"));
         assert_eq!(out.refused[0].reason, "exact_old_absent");
         assert_eq!(out.refused[0].matched_text.as_deref(), Some("helo world"));
+    }
+
+    /// Multi-op success with an exact soft no-match must list refused[] so
+    /// agents do not treat overall ok as every replace having applied
+    /// (fixrealloop 2026-07-16).
+    #[test]
+    fn build_full_tx_output_partial_success_surfaces_exact_soft_no_match() {
+        use std::collections::HashMap;
+        let cwd = Path::new("/project");
+        let created = PathBuf::from("/project/g.txt");
+        let missed = PathBuf::from("/project/f.txt");
+        let mut meta = HashMap::new();
+        meta.insert(
+            missed,
+            ReplaceMatchMeta {
+                mode: crate::api::MatchMode::Exact,
+                score: None,
+                match_count: 0,
+                matched_text: None,
+                refuse_reason: Some("no_matches"),
+            },
+        );
+        let mut result = TxExecResult {
+            changes: vec![(created, String::new(), "hi\n".into())],
+            deletions: HashSet::new(),
+            existed_before: HashSet::new(),
+            pending: HashMap::new(),
+            tx_reads: vec![],
+            tx_searches: vec![],
+            tx_lints: vec![],
+            tx_mutations: vec![],
+            no_effective_changes: false,
+            replace_no_matches: false,
+            replace_hint: Some("no matches for 'missing' in f.txt".into()),
+            replace_match_meta: meta,
+            renames: vec![],
+        };
+        let out = build_full_tx_output("success", &mut result, cwd);
+        assert_eq!(out.status, "success");
+        assert_eq!(out.files_created, 1);
+        assert_eq!(
+            out.refused.len(),
+            1,
+            "exact soft miss must surface: {out:?}"
+        );
+        assert_eq!(out.refused[0].path, "f.txt");
+        assert_eq!(out.refused[0].reason, "no_matches");
+        assert_eq!(out.refused[0].match_mode.as_deref(), Some("exact"));
+        assert!(out.refused[0].matched_text.is_none());
     }
 
     /// Hosts may deserialize older plan/tx JSON that never had match honesty

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -28,6 +28,20 @@ fn record_replace_match(
     record_replace_match_with_reason(tx, path, mode, score, match_count, matched_text, None);
 }
 
+/// Soft exact no-match (zero writes) for multi-op honesty. Listed in
+/// `refused[]` with reason `no_matches` when other ops still succeed.
+fn record_soft_no_match(tx: &mut TxState<'_>, path: &Path) {
+    record_replace_match_with_reason(
+        tx,
+        path,
+        MatchMode::Exact,
+        None,
+        0,
+        None,
+        Some("no_matches"),
+    );
+}
+
 /// Like [`record_replace_match`], with optional soft-refuse reason for `refused[]`.
 fn record_replace_match_with_reason(
     tx: &mut TxState<'_>,
@@ -415,6 +429,11 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     .unwrap_or_else(|| format!("no matches for {old:?} in {p}"));
                 return Err(crate::exit::NoMatchError { msg }.into());
             }
+            // Soft miss: keep plan success for other ops, but surface path in
+            // refused[] so agents do not treat multi-op ok as full coverage.
+            if !if_exists {
+                record_soft_no_match(tx, &file_path);
+            }
             Ok(0)
         } else {
             if !regex_mode {
@@ -435,6 +454,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     .clone()
                     .unwrap_or_else(|| format!("no matches for {old:?} in {p}"));
                 return Err(crate::exit::NoMatchError { msg }.into());
+            }
+            if !if_exists {
+                record_soft_no_match(tx, &file_path);
             }
             Ok(0)
         }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8275,6 +8275,68 @@ fn test_tx_replace_partial_fuzzy_reports_refused() {
     );
 }
 
+/// Multi-op exact soft no-match must appear in refused[] when another op
+/// succeeds (fixrealloop 2026-07-16). Without this, agents treat status=success
+/// as every replace having applied.
+#[test]
+fn test_tx_create_plus_soft_nomatch_replace_reports_refused() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("f.txt");
+    fs::write(&f, "old\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "file.create",
+                "path": "g.txt",
+                "content": "hi\n"
+            },
+            {
+                "op": "replace",
+                "path": "f.txt",
+                "old": "missing",
+                "new": "NEW"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path().to_str().unwrap())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "create should succeed (soft no-match): stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(json["status"], "success", "{json}");
+    assert_eq!(json["files_created"], 1, "{json}");
+    assert_eq!(fs::read_to_string(&f).unwrap(), "old\n");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("g.txt")).unwrap(),
+        "hi\n"
+    );
+    let refused = json["refused"]
+        .as_array()
+        .expect("soft no-match must surface in refused: {json}");
+    assert_eq!(refused.len(), 1, "one soft miss: {json}");
+    assert_eq!(refused[0]["path"], "f.txt", "{json}");
+    assert_eq!(refused[0]["reason"], "no_matches", "{json}");
+    assert_eq!(refused[0]["match_mode"], "exact", "{json}");
+}
+
 /// Multi-op floor: exact apply must not hide below-min_fuzzy_score on siblings.
 #[test]
 fn test_tx_replace_partial_floor_reports_refused() {


### PR DESCRIPTION
## Summary

- Multi-op `batch`/`tx` with a successful op plus a soft-miss replace returned `status: success` with no signal that the replace applied zero times
- Exact soft no-matches now record into replace meta and appear in `refused[]` with `reason: no_matches` (same surface as fuzzy soft refuses)
- `--if-exists` soft misses stay silent (intentional idempotent)
- CLI help for `--range` now states it requires `--whole-line`

Found by fixrealloop (create + soft no-match replace).

## Test plan

- [x] Unit: `build_full_tx_output_partial_success_surfaces_exact_soft_no_match`
- [x] Integration: `test_tx_create_plus_soft_nomatch_replace_reports_refused`
- [x] Existing partial fuzzy/floor refused tests still pass
- [ ] CI green