### PR TITLE
fix: patch check reports would_change like apply preview

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -895,9 +895,10 @@ Use these when the change already exists as a unified diff.
 <!-- ref:patch-action:check -->
 ### `patch check`
 
-- **What it does:** Verifies whether a patch applies cleanly, without writing files.
-- **Use when:** CI or review should fail early on stale patch context.
+- **What it does:** Dry-run a unified diff without writing. Per-file status is `would_change` (exit 2) when the patch applies and content would change, `unchanged` when the result equals the current file, or `stale`/`missing`/`error` (exit 5) when the patch cannot apply.
+- **Use when:** CI or agents need the same “would change” signal as `patch apply` preview before committing to `--apply`.
 - **Prefer instead:** Use `patch apply` when the patch should be written, or `replace` and `doc` when you do not actually need to carry a diff file.
+- **JSON:** Includes `applied: false`. Do not treat historical status `clean` as “nothing to do”; that name meant “applies without fuzz” and confused agents.
 
 <!-- ref:patch-action:apply -->
 ### `patch apply`

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -210,7 +210,8 @@ fn emit_patch_files_output(
     } else if !global.quiet {
         for r in results {
             let label = match r.status {
-                "clean" => "clean",
+                "clean" | "unchanged" => "clean",
+                "would_change" => "would change",
                 "stale" => "STALE",
                 "missing" => "MISSING",
                 "error" => "ERROR",
@@ -222,7 +223,7 @@ fn emit_patch_files_output(
                 eprintln!("patch check: {} -- {}: {}", r.path, label, err);
             } else if let Some(n) = r.conflicts {
                 eprintln!("patch check: {} -- {} ({} conflicts)", r.path, label, n);
-            } else if r.status != "clean" && r.status != "applied" {
+            } else if r.status != "clean" && r.status != "unchanged" && r.status != "applied" {
                 eprintln!("patch check: {} -- {}", r.path, label);
             }
         }
@@ -321,7 +322,13 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     );
 
     if matches!(args.action, PatchAction::Check { .. }) {
-        let mut all_clean = true;
+        // Agent honesty: "clean" used to mean "patch applies without fuzz"
+        // (git apply --check), which agents misread as "nothing to do" while
+        // `patch apply` preview correctly reported would_change + exit 2.
+        // Align check with apply preview: would_change + CHANGES_DETECTED when
+        // content would change; stale/missing/error stay fail-closed.
+        let mut any_would_change = false;
+        let mut any_problem = false;
         let mut results = Vec::new();
         for pf in &patch_files {
             let file_path = cwd.join(&pf.path);
@@ -339,7 +346,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                             error: Some(msg.clone()),
                             conflicts: None,
                         });
-                        all_clean = false;
+                        any_problem = true;
                         continue;
                     }
                 }
@@ -354,32 +361,54 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     if !global.json && !global.jsonl && !global.quiet {
                         eprintln!("patch check: {} -- READ ERROR: {}", pf.path, msg);
                     }
-                    all_clean = false;
+                    any_problem = true;
                     continue;
                 }
             };
-            if apply_hunks(&original, &pf.hunks).is_ok() {
-                results.push(PatchFileResult {
-                    path: pf.path.clone(),
-                    status: "clean",
-                    error: None,
-                    conflicts: None,
-                });
-            } else {
-                all_clean = false;
-                results.push(PatchFileResult {
-                    path: pf.path.clone(),
-                    status: "stale",
-                    error: None,
-                    conflicts: None,
-                });
+            match apply_hunks(&original, &pf.hunks) {
+                Ok(new_content) if new_content == original => {
+                    results.push(PatchFileResult {
+                        path: pf.path.clone(),
+                        status: "unchanged",
+                        error: None,
+                        conflicts: None,
+                    });
+                }
+                Ok(_) => {
+                    any_would_change = true;
+                    results.push(PatchFileResult {
+                        path: pf.path.clone(),
+                        status: "would_change",
+                        error: None,
+                        conflicts: None,
+                    });
+                }
+                Err(_) => {
+                    any_problem = true;
+                    results.push(PatchFileResult {
+                        path: pf.path.clone(),
+                        status: "stale",
+                        error: None,
+                        conflicts: None,
+                    });
+                }
             }
         }
