### PR TITLE
fix: tidy.fix op write-policy survives commit

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1168,7 +1168,7 @@ The operations below are the building blocks inside `operations`.
 
 - **What it does:** Applies tidy normalization inside a transaction.
 - **Use when:** Text cleanup should be part of the same atomic success criteria as other edits.
-- **Defaults (#1840):** When the op omits write-policy fields, matches bare CLI `tidy fix`: trim trailing whitespace and ensure final newline (`normalize_eol` stays keep unless set). Explicit op fields or plan `write_policy` still override.
+- **Defaults (#1840):** When the op omits write-policy fields, matches bare CLI `tidy fix`: trim trailing whitespace and ensure final newline (`normalize_eol` stays keep unless set). Precedence: tidy defaults → plan `write_policy` → op fields. Op fields win through commit (#1847); a later non-tidy write to the same path re-enables plan `write_policy` at commit.
 - **Related:** top level `tidy fix`
 
 <!-- ref:tx-op:file.append -->

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -193,17 +193,51 @@ pub(super) fn describe_operation(op: &Operation) -> String {
         }
         Operation::TidyFix {
             path,
+            ensure_final_newline,
+            trim_trailing_whitespace,
+            normalize_eol,
+            collapse_blanks,
             dedent,
             indent,
-            ..
+            lines,
         } => {
-            if dedent.is_some() {
+            let mut base = if dedent.is_some() {
                 format!("Dedent and normalize whitespace in {path}")
             } else if indent.is_some() {
                 format!("Indent and normalize whitespace in {path}")
             } else {
                 format!("Normalize whitespace in {path}")
+            };
+            // Surface explicit op overrides so agents see #1840/#1847 precedence
+            // (defaults → plan write_policy → op fields).
+            let mut notes: Vec<String> = Vec::new();
+            if let Some(v) = ensure_final_newline {
+                notes.push(format!("ensure_final_newline={v}"));
             }
+            if let Some(v) = trim_trailing_whitespace {
+                notes.push(format!("trim_trailing_whitespace={v}"));
+            }
+            if let Some(eol) = normalize_eol {
+                notes.push(format!("normalize_eol={eol}"));
+            }
+            if let Some(v) = collapse_blanks {
+                notes.push(format!("collapse_blanks={v}"));
+            }
+            if let Some(spec) = dedent {
+                notes.push(format!("dedent={spec}"));
+            }
+            if let Some(spec) = indent {
+                notes.push(format!("indent={spec}"));
+            }
+            if let Some(r) = lines {
+                notes.push(format!("lines={r}"));
+            }
+            if !notes.is_empty() {
+                base.push_str(" (");
+                base.push_str(&notes.join(", "));
+                base.push(')');
+            }
+            base
         }
         Operation::FileAppend { path, .. } => {
             format!("Append content to {path}")

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -1,4 +1,4 @@
-use super::execute::{TxState, read_file_content, update_file_content};
+use super::execute::{TxState, read_file_content};
 use crate::plan::Operation;
 
 use std::path::{Path, PathBuf};
@@ -42,7 +42,7 @@ fn ast_rename_single_file(
     let result = crate::ast::rename::rename_in_source(content, old, new, lang_val);
     match result {
         Some(r) if r.replacements > 0 => {
-            update_file_content(tx.pending, tx.deletions, tx.write_targets, abs, r.content);
+            tx.write_file(abs, r.content);
             Ok(r.replacements)
         }
         Some(_) => Err(crate::exit::NoMatchError {
@@ -56,13 +56,7 @@ fn ast_rename_single_file(
                 let new_content = re.replace_all(content, new).to_string();
                 let count = re.find_iter(content).count();
                 if count > 0 {
-                    update_file_content(
-                        tx.pending,
-                        tx.deletions,
-                        tx.write_targets,
-                        abs,
-                        new_content,
-                    );
+                    tx.write_file(abs, new_content);
                     return Ok(count);
                 }
             }
@@ -134,13 +128,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             )?;
             match result {
                 Some(r) if r.replacements > 0 => {
-                    update_file_content(
-                        tx.pending,
-                        tx.deletions,
-                        tx.write_targets,
-                        &abs,
-                        r.content,
-                    );
+                    tx.write_file(&abs, r.content);
                     Ok(r.replacements)
                 }
                 Some(_) => Err(crate::exit::NoMatchError {
@@ -205,13 +193,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             if new_content == content {
                 return Ok(0);
             }
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &abs,
-                new_content,
-            );
+            tx.write_file(&abs, new_content);
             Ok(1)
         }
 
@@ -243,13 +225,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 pos,
                 lang_val,
             )?;
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &abs,
-                result.content,
-            );
+            tx.write_file(&abs, result.content);
             Ok(1)
         }
 
@@ -275,13 +251,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 preamble.as_deref(),
                 lang_val,
             )?;
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &abs,
-                result.content,
-            );
+            tx.write_file(&abs, result.content);
             Ok(1)
         }
 
@@ -318,13 +288,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 file_content = result.content;
             }
             if total_changes > 0 {
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &abs,
-                    file_content,
-                );
+                tx.write_file(&abs, file_content);
             }
             Ok(total_changes)
         }
