### PR TITLE
fix: sole invalid UTF-8 is invalid_input; patch binary kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3700%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3800%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -461,7 +461,7 @@ flowchart LR
 
 ## Status
 
-3700+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3800+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -477,16 +477,24 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 // The engine error from apply_patch_with_loader already includes
                 // "patch apply: <path> -- <detail>", so we add the STALE/MERGE
                 // FAILED label to match the original CLI format.
-                // Prefer typed ConflictsError; keep conflict(s) text fallback for
-                // any remaining untyped paths.
+                // Prefer typed kinds. Sole-path binary / invalid UTF-8 from
+                // load_text_strict must stay invalid_input (exit 1), not get
+                // STALE/ambiguous labels (fixrealloop 2026-07-21).
                 let (exit_code, kind) = if exit::is_conflicts(&e) || msg.contains("conflict(s)") {
                     (exit::CONFLICTS, "conflicts")
+                } else if exit::is_invalid_input(&e) {
+                    (exit::FAILURE, "invalid_input")
                 } else {
+                    // Ambiguous / stale context and remaining untyped errors.
                     (exit::AMBIGUOUS, "ambiguous")
                 };
-                // Inject the STALE/MERGE FAILED label between path and error detail.
-                let label = if merge_mode { "MERGE FAILED" } else { "STALE" };
-                let err = inject_stale_label(&msg, label);
+                let err = if kind == "ambiguous" {
+                    // Inject the STALE/MERGE FAILED label between path and detail.
+                    let label = if merge_mode { "MERGE FAILED" } else { "STALE" };
+                    inject_stale_label(&msg, label)
+                } else {
+                    msg
+                };
                 emit_error(global, &err, kind)?;
                 return Ok(exit_code);
             }

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -85,8 +85,13 @@ pub fn ensure_not_binary_file(
     Ok(())
 }
 
-/// When the user names exactly one existing file and it is binary, return that
-/// display path. Directory walks and multi-path lists still soft-skip binaries.
+/// When the user names exactly one existing file that is not valid text
+/// (binary NUL **or** invalid UTF-8), return `InvalidInput`.
+///
+/// Soft-skip walks still use [`crate::files::read_text_file`]; multi-path
+/// lists use soft-skip / `refused[]`. Sole explicit non-text must not report
+/// pattern `no_matches` or vacuous tidy "clean" (#1894 honesty; fixrealloop
+/// 2026-07-21 found sole invalid UTF-8 soft-skipped as `no_matches`).
 pub fn single_explicit_binary_target(
     paths: &[String],
     cwd: &Path,
@@ -109,7 +114,15 @@ pub fn single_explicit_binary_target(
     if !path.is_file() {
         return None;
     }
-    ensure_not_binary_file(&path, display).err()
+    // Full Strict sole-path rule (binary + invalid UTF-8), not binary-only.
+    match crate::files::load_text_strict(&path, display) {
+        Ok(_) => None,
+        Err(e) => e
+            .downcast_ref::<crate::exit::InvalidInputError>()
+            .map(|inv| crate::exit::InvalidInputError {
+                msg: inv.msg.clone(),
+            }),
+    }
 }
 
 /// Path soft-refused for non-pattern reasons (parity with replace/search `refused[]`).
@@ -321,6 +334,20 @@ mod tests {
             single_explicit_binary_target(&["t.txt".into(), "b.bin".into()], dir.path()).is_none()
         );
         assert!(single_explicit_binary_target(&[".".into()], dir.path()).is_none());
+    }
+
+    #[test]
+    fn single_explicit_rejects_invalid_utf8() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("bad.txt");
+        fs::write(&path, b"hello \xff world\n").unwrap();
+        let err = single_explicit_binary_target(&["bad.txt".into()], dir.path()).unwrap();
+        assert!(
+            err.msg.contains("UTF-8") || err.msg.contains("utf"),
+            "got: {}",
+            err.msg
+        );
+        assert!(err.msg.contains("bad.txt"), "got: {}", err.msg);
     }
 
     #[test]

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -758,6 +758,66 @@ fn test_replace_sole_binary_target_is_invalid_input() {
     );
 }
 
