### PR TITLE
feat: EditErrorKind::TypeError and public is_binary_file

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1500,7 +1500,40 @@ fn doc_get_array_root_bare_key_is_type_error() {
         msg.contains("0.a") || msg.contains("[0].a"),
         "index hint missing: {msg}"
     );
+    // Library hosts branch on kind without scraping English (#1883).
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::TypeError),
+        "TypeErrorError must peel to EditErrorKind::TypeError, not InvalidInput"
+    );
     assert_eq!(doc_get(&file, "0.a").unwrap(), serde_json::json!(1));
+}
+
+#[test]
+fn empty_replace_pattern_is_invalid_input_not_type_error() {
+    // Sibling-path honesty for #1883: empty pattern stays InvalidInput.
+    let err = replace_in_content("a b", "", "x", &ReplaceOptions::default()).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
+}
+
+#[test]
+fn doc_set_multi_document_bare_key_is_type_error_kind() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("multi.yaml");
+    fs::write(&file, "a: 1\n---\nb: 2\n").unwrap();
+
+    let err = doc_set(&file, "a", serde_json::json!(9), ApplyMode::Preview, None).unwrap_err();
+    assert!(
+        crate::exit::is_type_error(&err),
+        "expected TypeErrorError, got: {err}"
+    );
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::TypeError)
+    );
 }
 
 #[test]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -107,6 +107,11 @@ pub enum EditErrorKind {
     GuardRejected,
     /// Invalid arguments or options for the edit.
     InvalidInput,
+    /// Wrong value type for a doc selector (multi-document YAML bare key,
+    /// navigate into array as object, etc.). CLI JSON uses `error_kind:
+    /// "type_error"`. Distinct from [`Self::InvalidInput`] so hosts can
+    /// recover with `0.key` / `[0].key` without scraping English (#1883).
+    TypeError,
     /// I/O or other operational failure.
     OperationFailed,
     /// Post-write format/lint hook failed (`format_failed` / #1663).
@@ -125,6 +130,7 @@ impl std::fmt::Display for EditErrorKind {
             EditErrorKind::ParseError => write!(f, "parse_error"),
             EditErrorKind::GuardRejected => write!(f, "guard_rejected"),
             EditErrorKind::InvalidInput => write!(f, "invalid_input"),
+            EditErrorKind::TypeError => write!(f, "type_error"),
             EditErrorKind::OperationFailed => write!(f, "operation_failed"),
             EditErrorKind::FormatFailed => write!(f, "format_failed"),
         }
