### PR TITLE
fix: reject create/rename when a path parent is a file

### DIFF
--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -48,6 +48,7 @@ fn file_write(
                     msg: format!("target is not a file: {}", path.display()),
                 }));
             }
+            crate::ops::file::ensure_parent_components_are_directories(path)?;
             let original = if path.exists() {
                 std::fs::read_to_string(path)
                     .with_context(|| format!("failed to read {}", path.display()))?

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -64,6 +64,12 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
+    // Reject file-as-parent before the engine so --json gets error_kind and
+    // apply does not create a backup for a path that was never written.
+    if let Err(e) = crate::ops::file::ensure_parent_components_are_directories(&path) {
+        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
+        return Ok(crate::exit::FAILURE);
+    }
     // Catch exists before the engine so --json gets error_kind (apply and
     // preview). --force continues into FileCreate overwrite.
     if !args.force && path.exists() {
@@ -460,5 +466,53 @@ mod tests {
 
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::FAILURE);
+    }
+
+    #[test]
+    fn create_rejects_when_parent_is_a_file() {
+        let dir = TempDir::new().unwrap();
+        let blocking = dir.path().join("notdir");
+        fs::write(&blocking, "i am a file\n").unwrap();
+        let child = blocking.join("child.txt");
+
+        let args = CreateArgs {
+            file: child.to_string_lossy().into_owned(),
+            content: Some("x\n".into()),
+            stdin: false,
+            force: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
+        // No backup session for a path that was never written.
+        assert!(
+            !dir.path().join(".patchloom/backups").exists(),
+            "must not create a backup when parent is not a directory"
+        );
+        assert!(!child.exists());
+        assert!(blocking.is_file());
+    }
+
+    #[test]
+    fn create_creates_missing_parent_dirs_on_apply() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("a").join("b").join("c.txt");
+
+        let args = CreateArgs {
+            file: nested.to_string_lossy().into_owned(),
+            content: Some("nested\n".into()),
+            stdin: false,
+            force: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert_eq!(fs::read_to_string(&nested).unwrap(), "nested\n");
     }
 }

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -65,6 +65,10 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
+    if let Err(e) = crate::ops::file::ensure_parent_components_are_directories(&dst) {
+        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
+        return Ok(crate::exit::FAILURE);
+    }
     if dst.exists() && !dst.is_file() {
         let msg = format!("destination is not a file: {}", args.to);
         global.emit_error_json_kind(Some("invalid_input"), &msg)?;

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -97,7 +97,7 @@ fn print_human_replace_honesty(result: &TxExecResult, cwd: &Path, quiet: bool) {
 // Direct execution (MCP / in-process callers)
 // ---------------------------------------------------------------------------
 
-pub use crate::tx::RestoreFailGuard;
+pub use crate::tx::{RestoreFailGuard, WriteFailGuard};
 
 fn handle_commit_error(err: CommitError, structured: bool, compact: bool) -> anyhow::Result<u8> {
     let error_kind = if err.rollback_ok {

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 /// Pure helpers for file append/prepend content computation.
 /// Used by api::file_* , plan execution (tx), and cmd/append for consistency.
 /// Centralizes the "ensure nl between existing and new" logic.
@@ -22,9 +24,40 @@ pub fn prepend_content(existing: &str, prepend: &str) -> String {
     combined
 }
 
+/// Walk ancestors of `path` and ensure every existing component is a directory.
+///
+/// Missing parents are fine (`create_dir_all` creates them on apply). An
+/// ancestor that exists as a file (or other non-dir) makes
+/// `create_dir_all` / tempfile placement fail at commit with a bare IO
+/// error and can leave a spurious backup entry for a path that was never
+/// written. Call this before staging `file.create` / rename destinations.
+pub fn ensure_parent_components_are_directories(
+    path: &Path,
+) -> Result<(), crate::exit::InvalidInputError> {
+    let mut current = path.parent();
+    while let Some(p) = current {
+        if p.as_os_str().is_empty() {
+            break;
+        }
+        if p.exists() {
+            if !p.is_dir() {
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("parent path is not a directory: {}", p.display()),
+                });
+            }
+            // An existing directory implies higher ancestors are also dirs.
+            break;
+        }
+        current = p.parent();
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn append_adds_newline_separator() {
@@ -83,5 +116,46 @@ mod tests {
         assert!(a.contains('\n'));
         let p = prepend_content("base", "added");
         assert!(p.contains('\n'));
+    }
+
+    #[test]
+    fn ensure_parents_ok_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("a").join("b").join("c.txt");
+        ensure_parent_components_are_directories(&path).unwrap();
+    }
+
+    #[test]
+    fn ensure_parents_ok_when_dirs_exist() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("a").join("b");
+        fs::create_dir_all(&nested).unwrap();
+        let path = nested.join("c.txt");
+        ensure_parent_components_are_directories(&path).unwrap();
+    }
+
+    #[test]
+    fn ensure_parents_rejects_file_as_parent() {
+        let dir = TempDir::new().unwrap();
+        let blocking = dir.path().join("notdir");
+        fs::write(&blocking, "file\n").unwrap();
+        let path = blocking.join("child.txt");
+        let err = ensure_parent_components_are_directories(&path).unwrap_err();
+        assert!(
+            err.msg.contains("not a directory"),
+            "unexpected message: {}",
+            err.msg
+        );
+        assert!(err.msg.contains("notdir"), "message should name the path");
+    }
+
+    #[test]
+    fn ensure_parents_rejects_file_as_intermediate() {
+        let dir = TempDir::new().unwrap();
+        let blocking = dir.path().join("a");
+        fs::write(&blocking, "file\n").unwrap();
+        let path = blocking.join("b").join("c.txt");
+        let err = ensure_parent_components_are_directories(&path).unwrap_err();
+        assert!(err.msg.contains("not a directory"), "got: {}", err.msg);
     }
 }

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -85,6 +85,9 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 }
                 .into());
             }
