### PR TITLE
fix: refuse sole binary on MCP/tx path replace

### DIFF
--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -349,6 +349,56 @@ fn file_prepend_rejects_binary_file() {
     assert_eq!(std::fs::read(&file).unwrap(), b"hello\x00world");
 }
 
+/// Sole-path replace must refuse binary (NUL) files; MCP/tx used to rewrite them.
+#[test]
+fn replace_rejects_sole_binary_file() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.bin");
+    std::fs::write(&file, b"hello\x00world").unwrap();
+
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+
+    let op = Operation::Replace {
+        glob: None,
+        path: Some("data.bin".into()),
+        regex: false,
+        old: "hello".into(),
+        new_text: Some("HELLO".into()),
+        nth: None,
+        insert_before: None,
+        insert_after: None,
+        case_insensitive: false,
+        multiline: false,
+        if_exists: false,
+        whole_line: false,
+        range: None,
+        word_boundary: false,
+        before_context: None,
+        after_context: None,
+        unique: false,
+        require_change: false,
+        command_position: false,
+        fuzzy: false,
+        min_fuzzy_score: None,
+        allow_absent_old: false,
+    };
+    let err = crate::tx::replace_op::execute_replace_op(&op, &mut tx).unwrap_err();
+    assert!(
+        crate::exit::is_invalid_input(&err),
+        "expected InvalidInputError, got: {err:#}"
+    );
+    assert!(
+        err.to_string().contains("binary file"),
+        "message should name binary: {err}"
+    );
+    assert!(
+        f.pending.is_empty() && f.write_targets.is_empty(),
+        "must not stage a write for binary replace"
+    );
+    assert_eq!(std::fs::read(&file).unwrap(), b"hello\x00world");
+}
+
 /// file.create through a path component that is a file must fail with
 /// InvalidInputError before staging (no bare tempfile / false backup).
 #[test]

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -210,6 +210,10 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
 
     if let Some(p) = path {
         let file_path = tx.cwd.join(p);
+        // Sole explicit path: refuse binary with invalid_input (CLI replace
+        // parity). `read_to_string` accepts NUL as UTF-8 and used to rewrite
+        // binaries as text via MCP/tx (fixrealloop MCP dogfood).
+        crate::ops::file::ensure_not_binary_file(&file_path, p)?;
         // CLI `replace --if-exists` soft-skips missing paths (`skipped[]`).
         // Plan/batch must match: without if_exists, missing paths stay hard
         // `not_found` (#1793). With if_exists, missing is a soft success so

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -4260,3 +4260,193 @@ async fn test_mcp_ast_imports_list_only() {
     );
     client.cancel().await.unwrap();
 }
