### PR TITLE
fix: read directory invalid_input + init --json report

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -33,13 +33,23 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     let auto_yes = args.yes;
     let quiet = global.quiet;
+    let structured = global.json || global.jsonl;
 
-    // Helper: print to stderr unless --quiet.
+    // Helper: print to stderr unless --quiet or structured (JSON owns stdout).
     macro_rules! status {
         ($($arg:tt)*) => {
-            if !quiet { eprintln!($($arg)*); }
+            if !quiet && !structured { eprintln!($($arg)*); }
         };
     }
+
+    #[derive(Default)]
+    struct InitReport {
+        agent_rules: String,
+        agent_rules_path: Option<String>,
+        completions: String,
+        gitignore: String,
+    }
+    let mut report = InitReport::default();
 
     // 1. Generate and write agent rules.
     let rules = generate_agent_rules(&AgentRulesArgs {
@@ -55,13 +65,16 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let rel_target = target_path
         .strip_prefix(&cwd)
         .unwrap_or(&target_path)
-        .display();
+        .display()
+        .to_string();
+    report.agent_rules_path = Some(rel_target.clone());
 
     if action == "append" {
         // Check if patchloom rules are already present.
         let content = std::fs::read_to_string(&target_path)
             .with_context(|| format!("reading existing {}", target_path.display()))?;
         if content.contains(AGENT_RULES_GENERATED_MARKER) {
+            report.agent_rules = "skipped_already_present".into();
             status!("{rel_target} already contains patchloom rules, skipping.");
         } else if auto_yes || confirm(&format!("Append patchloom rules to {rel_target}?")) {
             let mut content = content;
@@ -72,15 +85,19 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             content.push_str(&rules);
             std::fs::write(&target_path, content)
                 .with_context(|| format!("writing {}", target_path.display()))?;
+            report.agent_rules = "appended".into();
             status!("appended patchloom rules to {rel_target}");
         } else {
+            report.agent_rules = "skipped".into();
             status!("skipped {rel_target}");
         }
     } else if auto_yes || confirm(&format!("Create {rel_target}?")) {
         std::fs::write(&target_path, &rules)
             .with_context(|| format!("writing {}", target_path.display()))?;
+        report.agent_rules = "created".into();
         status!("created {rel_target}");
     } else {
+        report.agent_rules = "skipped".into();
         status!("skipped {rel_target}");
     }
 
@@ -96,6 +113,7 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 }
             });
             if let Err(e) = parent_ready {
+                report.completions = format!("failed:{e}");
                 status!("failed to prepare completion directory: {e}");
                 let cmd = completion_command(&shell);
                 status!("\nshell completions ({shell}):");
@@ -108,35 +126,56 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 ))
             {
                 match generate_completions(&shell, &target) {
-                    Ok(()) => status!("installed {shell} completions to {}", target.display()),
-                    Err(e) => status!("failed to install completions: {e}"),
+                    Ok(()) => {
+                        report.completions = format!("installed:{shell}");
+                        status!("installed {shell} completions to {}", target.display());
+                    }
+                    Err(e) => {
+                        report.completions = format!("failed:{e}");
+                        status!("failed to install completions: {e}");
+                    }
                 }
             } else {
+                report.completions = format!("hint:{shell}");
                 let cmd = completion_command(&shell);
                 status!("\nshell completions ({shell}):");
                 status!("  {cmd}");
             }
         } else {
+            report.completions = format!("hint:{shell}");
             let cmd = completion_command(&shell);
             status!("\nshell completions ({shell}):");
             status!("  {cmd}");
         }
-    } else if !quiet {
-        eprintln!("\nshell completions:");
-        eprintln!("  patchloom completions <bash|zsh|fish|elvish>");
+    } else {
+        report.completions = "hint:all".into();
+        if !quiet && !structured {
+            eprintln!("\nshell completions:");
+            eprintln!("  patchloom completions <bash|zsh|fish|elvish>");
+        }
     }
 
     // 3. Keep undo backups out of git noise (pairs with `status` filtering).
     match ensure_gitignore_patchloom(&cwd) {
-        Ok(GitignorePatchloom::Created) => status!("created .gitignore with .patchloom/"),
-        Ok(GitignorePatchloom::Appended) => status!("appended .patchloom/ to .gitignore"),
+        Ok(GitignorePatchloom::Created) => {
+            report.gitignore = "created".into();
+            status!("created .gitignore with .patchloom/");
+        }
+        Ok(GitignorePatchloom::Appended) => {
+            report.gitignore = "appended".into();
+            status!("appended .patchloom/ to .gitignore");
+        }
         Ok(GitignorePatchloom::AlreadyPresent) => {
+            report.gitignore = "already_present".into();
             status!(".gitignore already ignores .patchloom/");
         }
-        Err(e) => status!("could not update .gitignore: {e}"),
+        Err(e) => {
+            report.gitignore = format!("error:{e}");
+            status!("could not update .gitignore: {e}");
+        }
     }
 
