### PR TITLE
docs: tidy.fix defaults in schema and agent-rules

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -89,6 +89,7 @@ Placeholders: `{path}`, `{item}` (alias of `{path}`), `{dir}`, `{stem}`, `{ext}`
 **CLI vs plan/MCP names (#1809):** CLI replace is positional `OLD` + `--new NEW` (not plan aliases `from`/`to` as flags). CLI `doc set` is `doc set PATH SELECTOR VALUE` (not a `--key` flag). Plan/MCP accept legacy aliases `from`/`to` and `key` for selector.
 **CLI `md upsert-bullet`:** use `--bullet` (or alias `--content`; #1839) with `--heading`.
 **Doc query `--json` (#1838):** `doc get`/`has`/`keys`/`len`/`select`/`flatten` success is `{"ok":true,"value":...,"path":...,"selector":...}` (selector omitted for flatten). Text mode stays bare. `doc has` prints `true`/`false` and exits **0** for both (missing key is not `no_matches`; #1843).
+**Plan/batch `tidy.fix` defaults (#1840, #1847):** Omitting write-policy fields matches CLI `tidy fix` (trim trailing whitespace + ensure final newline). Precedence: defaults → plan `write_policy` → op fields. Op fields stick through commit (plan `write_policy` is not re-applied to that path); a later non-tidy write clears that. Bare example: `{"op":"tidy.fix","path":"f.txt"}`.
 **Replace jsonl multi-file (#1799):** Streams one object per success path (`status: ok`), refused soft-miss (`status: refused`), skipped missing (`status: skipped`), then a `type: summary` trailer with counts. Prefer this or MCP `batch_replace` over assuming success lines are the full path list.
 
 Use patchloom when:
@@ -406,7 +407,7 @@ dependencies[name=react].version # predicate filter
 - `file.create`: Create a new file with specified content.
 - `file.delete`: Delete a file.
 - `file.rename`: Rename (move) a file.
-- `tidy.fix`: Normalize whitespace, line endings, and final newline in a file.
+- `tidy.fix`: Normalize whitespace in a file. When op fields are omitted, defaults match CLI tidy fix (trim trailing whitespace + ensure final newline; normalize_eol stays keep). Precedence: defaults → plan write_policy → op fields. Plan write_policy is not re-applied at commit for paths last written by tidy.fix so op fields stick (#1840, #1847).
 - `doc.set`: Set a value at a selector path in a JSON, YAML, or TOML file. Parser-backed; output is always valid.
 - `doc.delete`: Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json and MCP/tx success include changed and removed (0 on missing key; exit 0 / ok is idempotent).
 - `doc.merge`: Deep-merge a JSON object into the root of a document.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1168,7 +1168,7 @@ The operations below are the building blocks inside `operations`.
 
 - **What it does:** Applies tidy normalization inside a transaction.
 - **Use when:** Text cleanup should be part of the same atomic success criteria as other edits.
-- **Defaults (#1840):** When the op omits write-policy fields, matches bare CLI `tidy fix`: trim trailing whitespace and ensure final newline (`normalize_eol` stays keep unless set). Precedence: tidy defaults → plan `write_policy` → op fields. Op fields win through commit (#1847); a later non-tidy write to the same path re-enables plan `write_policy` at commit.
+- **Defaults (#1840):** When the op omits write-policy fields, matches bare CLI `tidy fix`: trim trailing whitespace and ensure final newline (`normalize_eol` stays keep unless set). Precedence: tidy defaults → plan `write_policy` → op fields. At commit, plan `write_policy` is not re-applied to paths last written by `tidy.fix` so op fields stick (#1847); CLI/EditorConfig policy still applies. A later non-tidy write clears that and restores full plan policy.
 - **Related:** top level `tidy fix`
 
 <!-- ref:tx-op:file.append -->

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -195,6 +195,10 @@ includes `backup_session` when a backup was created (same field as `format_faile
              **Doc query `--json` (#1838):** `doc get`/`has`/`keys`/`len`/`select`/`flatten` success is \
 `{\"ok\":true,\"value\":...,\"path\":...,\"selector\":...}` (selector omitted for flatten). Text mode stays bare. \
 `doc has` prints `true`/`false` and exits **0** for both (missing key is not `no_matches`; #1843).\n\
+             **Plan/batch `tidy.fix` defaults (#1840, #1847):** Omitting write-policy fields matches CLI \
+`tidy fix` (trim trailing whitespace + ensure final newline). Precedence: defaults → plan \
+`write_policy` → op fields. Op fields stick through commit (plan `write_policy` is not re-applied \
+to that path); a later non-tidy write clears that. Bare example: `{\"op\":\"tidy.fix\",\"path\":\"f.txt\"}`.\n\
              **Replace jsonl multi-file (#1799):** Streams one object per success path \
 (`status: ok`), refused soft-miss (`status: refused`), skipped missing (`status: skipped`), \
 then a `type: summary` trailer with counts. Prefer this or MCP `batch_replace` over assuming \
@@ -1011,6 +1015,20 @@ mod tests {
         assert!(
             out.contains("doc has") && out.contains("#1843"),
             "must document doc has exit 0 for missing key"
+        );
+    }
+
+    #[test]
+    fn agent_rules_documents_tidy_fix_defaults() {
+        // #1840 / #1847
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(
+            out.contains("tidy.fix") && out.contains("#1840") && out.contains("#1847"),
+            "must document tidy.fix defaults and commit precedence"
+        );
+        assert!(
+            out.contains("{\"op\":\"tidy.fix\"") || out.contains(r#"{"op":"tidy.fix""#),
+            "must include bare tidy.fix plan example"
         );
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -243,12 +243,18 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "tidy.fix",
-        description: "Normalize whitespace, line endings, and final newline in a file.",
+        description: "Normalize whitespace in a file. When op fields are omitted, defaults match CLI tidy fix (trim trailing whitespace + ensure final newline; normalize_eol stays keep). Precedence: defaults → plan write_policy → op fields. Plan write_policy is not re-applied at commit for paths last written by tidy.fix so op fields stick (#1840, #1847).",
         tier: Tier::Weak,
-        examples: &[(
-            "Fix whitespace in a file",
-            r###"{"op":"tidy.fix","path":"src/main.rs","ensure_final_newline":true,"trim_trailing_whitespace":true}"###,
-        )],
+        examples: &[
+            (
+                "Fix whitespace with explicit flags (same as bare defaults)",
+                r###"{"op":"tidy.fix","path":"src/main.rs","ensure_final_newline":true,"trim_trailing_whitespace":true}"###,
+            ),
+            (
+                "Bare tidy.fix uses CLI tidy-fix defaults",
+                r###"{"op":"tidy.fix","path":"src/main.rs"}"###,
+            ),
+        ],
     },
     // --- Medium tier ---
     OpMeta {

--- a/src/tx/execute/policy.rs
+++ b/src/tx/execute/policy.rs
@@ -51,3 +51,56 @@ pub(crate) fn build_write_policy_with_plan(
     }
     Ok(write_policy)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::global::GlobalFlags;
+    use crate::plan::{Operation, Plan};
+    use crate::tx::context::EngineContext;
+    use crate::write::WritePolicyOverride;
+    use std::path::PathBuf;
+
+    fn ctx() -> EngineContext {
+        EngineContext::from_global(&GlobalFlags::default(), PathBuf::from("/tmp"))
+    }
+
+    fn plan_with_write_policy(ov: WritePolicyOverride) -> Plan {
+        Plan {
+            version: crate::plan::SCHEMA_VERSION,
+            operations: vec![Operation::Read {
+                path: "f.txt".into(),
+                lines: None,
+            }],
+            write_policy: Some(ov),
+            strict: None,
+            format: None,
+            validate: None,
+            verify: None,
+            cwd: None,
+            for_each: None,
+        }
+    }
+
+    #[test]
+    fn apply_plan_fields_false_skips_plan_trim() {
+        let plan = plan_with_write_policy(WritePolicyOverride {
+            trim_trailing_whitespace: Some(true),
+            ensure_final_newline: Some(true),
+            ..WritePolicyOverride::default()
+        });
+        let path = PathBuf::from("/tmp/f.txt");
+        let with_plan = build_write_policy_with_plan(&plan, &ctx(), &path, true).unwrap();
+        assert!(with_plan.trim_trailing_whitespace);
+        assert!(with_plan.ensure_final_newline);
+        let no_plan = build_write_policy_with_plan(&plan, &ctx(), &path, false).unwrap();
+        assert!(
+            !no_plan.trim_trailing_whitespace,
+            "plan trim must not apply when apply_plan_fields=false"
+        );
+        assert!(
+            !no_plan.ensure_final_newline,
+            "plan ensure_final_newline must not apply when apply_plan_fields=false"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up honesty for #1840/#1847 after the commit-path fix landed.

- Schema `tidy.fix` description documents defaults and plan/op precedence
- Bare `{"op":"tidy.fix","path":"..."}` example in schema
- agent-rules + PATCHLOOM.md lock strings
- Reference doc clarifies EditorConfig still applies at commit

## Test plan
- [x] `cargo test --lib agent_rules_documents_tidy_fix`
- [x] `make check-fast`

Note: release PR #1837 still open (needs approval).