@@ -349,13 +313,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 lang_val,
             )?;
             if result.symbols_reordered > 0 {
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &abs,
-                    result.content,
-                );
+                tx.write_file(&abs, result.content);
             }
             Ok(result.symbols_reordered)
         }
@@ -383,13 +341,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             };
             let result = crate::ast::group::group_symbols(file_content, &spec, lang_val)?;
             if result.symbols_moved > 0 {
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &abs,
-                    result.content,
-                );
+                tx.write_file(&abs, result.content);
             }
             Ok(result.symbols_moved)
         }
@@ -426,20 +378,8 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 pos,
                 lang_val,
             )?;
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &abs_source,
-                result.source_content,
-            );
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &abs_target,
-                result.target_content,
-            );
+            tx.write_file(&abs_source, result.source_content);
+            tx.write_file(&abs_target, result.target_content);
             Ok(result.symbols_moved)
         }
 
@@ -477,20 +417,8 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 prepend.as_deref(),
                 lang_val,
             )?;
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &abs_source,
-                result.source_content,
-            );
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &abs_target,
-                result.target_content,
-            );
+            tx.write_file(&abs_source, result.source_content);
+            tx.write_file(&abs_target, result.target_content);
             Ok(1)
         }
 
@@ -527,22 +455,10 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 exhaustive,
                 lang_val,
             )?;
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &abs_source,
-                result.source_content,
-            );
+            tx.write_file(&abs_source, result.source_content);
             for (target_path, target_content) in &result.targets {
                 let abs_target = tx.cwd.join(target_path);
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &abs_target,
-                    target_content.clone(),
-                );
+                tx.write_file(&abs_target, target_content.clone());
             }
             Ok(result.symbols_distributed)
         }

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -1,5 +1,5 @@
 //! File create/append/prepend/delete/rename for the tx engine.
-use super::{TxState, read_file_content, update_file_content};
+use super::{TxState, read_file_content};
 use crate::plan::Operation;
 
 // op_to_doc_mutation moved to plan.rs as the single source of truth for
@@ -35,13 +35,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let combined = crate::ops::file::append_content(existing, content);
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &file_path,
-                combined,
-            );
+            tx.write_file(&file_path, combined);
         }
 
         Operation::FilePrepend { path, content } => {
@@ -71,13 +65,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let combined = crate::ops::file::prepend_content(existing, content);
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &file_path,
-                combined,
-            );
+            tx.write_file(&file_path, combined);
         }
 
         Operation::FileCreate {
@@ -99,13 +87,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 if tx.pending.contains_key(&file_path) || file_path.exists() {
                     let _ = read_file_content(tx.pending, tx.existed_before, &file_path)?;
                 }
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &file_path,
-                    content.clone(),
-                );
+                tx.write_file(&file_path, content.clone());
             } else {
                 let exists_in_tx =
                     tx.pending.contains_key(&file_path) && !tx.deletions.contains(&file_path);
@@ -115,13 +97,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                     }
                     .into());
                 }
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &file_path,
-                    content.clone(),
-                );
+                tx.write_file(&file_path, content.clone());
             }
         }
 