-        emit_patch_files_output(global, all_clean, &results, Some(false), None)?;
-        return Ok(if all_clean {
-            exit::SUCCESS
-        } else {
+        let ok = !any_problem;
+        emit_patch_files_output(global, ok, &results, Some(false), None)?;
+        if !global.json && !global.jsonl && !global.quiet && any_would_change && !any_problem {
+            let n = results
+                .iter()
+                .filter(|r| r.status == "would_change")
+                .count();
+            println!("{n} file(s) would change");
+        }
+        return Ok(if any_problem {
             exit::AMBIGUOUS
+        } else if any_would_change {
+            exit::CHANGES_DETECTED
+        } else {
+            exit::SUCCESS
         });
     }
 

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -239,7 +239,7 @@ fn test_patch_apply_json_stale_error_returns_error_object() {
 }
 
 #[test]
-fn test_patch_check_exits_0_when_clean() {
+fn test_patch_check_exits_2_when_would_change() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
     fs::write(&file, "line1\nold line\nline3\n").unwrap();
@@ -251,6 +251,7 @@ fn test_patch_check_exits_0_when_clean() {
     )
     .unwrap();
 
+    // Applicable patch that mutates content is CHANGES_DETECTED (2), not SUCCESS.
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("--cwd")
@@ -259,7 +260,8 @@ fn test_patch_check_exits_0_when_clean() {
         .arg("check")
         .arg(&patch_file)
         .assert()
-        .code(0);
+        .code(2)
+        .stdout(predicates::str::contains("would change"));
 }
 
 #[test]
@@ -311,7 +313,7 @@ fn test_patch_apply_check_counts_only_changed_files() {
 }
 
 #[test]
-fn test_patch_check_json_output_clean() {
+fn test_patch_check_json_output_would_change() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.txt");
     fs::write(&file, "line1\nold line\nline3\n").unwrap();
@@ -334,12 +336,20 @@ fn test_patch_check_json_output_clean() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    // Align with patch apply preview: applicable patch that mutates content
+    // is would_change + exit 2, not "clean"/0 (agents misread that as done).
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], true);
+    assert_eq!(json["applied"], false);
     assert!(json["files"].is_array());
-    assert_eq!(json["files"][0]["status"], "clean");
+    assert_eq!(json["files"][0]["status"], "would_change");
 }
 
 #[test]
@@ -384,7 +394,11 @@ fn test_patch_check_jsonl_output() {
         .output()
         .unwrap();
 
-    assert!(output.status.success());
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "jsonl check should report changes_detected"
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let lines: Vec<serde_json::Value> = stdout
@@ -395,7 +409,7 @@ fn test_patch_check_jsonl_output() {
 
     assert_eq!(lines.len(), 1, "should have one JSONL line per patch file");
     assert_eq!(lines[0]["path"], "test.txt");
-    assert_eq!(lines[0]["status"], "clean");
+    assert_eq!(lines[0]["status"], "would_change");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Found by fixrealloop runtime dogfood: `patch check` reported `status: clean` with exit 0 for patches that would mutate files. Agents treated that as “nothing to do,” while `patch apply` preview correctly used `would_change` and exit 2.

### Changes

- `patch check`: `would_change` + exit 2 when content would change; `unchanged` when apply is a no-op; stale/missing/error stay fail-closed (exit 5)
- Align human/JSON/JSONL labels with apply preview
- Reference docs + regression tests

## Test plan

- [x] `make check-fast` green
- [x] Integration: `test_patch_check_*` updated for would_change
- [x] Dogfood: check and apply preview both exit 2 with `would_change`