### PR TITLE
docs: markdown section bounds and dedupe honesty

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -22,7 +22,7 @@
 | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |
 | Insert a sibling section after a full section body | `md_insert_after_section` |
 | Move a heading section (same file or cross-file) | `md_move_section` |
-| Remove duplicate headings | `md_dedupe_headings` |
+| Remove later whole sections with a duplicate heading | `md_dedupe_headings` |
 | Lint markdown for structural issues | `md_lint` |
 | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |
 | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |
@@ -378,6 +378,7 @@ dependencies[name=react].version # predicate filter
 
 **Multi-document YAML:** Files with multiple `---` documents parse as a **top-level array** (one element per document). Address a field with a document index first, e.g. `0.metadata.name` or `[0].metadata.name`, not a bare key at the stream root. A bare root key on multi-doc (or any top-level array) fails with `error_kind: type_error` and an index-form hint on both `doc get`/`select` and `doc set` (not soft `no_matches`). Writes keep the multi-doc form (still `---` separators, not a single YAML sequence).
 
+**Markdown section bounds:** `md_replace_section` / `md_insert_after_section` / section moves end at the next heading of the **same or higher** level. Nested lower-level headings belong to the parent (replacing `# Intro` also rewrites following `##` children until the next `#`). Prefer peer-level headings when siblings must survive. `md_dedupe_headings` removes later **whole sections** with a duplicate level+text heading (body under the second heading is discarded, not merged).
 **Markdown insert placement:** `md_insert_after_heading` inserts **under the heading line** (before existing body). To add a sibling `##` section after the full section body, use `md_insert_after_section`.
 
 ## Exit codes
@@ -416,7 +417,7 @@ dependencies[name=react].version # predicate filter
 - `doc.append`: Append a value to an array at a selector path.
 - `doc.move`: Move a value from one selector path to another within the same file.
 - `doc.ensure`: Set a value only if the selector path does not already exist.
-- `md.replace_section`: Replace the body of a markdown section identified by heading.
+- `md.replace_section`: Replace the body of a markdown section identified by heading (section ends at the next same-or-higher-level heading; nested lower-level headings are included).
 - `md.upsert_bullet`: Insert or update a bullet point under a markdown heading.
 - `md.table_append`: Append a row to a markdown table under a heading.
 - `md.insert_after_heading`: Insert content immediately after a markdown heading line (before any existing body). For a sibling section after the full body, use md.insert_after_section.
@@ -429,7 +430,7 @@ dependencies[name=react].version # predicate filter
 - `doc.delete_where`: Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path. CLI --json and MCP/tx success include changed and removed (0 when no elements match; exit 0 / ok is idempotent).
 - `search`: Search for text across files with optional regex, context, and count assertion. Supports advanced layered ignores: literal (vs regex), globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.
 - `read`: Read file contents with optional line range.
-- `md.dedupe_headings`: Remove duplicate markdown headings in a file.
+- `md.dedupe_headings`: Remove later whole sections whose heading text+level already appeared (heading and body until next same-or-higher heading; unique second-section content is discarded).
 - `md.lint_agents`: Lint an AGENTS.md file for common issues.
 - `ast.rename`: AST-aware rename: rename identifiers skipping strings and comments.
 - `ast.replace`: Replace text within a specific symbol's body (AST-scoped).

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -832,9 +832,9 @@ Use these when markdown structure matters more than raw text matching.
 <!-- ref:md-action:replace-section -->
 ### `md replace-section`
 
-- **What it does:** Replaces the body of a heading section.
-- **Use when:** A section should be treated as authoritative content that can be rewritten in one step.
-- **Prefer instead:** Use `md insert-after-heading` when existing section content should stay and you only need to add more text.
+- **What it does:** Replaces the body of a heading section. The section runs from after the matched heading until the next heading of the **same or higher** level (CommonMark hierarchy). Nested lower-level headings (for example `## API` under `# Intro`) are part of that section and are replaced too.
+- **Use when:** A section should be treated as authoritative content that can be rewritten in one step. Prefer peer-level headings (all `##`) when you must keep sibling sections.
+- **Prefer instead:** Use `md insert-after-heading` when existing section content should stay and you only need to add more text. Target a `##` heading when you only want that subsection, not a parent `#` that owns nested `##` children.
 
 <!-- ref:md-action:insert-after-heading -->
 ### `md insert-after-heading`
