### PR TITLE
docs: agent-rules batch content escapes and unquoted JSON

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -142,7 +142,7 @@ md.upsert_bullet CHANGELOG.md "## Changes" "- Bumped to 2.0.0"
 EOF
 ```
 
-One line per operation. Double-quote values with spaces. Escapes in quotes: only `\"` and `\\` (literal `\n` is not a newline; use `tx`/MCP JSON for multi-line content).
+One line per operation. Double-quote values with spaces. Unquoted JSON objects/arrays (`file.create f.json {"x":1}`) keep inner quotes. In `file.create`/`append`/`prepend` content, `\n` `\t` `\r` `\\` `\"` expand (multi-line scaffolds on one batch line).
 Batch `replace` accepts optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.
 
 On Windows (where heredocs are not available), write operations to a file and pass it:

--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -142,7 +142,7 @@ md.upsert_bullet CHANGELOG.md "## Changes" "- Bumped to 2.0.0"
 EOF
 ```
 
-One line per operation. Double-quote values with spaces. Unquoted JSON objects/arrays (`file.create f.json {"x":1}`) keep inner quotes. In `file.create`/`append`/`prepend` content, `\n` `\t` `\r` `\\` `\"` expand (multi-line scaffolds on one batch line).
+One line per operation. Double-quote values with spaces. Unquoted JSON objects/arrays (`file.create f.json {"x":1}`) keep inner quotes. In `file.create`/`append`/`prepend` content, `\n` `\t` `\r` `\\` `\"` expand (multi-line content on one batch line).
 Batch `replace` accepts optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.
 
 On Windows (where heredocs are not available), write operations to a file and pass it:

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -258,7 +258,7 @@ success lines are the full path list.\n\n\
                  ```\n\n\
                  One line per operation. Double-quote values with spaces. Unquoted JSON objects/arrays \
                  (`file.create f.json {\"x\":1}`) keep inner quotes. In `file.create`/`append`/`prepend` content, \
-                 `\\n` `\\t` `\\r` `\\\\` `\\\"` expand (multi-line scaffolds on one batch line).\n\
+                 `\\n` `\\t` `\\r` `\\\\` `\\\"` expand (multi-line content on one batch line).\n\
                  Batch `replace` accepts optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, \
                  `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, \
                  `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.\n\n",

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -256,8 +256,9 @@ success lines are the full path list.\n\n\
                  md.upsert_bullet CHANGELOG.md \"## Changes\" \"- Bumped to 2.0.0\"\n\
                  EOF\n\
                  ```\n\n\
-                 One line per operation. Double-quote values with spaces. Escapes in quotes: only `\\\"` and `\\\\` \
-                 (literal `\\n` is not a newline; use `tx`/MCP JSON for multi-line content).\n\
+                 One line per operation. Double-quote values with spaces. Unquoted JSON objects/arrays \
+                 (`file.create f.json {\"x\":1}`) keep inner quotes. In `file.create`/`append`/`prepend` content, \
+                 `\\n` `\\t` `\\r` `\\\\` `\\\"` expand (multi-line scaffolds on one batch line).\n\
                  Batch `replace` accepts optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, \
                  `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, \
                  `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.\n\n",
@@ -277,8 +278,8 @@ success lines are the full path list.\n\n\
             );
             if !show_linux {
                 out.push_str(
-                    "One line per operation in the file. Double-quote values with spaces. Escapes: only `\\\"` and `\\\\` \
-                     (use `tx`/MCP for multi-line content).\n\n",
+                    "One line per operation in the file. Double-quote values with spaces. Unquoted JSON objects \
+                     keep inner quotes. In `file.create`/`append`/`prepend` content, `\\n` `\\t` `\\r` expand.\n\n",
                 );
             }
         }


### PR DESCRIPTION
## Summary

Update agent-rules / PATCHLOOM.md after #1820/#1821: batch supports unquoted JSON objects and `\n` content escapes. Remove stale “literal \n is not a newline” guidance.

## Test plan

- [x] `make check-fast` green
- [x] agent_rules unit tests