### PR TITLE
fix: wrap schema --format prompt under global --json

### DIFF
--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -86,7 +86,15 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             if global.quiet {
                 return Ok(exit::SUCCESS);
             }
-            print!("{prompt}");
+            // Global --json/--jsonl must not print raw markdown (agents
+            // call `json.loads` on stdout). Parity with agent-rules.
+            if !global.emit_json(&serde_json::json!({
+                "ok": true,
+                "format": "prompt",
+                "content": prompt,
+            }))? {
+                print!("{prompt}");
+            }
         }
     }
 

--- a/tests/integration/schema_tests.rs
+++ b/tests/integration/schema_tests.rs
@@ -83,6 +83,32 @@ fn test_schema_prompt_output() {
     assert!(stdout.contains("replace"));
 }
 
+/// Global --json must wrap --format prompt as JSON (agents always pass --json).
+#[test]
+fn test_schema_prompt_with_global_json_is_valid_envelope() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "schema", "--format", "prompt", "--tier", "weak"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout must be JSON under --json, got parse error {e}: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["format"], "prompt", "{v}");
+    let content = v["content"].as_str().expect("content string");
+    assert!(
+        content.contains("# Patchloom Operations"),
+        "prompt body missing: {}",
+        &content[..content.len().min(120)]
+    );
+}
+
 #[test]
 fn test_schema_tier_filtering() {
     let weak_output = Command::cargo_bin("patchloom")


### PR DESCRIPTION
## Summary

- `patchloom --json schema --format prompt` printed raw markdown, so agents that always pass `--json` and `json.loads` stdout failed
- Wrap prompt text as `{ok, format: "prompt", content}` when global `--json`/`--jsonl` is set (parity with `agent-rules`)

Found by MPI cycle 4.

## Test plan

- [x] Integration: `test_schema_prompt_with_global_json_is_valid_envelope`
- [x] Bare `--format prompt` still prints markdown
- [x] `make check-fast`