-    if !quiet {
+    if !quiet && !structured {
         // 4. MCP setup hint.
         eprintln!();
         if cfg!(feature = "mcp") {
@@ -164,6 +203,28 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
         eprintln!();
         eprintln!("setup complete.");
+    }
+
+    if structured {
+        #[derive(serde::Serialize)]
+        struct InitJson<'a> {
+            ok: bool,
+            agent_rules: &'a str,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            agent_rules_path: Option<&'a str>,
+            completions: &'a str,
+            gitignore: &'a str,
+            mcp_available: bool,
+        }
+        let payload = InitJson {
+            ok: true,
+            agent_rules: &report.agent_rules,
+            agent_rules_path: report.agent_rules_path.as_deref(),
+            completions: &report.completions,
+            gitignore: &report.gitignore,
+            mcp_available: cfg!(feature = "mcp"),
+        };
+        global.emit_json(&payload)?;
     }
     Ok(exit::SUCCESS)
 }

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -31,8 +31,48 @@ struct ReadOutput {
 
 pub(crate) use crate::ops::read::{LineRange, parse_line_range, select_lines};
 
-fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, String> {
-    let content = fs::read_to_string(path).map_err(|e| format!("{path}: {e}"))?;
+/// Per-path read failure with a stable agent `error_kind`.
+#[derive(Debug, Clone)]
+struct ReadFail {
+    kind: &'static str,
+    msg: String,
+}
+
+impl std::fmt::Display for ReadFail {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.msg)
+    }
+}
+
+fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, ReadFail> {
+    let p = std::path::Path::new(path);
+    if p.exists() && !p.is_file() {
+        return Err(ReadFail {
+            kind: "invalid_input",
+            msg: format!("{path}: target is not a file"),
+        });
+    }
+    let content = fs::read_to_string(path).map_err(|e| {
+        let kind = if e.kind() == std::io::ErrorKind::NotFound {
+            "not_found"
+        } else if e.kind() == std::io::ErrorKind::IsADirectory {
+            "invalid_input"
+        } else {
+            // Permission denied and other IO: still surface as not_found for
+            // historical single-path "all failed" envelope? Prefer generic
+            // invalid_input only for directory-like cases; keep not_found for
+            // missing paths and leave other IO as not_found-ish for agents.
+            if e.kind() == std::io::ErrorKind::PermissionDenied {
+                "invalid_input"
+            } else {
+                "not_found"
+            }
+        };
+        ReadFail {
+            kind,
+            msg: format!("{path}: {e}"),
+        }
+    })?;
 
     // Fast path: no line range requested, skip split/join (#169).
     if lines.is_none() {
@@ -54,10 +94,13 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Str
     // (fixrealloop 2026-07-15).
     if selected.start_line == 0 {
         let n = selected.total_lines;
-        return Err(format!(
-            "{path}: line range outside file ({n} line{})",
-            if n == 1 { "" } else { "s" }
-        ));
+        return Err(ReadFail {
+            kind: "no_matches",
+            msg: format!(
+                "{path}: line range outside file ({n} line{})",
+                if n == 1 { "" } else { "s" }
+            ),
+        });
     }
 
     Ok(ReadOutput {
@@ -68,6 +111,28 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Str
         total_lines: selected.total_lines,
         content: selected.content,
     })
+}
+
+/// Pick a single envelope kind when every path failed (or for partial skipped).
+fn classify_read_failures(errors: &[ReadFail]) -> (&'static str, u8) {
+    if errors.is_empty() {
+        return ("not_found", exit::FAILURE);
+    }
+    if errors.iter().all(|e| e.kind == "no_matches") {
+        return ("no_matches", exit::NO_MATCHES);
+    }
+    if errors.iter().all(|e| e.kind == "invalid_input") {
+        return ("invalid_input", exit::FAILURE);
+    }
+    if errors.iter().all(|e| e.kind == "not_found") {
+        return ("not_found", exit::FAILURE);
+    }
+    // Mixed failures (e.g. missing + directory): prefer invalid_input so agents
+    // do not treat a directory path as create-missing.
+    if errors.iter().any(|e| e.kind == "invalid_input") {
+        return ("invalid_input", exit::FAILURE);
+    }
+    ("not_found", exit::FAILURE)
 }
 
 pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
@@ -92,7 +157,7 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let multi = args.files.len() > 1;
     let mut outputs: Vec<ReadOutput> = Vec::new();
-    let mut errors: Vec<String> = Vec::new();
+    let mut errors: Vec<ReadFail> = Vec::new();
 
     for (i, path) in args.files.iter().enumerate() {
         let resolved = cwd.join(path);
@@ -124,16 +189,14 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     if errors.len() == args.files.len() {
-        let msg = errors.join("\n");
-        // Prefer no_matches when every path failed only because --lines is past EOF.
-        let all_range_outside = errors.iter().all(|e| e.contains("line range outside file"));
-        if all_range_outside {
-            global.emit_error_json_kind(Some("no_matches"), &msg)?;
-            return Ok(exit::NO_MATCHES);
-        }
-        // Prefer not_found when every path failed (typical: missing files).
-        global.emit_error_json_kind(Some("not_found"), &msg)?;
-        return Ok(exit::FAILURE);
+        let msg = errors
+            .iter()
+            .map(|e| e.msg.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        let (kind, code) = classify_read_failures(&errors);
+        global.emit_error_json_kind(Some(kind), &msg)?;
+        return Ok(code);
     }
 
     if global.json {
@@ -150,12 +213,12 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 error_kind: &'static str,
                 error: String,
             }
-            // Errors are "{path}: {io}"; keep full diagnostic string.
+            let (kind, _) = classify_read_failures(&errors);
             let report = PartialReadReport {
                 ok: false,
                 files: outputs,
-                skipped: errors.clone(),
-                error_kind: "not_found",
+                skipped: errors.iter().map(|e| e.msg.clone()).collect(),
+                error_kind: kind,
                 error: format!("partial read failure: {} path(s) failed", errors.len()),
             };
             global.emit_json(&report)?;
@@ -337,8 +400,9 @@ mod tests {
             "empty file with --lines must not look like success: {result:?}"
         );
         let err = result.unwrap_err();
+        assert_eq!(err.kind, "no_matches");
         assert!(
-            err.contains("line range outside file"),
+            err.msg.contains("line range outside file"),
             "expected outside-file error, got: {err}"
         );
     }
@@ -351,8 +415,9 @@ mod tests {
         let result = read_one_file(file.to_str().unwrap(), Some((5, Some(10))));
         assert!(result.is_err(), "expected error, got Ok: {result:?}");
         let err = result.unwrap_err();
+        assert_eq!(err.kind, "no_matches");
         assert!(
-            err.contains("line range outside file") && err.contains("3 lines"),
+            err.msg.contains("line range outside file") && err.msg.contains("3 lines"),
             "got: {err}"
         );
     }
@@ -361,6 +426,17 @@ mod tests {
     fn read_one_file_nonexistent_returns_error() {
         let result = read_one_file("/tmp/does-not-exist-patchloom-test.txt", None);
         assert!(result.is_err(), "expected error, got Ok: {result:?}");
+        let err = result.unwrap_err();
+        assert_eq!(err.kind, "not_found");
+    }
+
+    #[test]
+    fn read_one_file_directory_is_invalid_input() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let result = read_one_file(dir.path().to_str().unwrap(), None);
+        let err = result.expect_err("directory must fail");
+        assert_eq!(err.kind, "invalid_input");
+        assert!(err.msg.contains("not a file"), "got: {err}");
     }
 
     #[test]

--- a/tests/integration/init_tests.rs
+++ b/tests/integration/init_tests.rs
@@ -143,6 +143,37 @@ fn test_init_quiet_suppresses_output() {
     assert!(stderr.is_empty(), "stderr should be empty with --quiet");
 }
 
+/// Global --json must not leave agents with human text on stdout.
+#[test]
+fn test_init_json_emits_structured_report() {
+    let dir = TempDir::new().unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "init", "--yes", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "init --json must be JSON ({e}): {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(json["agent_rules"], "created", "{json}");
+    assert_eq!(json["agent_rules_path"], "AGENTS.md", "{json}");
+    assert!(
+        json["gitignore"].as_str().is_some_and(|s| !s.is_empty()),
+        "gitignore field required: {json}"
+    );
+    assert!(dir.path().join("AGENTS.md").exists());
+}
+
 #[test]
 fn test_init_falls_back_to_completion_command_when_completion_dir_creation_fails() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -356,6 +356,33 @@ fn test_read_json_all_fail_returns_error_object() {
     );
 }
 
+/// Directory targets are not missing files: agents must not retry as create.
+#[test]
+fn test_read_directory_json_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let sub = dir.path().join("is_dir");
+    fs::create_dir(&sub).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "read"])
+        .arg(&sub)
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "directory read must be invalid_input, not not_found: {json}"
+    );
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("not a file"),
+        "error should say not a file: {json}"
+    );
+}
+
 #[test]
 fn test_read_jsonl_all_fail_returns_error_object() {
     let output = Command::cargo_bin("patchloom")


### PR DESCRIPTION
## Summary

- `patchloom read` on a directory (or other non-file) now sets `error_kind: invalid_input` instead of `not_found`, so agents do not treat the path as missing.
- `patchloom --json init` emits a structured setup report (`ok`, `agent_rules`, `gitignore`, `completions`, `mcp_available`) instead of human status text on stdout.

Follow-up to #1779 (format_failed backup_session / doc directory), which merged while this polish was still local.

## Test plan

- [x] `make check-fast`
- [x] Integration: `test_read_directory_json_invalid_input`
- [x] Integration: `test_init_json_emits_structured_report`
- [x] Unit: `read_one_file_directory_is_invalid_input`