+/// Sole explicit invalid UTF-8 must be invalid_input, not pattern no_matches
+/// (soft-skip misreported as a miss; fixrealloop 2026-07-21).
+#[test]
+fn test_replace_sole_invalid_utf8_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bad.txt"), b"hello \xff world\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "--json", "replace", "hello", "bad.txt", "--new", "hi", "--apply", "--cwd",
+        ])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input", "{json}");
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("UTF-8") || err.contains("utf"),
+        "replace sole invalid UTF-8: {json}"
+    );
+    assert_eq!(
+        fs::read(dir.path().join("bad.txt")).unwrap(),
+        b"hello \xff world\n"
+    );
+}
+
+/// Sole tidy check on invalid UTF-8 must not report vacuous clean (exit 0).
+#[test]
+fn test_tidy_check_sole_invalid_utf8_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bad.txt"), b"line  \xff\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tidy", "check", "bad.txt", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input", "{json}");
+}
+
 #[test]
 fn test_tidy_check_sole_binary_is_invalid_input() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -928,3 +928,42 @@ fn test_patch_apply_json_applied_true() {
         "world\n"
     );
 }
+
+/// Binary target must refuse with invalid_input (exit 1), not STALE/ambiguous.
+/// Engine already load_text_strict; CLI error mapping was wrong (fixrealloop).
+#[test]
+fn test_patch_apply_binary_target_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bin_line.bin"), b"line one\x00line two\n").unwrap();
+    fs::write(
+        dir.path().join("p.patch"),
+        "--- a/bin_line.bin\n+++ b/bin_line.bin\n@@ -1 +1 @@\n-line one\n+line ONE\n",
+    )
+    .unwrap();
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["patch", "apply", "p.patch", "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(err.contains("binary"), "expected binary guidance, got: {v}");
+    assert!(
+        !err.contains("STALE"),
+        "must not STALE-label invalid_input: {v}"
+    );
+    assert_eq!(
+        fs::read(dir.path().join("bin_line.bin")).unwrap(),
+        b"line one\x00line two\n"
+    );
+}

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1084,6 +1084,36 @@ fn test_search_sole_explicit_binary_is_invalid_input() {
     assert!(err.contains("binary"), "expected binary guidance, got: {v}");
 }
 
+/// Sole explicit invalid UTF-8 must be invalid_input, not soft-skip no_matches.
+/// fixrealloop 2026-07-21.
+#[test]
+fn test_search_sole_invalid_utf8_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let bad = dir.path().join("bad.txt");
+    fs::write(&bad, b"needle \xff here\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "search", "needle"])
+        .arg(&bad)
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("UTF-8") || err.contains("utf"),
+        "expected UTF-8 guidance, got: {v}"
+    );
+}
+
 /// Explicit multi-path search must list binary co-paths in refused[] (parity
 /// with replace; agents otherwise assume every listed path was scanned).
 /// MPI 2026-07-20.


### PR DESCRIPTION
## Summary

Runtime dogfood (fixrealloop) found sole-path invalid UTF-8 soft-skipped as pattern `no_matches` (replace/search) or vacuous tidy "clean", while sole binary already returned `invalid_input`. Patch apply on binary targets refused correctly but reported `error_kind: ambiguous` with a STALE label.

### Fixes

- `single_explicit_binary_target` uses `load_text_strict` (binary **and** invalid UTF-8)
- CLI `patch apply` maps typed `InvalidInput` → exit 1 / `invalid_input` (no STALE injection)
- Regression tests for replace/search/tidy sole UTF-8 and patch binary target

### Related

- Ref #1894 / #1895 text I/O honesty
- Partial progress on #1896 (CLI patch binary kind fixed; full NotFound-aware check-path Strict still open)

## Test plan

- [x] `make check-fast` green
- [x] New integration tests for sole UTF-8 + patch binary
- [ ] CI full matrix green