### PR TITLE
fix: expand newline escapes in batch file content

### DIFF
--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -646,6 +646,8 @@ fn parse_json_value(s: &str) -> anyhow::Result<serde_json::Value> {
 /// Requires at least a path. Remaining tokens are joined with a single space so
 /// unquoted multi-word content (`file.create f.txt hello world`) works. Prefer
 /// JSON-aware tokens (see [`tokenize`]) so unquoted `{"x":1}` is not mangled.
+/// Content expands `\n` `\t` `\r` `\\` `\"` so agents can write multi-line files
+/// on one batch line (fixrealloop: TOML/Rust scaffolds).
 fn path_and_joined_content(
     op: &str,
     args: &[String],
@@ -657,12 +659,37 @@ fn path_and_joined_content(
         }));
     }
     let path = args[0].clone();
-    let content = if args.len() == 1 {
+    let raw = if args.len() == 1 {
         String::new()
     } else {
         args[1..].join(" ")
     };
-    Ok((path, content))
+    Ok((path, expand_content_escapes(&raw)))
+}
+
+/// Expand common escapes in batch file content (`\n` `\t` `\r` `\\` `\"`).
+fn expand_content_escapes(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some('n') => out.push('\n'),
+            Some('t') => out.push('\t'),
+            Some('r') => out.push('\r'),
+            Some('\\') => out.push('\\'),
+            Some('"') => out.push('"'),
+            Some(other) => {
+                out.push('\\');
+                out.push(other);
+            }
+            None => out.push('\\'),
+        }
+    }
+    out
 }
 
 /// Tokenize a line using shell-like quoting rules.

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -83,6 +83,22 @@ mod basic {
     }
 
     #[test]
+    fn parse_file_create_expands_newline_escapes() {
+        let op = parse_line(
+            r#"file.create main.rs "fn main() {\n    println!(\"hi\");\n}""#,
+            1,
+        )
+        .unwrap();
+        match op {
+            Operation::FileCreate { path, content, .. } => {
+                assert_eq!(path, "main.rs");
+                assert_eq!(content, "fn main() {\n    println!(\"hi\");\n}");
+            }
+            other => panic!("expected FileCreate, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn parse_json_value_number() {
         let v = parse_json_value("42").unwrap();
         assert_eq!(v, serde_json::json!(42));


### PR DESCRIPTION
## Summary

Found by fixrealloop: multi-line scaffolds via batch failed (line breaks became new ops; literal `\n` was not expanded). Tx plans already support real newlines.

### Changes

- Expand `\n` `\t` `\r` `\\` `\"` in `file.create` / `append` / `prepend` content
- Unit test for multi-line Rust stub content

## Test plan

- [x] `make check-fast` green
- [x] Dogfood: batch create multi-line Cargo.toml + main.rs