### PR TITLE
fix: report file.rename as renamed in tx/batch JSON

### DIFF
--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -36,6 +36,7 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
 /// md.insert_after_heading <path> <heading> <content>
 /// md.insert_after_section <path> <heading> <content>
 /// md.insert_before_heading <path> <heading> <content>
+/// md.insert_before_section <path> <heading> <content> (alias of insert_before_heading)
 /// md.move_section <path> <heading> before|after <target_heading>
 /// md.move_section <path> <heading> <to> before|after <target_heading>
 /// md.dedupe_headings <path>
@@ -54,7 +55,8 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
   doc.update, doc.move, doc.delete_where, replace (optional flags: --fuzzy, …), file.create,
   file.delete, file.rename, file.append, file.prepend, md.upsert_bullet,
   md.table_append, md.replace_section, md.insert_after_heading,
-  md.insert_after_section, md.insert_before_heading, md.move_section, md.dedupe_headings,
+  md.insert_after_section, md.insert_before_heading (alias md.insert_before_section),
+  md.move_section, md.dedupe_headings,
   md.lint_agents, tidy.fix, ast.rename, ast.replace, ast.rewrite_signature
 
 EXAMPLES:
@@ -121,7 +123,12 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
             msg: format!("line {line_num}: empty operation"),
         }));
     }
