### PR TITLE
fix: fail closed on sole explicit binary replace/tidy target

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -687,6 +687,12 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             global.emit_error_json_kind(Some("not_found"), &msg)?;
             return Ok(exit::FAILURE);
         }
+        // Sole explicit binary is skipped by the text reader; do not report
+        // no_matches (agents retry with different patterns forever).
+        if let Some(err) = crate::ops::file::single_explicit_binary_target(&args.paths, &cwd) {
+            global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+            return Ok(exit::FAILURE);
+        }
         let similar = similar_targets_for_no_match(&args, global, &cwd);
         let path_desc = global.path_scope_description(&args.paths);
         // Agents reading `error` (tx parity) should not need to scrape stderr.

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -237,6 +237,11 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(exit::FAILURE);
     }
+    // Sole explicit binary: do not report vacuous "clean" (never scanned).
+    if let Some(err) = crate::ops::file::single_explicit_binary_target(paths, &cwd) {
+        global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+        return Ok(exit::FAILURE);
+    }
     let skipped = crate::files::scan_missing_entries(global, &cwd, paths)?;
     let issues = collect_issues(paths, global)?;
     if !global.quiet || global.json || global.jsonl {

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -250,6 +250,11 @@ pub(super) fn run_fix(
             global.emit_error_json_kind(Some("not_found"), &msg)?;
             return Ok(exit::FAILURE);
         }
+        // Sole explicit binary: soft-skip would look like "already tidy".
+        if let Some(err) = crate::ops::file::single_explicit_binary_target(&paths, &cwd) {
+            global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+            return Ok(exit::FAILURE);
+        }
         emit_tidy_fix_output(global, &[], None, skipped)?;
         return Ok(exit::SUCCESS);
     }

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -85,6 +85,33 @@ pub fn ensure_not_binary_file(
     Ok(())
 }
 
+/// When the user names exactly one existing file and it is binary, return that
+/// display path. Directory walks and multi-path lists still soft-skip binaries.
+pub fn single_explicit_binary_target(
+    paths: &[String],
+    cwd: &Path,
+) -> Option<crate::exit::InvalidInputError> {
+    if paths.len() != 1 {
+        return None;
+    }
+    let display = paths[0].as_str();
+    if display.is_empty() {
+        return None;
+    }
+    let path = {
+        let p = Path::new(display);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            cwd.join(p)
+        }
+    };
+    if !path.is_file() {
+        return None;
+    }
+    ensure_not_binary_file(&path, display).err()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -213,5 +240,26 @@ mod tests {
     fn ensure_not_binary_missing_path_ok() {
         let dir = TempDir::new().unwrap();
         ensure_not_binary_file(&dir.path().join("nope"), "nope").unwrap();
+    }
+
+    #[test]
+    fn single_explicit_binary_detects_sole_file() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("b.bin");
+        fs::write(&path, b"x\x00y").unwrap();
+        let err = single_explicit_binary_target(&["b.bin".into()], dir.path()).unwrap();
+        assert!(err.msg.contains("binary"));
+    }
+
+    #[test]
+    fn single_explicit_binary_none_for_text_or_multi() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("t.txt"), "hi\n").unwrap();
+        fs::write(dir.path().join("b.bin"), b"x\x00y").unwrap();
+        assert!(single_explicit_binary_target(&["t.txt".into()], dir.path()).is_none());
+        assert!(
+            single_explicit_binary_target(&["t.txt".into(), "b.bin".into()], dir.path()).is_none()
+        );
+        assert!(single_explicit_binary_target(&[".".into()], dir.path()).is_none());
     }
 }

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -690,3 +690,76 @@ fn test_tx_append_rejects_binary_file() {
         b"hello\x00world"
     );
 }
+
+#[test]
+fn test_replace_sole_binary_target_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("only.bin"), b"hello\x00world").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json", "replace", "hello", "only.bin", "--new", "hi", "--apply", "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input");
+    assert!(
+        json["error"].as_str().unwrap_or("").contains("binary"),
+        "replace sole binary: {json}"
+    );
+    assert_eq!(
+        fs::read(dir.path().join("only.bin")).unwrap(),
+        b"hello\x00world"
+    );
+}
+
+#[test]
+fn test_tidy_check_sole_binary_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("only.bin"), b"a\x00b  \n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tidy", "check", "only.bin", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input");
+}
+
+#[test]
+fn test_tidy_fix_sole_binary_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("only.bin"), b"a\x00b  \n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json",
+            "tidy",
+            "fix",
+            "only.bin",
+            "--trim-trailing-whitespace",
+            "--apply",
+            "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input");
+    assert_eq!(
+        fs::read(dir.path().join("only.bin")).unwrap(),
+        b"a\x00b  \n"
+    );
+}


### PR DESCRIPTION
## Summary

- Sole explicit binary target for `replace`, `tidy check`, and `tidy fix` now returns `error_kind: invalid_input` (not silent no_matches / vacuous clean).
- Directory walks and multi-path lists still soft-skip binaries (unchanged).
- Shared helper: `single_explicit_binary_target`.

## Test plan

- [x] Unit: `single_explicit_binary_*`
- [x] Integration: replace/tidy sole binary
- [x] Existing binary skip tests still pass
- [x] `make check-fast`