### PR TITLE
fix: fail sole non-text before soft-skip scan log

### DIFF
--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -644,6 +644,12 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // outside the workspace while computing matches (precomputed write-path
     // guard remains defense-in-depth).
     global.check_paths_contained(&cwd, &args.paths)?;
+    // Sole non-text before soft-skip scan so stderr is not "skipping" then
+    // invalid_input (fixrealloop 2026-07-21).
+    if let Some(err) = crate::ops::file::single_explicit_binary_target(&args.paths, &cwd) {
+        global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+        return Ok(exit::FAILURE);
+    }
     let skipped = crate::files::scan_missing_entries(global, &cwd, &args.paths)?;
 
     // Context / pure fuzzy: route through the tx engine where the

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -479,8 +479,13 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::FAILURE);
     }
 
-    let results = collect_matches(&args, global)?;
     let cwd = global.resolve_cwd()?;
+    // Sole non-text before soft-skip scan (no "skipping" then invalid_input).
+    if let Some(err) = crate::ops::file::single_explicit_binary_target(&args.paths, &cwd) {
+        global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+        return Ok(exit::FAILURE);
+    }
+    let results = collect_matches(&args, global)?;
     let skipped = crate::files::scan_missing_entries(global, &cwd, &args.paths)?;
     let refused = explicit_binary_refused(&args, global, &cwd);
 

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -781,6 +781,11 @@ fn test_replace_sole_invalid_utf8_is_invalid_input() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("skipping"),
+        "sole non-text must not soft-skip first: {stderr}"
+    );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["error_kind"], "invalid_input", "{json}");
     let err = json["error"].as_str().unwrap_or("");

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1105,6 +1105,11 @@ fn test_search_sole_invalid_utf8_is_invalid_input() {
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !stderr.contains("skipping"),
+        "sole non-text must not soft-skip first: {stderr}"
+    );
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
     assert_eq!(v["error_kind"], "invalid_input", "{v}");
     let err = v["error"].as_str().unwrap_or("");


### PR DESCRIPTION
## Summary

Follow-up to #1898: sole invalid UTF-8 / binary already returned `invalid_input`, but replace/search still logged soft-skip "skipping … (invalid UTF-8)" before the hard fail. Fail closed **before** the soft walk.

## Test plan

- [x] Integration tests assert stderr has no `skipping` on sole invalid UTF-8
- [ ] CI green

Ref #1898