### PR TITLE
fix: treat CR/CRLF as whole-line insert boundaries

### DIFF
--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -155,8 +155,7 @@ pub fn explicit_multi_path_binary_refused(
                 cwd.join(raw)
             }
         };
-        // Use ensure_not_binary_file (not is_binary_file) so this works under
-        // --features files without the cli-only is_binary_file cfg.
+        // Path preflight via ensure_not_binary_file (typed InvalidInput on NUL).
         if path.is_file() && ensure_not_binary_file(&path, p).is_err() {
             // Keep the user-facing path string (CLI arg), not only the abs path.
             refused.push(PathRefused {

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -225,6 +225,9 @@ fn looks_like_new_line_payload(insert_content: &str) -> bool {
 
 /// True when every occurrence of `anchor` is alone on its line (bounded by
 /// newlines / file edges). Empty content or empty anchor → false.
+///
+/// Accepts LF, CRLF, and bare CR as line boundaries so whole-line bare
+/// inserts on Windows-style files still line-orient (#1885 follow-up).
 pub fn anchor_is_whole_line(file_content: &str, anchor: &str) -> bool {
     if anchor.is_empty() || file_content.is_empty() {
         return false;
@@ -233,14 +236,20 @@ pub fn anchor_is_whole_line(file_content: &str, anchor: &str) -> bool {
     let mut any = false;
     for (i, _) in file_content.match_indices(anchor) {
         any = true;
-        let before_ok = i == 0 || bytes[i - 1] == b'\n';
+        let before_ok = i == 0 || is_line_boundary_byte(bytes[i - 1]);
         let end = i + anchor.len();
-        let after_ok = end == file_content.len() || bytes.get(end) == Some(&b'\n');
+        let after_ok =
+            end == file_content.len() || bytes.get(end).copied().is_some_and(is_line_boundary_byte);
         if !(before_ok && after_ok) {
             return false;
         }
     }
     any
+}
+
+#[inline]
+fn is_line_boundary_byte(b: u8) -> bool {
+    b == b'\n' || b == b'\r'
 }
 
 /// Build the replacement string for replace / insert modes.

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -190,6 +190,27 @@ mod replace_tests {
         }
 
         #[test]
+        fn normalize_line_insert_after_whole_line_crlf_bare_payload() {
+            // CRLF after anchor must still count as a line boundary.
+            let file = "alpha\r\n";
+            assert!(
+                anchor_is_whole_line(file, "alpha"),
+                "CRLF-terminated line should be whole-line"
+            );
+            let out = normalize_line_insert(file, "alpha", "beta", InsertSide::After);
+            assert_eq!(out, "\nbeta");
+        }
+
+        #[test]
+        fn normalize_line_insert_after_whole_line_bare_cr() {
+            let file = "alpha\rbeta\r";
+            // "alpha" is alone before CR; "beta" alone before CR.
+            assert!(anchor_is_whole_line(file, "alpha"));
+            let out = normalize_line_insert(file, "alpha", "x", InsertSide::After);
+            assert_eq!(out, "\nx");
+        }
+
+        #[test]
         fn normalize_line_insert_after_midline_stays_byte_exact() {
             let file = "prefix foo suffix\n";
             let out = normalize_line_insert(file, "foo", "X", InsertSide::After);


### PR DESCRIPTION
## Summary

Follow-up to #1885 (reviewer finding on #1883/#1884/#1885 pass).

`anchor_is_whole_line` only treated `\\n` as a boundary, so on CRLF files a bare whole-line `insert_after` still glued (`alpha` + `beta` → `alphabeta\\r\\n`). Indent/comment payloads still worked via the payload heuristic.

### Changes
- Accept `\\r` and `\\n` as line boundaries for whole-line detection
- Unit tests: CRLF and bare CR whole-line bare insert
- Stale `ops/file.rs` comment after #1884

## Test plan

- [x] `cargo test --lib normalize_line` (7 tests)
- [x] Local unit gate for the module