+            // Reject ancestors that exist as files before staging so commit
+            // does not leave a bare tempfile error or a backup for an unwritten path.
+            crate::ops::file::ensure_parent_components_are_directories(&file_path)?;
             if force.unwrap_or(false) {
                 if tx.pending.contains_key(&file_path) || file_path.exists() {
                     let _ = read_file_content(tx.pending, tx.existed_before, &file_path)?;
@@ -189,6 +192,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 }
                 .into());
             }
+            crate::ops::file::ensure_parent_components_are_directories(&dst_path)?;
 
             // If source and destination resolve to the same file, no-op.
             // Allow case-only renames on case-insensitive filesystems (#1167).

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -301,6 +301,37 @@ fn file_prepend_to_deleted_file_errors() {
     );
 }
 
+/// file.create through a path component that is a file must fail with
+/// InvalidInputError before staging (no bare tempfile / false backup).
+#[test]
+fn file_create_rejects_parent_that_is_a_file() {
+    let dir = TempDir::new().unwrap();
+    let blocking = dir.path().join("notdir");
+    std::fs::write(&blocking, "file\n").unwrap();
+
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+
+    let op = Operation::FileCreate {
+        path: "notdir/child.txt".into(),
+        content: "x\n".into(),
+        force: None,
+    };
+    let err = execute_file_op(&op, &mut tx).unwrap_err();
+    assert!(
+        crate::exit::is_invalid_input(&err),
+        "expected InvalidInputError, got: {err:#}"
+    );
+    assert!(
+        err.to_string().contains("not a directory"),
+        "message should name the problem: {err}"
+    );
+    assert!(
+        f.pending.is_empty(),
+        "must not stage a write when parent is not a directory"
+    );
+}
+
 #[test]
 fn md_move_section_same_file_by_path_equality() {
     // Regression: MdMoveSection with to=Some(same_path) must detect

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -37,6 +37,11 @@ thread_local! {
     /// Per-thread test hook; never set in production.
     pub(crate) static FORCE_RESTORE_FAIL: std::sync::atomic::AtomicBool =
         const { std::sync::atomic::AtomicBool::new(false) };
+    /// When set, commit write fails for any path whose display string contains
+    /// this fragment. Used by mid-commit rollback tests (parent-as-file can no
+    /// longer reach commit: create/rename stage reject that case).
+    pub(crate) static FORCE_WRITE_FAIL_CONTAINS: std::cell::RefCell<Option<String>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 /// RAII guard that forces restore failure on the current thread only.
@@ -54,6 +59,41 @@ impl Drop for RestoreFailGuard {
     fn drop(&mut self) {
         FORCE_RESTORE_FAIL.with(|flag| flag.store(false, std::sync::atomic::Ordering::SeqCst));
     }
+}
+
+/// RAII guard that fails commit writes for paths containing `fragment`.
+#[doc(hidden)]
+pub struct WriteFailGuard;
+
+impl WriteFailGuard {
+    pub fn fail_paths_containing(fragment: &str) -> Self {
+        FORCE_WRITE_FAIL_CONTAINS.with(|c| {
+            *c.borrow_mut() = Some(fragment.to_string());
+        });
+        Self
+    }
+}
+
+impl Drop for WriteFailGuard {
+    fn drop(&mut self) {
+        FORCE_WRITE_FAIL_CONTAINS.with(|c| {
+            *c.borrow_mut() = None;
+        });
+    }
+}
+
+fn injected_write_failure(path: &Path) -> anyhow::Result<()> {
+    FORCE_WRITE_FAIL_CONTAINS.with(|c| {
+        if let Some(ref frag) = *c.borrow()
+            && path.to_string_lossy().contains(frag.as_str())
+        {
+            return Err(anyhow::anyhow!(
+                "injected write failure for {}",
+                path.display()
+            ));
+        }
+        Ok(())
+    })
 }
 
 /// Restore files from a backup session after a failed commit. Returns `true`
@@ -148,11 +188,13 @@ pub(crate) fn commit_changes(
                 continue;
             }
             if deletions.contains(path) {
+                injected_write_failure(path)?;
                 std::fs::remove_file(path)
                     .with_context(|| format!("deleting {}", path.display()))?;
             } else if renamed_to.contains(path.as_path()) {
                 // Dest exists after rename; rewrite final content in place so
                 // multi-hardlinked siblings stay in sync (nlink > 1 path).
+                injected_write_failure(path)?;
                 atomic_write(path, new_content, &noop_policy)?;
             } else {
                 if let Some(parent) = path.parent()
@@ -162,6 +204,7 @@ pub(crate) fn commit_changes(
                     std::fs::create_dir_all(parent)
                         .with_context(|| format!("creating directory {}", parent.display()))?;
                 }
+                injected_write_failure(path)?;
                 if !existed_before.contains(path) {
                     atomic_create_new(path, new_content, &noop_policy)?;
                 } else {

--- a/src/tx/lifecycle/mod.rs
+++ b/src/tx/lifecycle/mod.rs
@@ -10,7 +10,7 @@ mod commit;
 mod plan_exec;
 mod steps;
 
-pub use commit::{CommitError, RestoreFailGuard};
+pub use commit::{CommitError, RestoreFailGuard, WriteFailGuard};
 pub use plan_exec::execute_plan_direct;
 
 pub(crate) use commit::{commit_changes, restore_after_failed_commit};

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -54,7 +54,7 @@ pub(crate) use execute::TxStateFixture;
 pub(crate) use execute::{path_err, read_and_probe, read_file_content, update_file_content};
 
 // lifecycle.rs
-pub use lifecycle::{CommitError, RestoreFailGuard, execute_plan_direct};
+pub use lifecycle::{CommitError, RestoreFailGuard, WriteFailGuard, execute_plan_direct};
 pub(crate) use lifecycle::{
     commit_changes, rollback_strict, run_lifecycle, validate_and_prepare_plan,
 };

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -314,46 +314,84 @@ fn test_create_json_confirm_output_reports_applied_false_on_tty_eof() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_create_check_fails_if_parent_missing() {
+fn test_create_check_allows_missing_parent() {
+    // --apply creates parent dirs; --check must not reject missing parents
+    // (parity restored after brief parent-must-exist check was removed).
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("nonexistent").join("sub").join("file.txt");
 
-    let output = Command::cargo_bin("patchloom")
+    Command::cargo_bin("patchloom")
         .unwrap()
         .arg("create")
         .arg(&file)
         .arg("--content")
         .arg("hello\n")
         .arg("--check")
-        .output()
-        .unwrap();
+        .assert()
+        .code(2)
+        .stdout(predicate::str::contains("would create"));
 
-    assert!(
-        !output.status.success(),
-        "create --check should fail when parent dir doesn't exist"
-    );
+    assert!(!file.exists(), "check mode must not create the file");
 }
 
 #[test]
-fn test_create_check_force_skips_parent_verification() {
+fn test_create_apply_creates_missing_parent_dirs() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("nonexistent").join("sub").join("file.txt");
 
-    let output = Command::cargo_bin("patchloom")
+    Command::cargo_bin("patchloom")
         .unwrap()
         .arg("create")
         .arg(&file)
         .arg("--content")
         .arg("hello\n")
-        .arg("--force")
-        .arg("--check")
+        .arg("--apply")
+        .arg("--cwd")
+        .arg(dir.path())
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "hello\n");
+}
+
+#[test]
+fn test_create_rejects_parent_that_is_a_file() {
+    let dir = TempDir::new().unwrap();
+    let blocking = dir.path().join("notdir");
+    fs::write(&blocking, "i am a file\n").unwrap();
+    let child = blocking.join("child.txt");
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("create")
+        .arg(&child)
+        .arg("--content")
+        .arg("x\n")
+        .arg("--apply")
+        .arg("--cwd")
+        .arg(dir.path())
         .output()
         .unwrap();
 
-    assert_eq!(
-        output.status.code(),
-        Some(2),
-        "create --check --force should succeed even if parent doesn't exist"
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "invalid_input");
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("not a directory"),
+        "error should mention not a directory: {json}"
+    );
+
+    assert!(!child.exists());
+    assert!(blocking.is_file());
+    assert!(
+        !dir.path().join(".patchloom/backups").exists(),
+        "must not leave a backup session for an unwritten create"
     );
 }
 

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -647,7 +647,7 @@ fn test_rename_creates_parent_dirs() {
 }
 
 // ---------------------------------------------------------------------------
-// create --check parent directory verification
+// rename backup session
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -483,72 +483,60 @@ fn test_tx_rollback_preserves_original_content() {
 
 #[test]
 fn test_tx_mid_commit_failure_rolls_back() {
+    // Parent-as-file is rejected at stage time (invalid_input). Inject write
+    // failure in-process so the second path fails only during commit.
     let dir = TempDir::new().unwrap();
-    let good = dir.path().join("good.txt");
+    let good = dir.path().join("a_good.txt");
     fs::write(&good, "original\n").unwrap();
-    let blocker = dir.path().join("blocker");
-    fs::write(&blocker, "not-a-directory").unwrap();
 
-    let plan = serde_json::json!({
+    let plan: patchloom::plan::Plan = serde_json::from_value(serde_json::json!({
         "version": 1,
         "operations": [
-            {"op": "file.create", "path": "good.txt", "content": "changed\n", "force": true},
-            {"op": "file.create", "path": "blocker/child.txt", "content": "fail\n"}
+            {"op": "file.create", "path": "a_good.txt", "content": "changed\n", "force": true},
+            {"op": "file.create", "path": "z_fail/child.txt", "content": "fail\n"}
         ]
-    });
-    let plan_file = dir.path().join("plan.json");
-    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+    }))
+    .unwrap();
 
-    let output = Command::cargo_bin("patchloom")
-        .unwrap()
-        .arg("--cwd")
-        .arg(dir.path())
-        .arg("--json")
-        .arg("tx")
-        .arg(&plan_file)
-        .arg("--apply")
-        .output()
-        .unwrap();
+    let _write_fail = patchloom::cmd::tx::WriteFailGuard::fail_paths_containing("z_fail");
+    let (code, json_str) = patchloom::cmd::tx::execute_plan_direct(plan, dir.path(), None).unwrap();
 
-    assert_eq!(output.status.code(), Some(7)); // ROLLBACK after mid-commit failure
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        code, 7,
+        "ROLLBACK after mid-commit failure; json: {json_str}"
+    );
+    let json: serde_json::Value = serde_json::from_str(&json_str).unwrap();
     assert_eq!(json["error_kind"], "rollback");
     assert!(json["backup_session"].is_string());
     assert_eq!(fs::read_to_string(&good).unwrap(), "original\n");
-    assert!(!dir.path().join("blocker/child.txt").exists());
+    assert!(!dir.path().join("z_fail/child.txt").exists());
 }
 
 /// End-to-end tx path when mid-commit restore cannot complete (exit 1,
 /// `rollback_failed`). Uses [`patchloom::cmd::tx::RestoreFailGuard`] because
 /// racing filesystem permissions against restore is unreliable.
 ///
-/// This test is unrelated to library embedding (#792); it exists to cover
-/// internal tx rollback error paths. The "z_blocker" / "a_good" naming
-/// ensures a successful write precedes the failing one (lexical sort),
-/// making the restore-fail case reliably hit across platforms / temp dirs.
+/// Mid-commit write failure is injected via [`WriteFailGuard`] (parent-as-file
+/// no longer reaches commit after stage-time parent validation).
 
 #[test]
 fn test_tx_rollback_failed_when_restore_incomplete() {
     let dir = TempDir::new().unwrap();
-    // Use names so lexical sort in changes puts the successful write first,
-    // ensuring a real on-disk change exists before the failing write attempt.
-    // This makes restore path (and rollback_failed case) reliably exercised
-    // independent of temp dir internals / macOS symlink behavior in /tmp etc.
+    // Lexical sort: successful write (a_good) before failing write (z_fail).
     let good = dir.path().join("a_good.txt");
     fs::write(&good, "original\n").unwrap();
-    let blocker = dir.path().join("z_blocker");
-    fs::write(&blocker, "not-a-directory").unwrap();
 
     let plan: patchloom::plan::Plan = serde_json::from_value(serde_json::json!({
         "version": 1,
         "operations": [
             {"op": "file.create", "path": "a_good.txt", "content": "changed\n", "force": true},
-            {"op": "file.create", "path": "z_blocker/child.txt", "content": "fail\n"}
+            {"op": "file.create", "path": "z_fail/child.txt", "content": "fail\n"}
         ]
     }))
     .unwrap();
 
-    let _guard = patchloom::cmd::tx::RestoreFailGuard::engage();
+    let _write_fail = patchloom::cmd::tx::WriteFailGuard::fail_paths_containing("z_fail");
+    let _restore_fail = patchloom::cmd::tx::RestoreFailGuard::engage();
     let (code, json_str) = patchloom::cmd::tx::execute_plan_direct(plan, dir.path(), None).unwrap();
 
     assert_eq!(code, 1, "json: {json_str}");


### PR DESCRIPTION
## Summary

- Validate that every existing ancestor of a create/rename target is a directory before staging.
- When a path component is a file (e.g. `create notdir/child.txt` after `notdir` is a regular file), return `error_kind: invalid_input` and do not create a backup session for an unwritten path.
- Covers CLI `create`/`rename`, tx `file.create`/`file.rename`, and the library no-cli file create fallback.
- Mid-commit rollback tests now inject write failure via `WriteFailGuard` (parent-as-file can no longer reach commit).
- Fix dishonest create `--check` parent-missing tests (missing parents are allowed; apply creates them).

## Test plan

- [x] `cargo test --lib --all-features ensure_parent`
- [x] `cargo test --lib --all-features create_rejects_when_parent`
- [x] `cargo test --test integration --all-features test_create_rejects_parent_that_is_a_file`
- [x] `cargo test --test integration --all-features test_tx_mid_commit_failure_rolls_back`
- [x] `make check-fast`