### PR TITLE
fix: batch file.create preserves unquoted JSON content

### DIFF
--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -167,25 +167,21 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
         "replace" => parse_replace_line(args, line_num),
 
         // -- file operations ---------------------------------------------------
+        // Content is path + remainder (joined). Agents write unquoted multi-word
+        // text and unquoted JSON objects; exact-arity-2 rejected those.
         "file.append" => {
-            require_args(op, args, 2, line_num)?;
-            op!(FileAppend {
-                path: args[0].clone(),
-                content: args[1].clone()
-            })
+            let (path, content) = path_and_joined_content(op, args, line_num)?;
+            op!(FileAppend { path, content })
         }
         "file.prepend" => {
-            require_args(op, args, 2, line_num)?;
-            op!(FilePrepend {
-                path: args[0].clone(),
-                content: args[1].clone()
-            })
+            let (path, content) = path_and_joined_content(op, args, line_num)?;
+            op!(FilePrepend { path, content })
         }
         "file.create" => {
-            require_args(op, args, 2, line_num)?;
+            let (path, content) = path_and_joined_content(op, args, line_num)?;
             op!(FileCreate {
-                path: args[0].clone(),
-                content: args[1].clone(),
+                path,
+                content,
                 force: None
             })
         }
@@ -645,9 +641,35 @@ fn parse_json_value(s: &str) -> anyhow::Result<serde_json::Value> {
     Ok(crate::ops::doc::parse_value(s))
 }
 
+/// Path + free-form content for file.create/append/prepend.
+///
+/// Requires at least a path. Remaining tokens are joined with a single space so
+/// unquoted multi-word content (`file.create f.txt hello world`) works. Prefer
+/// JSON-aware tokens (see [`tokenize`]) so unquoted `{"x":1}` is not mangled.
+fn path_and_joined_content(
+    op: &str,
+    args: &[String],
+    line_num: usize,
+) -> anyhow::Result<(String, String)> {
+    if args.is_empty() {
+        return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("line {line_num}: '{op}' requires a path argument, got 0"),
+        }));
+    }
+    let path = args[0].clone();
+    let content = if args.len() == 1 {
+        String::new()
+    } else {
+        args[1..].join(" ")
+    };
+    Ok((path, content))
+}
+
 /// Tokenize a line using shell-like quoting rules.
 /// - Whitespace separates tokens
 /// - Double-quoted strings preserve spaces and allow escapes (\", \\)
+/// - Unquoted `{...}` / `[...]` are brace-balanced (JSON objects/arrays) so
+///   agents can write `file.create f.json {"x":1}` without silent quote stripping
 pub fn tokenize(line: &str) -> anyhow::Result<Vec<String>> {
     let mut tokens = Vec::new();
     let mut chars = line.chars().peekable();
@@ -688,6 +710,40 @@ pub fn tokenize(line: &str) -> anyhow::Result<Vec<String>> {
                         return Err(anyhow::Error::new(crate::exit::ParseErrorError {
                             msg: "unterminated double quote".into(),
                         }));
+                    }
+                }
+            }
+        } else if !in_token && (ch == '{' || ch == '[') {
+            // Brace-balanced JSON token (preserves internal double quotes).
+            in_token = true;
+            let open = ch;
+            let close = if ch == '{' { '}' } else { ']' };
+            let mut depth = 0i32;
+            let mut in_string = false;
+            let mut escape = false;
+            loop {
+                let c = chars.next().ok_or_else(|| {
+                    anyhow::Error::new(crate::exit::ParseErrorError {
+                        msg: format!("unterminated JSON value starting with '{open}'"),
+                    })
+                })?;
+                current.push(c);
+                if in_string {
+                    if escape {
+                        escape = false;
+                    } else if c == '\\' {
+                        escape = true;
+                    } else if c == '"' {
+                        in_string = false;
+                    }
+                } else if c == '"' {
+                    in_string = true;
+                } else if c == open {
+                    depth += 1;
+                } else if c == close {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
                     }
                 }
             }

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -42,6 +42,47 @@ mod basic {
     }
 
     #[test]
+    fn tokenize_unquoted_json_object_preserves_inner_quotes() {
+        // Agents write file.create f.json {"x":1} without outer quotes.
+        // Quote-stripping must not produce invalid JSON {x:1}.
+        let tokens = tokenize(r#"file.create f.json {"x":1}"#).unwrap();
+        assert_eq!(
+            tokens,
+            vec!["file.create", "f.json", r#"{"x":1}"#],
+            "unquoted JSON object must stay one token with quotes"
+        );
+    }
+
+    #[test]
+    fn tokenize_unquoted_json_array() {
+        let tokens = tokenize(r#"doc.set f.json items [1,2,{"a":"b"}]"#).unwrap();
+        assert_eq!(
+            tokens,
+            vec!["doc.set", "f.json", "items", r#"[1,2,{"a":"b"}]"#]
+        );
+    }
+
+    #[test]
+    fn parse_file_create_unquoted_json_content() {
+        let op = parse_line(r#"file.create cfg.json {"x":1,"y":"z"}"#, 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::FileCreate { path, content, .. }
+            if path == "cfg.json" && content == r#"{"x":1,"y":"z"}"#
+        ));
+    }
+
+    #[test]
+    fn parse_file_create_multiword_unquoted_content() {
+        let op = parse_line("file.create note.txt hello world", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::FileCreate { path, content, .. }
+            if path == "note.txt" && content == "hello world"
+        ));
+    }
+
+    #[test]
     fn parse_json_value_number() {
         let v = parse_json_value("42").unwrap();
         assert_eq!(v, serde_json::json!(42));
@@ -616,11 +657,11 @@ mod error_handling {
 
     #[test]
     fn parse_line_extra_args_rejected_all_operations() {
-        // 2-arg operations (require exactly 2)
+        // 2-arg operations (require exactly 2). file.create/append/prepend join
+        // trailing tokens as content (agent multi-word / unquoted JSON).
         let two_arg_ops = [
             r#"doc.delete f.json sel extra"#,
             r#"doc.merge f.json "{}" extra"#,
-            r#"file.create f.txt content extra"#,
             r#"file.rename old.txt new.txt extra"#,
         ];
         for line in &two_arg_ops {


### PR DESCRIPTION
## Summary

Found by fixrealloop: `file.create cfg.json {"x":1}` succeeded but wrote invalid `{x:1}` (inner quotes stripped by shell-style tokenization). Agents then hit cryptic doc.set errors on the broken file.

### Changes

- Brace-balanced `{…}` / `[…]` tokens keep internal double quotes
- `file.create` / `append` / `prepend` join trailing tokens so multi-word content works without arity errors

## Test plan

- [x] `make check-fast` green
- [x] Unit: unquoted JSON object/array tokenize + file.create multiword
- [x] Dogfood: batch create JSON + doc.set + multiword text