+
+// --- fixrealloop / MCP dogfood (agent-shaped replace insert + multi-doc) ---
+
+/// MCP `replace_text` insert_after is line-oriented by default (#1885).
+#[tokio::test]
+async fn test_mcp_replace_text_insert_after_line_oriented() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("code.rs"), "fn process_data() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "code.rs",
+            "old": "fn process_data() {}",
+            "insert_after": "    // after body"
+        }),
+    )
+    .await;
+    assert!(!is_error, "replace_text insert_after should succeed: {val}");
+    assert_eq!(val["ok"], true, "insert_after ok: {val}");
+    let content = fs::read_to_string(dir.path().join("code.rs")).unwrap();
+    assert!(
+        content.contains("fn process_data() {}\n    // after body"),
+        "line-oriented insert_after: {content}"
+    );
+    assert!(
+        !content.contains("fn process_data() {}    // after body"),
+        "must not glue comment onto line: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// MCP insert_after on CRLF files must keep CRLF separators (#1892).
+#[tokio::test]
+async fn test_mcp_replace_text_insert_after_preserves_crlf() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("win.txt"), b"line1\r\nTARGET\r\nline3\r\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "win.txt",
+            "old": "TARGET",
+            "insert_after": "// post"
+        }),
+    )
+    .await;
+    assert!(!is_error, "CRLF insert_after should succeed: {val}");
+    let on_disk = fs::read(dir.path().join("win.txt")).unwrap();
+    assert_eq!(
+        on_disk,
+        b"line1\r\nTARGET\r\n// post\r\nline3\r\n",
+        "MCP insert_after must preserve CRLF: {:?}",
+        String::from_utf8_lossy(&on_disk)
+    );
+    client.cancel().await.unwrap();
+}
+
+/// Multi-doc bare key via MCP peels to type_error (#1883).
+#[tokio::test]
+async fn test_mcp_doc_get_multi_doc_bare_key_type_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("multi.yaml"),
+        "---\nname: a\n---\nname: b\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_get",
+        serde_json::json!({"path": "multi.yaml", "selector": "name"}),
+    )
+    .await;
+    assert!(
+        is_error || val["ok"] == false,
+        "bare multi-doc key should fail: {val}"
+    );
+    let text = val.to_string();
+    assert!(
+        text.contains("type_error") || text.contains("TypeError") || text.contains("multi"),
+        "expect type_error envelope: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// Multi-doc indexed selector works over MCP.
+#[tokio::test]
+async fn test_mcp_doc_get_multi_doc_indexed_selector() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("multi.yaml"),
+        "---\nname: a\n---\nname: b\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_get",
+        serde_json::json!({"path": "multi.yaml", "selector": "0.name"}),
+    )
+    .await;
+    assert!(!is_error, "0.name should succeed: {val}");
+    // doc_get may return bare value or envelope with value field
+    let s = val.to_string();
+    assert!(
+        s.contains("\"a\"") || val == "a" || val.get("value") == Some(&serde_json::json!("a")),
+        "expected name a: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// execute_plan insert_after is line-oriented over MCP.
+#[tokio::test]
+async fn test_mcp_execute_plan_insert_after_line_oriented() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("t.txt"), "alpha\nbeta\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": "t.txt",
+            "old": "beta",
+            "insert_after": "// next"
+        }]
+    });
+    let (is_error, val) =
+        call_tool_value(&client, "execute_plan", serde_json::json!({"plan": plan})).await;
+    assert!(!is_error, "execute_plan insert_after should succeed: {val}");
+    let content = fs::read_to_string(dir.path().join("t.txt")).unwrap();
+    assert!(
+        content.contains("// next") && !content.contains("beta// next"),
+        "plan insert_after line-oriented: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// Sole binary path via MCP replace_text is invalid_input / binary, not silent.
+#[tokio::test]
+async fn test_mcp_replace_text_sole_binary_refused() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bin.dat"), b"hello\x00world").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "bin.dat",
+            "old": "hello",
+            "new": "HELLO"
+        }),
+    )
+    .await;
+    assert!(
+        is_error || val["ok"] == false,
+        "sole binary should fail: {val}"
+    );
+    let text = val.to_string().to_lowercase();
+    assert!(
+        text.contains("binary") || text.contains("invalid_input"),
+        "binary/invalid_input kind: {val}"
+    );
+    client.cancel().await.unwrap();
+}


### PR DESCRIPTION
## Summary

MCP dogfood found a real CLI/MCP honesty gap: **sole binary** `replace_text` / tx `replace` applied successfully while CLI returned `invalid_input` and left the file untouched.

Root cause: single-path replace loaded content with `read_to_string`. Bytes with embedded NUL are valid UTF-8, so the engine rewrote binaries as text. Glob/walk paths already soft-skip via `read_and_probe`.

## Fix

- Call `ensure_not_binary_file` on the explicit path before `read_file_content` in `tx/replace_op.rs`
- Unit test: `replace_rejects_sole_binary_file`
- MCP integration dogfood: insert_after line-orient, CRLF insert, multi-doc type_error + `0.name`, execute_plan insert_after, sole binary refuse

## Found by

fixrealloop MCP testing against the stdio server (integration harness). Ad-hoc Python client hung on framing; project `rmcp` client is the reliable path.

## Test plan

- [x] `cargo test --test integration --all-features test_mcp_replace_text_sole_binary`
- [x] Other new MCP dogfood tests green
- [x] `make check-fast`