@@ -165,13 +141,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 tx.pending.remove(&file_path);
                 tx.deletions.remove(&file_path);
             } else {
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &file_path,
-                    String::new(),
-                );
+                tx.write_file(&file_path, String::new());
                 tx.deletions.insert(file_path);
             }
         }
@@ -263,13 +233,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             }
 
             // Write content to destination.
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &dst_path,
-                content,
-            );
+            tx.write_file(&dst_path, content);
 
             // Delete source (same logic as file.delete for tx-created files).
             let created_in_tx = match tx.pending.get(&src_path) {
@@ -280,13 +244,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 tx.pending.remove(&src_path);
                 tx.deletions.remove(&src_path);
             } else {
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &src_path,
-                    String::new(),
-                );
+                tx.write_file(&src_path, String::new());
                 tx.deletions.insert(src_path);
             }
         }

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -113,6 +113,21 @@ pub(crate) fn update_file_content(
     }
 }
 
+impl TxState<'_> {
+    /// Write pending content and clear tidy policy-finalized state for the path
+    /// so commit-time write_policy can re-apply after non-tidy writers (#1847).
+    pub(crate) fn write_file(&mut self, path: &Path, new_content: String) {
+        self.policy_finalized.remove(path);
+        update_file_content(
+            self.pending,
+            self.deletions,
+            self.write_targets,
+            path,
+            new_content,
+        );
+    }
+}
+
 /// Mark a file as targeted by a write operation. Write policy is only
 /// applied to files in this set, not to files loaded solely for reading
 /// (#1108).
@@ -129,6 +144,7 @@ pub(crate) fn flush_doc_cache_entry(
     pending: &mut HashMap<PathBuf, (String, String)>,
     deletions: &mut HashSet<PathBuf>,
     write_targets: &mut HashSet<PathBuf>,
+    policy_finalized: &mut HashSet<PathBuf>,
     path: PathBuf,
     cached: CachedDoc,
 ) -> anyhow::Result<()> {
@@ -139,6 +155,7 @@ pub(crate) fn flush_doc_cache_entry(
         &cached.format,
     )
     .map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
+    policy_finalized.remove(&path);
     update_file_content(pending, deletions, write_targets, &path, new_content);
     Ok(())
 }
@@ -149,10 +166,18 @@ pub(crate) fn flush_doc_cache(
     pending: &mut HashMap<PathBuf, (String, String)>,
     deletions: &mut HashSet<PathBuf>,
     write_targets: &mut HashSet<PathBuf>,
+    policy_finalized: &mut HashSet<PathBuf>,
     doc_cache: &mut HashMap<PathBuf, CachedDoc>,
 ) -> anyhow::Result<()> {
     for (path, cached) in doc_cache.drain() {
-        flush_doc_cache_entry(pending, deletions, write_targets, path, cached)?;
+        flush_doc_cache_entry(
+            pending,
+            deletions,
+            write_targets,
+            policy_finalized,
+            path,
+            cached,
+        )?;
     }
     Ok(())
 }
@@ -254,6 +279,10 @@ pub(crate) struct TxState<'a> {
     /// Plan-level `write_policy` (if any). Used by `tidy.fix` so defaults
     /// honor plan overrides before op-level fields (#1840 honesty).
     pub(crate) plan_write_policy: Option<&'a crate::write::WritePolicyOverride>,
