### PR TITLE
fix: preserve file EOL in line-oriented insert separators

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1651,6 +1651,50 @@ fn replace_text_insert_after() {
 }
 
 #[test]
+fn replace_text_insert_after_preserves_crlf() {
+    // fixrealloop: whole-line insert into CRLF files must use \r\n, not bare LF.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("win.txt");
+    fs::write(&file, "line1\r\nTARGET\r\nline3\r\n").unwrap();
+
+    let opts = ReplaceOptions {
+        insert_after: Some("// post".to_string()),
+        ..ReplaceOptions::default()
+    };
+    let result = replace_text(&file, "TARGET", "", &opts, ApplyMode::Apply, None).unwrap();
+    assert!(result.changed);
+    assert!(result.applied);
+    let on_disk = fs::read(&file).unwrap();
+    assert_eq!(
+        on_disk,
+        b"line1\r\nTARGET\r\n// post\r\nline3\r\n",
+        "insert_after must preserve CRLF separators: {:?}",
+        String::from_utf8_lossy(&on_disk)
+    );
+}
+
+#[test]
+fn replace_text_insert_before_preserves_crlf() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("win.txt");
+    fs::write(&file, "A\r\nB\r\n").unwrap();
+
+    let opts = ReplaceOptions {
+        insert_before: Some("PRE".to_string()),
+        ..ReplaceOptions::default()
+    };
+    let result = replace_text(&file, "B", "", &opts, ApplyMode::Apply, None).unwrap();
+    assert!(result.changed);
+    let on_disk = fs::read(&file).unwrap();
+    assert_eq!(
+        on_disk,
+        b"A\r\nPRE\r\nB\r\n",
+        "insert_before must preserve CRLF: {:?}",
+        String::from_utf8_lossy(&on_disk)
+    );
+}
+
+#[test]
 fn replace_text_insert_after_midline_bare() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("code.rs");

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -175,44 +175,71 @@ pub enum InsertSide {
 /// mid-line inserts (e.g. `"X"` after `"foo"` inside a line) are unchanged.
 ///
 /// Rules (from Bline host glue, now product default):
-/// - insert_after: prepend `\\n` when the payload looks like a new line, or
-///   every occurrence of `anchor` is alone on its line, unless the payload
-///   already starts with `\\n` or the anchor ends with `\\n`.
-/// - insert_before: append `\\n` under the same conditions (so the anchor
-///   stays on the next line), unless the payload already ends with `\\n`
-///   or the anchor starts with `\\n`.
+/// - insert_after: prepend a line ending when the payload looks like a new
+///   line, or every occurrence of `anchor` is alone on its line, unless the
+///   payload already starts with a line ending or the anchor ends with one.
+/// - insert_before: append a line ending under the same conditions (so the
+///   anchor stays on the next line), unless the payload already ends with a
+///   line ending or the anchor starts with one.
+///
+/// The separator matches the file's dominant line ending (CRLF / bare CR /
+/// LF) so Windows-style files do not get mixed LF inserts (fixrealloop).
 pub fn normalize_line_insert(
     file_content: &str,
     anchor: &str,
     insert_content: &str,
     side: InsertSide,
 ) -> String {
+    let eol = preferred_line_ending(file_content);
     match side {
         InsertSide::After => {
-            if insert_content.starts_with('\n') || anchor.ends_with('\n') {
+            if starts_with_line_ending(insert_content) || ends_with_line_ending(anchor) {
                 return insert_content.to_string();
             }
             if looks_like_new_line_payload(insert_content)
                 || anchor_is_whole_line(file_content, anchor)
             {
-                format!("\n{insert_content}")
+                format!("{eol}{insert_content}")
             } else {
                 insert_content.to_string()
             }
         }
         InsertSide::Before => {
-            if insert_content.ends_with('\n') || anchor.starts_with('\n') {
+            if ends_with_line_ending(insert_content) || starts_with_line_ending(anchor) {
                 return insert_content.to_string();
             }
             if looks_like_new_line_payload(insert_content)
                 || anchor_is_whole_line(file_content, anchor)
             {
-                format!("{insert_content}\n")
+                format!("{insert_content}{eol}")
             } else {
                 insert_content.to_string()
             }
         }
     }
+}
+
+/// Dominant line ending in `content` for line-oriented insert separators.
+///
+/// Prefer CRLF when present, else bare CR, else LF. Empty content uses LF.
+pub fn preferred_line_ending(content: &str) -> &'static str {
+    if content.contains("\r\n") {
+        "\r\n"
+    } else if content.contains('\r') {
+        "\r"
+    } else {
+        "\n"
+    }
+}
+
+#[inline]
+fn starts_with_line_ending(s: &str) -> bool {
+    s.starts_with("\r\n") || s.starts_with('\n') || s.starts_with('\r')
+}
+
+#[inline]
+fn ends_with_line_ending(s: &str) -> bool {
+    s.ends_with("\r\n") || s.ends_with('\n') || s.ends_with('\r')
 }
 
 fn looks_like_new_line_payload(insert_content: &str) -> bool {

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -191,14 +191,22 @@ mod replace_tests {
 
         #[test]
         fn normalize_line_insert_after_whole_line_crlf_bare_payload() {
-            // CRLF after anchor must still count as a line boundary.
+            // CRLF after anchor must still count as a line boundary, and the
+            // separator must be CRLF so the file does not get mixed LF (fixrealloop).
             let file = "alpha\r\n";
             assert!(
                 anchor_is_whole_line(file, "alpha"),
                 "CRLF-terminated line should be whole-line"
             );
             let out = normalize_line_insert(file, "alpha", "beta", InsertSide::After);
-            assert_eq!(out, "\nbeta");
+            assert_eq!(out, "\r\nbeta");
+        }
+
+        #[test]
+        fn normalize_line_insert_before_whole_line_crlf() {
+            let file = "A\r\nB\r\n";
+            let out = normalize_line_insert(file, "B", "PRE", InsertSide::Before);
+            assert_eq!(out, "PRE\r\n");
         }
 
         #[test]
@@ -207,7 +215,15 @@ mod replace_tests {
             // "alpha" is alone before CR; "beta" alone before CR.
             assert!(anchor_is_whole_line(file, "alpha"));
             let out = normalize_line_insert(file, "alpha", "x", InsertSide::After);
-            assert_eq!(out, "\nx");
+            assert_eq!(out, "\rx");
+        }
+
+        #[test]
+        fn preferred_line_ending_prefers_crlf() {
+            assert_eq!(preferred_line_ending("a\r\nb\n"), "\r\n");
+            assert_eq!(preferred_line_ending("a\rb\r"), "\r");
+            assert_eq!(preferred_line_ending("a\nb\n"), "\n");
+            assert_eq!(preferred_line_ending(""), "\n");
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Line-oriented `insert_before` / `insert_after` (`normalize_line_insert`, #1885) always used bare LF as the separator when placing the payload on its own line. On CRLF (and bare-CR) files that mixed endings:

```
# before (buggy)
line1\r\nTARGET\n// post\r\nline3\r\n

# after
line1\r\nTARGET\r\n// post\r\nline3\r\n
```

## Fix

- Add `preferred_line_ending` (CRLF if present, else bare CR, else LF)
- Use it when prepending/appending the line separator in `normalize_line_insert`
- Treat `\r\n` / `\r` / `\n` as already-present line endings on payload and anchor

## Found by

fixrealloop Round 1 (CLI dogfood after #1888–#1891): whole-line insert into CRLF fixtures.

## Test plan

- [x] Unit: `normalize_line_insert_*_crlf`, bare CR, `preferred_line_ending`
- [x] API apply: `replace_text_insert_after/before_preserves_crlf` (on-disk bytes)
- [x] `make check-fast`
- [x] Release binary re-dogfood S26/S27 + LF still OK