### PR TITLE
fix: report applied:true in write --json after --apply

### DIFF
--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -1,5 +1,4 @@
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::WritePhase;
 use crate::cmd::output::execute_via_engine;
 use crate::plan::Operation;
 use clap::Args;
@@ -119,10 +118,7 @@ pub(crate) fn run_content_inject(
             ok: true,
             path: file_owned.clone(),
             diff,
-            applied: match phase {
-                WritePhase::Confirmed(a) => Some(a),
-                _ => None,
-            },
+            applied: phase.applied_flag(),
         },
         &check_msg,
         &apply_msg,

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -2,7 +2,7 @@
 
 use super::common::{resolve_lang, setup_multi_file};
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::{WritePhase, run_write_op, stage_for_write};
+use crate::cmd::output::{run_write_op, stage_for_write};
 use crate::cmd::write_mode::{RenderPolicy, WriteMessages, finalize_execution_result};
 use crate::exit;
 use crate::plan::Operation;
@@ -208,10 +208,7 @@ pub(super) fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Re
             symbol: symbol.clone(),
             replacements: None, // tx engine doesn't expose count
             diff,
-            applied: match phase {
-                WritePhase::Confirmed(a) => Some(a),
-                _ => None,
-            },
+            applied: phase.applied_flag(),
         },
         &check_msg,
         &apply_msg,

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -1,5 +1,4 @@
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::WritePhase;
 use crate::cmd::output::execute_via_engine;
 use crate::plan::Operation;
 use clap::Args;
@@ -94,10 +93,7 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             ok: true,
             path: args.file.clone(),
             diff,
-            applied: match phase {
-                WritePhase::Confirmed(a) => Some(a),
-                _ => None,
-            },
+            applied: phase.applied_flag(),
         },
         &check_msg,
         &apply_msg,
@@ -514,5 +510,26 @@ mod tests {
         let code = run(args, &global).unwrap();
         assert_eq!(code, exit::SUCCESS);
         assert_eq!(fs::read_to_string(&nested).unwrap(), "nested\n");
+    }
+
+    #[test]
+    fn create_apply_json_includes_applied_true() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("applied.txt");
+        let args = CreateArgs {
+            file: file.to_string_lossy().into_owned(),
+            content: Some("x\n".into()),
+            stdin: false,
+            force: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        global.json = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        // applied_flag() must surface Apply as applied:true (parity with delete).
+        assert!(file.exists());
     }
 }

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -1,5 +1,4 @@
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::WritePhase;
 use crate::cmd::output::execute_via_engine_no_preview_diffs;
 use crate::plan::Operation;
 use clap::Args;
@@ -54,7 +53,7 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         |phase, _diff| DeleteOutput {
             ok: true,
             path: args.file.clone(),
-            applied: matches!(phase, WritePhase::Applied | WritePhase::Confirmed(true)),
+            applied: phase.applied_flag().unwrap_or(false),
         },
         &check_msg,
         &apply_msg,

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -1,5 +1,4 @@
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::WritePhase;
 use crate::exit;
 use crate::ops::doc::{detect_format, diff_values, flatten_value, parse_doc, parse_value};
 use crate::plan::Operation;
@@ -817,10 +816,7 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     changed,
                     removed,
                     diff,
-                    applied: match phase {
-                        WritePhase::Confirmed(a) => Some(a),
-                        _ => None,
-                    },
+                    applied: phase.applied_flag(),
                 },
                 crate::cmd::write_mode::WriteMessages {
                     check: &check_msg,

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -204,10 +204,7 @@ fn execute_md_op(
                 _ => None,
             },
             diff,
-            applied: match phase {
-                WritePhase::Confirmed(a) => Some(a),
-                _ => None,
-            },
+            applied: phase.applied_flag(),
         },
         check_msg,
         apply_msg,
@@ -492,10 +489,7 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                                 _ => None,
                             },
                             diff,
-                            applied: match phase {
-                                WritePhase::Confirmed(a) => Some(a),
-                                _ => None,
-                            },
+                            applied: phase.applied_flag(),
                         },
                         &format!("would modify {file}"),
                         &format!("modified {file}"),

