### PR TITLE
fix: include applied on plan/batch/tx JSON

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -84,7 +84,7 @@ Placeholders: `{path}`, `{item}` (alias of `{path}`), `{dir}`, `{stem}`, `{ext}`
 
 **Multi-result `--json`:** Commands that emit many items (`ast list` / `ast search` / `ast validate` / `ast deps`, `ast map`, undo list, etc.) print one JSON array under `--json` (single `json.loads` on full stdout) and one object per line under `--jsonl`. Do not expect concatenated pretty multi-documents for `--json`.
 
-**Preview vs apply (#1808, #1810, #1812):** CLI write JSON always includes `applied` (`true` after apply mode, `false` for default preview / check mode). `changed: true` or `files_changed: N` on preview means **would** change, not that bytes were written. Exit 2 = changes detected / dry-run.
+**Preview vs apply (#1808, #1810, #1812):** CLI write JSON always includes `applied` (`true` after apply mode, `false` for default preview / check mode). Plan/batch/tx JSON also includes `applied` (same meaning; pair with `status`: `success` vs `changes_detected`). `changed: true` or `files_changed: N` on preview means **would** change, not that bytes were written. Exit 2 = changes detected / dry-run.
 **`backup_session` on success (#1802):** Successful CLI replace/doc/tx apply JSON includes `backup_session` when a backup was created (same field as `format_failed` and library `EditResult`). Use it for surgical undo; do not guess newest session under parallel agents.
 **CLI vs plan/MCP names (#1809):** CLI replace is positional `OLD` + `--new NEW` (not plan aliases `from`/`to` as flags). CLI `doc set` is `doc set PATH SELECTOR VALUE` (not a `--key` flag). Plan/MCP accept legacy aliases `from`/`to` and `key` for selector.
 **CLI `md upsert-bullet`:** use `--bullet` (or alias `--content`; #1839) with `--heading`.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -213,6 +213,7 @@ Returns:
 {
   "ok": true,
   "status": "success",
+  "applied": true,
   "files_changed": 3,
   "files_created": 0,
   "files_deleted": 0,

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -182,9 +182,10 @@ Do not put `for_each` inside `operations` and do not pass a bare path array.\n\
     if show_cli {
         out.push_str(
             "**Preview vs apply (#1808, #1810, #1812):** CLI write JSON always includes `applied` \
-(`true` after apply mode, `false` for default preview / check mode). `changed: true` or \
-`files_changed: N` on preview means **would** change, not that bytes were written. Exit 2 = \
-changes detected / dry-run.\n\
+(`true` after apply mode, `false` for default preview / check mode). Plan/batch/tx JSON also \
+includes `applied` (same meaning; pair with `status`: `success` vs `changes_detected`). \
+`changed: true` or `files_changed: N` on preview means **would** change, not that bytes were \
+written. Exit 2 = changes detected / dry-run.\n\
              **`backup_session` on success (#1802):** Successful CLI replace/doc/tx apply JSON \
 includes `backup_session` when a backup was created (same field as `format_failed` and library \
 `EditResult`). Use it for surgical undo; do not guess newest session under parallel agents.\n\

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -829,6 +829,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         if !global.emit_json(&serde_json::json!({
             "ok": true,
             "status": "success",
+            "applied": false,
             "files_changed": 0,
             "files_created": 0,
             "files_deleted": 0,

--- a/src/json_emit.rs
+++ b/src/json_emit.rs
@@ -221,6 +221,7 @@ mod tests {
         let report = TxOutput {
             ok: true,
             status: "success".into(),
+            applied: true,
             files_changed: 1,
             files_created: 0,
             files_deleted: 0,

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -21,6 +21,11 @@ use std::path::{Path, PathBuf};
 pub struct TxOutput {
     pub ok: bool,
     pub status: String,
+    /// Whether bytes were written to disk for this report (#1808 parity for
+    /// plan/batch/tx). True after successful apply or post-commit lifecycle
+    /// errors; false for preview/check and pure failures.
+    #[serde(default)]
+    pub applied: bool,
     pub files_changed: usize,
     pub files_created: usize,
     pub files_deleted: usize,
@@ -419,6 +424,8 @@ pub(crate) fn build_tx_output_with_meta(
     TxOutput {
         ok,
         status: status.to_string(),
+        // success = committed apply; changes_detected/no_matches = dry-run
+        applied: status == "success",
         files_changed: modified,
         files_created: created,
         files_deleted: deleted_count,
@@ -518,6 +525,7 @@ pub(crate) fn build_error_output(
     TxOutput {
         ok: false,
         status: "error".to_string(),
+        applied: false,
         files_changed: 0,
         files_created: 0,
         files_deleted: 0,
@@ -555,6 +563,8 @@ pub(crate) fn build_applied_with_error_output(
 ) -> TxOutput {
     let mut output = build_full_tx_output("error", result, cwd);
     output.ok = false;
+    // Writes already committed before this error path.
+    output.applied = true;
     output.error_kind = Some(error_kind.to_string());
     output.error = Some(format!(
         "{error_kind}: {}",
@@ -685,6 +695,7 @@ mod tests {
         TxOutput {
             ok: true,
             status: status.to_string(),
+            applied: status == "success",
             files_changed: 0,
             files_created: 0,
             files_deleted: 0,
@@ -710,6 +721,7 @@ mod tests {
         TxOutput {
             ok: false,
             status: "error".to_string(),
+            applied: false,
             files_changed: 0,
             files_created: 0,
             files_deleted: 0,
@@ -1023,6 +1035,32 @@ mod tests {
             "single replace path must surface matched_text even when other files changed"
         );
         assert_eq!(out.match_score, Some(0.88));
+    }
+
+    #[test]
+    fn applied_true_on_success_status_false_on_preview() {
+        let preview = build_tx_output_with_meta(
+            "changes_detected",
+            true,
+            &[],
+            &Default::default(),
+            &Default::default(),
+            Path::new("/tmp"),
+            &Default::default(),
+        );
+        assert!(!preview.applied, "preview must set applied=false");
+        let applied = build_tx_output_with_meta(
+            "success",
+            true,
+            &[],
+            &Default::default(),
+            &Default::default(),
+            Path::new("/tmp"),
+            &Default::default(),
+        );
+        assert!(applied.applied, "success must set applied=true");
+        let err = build_error_output("invalid_input", "nope", None);
+        assert!(!err.applied, "pure error must set applied=false");
     }
 
     // ---- TxOutput serde round-trip ----

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8810,3 +8810,46 @@ fn test_tx_for_each_item_alias_and_unknown_placeholder() {
     assert_eq!(v["error_kind"], "parse_error", "{v}");
     assert!(v["error"].as_str().unwrap_or("").contains("{file}"), "{v}");
 }
+
+/// Plan/batch JSON must expose `applied` like other CLI write commands (fixrealloop).
+#[test]
+fn test_tx_json_includes_applied_field() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "hi\n").unwrap();
+    let plan = dir.path().join("plan.json");
+    fs::write(
+        &plan,
+        r#"{"version":1,"operations":[{"op":"replace","path":"f.txt","old":"hi","new":"yo"}]}"#,
+    )
+    .unwrap();
+
+    // Preview
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["tx", "plan.json"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(2));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["status"], "changes_detected", "{v}");
+    assert_eq!(v["applied"], false, "preview must set applied=false: {v}");
+
+    // Apply
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["tx", "plan.json", "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(0));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["status"], "success", "{v}");
+    assert_eq!(v["applied"], true, "apply must set applied=true: {v}");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "yo\n");
+}


### PR DESCRIPTION
## Summary

Found by fixrealloop while running multi-file batch/tx scenarios against the release binary.

CLI write commands always emit `applied` (#1808). Plan/batch/tx reports only had `status` (`success` vs `changes_detected`), so agents that branch on `applied` could not tell preview from apply for the main multi-op path.

### Change
- `TxOutput.applied` always present (serde default false for old JSON)
- `true` when `status == "success"` or post-commit lifecycle error path
- `false` for preview (`changes_detected`), pure errors, empty batch
- agent-rules / PATCHLOOM.md updated
- Integration + unit tests

## Test plan
- [x] `cargo test --lib applied_true_on_success`
- [x] `cargo test --lib output::tests`
- [x] `cargo test --test integration test_tx_json_includes_applied`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] CI matrix