### PR TITLE
fix: agent honesty for doc query, tidy.fix, md/AST docs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -69,8 +69,17 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 **`identity: true` (#1801):** Replace JSON when the pattern matched but every replacement was identical (`old == new`); `match_count > 0` but `file_count: 0` / empty `files` and no write.
 **`require_change` + `if_exists` (#1800):** When both are set, `if_exists` wins: zero matches → success (`ok: true`, `match_count: 0`), not fail-closed `no_matches`.
 **`tx`/`execute_plan` `strict: false` (#1803):** Continues past soft replace `no_matches` on existing paths. Does **not** continue past hard errors such as `not_found` (missing path). Optional **files** must be omitted from the plan or ensured to exist; optional **content** can use soft miss.
-**`for_each` templates:** Valid placeholders are `{path}`, `{item}` (alias of `{path}`), `{dir}`, `{stem}`, `{ext}`, `{name}`. Unknown lone `{name}` in path/from/to fields fails with `invalid_input` (not opaque `not_found`).
-             **Binary paths (#1813):** Sole explicit binary replace is `invalid_input`. Multi-file lists put binary co-paths in `refused[]` with `reason: binary` (not pattern `no_matches`).
+**`for_each` (plan-level field, not an op; #1842):** Fan-out is a top-level plan field with required `glob`. Example:
+```json
+{
+"for_each": { "glob": "**/*.txt" },
+"operations": [
+{ "op": "replace", "path": "{path}", "old": "x", "new": "y" }
+]
+}
+```
+Placeholders: `{path}`, `{item}` (alias of `{path}`), `{dir}`, `{stem}`, `{ext}`, `{name}`. Unknown lone `{name}` in path/from/to fields fails with `invalid_input` (not opaque `not_found`). Do not put `for_each` inside `operations` and do not pass a bare path array.
+**Binary paths (#1813):** Sole explicit binary replace is `invalid_input`. Multi-file lists put binary co-paths in `refused[]` with `reason: binary` (not pattern `no_matches`).
 **Search max_results:** CLI/MCP/tx `search` with `max_results` keeps full `match_count` (and full `file_count`) but may cap the detailed `matches` array **and** the `files` list in `--count` / `--files-with-matches` modes; when capped, JSON sets `truncated: true` (omitted when complete; #1798). Under `--jsonl`, capped content searches append a final `{"type":"summary","match_count":N,"match_emitted":M,"truncated":true}` line so agents still see the total. Do not treat `matches.len()` or `files.len()` as total coverage when `truncated` is true.
 
 **Multi-result `--json`:** Commands that emit many items (`ast list` / `ast search` / `ast validate` / `ast deps`, `ast map`, undo list, etc.) print one JSON array under `--json` (single `json.loads` on full stdout) and one object per line under `--jsonl`. Do not expect concatenated pretty multi-documents for `--json`.
@@ -78,6 +87,8 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 **Preview vs apply (#1808, #1810, #1812):** CLI write JSON always includes `applied` (`true` after apply mode, `false` for default preview / check mode). `changed: true` or `files_changed: N` on preview means **would** change, not that bytes were written. Exit 2 = changes detected / dry-run.
 **`backup_session` on success (#1802):** Successful CLI replace/doc/tx apply JSON includes `backup_session` when a backup was created (same field as `format_failed` and library `EditResult`). Use it for surgical undo; do not guess newest session under parallel agents.
 **CLI vs plan/MCP names (#1809):** CLI replace is positional `OLD` + `--new NEW` (not plan aliases `from`/`to` as flags). CLI `doc set` is `doc set PATH SELECTOR VALUE` (not a `--key` flag). Plan/MCP accept legacy aliases `from`/`to` and `key` for selector.
+**CLI `md upsert-bullet`:** use `--bullet` (or alias `--content`; #1839) with `--heading`.
+**Doc query `--json` (#1838):** `doc get`/`has`/`keys`/`len`/`select`/`flatten` success is `{"ok":true,"value":...,"path":...,"selector":...}` (selector omitted for flatten). Text mode stays bare. `doc has` prints `true`/`false` and exits **0** for both (missing key is not `no_matches`; #1843).
 **Replace jsonl multi-file (#1799):** Streams one object per success path (`status: ok`), refused soft-miss (`status: refused`), skipped missing (`status: skipped`), then a `type: summary` trailer with counts. Prefer this or MCP `batch_replace` over assuming success lines are the full path list.
 
 Use patchloom when:
@@ -124,7 +135,8 @@ Use these names in plans, MCP args, and CLI flags (do not invent alternates):
 | Text/identifier before | `old` | CLI **replace**: positional `OLD` (not `--old`). CLI **ast rename/replace**: `--old`. Plans/MCP: `"old"`. |
 | Text/identifier after | `new` | CLI: `--new`. Plans/MCP: `"new"`. |
 | Doc path into a document | `selector` | CLI positional. Plans/MCP: `"selector"`. |
-| AST rename / replace | path first | `ast rename PATH --old X --new Y`; plan `ast.rename` uses `path`/`old`/`new`. |
+| AST rename / replace / read | path first | `ast rename PATH --old X --new Y`; `ast replace PATH SYMBOL --old … --new …` (no `--symbol` flag). |
+| AST refs / impact | symbol first | `ast refs SYMBOL PATH` / `ast impact SYMBOL PATH` (no `--name` flag; #1841). |
 | Schema capability filter | `weak` / `medium` / `strong` | `schema --tier` only accepts these (not `small`/`large`). |
 
 Replace example: `patchloom replace OLD --new NEW path` (positional OLD + `--new`; never `replace --old …`).
@@ -311,17 +323,23 @@ Tree-sitter-backed operations that understand code structure (20 languages).
 
 ```bash
 # Rename an identifier across a file, skipping strings and comments
+# (path first, then --old / --new)
 patchloom ast rename src/lib.rs --old OldName --new NewName --apply
 
 # Replace text only within a specific function body
-patchloom ast replace src/config.rs --symbol default_timeout --old 30 --new 60 --apply
+# (PATH then SYMBOL are positionals — no --symbol flag; #1841)
+patchloom ast replace src/config.rs default_timeout --old 30 --new 60 --apply
 
 # List all symbol definitions
 patchloom ast list src/lib.rs
 
 # Find all references to a symbol
-patchloom ast refs src/ --name my_function
+# (SYMBOL then PATH — order differs from replace/read; #1841)
+patchloom ast refs my_function src/
+# impact is also SYMBOL then PATH: ast impact my_function src/
 ```
+
+**AST CLI arg order:** `rename`/`replace`/`read`/`validate` use path-first; `refs`/`impact` use symbol-first. There is no `--symbol` or `--name` flag on these commands.
 
 AST rename, replace, and rewrite_signature can also be used in batch and tx plans:
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -709,6 +709,7 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 - **What it does:** Reads the value at a selector path from a JSON, YAML, or TOML file.
 - **Use when:** You need one precise value without mutating the document.
+- **JSON success (#1838):** Under `--json`/`--jsonl`, success is `{"ok":true,"value":...,"path":...,"selector":...}` (not a bare JSON value). Text mode stays bare. Missing selector is `error_kind: no_matches` (exit 3).
 - **Prefer instead:** Use `doc flatten` when you are exploring an unfamiliar file and need a broader map of its contents.
 
 <!-- ref:doc-action:has -->
@@ -716,6 +717,8 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 - **What it does:** Checks whether a selector path exists.
 - **Use when:** A script or workflow needs a presence check before choosing a later action.
+- **Exit codes (#1843):** Always exits **0** for a valid document when the answer is `true` or `false`. Missing key is not `no_matches`. Real failures (missing file, parse error) still fail non-zero.
+- **JSON success (#1838):** `{"ok":true,"value":true|false,"path":...,"selector":...}` under `--json`/`--jsonl`.
 - **Prefer instead:** Use `doc ensure` when the real goal is to create the value if it is missing.
 
 <!-- ref:doc-action:keys -->
@@ -1165,6 +1168,7 @@ The operations below are the building blocks inside `operations`.
 
 - **What it does:** Applies tidy normalization inside a transaction.
 - **Use when:** Text cleanup should be part of the same atomic success criteria as other edits.
+- **Defaults (#1840):** When the op omits write-policy fields, matches bare CLI `tidy fix`: trim trailing whitespace and ensure final newline (`normalize_eol` stays keep unless set). Explicit op fields or plan `write_policy` still override.
 - **Related:** top level `tidy fix`
 
 <!-- ref:tx-op:file.append -->

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -580,7 +580,10 @@ pub(crate) fn match_mode_from_strategy(
 ///
 /// Shared by multi-op content edits, plan/tx aggregates, and replace_op path
 /// re-visits so every surface reports the same confidence ordering.
-pub(crate) fn merge_match_modes(prev: Option<MatchMode>, next: MatchMode) -> MatchMode {
+///
+/// Public for embedder hosts that combine multiple [`MatchMode`] values from
+/// multi-op content edits (#1844).
+pub fn merge_match_modes(prev: Option<MatchMode>, next: MatchMode) -> MatchMode {
     match (prev, next) {
         (Some(MatchMode::Fuzzy), _) | (_, MatchMode::Fuzzy) => MatchMode::Fuzzy,
         (Some(MatchMode::Anchored), _) | (_, MatchMode::Anchored) => MatchMode::Anchored,

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -949,16 +949,20 @@ mod tests {
     }
 
     /// Canonical names table must stay present so agents do not invent alternates.
+    /// Full AST CLI examples live under `#[cfg(feature = "ast")]`; the names table
+    /// always documents PATH/SYMBOL order so this still holds for test-mcp-no-ast.
     #[test]
     fn agent_rules_ast_cli_examples_use_real_clap_shapes() {
         // #1841: no --symbol / --name; correct positional order.
         let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
         assert!(
-            out.contains("ast replace src/config.rs default_timeout --old 30 --new 60"),
+            out.contains("ast replace PATH SYMBOL")
+                || out.contains("ast replace src/config.rs default_timeout"),
             "replace must use PATH SYMBOL positionals"
         );
         assert!(
-            !out.contains("ast replace src/config.rs --symbol"),
+            !out.contains("ast replace src/config.rs --symbol")
+                && !out.contains("ast replace PATH --symbol"),
             "must not document nonexistent --symbol"
         );
         assert!(
@@ -966,9 +970,20 @@ mod tests {
             "refs must document SYMBOL PATH order"
         );
         assert!(
-            !out.contains("ast refs src/ --name"),
+            !out.contains("ast refs src/ --name") && !out.contains("ast refs PATH --name"),
             "must not document nonexistent --name on refs"
         );
+        #[cfg(feature = "ast")]
+        {
+            assert!(
+                out.contains("ast replace src/config.rs default_timeout --old 30 --new 60"),
+                "AST section example must use PATH SYMBOL positionals"
+            );
+            assert!(
+                out.contains("ast refs my_function src/"),
+                "AST section example must use SYMBOL PATH for refs"
+            );
+        }
     }
 
     #[test]

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -986,6 +986,20 @@ mod tests {
     }
 
     #[test]
+    fn agent_rules_documents_doc_query_envelope_and_has_exit() {
+        // #1838 / #1843 lock strings for CLI agent hosts.
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(
+            out.contains("Doc query") && out.contains("\"ok\":true") && out.contains("value"),
+            "must document doc query JSON success envelope"
+        );
+        assert!(
+            out.contains("doc has") && out.contains("#1843"),
+            "must document doc has exit 0 for missing key"
+        );
+    }
+
+    #[test]
     fn agent_rules_includes_canonical_parameter_names() {
         let out = generate_agent_rules(&args(AgentMode::All, AgentPlatform::All));
         assert!(

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -159,7 +159,18 @@ resort for typos in non-AST text (prose, comments), not a general rename tool.\n
              **`identity: true` (#1801):** Replace JSON when the pattern matched but every replacement was identical (`old == new`); `match_count > 0` but `file_count: 0` / empty `files` and no write.\n\
              **`require_change` + `if_exists` (#1800):** When both are set, `if_exists` wins: zero matches → success (`ok: true`, `match_count: 0`), not fail-closed `no_matches`.\n\
              **`tx`/`execute_plan` `strict: false` (#1803):** Continues past soft replace `no_matches` on existing paths. Does **not** continue past hard errors such as `not_found` (missing path). Optional **files** must be omitted from the plan or ensured to exist; optional **content** can use soft miss.\n\
-             **`for_each` templates:** Valid placeholders are `{path}`, `{item}` (alias of `{path}`), `{dir}`, `{stem}`, `{ext}`, `{name}`. Unknown lone `{name}` in path/from/to fields fails with `invalid_input` (not opaque `not_found`).
+             **`for_each` (plan-level field, not an op; #1842):** Fan-out is a top-level plan field with required `glob`. Example:\n\
+             ```json\n\
+             {\n\
+               \"for_each\": { \"glob\": \"**/*.txt\" },\n\
+               \"operations\": [\n\
+                 { \"op\": \"replace\", \"path\": \"{path}\", \"old\": \"x\", \"new\": \"y\" }\n\
+               ]\n\
+             }\n\
+             ```\n\
+             Placeholders: `{path}`, `{item}` (alias of `{path}`), `{dir}`, `{stem}`, `{ext}`, `{name}`. \
+Unknown lone `{name}` in path/from/to fields fails with `invalid_input` (not opaque `not_found`). \
+Do not put `for_each` inside `operations` and do not pass a bare path array.\n\
              **Binary paths (#1813):** Sole explicit binary replace is `invalid_input`. Multi-file lists put binary co-paths in `refused[]` with `reason: binary` (not pattern `no_matches`).\n\
              **Search max_results:** CLI/MCP/tx `search` with `max_results` keeps full `match_count` (and full `file_count`) but may cap the detailed `matches` array **and** the `files` list in `--count` / `--files-with-matches` modes; when capped, JSON sets `truncated: true` (omitted when complete; #1798). Under `--jsonl`, capped content searches append a final `{\"type\":\"summary\",\"match_count\":N,\"match_emitted\":M,\"truncated\":true}` line so agents still see the total. Do not treat `matches.len()` or `files.len()` as total coverage when `truncated` is true.\n\n\
              **Multi-result `--json`:** Commands that emit many items (`ast list` / `ast search` / `ast validate` / \
@@ -180,6 +191,10 @@ includes `backup_session` when a backup was created (same field as `format_faile
              **CLI vs plan/MCP names (#1809):** CLI replace is positional `OLD` + `--new NEW` \
 (not plan aliases `from`/`to` as flags). CLI `doc set` is `doc set PATH SELECTOR VALUE` \
 (not a `--key` flag). Plan/MCP accept legacy aliases `from`/`to` and `key` for selector.\n\
+             **CLI `md upsert-bullet`:** use `--bullet` (or alias `--content`; #1839) with `--heading`.\n\
+             **Doc query `--json` (#1838):** `doc get`/`has`/`keys`/`len`/`select`/`flatten` success is \
+`{\"ok\":true,\"value\":...,\"path\":...,\"selector\":...}` (selector omitted for flatten). Text mode stays bare. \
+`doc has` prints `true`/`false` and exits **0** for both (missing key is not `no_matches`; #1843).\n\
              **Replace jsonl multi-file (#1799):** Streams one object per success path \
 (`status: ok`), refused soft-miss (`status: refused`), skipped missing (`status: skipped`), \
 then a `type: summary` trailer with counts. Prefer this or MCP `batch_replace` over assuming \
@@ -242,7 +257,8 @@ success lines are the full path list.\n\n\
          | Text/identifier before | `old` | CLI **replace**: positional `OLD` (not `--old`). CLI **ast rename/replace**: `--old`. Plans/MCP: `\"old\"`. |\n\
          | Text/identifier after | `new` | CLI: `--new`. Plans/MCP: `\"new\"`. |\n\
          | Doc path into a document | `selector` | CLI positional. Plans/MCP: `\"selector\"`. |\n\
-         | AST rename / replace | path first | `ast rename PATH --old X --new Y`; plan `ast.rename` uses `path`/`old`/`new`. |\n\
+         | AST rename / replace / read | path first | `ast rename PATH --old X --new Y`; `ast replace PATH SYMBOL --old … --new …` (no `--symbol` flag). |\n\
+         | AST refs / impact | symbol first | `ast refs SYMBOL PATH` / `ast impact SYMBOL PATH` (no `--name` flag; #1841). |\n\
          | Schema capability filter | `weak` / `medium` / `strong` | `schema --tier` only accepts these (not `small`/`large`). |\n\n\
          Replace example: `patchloom replace OLD --new NEW path` (positional OLD + `--new`; never `replace --old …`).\n\
          Some plan/MCP fields still **accept** legacy aliases (`from`/`to` for replace, `key` for doc selector, \
@@ -486,14 +502,20 @@ success lines are the full path list.\n\n\
              Tree-sitter-backed operations that understand code structure (20 languages).\n\n\
              ```bash\n\
              # Rename an identifier across a file, skipping strings and comments\n\
+             # (path first, then --old / --new)\n\
              patchloom ast rename src/lib.rs --old OldName --new NewName --apply\n\n\
              # Replace text only within a specific function body\n\
-             patchloom ast replace src/config.rs --symbol default_timeout --old 30 --new 60 --apply\n\n\
+             # (PATH then SYMBOL are positionals — no --symbol flag; #1841)\n\
+             patchloom ast replace src/config.rs default_timeout --old 30 --new 60 --apply\n\n\
              # List all symbol definitions\n\
              patchloom ast list src/lib.rs\n\n\
              # Find all references to a symbol\n\
-             patchloom ast refs src/ --name my_function\n\
+             # (SYMBOL then PATH — order differs from replace/read; #1841)\n\
+             patchloom ast refs my_function src/\n\
+             # impact is also SYMBOL then PATH: ast impact my_function src/\n\
              ```\n\n\
+             **AST CLI arg order:** `rename`/`replace`/`read`/`validate` use path-first; \
+`refs`/`impact` use symbol-first. There is no `--symbol` or `--name` flag on these commands.\n\n\
              AST rename, replace, and rewrite_signature can also be used in batch and tx plans:\n\n\
              ```bash\n\
              # In a batch file (path, then old, then new — same names as CLI flags):\n\
@@ -927,6 +949,42 @@ mod tests {
     }
 
     /// Canonical names table must stay present so agents do not invent alternates.
+    #[test]
+    fn agent_rules_ast_cli_examples_use_real_clap_shapes() {
+        // #1841: no --symbol / --name; correct positional order.
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(
+            out.contains("ast replace src/config.rs default_timeout --old 30 --new 60"),
+            "replace must use PATH SYMBOL positionals"
+        );
+        assert!(
+            !out.contains("ast replace src/config.rs --symbol"),
+            "must not document nonexistent --symbol"
+        );
+        assert!(
+            out.contains("ast refs my_function src/") || out.contains("ast refs SYMBOL PATH"),
+            "refs must document SYMBOL PATH order"
+        );
+        assert!(
+            !out.contains("ast refs src/ --name"),
+            "must not document nonexistent --name on refs"
+        );
+    }
+
+    #[test]
+    fn agent_rules_documents_for_each_plan_json_shape() {
+        // #1842: complete plan-level for_each example.
+        let out = generate_agent_rules(&args(AgentMode::All, AgentPlatform::All));
+        assert!(
+            out.contains("\"for_each\"") && out.contains("\"glob\""),
+            "must show plan-level for_each with glob"
+        );
+        assert!(
+            out.contains("plan-level field") || out.contains("#1842"),
+            "must say for_each is plan-level not an op"
+        );
+    }
+
     #[test]
     fn agent_rules_includes_canonical_parameter_names() {
         let out = generate_agent_rules(&args(AgentMode::All, AgentPlatform::All));

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -460,25 +460,33 @@ fn format_json_value(value: &serde_json::Value, compact: bool) -> String {
     }
 }
 
-fn format_values(values: &[&serde_json::Value], mode: OutputMode) -> anyhow::Result<String> {
+/// Agent JSON envelope for successful doc query results (#1838).
+///
+/// Text mode stays bare (jq-friendly / human). Json/Jsonl wrap `value` so
+/// agents can branch on `ok` like other commands.
+fn format_query_success(
+    value: serde_json::Value,
+    mode: OutputMode,
+    path: &str,
+    selector: Option<&str>,
+) -> anyhow::Result<String> {
     match mode {
-        OutputMode::Text => Ok(values
-            .iter()
-            .map(|value| format_value(value, mode))
-            .collect::<Vec<_>>()
-            .join("\n")),
-        OutputMode::Json => {
-            if values.len() == 1 {
-                Ok(serde_json::to_string_pretty(values[0])?)
+        OutputMode::Text => Ok(format_value(&value, mode)),
+        OutputMode::Json | OutputMode::Jsonl => {
+            let mut payload = serde_json::json!({
+                "ok": true,
+                "value": value,
+                "path": path,
+            });
+            if let Some(sel) = selector {
+                payload["selector"] = serde_json::Value::String(sel.to_string());
+            }
+            if mode == OutputMode::Json {
+                Ok(serde_json::to_string_pretty(&payload)?)
             } else {
-                Ok(serde_json::to_string_pretty(values)?)
+                Ok(serde_json::to_string(&payload)?)
             }
         }
-        OutputMode::Jsonl => Ok(values
-            .iter()
-            .map(serde_json::to_string)
-            .collect::<Result<Vec<_>, _>>()?
-            .join("\n")),
     }
 }
 
@@ -546,8 +554,15 @@ fn execute_with_mode_inner(
                     quiet,
                 ),
                 crate::ops::doc::query::QueryResult::Values(vals) => {
-                    let refs: Vec<&serde_json::Value> = vals.iter().collect();
-                    Ok((format_values(&refs, output_mode)?, exit::SUCCESS))
+                    let value = if vals.len() == 1 {
+                        vals.into_iter().next().unwrap_or(serde_json::Value::Null)
+                    } else {
+                        serde_json::Value::Array(vals)
+                    };
+                    Ok((
+                        format_query_success(value, output_mode, file, Some(selector))?,
+                        exit::SUCCESS,
+                    ))
                 }
             }
         }
@@ -556,18 +571,15 @@ fn execute_with_mode_inner(
             crate::verbose!("doc: has file={}, selector={:?}", file, selector);
             let root = load_file(file)?;
             let found = crate::ops::doc::query::query_has(&root, selector)?;
-            let output = match output_mode {
-                OutputMode::Text => found.to_string(),
-                OutputMode::Json => serde_json::to_string_pretty(&found)?,
-                OutputMode::Jsonl => serde_json::to_string(&found)?,
-            };
+            // Boolean query: missing is a valid answer (exit 0), not no_matches (#1843).
             Ok((
-                output,
-                if found {
-                    exit::SUCCESS
-                } else {
-                    exit::NO_MATCHES
-                },
+                format_query_success(
+                    serde_json::Value::Bool(found),
+                    output_mode,
+                    file,
+                    Some(selector),
+                )?,
+                exit::SUCCESS,
             ))
         }
 
@@ -590,12 +602,14 @@ fn execute_with_mode_inner(
                 crate::ops::doc::query::QueryKeysResult::Keys(keys) => {
                     let output = match output_mode {
                         OutputMode::Text => keys.join("\n"),
-                        OutputMode::Json => serde_json::to_string_pretty(&keys)?,
-                        OutputMode::Jsonl => keys
-                            .iter()
-                            .map(serde_json::to_string)
-                            .collect::<Result<Vec<_>, _>>()?
-                            .join("\n"),
+                        OutputMode::Json | OutputMode::Jsonl => format_query_success(
+                            serde_json::Value::Array(
+                                keys.into_iter().map(serde_json::Value::String).collect(),
+                            ),
+                            output_mode,
+                            file,
+                            Some(selector),
+                        )?,
                     };
                     Ok((output, exit::SUCCESS))
                 }
@@ -618,14 +632,15 @@ fn execute_with_mode_inner(
                     exit::FAILURE,
                     Some("type_error"),
                 ),
-                crate::ops::doc::query::QueryLenResult::Len(len) => {
-                    let output = match output_mode {
-                        OutputMode::Text => len.to_string(),
-                        OutputMode::Json => serde_json::to_string_pretty(&len)?,
-                        OutputMode::Jsonl => serde_json::to_string(&len)?,
-                    };
-                    Ok((output, exit::SUCCESS))
-                }
+                crate::ops::doc::query::QueryLenResult::Len(len) => Ok((
+                    format_query_success(
+                        serde_json::json!(len),
+                        output_mode,
+                        file,
+                        Some(selector),
+                    )?,
+                    exit::SUCCESS,
+                )),
             }
         }
 
@@ -643,23 +658,18 @@ fn execute_with_mode_inner(
                 );
             }
             match output_mode {
-                OutputMode::Json => {
+                OutputMode::Json | OutputMode::Jsonl => {
                     let obj: serde_json::Map<String, serde_json::Value> =
                         entries.into_iter().map(|(k, v)| (k, v.clone())).collect();
-                    Ok((serde_json::to_string_pretty(&obj)?, exit::SUCCESS))
-                }
-                OutputMode::Jsonl => {
-                    let lines = entries
-                        .iter()
-                        .map(|(k, v)| {
-                            serde_json::to_string(&serde_json::json!({
-                                "path": k,
-                                "value": v,
-                            }))
-                        })
-                        .collect::<Result<Vec<_>, _>>()?
-                        .join("\n");
-                    Ok((lines, exit::SUCCESS))
+                    Ok((
+                        format_query_success(
+                            serde_json::Value::Object(obj),
+                            output_mode,
+                            file,
+                            None,
+                        )?,
+                        exit::SUCCESS,
+                    ))
                 }
                 OutputMode::Text => {
                     let lines: Vec<String> = entries

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -81,7 +81,8 @@ mod basic {
     }
 
     #[test]
-    fn has_returns_no_matches_for_missing_key() {
+    fn has_returns_false_success_for_missing_key() {
+        // #1843: missing is a valid boolean answer (exit 0), not no_matches.
         let dir = TempDir::new().unwrap();
         let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
         let action = DocAction::Has {
@@ -89,22 +90,16 @@ mod basic {
             selector: "missing".into(),
         };
         let (output, code) = execute_with_mode(&action, OutputMode::Text).unwrap();
-        assert_eq!(
-            code,
-            exit::NO_MATCHES,
-            "doc has should return NO_MATCHES when selector is absent"
-        );
+        assert_eq!(code, exit::SUCCESS, "missing key still exits 0");
         assert_eq!(output, "false");
     }
 
     #[test]
-    fn has_exit_code_consistent_with_get() {
-        // Regression: doc has always returned SUCCESS even for missing keys,
-        // while doc get returned NO_MATCHES. Both should use NO_MATCHES.
+    fn has_missing_exits_success_while_get_exits_no_matches() {
+        // #1843: has is boolean; get is lookup. Missing key: has=0, get=3.
         let dir = TempDir::new().unwrap();
         let path = write_file(&dir, "data.json", r#"{"a": 1}"#);
 
-        // Existing key: both return SUCCESS.
         let (_, has_code) = execute_with_mode(
             &DocAction::Has {
                 file: path.clone(),
@@ -124,8 +119,7 @@ mod basic {
         assert_eq!(has_code, exit::SUCCESS);
         assert_eq!(get_code, exit::SUCCESS);
 
-        // Missing key: both return NO_MATCHES.
-        let (_, has_code) = execute_with_mode(
+        let (has_out, has_code) = execute_with_mode(
             &DocAction::Has {
                 file: path.clone(),
                 selector: "missing".into(),
@@ -141,8 +135,29 @@ mod basic {
             OutputMode::Text,
         )
         .unwrap();
-        assert_eq!(has_code, exit::NO_MATCHES);
+        assert_eq!(has_code, exit::SUCCESS);
+        assert_eq!(has_out, "false");
         assert_eq!(get_code, exit::NO_MATCHES);
+    }
+
+    #[test]
+    fn has_json_success_envelope_includes_value() {
+        // #1838: structured success is ok envelope.
+        let dir = TempDir::new().unwrap();
+        let path = write_file(&dir, "test.json", r#"{"name": "hello"}"#);
+        let (output, code) = execute_with_mode(
+            &DocAction::Has {
+                file: path,
+                selector: "name".into(),
+            },
+            OutputMode::Json,
+        )
+        .unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(v["ok"], true);
+        assert_eq!(v["value"], true);
+        assert_eq!(v["selector"], "name");
     }
 
     // -- keys ---------------------------------------------------------------
@@ -633,9 +648,11 @@ mod edge_cases {
         let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-        assert_eq!(parsed["tags"], serde_json::json!([]));
-        assert_eq!(parsed["name"], serde_json::json!("foo"));
-        assert_eq!(parsed["items[0]"], serde_json::json!(1));
+        assert_eq!(parsed["ok"], true);
+        let map = &parsed["value"];
+        assert_eq!(map["tags"], serde_json::json!([]));
+        assert_eq!(map["name"], serde_json::json!("foo"));
+        assert_eq!(map["items[0]"], serde_json::json!(1));
     }
 
     #[test]
@@ -646,8 +663,10 @@ mod edge_cases {
         let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-        assert_eq!(parsed["config"], serde_json::json!({}));
-        assert_eq!(parsed["name"], serde_json::json!("bar"));
+        assert_eq!(parsed["ok"], true);
+        let map = &parsed["value"];
+        assert_eq!(map["config"], serde_json::json!({}));
+        assert_eq!(map["name"], serde_json::json!("bar"));
     }
 
     #[test]
@@ -658,9 +677,11 @@ mod edge_cases {
         let (output, code) = execute_with_mode(&action, OutputMode::Json).unwrap();
         assert_eq!(code, exit::SUCCESS);
         let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-        assert_eq!(parsed["a.b"], serde_json::json!([]));
-        assert_eq!(parsed["a.c"], serde_json::json!({}));
-        assert_eq!(parsed["d[0]"], serde_json::json!(1));
+        assert_eq!(parsed["ok"], true);
+        let map = &parsed["value"];
+        assert_eq!(map["a.b"], serde_json::json!([]));
+        assert_eq!(map["a.c"], serde_json::json!({}));
+        assert_eq!(map["d[0]"], serde_json::json!(1));
     }
 }
 

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -344,17 +344,39 @@ fn doc_readonly(action: &crate::cmd::doc::DocAction) -> Result<CallToolResult, M
         crate::cmd::doc::execute_with_mode(action, crate::cmd::doc::OutputMode::Json)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
     // CHANGES_DETECTED (2) is a valid success for doc diff (differences found).
-    // NO_MATCHES (3) with non-empty output is a valid answer (e.g. "has"
-    // returning "false", "len" returning "0"). Only treat it as an error
-    // when the output is empty (genuinely no result).
-    let effective = if code == exit::CHANGES_DETECTED
-        || (code == exit::NO_MATCHES && !output.trim().is_empty())
-    {
+    // After #1843, doc has always exits 0 for true/false, so do not promote
+    // NO_MATCHES (real get/keys/len misses) to success.
+    let effective = if code == exit::CHANGES_DETECTED {
         exit::SUCCESS
     } else {
         code
     };
-    exit_code_to_result(effective, &output, "No results.")
+    // CLI --json uses an ok/value envelope (#1838). MCP tools keep returning
+    // the bare value so existing agent prompts and tests stay stable.
+    let text = if effective == exit::SUCCESS {
+        peel_doc_query_success_value(&output)
+    } else {
+        output
+    };
+    exit_code_to_result(effective, &text, "No results.")
+}
+
+/// If `output` is a successful CLI doc-query envelope, return pretty `value`.
+/// Otherwise return the original string (errors, doc diff, already-bare).
+fn peel_doc_query_success_value(output: &str) -> String {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(output) else {
+        return output.to_string();
+    };
+    if v.get("ok").and_then(|o| o.as_bool()) != Some(true) {
+        return output.to_string();
+    }
+    let Some(value) = v.get("value") else {
+        return output.to_string();
+    };
+    match serde_json::to_string_pretty(value) {
+        Ok(s) => s,
+        Err(_) => output.to_string(),
+    }
 }
 
 fn make_plan_strict(operations: Vec<Operation>, strict: Option<bool>) -> Plan {

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -14,6 +14,7 @@ EXAMPLES:
   patchloom md table-append README.md --heading '## API' --row '| /users | List users |'
   patchloom md table-append README.md --heading '## API' --row '/users|List users'
   patchloom md upsert-bullet AGENTS.md --heading '## Rules' --bullet '- Run make check'
+  patchloom md upsert-bullet AGENTS.md --heading '## Rules' --content '- Alias of --bullet' --apply
   patchloom md replace-section CHANGELOG.md --heading '## Unreleased' --content '- New feature' --apply")]
 pub struct MdArgs {
     #[command(subcommand)]
@@ -99,7 +100,8 @@ pub enum MdAction {
         #[arg(long)]
         heading: String,
         /// Bullet text (leading `- ` is optional).
-        #[arg(long, allow_hyphen_values = true)]
+        /// Alias `--content` matches sibling `md` mutators (#1839).
+        #[arg(long, visible_alias = "content", allow_hyphen_values = true)]
         bullet: String,
     },
     /// Remove duplicate headings.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,7 +251,7 @@ pub use api::{
     ReplaceOptions, SearchOptions, SearchResult, WritePolicyOptions, apply_content_edits,
     apply_content_edits_with_label, apply_post_write_validator, build_context_lines,
     classify_error, classify_error_ref, edit_error_kind, edit_error_ref, format_search_results,
-    parse_unified_diff, run_post_write_validation, search_file, text_diff,
+    merge_match_modes, parse_unified_diff, run_post_write_validation, search_file, text_diff,
 };
 pub use plan::Plan;
 

--- a/src/tx/tidy_op.rs
+++ b/src/tx/tidy_op.rs
@@ -19,9 +19,11 @@ pub(crate) fn execute_tidy_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             let file_path = tx.cwd.join(path);
             mark_write_target(tx.write_targets, &file_path);
             let content = read_file_content(tx.pending, tx.existed_before, &file_path)?.to_owned();
+            // Defaults match CLI `tidy fix` when no flags / write_policy override
+            // are set (#1840): trim trailing whitespace + ensure final newline.
             let policy = WritePolicy {
                 ensure_final_newline: ensure_final_newline.unwrap_or(true),
-                trim_trailing_whitespace: trim_trailing_whitespace.unwrap_or(false),
+                trim_trailing_whitespace: trim_trailing_whitespace.unwrap_or(true),
                 normalize_eol: if let Some(eol) = normalize_eol {
                     crate::write::parse_eol_mode(eol)?
                 } else {

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -944,3 +944,37 @@ fn test_batch_json_unknown_op_sets_parse_error_kind() {
         "batch parse failure should set error_kind: {json}"
     );
 }
+
+/// #1840: batch tidy.fix applies CLI tidy-fix defaults (trim + final newline).
+#[test]
+fn test_batch_tidy_fix_trims_trailing_whitespace_by_default() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("t.txt"), "trail  \n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["batch", "--apply"])
+        .write_stdin("tidy.fix t.txt\n")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(
+        json["files_changed"], 1,
+        "tidy.fix must change dirty file without write_policy (#1840): {json}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.txt")).unwrap(),
+        "trail\n",
+        "trailing spaces must be trimmed by default"
+    );
+}

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1444,22 +1444,25 @@ fn test_doc_flatten_includes_empty_arrays() {
     assert_eq!(output.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    // #1838: --json success is an ok envelope; flatten map lives under value.
+    assert_eq!(parsed["ok"], true, "envelope: {stdout}");
+    let value = &parsed["value"];
     assert_eq!(
-        parsed["empty_arr"],
+        value["empty_arr"],
         serde_json::json!([]),
         "empty array missing: {stdout}"
     );
     assert_eq!(
-        parsed["empty_obj"],
+        value["empty_obj"],
         serde_json::json!({}),
         "empty object missing: {stdout}"
     );
     assert_eq!(
-        parsed["nested.deep_empty"],
+        value["nested.deep_empty"],
         serde_json::json!([]),
         "nested empty array missing: {stdout}"
     );
-    assert_eq!(parsed["default[0]"], serde_json::json!("a"));
+    assert_eq!(value["default[0]"], serde_json::json!("a"));
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -150,7 +150,7 @@ fn test_doc_has_json_missing_exit_0_envelope() {
 }
 
 #[test]
-fn test_doc_keys_jsonl_outputs_one_key_per_line() {
+fn test_doc_keys_jsonl_success_envelope() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.json");
     fs::write(&file, r#"{"scripts":{"build":"tsc","lint":"eslint"}}"#).unwrap();
@@ -1490,7 +1490,7 @@ fn test_doc_diff_shows_changes() {
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_doc_flatten_jsonl_outputs_path_value_objects() {
+fn test_doc_flatten_jsonl_success_envelope() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("test.json");
     fs::write(&file, r#"{"a":1,"b":{"c":2}}"#).unwrap();

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -21,8 +21,10 @@ fn test_doc_get_jsonl_compound_value_is_single_line_json() {
     let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
     assert_eq!(lines.len(), 1);
     let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
-    assert_eq!(json["name"], "patchloom");
-    assert_eq!(json["version"], 1);
+    // #1838: success is ok envelope; value holds the document fragment.
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(json["value"]["name"], "patchloom");
+    assert_eq!(json["value"]["version"], 1);
 }
 
 #[test]
@@ -88,6 +90,7 @@ fn test_doc_has_missing_key() {
     let file = dir.path().join("test.json");
     fs::write(&file, r#"{"name":"patchloom"}"#).unwrap();
 
+    // Missing key is a valid boolean answer (exit 0), not no_matches (#1843).
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("doc")
@@ -95,8 +98,55 @@ fn test_doc_has_missing_key() {
         .arg(&file)
         .arg("missing")
         .assert()
-        .code(3) // NO_MATCHES: key doesn't exist
+        .code(0)
         .stdout(predicate::str::contains("false"));
+}
+
+/// #1838: doc query --json success is an ok envelope, not a bare value.
+#[test]
+fn test_doc_get_json_success_envelope() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("o.json");
+    fs::write(&file, r#"{"a":1,"c":null}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("a")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["value"], 1, "{v}");
+    assert!(v["path"].as_str().is_some(), "{v}");
+    assert_eq!(v["selector"], "a", "{v}");
+}
+
+/// #1843: doc has missing under --json exits 0 with value false.
+#[test]
+fn test_doc_has_json_missing_exit_0_envelope() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("o.json");
+    fs::write(&file, r#"{"a":1}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "has"])
+        .arg(&file)
+        .arg("missing")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "missing key is not no_matches: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["value"], false, "{v}");
 }
 
 #[test]
@@ -117,14 +167,14 @@ fn test_doc_keys_jsonl_outputs_one_key_per_line() {
 
     assert_eq!(output.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let lines: Vec<serde_json::Value> = stdout
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| serde_json::from_str(l).unwrap())
-        .collect();
-    assert_eq!(lines.len(), 2);
-    assert!(lines.iter().any(|v| v == "build"));
-    assert!(lines.iter().any(|v| v == "lint"));
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "single envelope line (#1838): {stdout}");
+    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    let keys = json["value"].as_array().expect("value array of keys");
+    assert_eq!(keys.len(), 2);
+    assert!(keys.iter().any(|v| v == "build"));
+    assert!(keys.iter().any(|v| v == "lint"));
 }
 
 #[test]
@@ -1456,14 +1506,13 @@ fn test_doc_flatten_jsonl_outputs_path_value_objects() {
 
     assert_eq!(output.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let lines: Vec<serde_json::Value> = stdout
-        .lines()
-        .filter(|l| !l.is_empty())
-        .map(|l| serde_json::from_str(l).unwrap())
-        .collect();
-
-    assert!(lines.iter().any(|v| v["path"] == "a" && v["value"] == 1));
-    assert!(lines.iter().any(|v| v["path"] == "b.c" && v["value"] == 2));
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "single envelope line (#1838): {stdout}");
+    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    let map = json["value"].as_object().expect("flatten map");
+    assert_eq!(map.get("a"), Some(&serde_json::json!(1)));
+    assert_eq!(map.get("b.c"), Some(&serde_json::json!(2)));
 }
 
 #[test]

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -263,6 +263,35 @@ fn test_md_upsert_bullet_adds_new() {
     );
 }
 
+/// #1839: --content is a visible alias of --bullet (sibling md mutator habit).
+#[test]
+fn test_md_upsert_bullet_accepts_content_alias() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("notes.md");
+    fs::write(&file, "## Rules\n\n- existing\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "md",
+            "upsert-bullet",
+            file.to_str().unwrap(),
+            "--heading",
+            "## Rules",
+            "--content",
+            "via content alias",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("via content alias"),
+        "content alias must write bullet: {content}"
+    );
+}
+
 #[test]
 fn test_md_upsert_bullet_skips_duplicate() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Agent honesty fixes from Grok/stickynote evals (issues #1838–#1844).

| Issue | Change |
|-------|--------|
| **#1838** | Doc query success under `--json`/`--jsonl` is an `ok`+`value` envelope (text mode stays bare). |
| **#1839** | `md upsert-bullet --content` aliases `--bullet`. |
| **#1840** | Batch/tx `tidy.fix` defaults trim trailing whitespace like CLI `tidy fix`. |
| **#1841** | agent-rules AST examples match real clap (PATH/SYMBOL order). |
| **#1842** | Working plan-level `for_each: {glob}` JSON example. |
| **#1843** | `doc has` missing key exits **0** with `false` (not exit 3). |
| **#1844** | `merge_match_modes` is public for embedders. |

Closes #1838
Closes #1839
Closes #1840
Closes #1841
Closes #1842
Closes #1843
Closes #1844

## Test plan

- [x] Unit: doc has exit 0 / JSON envelope; flatten envelope; agent-rules AST/for_each; merge_match_modes
- [x] Integration: doc get/has/keys/flatten jsonl envelopes; md content alias; batch tidy.fix trim
- [x] clippy `-D warnings`
- [ ] CI full matrix

Note: release PR #1837 left open (do not merge without explicit approval).