### PR TITLE
fix: honest explain for md section bounds and dedupe discard

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -423,7 +423,7 @@ dependencies[name=react].version # predicate filter
 - `md.insert_after_heading`: Insert content immediately after a markdown heading line (before any existing body). For a sibling section after the full body, use md.insert_after_section.
 - `md.insert_after_section`: Insert content after the full section body (sibling placement). Use when adding a new ## section after this section's content. Prefer md.insert_after_heading for content under the heading line.
 - `md.insert_before_heading`: Insert content immediately before a markdown heading line.
-- `md.move_section`: Move a heading section to a new position (same-file reorder or cross-file move). Exactly one of before or after is required.
+- `md.move_section`: Move a heading section to a new position (same-file reorder or cross-file move). The moved range ends at the next same-or-higher-level heading (nested lower headings included). Exactly one of before or after is required.
 - `patch.apply`: Apply a unified diff patch to one or more files. Supports three-way merge on stale context.
 - `doc.prepend`: Prepend a value to the beginning of an array at a selector path.
 - `doc.update`: Set a new value at every location matching a selector. Use wildcards (items[*].enabled) or selector predicates (items[name=foo].v). Not a separate --where flag; the filter is part of the selector string.

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -114,11 +114,11 @@ AST tools so `list_tools` stays honest about what is callable.
 | `replace_text` | Replace text in a text file (literal or regex). Binary and invalid UTF-8 files are skipped |
 | `md_upsert_bullet` | Add a bullet under a markdown heading |
 | `md_table_append` | Append a row to a markdown table |
-| `md_replace_section` | Replace a markdown section by heading |
+| `md_replace_section` | Replace a section by heading (through next same-or-higher heading) |
 | `md_insert_after_heading` | Insert content immediately after a heading line (before body) |
 | `md_insert_after_section` | Insert content after the full section body (sibling section) |
 | `md_insert_before_heading` | Insert content before a markdown heading |
-| `md_move_section` | Move a heading section (same file reorder or cross-file) |
+| `md_move_section` | Move a heading section through next same-or-higher heading (same-file or cross-file) |
 | `md_dedupe_headings` | Remove later whole sections with a duplicate heading (second body discarded) |
 | `md_lint` | Lint an AGENTS.md file; returns `{ok, path, issue_count, issues}` (CLI lint-agents --json parity). Branch on `ok`; isError stays false when issues are present |
 | `fix_whitespace` | Fix whitespace and line endings in a text file. Binary and invalid UTF-8 files are skipped |

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -119,7 +119,7 @@ AST tools so `list_tools` stays honest about what is callable.
 | `md_insert_after_section` | Insert content after the full section body (sibling section) |
 | `md_insert_before_heading` | Insert content before a markdown heading |
 | `md_move_section` | Move a heading section (same file reorder or cross-file) |
-| `md_dedupe_headings` | Remove duplicate markdown headings in a file |
+| `md_dedupe_headings` | Remove later whole sections with a duplicate heading (second body discarded) |
 | `md_lint` | Lint an AGENTS.md file; returns `{ok, path, issue_count, issues}` (CLI lint-agents --json parity). Branch on `ok`; isError stays false when issues are present |
 | `fix_whitespace` | Fix whitespace and line endings in a text file. Binary and invalid UTF-8 files are skipped |
 | `create_file` | Create a new file with content |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1104,8 +1104,8 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:md.replace_section -->
 ### `md.replace_section`
 
-- **What it does:** Replaces a markdown section inside a transaction.
-- **Use when:** Docs regeneration should be part of a larger all or nothing repo change.
+- **What it does:** Replaces a markdown section body inside a transaction. The section ends at the next heading of the same or higher level; nested lower-level headings are included in the replaced range.
+- **Use when:** Docs regeneration should be part of a larger all or nothing repo change. Prefer peer-level headings when siblings must survive.
 - **Failure behavior:** Missing heading exits 3 (`no_matches`) with the heading name in the error.
 - **Related:** top level `md replace-section`
 
@@ -1154,8 +1154,8 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:md.dedupe_headings -->
 ### `md.dedupe_headings`
 
-- **What it does:** Removes duplicate markdown headings inside a transaction.
-- **Use when:** Cleanup of generated docs should stay atomic with the rest of the plan.
+- **What it does:** Removes later whole sections whose heading text+level already appeared (heading and body until the next same-or-higher heading). Unique content under the second heading is discarded, not merged.
+- **Use when:** Cleanup of generated docs should stay atomic with the rest of the plan. Do not use when duplicate headings intentionally hold different bodies that must both survive.
 - **Related:** top level `md dedupe-headings`
 
 <!-- ref:tx-op:md.lint_agents -->

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1147,7 +1147,7 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:md.move_section -->
 ### `md.move_section`
 
