### PR TITLE
fix: reject append/prepend on binary (NUL) files

### DIFF
--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -125,6 +125,7 @@ fn file_write(
                 )
                 .into());
             }
+            crate::ops::file::ensure_not_binary_file(path, &path_str)?;
             let original = std::fs::read_to_string(path)
                 .with_context(|| format!("failed to read {}", path.display()))?;
             let combined = if is_append {

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -95,6 +95,12 @@ pub(crate) fn run_content_inject(
         global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
+    // Fail before the engine so --json gets error_kind and binaries are not
+    // rewritten as text (NUL is valid UTF-8).
+    if let Err(e) = crate::ops::file::ensure_not_binary_file(&path, file) {
+        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
+        return Ok(crate::exit::FAILURE);
+    }
 
     let op = match position {
         ContentPosition::Append => Operation::FileAppend {
@@ -261,5 +267,46 @@ mod tests {
 
         let code = run(args, &GlobalFlags::default()).unwrap();
         assert_eq!(code, exit::FAILURE);
+    }
+
+    #[test]
+    fn append_rejects_binary_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("data.bin");
+        fs::write(&file, b"hello\x00world").unwrap();
+
+        let args = AppendArgs {
+            file: file.to_string_lossy().into_owned(),
+            content: Some("evil\n".into()),
+            stdin: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
+        assert_eq!(fs::read(&file).unwrap(), b"hello\x00world");
+    }
+
+    #[test]
+    fn prepend_rejects_binary_file() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("data.bin");
+        fs::write(&file, b"hello\x00world").unwrap();
+
+        let code = run_content_inject(
+            &file.to_string_lossy(),
+            Some("evil\n"),
+            false,
+            ContentPosition::Prepend,
+            &GlobalFlags {
+                apply: true,
+                ..GlobalFlags::test_with_cwd(dir.path())
+            },
+        )
+        .unwrap();
+        assert_eq!(code, exit::FAILURE);
+        assert_eq!(fs::read(&file).unwrap(), b"hello\x00world");
     }
 }

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -53,6 +53,38 @@ pub fn ensure_parent_components_are_directories(
     Ok(())
 }
 
+/// Reject on-disk binary targets for text-oriented file ops (append/prepend).
+///
+/// NUL bytes are valid UTF-8, so `read_to_string` succeeds and used to rewrite
+/// binaries as text. Matches replace/search skip policy (`is_binary` on the
+/// first 8 KiB). `display` is the path shown in the error (CLI arg or op path).
+pub fn ensure_not_binary_file(
+    path: &Path,
+    display: &str,
+) -> Result<(), crate::exit::InvalidInputError> {
+    use std::io::Read;
+
+    if !path.exists() {
+        return Ok(());
+    }
+    let mut file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        // Existence was checked by the caller; open errors surface on full read.
+        Err(_) => return Ok(()),
+    };
+    let mut buf = [0u8; 8192];
+    let n = match file.read(&mut buf) {
+        Ok(n) => n,
+        Err(_) => return Ok(()),
+    };
+    if crate::files::is_binary(&buf[..n]) {
+        return Err(crate::exit::InvalidInputError {
+            msg: format!("target is a binary file: {display}"),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -157,5 +189,29 @@ mod tests {
         let path = blocking.join("b").join("c.txt");
         let err = ensure_parent_components_are_directories(&path).unwrap_err();
         assert!(err.msg.contains("not a directory"), "got: {}", err.msg);
+    }
+
+    #[test]
+    fn ensure_not_binary_ok_for_text() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.txt");
+        fs::write(&path, "hello\n").unwrap();
+        ensure_not_binary_file(&path, "t.txt").unwrap();
+    }
+
+    #[test]
+    fn ensure_not_binary_rejects_nul() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("b.bin");
+        fs::write(&path, b"hello\x00world").unwrap();
+        let err = ensure_not_binary_file(&path, "b.bin").unwrap_err();
+        assert!(err.msg.contains("binary file"), "got: {}", err.msg);
+        assert!(err.msg.contains("b.bin"));
+    }
+
+    #[test]
+    fn ensure_not_binary_missing_path_ok() {
+        let dir = TempDir::new().unwrap();
+        ensure_not_binary_file(&dir.path().join("nope"), "nope").unwrap();
     }
 }

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -29,6 +29,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 )
                 .into());
             }