-    let op = tokens[0].as_str();
+    // Normalize agent-facing aliases to canonical batch op names before match
+    // (keeps inventory/`"name" =>` collector at one primary name per op).
+    let op = match tokens[0].as_str() {
+        "md.insert_before_section" => "md.insert_before_heading",
+        other => other,
+    };
     let args = &tokens[1..];
 
     match op {

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -407,6 +407,20 @@ mod basic {
     }
 
     #[test]
+    fn parse_line_md_insert_before_section_alias() {
+        let op = parse_line(
+            "md.insert_before_section README.md \"## Rules\" \"Preamble\"",
+            1,
+        )
+        .unwrap();
+        assert!(matches!(
+            op,
+            Operation::MdInsertBeforeHeading { path, heading, content }
+            if path == "README.md" && heading == "## Rules" && content == "Preamble"
+        ));
+    }
+
+    #[test]
     fn parse_line_md_dedupe_headings() {
         let op = parse_line("md.dedupe_headings CHANGELOG.md", 1).unwrap();
         assert!(matches!(

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -82,6 +82,11 @@ pub enum MdAction {
         content: Option<String>,
     },
     /// Insert content immediately before a heading line.
+    ///
+    /// Alias `insert-before-section`: a section starts at its heading, so
+    /// sibling-before-section placement is the same as before-heading
+    /// (symmetry with `insert-after-section` / `insert-after-heading`).
+    #[command(visible_alias = "insert-before-section")]
     InsertBeforeHeading {
         /// Markdown file to edit.
         file: String,

--- a/src/json_emit.rs
+++ b/src/json_emit.rs
@@ -225,6 +225,7 @@ mod tests {
             files_changed: 1,
             files_created: 0,
             files_deleted: 0,
+            files_renamed: 0,
             changes: vec![],
             reads: vec![],
             searches: vec![],

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -185,7 +185,11 @@ pub enum Operation {
         heading: String,
         content: String,
     },
-    #[serde(rename = "md.insert_before_heading")]
+    /// Alias `md.insert_before_section`: section start == heading line.
+    #[serde(
+        rename = "md.insert_before_heading",
+        alias = "md.insert_before_section"
+    )]
     MdInsertBeforeHeading {
         path: String,
         heading: String,

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -186,6 +186,20 @@ fn parse_plan_ops_alias_accepted() {
     assert_eq!(plan.operations.len(), 1);
 }
 
+/// Agents invent `md.insert_before_section` by symmetry with insert_after_section.
+#[test]
+fn parse_md_insert_before_section_alias() {
+    let json = r#"{"version":1,"operations":[{"op":"md.insert_before_section","path":"f.md","heading":"H","content":"x"}]}"#;
+    let plan = parse_plan(json).expect("insert_before_section alias should parse");
+    assert!(
+        matches!(
+            plan.operations[0],
+            crate::plan::Operation::MdInsertBeforeHeading { .. }
+        ),
+        "alias must map to MdInsertBeforeHeading"
+    );
+}
+
 #[test]
 #[cfg(feature = "ast")]
 fn parse_all_operation_variants() {

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -29,6 +29,11 @@ pub struct TxOutput {
     pub files_changed: usize,
     pub files_created: usize,
     pub files_deleted: usize,
+    /// Number of `file.rename` pairs reported as a single `action: "renamed"`
+    /// change (not double-counted as create+delete). Fixrealloop 2026-07-20.
+    /// Omitted when zero so agents without renames keep the prior JSON shape.
+    #[serde(default, skip_serializing_if = "is_zero_usize")]
+    pub files_renamed: usize,
     pub changes: Vec<TxChange>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub reads: Vec<TxReadResult>,
@@ -111,6 +116,12 @@ pub struct TxDocMutation {
 pub struct TxChange {
     pub path: String,
     pub action: String,
+    /// Source path when [`Self::action`] is `renamed` (display-relative).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub from: Option<String>,
+    /// Destination path when [`Self::action`] is `renamed` (display-relative).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub to: Option<String>,
     /// Replace match honesty for this path (`exact` / `fuzzy` / `anchored`).
     /// Omitted for non-replace changes. See #1674 / #1669.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -250,19 +261,37 @@ fn match_meta_for_path(
     }
 }
 
+fn is_zero_usize(n: &usize) -> bool {
+    *n == 0
+}
+
+/// Staged path/meta inputs for [`build_tx_output_with_meta`] (keeps arg count low).
+pub(crate) struct TxOutputMetaInputs<'a> {
+    pub changes: &'a [(PathBuf, String, String)],
+    pub deletions: &'a HashSet<PathBuf>,
+    pub existed_before: &'a HashSet<PathBuf>,
+    pub replace_match_meta: &'a HashMap<PathBuf, ReplaceMatchMeta>,
+    pub renames: &'a [(PathBuf, PathBuf)],
+}
+
 pub(crate) fn build_tx_output_with_meta(
     status: &'static str,
     ok: bool,
-    changes: &[(PathBuf, String, String)],
-    deletions: &HashSet<PathBuf>,
-    existed_before: &HashSet<PathBuf>,
     cwd: &Path,
-    replace_match_meta: &HashMap<PathBuf, ReplaceMatchMeta>,
+    inputs: TxOutputMetaInputs<'_>,
 ) -> TxOutput {
+    let TxOutputMetaInputs {
+        changes,
+        deletions,
+        existed_before,
+        replace_match_meta,
+        renames,
+    } = inputs;
     let mut tx_changes = Vec::new();
     let mut created = 0usize;
     let mut deleted_count = 0usize;
     let mut modified = 0usize;
+    let mut renamed_count = 0usize;
     let mut agg_mode: Option<crate::api::MatchMode> = None;
     let mut agg_score: Option<f64> = None;
     let mut agg_count: usize = 0;
@@ -275,7 +304,48 @@ pub(crate) fn build_tx_output_with_meta(
             .into_owned()
     };
 
+    // Explicit file.rename pairs: one "renamed" row (not create+delete).
+    let mut rename_from: HashSet<PathBuf> = HashSet::new();
+    let mut rename_to: HashSet<PathBuf> = HashSet::new();
+    for (from, to) in renames {
+        rename_from.insert(from.clone());
+        rename_to.insert(to.clone());
+        let (match_mode, match_score, match_count, matched_text) =
+            match_meta_for_path(to, replace_match_meta);
+        if let Some(m) = replace_match_meta.get(to) {
+            any_replace_meta = true;
+            agg_mode = Some(merge_match_modes(agg_mode, m.mode));
+            if matches!(m.mode, crate::api::MatchMode::Fuzzy)
+                && let Some(s) = m.score
+            {
+                agg_score = Some(agg_score.map_or(s, |prev| prev.min(s)));
+            }
+            agg_count = agg_count.saturating_add(m.match_count);
+            if top_matched_text.is_none() {
+                top_matched_text = m.matched_text.clone();
+            }
+        }
+        let from_str = display_path(from);
+        let to_str = display_path(to);
+        tx_changes.push(TxChange {
+            // Destination is the surviving path agents care about.
+            path: to_str.clone(),
+            action: "renamed".to_string(),
+            from: Some(from_str),
+            to: Some(to_str),
+            match_mode,
+            match_score,
+            match_count,
+            matched_text,
+        });
+        renamed_count += 1;
+    }
+
     for (path, _original, _) in changes {
+        // Covered by a renamed entry (source deleted / dest created).
+        if rename_from.contains(path) || rename_to.contains(path) {
+            continue;
+        }
         let path_str = display_path(path);
         let (match_mode, match_score, match_count, matched_text) =
             match_meta_for_path(path, replace_match_meta);
@@ -297,6 +367,8 @@ pub(crate) fn build_tx_output_with_meta(
             tx_changes.push(TxChange {
                 path: path_str,
                 action: "deleted".to_string(),
+                from: None,
+                to: None,
                 match_mode,
                 match_score,
                 match_count,
@@ -307,6 +379,8 @@ pub(crate) fn build_tx_output_with_meta(
             tx_changes.push(TxChange {
                 path: path_str,
                 action: "created".to_string(),
+                from: None,
+                to: None,
                 match_mode,
                 match_score,
                 match_count,
@@ -317,6 +391,8 @@ pub(crate) fn build_tx_output_with_meta(
             tx_changes.push(TxChange {
                 path: path_str,
                 action: "modified".to_string(),
+                from: None,
+                to: None,
                 match_mode,
                 match_score,
                 match_count,
@@ -327,6 +403,9 @@ pub(crate) fn build_tx_output_with_meta(
     }
     // Deletions not captured in changes (empty files).
     for path in deletions {
+        if rename_from.contains(path) {
+            continue;
+        }
         if !changes.iter().any(|(c, _, _)| c == path) {
             let (match_mode, match_score, match_count, matched_text) =
                 match_meta_for_path(path, replace_match_meta);
@@ -346,6 +425,8 @@ pub(crate) fn build_tx_output_with_meta(
             tx_changes.push(TxChange {
                 path: display_path(path),
                 action: "deleted".to_string(),
+                from: None,
+                to: None,
                 match_mode,
                 match_score,
                 match_count,
@@ -429,6 +510,7 @@ pub(crate) fn build_tx_output_with_meta(
         files_changed: modified,
         files_created: created,
         files_deleted: deleted_count,
+        files_renamed: renamed_count,
         changes: tx_changes,
         reads: Vec::new(),
         searches: Vec::new(),
@@ -467,11 +549,14 @@ pub(crate) fn build_full_tx_output(
     let mut output = build_tx_output_with_meta(
         status,
         true,
-        &result.changes,
-        &result.deletions,
-        &result.existed_before,
         cwd,
-        &result.replace_match_meta,
+        TxOutputMetaInputs {
+            changes: &result.changes,
+            deletions: &result.deletions,
+            existed_before: &result.existed_before,
+            replace_match_meta: &result.replace_match_meta,
+            renames: &result.renames,
+        },
     );
     output.reads = std::mem::take(&mut result.tx_reads);
     output.searches = std::mem::take(&mut result.tx_searches);
@@ -529,6 +614,7 @@ pub(crate) fn build_error_output(
         files_changed: 0,
         files_created: 0,
         files_deleted: 0,
+        files_renamed: 0,
         changes: Vec::new(),
         reads: Vec::new(),
         searches: Vec::new(),
@@ -699,6 +785,7 @@ mod tests {
             files_changed: 0,
             files_created: 0,
             files_deleted: 0,
+            files_renamed: 0,
             changes: Vec::new(),
             reads: Vec::new(),
             searches: Vec::new(),
@@ -725,6 +812,7 @@ mod tests {
             files_changed: 0,
             files_created: 0,
             files_deleted: 0,
+            files_renamed: 0,
             changes: Vec::new(),
             reads: Vec::new(),
             searches: Vec::new(),
@@ -866,11 +954,14 @@ mod tests {
         let out = build_tx_output_with_meta(
             "success",
             true,
-            &changes,
-            &deletions,
-            &existed,
             cwd,
-            &HashMap::new(),
+            TxOutputMetaInputs {
+                changes: &changes,
+                deletions: &deletions,
+                existed_before: &existed,
+                replace_match_meta: &HashMap::new(),
+                renames: &[],
+            },
         );
         assert!(out.ok);
         assert_eq!(out.files_changed, 1); // existing.txt modified
@@ -884,17 +975,55 @@ mod tests {
         assert!(actions.contains(&"deleted"));
     }
 
+    /// Explicit file.rename must surface as one `renamed` change, not create+delete.
+    #[test]
+    fn build_tx_output_classifies_file_rename() {
+        let cwd = Path::new("/project");
+        let from = PathBuf::from("/project/old.txt");
+        let to = PathBuf::from("/project/new.txt");
+        let changes = vec![
+            (to.clone(), String::new(), "body\n".to_string()),
+            (from.clone(), "body\n".to_string(), String::new()),
+        ];
+        let deletions = HashSet::from([from.clone()]);
+        let renames = vec![(from, to)];
+        let out = build_tx_output_with_meta(
+            "success",
+            true,
+            cwd,
+            TxOutputMetaInputs {
+                changes: &changes,
+                deletions: &deletions,
+                existed_before: &HashSet::new(),
+                replace_match_meta: &HashMap::new(),
+                renames: &renames,
+            },
+        );
+        assert_eq!(out.files_renamed, 1);
+        assert_eq!(out.files_created, 0);
+        assert_eq!(out.files_deleted, 0);
+        assert_eq!(out.files_changed, 0);
+        assert_eq!(out.changes.len(), 1);
+        assert_eq!(out.changes[0].action, "renamed");
+        assert_eq!(out.changes[0].path, "new.txt");
+        assert_eq!(out.changes[0].from.as_deref(), Some("old.txt"));
+        assert_eq!(out.changes[0].to.as_deref(), Some("new.txt"));
+    }
+
     #[test]
     fn build_tx_output_empty_changes() {
         let cwd = Path::new("/project");
         let out = build_tx_output_with_meta(
             "success",
             true,
-            &[],
-            &HashSet::new(),
-            &HashSet::new(),
             cwd,
-            &HashMap::new(),
+            TxOutputMetaInputs {
+                changes: &[],
+                deletions: &HashSet::new(),
+                existed_before: &HashSet::new(),
+                replace_match_meta: &HashMap::new(),
+                renames: &[],
+            },
         );
         assert_eq!(out.files_changed, 0);
         assert_eq!(out.files_created, 0);
@@ -922,11 +1051,14 @@ mod tests {
         let out = build_tx_output_with_meta(
             "success",
             true,
-            &changes,
-            &HashSet::new(),
-            &existed,
             cwd,
-            &meta,
+            TxOutputMetaInputs {
+                changes: &changes,
+                deletions: &HashSet::new(),
+                existed_before: &existed,
+                replace_match_meta: &meta,
+                renames: &[],
+            },
         );
         assert_eq!(out.match_mode.as_deref(), Some("fuzzy"));
         assert_eq!(out.match_score, Some(0.91));
@@ -978,11 +1110,14 @@ mod tests {
         let out = build_tx_output_with_meta(
             "success",
             true,
-            &changes,
-            &HashSet::new(),
-            &existed,
             cwd,
-            &meta,
+            TxOutputMetaInputs {
+                changes: &changes,
+                deletions: &HashSet::new(),
+                existed_before: &existed,
+                replace_match_meta: &meta,
+                renames: &[],
+            },
         );
         assert_eq!(out.match_mode.as_deref(), Some("fuzzy"));
         assert_eq!(
@@ -1023,11 +1158,14 @@ mod tests {
         let out = build_tx_output_with_meta(
             "success",
             true,
-            &changes,
-            &HashSet::new(),
-            &existed,
             cwd,
-            &meta,
+            TxOutputMetaInputs {
+                changes: &changes,
+                deletions: &HashSet::new(),
+                existed_before: &existed,
+                replace_match_meta: &meta,
+                renames: &[],
+            },
         );
         assert_eq!(
             out.matched_text.as_deref(),
@@ -1042,21 +1180,27 @@ mod tests {
         let preview = build_tx_output_with_meta(
             "changes_detected",
             true,
-            &[],
-            &Default::default(),
-            &Default::default(),
             Path::new("/tmp"),
-            &Default::default(),
+            TxOutputMetaInputs {
+                changes: &[],
+                deletions: &Default::default(),
+                existed_before: &Default::default(),
+                replace_match_meta: &Default::default(),
+                renames: &[],
+            },
         );
         assert!(!preview.applied, "preview must set applied=false");
         let applied = build_tx_output_with_meta(
             "success",
             true,
-            &[],
-            &Default::default(),
-            &Default::default(),
             Path::new("/tmp"),
-            &Default::default(),
+            TxOutputMetaInputs {
+                changes: &[],
+                deletions: &Default::default(),
+                existed_before: &Default::default(),
+                replace_match_meta: &Default::default(),
+                renames: &[],
+            },
         );
         assert!(applied.applied, "success must set applied=true");
         let err = build_error_output("invalid_input", "nope", None);

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -622,8 +622,21 @@ async fn test_mcp_file_rename_round_trip() {
     .await;
     assert!(!is_error, "rename should succeed: {val}");
     assert_eq!(val["ok"], true, "rename ok field: {val}");
-    assert_eq!(val["files_created"], 1, "rename files_created: {val}");
-    assert_eq!(val["files_deleted"], 1, "rename files_deleted: {val}");
+    // file.rename is one renamed change (not create+delete double-count).
+    assert_eq!(val["files_renamed"], 1, "rename files_renamed: {val}");
+    assert_eq!(val["files_created"], 0, "rename files_created: {val}");
+    assert_eq!(val["files_deleted"], 0, "rename files_deleted: {val}");
+    let empty: Vec<serde_json::Value> = Vec::new();
+    let actions: Vec<&str> = val["changes"]
+        .as_array()
+        .unwrap_or(&empty)
+        .iter()
+        .filter_map(|c| c["action"].as_str())
+        .collect();
+    assert!(
+        actions.contains(&"renamed"),
+        "rename changes must include action renamed: {val}"
+    );
     assert!(
         !dir.path().join("old_name.txt").exists(),
         "old file should not exist"

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -995,6 +995,34 @@ fn test_md_insert_before_heading() {
     assert!(content.contains("Inserted before B.\n\n## Section B"));
 }
 
+/// CLI alias: agents invent `insert-before-section` by symmetry with after-section.
+#[test]
+fn test_md_insert_before_section_alias() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(
+        &file,
+        "# Title\n\nIntro.\n\n## Section A\n\nContent A.\n\n## Section B\n\nContent B.\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("md")
+        .arg("insert-before-section")
+        .arg(file.to_str().unwrap())
+        .arg("--heading")
+        .arg("Section B")
+        .arg("--content")
+        .arg("Inserted via section alias.")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(content.contains("Inserted via section alias.\n\n## Section B"));
+}
+
 #[test]
 fn test_md_table_append_missing_file_includes_path_in_error() {
     Command::cargo_bin("patchloom")

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -1198,6 +1198,48 @@ fn test_tx_file_rename_moves_file() {
     );
 }
 
+/// file.rename JSON must report one `renamed` change (not create+delete).
+#[test]
+fn test_tx_file_rename_json_action_renamed() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.txt"), "content\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {"op": "file.rename", "from": "old.txt", "to": "new.txt"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["files_renamed"], 1, "{json}");
+    assert_eq!(json["files_created"], 0, "{json}");
+    assert_eq!(json["files_deleted"], 0, "{json}");
+    let changes = json["changes"].as_array().expect("changes array");
+    assert_eq!(changes.len(), 1, "{json}");
+    assert_eq!(changes[0]["action"], "renamed");
+    assert_eq!(changes[0]["from"], "old.txt");
+    assert_eq!(changes[0]["to"], "new.txt");
+    assert_eq!(changes[0]["path"], "new.txt");
+}
+
 #[test]
 fn test_tx_file_rename_fails_if_dst_exists() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

fixrealloop Round 2 found that batch/tx `file.rename` JSON reported `files_created: 1` + `files_deleted: 1` with `action: "deleted"` / `"created"`, so agents could not distinguish a rename from a delete+create pair (`files_changed` stayed 0).

Also found that agents invent `md insert-before-section` by symmetry with `insert-after-section`; only `insert-before-heading` existed (same placement: section start is the heading line).

## Changes

- Classify explicit `file.rename` pairs as one change with `action: "renamed"`, plus `from` / `to` fields
- Add `files_renamed` (omitted when zero so non-rename JSON shape is stable)
- CLI visible alias `insert-before-section`, plan serde alias `md.insert_before_section`, batch alias normalize

## Test plan

- [x] Unit: `build_tx_output_classifies_file_rename`
- [x] Integration: `test_tx_file_rename_json_action_renamed`
- [x] MCP: `test_mcp_file_rename_round_trip` expects `files_renamed`
- [x] Alias: plan parse, batch parse, CLI `insert-before-section`
- [x] `make check-fast`
- [x] Dogfood: batch rename + md alias on release binary