@@ -212,9 +218,11 @@ pub fn classify_error(err: &(dyn std::error::Error + 'static)) -> Option<EditErr
         if e.downcast_ref::<crate::exit::InvalidInputError>().is_some()
             || e.downcast_ref::<crate::exit::AlreadyExistsError>()
                 .is_some()
-            || e.downcast_ref::<crate::exit::TypeErrorError>().is_some()
         {
             return Some(EditErrorKind::InvalidInput);
+        }
+        if e.downcast_ref::<crate::exit::TypeErrorError>().is_some() {
+            return Some(EditErrorKind::TypeError);
         }
         if e.downcast_ref::<crate::exit::ParseErrorError>().is_some() {
             return Some(EditErrorKind::ParseError);
@@ -925,6 +933,9 @@ mod tests {
             "conflicting_edit"
         );
         assert_eq!(EditErrorKind::ParseError.to_string(), "parse_error");
+        assert_eq!(EditErrorKind::TypeError.to_string(), "type_error");
+        assert_eq!(EditErrorKind::InvalidInput.to_string(), "invalid_input");
+        assert_eq!(EditErrorKind::FormatFailed.to_string(), "format_failed");
     }
 
     #[test]
@@ -944,6 +955,13 @@ mod tests {
         assert_eq!(
             classify_error(&e as &(dyn Error + 'static)),
             Some(EditErrorKind::FormatFailed)
+        );
+        let e = crate::exit::TypeErrorError {
+            msg: "parent is an array".into(),
+        };
+        assert_eq!(
+            classify_error(&e as &(dyn Error + 'static)),
+            Some(EditErrorKind::TypeError)
         );
     }
 
@@ -982,6 +1000,16 @@ mod tests {
         .into();
         assert_eq!(edit_error_kind(&exists), Some(EditErrorKind::InvalidInput));
 
+        let type_err: anyhow::Error = crate::exit::TypeErrorError {
+            msg: "parent is an array, not an object".into(),
+        }
+        .into();
+        assert_eq!(
+            edit_error_kind(&type_err),
+            Some(EditErrorKind::TypeError),
+            "TypeErrorError must not collapse to InvalidInput (#1883)"
+        );
+
         let format_failed: anyhow::Error =
             crate::exit::FormatFailedError::new("format command failed").into();
         assert_eq!(
@@ -1001,6 +1029,12 @@ mod tests {
         // Intermediate .context() must not hide the typed kind.
         let wrapped = invalid.context("operation 1 (replace) failed");
         assert_eq!(edit_error_kind(&wrapped), Some(EditErrorKind::InvalidInput));
+
+        let type_wrapped = type_err.context("operation 1 (doc.set) failed");
+        assert_eq!(
+            edit_error_kind(&type_wrapped),
+            Some(EditErrorKind::TypeError)
+        );
 
         let plain = anyhow::anyhow!("plain error");
         assert_eq!(edit_error_kind(&plain), None);

--- a/src/files.rs
+++ b/src/files.rs
@@ -51,10 +51,18 @@ pub fn is_binary(data: &[u8]) -> bool {
 }
 
 /// Returns whether the file at `path` appears to be binary by reading only its
-/// first 8 KiB (streaming, no full allocation for large files). Returns false
-/// on open/read errors (the subsequent content read will surface the real error).
-#[cfg(any(test, feature = "cli"))]
-pub(crate) fn is_binary_file(path: &Path) -> bool {
+/// first 8 KiB (streaming, no full allocation for large files).
+///
+/// Heuristic: true when a NUL byte appears in the probe window (same rule as
+/// [`is_binary`]). Returns **false** if the path cannot be opened or read
+/// (missing, permission, …); callers that need a typed open error should open
+/// the path themselves.
+///
+/// Public for embedder preflight (#1884) so hosts do not reimplement the
+/// window size or probe semantics. Writers still enforce binary themselves.
+/// Available with default features and under `features = ["files"]` (always
+/// compiled; no `cli` gate).
+pub fn is_binary_file(path: &Path) -> bool {
     let mut file = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(_) => return false,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! - [`containment`] -- workspace path guard (flexible `AbsolutePathPolicy` via builder for temp dirs/extra roots in library use; strict `Reject` for MCP)
 //! - [`exec`] -- shell command execution with process-tree management
 //! - [`fallback`] -- multi-strategy edit recovery (exact, anchor, similarity)
-//! - [`files`] -- `is_binary`, `read_text_file`, and (with "files" feature) parallel scanning helpers
+//! - [`files`] -- `is_binary`, `is_binary_file` (#1884 path preflight), `read_text_file`, and (with "files" feature) parallel scanning helpers
 //! - [`write`] -- atomic file writes with write-policy transformations
 //!
 //! With "files" feature you also get `api::search_directory`, `api::execute_plan`,
@@ -87,7 +87,8 @@
 //! Fail-closed text edits for agent hosts (#1492): set `ReplaceOptions.require_change = true`
 //! so zero matches become `EditErrorKind::NoMatch` (not `Ok(changed=false)`). Match kinds via
 //! `api::edit_error_kind(&err)` without scraping English. That helper also peels CLI/tx typed
-//! errors (`InvalidInputError` for empty patterns / bad regex, `NoMatchError`, …) so hosts
+//! errors (`InvalidInputError` for empty patterns / bad regex, `NoMatchError`,
+//! `TypeErrorError` → `EditErrorKind::TypeError` for multi-doc bare keys (#1883), …) so hosts
 //! need not know which construction path produced the failure. Example:
 //!
 //! ```rust,no_run
@@ -168,7 +169,8 @@
 //! );
 //! ```
 //!
-//! The `files` module (pure helpers like `is_binary`, `read_text_file`, and scanning tools when "files" feature enabled) is always available.
+//! The `files` module (pure helpers like `is_binary`, `is_binary_file` path preflight,
+//! `read_text_file`, and scanning tools when "files" feature enabled) is always available.
 //! The `cli` and `cmd` modules require the `cli` feature.
 //!
 //! For pure library use with plans and execution (post #792), prefer


### PR DESCRIPTION
## Summary

Closes #1883.
Closes #1884.

Bline (and other crate embedders) map `edit_error_kind` into agent tool errors. After multi-doc honesty, CLI already emits `error_kind: type_error`, but the library collapsed `TypeErrorError` into `EditErrorKind::InvalidInput`. Binary path preflight also required reimplementing the 8 KiB NUL probe.

### #1883
- Add `EditErrorKind::TypeError` (`type_error` in Display/serde)
- `classify_error` / `edit_error_kind` peel `TypeErrorError` to TypeError
- Empty pattern / AlreadyExists remain InvalidInput

### #1884
- `files::is_binary_file` is `pub` (was `pub(crate)` + cli/test cfg)
- Same semantics: text false, NUL true, open fail false
- Document for embedder preflight under default and `files` feature

## Test plan

- [x] Unit: classify/edit_error_kind TypeError + InvalidInput sibling
- [x] API: multi-doc doc_get/doc_set bare key → TypeError
- [x] is_binary_file unit tests
- [x] `cargo test --no-default-features --features "ast,files"` for both
- [x] `make check-fast`