### PR TITLE
fix: honor tidy.fix plan write_policy; lock doc query envelopes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd patchloom
 make check
 ```
 
-`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks (`check-patchloom-md`, `check-readme`). While iterating locally, `make check-fast` is almost the same but skips only `check-patchloom-md` (still runs `check-readme` so a drifted README test badge fails before CI).
+`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast + library-hygiene), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks (`check-patchloom-md`, `check-readme`). While iterating locally, `make check-fast` is almost the same but skips only `check-patchloom-md` (still runs `check-readme` so a drifted README test badge fails before CI).
 
 ## Issues and triage
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3600%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3700%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -459,7 +459,7 @@ flowchart LR
 
 ## Status
 
-3600+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3700+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -36,6 +36,27 @@ async fn spawn_test_client_with_log(
     ().serve(client_transport).await.unwrap()
 }
 
+/// #1838: MCP peels CLI doc-query ok/value envelopes back to bare values.
+#[test]
+fn peel_doc_query_success_value_extracts_value() {
+    let envelope = r#"{"ok":true,"value":{"a":1},"path":"/tmp/x.json","selector":"a"}"#;
+    let peeled = peel_doc_query_success_value(envelope);
+    let v: serde_json::Value = serde_json::from_str(&peeled).unwrap();
+    assert_eq!(v, serde_json::json!({"a": 1}), "peeled: {peeled}");
+}
+
+#[test]
+fn peel_doc_query_success_value_leaves_errors_and_diff() {
+    let err = r#"{"ok":false,"error":"no match","error_kind":"no_matches"}"#;
+    assert_eq!(peel_doc_query_success_value(err), err);
+
+    let diff = r#"{"identical":false,"differences":["~ a"]}"#;
+    assert_eq!(peel_doc_query_success_value(diff), diff);
+
+    let not_json = "plain text";
+    assert_eq!(peel_doc_query_success_value(not_json), not_json);
+}
+
 mod basic {
     use super::*;
 

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -251,6 +251,9 @@ pub(crate) struct TxState<'a> {
     /// upfront declared_paths check covers static paths; this catches paths
     /// discovered at runtime (#1361).
     pub(crate) guard: Option<&'a crate::containment::PathGuard>,
+    /// Plan-level `write_policy` (if any). Used by `tidy.fix` so defaults
+    /// honor plan overrides before op-level fields (#1840 honesty).
+    pub(crate) plan_write_policy: Option<&'a crate::write::WritePolicyOverride>,
 }
 
 /// Test fixture that owns all the storage behind a `TxState`, avoiding
@@ -306,6 +309,7 @@ impl TxStateFixture {
             quiet: true,
             structured: false,
             guard: None,
+            plan_write_policy: None,
         }
     }
 }
@@ -593,6 +597,7 @@ pub(crate) fn execute_and_collect(
             quiet,
             structured,
             guard,
+            plan_write_policy: plan.write_policy.as_ref(),
         };
         match execute_operation(op, &mut tx) {
             Ok(count) => {

--- a/src/tx/tidy_op.rs
+++ b/src/tx/tidy_op.rs
@@ -19,18 +19,29 @@ pub(crate) fn execute_tidy_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             let file_path = tx.cwd.join(path);
             mark_write_target(tx.write_targets, &file_path);
             let content = read_file_content(tx.pending, tx.existed_before, &file_path)?.to_owned();
-            // Defaults match CLI `tidy fix` when no flags / write_policy override
-            // are set (#1840): trim trailing whitespace + ensure final newline.
-            let policy = WritePolicy {
-                ensure_final_newline: ensure_final_newline.unwrap_or(true),
-                trim_trailing_whitespace: trim_trailing_whitespace.unwrap_or(true),
-                normalize_eol: if let Some(eol) = normalize_eol {
-                    crate::write::parse_eol_mode(eol)?
-                } else {
-                    EolMode::Keep
-                },
-                collapse_blanks: collapse_blanks.unwrap_or(false),
+            // Precedence (#1840): CLI tidy-fix defaults (trim + final newline)
+            // -> plan write_policy (if set) -> op-level fields (if Some).
+            let mut policy = WritePolicy {
+                ensure_final_newline: true,
+                trim_trailing_whitespace: true,
+                normalize_eol: EolMode::Keep,
+                collapse_blanks: false,
             };
+            if let Some(ov) = tx.plan_write_policy {
+                policy.apply_override(ov)?;
+            }
+            if let Some(v) = *ensure_final_newline {
+                policy.ensure_final_newline = v;
+            }
+            if let Some(v) = *trim_trailing_whitespace {
+                policy.trim_trailing_whitespace = v;
+            }
+            if let Some(eol) = normalize_eol {
+                policy.normalize_eol = crate::write::parse_eol_mode(eol)?;
+            }
+            if let Some(v) = *collapse_blanks {
+                policy.collapse_blanks = v;
+            }
             let mut new = crate::write::apply_policy(&content, &policy).into_owned();
 
             // Apply dedent/indent after policy normalization.

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1725,6 +1725,33 @@ fn test_doc_select_filters_by_predicate() {
         .stdout(predicate::str::contains("\"b\"").not());
 }
 
+/// #1838: doc select --json success uses ok/value envelope (same path as get).
+#[test]
+fn test_doc_select_json_success_envelope() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.json");
+    fs::write(
+        &file,
+        r#"{"items":[{"status":"active","name":"a"},{"status":"done","name":"b"}]}"#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "select"])
+        .arg(&file)
+        .arg("items[status=active]")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    // Single match unwraps to the object (same as doc get multi-value rule).
+    assert_eq!(v["value"]["name"], "a", "{v}");
+    assert_eq!(v["value"]["status"], "active", "{v}");
+    assert_eq!(v["selector"], "items[status=active]", "{v}");
+}
+
 #[test]
 fn test_doc_ensure_creates_missing_key() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1363,6 +1363,28 @@ fn test_doc_len_array() {
         .stdout(predicate::str::starts_with("5"));
 }
 
+/// #1838: doc len --json success uses ok/value envelope (not bare number).
+#[test]
+fn test_doc_len_json_success_envelope() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"items":[1,2,3,4,5]}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "len"])
+        .arg(&file)
+        .arg("items")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["value"], 5, "{v}");
+    assert_eq!(v["selector"], "items", "{v}");
+    assert!(v["path"].as_str().is_some(), "{v}");
+}
+
 #[test]
 fn test_doc_append_to_array() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2744,6 +2744,80 @@ fn test_tx_tidy_fix_defaults_trim_and_final_newline() {
     );
 }
 
+/// #1840: plan-level write_policy must override tidy.fix CLI-matching defaults.
+#[test]
+fn test_tx_tidy_fix_plan_write_policy_overrides_defaults() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("messy.txt");
+    fs::write(&file, "hello   ").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "write_policy": {
+            "trim_trailing_whitespace": false,
+            "ensure_final_newline": false
+        },
+        "operations": [{
+            "op": "tidy.fix",
+            "path": file.to_str().unwrap()
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        result, "hello   ",
+        "plan write_policy must disable tidy.fix defaults: got {result:?}"
+    );
+}
+
+/// Op-level tidy fields win over plan write_policy.
+#[test]
+fn test_tx_tidy_fix_op_fields_win_over_plan_write_policy() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("messy.txt");
+    fs::write(&file, "hello   ").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "write_policy": {
+            "trim_trailing_whitespace": false,
+            "ensure_final_newline": false
+        },
+        "operations": [{
+            "op": "tidy.fix",
+            "path": file.to_str().unwrap(),
+            "trim_trailing_whitespace": true,
+            "ensure_final_newline": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        result, "hello\n",
+        "op-level tidy fields must beat plan write_policy: got {result:?}"
+    );
+}
+
 #[test]
 fn test_tx_tidy_fix_trim_trailing_whitespace() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2712,6 +2712,38 @@ fn test_tx_tidy_fix_in_plan() {
     assert_eq!(result, "line1\nline2\n");
 }
 
+/// #1840: bare tidy.fix (no write-policy fields) must match CLI tidy fix defaults.
+#[test]
+fn test_tx_tidy_fix_defaults_trim_and_final_newline() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("messy.txt");
+    fs::write(&file, "hello   \nworld\t").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "tidy.fix",
+            "path": file.to_str().unwrap()
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        result, "hello\nworld\n",
+        "bare tidy.fix must trim trailing whitespace and ensure final newline (#1840)"
+    );
+}
+
 #[test]
 fn test_tx_tidy_fix_trim_trailing_whitespace() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Multi-perspective improvement cycle after #1846 landed agent honesty work.

### Product fix
- **`tidy.fix` + plan `write_policy`:** bare defaults still match CLI `tidy fix` (#1840), but plan-level `write_policy` was ignored at stage. Precedence is now defaults → plan `write_policy` → op fields.

### Test / docs locks
- Doc `len` / `select` `--json` success envelopes (#1838)
- Bare tx `tidy.fix` defaults + plan/op precedence
- MCP `peel_doc_query_success_value` unit tests
- CONTRIBUTING documents `test-library-hygiene` in the `make check` list
- README test badge → 3700+

### Follow-up
- Closes nothing for #1847 (filed): op-level tidy fields can still lose to plan `write_policy` at **commit** re-apply.

## Test plan
- [x] `cargo test --test integration test_tx_tidy_fix`
- [x] `cargo test --test integration test_doc_len_json_success_envelope`
- [x] `cargo test --test integration test_doc_select_json_success_envelope`
- [x] `cargo test --lib peel_doc_query`
- [x] `make check-fast` (except README until badge bump; then `make check-readme`)

Note: release PR #1837 left open (do not merge without approval).