@@ -867,9 +867,9 @@ Use these when markdown structure matters more than raw text matching.
 <!-- ref:md-action:dedupe-headings -->
 ### `md dedupe-headings`
 
-- **What it does:** Removes duplicate headings.
-- **Use when:** Generated markdown or hand edited docs have accumulated repeated sections that should collapse to one.
-- **Prefer instead:** Use `md lint-agents` when the goal is diagnosis rather than mutation.
+- **What it does:** Removes **later whole sections** whose heading text and level match an earlier heading (heading line plus body until the next same-or-higher heading). It does not only delete the duplicate heading line; unique content under the second heading is removed with it.
+- **Use when:** Generated markdown or hand edited docs have accumulated repeated sections that should collapse to one, and keeping only the first section body is correct.
+- **Prefer instead:** Use `md lint-agents` when the goal is diagnosis rather than mutation. Do not use dedupe if later duplicate-titled sections hold unique content you need to keep or merge.
 - **JSON:** Object with `ok`, `path`, `removed` (heading strings), `applied` (false for preview/check), and `backup_session` after a real apply. JSONL still emits one JSON string per removed heading.
 
 <!-- ref:md-action:lint-agents -->

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -112,7 +112,7 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
              | Insert text after/before a heading | `md_insert_after_heading`, `md_insert_before_heading` |\n\
              | Insert a sibling section after a full section body | `md_insert_after_section` |\n\
              | Move a heading section (same file or cross-file) | `md_move_section` |\n\
-             | Remove duplicate headings | `md_dedupe_headings` |\n\
+             | Remove later whole sections with a duplicate heading | `md_dedupe_headings` |\n\
              | Lint markdown for structural issues | `md_lint` |\n\
              | Fix trailing whitespace or missing newlines | `fix_whitespace` (one file) or `batch_tidy` (multiple files) |\n\
              | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |\n\
@@ -568,6 +568,12 @@ success lines are the full path list.\n\n\
          (or any top-level array) fails with `error_kind: type_error` and an index-form hint on both \
          `doc get`/`select` and `doc set` (not soft `no_matches`). Writes keep the multi-doc form \
          (still `---` separators, not a single YAML sequence).\n\n\
+         **Markdown section bounds:** `md_replace_section` / `md_insert_after_section` / section moves \
+         end at the next heading of the **same or higher** level. Nested lower-level headings belong to \
+         the parent (replacing `# Intro` also rewrites following `##` children until the next `#`). Prefer \
+         peer-level headings when siblings must survive. `md_dedupe_headings` removes later **whole \
+         sections** with a duplicate level+text heading (body under the second heading is discarded, not \
+         merged).\n\
          **Markdown insert placement:** `md_insert_after_heading` inserts **under the heading line** \
          (before existing body). To add a sibling `##` section after the full section body, use \
          `md_insert_after_section`.\n\n",