+    /// Paths whose pending content already has write-policy fully applied by
+    /// `tidy.fix` (op fields win). Cleared when a later non-tidy write updates
+    /// the path (#1847).
+    pub(crate) policy_finalized: &'a mut HashSet<PathBuf>,
 }
 
 /// Test fixture that owns all the storage behind a `TxState`, avoiding
@@ -271,6 +300,7 @@ pub(crate) struct TxStateFixture {
     pub write_targets: HashSet<PathBuf>,
     pub replace_match_meta: HashMap<PathBuf, crate::tx::output::ReplaceMatchMeta>,
     pub renames: Vec<(PathBuf, PathBuf)>,
+    pub policy_finalized: HashSet<PathBuf>,
 }
 
 #[cfg(test)]
@@ -288,6 +318,7 @@ impl TxStateFixture {
             write_targets: HashSet::new(),
             replace_match_meta: HashMap::new(),
             renames: Vec::new(),
+            policy_finalized: HashSet::new(),
         }
     }
 
@@ -310,6 +341,7 @@ impl TxStateFixture {
             structured: false,
             guard: None,
             plan_write_policy: None,
+            policy_finalized: &mut self.policy_finalized,
         }
     }
 }
@@ -538,6 +570,7 @@ pub(crate) fn execute_and_collect(
     let mut replace_hint: Option<String> = None;
     let mut replace_match_meta: HashMap<PathBuf, super::output::ReplaceMatchMeta> = HashMap::new();
     let mut renames: Vec<(PathBuf, PathBuf)> = Vec::new();
+    let mut policy_finalized: HashSet<PathBuf> = HashSet::new();
 
     // Upfront PathGuard on declared paths (same contract as execute_plan_inner /
     // execute_plan_direct). CLI `tx` and `batch` call this function directly and
@@ -577,6 +610,7 @@ pub(crate) fn execute_and_collect(
                 &mut pending,
                 &mut deletions,
                 &mut write_targets,
+                &mut policy_finalized,
                 &mut doc_cache,
             )?;
         }
