### PR TITLE
fix: delete and rename JSON include backup_session

### DIFF
--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -21,6 +21,9 @@ struct DeleteOutput {
     ok: bool,
     path: String,
     applied: bool,
+    /// Backup session id after a successful apply (#1802).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backup_session: Option<String>,
 }
 
 pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
@@ -50,10 +53,11 @@ pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     execute_via_engine_no_preview_diffs(
         op,
         global,
-        |phase, _diff, _backup| DeleteOutput {
+        |phase, _diff, backup| DeleteOutput {
             ok: true,
             path: args.file.clone(),
             applied: phase.applied_flag().unwrap_or(false),
+            backup_session: backup,
         },
         &check_msg,
         &apply_msg,

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -284,9 +284,9 @@ fn run_direct_rename(
             {
                 fs::create_dir_all(parent)?;
             }
-            backup.finalize()?;
+            let session = backup.finalize()?;
             rename_or_copy(src, dst)?;
-            Ok(())
+            Ok(session)
         },
         WriteMessages {
             check: &check_msg,

--- a/src/cmd/write_dispatch.rs
+++ b/src/cmd/write_dispatch.rs
@@ -13,7 +13,7 @@ pub fn execute_write<T: Serialize>(
     cwd: &Path,
     make_output: impl Fn(WritePhase, Option<String>, Option<String>) -> T,
     diff_fn: Option<&dyn Fn(bool) -> String>,
-    apply_fn: impl FnMut() -> anyhow::Result<()>,
+    apply_fn: impl FnMut() -> anyhow::Result<Option<String>>,
     msgs: WriteMessages<'_>,
 ) -> anyhow::Result<u8> {
     // Callback paths are only entered when a change is known to be needed.
@@ -73,7 +73,7 @@ mod tests {
             Some(&|_color| "diff".to_string()),
             || {
                 applied = true;
-                Ok(())
+                Ok(None)
             },
             test_msgs(),
         )
@@ -97,7 +97,7 @@ mod tests {
             Some(&|_color| "diff".to_string()),
             || {
                 applied = true;
-                Ok(())
+                Ok(None)
             },
             test_msgs(),
         )
@@ -120,7 +120,7 @@ mod tests {
             Some(&|_color| "diff".to_string()),
             || {
                 applied = true;
-                Ok(())
+                Ok(None)
             },
             test_msgs(),
         )
@@ -140,7 +140,7 @@ mod tests {
             dir.path(),
             make_test_output,
             None::<&dyn Fn(bool) -> String>,
-            || Ok(()),
+            || Ok(None),
             WriteMessages {
                 check: "would delete foo.txt",
                 apply: "deleted foo.txt",
@@ -170,7 +170,7 @@ mod tests {
             Some(&|_color| "diff".to_string()),
             || {
                 applied = true;
-                Ok(())
+                Ok(None)
             },
             test_msgs(),
         )

--- a/src/cmd/write_mode.rs
+++ b/src/cmd/write_mode.rs
@@ -47,18 +47,20 @@ fn commit_then_format(
 }
 
 /// Apply callback write, then run `--format` with the same backup attachment.
+///
+/// `apply_fn` returns the backup session id when one was created (rename
+/// direct path, etc.). That id is passed through to agent JSON and format
+/// failure envelopes (#1802).
 fn apply_then_format(
-    mut apply_fn: impl FnMut() -> anyhow::Result<()>,
+    mut apply_fn: impl FnMut() -> anyhow::Result<Option<String>>,
     global: &GlobalFlags,
     cwd: &Path,
 ) -> anyhow::Result<Option<String>> {
-    apply_fn()?;
-    // Binary/case-only rename paths do not return a session id from the
-    // callback; still map format failures to FormatFailedError for JSON.
+    let backup = apply_fn()?;
     if let Err(e) = crate::write::run_format_command(global, cwd) {
-        return Err(attach_format_backup(e, None, Vec::new()));
+        return Err(attach_format_backup(e, backup, Vec::new()));
     }
-    Ok(None)
+    Ok(backup)
 }
 
 fn attach_format_backup(
@@ -421,7 +423,7 @@ pub fn finalize_callback_write<T: Serialize>(
     has_changes: bool,
     make_output: impl Fn(WritePhase, Option<String>, Option<String>) -> T,
     diff_fn: Option<&dyn Fn(bool) -> String>,
-    mut apply_fn: impl FnMut() -> anyhow::Result<()>,
+    mut apply_fn: impl FnMut() -> anyhow::Result<Option<String>>,
     msgs: WriteMessages<'_>,
 ) -> anyhow::Result<u8> {
     match classify_write_mode(global) {
@@ -433,13 +435,13 @@ pub fn finalize_callback_write<T: Serialize>(
             Ok(write_exit_code(has_changes, false))
         }
         WriteMode::Apply => {
-            let _backup = apply_then_format(&mut apply_fn, global, cwd)?;
+            let backup = apply_then_format(&mut apply_fn, global, cwd)?;
             let diff_text = if global.diff {
                 diff_fn.map(|f| f(false))
             } else {
                 None
             };
-            let output = make_output(WritePhase::Applied, diff_text, None);
+            let output = make_output(WritePhase::for_apply(has_changes), diff_text, backup);
             if !global.emit_json(&output)? {
                 if global.diff {
                     if let Some(f) = diff_fn {
@@ -449,15 +451,18 @@ pub fn finalize_callback_write<T: Serialize>(
                     println!("{}", msgs.apply);
                 }
             }
-            Ok(write_exit_code(has_changes, true))
+            Ok(write_exit_code(has_changes, has_changes))
         }
         WriteMode::ConfirmJson => {
             let diff_text = diff_fn.map(|f| f(false));
-            let applied = global.should_apply();
-            if applied {
-                let _backup = apply_then_format(&mut apply_fn, global, cwd)?;
-            }
-            let output = make_output(WritePhase::Confirmed(applied), diff_text, None);
+            let confirmed = global.should_apply();
+            let backup = if confirmed {
+                apply_then_format(&mut apply_fn, global, cwd)?
+            } else {
+                None
+            };
+            let applied = confirmed && has_changes;
+            let output = make_output(WritePhase::Confirmed(applied), diff_text, backup);
             global.emit_json(&output)?;
             Ok(write_exit_code(has_changes, applied))
         }
@@ -480,7 +485,7 @@ pub fn finalize_callback_write<T: Serialize>(
                     eprintln!("{msg}");
                 }
             }
-            Ok(write_exit_code(has_changes, applied))
+            Ok(write_exit_code(has_changes, applied && has_changes))
         }
     }
 }

--- a/tests/integration/delete_tests.rs
+++ b/tests/integration/delete_tests.rs
@@ -61,6 +61,14 @@ fn test_delete_json_apply_output() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["applied"], true);
     assert!(json["path"].as_str().unwrap().contains("doomed.txt"));
+    // Agents need backup_session to undo without --list (#1802 parity).
+    let session = json["backup_session"]
+        .as_str()
+        .expect("delete --apply must include backup_session");
+    assert!(
+        !session.is_empty(),
+        "backup_session must be non-empty: {json}"
+    );
 }
 
 #[cfg(unix)]

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -405,6 +405,12 @@ fn test_rename_json_output() {
     assert_eq!(json["ok"], true);
     assert_eq!(json["from"], src.to_str().unwrap());
     assert_eq!(json["to"], dst.to_str().unwrap());
+    assert_eq!(json["applied"], true, "{json}");
+    // Direct rename creates a backup; agents need the session id for undo.
+    assert!(
+        json["backup_session"].as_str().is_some_and(|s| !s.is_empty()),
+        "rename --apply must include backup_session: {json}"
+    );
     assert!(!src.exists());
     assert_eq!(fs::read_to_string(&dst).unwrap(), "content\n");
 }

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -408,7 +408,9 @@ fn test_rename_json_output() {
     assert_eq!(json["applied"], true, "{json}");
     // Direct rename creates a backup; agents need the session id for undo.
     assert!(
-        json["backup_session"].as_str().is_some_and(|s| !s.is_empty()),
+        json["backup_session"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
         "rename --apply must include backup_session: {json}"
     );
     assert!(!src.exists());


### PR DESCRIPTION
## Summary

Agent JSON for `delete --apply` and direct `rename --apply` created backup sessions on disk but omitted `backup_session` in the success payload, so agents could not undo without listing sessions first.

- Delete: pass engine backup id through `DeleteOutput`
- Rename (direct/plain path): `apply_fn` returns the session from `BackupSession::finalize`; `finalize_callback_write` surfaces it

## Test plan

- [x] `make check-fast` green
- [x] Integration: delete apply JSON has `backup_session`; rename apply JSON has `backup_session`