@@ -838,6 +844,18 @@ mod tests {
                 && out.contains("type_error")
                 && out.contains("doc get"),
             "agents need multi-doc index guidance + bare-key type_error on get/set"
+        );
+    }
+
+    #[test]
+    fn workflow_documents_markdown_section_bounds_and_dedupe() {
+        let out = generate_agent_rules(&args(AgentMode::Cli, AgentPlatform::All));
+        assert!(
+            out.contains("Markdown section bounds")
+                && out.contains("same or higher")
+                && out.contains("md_dedupe_headings")
+                && out.contains("whole sections"),
+            "agents need hierarchical section + dedupe body-loss guidance"
         );
     }
 

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -25,7 +25,11 @@ pub struct MdArgs {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum MdAction {
-    /// Replace a heading section.
+    /// Replace a heading section body (until next same-or-higher heading).
+    ///
+    /// Nested lower-level headings under the match are included (e.g. `# Intro`
+    /// owns following `##` sections until the next `#`). Prefer peer-level
+    /// headings when sibling sections must survive.
     ReplaceSection {
         /// Markdown file to edit.
         file: String,
@@ -104,7 +108,10 @@ pub enum MdAction {
         #[arg(long, visible_alias = "content", allow_hyphen_values = true)]
         bullet: String,
     },
-    /// Remove duplicate headings.
+    /// Remove later whole sections with a duplicate heading (level+text).
+    ///
+    /// Drops heading **and** body until the next same-or-higher heading; unique
+    /// content under the second heading is not kept.
     DedupeHeadings {
         /// Markdown file to scan for duplicate headings.
         file: String,

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -141,6 +141,26 @@ mod basic {
         );
     }
 
+    /// Parent `#` section includes nested `##` until the next same-or-higher
+    /// heading (fixrealloop agent footgun when targeting Intro above ## API).
+    #[test]
+    fn replace_section_parent_heading_includes_nested_children() {
+        let content = "# Intro\n\nhello\n\n## API\n\ntable\n\n## Notes\n\n- bullet\n";
+        let result = replace_section_in(content, "Intro", "hello world").unwrap();
+        assert_eq!(result, "# Intro\nhello world\n");
+        assert!(
+            !result.contains("## API") && !result.contains("## Notes"),
+            "nested ## sections must be inside # Intro bounds: {result}"
+        );
+        // Peer-level headings: only the targeted ## is replaced.
+        let peers = "## Intro\n\nhello\n\n## API\n\ntable\n";
+        let peer = replace_section_in(peers, "Intro", "hello world").unwrap();
+        assert!(
+            peer.contains("## API") && peer.contains("table"),
+            "peer ## API must survive replacing ## Intro: {peer}"
+        );
+    }
+
     #[test]
     fn replace_section_no_extra_blank_when_original_had_none() {
         // When the original had no blank line before the next heading, don't add one.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -313,7 +313,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "md.replace_section",
-        description: "Replace the body of a markdown section identified by heading.",
+        description: "Replace the body of a markdown section identified by heading (section ends at the next same-or-higher-level heading; nested lower-level headings are included).",
         tier: Tier::Medium,
         examples: &[(
             "Update the install section of README",
@@ -425,7 +425,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "md.dedupe_headings",
-        description: "Remove duplicate markdown headings in a file.",
+        description: "Remove later whole sections whose heading text+level already appeared (heading and body until next same-or-higher heading; unique second-section content is discarded).",
         tier: Tier::Strong,
         examples: &[],
     },

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -42,6 +42,41 @@ fn test_md_replace_section() {
     );
 }
 
+/// Replacing `# Intro` includes nested `##` children until the next `#`
+/// (fixrealloop: agents expected sibling ## API to survive).
+#[test]
+fn test_md_replace_section_parent_includes_nested_headings() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(
+        &file,
+        "# Intro\n\nhello\n\n## API\n\ntable\n\n## Notes\n\n- bullet\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["md", "replace-section"])
+        .arg(&file)
+        .args(["--heading", "Intro", "--content", "hello world", "--apply"])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("hello world"),
+        "replacement body missing: {content}"
+    );
+    assert!(
+        !content.contains("## API") && !content.contains("table"),
+        "nested ## API must be inside # Intro bounds: {content}"
+    );
+    assert!(
+        !content.contains("## Notes"),
+        "nested ## Notes must be inside # Intro bounds: {content}"
+    );
+}
+
 #[test]
 fn test_md_default_mode_shows_diff() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixrealloop runtime scenarios exposed two agent footguns (behavior was intentional; docs/schema/help understated it):

1. **`md replace-section`:** Section ends at the next heading of the **same or higher** level. Nested lower-level headings (e.g. `## API` under `# Intro`) are included and replaced. Agents that rewrote `# Intro` lost sibling `##` content.
2. **`md dedupe-headings`:** Removes later **whole sections** with a duplicate level+text heading (heading + body), not only the heading line. Unique content under the second heading is discarded.

## Changes

- Reference docs, clap help, schema `OpMeta`, agent-rules / PATCHLOOM.md
- Unit + CLI integration tests locking hierarchical replace
- Agent-rules inventory row for dedupe wording

## Test plan

- [x] `make check-fast`
- [x] `replace_section_parent_heading_includes_nested_children`
- [x] `test_md_replace_section_parent_includes_nested_headings`
- [x] agent-rules section bounds test
- [ ] CI green