### PR TITLE
fix: finish text I/O honesty Strict/SoftSkip loaders

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1986,7 +1986,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2396,7 +2396,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2537,13 +2537,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3094,7 +3095,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1333,6 +1333,7 @@ The operations below are the building blocks inside `operations`.
 | Fail-closed text replace | `ReplaceOptions.require_change` + `edit_error_kind` / `classify_error` |
 | Non-`anyhow` error kinds | `classify_error(&dyn Error)` / `classify_error_ref` (#1659); `EditErrorKind::FormatFailed` for post-write hooks; `EditErrorKind::TypeError` for multi-doc / wrong-root doc navigation (CLI `error_kind: type_error`; #1883) |
 | Path binary preflight | `files::is_binary_file` (8 KiB NUL probe; open fail → false; #1884); writers still enforce binary on apply |
+| Text I/O honesty | Sole path: `files::load_text_strict` (binary / invalid UTF-8 → `InvalidInput`); walks: `read_text_file` / `read_and_probe` soft-skip; byte rule `classify_text_bytes` (#1894) |
 | Line-oriented insert | `insert_before` / `insert_after` default (#1885): newline when payload looks like a new line or anchor is whole-line; mid-line bare stays byte-exact |
 | Shell token rename | `ReplaceOptions.command_position` / `ContentEdit::Replace` (#1666) |
 | Scoped symbol replace (literal/regex) | `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (#1658) |

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -5,8 +5,6 @@
 
 use std::path::Path;
 
-use anyhow::Context;
-
 use crate::containment::PathGuard;
 use crate::plan::Operation;
 
@@ -65,8 +63,8 @@ fn patch_write(
         // Apply to the first file in the patch.
         let pf = &patch_files[0];
         let file_path = cwd.join(&pf.path);
-        let original = std::fs::read_to_string(&file_path)
-            .with_context(|| format!("failed to read {}", file_path.display()))?;
+        // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+        let original = crate::files::load_text_strict(&file_path, &pf.path)?;
 
         let new_content = ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
             if e.contains("stale context") {
@@ -114,8 +112,8 @@ pub fn apply_patch_file(
     let mut results = Vec::new();
     for pf in &patch_files {
         let file_path = cwd.join(&pf.path);
-        let original = std::fs::read_to_string(&file_path)
-            .with_context(|| format!("failed to read {}", file_path.display()))?;
+        // Strict sole-path (#1894).
+        let original = crate::files::load_text_strict(&file_path, &pf.path)?;
 
         let new_content = crate::ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
             if e.contains("stale context") {

--- a/src/ast/deps.rs
+++ b/src/ast/deps.rs
@@ -34,7 +34,8 @@ pub fn extract_imports_from_file(path: &Path, lang_hint: Option<Language>) -> Ve
     if !lang.has_grammar() {
         return Vec::new();
     }
-    let Ok(source) = std::fs::read_to_string(path) else {
+    // SoftSkip multi-path (#1894): binary / invalid UTF-8 → empty.
+    let Some(source) = crate::files::read_text_file(path) else {
         return Vec::new();
     };
     extract_imports(&source, lang)

--- a/src/ast/impact.rs
+++ b/src/ast/impact.rs
@@ -39,7 +39,8 @@ pub fn compute_impact(
             if !lang.has_grammar() {
                 return None;
             }
-            let source = std::fs::read_to_string(path).ok()?;
+            // SoftSkip multi-path (#1894): binary / invalid UTF-8 → skip.
+            let source = crate::files::read_text_file(path)?;
             Some((path, display.as_str(), source, lang))
         })
         .collect();

--- a/src/ast/map.rs
+++ b/src/ast/map.rs
@@ -65,7 +65,8 @@ pub fn generate_map(files: &[(impl AsRef<Path>, String)], opts: &MapOptions<'_>)
             if !lang.has_grammar() {
                 return None;
             }
-            let source = std::fs::read_to_string(path).ok()?;
+            // SoftSkip multi-path (#1894): binary / invalid UTF-8 → skip.
+            let source = crate::files::read_text_file(path)?;
             let symbols = extract_symbols(&source, lang);
             if symbols.is_empty() {
                 return None;

--- a/src/ast/refs.rs
+++ b/src/ast/refs.rs
@@ -148,7 +148,8 @@ pub fn find_refs_in_file(
     if !lang.has_grammar() {
         return Vec::new();
     }
-    let Ok(source) = std::fs::read_to_string(path) else {
+    // SoftSkip multi-path (#1894): binary / invalid UTF-8 → empty.
+    let Some(source) = crate::files::read_text_file(path) else {
         return Vec::new();
     };
     find_refs_in_source(&source, symbol_name, lang, display_path)

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -3,8 +3,6 @@
 
 use std::path::Path;
 
-use anyhow::Context;
-
 use super::{Language, parse_source};
 
 /// Node kinds that represent identifier tokens (rename targets).
@@ -89,8 +87,8 @@ pub fn rename_in_file(
     lang_hint: Option<Language>,
 ) -> anyhow::Result<Option<RenameResult>> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
-    let source =
-        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    let source = crate::files::load_text_strict(path, &path.display().to_string())?;
     Ok(rename_in_source(&source, old_name, new_name, lang))
 }
 

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -2,8 +2,6 @@
 
 use std::path::Path;
 
-use anyhow::Context;
-
 use super::Language;
 use super::symbols::{extract_symbols, find_symbol};
 
@@ -124,8 +122,8 @@ pub fn replace_in_symbol_file(
     if !lang.has_grammar() {
         return Ok(None);
     }
-    let source =
-        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    let source = crate::files::load_text_strict(path, &path.display().to_string())?;
     replace_in_symbol(&source, symbol_name, from, to, regex, lang)
 }
 

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -5,7 +5,6 @@
 
 use std::path::Path;
 
-use anyhow::Context;
 use serde::Serialize;
 
 use tree_sitter_lib::StreamingIterator;
@@ -111,8 +110,8 @@ pub fn search_file(
     if !lang.has_grammar() {
         return Ok(Vec::new());
     }
-    let source =
-        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    let source = crate::files::load_text_strict(path, &path.display().to_string())?;
     search_query(&source, query_str, lang, max_results)
 }
 

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -109,7 +109,8 @@ pub fn extract_symbols_from_file(path: &Path, lang_hint: Option<Language>) -> Ve
     if !lang.has_grammar() {
         return Vec::new();
     }
-    let Ok(source) = std::fs::read_to_string(path) else {
+    // SoftSkip multi-path (#1894): binary / invalid UTF-8 → empty.
+    let Some(source) = crate::files::read_text_file(path) else {
         return Vec::new();
     };
     extract_symbols(&source, lang)

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -2,7 +2,6 @@
 
 use std::path::Path;
 
-use anyhow::Context;
 use serde::Serialize;
 
 use super::{Language, parse_source};
@@ -54,8 +53,8 @@ pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result
             msg: format!("no grammar available for {lang}"),
         }));
     }
-    let source =
-        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    let source = crate::files::load_text_strict(path, &path.display().to_string())?;
     validate_source(&source, lang).ok_or_else(|| {
         anyhow::Error::new(crate::exit::ParseErrorError {
             msg: format!("failed to parse {}", path.display()),

--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -3,7 +3,6 @@
 use crate::ast::Language;
 use crate::ast::symbols::SymbolDef;
 use crate::cli::global::GlobalFlags;
-use anyhow::Context;
 use std::path::{Path, PathBuf};
 
 /// Resolve `--lang` hint to a `Language`, falling back to extension detection.
@@ -23,10 +22,9 @@ pub(super) fn setup_single_file(
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, [path_arg])?;
     let target = cwd.join(path_arg);
-    // Sole binary must not look like unsupported-language / missing-symbol.
-    crate::ops::file::ensure_not_binary_file(&target, path_arg)?;
+    // Strict sole-path text load (#1894): binary / invalid UTF-8 → InvalidInput.
+    let source = crate::files::load_text_strict(&target, path_arg)?;
     let lang = resolve_lang(lang_arg, &target);
-    let source = std::fs::read_to_string(&target).with_context(|| format!("reading {path_arg}"))?;
     Ok((cwd, target, lang, source))
 }
 

--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -28,9 +28,10 @@ pub(super) fn setup_single_file(
     Ok((cwd, target, lang, source))
 }
 
-/// When the user names exactly one file path that is binary, fail as
-/// `invalid_input` (parity with replace/search/tidy/md). Directory walks still
-/// soft-skip non-source files.
+/// When the user names exactly one file path, fail closed as `invalid_input` for
+/// binary or invalid UTF-8 (parity with replace/search/tidy/md / #1894).
+/// Directory walks still soft-skip non-text files. IO/missing errors are left
+/// to the walk (return `Ok` here).
 pub(super) fn reject_sole_explicit_binary(
     paths: &[PathBuf],
     path_arg: &str,
@@ -38,7 +39,18 @@ pub(super) fn reject_sole_explicit_binary(
     if paths.len() != 1 {
         return Ok(());
     }
-    crate::ops::file::ensure_not_binary_file(&paths[0], path_arg)
+    match crate::files::load_text_strict(&paths[0], path_arg) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
+                Err(crate::exit::InvalidInputError {
+                    msg: inv.msg.clone(),
+                })
+            } else {
+                Ok(())
+            }
+        }
+    }
 }
 
 /// Common preamble for multi-file AST commands: resolve cwd, join path, resolve

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -53,24 +53,10 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
     let old = args.old.as_str();
     let new = args.new.as_str();
     let lang_cli = args.lang.clone();
-    // Surface the first IO error (same as sequential pre-scan); do not hide
-    // unreadable files as soft no-matches.
-    let read_errors = std::sync::Mutex::new(Vec::<anyhow::Error>::new());
     let operations: Vec<Operation> = crate::par_process_files(&paths, None, &[], |path| {
-        // Directory walks soft-skip binaries (no refused[] expansion).
-        if crate::ops::file::ensure_not_binary_file(path, &path.display().to_string()).is_err() {
-            return None;
-        }
+        // SoftSkip walk (#1894): binary / invalid UTF-8 / unreadable → skip.
+        let source = crate::files::read_text_file(path)?;
         let lang = resolve_lang(lang_hint, path);
-        let source = match std::fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(e) => {
-                if let Ok(mut guard) = read_errors.lock() {
-                    guard.push(anyhow::anyhow!("reading {}: {e}", path.display()));
-                }
-                return None;
-            }
-        };
 
         // Check if this file has any matches (AST or word-boundary fallback).
         let has_match = if lang.has_grammar() {
@@ -101,11 +87,6 @@ pub(super) fn run_rename(args: RenameArgs, global: &GlobalFlags) -> anyhow::Resu
             lang: lang_cli.clone(),
         })
     });
-    if let Ok(mut errs) = read_errors.into_inner()
-        && let Some(e) = errs.drain(..).next()
-    {
-        return Err(e);
-    }
 
     if operations.is_empty() {
         let msg = format!("symbol '{}' not found in {}", args.old, args.path);

--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -194,9 +194,13 @@ pub(super) fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Re
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, [&args.path])?;
     let target = cwd.join(&args.path);
-    if let Err(err) = crate::ops::file::ensure_not_binary_file(&target, &args.path) {
-        global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
-        return Ok(exit::FAILURE);
+    // Strict sole-path preflight (#1894); engine also loads via load_text_strict.
+    if let Err(e) = crate::files::load_text_strict(&target, &args.path) {
+        if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
+            global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
+            return Ok(exit::FAILURE);
+        }
+        return Err(e);
     }
 
     let op = Operation::AstReplace {

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -9,7 +9,6 @@ use super::common::{
 use crate::ast::symbols::{self, SymbolDef};
 use crate::cli::global::GlobalFlags;
 use crate::exit;
-use anyhow::Context;
 use clap::Args;
 
 #[derive(Debug, Args)]
@@ -52,12 +51,17 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
     let structured = global.json || global.jsonl;
 
     if target.is_file() {
-        // Binary before "unsupported language" so agents do not treat NUL files
-        // as a soft language miss (parity with replace/tidy/md).
-        if let Err(err) = crate::ops::file::ensure_not_binary_file(&target, &args.path) {
-            global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
-            return Ok(exit::FAILURE);
-        }
+        // Strict sole-path (#1894): binary / invalid UTF-8 before language miss.
+        let source = match crate::files::load_text_strict(&target, &args.path) {
+            Ok(s) => s,
+            Err(e) => {
+                if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
+                    global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
+                    return Ok(exit::FAILURE);
+                }
+                return Err(e);
+            }
+        };
         let lang = resolve_lang(lang_hint, &target);
         crate::verbose!("ast list: detected language={lang} for {}", args.path);
         if !lang.has_grammar() {
@@ -71,7 +75,7 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
             global.emit_error_json_kind(Some("no_matches"), &msg)?;
             return Ok(exit::NO_MATCHES);
         }
-        let symbols = symbols::extract_symbols_from_file(&target, Some(lang));
+        let symbols = symbols::extract_symbols(&source, lang);
         let filtered = filter_symbols(&symbols, &kind_filter);
         if !filtered.is_empty() {
             any_output = true;
@@ -788,7 +792,8 @@ pub(super) fn run_diff(args: DiffArgs, global: &GlobalFlags) -> anyhow::Result<u
     let new_source = if let Some(ref to_ref) = args.to {
         get_git_file_content(&cwd, &args.path, to_ref)?
     } else {
-        std::fs::read_to_string(&target).with_context(|| format!("reading {}", args.path))?
+        // Strict sole-path working tree (#1894).
+        crate::files::load_text_strict(&target, &args.path)?
     };
 
     let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -837,16 +837,20 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         std::io::read_to_string(std::io::stdin())?
     } else {
         let input_path = global.resolve_user_path(&args.input)?;
-        std::fs::read_to_string(&input_path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
+        // Strict sole-path input (#1894): binary / invalid UTF-8 → InvalidInput.
+        let display = input_path.display().to_string();
+        crate::files::load_text_strict(&input_path, &display).map_err(|e| {
+            if crate::exit::is_io_not_found(&e) {
                 std::io::Error::new(
                     std::io::ErrorKind::NotFound,
-                    format!("failed to read '{}': {e}", input_path.display()),
+                    format!("failed to read '{display}': {e}"),
                 )
                 .into()
+            } else if crate::exit::is_invalid_input(&e) {
+                e
             } else {
                 anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("failed to read '{}': {e}", input_path.display()),
+                    msg: format!("failed to read '{display}': {e}"),
                 })
             }
         })?

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -247,7 +247,8 @@ impl DocAction {
 }
 
 fn load_file(path: &str) -> anyhow::Result<serde_json::Value> {
-    let content = std::fs::read_to_string(path).with_context(|| format!("reading {path}"))?;
+    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    let content = crate::files::load_text_strict(std::path::Path::new(path), path)?;
     let format = detect_format(path)?;
     parse_doc(&content, &format).with_context(|| format!("parsing {path}"))
 }

--- a/src/cmd/explain/mod.rs
+++ b/src/cmd/explain/mod.rs
@@ -57,8 +57,18 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         };
         let full = global.resolve_user_path(p)?;
-        let content = match std::fs::read_to_string(&full) {
+        // Strict sole-path plan load (#1894).
+        let content = match crate::files::load_text_strict(&full, &full.display().to_string()) {
             Ok(c) => c,
+            Err(e) if crate::exit::is_io_not_found(&e) => {
+                let msg = format!("cannot read {}: {e}", full.display());
+                global.emit_error_json_kind(Some("not_found"), &msg)?;
+                return Ok(exit::FAILURE);
+            }
+            Err(e) if crate::exit::is_invalid_input(&e) => {
+                global.emit_error_json_kind(Some("invalid_input"), &e.to_string())?;
+                return Ok(exit::FAILURE);
+            }
             Err(e) => {
                 let msg = format!("cannot read {}: {e}", full.display());
                 global.emit_error_json_kind(Some("not_found"), &msg)?;

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -102,8 +102,14 @@ pub(super) fn handle_ast_read(
 
     let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
     let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
-    let source = std::fs::read_to_string(&target)
-        .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
+    // Strict sole-path text load (#1894): binary / invalid UTF-8 → invalid_params.
+    let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
+        if crate::exit::is_invalid_input(&e) {
+            McpError::invalid_params(e.to_string(), None)
+        } else {
+            McpError::internal_error(format!("reading {}: {e}", p.path), None)
+        }
+    })?;
     let all_symbols = crate::ast::symbols::extract_symbols(&source, lang);
     let sym = crate::ast::symbols::find_symbol(&all_symbols, &p.symbol).ok_or_else(|| {
         McpError::invalid_params(
@@ -166,19 +172,11 @@ pub(super) fn handle_ast_rename(
     let old = p.old.as_str();
     let new = p.new.as_str();
     let lang_cli = p.lang.clone();
-    let read_errors = std::sync::Mutex::new(Vec::<String>::new());
     let operations: Vec<crate::plan::Operation> =
         crate::par_process_files(&paths, None, &[], |path| {
+            // SoftSkip walk (#1894): binary / invalid UTF-8 / unreadable → skip.
+            let source = crate::files::read_text_file(path)?;
             let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
-            let source = match std::fs::read_to_string(path) {
-                Ok(s) => s,
-                Err(e) => {
-                    if let Ok(mut guard) = read_errors.lock() {
-                        guard.push(format!("reading {}: {e}", path.display()));
-                    }
-                    return None;
-                }
-            };
 
             let has_match = if lang.has_grammar() {
                 crate::ast::rename::rename_in_source(&source, old, new, lang)
@@ -207,11 +205,6 @@ pub(super) fn handle_ast_rename(
                 lang: lang_cli.clone(),
             })
         });
-    if let Ok(mut errs) = read_errors.into_inner()
-        && let Some(msg) = errs.drain(..).next()
-    {
-        return Err(McpError::internal_error(msg, None));
-    }
 
     if operations.is_empty() {
         return no_results("No matches found.");
@@ -537,8 +530,14 @@ pub(super) fn handle_ast_diff(
         crate::cmd::ast::get_git_file_content(&cwd, &p.path, to_ref)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?
     } else {
-        std::fs::read_to_string(&target)
-            .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?
+        // Strict sole-path (#1894): working-tree binary / invalid UTF-8.
+        crate::files::load_text_strict(&target, &p.path).map_err(|e| {
+            if crate::exit::is_invalid_input(&e) {
+                McpError::invalid_params(e.to_string(), None)
+            } else {
+                McpError::internal_error(format!("reading {}: {e}", p.path), None)
+            }
+        })?
     };
 
     let changes = crate::ast::diff::structural_diff(&old_source, &new_source, lang);
@@ -684,8 +683,14 @@ pub(super) fn handle_ast_imports(
         let target = cwd.join(&p.path);
         let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
-        let source = std::fs::read_to_string(&target)
-            .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
+        // Strict sole-path (#1894).
+        let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
+            if crate::exit::is_invalid_input(&e) {
+                McpError::invalid_params(e.to_string(), None)
+            } else {
+                McpError::internal_error(format!("reading {}: {e}", p.path), None)
+            }
+        })?;
         let imports = crate::ast::imports::list_imports(&source, lang);
         let obj = serde_json::json!({
             "file": p.path,

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -369,7 +369,8 @@ impl PatchloomService {
                 && p.after_context.is_none()
             {
                 let abs = svc.cwd().join(&p.path);
-                if let Ok(content) = std::fs::read_to_string(&abs) {
+                // Soft-or-preflight (#1894): skip non-text; engine still Strict.
+                if let Some(content) = crate::files::read_text_file(&abs) {
                     let to_str = p.new_text.as_deref().unwrap_or("");
                     let result = crate::fallback::validate_edit_nth(
                         &content,
@@ -485,8 +486,14 @@ impl PatchloomService {
         self.blocking(move |svc| {
             svc.check_path(&p.path)?;
             let abs = svc.cwd().join(&p.path);
-            let content = std::fs::read_to_string(&abs)
-                .map_err(|e| McpError::internal_error(format!("reading {}: {e}", p.path), None))?;
+            // Strict sole-path (#1894): binary / invalid UTF-8 → invalid_params.
+            let content = crate::files::load_text_strict(&abs, &p.path).map_err(|e| {
+                if crate::exit::is_invalid_input(&e) {
+                    McpError::invalid_params(e.to_string(), None)
+                } else {
+                    McpError::internal_error(format!("reading {}: {e}", p.path), None)
+                }
+            })?;
             let issues = crate::ops::md::lint_agents_content(&content);
             // Envelope matches CLI `md lint-agents --json` (#1854 / #1859).
             // Always tool success (isError=false); agents branch on ok / issue_count.
@@ -633,8 +640,13 @@ impl PatchloomService {
             } else if let Some(path) = &p.plan_path {
                 svc.check_path(path)?;
                 let abs = svc.cwd().join(path);
-                let content = std::fs::read_to_string(&abs).map_err(|e| {
-                    McpError::internal_error(format!("failed to read plan_path: {e}"), None)
+                // Strict sole-path plan load (#1894).
+                let content = crate::files::load_text_strict(&abs, path).map_err(|e| {
+                    if crate::exit::is_invalid_input(&e) {
+                        McpError::invalid_params(e.to_string(), None)
+                    } else {
+                        McpError::internal_error(format!("failed to read plan_path: {e}"), None)
+                    }
                 })?;
                 crate::plan::parse_plan_auto(&content, Some(path), None).map_err(|e| {
                     McpError::invalid_params(format!("failed to parse plan: {e}"), None)

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -381,12 +381,16 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let cwd = global.resolve_cwd()?;
             global.check_paths_contained(&cwd, [&file])?;
             let path = cwd.join(&file);
-            if let Err(err) = crate::ops::file::ensure_not_binary_file(&path, &file) {
-                global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
-                return Ok(exit::FAILURE);
-            }
-            let original =
-                std::fs::read_to_string(&path).with_context(|| format!("reading {file}"))?;
+            let original = match crate::files::load_text_strict(&path, &file) {
+                Ok(s) => s,
+                Err(e) => {
+                    if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
+                        global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
+                        return Ok(exit::FAILURE);
+                    }
+                    return Err(e).with_context(|| format!("reading {file}"));
+                }
+            };
             let (_new, removed) = dedupe_headings_in(&original);
 
             // Human / JSONL: one line (or item) per removed heading.
@@ -494,12 +498,16 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let cwd = global.resolve_cwd()?;
             global.check_paths_contained(&cwd, [&file])?;
             let path = cwd.join(&file);
-            if let Err(err) = crate::ops::file::ensure_not_binary_file(&path, &file) {
-                global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
-                return Ok(exit::FAILURE);
-            }
-            let content =
-                std::fs::read_to_string(&path).with_context(|| format!("reading {file}"))?;
+            let content = match crate::files::load_text_strict(&path, &file) {
+                Ok(s) => s,
+                Err(e) => {
+                    if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
+                        global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
+                        return Ok(exit::FAILURE);
+                    }
+                    return Err(e).with_context(|| format!("reading {file}"));
+                }
+            };
             let issues = lint_agents_content(&content);
 
             // --json: object envelope (tidy check parity, #1854). --jsonl: one
@@ -551,12 +559,16 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let cwd = global.resolve_cwd()?;
             global.check_paths_contained(&cwd, [&file])?;
             let path = cwd.join(&file);
-            if let Err(err) = crate::ops::file::ensure_not_binary_file(&path, &file) {
-                global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
-                return Ok(exit::FAILURE);
-            }
-            let content =
-                std::fs::read_to_string(&path).with_context(|| format!("reading {file}"))?;
+            let content = match crate::files::load_text_strict(&path, &file) {
+                Ok(s) => s,
+                Err(e) => {
+                    if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
+                        global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
+                        return Ok(exit::FAILURE);
+                    }
+                    return Err(e).with_context(|| format!("reading {file}"));
+                }
+            };
             match find_section(&content, &heading) {
                 None => {
                     let msg = format!("heading {:?} not found in {file}", heading);

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -259,7 +259,8 @@ fn similar_targets_for_no_match(
     }
     files.truncate(5);
     for f in files {
-        let Ok(content) = std::fs::read_to_string(&f) else {
+        // SoftSkip multi-path scan (#1894); binary/invalid UTF-8 skipped.
+        let Some(content) = crate::files::read_text_file(&f) else {
             continue;
         };
         let similar = crate::fallback::find_similar_targets(&content, &args.old, 3);
@@ -723,7 +724,8 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
         let range = parse_range_arg(args.range.as_deref())?;
         for path in &file_paths {
-            let Ok(content) = std::fs::read_to_string(path) else {
+            // SoftSkip multi-path (#1894).
+            let Some(content) = crate::files::read_text_file(path) else {
                 continue;
             };
             let total = count_nth_candidates(

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -305,16 +305,20 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let plan_path = plan_path
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("internal error: plan path missing"))?;
-        std::fs::read_to_string(plan_path).map_err(|e| {
-            if e.kind() == std::io::ErrorKind::NotFound {
+        // Strict sole-path plan load (#1894): binary / invalid UTF-8 → InvalidInput.
+        let display = plan_path.display().to_string();
+        crate::files::load_text_strict(plan_path, &display).map_err(|e| {
+            if crate::exit::is_io_not_found(&e) {
                 std::io::Error::new(
                     std::io::ErrorKind::NotFound,
-                    format!("failed to read plan file '{}': {e}", plan_path.display()),
+                    format!("failed to read plan file '{display}': {e}"),
                 )
                 .into()
+            } else if crate::exit::is_invalid_input(&e) {
+                e
             } else {
                 anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("failed to read plan file '{}': {e}", plan_path.display()),
+                    msg: format!("failed to read plan file '{display}': {e}"),
                 })
             }
         })?

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -120,18 +120,14 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                         .into());
                     }
                     tx.existed_before.insert(file_path.clone());
-                    // Try to read as text for strict rollback; fall back to
-                    // empty for binary files that cannot be represented as
-                    // UTF-8 (#1163).
-                    match std::fs::read_to_string(&file_path) {
-                        Ok(content) => {
-                            tx.pending
-                                .insert(file_path.clone(), (content.clone(), content));
-                        }
-                        Err(_) => {
-                            tx.pending
-                                .insert(file_path.clone(), (String::new(), String::new()));
-                        }
+                    // Soft text load for rollback snapshot: binary / invalid
+                    // UTF-8 / unreadable → empty pair (#1163 / #1894 SoftSkip).
+                    if let Some(content) = crate::files::read_text_file(&file_path) {
+                        tx.pending
+                            .insert(file_path.clone(), (content.clone(), content));
+                    } else {
+                        tx.pending
+                            .insert(file_path.clone(), (String::new(), String::new()));
                     }
                     false
                 }

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -182,7 +182,8 @@ pub(crate) fn snapshot_symbols(files: &[PathBuf], check: &VerifyCheck) -> Symbol
         // Single read: extract + attr filter share the same source so a failed
         // second open cannot zero out attrs while symbols still appear (TOCTOU /
         // unwrap_or_default soft-fail). Matches snapshot_symbols_from_pending.
-        let Ok(source) = std::fs::read_to_string(path) else {
+        // SoftSkip multi-path (#1894): binary / invalid UTF-8 → skip file.
+        let Some(source) = crate::files::read_text_file(path) else {
             continue;
         };
         let all_symbols = symbols::extract_symbols(&source, lang);
@@ -253,10 +254,10 @@ pub(crate) fn snapshot_symbols_from_pending(
             continue;
         }
 
-        // Use pending content (post-edit) if available, otherwise read from disk
+        // Use pending content (post-edit) if available, otherwise SoftSkip disk.
         let source = if let Some((_, current)) = pending.get(path) {
             current.clone()
-        } else if let Ok(s) = std::fs::read_to_string(path) {
+        } else if let Some(s) = crate::files::read_text_file(path) {
             s
         } else {
             continue;


### PR DESCRIPTION
## Summary

Complete the #1894 / #1895 text I/O honesty migration across remaining sole-path and multi-path readers so binary and invalid UTF-8 fail closed (`invalid_input`) on sole paths and soft-skip on walks, instead of `read_to_string` + ad-hoc NUL preflight.

### Changes

- **Strict sole-path** via `files::load_text_strict`:
  - CLI: `md` (dedupe/lint/table), `ast` setup/list/diff/replace preflight, `doc` load, `tx`/`batch`/`explain` plan input
  - MCP: AST read/imports/diff/rename walk, md lint-agents, plan_path
  - API: patch apply (+ multi-file)
  - AST lib: rename/replace/validate/search file loaders
- **SoftSkip multi-path** via `read_text_file`:
  - `ast rename` CLI + MCP, replace similar-targets / nth scan
  - AST map/impact/deps/refs/symbols file readers
  - tx verify snapshots and file-delete rollback snapshot
- Docs: embedder table row for text I/O honesty
- Lockfile: tokio-util 0.7.18 → 0.7.19

### Follow-up

- **#1896**: CLI `patch` apply/check still needs NotFound-aware Strict migration (API path done)

### Not in scope

- Release PR #1882 (hold until explicit yes)
- Dist B-path #632 / #960 / #961

## Test plan

- [x] `make check-fast` green locally
- [x] Existing sole-binary AST/MCP integration tests still pass
- [ ] CI full matrix green

Ref #1894
Ref #1895
Ref #1896