### PR TITLE
fix: explain - as stdin; explicit missing paths in skipped

### DIFF
--- a/src/cmd/explain/mod.rs
+++ b/src/cmd/explain/mod.rs
@@ -16,9 +16,10 @@ use describe::describe_operation;
 EXAMPLES:
   patchloom explain plan.json
   cat plan.json | patchloom explain --stdin
+  cat plan.json | patchloom explain -
   patchloom explain plan.yaml --json")]
 pub struct ExplainArgs {
-    /// Path to a tx plan file (JSON, YAML, or TOML).
+    /// Path to a tx plan file (JSON, YAML, or TOML). Use `-` for stdin (same as `tx -` / `--stdin`).
     #[arg(required_unless_present = "stdin")]
     pub path: Option<String>,
 
@@ -38,7 +39,9 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.stdin,
         args.format
     );
-    let (input, path) = if args.stdin {
+    // Path `-` means stdin (parity with `tx -` and `batch -`).
+    let from_stdin = args.stdin || args.path.as_deref() == Some("-");
+    let (input, path) = if from_stdin {
         let mut buf = String::new();
         std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)?;
         (buf, None)

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -534,7 +534,7 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // outside the workspace while computing matches (precomputed write-path
     // guard remains defense-in-depth).
     global.check_paths_contained(&cwd, &args.paths)?;
-    let skipped = crate::files::files_from_missing_entries(global, &cwd)?;
+    let skipped = crate::files::scan_missing_entries(global, &cwd, &args.paths)?;
 
     // Context / pure fuzzy: route through the tx engine where the
     // context_filtered_offset and fallback chain live (#1668).

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -372,7 +372,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let results = collect_matches(&args, global)?;
     let cwd = global.resolve_cwd()?;
-    let skipped = crate::files::files_from_missing_entries(global, &cwd)?;
+    let skipped = crate::files::scan_missing_entries(global, &cwd, &args.paths)?;
 
     // --assert-count mode: succeed only if total count equals N.
     // JSON matches MCP search_files: ok == matched; mismatch sets

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -237,7 +237,7 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(exit::FAILURE);
     }
-    let skipped = crate::files::files_from_missing_entries(global, &cwd)?;
+    let skipped = crate::files::scan_missing_entries(global, &cwd, paths)?;
     let issues = collect_issues(paths, global)?;
     if !global.quiet || global.json || global.jsonl {
         render_issues(&issues, global, skipped)?;

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -186,7 +186,7 @@ pub(super) fn run_fix(
 
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, &paths)?;
-    let skipped = crate::files::files_from_missing_entries(global, &cwd)?;
+    let skipped = crate::files::scan_missing_entries(global, &cwd, &paths)?;
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
     let fix_file_paths = crate::collect_file_paths_opts(&paths, global, true, Some(&cwd))?;
     let glob_roots = crate::collect_glob_roots_from_global(&paths, global, Some(&cwd))?;

--- a/src/files.rs
+++ b/src/files.rs
@@ -122,16 +122,49 @@ pub(crate) fn files_from_missing_entries(
     let Some(files) = global.read_files_from()? else {
         return Ok(None);
     };
+    Ok(missing_paths_under(cwd, &files))
+}
+
+/// Explicit CLI path args that do not exist under `cwd` (agent JSON `skipped`).
+///
+/// Mirrors [`files_from_missing_entries`] for positional paths so partial
+/// multi-path replace/search is not `ok: true` with only stderr warnings.
+/// Returns `None` when `paths` is empty (directory walk) or every path exists.
+#[cfg(feature = "cli")]
+#[must_use]
+pub(crate) fn explicit_paths_missing_entries(cwd: &Path, paths: &[String]) -> Option<Vec<String>> {
+    if paths.is_empty() {
+        return None;
+    }
+    missing_paths_under(cwd, paths)
+}
+
+/// Prefer `--files-from` missing entries when set; otherwise explicit path args.
+#[cfg(feature = "cli")]
+pub(crate) fn scan_missing_entries(
+    global: &crate::cli::global::GlobalFlags,
+    cwd: &Path,
+    paths: &[String],
+) -> anyhow::Result<Option<Vec<String>>> {
+    if global.files_from.is_some() {
+        files_from_missing_entries(global, cwd)
+    } else {
+        Ok(explicit_paths_missing_entries(cwd, paths))
+    }
+}
+
+#[cfg(feature = "cli")]
+fn missing_paths_under(cwd: &Path, paths: &[String]) -> Option<Vec<String>> {
     let mut missing = Vec::new();
-    for f in files {
-        if !cwd.join(&f).exists() {
-            missing.push(f);
+    for f in paths {
+        if !cwd.join(f).exists() {
+            missing.push(f.clone());
         }
     }
     if missing.is_empty() {
-        Ok(None)
+        None
     } else {
-        Ok(Some(missing))
+        Some(missing)
     }
 }
 

--- a/tests/integration/explain_tests.rs
+++ b/tests/integration/explain_tests.rs
@@ -233,6 +233,19 @@ fn test_explain_stdin() {
         .stdout(predicates::str::contains("Delete file x.txt"));
 }
 
+/// Path `-` is stdin (parity with `tx -` / `batch -`).
+#[test]
+fn test_explain_dash_path_reads_stdin() {
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "explain", "-"])
+        .write_stdin(r#"{"version": 1, "operations": [{"op": "file.delete", "path": "x.txt"}]}"#)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(r#""ok": true"#))
+        .stdout(predicates::str::contains("file.delete"));
+}
+
 #[test]
 fn test_explain_stdin_takes_precedence_over_path() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2319,6 +2319,47 @@ fn test_replace_word_boundary_fuzzy_does_not_partial_match() {
     }
 }
 
+/// Explicit missing paths (not only --files-from) must appear in JSON `skipped`.
+#[test]
+fn test_replace_explicit_missing_path_reported_in_json() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.txt");
+    fs::write(&a, "hello\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--quiet", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace",
+            "hello",
+            "--new",
+            "hi",
+            "a.txt",
+            "missing.txt",
+            "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["match_count"], 1, "{v}");
+    let skipped = v["skipped"]
+        .as_array()
+        .expect("skipped array for explicit missing path");
+    assert!(
+        skipped.iter().any(|s| s.as_str() == Some("missing.txt")),
+        "expected missing.txt in skipped: {v}"
+    );
+    assert_eq!(fs::read_to_string(&a).unwrap(), "hi\n");
+}
+
 /// #1756: --files-from missing paths must appear in JSON under --quiet.
 #[test]
 fn test_replace_files_from_missing_reported_in_json() {


### PR DESCRIPTION
## Summary

- `patchloom explain -` reads the plan from stdin (same as `tx -` / `batch -` / `explain --stdin`).
- Positional missing paths on replace/search/tidy populate JSON `skipped[]` (previously only `--files-from` did), so agents see soft-skips under `--json`/`--quiet`.

## Test plan

- [x] `make check-fast`
- [x] Integration: `test_explain_dash_path_reads_stdin`
- [x] Integration: `test_replace_explicit_missing_path_reported_in_json`
- [x] Existing: `test_replace_files_from_missing_reported_in_json`