@@ -598,6 +632,7 @@ pub(crate) fn execute_and_collect(
             structured,
             guard,
             plan_write_policy: plan.write_policy.as_ref(),
+            policy_finalized: &mut policy_finalized,
         };
         match execute_operation(op, &mut tx) {
             Ok(count) => {
@@ -681,6 +716,7 @@ pub(crate) fn execute_and_collect(
         &mut pending,
         &mut deletions,
         &mut write_targets,
+        &mut policy_finalized,
         &mut doc_cache,
     )?;
 
@@ -692,8 +728,14 @@ pub(crate) fn execute_and_collect(
         if !write_targets.contains(path) {
             continue;
         }
-        let write_policy = build_write_policy(plan, ctx, path)?;
-        let final_content = apply_policy(current, &write_policy);
+        // #1847: tidy.fix already applied effective policy (incl. op fields).
+        // Skip commit re-apply so plan write_policy cannot undo op overrides.
+        let final_content = if policy_finalized.contains(path) {
+            std::borrow::Cow::Borrowed(current.as_str())
+        } else {
+            let write_policy = build_write_policy(plan, ctx, path)?;
+            apply_policy(current, &write_policy)
+        };
         // A file creation with empty content still has original == final == "",
         // but must be treated as an effective change because the file does not
         // exist on disk yet (#create-empty-file).

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -24,7 +24,7 @@ mod policy;
 mod tests;
 
 pub(crate) use file_ops::execute_file_op;
-pub(crate) use policy::build_write_policy;
+pub(crate) use policy::{build_write_policy, build_write_policy_with_plan};
 
 // ---------------------------------------------------------------------------
 // Pending file changes
@@ -728,14 +728,16 @@ pub(crate) fn execute_and_collect(
         if !write_targets.contains(path) {
             continue;
         }
-        // #1847: tidy.fix already applied effective policy (incl. op fields).
-        // Skip commit re-apply so plan write_policy cannot undo op overrides.
-        let final_content = if policy_finalized.contains(path) {
-            std::borrow::Cow::Borrowed(current.as_str())
+        // #1847: tidy.fix staged with defaults→plan→op. Re-applying plan
+        // write_policy here would undo op fields. Still run CLI/EditorConfig
+        // policy (apply_plan_fields=false) so `tidy fix --respect-editorconfig`
+        // is not a no-op.
+        let write_policy = if policy_finalized.contains(path) {
+            build_write_policy_with_plan(plan, ctx, path, false)?
         } else {
-            let write_policy = build_write_policy(plan, ctx, path)?;
-            apply_policy(current, &write_policy)
+            build_write_policy(plan, ctx, path)?
         };
+        let final_content = apply_policy(current, &write_policy);
         // A file creation with empty content still has original == final == "",
         // but must be treated as an effective change because the file does not
         // exist on disk yet (#create-empty-file).

--- a/src/tx/execute/policy.rs
+++ b/src/tx/execute/policy.rs
@@ -19,6 +19,22 @@ pub(crate) fn build_write_policy(
     ctx: &EngineContext,
     path: &Path,
 ) -> anyhow::Result<WritePolicy> {
+    build_write_policy_with_plan(plan, ctx, path, true)
+}
+
+/// Like [`build_write_policy`], but when `apply_plan_fields` is false skip
+/// plan `write_policy` field overrides (trim/ensure/eol/collapse).
+///
+/// Used for paths whose content was already staged by `tidy.fix` with the
+/// full defaults→plan→op precedence (#1847). Still resolves EditorConfig via
+/// CLI flags (and plan `respect_editorconfig` when set) so CLI
+/// `tidy fix --respect-editorconfig` keeps working.
+pub(crate) fn build_write_policy_with_plan(
+    plan: &Plan,
+    ctx: &EngineContext,
+    path: &Path,
+    apply_plan_fields: bool,
+) -> anyhow::Result<WritePolicy> {
     // If the plan explicitly sets respect_editorconfig, build the policy
     // with that flag applied. This must happen before policy_from_flags
     // because EditorConfig properties are resolved during construction,
@@ -30,7 +46,7 @@ pub(crate) fn build_write_policy(
         base_flags = GlobalFlags::with_editorconfig(&base_flags, ec);
     }
     let mut write_policy = crate::write::policy_from_flags(&base_flags, Some(path));
-    if let Some(ov) = &plan.write_policy {
+    if apply_plan_fields && let Some(ov) = &plan.write_policy {
         write_policy.apply_override(ov)?;
     }
     Ok(write_policy)

--- a/src/tx/md_op.rs
+++ b/src/tx/md_op.rs
@@ -1,4 +1,4 @@
-use super::execute::{TxState, read_file_content, update_file_content};
+use super::execute::{TxState, read_file_content};
 use super::output::TxLintResult;
 use crate::ops::md::{
     dedupe_headings_in, insert_after_heading_in, insert_after_section_in, insert_before_heading_in,
@@ -25,13 +25,7 @@ fn apply_md_heading_op(
         op(file_content, heading, extra).ok_or_else(|| crate::exit::NoMatchError {
             msg: format!("{err_label} not found: {heading}"),
         })?;
-    update_file_content(
-        tx.pending,
-        tx.deletions,
-        tx.write_targets,
-        &file_path,
-        new_content,
-    );
+    tx.write_file(&file_path, new_content);
     Ok(())
 }
 
@@ -114,13 +108,7 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
                         })
                     },
                 )?;
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &file_path,
-                new_content,
-            );
+            tx.write_file(&file_path, new_content);
         }
 
         Operation::MdMoveSection {
@@ -161,21 +149,9 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
                     .ok_or_else(|| crate::exit::NoMatchError {
                         msg: "md.move_section: heading or target not found".to_string(),
                     })?;
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &source_path,
-                new_source,
-            );
+            tx.write_file(&source_path, new_source);
             if !same_file {
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &dest_path,
-                    new_dest,
-                );
+                tx.write_file(&dest_path, new_dest);
             }
         }
 
