### PR TITLE
test: multi-doc bare-key honesty for get/set/keys

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -376,7 +376,7 @@ dependencies[name=react].version # predicate filter
 
 **Write ops and predicates:** `doc set` / `doc ensure` / `doc delete` / `doc move` are **single-path only** (keys and indexes such as `items.0.val`). Wildcards and predicates (`items[id=b].val`, `items[*].enabled`) belong on `doc update` (multi-match write) or `doc delete-where` (array filter). If you pass a predicate to `doc set`, the error points you at `doc update` or an index path.
 
-**Multi-document YAML:** Files with multiple `---` documents parse as a **top-level array** (one element per document). Address a field with a document index first, e.g. `0.metadata.name` or `[0].metadata.name`, not a bare key at the stream root. Writes keep the multi-doc form (still `---` separators, not a single YAML sequence).
+**Multi-document YAML:** Files with multiple `---` documents parse as a **top-level array** (one element per document). Address a field with a document index first, e.g. `0.metadata.name` or `[0].metadata.name`, not a bare key at the stream root. A bare root key on multi-doc (or any top-level array) fails with `error_kind: type_error` and an index-form hint on both `doc get`/`select` and `doc set` (not soft `no_matches`). Writes keep the multi-doc form (still `---` separators, not a single YAML sequence).
 
 **Markdown insert placement:** `md_insert_after_heading` inserts **under the heading line** (before existing body). To add a sibling `##` section after the full section body, use `md_insert_after_section`.
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1484,6 +1484,26 @@ fn doc_get_zero_match_error() {
 }
 
 #[test]
+fn doc_get_array_root_bare_key_is_type_error() {
+    // Multi-doc YAML / top-level JSON array: bare key must not soft no_match.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("multi.yaml");
+    fs::write(&file, "a: 1\n---\nb: 2\n").unwrap();
+
+    let err = doc_get(&file, "a").unwrap_err();
+    assert!(
+        crate::exit::is_type_error(&err),
+        "expected TypeErrorError, got: {err}"
+    );
+    let msg = err.to_string();
+    assert!(
+        msg.contains("0.a") || msg.contains("[0].a"),
+        "index hint missing: {msg}"
+    );
+    assert_eq!(doc_get(&file, "0.a").unwrap(), serde_json::json!(1));
+}
+
+#[test]
 fn doc_get_multi_match_returns_array() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("data.json");

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -564,7 +564,9 @@ success lines are the full path list.\n\n\
          you at `doc update` or an index path.\n\n\
          **Multi-document YAML:** Files with multiple `---` documents parse as a **top-level array** \
          (one element per document). Address a field with a document index first, e.g. `0.metadata.name` \
-         or `[0].metadata.name`, not a bare key at the stream root. Writes keep the multi-doc form \
+         or `[0].metadata.name`, not a bare key at the stream root. A bare root key on multi-doc \
+         (or any top-level array) fails with `error_kind: type_error` and an index-form hint on both \
+         `doc get`/`select` and `doc set` (not soft `no_matches`). Writes keep the multi-doc form \
          (still `---` separators, not a single YAML sequence).\n\n\
          **Markdown insert placement:** `md_insert_after_heading` inserts **under the heading line** \
          (before existing body). To add a sibling `##` section after the full section body, use \
@@ -832,8 +834,10 @@ mod tests {
         assert!(
             out.contains("Multi-document YAML")
                 && out.contains("0.metadata.name")
-                && out.contains("top-level array"),
-            "agents need multi-doc index guidance"
+                && out.contains("top-level array")
+                && out.contains("type_error")
+                && out.contains("doc get"),
+            "agents need multi-doc index guidance + bare-key type_error on get/set"
         );
     }
 

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -592,13 +592,16 @@ fn execute_with_mode_inner(
                     output_mode,
                     quiet,
                 ),
-                crate::ops::doc::query::QueryKeysResult::NotAnObject => format_error(
-                    &format!("doc keys: target at '{selector}' is not an object"),
-                    output_mode,
-                    quiet,
-                    exit::FAILURE,
-                    Some("type_error"),
-                ),
+                crate::ops::doc::query::QueryKeysResult::NotAnObject => {
+                    let msg = if selector.is_empty() && root.is_array() {
+                        "doc keys: target is a top-level array (multi-document YAML or JSON \
+                         array); use a document/element index first, e.g. keys on `0` or `[0]`"
+                            .to_string()
+                    } else {
+                        format!("doc keys: target at '{selector}' is not an object")
+                    };
+                    format_error(&msg, output_mode, quiet, exit::FAILURE, Some("type_error"))
+                }
                 crate::ops::doc::query::QueryKeysResult::Keys(keys) => {
                     let output = match output_mode {
                         OutputMode::Text => keys.join("\n"),

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2870,18 +2870,49 @@ fn test_doc_set_multi_document_bare_key_hints_index() {
         .args(["a", "9", "--apply"])
         .output()
         .unwrap();
-    assert_ne!(out.status.code(), Some(0));
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    let combined = format!("{stdout}{stderr}");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "type_error exit 1, not generic failure: stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["error_kind"], "type_error", "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
     assert!(
-        combined.contains("array")
-            && (combined.contains("0.a") || combined.contains("[0].a"))
-            && combined.contains("index"),
-        "expected multi-doc index hint, got: {combined}"
+        err.contains("array")
+            && (err.contains("0.a") || err.contains("[0].a"))
+            && err.contains("index"),
+        "expected multi-doc index hint, got: {v}"
     );
     // File must be unchanged.
     assert_eq!(fs::read_to_string(&file).unwrap(), "a: 1\n---\nb: 2\n");
+}
+
+/// `doc keys` on multi-doc root (empty selector) should name the array/index shape.
+#[test]
+fn test_doc_keys_multi_document_root_hints_index() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("multi.yaml");
+    fs::write(&file, "a: 1\n---\nb: 2\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "keys"])
+        .arg(&file)
+        .arg("")
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "type_error", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("array") && (err.contains("0") || err.contains("index")),
+        "expected multi-doc keys guidance, got: {v}"
+    );
 }
 
 /// Read path: bare key on multi-doc must be type_error + index hint, not no_matches.


### PR DESCRIPTION
## Summary

MPI cycle (Test Auditor + End User / Observability) after #1862:

- Strengthen `doc set` multi-doc bare-key integration test to assert `error_kind: type_error`, exit 1, and `applied: false` (same shape as get).
- Library `doc_get` array-root bare-key unit test.
- `doc keys` on multi-doc root (empty selector) now names the top-level array / index form instead of a generic "not an object".
- Agent-rules / PATCHLOOM.md: bare root key on multi-doc is `type_error` for get/select and set (not soft `no_matches`).

## Test plan

- [x] `make check-fast`
- [x] Unit: `doc_get_array_root_bare_key_is_type_error`, multi-doc agent-rules test
- [x] Integration: multi-doc set/get/keys bare-key tests
- [ ] CI green

Release #1857 (0.15.3) remains open and untouched.