### PR TITLE
fix: line-oriented insert_before/after by default

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -102,6 +102,7 @@ Use patchloom when:
 
 **CLI undo (dry-run by default):** `patchloom undo` only previews the most recent backup and exits 2 with `applied: false` and `status: changes_detected`. Restore with `patchloom undo --apply` (optional `--session <timestamp>`), which sets `applied: true` and `status: restored` (#1830). List sessions with `patchloom undo --list`. There is no `--latest` flag.
 **Replace mode flags (#1829):** CLI replacement text is `--new` (not positional NEW and not `--to`). Missing mode errors name `--new` / `--insert-before` / `--insert-after` first; plan/MCP still accept field aliases `new`/`to`.
+**Insert line placement (#1885):** `--insert-before` / `--insert-after` (and plan/MCP `insert_before` / `insert_after`) are line-oriented by default: payloads that look like a new line (indent, `//`/`#` comment, embedded newline) or a whole-line anchor get a separating newline so agents do not glue text onto the match. Pure mid-line inserts (e.g. `X` after `foo` inside a line) stay byte-exact.
 
 ## MCP mode
 

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -245,9 +245,15 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<OneEdit> {
             // anchor span.
             match content.find(anchor.as_str()) {
                 Some(idx) => {
+                    let insert = crate::ops::replace::normalize_line_insert(
+                        content,
+                        anchor,
+                        insert,
+                        crate::ops::replace::InsertSide::Before,
+                    );
                     let mut out = String::with_capacity(content.len() + insert.len());
                     out.push_str(&content[..idx]);
-                    out.push_str(insert);
+                    out.push_str(&insert);
                     out.push_str(&content[idx..]);
                     Ok(OneEdit {
                         content: out,
@@ -276,10 +282,16 @@ fn apply_one(content: &str, edit: &ContentEdit) -> anyhow::Result<OneEdit> {
             // First-match only (see InsertBefore).
             match content.find(anchor.as_str()) {
                 Some(idx) => {
+                    let insert = crate::ops::replace::normalize_line_insert(
+                        content,
+                        anchor,
+                        insert,
+                        crate::ops::replace::InsertSide::After,
+                    );
                     let end = idx + anchor.len();
                     let mut out = String::with_capacity(content.len() + insert.len());
                     out.push_str(&content[..end]);
-                    out.push_str(insert);
+                    out.push_str(&insert);
                     out.push_str(&content[end..]);
                     Ok(OneEdit {
                         content: out,
@@ -387,6 +399,24 @@ mod tests {
 
     #[test]
     fn multi_op_insert_before_after() {
+        // Mid-line bare inserts stay byte-exact (no leading indent / newline).
+        let edits = [
+            ContentEdit::InsertBefore {
+                anchor: "B".into(),
+                content: "A".into(),
+            },
+            ContentEdit::InsertAfter {
+                anchor: "B".into(),
+                content: "C".into(),
+            },
+        ];
+        let r = apply_content_edits("xBy", &edits).unwrap();
+        assert_eq!(r.modified, "xABCy");
+    }
+
+    #[test]
+    fn multi_op_insert_line_oriented_on_whole_line_anchor() {
+        // Whole-line anchor "B": bare payloads get newlines (#1885).
         let edits = [
             ContentEdit::InsertBefore {
                 anchor: "B".into(),
@@ -398,7 +428,8 @@ mod tests {
             },
         ];
         let r = apply_content_edits("B", &edits).unwrap();
-        assert_eq!(r.modified, "ABC");
+        // Before: "A\n" + "B" → "A\nB"; After: "B" + "\nC" on that buffer → "A\nB\nC"
+        assert_eq!(r.modified, "A\nB\nC");
     }
 
     #[test]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -262,9 +262,17 @@ pub struct ReplaceOptions {
     pub multiline: bool,
     /// Text to insert before each match instead of replacing.
     /// Mutually exclusive with `to` (the replacement text) and `insert_after`.
+    ///
+    /// **Line-oriented by default (#1885):** when the payload looks like a new
+    /// line (indent, `//`/`#` comment, embedded newline) or every match of the
+    /// anchor is alone on its line, a separating newline is added so the insert
+    /// does not glue onto the anchor. Pure mid-line inserts (e.g. `"X"` after
+    /// `"foo"` inside a line) stay byte-exact.
     pub insert_before: Option<String>,
     /// Text to insert after each match instead of replacing.
     /// Mutually exclusive with `to` (the replacement text) and `insert_before`.
+    ///
+    /// Same line-oriented default as [`Self::insert_before`] (#1885).
     pub insert_after: Option<String>,
     /// Delete/replace entire lines containing the match rather than just the
     /// matched text. When `to` is empty, matching lines are removed.

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -225,6 +225,7 @@ fn replace_write(
             &insert_after,
             compiled_re.is_some(),
             is_regex,
+            &original,
         );
 
         let parsed_range = range.as_deref().map(|r| {
@@ -402,8 +403,20 @@ fn replace_write(
                         return Err(anyhow::Error::new(crate::exit::NoMatchError { msg }));
                     }
                     let to_text = if let Some(ib) = &insert_before {
+                        let ib = ops::replace::normalize_line_insert(
+                            &original,
+                            &anchor.matched_text,
+                            ib,
+                            ops::replace::InsertSide::Before,
+                        );
                         format!("{}{}", ib, anchor.matched_text)
                     } else if let Some(ia) = &insert_after {
+                        let ia = ops::replace::normalize_line_insert(
+                            &original,
+                            &anchor.matched_text,
+                            ia,
+                            ops::replace::InsertSide::After,
+                        );
                         format!("{}{}", anchor.matched_text, ia)
                     } else {
                         new_text.as_deref().unwrap_or("").to_string()
@@ -569,6 +582,7 @@ pub fn replace_in_content(
         &opts.insert_after,
         compiled_re.is_some(),
         is_regex,
+        content,
     );
 
     let parsed_range = opts.range;
@@ -735,8 +749,20 @@ pub fn replace_in_content(
                     .into());
                 }
                 let to_text = if let Some(ib) = &opts.insert_before {
+                    let ib = ops::replace::normalize_line_insert(
+                        content,
+                        &anchor.matched_text,
+                        ib,
+                        ops::replace::InsertSide::Before,
+                    );
                     format!("{}{}", ib, anchor.matched_text)
                 } else if let Some(ia) = &opts.insert_after {
+                    let ia = ops::replace::normalize_line_insert(
+                        content,
+                        &anchor.matched_text,
+                        ia,
+                        ops::replace::InsertSide::After,
+                    );
                     format!("{}{}", anchor.matched_text, ia)
                 } else {
                     to.to_string()

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1602,6 +1602,7 @@ fn replace_text_insert_after() {
     let file = dir.path().join("code.rs");
     fs::write(&file, "hello world\n").unwrap();
 
+    // Leading space looks like a new-line payload (#1885): insert on next line.
     let opts = ReplaceOptions {
         insert_after: Some(" beautiful".to_string()),
         ..ReplaceOptions::default()
@@ -1610,8 +1611,27 @@ fn replace_text_insert_after() {
 
     assert!(result.changed);
     assert!(
-        result.new_content.contains("hello beautiful"),
-        "insert_after should add text after match: {}",
+        result.new_content.contains("hello\n beautiful"),
+        "line-oriented insert_after: {}",
+        result.new_content
+    );
+}
+
+#[test]
+fn replace_text_insert_after_midline_bare() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "hello world\n").unwrap();
+
+    let opts = ReplaceOptions {
+        insert_after: Some("X".to_string()),
+        ..ReplaceOptions::default()
+    };
+    let result = replace_text(&file, "hello", "", &opts, ApplyMode::Preview, None).unwrap();
+    assert!(result.changed);
+    assert!(
+        result.new_content.contains("helloX world"),
+        "mid-line bare insert stays byte-exact: {}",
         result.new_content
     );
 }

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -223,7 +223,12 @@ success lines are the full path list.\n\n\
              `--latest` flag.\n\
              **Replace mode flags (#1829):** CLI replacement text is `--new` (not positional NEW and not \
              `--to`). Missing mode errors name `--new` / `--insert-before` / `--insert-after` first; \
-             plan/MCP still accept field aliases `new`/`to`.\n\n",
+             plan/MCP still accept field aliases `new`/`to`.\n\
+             **Insert line placement (#1885):** `--insert-before` / `--insert-after` (and plan/MCP \
+             `insert_before` / `insert_after`) are line-oriented by default: payloads that look like a \
+             new line (indent, `//`/`#` comment, embedded newline) or a whole-line anchor get a separating \
+             newline so agents do not glue text onto the match. Pure mid-line inserts (e.g. `X` after \
+             `foo` inside a line) stay byte-exact.\n\n",
         );
         if !show_mcp {
             out.push_str(

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -282,17 +282,6 @@ fn parse_range_arg(spec: Option<&str>) -> anyhow::Result<Option<(usize, Option<u
     }
 }
 
-fn build_replacement(args: &ReplaceArgs) -> String {
-    replacement_text(
-        &args.old,
-        &args.new,
-        &args.insert_before,
-        &args.insert_after,
-        args.regex || args.case_insensitive || args.word_boundary,
-        args.regex,
-    )
-}
-
 /// Walk files and collect replacements using parallel file processing.
 ///
 /// Includes identity matches (`new == old`) so callers can enforce `--unique`
@@ -311,7 +300,6 @@ fn collect_replacements(
     // Detected here (single read of stdin) before soft no_matches handling.
     crate::files::ensure_files_from_nonempty(global, &file_paths)?;
     let glob_roots = crate::collect_glob_roots_from_global(&args.paths, global, Some(&cwd))?;
-    let replacement = build_replacement(args);
     let quiet = global.quiet;
 
     let compiled_re = compile_replace_regex(
@@ -328,11 +316,26 @@ fn collect_replacements(
     let command_position = args.command_position;
     let to = args.new.as_deref().unwrap_or("");
     let range = parse_range_arg(args.range.as_deref())?;
+    // Capture for per-file line-oriented insert normalize (#1885).
+    let insert_before = args.insert_before.clone();
+    let insert_after = args.insert_after.clone();
+    let new_opt = args.new.clone();
+    let use_match_anchor = args.regex || args.case_insensitive || args.word_boundary;
+    let regex_mode = args.regex;
 
     let cwd_ref = &cwd;
     let mut replacements: Vec<FileReplacement> =
         crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let content = crate::files::read_text_file_logged(path, "replace", quiet)?;
+            let replacement = replacement_text(
+                from,
+                &new_opt,
+                &insert_before,
+                &insert_after,
+                use_match_anchor,
+                regex_mode,
+                &content,
+            );
             let (replaced, count) = if command_position {
                 let (out, n) =
                     crate::ops::shell_token::replace_command_position(&content, from, to);

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -218,14 +218,14 @@ mod basic {
 
     #[test]
     fn regex_insert_before_uses_match_anchor_in_replacement_text() {
-        let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true, true);
+        let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true, true, "");
 
         assert_eq!(text, "X${0}");
     }
 
     #[test]
     fn regex_insert_after_uses_match_anchor_in_replacement_text() {
-        let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true, true);
+        let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true, true, "");
 
         assert_eq!(text, "${0}X");
     }

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -162,6 +162,92 @@ pub fn validate_replace_args(
         .map_err(ReplaceValidationError::Mode)
 }
 
+/// Which side of the match an insert lands on (for line-oriented default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InsertSide {
+    Before,
+    After,
+}
+
+/// Normalize an insert payload so agent-style inserts land on their own line.
+///
+/// Default for all insert_before / insert_after paths (#1885). Byte-exact
+/// mid-line inserts (e.g. `"X"` after `"foo"` inside a line) are unchanged.
+///
+/// Rules (from Bline host glue, now product default):
+/// - insert_after: prepend `\\n` when the payload looks like a new line, or
+///   every occurrence of `anchor` is alone on its line, unless the payload
+///   already starts with `\\n` or the anchor ends with `\\n`.
+/// - insert_before: append `\\n` under the same conditions (so the anchor
+///   stays on the next line), unless the payload already ends with `\\n`
+///   or the anchor starts with `\\n`.
+pub fn normalize_line_insert(
+    file_content: &str,
+    anchor: &str,
+    insert_content: &str,
+    side: InsertSide,
+) -> String {
+    match side {
+        InsertSide::After => {
+            if insert_content.starts_with('\n') || anchor.ends_with('\n') {
+                return insert_content.to_string();
+            }
+            if looks_like_new_line_payload(insert_content)
+                || anchor_is_whole_line(file_content, anchor)
+            {
+                format!("\n{insert_content}")
+            } else {
+                insert_content.to_string()
+            }
+        }
+        InsertSide::Before => {
+            if insert_content.ends_with('\n') || anchor.starts_with('\n') {
+                return insert_content.to_string();
+            }
+            if looks_like_new_line_payload(insert_content)
+                || anchor_is_whole_line(file_content, anchor)
+            {
+                format!("{insert_content}\n")
+            } else {
+                insert_content.to_string()
+            }
+        }
+    }
+}
+
+fn looks_like_new_line_payload(insert_content: &str) -> bool {
+    let trimmed = insert_content.trim_start_matches([' ', '\t']);
+    insert_content.starts_with([' ', '\t'])
+        || trimmed.starts_with("//")
+        || trimmed.starts_with('#')
+        || insert_content.contains('\n')
+}
+
+/// True when every occurrence of `anchor` is alone on its line (bounded by
+/// newlines / file edges). Empty content or empty anchor → false.
+pub fn anchor_is_whole_line(file_content: &str, anchor: &str) -> bool {
+    if anchor.is_empty() || file_content.is_empty() {
+        return false;
+    }
+    let bytes = file_content.as_bytes();
+    let mut any = false;
+    for (i, _) in file_content.match_indices(anchor) {
+        any = true;
+        let before_ok = i == 0 || bytes[i - 1] == b'\n';
+        let end = i + anchor.len();
+        let after_ok = end == file_content.len() || bytes.get(end) == Some(&b'\n');
+        if !(before_ok && after_ok) {
+            return false;
+        }
+    }
+    any
+}
+
+/// Build the replacement string for replace / insert modes.
+///
+/// `file_content` is the file (or buffer) being edited; it is used to decide
+/// line-oriented insert normalization (#1885). Pass `""` only in pure unit
+/// tests that do not exercise whole-line-anchor detection.
 pub fn replacement_text(
     from: &str,
     to: &Option<String>,
@@ -169,6 +255,7 @@ pub fn replacement_text(
     insert_after: &Option<String>,
     use_match_anchor: bool,
     regex_mode: bool,
+    file_content: &str,
 ) -> String {
     let anchor = if use_match_anchor { "${0}" } else { from };
 
@@ -178,19 +265,23 @@ pub fn replacement_text(
     let needs_escape = use_match_anchor && !regex_mode;
 
     if let Some(text) = insert_before {
+        // Normalize against the literal `from` pattern (not ${0}) so whole-line
+        // detection sees the real anchor text in the file.
+        let normalized = normalize_line_insert(file_content, from, text, InsertSide::Before);
         let safe = if needs_escape {
-            text.replace('$', "$$")
+            normalized.replace('$', "$$")
         } else {
-            text.clone()
+            normalized
         };
         return format!("{safe}{anchor}");
     }
 
     if let Some(text) = insert_after {
+        let normalized = normalize_line_insert(file_content, from, text, InsertSide::After);
         let safe = if needs_escape {
-            text.replace('$', "$$")
+            normalized.replace('$', "$$")
         } else {
-            text.clone()
+            normalized
         };
         return format!("{anchor}{safe}");
     }

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -87,7 +87,8 @@ mod replace_tests {
 
         #[test]
         fn replacement_text_with_to() {
-            let result = replacement_text("from", &Some("to".into()), &None, &None, false, false);
+            let result =
+                replacement_text("from", &Some("to".into()), &None, &None, false, false, "");
             assert_eq!(result, "to");
         }
 
@@ -100,6 +101,7 @@ mod replace_tests {
                 &None,
                 false,
                 false,
+                "original",
             );
             assert_eq!(result, "PREFIX\noriginal");
         }
@@ -113,6 +115,7 @@ mod replace_tests {
                 &Some("\nSUFFIX".into()),
                 false,
                 false,
+                "original",
             );
             assert_eq!(result, "original\nSUFFIX");
         }
@@ -126,6 +129,7 @@ mod replace_tests {
                 &None,
                 true,
                 true,
+                "ignored",
             );
             assert_eq!(result, "PREFIX\n${0}");
         }
@@ -139,6 +143,7 @@ mod replace_tests {
                 &Some("\nSUFFIX".into()),
                 true,
                 true,
+                "ignored",
             );
             assert_eq!(result, "${0}\nSUFFIX");
         }
@@ -148,16 +153,63 @@ mod replace_tests {
         #[test]
         fn replacement_text_escapes_dollars_for_internal_regex() {
             // use_match_anchor=true (internal regex), regex_mode=false (not user-requested)
-            let result = replacement_text("cost", &Some("$100".into()), &None, &None, true, false);
+            let result =
+                replacement_text("cost", &Some("$100".into()), &None, &None, true, false, "");
             assert_eq!(result, "$$100");
         }
 
         #[test]
         fn replacement_text_preserves_dollars_for_user_regex() {
             // use_match_anchor=true, regex_mode=true (user explicitly requested regex)
-            let result =
-                replacement_text("(c)ost", &Some("$1ost".into()), &None, &None, true, true);
+            let result = replacement_text(
+                "(c)ost",
+                &Some("$1ost".into()),
+                &None,
+                &None,
+                true,
+                true,
+                "",
+            );
             assert_eq!(result, "$1ost");
+        }
+
+        #[test]
+        fn normalize_line_insert_after_comment_after_brace() {
+            let file = "fn f() {\n}\n";
+            let out =
+                normalize_line_insert(file, "fn f() {", "    // comment\n", InsertSide::After);
+            assert_eq!(out, "\n    // comment\n");
+        }
+
+        #[test]
+        fn normalize_line_insert_after_whole_line_bare_payload() {
+            // avoid alphabeta when every match is a whole line
+            let file = "alpha\n";
+            let out = normalize_line_insert(file, "alpha", "beta", InsertSide::After);
+            assert_eq!(out, "\nbeta");
+        }
+
+        #[test]
+        fn normalize_line_insert_after_midline_stays_byte_exact() {
+            let file = "prefix foo suffix\n";
+            let out = normalize_line_insert(file, "foo", "X", InsertSide::After);
+            assert_eq!(out, "X");
+        }
+
+        #[test]
+        fn normalize_line_insert_before_appends_newline() {
+            let file = "fn f() {\n}\n";
+            let out = normalize_line_insert(file, "fn f() {", "// header", InsertSide::Before);
+            assert_eq!(out, "// header\n");
+        }
+
+        #[test]
+        fn normalize_line_insert_already_has_newline_unchanged() {
+            let file = "fn f() {\n}\n";
+            let after = normalize_line_insert(file, "fn f() {", "\n// c\n", InsertSide::After);
+            assert_eq!(after, "\n// c\n");
+            let before = normalize_line_insert(file, "fn f() {", "// c\n", InsertSide::Before);
+            assert_eq!(before, "// c\n");
         }
 
         #[test]

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -6,8 +6,8 @@
 use super::execute::{TxState, read_and_probe, read_file_content};
 use crate::api::MatchMode;
 use crate::ops::replace::{
-    compile_replace_regex, context_filtered_offset, replace_content, replace_whole_lines,
-    replacement_text,
+    InsertSide, compile_replace_regex, context_filtered_offset, normalize_line_insert,
+    replace_content, replace_whole_lines, replacement_text,
 };
 use crate::plan::Operation;
 use crate::tx::output::merge_match_modes;
@@ -190,14 +190,6 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         return Err(crate::exit::InvalidInputError { msg: msg.into() }.into());
     }
     let use_regex = regex_mode || *case_insensitive || word_boundary;
-    let replacement = replacement_text(
-        old,
-        new_text,
-        insert_before,
-        insert_after,
-        use_regex,
-        regex_mode,
-    );
     let compiled_re = compile_replace_regex(
         old,
         regex_mode,
@@ -227,6 +219,16 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             Err(e) if if_exists && crate::exit::is_io_not_found(&e) => return Ok(0),
             Err(e) => return Err(e),
         };
+        // Per-file content so whole-line anchor detection is accurate (#1885).
+        let replacement = replacement_text(
+            old,
+            new_text,
+            insert_before,
+            insert_after,
+            use_regex,
+            regex_mode,
+            content,
+        );
         let (replaced, match_count) = if *command_position {
             let to = new_text.as_deref().unwrap_or("");
             let (out, n) = crate::ops::shell_token::replace_command_position(content, old, to);
@@ -380,8 +382,20 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         );
                     } else {
                         let to_text = if let Some(ib) = insert_before {
+                            let ib = normalize_line_insert(
+                                content,
+                                &anchor.matched_text,
+                                ib,
+                                InsertSide::Before,
+                            );
                             format!("{}{}", ib, anchor.matched_text)
                         } else if let Some(ia) = insert_after {
+                            let ia = normalize_line_insert(
+                                content,
+                                &anchor.matched_text,
+                                ia,
+                                InsertSide::After,
+                            );
                             format!("{}{}", anchor.matched_text, ia)
                         } else {
                             new_text.as_deref().unwrap_or("").to_string()
@@ -521,6 +535,15 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 .get(&file_path)
                 .map(|(_, c)| c.clone())
                 .expect("read_and_probe guarantees entry exists in pending");
+            let replacement = replacement_text(
+                old,
+                new_text,
+                insert_before,
+                insert_after,
+                use_regex,
+                regex_mode,
+                &content,
+            );
             let (replaced, match_count) = if *command_position {
                 let to = new_text.as_deref().unwrap_or("");
                 let (out, n) = crate::ops::shell_token::replace_command_position(&content, old, to);

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1004,6 +1004,7 @@ fn test_replace_insert_before() {
 fn test_replace_insert_after() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("code.rs");
+    // Whole-line anchor + leading-space payload → line-oriented insert (#1885).
     fs::write(&file, "line1\nanchor\nline3\n").unwrap();
 
     Command::cargo_bin("patchloom")
@@ -1019,7 +1020,30 @@ fn test_replace_insert_after() {
 
     assert_eq!(
         fs::read_to_string(&file).unwrap(),
-        "line1\nanchor // tagged\nline3\n"
+        "line1\nanchor\n // tagged\nline3\n"
+    );
+}
+
+#[test]
+fn test_replace_insert_after_midline_bare_stays_exact() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "line1\nxx anchor yy\nline3\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("replace")
+        .arg("anchor")
+        .arg("--insert-after")
+        .arg("X")
+        .arg(file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line1\nxx anchorX yy\nline3\n"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #1885.

`insert_before` / `insert_after` (CLI, plan/tx, library, content_edits, fuzzy) now use **line-oriented** placement by default so agent inserts do not glue onto anchors:

| Case | Result |
|------|--------|
| `// comment` or indented payload after `fn f() {` | newline before insert |
| bare `beta` after whole-line `alpha` | `alpha\nbeta` (not `alphabeta`) |
| bare `X` after mid-line `foo` | still `fooX` (byte-exact) |

This is the default (not opt-in). Mid-line exact inserts remain byte-exact when the payload does not look like a new line and the anchor is not alone on its line.

## Test plan

- [x] Unit: normalize_line_insert cases from #1885
- [x] Integration: insert_after line-oriented + mid-line bare
- [x] content_edits whole-line vs mid-line
- [x] `make check-fast`
- [x] Dogfood: brace comment, whole-line beta, mid-line X