### PR TITLE
fix: ast validate fails closed on unsupported or empty targets

### DIFF
--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -208,6 +208,30 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
     let lang_hint = args.lang.as_deref();
     crate::verbose!("ast validate: target={}", args.path);
 
+    // Empty directory / no grammar files: fail closed (not vacuous success).
+    if paths.is_empty() {
+        let msg = format!("no source files to validate in {}", args.path);
+        global.emit_error_json_kind(Some("no_matches"), &msg)?;
+        return Ok(exit::NO_MATCHES);
+    }
+
+    // Single explicit path with no grammar: same honesty as `ast list` so agents
+    // do not treat `[]` + exit 0 as "validated OK".
+    if paths.len() == 1 {
+        let lang = resolve_lang(lang_hint, &paths[0]);
+        if !lang.has_grammar() {
+            let msg = format!(
+                "Unsupported language: {} (detected from {}). \
+                 Supported: Rust, Python, TypeScript, JavaScript, Go, Java, \
+                 C#, Ruby, PHP, Swift, Kotlin, C, C++, HCL, XML, Protobuf, \
+                 TOML, YAML, JSON, Shell.",
+                lang, args.path,
+            );
+            global.emit_error_json_kind(Some("no_matches"), &msg)?;
+            return Ok(exit::NO_MATCHES);
+        }
+    }
+
     let mut all_valid = true;
     crate::verbose!("ast validate: checking {} files", paths.len());
 
@@ -228,6 +252,15 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
             let display = display_path(path, &cwd);
             Some(ValidateFileResult { display, result })
         });
+
+    // Directory walk can include only non-grammar files filtered inside the
+    // loop, or every validate_file call can fail. Do not report success with
+    // zero checks performed.
+    if results.is_empty() {
+        let msg = format!("no source files to validate in {}", args.path);
+        global.emit_error_json_kind(Some("no_matches"), &msg)?;
+        return Ok(exit::NO_MATCHES);
+    }
 
     let structured = global.json || global.jsonl;
     let mut structured_items: Vec<serde_json::Value> = Vec::new();

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -969,3 +969,76 @@ fn test_ast_list_whitespace_only_path_rejected() {
         .code(1)
         .stderr(predicate::str::contains("path must not be empty"));
 }
+
+// ---------------------------------------------------------------------------
+// ast validate must not vacuous-succeed on unsupported / empty targets
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "ast")]
+#[test]
+fn test_ast_validate_unsupported_language_is_no_matches() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("notes.txt"), "not source code\n").unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "ast", "validate", "notes.txt"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "unsupported language must not exit 0; stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "no_matches");
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("Unsupported language"),
+        "error should name unsupported language: {json}"
+    );
+}
+
+#[cfg(feature = "ast")]
+#[test]
+fn test_ast_validate_empty_dir_is_no_matches() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir(dir.path().join("empty")).unwrap();
+    fs::write(dir.path().join("empty/readme.md"), "# no grammar\n").unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "ast", "validate", "empty"])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "dir with no source files must not vacuous-succeed; stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "no_matches");
+}
+
+#[cfg(feature = "ast")]
+#[test]
+fn test_ast_validate_ok_rust_still_succeeds() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("ok.rs"), "fn main() {}\n").unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "ast", "validate", "ok.rs"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let arr = json.as_array().expect("validate --json is an array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["valid"], true);
+}


### PR DESCRIPTION
## Summary

- `ast validate` no longer returns empty success (`[]`, exit 0) when the target is an unsupported language or a directory with no grammar-backed source files.
- Matches `ast list` honesty: `error_kind: no_matches`, exit 3, so agents cannot treat "never checked" as "valid".
- Integration tests cover unsupported file, empty dir, and still-OK Rust.

## Test plan

- [x] `cargo test --test integration --all-features test_ast_validate_`
- [x] `make check-fast`