### PR TITLE
fix: multi-doc doc get bare key type_error hint

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -710,7 +710,7 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 - **What it does:** Reads the value at a selector path from a JSON, YAML, or TOML file.
 - **Use when:** You need one precise value without mutating the document.
-- **JSON success (#1838):** Under `--json`/`--jsonl`, success is `{"ok":true,"value":...,"path":...,"selector":...}` (not a bare JSON value). Text mode stays bare. Missing selector is `error_kind: no_matches` (exit 3).
+- **JSON success (#1838):** Under `--json`/`--jsonl`, success is `{"ok":true,"value":...,"path":...,"selector":...}` (not a bare JSON value). Text mode stays bare. Missing selector is `error_kind: no_matches` (exit 3). A bare top-level key on multi-document YAML (array root) is `error_kind: type_error` (exit 1) with an index-form hint (`0.key` / `[0].key`), same as `doc set` on that shape.
 - **Prefer instead:** Use `doc flatten` when you are exploring an unfamiliar file and need a broader map of its contents.
 
 <!-- ref:doc-action:has -->

--- a/src/ops/doc/query.rs
+++ b/src/ops/doc/query.rs
@@ -20,13 +20,44 @@ pub enum QueryResult {
 /// Query values at a selector path.
 ///
 /// Returns cloned values so the caller owns them.
+///
+/// When the document root is an array (multi-document YAML or a top-level JSON
+/// array) and the selector begins with a non-numeric key, returns
+/// [`crate::exit::TypeErrorError`] with an index form hint (`0.key` / `[0].key`)
+/// instead of soft [`QueryResult::NoMatch`]. Matches write-path honesty for
+/// multi-doc bare keys (docs/reference multi-document YAML; fixrealloop).
 pub fn query_get(root: &serde_json::Value, selector: &str) -> anyhow::Result<QueryResult> {
     let segments = selector::parse_anyhow(selector)?;
     let results = selector::eval(root, &segments);
     if results.is_empty() {
+        if let Some(hint) = array_root_bare_key_hint(root, &segments) {
+            return Err(crate::exit::TypeErrorError { msg: hint }.into());
+        }
         return Ok(QueryResult::NoMatch);
     }
     Ok(QueryResult::Values(results.into_iter().cloned().collect()))
+}
+
+/// Actionable error when a bare object key is used at an array root.
+fn array_root_bare_key_hint(
+    root: &serde_json::Value,
+    segments: &[selector::Segment],
+) -> Option<String> {
+    if !root.is_array() {
+        return None;
+    }
+    let selector::Segment::Key(k) = segments.first()? else {
+        return None;
+    };
+    // Numeric keys are array indices via dot notation (#1288).
+    if k.parse::<usize>().is_ok() {
+        return None;
+    }
+    Some(format!(
+        "parent is an array, not an object (for multi-document YAML or \
+         top-level arrays, address a document/element with an index first, \
+         e.g. 0.{k} or [0].{k})"
+    ))
 }
 
 /// Check whether a selector path exists.
@@ -139,6 +170,48 @@ mod tests {
             QueryResult::Values(v) => assert_eq!(v, vec![serde_json::json!(1)]),
             QueryResult::NoMatch => panic!("expected match"),
         }
+    }
+
+    #[test]
+    fn get_bare_key_on_array_root_type_error_with_index_hint() {
+        // Multi-document YAML / top-level array: bare key must not look like a
+        // soft no_matches (agents widen the wrong thing).
+        let doc = serde_json::json!([{"a": 1}, {"b": 2}]);
+        let err = query_get(&doc, "a").expect_err("bare key at array root");
+        let msg = err.to_string();
+        assert!(
+            crate::exit::is_type_error(&err),
+            "expected type_error, got: {err}"
+        );
+        assert!(
+            msg.contains("array")
+                && (msg.contains("0.a") || msg.contains("[0].a"))
+                && msg.contains("index"),
+            "actionable multi-doc hint missing: {msg}"
+        );
+    }
+
+    #[test]
+    fn get_indexed_key_on_array_root_still_matches() {
+        let doc = serde_json::json!([{"a": 1}, {"b": 2}]);
+        match query_get(&doc, "0.a").unwrap() {
+            QueryResult::Values(v) => assert_eq!(v, vec![serde_json::json!(1)]),
+            QueryResult::NoMatch => panic!("expected match"),
+        }
+        match query_get(&doc, "[1].b").unwrap() {
+            QueryResult::Values(v) => assert_eq!(v, vec![serde_json::json!(2)]),
+            QueryResult::NoMatch => panic!("expected match"),
+        }
+    }
+
+    #[test]
+    fn get_missing_key_inside_doc_still_no_match() {
+        // Document 0 is an object; missing nested key stays soft no_matches.
+        let doc = serde_json::json!([{"a": 1}, {"b": 2}]);
+        assert!(matches!(
+            query_get(&doc, "0.missing").unwrap(),
+            QueryResult::NoMatch
+        ));
     }
 
     // -- query_has --

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2884,6 +2884,48 @@ fn test_doc_set_multi_document_bare_key_hints_index() {
     assert_eq!(fs::read_to_string(&file).unwrap(), "a: 1\n---\nb: 2\n");
 }
 
+/// Read path: bare key on multi-doc must be type_error + index hint, not no_matches.
+/// Found by fixrealloop (docs already promised set/get parity).
+#[test]
+fn test_doc_get_multi_document_bare_key_hints_index() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("multi.yaml");
+    fs::write(&file, "a: 1\n---\nb: 2\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("a")
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "type_error exit 1, not no_matches 3: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["error_kind"], "type_error", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("array")
+            && (err.contains("0.a") || err.contains("[0].a"))
+            && err.contains("index"),
+        "expected multi-doc index hint, got: {v}"
+    );
+    // Indexed form still works.
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("0.a")
+        .assert()
+        .code(0)
+        .stdout(predicates::str::contains("\"value\": 1"));
+}
+
 /// doc set Apply shares `atomic_write`; hardlinked siblings must stay in sync (#1733).
 #[cfg(unix)]
 #[test]


### PR DESCRIPTION
## Summary

- `doc get` / `doc select` on multi-document YAML with a bare top-level key (array root) now returns `error_kind: type_error` with the same `0.key` / `[0].key` hint as `doc set`, instead of soft `no_matches`.
- Agents no longer treat this as a missing key and retry the wrong recovery path.

Found by fixrealloop runtime multi-doc scenarios (docs already promised the write-path behavior for multi-doc bare keys).

## Test plan

- [x] Unit: `ops::doc::query` array-root bare key / indexed / nested missing
- [x] Integration: `test_doc_get_multi_document_bare_key_hints_index`
- [x] Manual release binary re-probe
- [ ] CI green