@@ -183,13 +159,7 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
             let file_path = tx.cwd.join(path);
             let file_content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let (new_content, _removed) = dedupe_headings_in(file_content);
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &file_path,
-                new_content,
-            );
+            tx.write_file(&file_path, new_content);
         }
 
         Operation::MdLintAgents { path } => {

--- a/src/tx/patch_op.rs
+++ b/src/tx/patch_op.rs
@@ -1,4 +1,4 @@
-use super::execute::{TxState, read_file_content, update_file_content};
+use super::execute::{TxState, read_file_content};
 use crate::ops::patch::{ApplyHunksOptions, apply_patch_with_loader};
 use crate::plan::Operation;
 
@@ -32,13 +32,7 @@ pub(crate) fn execute_patch_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::
                     tx.deletions.insert(file_path.clone());
                     tx.write_targets.insert(file_path);
                 } else {
-                    update_file_content(
-                        tx.pending,
-                        tx.deletions,
-                        tx.write_targets,
-                        &file_path,
-                        result.content,
-                    );
+                    tx.write_file(&file_path, result.content);
                 }
             }
             Ok(0)

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -3,7 +3,7 @@
 //! size-waiver: accepted single-domain bulk (policy #1408). Path + glob replace
 //! with fuzzy/context fallback co-located; do not split for LOC alone.
 
-use super::execute::{TxState, read_and_probe, read_file_content, update_file_content};
+use super::execute::{TxState, read_and_probe, read_file_content};
 use crate::api::MatchMode;
 use crate::ops::replace::{
     compile_replace_regex, context_filtered_offset, replace_content, replace_whole_lines,
@@ -277,13 +277,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         replacement,
                         &content[target_offset + old.len()..],
                     );
-                    update_file_content(
-                        tx.pending,
-                        tx.deletions,
-                        tx.write_targets,
-                        &file_path,
-                        new_content,
-                    );
+                    tx.write_file(&file_path, new_content);
                     record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
                     return Ok(1);
                 }
@@ -298,13 +292,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 .into());
             }
             let owned = replaced.into_owned();
-            update_file_content(
-                tx.pending,
-                tx.deletions,
-                tx.write_targets,
-                &file_path,
-                owned,
-            );
+            tx.write_file(&file_path, owned);
             record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count, None);
             Ok(match_count)
         } else if let Some((n, total)) = (*nth).and_then(|n| {
@@ -404,13 +392,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             to_text,
                             &content[anchor.start_offset + anchor.matched_text.len()..]
                         );
-                        update_file_content(
-                            tx.pending,
-                            tx.deletions,
-                            tx.write_targets,
-                            &file_path,
-                            new_content,
-                        );
+                        tx.write_file(&file_path, new_content);
                         record_replace_match(
                             tx,
                             &file_path,
@@ -590,13 +572,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             replacement,
                             &content[target_offset + old.len()..],
                         );
-                        update_file_content(
-                            tx.pending,
-                            tx.deletions,
-                            tx.write_targets,
-                            &file_path,
-                            new_content,
-                        );
+                        tx.write_file(&file_path, new_content);
                         record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
                         total_matches += 1;
                         continue;
@@ -616,13 +592,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     .into());
                 }
                 total_matches += match_count;
