### PR TITLE
fix: set error_kind no_matches for unknown undo --session

### DIFF
--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -116,12 +116,19 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // Resolve session across nested backup roots (#1695).
-    let (backup_root, timestamp, session) = match resolve_session(&cwd, args.session.as_deref())? {
-        Some(v) => v,
-        None => {
+    let (backup_root, timestamp, session) = match resolve_session(&cwd, args.session.as_deref()) {
+        Ok(Some(v)) => v,
+        Ok(None) => {
             global.emit_error_json_kind(Some("no_matches"), "no backup sessions found")?;
             return Ok(exit::NO_MATCHES);
         }
+        // Named session miss: return Ok(NO_MATCHES) so human CLI exit is 3
+        // (not bare Err → exit 1) and --json always has error_kind.
+        Err(e) if crate::exit::is_no_match(&e) => {
+            global.emit_error_json_kind(Some("no_matches"), &e.to_string())?;
+            return Ok(exit::NO_MATCHES);
+        }
+        Err(e) => return Err(e),
     };
 
     if !args.apply {
@@ -224,10 +231,14 @@ fn resolve_session(
             }
         }
         // Named session missing (whether or not any other sessions exist).
-        // Match restore_session wording; generic anyhow → exit 1.
-        return Err(anyhow::anyhow!(
-            "no backup session found for {ts} (use `patchloom undo --list` to see available sessions)"
-        ));
+        // Typed no_matches so --json sets error_kind (MPI 2026-07-16: bare
+        // anyhow lost error_kind and agents could not branch).
+        return Err(crate::exit::NoMatchError {
+            msg: format!(
+                "no backup session found for {ts} (use `patchloom undo --list` to see available sessions)"
+            ),
+        }
+        .into());
     }
     if sessions.is_empty() {
         return Ok(None);
@@ -440,7 +451,7 @@ mod tests {
     }
 
     #[test]
-    fn nonexistent_session_errors() {
+    fn nonexistent_session_exits_no_matches() {
         let dir = TempDir::new().unwrap();
         create_backup(dir.path(), "e.txt", "content");
         let mut global = GlobalFlags::test_default();
@@ -451,8 +462,8 @@ mod tests {
             session: Some("99999999".to_string()),
             apply: false,
         };
-        let result = run(args, &global);
-        result.expect_err("expected error");
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::NO_MATCHES);
     }
 
     #[test]

--- a/tests/integration/undo_tests.rs
+++ b/tests/integration/undo_tests.rs
@@ -436,13 +436,48 @@ fn test_undo_list_no_sessions_quiet_suppresses_stderr() {
 }
 
 #[test]
-fn test_undo_invalid_session_apply_exits_1() {
+fn test_undo_invalid_session_apply_exits_3() {
     let dir = TempDir::new().unwrap();
 
+    // Unknown session id is no_matches (exit 3), same family as empty list.
     patchloom_in(dir.path())
         .args(["undo", "--session", "BOGUS_TIMESTAMP", "--apply", "--cwd"])
         .arg(dir.path())
         .assert()
-        .code(1)
+        .code(3)
         .stderr(predicates::str::contains("no backup session found"));
+}
+
+/// Unknown --session must set error_kind so agents can branch (MPI 2026-07-16).
+#[test]
+fn test_undo_json_invalid_session_sets_error_kind() {
+    let dir = TempDir::new().unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "undo",
+            "--session",
+            "BOGUS_TIMESTAMP",
+            "--apply",
+            "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(3));
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(parsed["ok"], false);
+    assert_eq!(
+        parsed["error_kind"], "no_matches",
+        "unknown session must set error_kind: {parsed}"
+    );
+    assert!(
+        parsed["error"]
+            .as_str()
+            .is_some_and(|e| e.contains("no backup session found")),
+        "{parsed}"
+    );
 }


### PR DESCRIPTION
## Summary

- Unknown `undo --session <id>` returned bare `anyhow` (exit 1, no `error_kind` under `--json`)
- Agents could not branch on the failure
- Use `NoMatchError` and `Ok(NO_MATCHES)` like the empty-session path (exit 3 + `error_kind: no_matches`)

Found by MPI cycle 2 Observability probe.

## Test plan

- [x] Unit: `nonexistent_session_exits_no_matches`
- [x] Integration: `test_undo_invalid_session_apply_exits_3`
- [x] Integration: `test_undo_json_invalid_session_sets_error_kind`
- [x] `make check-fast`