-- **What it does:** Moves a markdown section to a new position, optionally to a different file.
+- **What it does:** Moves a markdown section to a new position, optionally to a different file. The moved range ends at the next heading of the same or higher level; nested lower-level headings move with the parent.
 - **Use when:** Section reordering or cross-file moves should be atomic with the rest of the plan.
 - **Related:** top level `md move-section`
 

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -146,7 +146,9 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             format!("Delete from {selector} where {predicate} in {path}")
         }
         Operation::MdReplaceSection { path, heading, .. } => {
-            format!("Replace section \"{heading}\" in {path}")
+            format!(
+                "Replace section \"{heading}\" in {path} (ends at next same-or-higher heading; nested lower headings included)"
+            )
         }
         Operation::MdInsertAfterHeading { path, heading, .. } => {
             format!("Insert content after heading line \"{heading}\" in {path}")
@@ -189,7 +191,9 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             }
         }
         Operation::MdDedupeHeadings { path } => {
-            format!("Deduplicate headings in {path}")
+            format!(
+                "Deduplicate headings in {path} (remove later whole sections with same level+text; second body discarded, not merged)"
+            )
         }
         Operation::TidyFix {
             path,
@@ -1041,6 +1045,42 @@ mod tests {
         assert_eq!(
             describe_operation(&op),
             "Apply unified diff patch (merge on stale, allow conflicts)"
+        );
+    }
+
+    #[test]
+    fn describe_md_replace_section_names_bounds() {
+        let op = Operation::MdReplaceSection {
+            path: "README.md".into(),
+            heading: "## Install".into(),
+            content: "new body\n".into(),
+        };
+        let desc = describe_operation(&op);
+        assert!(
+            desc.contains("same-or-higher") && desc.contains("nested lower"),
+            "explain must name hierarchical section bounds: {desc}"
+        );
+        assert!(
+            desc.contains("## Install") && desc.contains("README.md"),
+            "explain must name heading and path: {desc}"
+        );
+    }
+
+    #[test]
+    fn describe_md_dedupe_headings_names_whole_section_discard() {
+        let op = Operation::MdDedupeHeadings {
+            path: "CHANGELOG.md".into(),
+        };
+        let desc = describe_operation(&op);
+        assert!(
+            desc.contains("whole sections")
+                && desc.contains("discarded")
+                && !desc.eq("Deduplicate headings in CHANGELOG.md"),
+            "explain must warn that later whole-section bodies are discarded: {desc}"
+        );
+        assert!(
+            desc.contains("CHANGELOG.md"),
+            "explain must name path: {desc}"
         );
     }
 

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -184,10 +184,15 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             } else {
                 "(no position)".to_string()
             };
+            // Section body ends at next same-or-higher heading (nested lower included).
             if to.is_some() {
-                format!("Move section \"{heading}\" from {path} to {dest} {pos}")
+                format!(
+                    "Move section \"{heading}\" from {path} to {dest} {pos} (through next same-or-higher heading)"
+                )
             } else {
-                format!("Move section \"{heading}\" {pos} in {path}")
+                format!(
+                    "Move section \"{heading}\" {pos} in {path} (through next same-or-higher heading)"
+                )
             }
         }
         Operation::MdDedupeHeadings { path } => {
@@ -785,9 +790,14 @@ mod tests {
             before: Some("License".into()),
             after: None,
         };
+        let desc = describe_operation(&op);
         assert_eq!(
-            describe_operation(&op),
-            r#"Move section "FAQ" before "License" in README.md"#
+            desc,
+            r#"Move section "FAQ" before "License" in README.md (through next same-or-higher heading)"#
+        );
+        assert!(
+            desc.contains("same-or-higher"),
+            "move explain must name hierarchical bounds: {desc}"
         );
     }
 
@@ -802,7 +812,7 @@ mod tests {
         };
         assert_eq!(
             describe_operation(&op),
-            r#"Move section "Appendix" from spec.md to notes.md after "Body""#
+            r#"Move section "Appendix" from spec.md to notes.md after "Body" (through next same-or-higher heading)"#
         );
     }
 

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -254,7 +254,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         tool_name: "md_dedupe_headings",
         op_name: "md.dedupe_headings",
         extra: Some(
-            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+            "Removes later whole sections with the same heading level+text (body under the second heading is discarded, not merged). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: false,
         validations: &[FieldValidation::Path("path")],

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -206,7 +206,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         tool_name: "md_replace_section",
         op_name: "md.replace_section",
         extra: Some(
-            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+            "Section ends at the next same-or-higher-level heading; nested lower-level headings are included in the replaced range. Prefer peer-level headings when siblings must survive. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: false,
         validations: &[

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -361,7 +361,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "md.move_section",
-        description: "Move a heading section to a new position (same-file reorder or cross-file move). Exactly one of before or after is required.",
+        description: "Move a heading section to a new position (same-file reorder or cross-file move). The moved range ends at the next same-or-higher-level heading (nested lower headings included). Exactly one of before or after is required.",
         tier: Tier::Medium,
         examples: &[
             (

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -370,6 +370,15 @@ fn test_md_dedupe_headings_removes_duplicate() {
     let content = fs::read_to_string(&file).unwrap();
     let count = content.matches("## Dup").count();
     assert_eq!(count, 1, "duplicate heading should be removed");
+    // Whole later section is discarded (body under second heading is not merged).
+    assert!(
+        content.contains("First"),
+        "first section body must be kept: {content}"
+    );
+    assert!(
+        !content.contains("Second"),
+        "second section body must be discarded, not merged: {content}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `explain` / plan JSON descriptions for `md.replace_section` and `md.dedupe_headings` now state same-or-higher section bounds and that later whole-section bodies are discarded (not merged).
- MCP `md_dedupe_headings` tool extra and reference/MCP-setup docs match that contract.
- Integration test for `md dedupe-headings --apply` asserts first body kept and second body discarded (not only heading count).

Follow-up to #1864 (agent-rules / schema prose). Behavior was already hierarchical; this closes the remaining agent-facing honesty gap in `explain` and thin tests.

## Test plan

- [x] `cargo test --lib describe_md_` (new bounds/discard asserts)
- [x] `cargo test --test integration test_md_dedupe_headings_removes_duplicate`
- [x] `make check-fast`