-                update_file_content(
-                    tx.pending,
-                    tx.deletions,
-                    tx.write_targets,
-                    &file_path,
-                    replaced.into_owned(),
-                );
+                tx.write_file(&file_path, replaced.into_owned());
                 record_replace_match(tx, &file_path, MatchMode::Exact, None, match_count, None);
             } else if let Some((n, total)) = (*nth).and_then(|n| {
                 let total = crate::ops::replace::count_nth_candidates(
@@ -727,13 +697,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             to_text,
                             &content[anchor.start_offset + anchor.matched_text.len()..]
                         );
-                        update_file_content(
-                            tx.pending,
-                            tx.deletions,
-                            tx.write_targets,
-                            &file_path,
-                            new_content,
-                        );
+                        tx.write_file(&file_path, new_content);
                         record_replace_match(
                             tx,
                             &file_path,

--- a/src/tx/tidy_op.rs
+++ b/src/tx/tidy_op.rs
@@ -57,8 +57,11 @@ pub(crate) fn execute_tidy_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             }
 
             if content != new {
+                // Do not use write_file: that clears policy_finalized.
                 update_file_content(tx.pending, tx.deletions, tx.write_targets, &file_path, new);
             }
+            // #1847: content already reflects effective tidy policy (op wins).
+            tx.policy_finalized.insert(file_path);
             Ok(0)
         }
 

--- a/tests/integration/explain_tests.rs
+++ b/tests/integration/explain_tests.rs
@@ -374,4 +374,26 @@ fn test_explain_file_prepend_description() {
         .stdout(predicates::str::contains("Prepend"));
 }
 
+/// #1847: explain must surface explicit tidy.fix write-policy fields.
+#[test]
+fn test_explain_tidy_fix_shows_explicit_write_policy_fields() {
+    let dir = TempDir::new().unwrap();
+    let plan = dir.path().join("plan.json");
+    fs::write(
+        &plan,
+        r#"{"version":1,"operations":[{"op":"tidy.fix","path":"x.txt","ensure_final_newline":false,"trim_trailing_whitespace":false,"normalize_eol":"lf"}]}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["explain"])
+        .arg(&plan)
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("ensure_final_newline=false"))
+        .stdout(predicates::str::contains("trim_trailing_whitespace=false"))
+        .stdout(predicates::str::contains("normalize_eol=lf"));
+}
+
 // ── --format flag on write commands ────────────────────────────

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2818,6 +2818,43 @@ fn test_tx_tidy_fix_op_fields_win_over_plan_write_policy() {
     );
 }
 
+/// #1847: op-level ensure_final_newline false must survive commit despite plan ensure true.
+#[test]
+fn test_tx_tidy_fix_op_fields_survive_commit_write_policy() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("messy.txt");
+    fs::write(&file, "hello").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "write_policy": {
+            "ensure_final_newline": true
+        },
+        "operations": [{
+            "op": "tidy.fix",
+            "path": file.to_str().unwrap(),
+            "ensure_final_newline": false,
+            "trim_trailing_whitespace": false
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let result = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        result, "hello",
+        "op ensure_final_newline=false must not be undone by plan write_policy at commit (#1847): got {result:?}"
+    );
+}
+
 #[test]
 fn test_tx_tidy_fix_trim_trailing_whitespace() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Closes #1847

`tidy.fix` stages with precedence defaults → plan `write_policy` → op fields, but commit re-applied plan `write_policy` and could undo op fields (e.g. `ensure_final_newline: false` lost when plan set `true`).

### Fix
- Track paths last written by `tidy.fix` (`policy_finalized`)
- At commit, for those paths, apply CLI/EditorConfig policy **without** plan field overrides
- Later non-tidy writes clear finalization so plan policy applies again
- `tx.write_file` helper clears finalization for replace/md/ast/file/patch writers

### Also
- `explain` surfaces explicit tidy.fix write-policy fields
- Integration tests for #1847 and explain field display
- Regression: EditorConfig via `tidy fix --respect-editorconfig` still applies at commit

## Test plan
- [x] `cargo test --test integration test_tx_tidy_fix`
- [x] `cargo test --test integration test_editorconfig`
- [x] `cargo test --test integration test_explain_tidy_fix`
- [x] `make check-fast`

Note: release PR #1837 left open (needs approval to merge).