--- a/src/cmd/output.rs
+++ b/src/cmd/output.rs
@@ -158,10 +158,7 @@ mod tests {
             |phase, _diff| TestOutput {
                 ok: true,
                 path: "new.txt".to_string(),
-                applied: match phase {
-                    WritePhase::Confirmed(a) => Some(a),
-                    _ => None,
-                },
+                applied: phase.applied_flag(),
             },
             "would create new.txt",
             "created new.txt",
@@ -193,10 +190,7 @@ mod tests {
             |phase, _diff| TestOutput {
                 ok: true,
                 path: "new.txt".to_string(),
-                applied: match phase {
-                    WritePhase::Confirmed(a) => Some(a),
-                    _ => None,
-                },
+                applied: phase.applied_flag(),
             },
             "would create new.txt",
             "created new.txt",
@@ -225,10 +219,7 @@ mod tests {
             |phase, _diff| TestOutput {
                 ok: true,
                 path: "del.txt".to_string(),
-                applied: match phase {
-                    WritePhase::Confirmed(a) => Some(a),
-                    _ => None,
-                },
+                applied: phase.applied_flag(),
             },
             "would delete del.txt",
             "deleted del.txt",
@@ -258,10 +249,7 @@ mod tests {
             |phase, _diff| TestOutput {
                 ok: true,
                 path: "a.txt".to_string(),
-                applied: match phase {
-                    WritePhase::Confirmed(a) => Some(a),
-                    _ => None,
-                },
+                applied: phase.applied_flag(),
             },
             "would append",
             "appended",
@@ -289,10 +277,7 @@ mod tests {
             |phase, _diff| TestOutput {
                 ok: true,
                 path: "new.txt".to_string(),
-                applied: match phase {
-                    WritePhase::Confirmed(a) => Some(a),
-                    _ => None,
-                },
+                applied: phase.applied_flag(),
             },
             "would create new.txt",
             "created new.txt",
@@ -325,10 +310,7 @@ mod tests {
             |phase, _diff| TestOutput {
                 ok: true,
                 path: "new.txt".to_string(),
-                applied: match phase {
-                    WritePhase::Confirmed(a) => Some(a),
-                    _ => None,
-                },
+                applied: phase.applied_flag(),
             },
             "would create new.txt",
             "created new.txt",
@@ -358,10 +340,7 @@ mod tests {
             |phase, _diff| TestOutput {
                 ok: true,
                 path: "existing.txt".to_string(),
-                applied: match phase {
-                    WritePhase::Confirmed(a) => Some(a),
-                    _ => None,
-                },
+                applied: phase.applied_flag(),
             },
             "would append",
             "appended",

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -1,5 +1,4 @@
 use crate::cli::global::GlobalFlags;
-use crate::cmd::output::WritePhase;
 use crate::cmd::output::execute_via_engine;
 use crate::cmd::write_dispatch::{WriteMessages, execute_write};
 use crate::exit;
@@ -160,10 +159,7 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             to: Some(args.to.clone()),
 
             diff,
-            applied: match phase {
-                WritePhase::Confirmed(a) => Some(a),
-                _ => None,
-            },
+            applied: phase.applied_flag(),
         },
         &check_msg,
         &apply_msg,
@@ -255,10 +251,7 @@ fn run_direct_rename(
             to: Some(args.to.clone()),
 
             diff,
-            applied: match phase {
-                WritePhase::Confirmed(a) => Some(a),
-                _ => None,
-            },
+            applied: phase.applied_flag(),
         },
         Some(&|_| {
             if let Some(ref body) = content_for_diff {

--- a/src/cmd/write_mode.rs
+++ b/src/cmd/write_mode.rs
@@ -81,6 +81,19 @@ pub enum WritePhase {
     Preview,
 }
 
+impl WritePhase {
+    /// Agent-facing `applied` for success JSON: `Some(true)` after `--apply`,
+    /// `Some(confirmed)` after confirm+json, `None` for check/preview (omit).
+    #[must_use]
+    pub fn applied_flag(self) -> Option<bool> {
+        match self {
+            WritePhase::Applied => Some(true),
+            WritePhase::Confirmed(a) => Some(a),
+            WritePhase::Check(_) | WritePhase::Preview => None,
+        }
+    }
+}
+
 /// How a write command should behave given the global flags.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WriteMode {
@@ -393,6 +406,15 @@ fn plain_diff_opt(diffs: &[FileDiff]) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn applied_flag_maps_phases() {
+        assert_eq!(WritePhase::Applied.applied_flag(), Some(true));
+        assert_eq!(WritePhase::Confirmed(true).applied_flag(), Some(true));
+        assert_eq!(WritePhase::Confirmed(false).applied_flag(), Some(false));
+        assert_eq!(WritePhase::Preview.applied_flag(), None);
+        assert_eq!(WritePhase::Check(true).applied_flag(), None);
+    }
 
     #[test]
     fn classify_priority_check_over_apply() {

--- a/tests/integration/create_tests.rs
+++ b/tests/integration/create_tests.rs
@@ -778,3 +778,30 @@ fn test_create_json_already_exists_sets_error_kind() {
         "create --json existing file should set error_kind: {parsed}"
     );
 }
+
+#[test]
+fn test_create_apply_json_reports_applied_true() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("new.txt");
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("create")
+        .arg(&file)
+        .arg("--content")
+        .arg("hello\n")
+        .arg("--apply")
+        .arg("--cwd")
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(0));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true);
+    assert_eq!(
+        json["applied"], true,
+        "create --apply --json must set applied:true for agent parity with delete: {json}"
+    );
+}


### PR DESCRIPTION
## Summary

- Add `WritePhase::applied_flag()` for consistent agent JSON.
- create / append / rename / doc / md / ast replace now emit `applied: true` after `--apply --json` (same as delete).
- Preview and `--check` still omit `applied`.

## Test plan

- [x] `cargo test --lib --all-features applied_flag_maps`
- [x] `cargo test --test integration --all-features test_create_apply_json_reports_applied`
- [x] `make check-fast`