+            // On-disk binary only (in-tx text create then append is fine).
+            if !tx.pending.contains_key(&file_path) {
+                crate::ops::file::ensure_not_binary_file(&file_path, path)?;
+            }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let combined = crate::ops::file::append_content(existing, content);
             update_file_content(
@@ -61,6 +65,9 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                     format!("file does not exist: {path}"),
                 )
                 .into());
+            }
+            if !tx.pending.contains_key(&file_path) {
+                crate::ops::file::ensure_not_binary_file(&file_path, path)?;
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let combined = crate::ops::file::prepend_content(existing, content);

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -301,6 +301,54 @@ fn file_prepend_to_deleted_file_errors() {
     );
 }
 
+/// append/prepend must not rewrite binary (NUL) files as text.
+#[test]
+fn file_append_rejects_binary_file() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.bin");
+    std::fs::write(&file, b"hello\x00world").unwrap();
+
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+
+    let op = Operation::FileAppend {
+        path: "data.bin".into(),
+        content: "evil\n".into(),
+    };
+    let err = execute_file_op(&op, &mut tx).unwrap_err();
+    assert!(
+        crate::exit::is_invalid_input(&err),
+        "expected InvalidInputError, got: {err:#}"
+    );
+    assert!(
+        err.to_string().contains("binary file"),
+        "message should name binary: {err}"
+    );
+    assert!(
+        f.pending.is_empty(),
+        "must not stage a write for a binary append"
+    );
+    assert_eq!(std::fs::read(&file).unwrap(), b"hello\x00world");
+}
+
+#[test]
+fn file_prepend_rejects_binary_file() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.bin");
+    std::fs::write(&file, b"hello\x00world").unwrap();
+
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+
+    let op = Operation::FilePrepend {
+        path: "data.bin".into(),
+        content: "evil\n".into(),
+    };
+    let err = execute_file_op(&op, &mut tx).unwrap_err();
+    assert!(crate::exit::is_invalid_input(&err), "got: {err:#}");
+    assert_eq!(std::fs::read(&file).unwrap(), b"hello\x00world");
+}
+
 /// file.create through a path component that is a file must fail with
 /// InvalidInputError before staging (no bare tempfile / false backup).
 #[test]

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -596,3 +596,97 @@ fn test_append_json_not_found_sets_error_kind() {
         "append --json missing file should set error_kind: {parsed}"
     );
 }
+
+#[test]
+fn test_append_rejects_binary_file_json() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.bin");
+    fs::write(&file, b"hello\x00world").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "append",
+            "data.bin",
+            "--content",
+            "evil\n",
+            "--apply",
+            "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "invalid_input");
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("binary file"),
+        "error should name binary: {json}"
+    );
+    assert_eq!(fs::read(&file).unwrap(), b"hello\x00world");
+}
+
+#[test]
+fn test_prepend_rejects_binary_file_json() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.bin");
+    fs::write(&file, b"hello\x00world").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "prepend",
+            "data.bin",
+            "--content",
+            "evil\n",
+            "--apply",
+            "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input");
+    assert_eq!(fs::read(&file).unwrap(), b"hello\x00world");
+}
+
+#[test]
+fn test_tx_append_rejects_binary_file() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("data.bin"), b"hello\x00world").unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {"op": "file.append", "path": "data.bin", "content": "evil\n"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tx"])
+        .arg(&plan_file)
+        .args(["--apply", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input");
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("binary"),
+        "tx append binary: {json}"
+    );
+    assert_eq!(
+        fs::read(dir.path().join("data.bin")).unwrap(),
+        b"hello\x00world"
+    );
+}


### PR DESCRIPTION
## Summary

- `append` / `prepend` (CLI, `file.append`/`file.prepend` in tx, library no-cli fallback) reject on-disk binary targets.
- Binary means NUL in the first 8 KiB (`is_binary`), same policy as replace/search skip.
- Returns `error_kind: invalid_input` and leaves the file unchanged (previously rewrote binaries as text with success).

## Test plan

- [x] Unit: `ensure_not_binary_*`, `file_append_rejects_binary_file`, `append_rejects_binary_file`
- [x] Integration: append/prepend/tx binary JSON
- [x] `make check-fast`