### PR TITLE
feat: library doc_merge selector and embedder text I/O surface

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -59,7 +59,10 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - CLI: `patchloom undo --list` walks nested `.patchloom/backups` under the cwd (#1695). Bare CLI undo is dry-run (exit 2); restore needs the write apply flag (see CLI agent-rules).
 - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`
 - Multi-doc / wrong-root doc navigation peels to `EditErrorKind::TypeError` via `edit_error_kind` / `classify_error` (CLI JSON `error_kind: type_error`; #1883). Do not collapse with `InvalidInput` (empty patterns, bad options, sole binary).
-- Path binary preflight: `files::is_binary_file` (8 KiB NUL probe; open fail → false; #1884)
+- Multi-doc `api::doc_merge(path, value, mode, guard, selector)`: pass `Some("0")` (or `"[0]"`) to merge into document 0; `None` is root-only and refuses a non-array overlay on multi-doc root with `TypeError` (#1909).
+- Path binary preflight: `api::is_binary_file` / `files::is_binary_file` (8 KiB NUL probe; open fail → false; #1884)
+- Sole-path text load for hosts: `api::load_text(path)` or `files::load_text_strict` (#1894, #1910)
+- `EditErrorKind` is `#[non_exhaustive]`; match with a wildcard arm (#1910)
 - Text I/O honesty (#1894):
 | Surface | Binary / invalid UTF-8 | Unreadable (IO) |
 |---------|------------------------|-----------------|

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -122,16 +122,50 @@ pub fn doc_delete(
     doc_write(op, path, mode, guard, "doc.delete")
 }
 
-/// Deep-merge a value into the root of a JSON, YAML, or TOML file.
+/// Deep-merge a value into a JSON, YAML, or TOML file.
+///
+/// When `selector` is [`None`], merges into the document root (single-document
+/// files). For multi-document YAML (top-level array of documents), pass
+/// `Some("0")` or `Some("[0]")` to merge into the first document without
+/// replacing the whole stream. Merging a non-array overlay into a multi-doc
+/// **root** returns [`crate::exit::TypeErrorError`] (peels to
+/// [`crate::fallback::EditErrorKind::TypeError`]).
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use patchloom::api::{self, ApplyMode};
+/// use std::path::Path;
+///
+/// // Root merge (single-doc JSON/YAML/TOML)
+/// let _ = api::doc_merge(
+///     Path::new("config.json"),
+///     serde_json::json!({"debug": true}),
+///     ApplyMode::Apply,
+///     None,
+///     None,
+/// )?;
+///
+/// // Multi-doc YAML: merge into document 0 only
+/// let _ = api::doc_merge(
+///     Path::new("stream.yaml"),
+///     serde_json::json!({"c": 3}),
+///     ApplyMode::Apply,
+///     None,
+///     Some("0"),
+/// )?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
 pub fn doc_merge(
     path: &Path,
     value: serde_json::Value,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
+    selector: Option<&str>,
 ) -> anyhow::Result<EditResult> {
     let op = Operation::DocMerge {
         path: path.to_string_lossy().into(),
-        selector: None,
+        selector: selector.map(|s| s.into()),
         value,
     };
     doc_write(op, path, mode, guard, "doc.merge")

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -80,6 +80,43 @@
 //! Backup sessions use unique directory names (nanosecond timestamp +
 //! monotonic counter), so concurrent `ApplyMode::Apply` calls never collide
 //! on backup directories.
+//!
+//! # Text I/O and multi-doc for embedders (#1894 / #1909 / #1910)
+//!
+//! Prefer these entry points instead of reimplementing binary / UTF-8 probes:
+//!
+//! - [`load_text`] / [`crate::files::load_text_strict`]: sole-path text load;
+//!   binary and invalid UTF-8 become `EditErrorKind::InvalidInput`
+//! - [`is_binary_file`]: cheap 8 KiB NUL preflight (open fail → `false`; use
+//!   `load_text` when you need a typed open error)
+//! - [`edit_error_kind`]: peel `TypeError` (multi-doc bare key / wrong root)
+//!   separately from `InvalidInput` (empty pattern, sole binary, …)
+//! - [`doc_merge`]: optional `selector` for multi-doc YAML (`Some("0")`)
+//!
+//! ```rust,no_run
+//! use patchloom::api::{self, edit_error_kind, EditErrorKind, ApplyMode};
+//! use std::path::Path;
+//!
+//! let path = Path::new("stream.yaml");
+//! if api::is_binary_file(path) {
+//!     // refuse before replace_text
+//! }
+//! match api::load_text(path) {
+//!     Ok(_text) => { /* safe to treat as agent-editable text */ }
+//!     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::InvalidInput)),
+//! }
+//! // Multi-doc merge into document 0 (not root wipe)
+//! let _ = api::doc_merge(
+//!     path,
+//!     serde_json::json!({"c": 3}),
+//!     ApplyMode::Apply,
+//!     None,
+//!     Some("0"),
+//! );
+//! ```
+//!
+//! `EditErrorKind` is `#[non_exhaustive]`; match with a wildcard arm so new
+//! honesty kinds can land in minor releases without breaking hosts.
 
 use std::path::Path;
 
@@ -97,6 +134,24 @@ pub use crate::tx::{
 
 mod doc;
 pub use self::doc::*;
+
+/// Load a path as agent-editable UTF-8 text (sole-path **Strict** policy).
+///
+/// Thin alias of [`crate::files::load_text_strict`] for hosts that follow
+/// `api::*` only (#1910). Binary and invalid UTF-8 return
+/// [`crate::exit::InvalidInputError`] (peels to [`EditErrorKind::InvalidInput`]).
+///
+/// Display string in errors is the path's lossy string form.
+pub fn load_text(path: &Path) -> anyhow::Result<String> {
+    let display = path.to_string_lossy();
+    crate::files::load_text_strict(path, &display)
+}
+
+/// Re-export of [`crate::files::is_binary_file`] for `api::*` discoverability (#1910).
+pub use crate::files::is_binary_file;
+
+/// Re-export of [`crate::files::load_text_strict`] (display string control) (#1910).
+pub use crate::files::load_text_strict;
 
 mod replace;
 pub use self::replace::*;

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -155,7 +155,14 @@ fn doc_merge_merges_values() {
     let file = dir.path().join("config.json");
     fs::write(&file, r#"{"a": 1}"#).unwrap();
 
-    let result = doc_merge(&file, serde_json::json!({"b": 2}), ApplyMode::Apply, None).unwrap();
+    let result = doc_merge(
+        &file,
+        serde_json::json!({"b": 2}),
+        ApplyMode::Apply,
+        None,
+        None,
+    )
+    .unwrap();
 
     assert!(result.changed);
     let on_disk = fs::read_to_string(&file).unwrap();
@@ -166,6 +173,64 @@ fn doc_merge_merges_values() {
         "merge must preserve existing keys"
     );
     assert_eq!(parsed["b"], serde_json::json!(2), "merge must add new keys");
+}
+
+#[test]
+fn doc_merge_multi_doc_selector_preserves_second_document() {
+    // Library hosts must multi-doc merge without execute_plan (#1909).
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("stream.yaml");
+    fs::write(&file, "a: 1\nb: 2\n---\nx: 9\n").unwrap();
+
+    let result = doc_merge(
+        &file,
+        serde_json::json!({"c": 3}),
+        ApplyMode::Apply,
+        None,
+        Some("0"),
+    )
+    .unwrap();
+
+    assert!(result.changed);
+    assert!(result.applied);
+    let on_disk = fs::read_to_string(&file).unwrap();
+    assert!(
+        on_disk.contains("c:") || on_disk.contains("c: 3"),
+        "merged key missing: {on_disk}"
+    );
+    assert!(
+        on_disk.contains("x:") || on_disk.contains("x: 9"),
+        "second document must be preserved: {on_disk}"
+    );
+    // First document should still have a/b and gain c.
+    assert_eq!(doc_get(&file, "0.a").unwrap(), serde_json::json!(1));
+    assert_eq!(doc_get(&file, "0.c").unwrap(), serde_json::json!(3));
+    assert_eq!(doc_get(&file, "1.x").unwrap(), serde_json::json!(9));
+}
+
+#[test]
+fn doc_merge_multi_doc_root_object_overlay_is_type_error() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("stream.yaml");
+    fs::write(&file, "a: 1\n---\nb: 2\n").unwrap();
+
+    let err = doc_merge(
+        &file,
+        serde_json::json!({"c": 3}),
+        ApplyMode::Preview,
+        None,
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        crate::exit::is_type_error(&err),
+        "expected TypeErrorError, got: {err}"
+    );
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::TypeError),
+        "root multi-doc merge must peel to TypeError for hosts (#1909)"
+    );
 }
 
 #[test]
@@ -1517,6 +1582,28 @@ fn empty_replace_pattern_is_invalid_input_not_type_error() {
         crate::fallback::edit_error_kind(&err),
         Some(EditErrorKind::InvalidInput)
     );
+}
+
+#[test]
+fn load_text_api_rejects_binary_and_loads_utf8() {
+    // api::load_text discoverability (#1910)
+    let dir = TempDir::new().unwrap();
+    let text = dir.path().join("ok.txt");
+    fs::write(&text, "hello\n").unwrap();
+    assert_eq!(load_text(&text).unwrap(), "hello\n");
+
+    let bin = dir.path().join("blob.bin");
+    fs::write(&bin, b"a\0b").unwrap();
+    let err = load_text(&bin).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput)
+    );
+    assert!(
+        is_binary_file(&bin),
+        "is_binary_file should detect NUL probe"
+    );
+    assert!(!is_binary_file(&text));
 }
 
 #[test]

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -151,7 +151,12 @@ resort for typos in non-AST text (prose, comments), not a general rename tool.\n
              - Multi-doc / wrong-root doc navigation peels to `EditErrorKind::TypeError` via \
                `edit_error_kind` / `classify_error` (CLI JSON `error_kind: type_error`; #1883). Do not \
                collapse with `InvalidInput` (empty patterns, bad options, sole binary).\n\
-             - Path binary preflight: `files::is_binary_file` (8 KiB NUL probe; open fail → false; #1884)\n\
+             - Multi-doc `api::doc_merge(path, value, mode, guard, selector)`: pass `Some(\"0\")` \
+               (or `\"[0]\"`) to merge into document 0; `None` is root-only and refuses a non-array \
+               overlay on multi-doc root with `TypeError` (#1909).\n\
+             - Path binary preflight: `api::is_binary_file` / `files::is_binary_file` (8 KiB NUL probe; open fail → false; #1884)\n\
+             - Sole-path text load for hosts: `api::load_text(path)` or `files::load_text_strict` (#1894, #1910)\n\
+             - `EditErrorKind` is `#[non_exhaustive]`; match with a wildcard arm (#1910)\n\
              - Text I/O honesty (#1894):\n\
                | Surface | Binary / invalid UTF-8 | Unreadable (IO) |\n\
                |---------|------------------------|-----------------|\n\
@@ -1160,6 +1165,18 @@ mod tests {
         assert!(
             out.contains("load_text_strict"),
             "library hosts need text I/O honesty load_text_strict (#1894)"
+        );
+        assert!(
+            out.contains("api::load_text"),
+            "library hosts need api::load_text alias (#1910)"
+        );
+        assert!(
+            out.contains("api::doc_merge") && out.contains("Some(\"0\")"),
+            "library hosts need multi-doc doc_merge selector (#1909)"
+        );
+        assert!(
+            out.contains("non_exhaustive"),
+            "library hosts need EditErrorKind non_exhaustive note (#1910)"
         );
         // Line-oriented insert is CLI-facing as well (mode All includes CLI).
         assert!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,8 +172,39 @@
 //! ```
 //!
 //! The `files` module (pure helpers like `is_binary`, `is_binary_file` path preflight,
-//! `read_text_file`, and scanning tools when "files" feature enabled) is always available.
-//! The `cli` and `cmd` modules require the `cli` feature.
+//! `load_text_strict`, `read_text_file`, and scanning tools when "files" feature enabled)
+//! is always available. The `cli` and `cmd` modules require the `cli` feature.
+//!
+//! ## Embedder cookbook: text load, binary preflight, multi-doc (#1910 / #1909)
+//!
+//! | Need | Use |
+//! |------|-----|
+//! | Sole path as editable text (binary / bad UTF-8 → typed error) | [`api::load_text`] or [`files::load_text_strict`] |
+//! | Cheap binary path check before open (open fail → `false`) | [`api::is_binary_file`] / [`files::is_binary_file`] |
+//! | Map multi-doc bare key / wrong-root merge to tool `invalid_args` | [`api::edit_error_kind`] → [`EditErrorKind::TypeError`] |
+//! | Multi-doc YAML merge into document 0 | [`api::doc_merge`](..., `Some("0")`) |
+//! | Map empty pattern / sole binary to `invalid_args` | [`EditErrorKind::InvalidInput`] |
+//!
+//! `EditErrorKind` is `#[non_exhaustive]`: always include a wildcard arm when matching.
+//!
+//! ```rust,no_run
+//! use patchloom::api::{self, edit_error_kind, EditErrorKind, ApplyMode};
+//! use std::path::Path;
+//!
+//! let path = Path::new("stream.yaml");
+//! if api::is_binary_file(path) {
+//!     // host: refuse tool call as invalid_args
+//! }
+//! let _text = api::load_text(path)?; // InvalidInput if binary / not UTF-8
+//! match api::doc_merge(path, serde_json::json!({"c": 3}), ApplyMode::Apply, None, Some("0")) {
+//!     Ok(r) => assert!(r.changed),
+//!     Err(e) if edit_error_kind(&e) == Some(EditErrorKind::TypeError) => {
+//!         // multi-doc bare root / wrong type
+//!     }
+//!     Err(e) => return Err(e),
+//! }
+//! # Ok::<(), anyhow::Error>(())
+//! ```
 //!
 //! For pure library use with plans and execution (post #792), prefer
 //! `features = ["ast", "files"]` (or "files"). `execute_plan` is available
@@ -255,7 +286,8 @@ pub use api::{
     ReplaceOptions, SearchOptions, SearchResult, WritePolicyOptions, apply_content_edits,
     apply_content_edits_with_label, apply_post_write_validator, build_context_lines,
     classify_error, classify_error_ref, edit_error_kind, edit_error_ref, format_search_results,
-    merge_match_modes, parse_unified_diff, run_post_write_validation, search_file, text_diff,
+    is_binary_file, load_text, load_text_strict, merge_match_modes, parse_unified_diff,
+    run_post_write_validation, search_file, text_diff,
 };
 pub use plan::Plan;
 


### PR DESCRIPTION
## Summary

Embedder-facing library gaps from Bline after 0.16.0.

### Closes #1909
- `api::doc_merge(..., selector: Option<&str>)` so multi-doc YAML can merge into document `0` without `execute_plan`
- Returns `EditResult` like other `api::doc_*` writers
- Root object overlay on multi-doc still peels to `EditErrorKind::TypeError`
- Tests: multi-doc merge preserves second document; root type error; existing root merge updated

### Closes #1910
- `api::load_text` alias of `load_text_strict`
- Re-export `load_text_strict` and `is_binary_file` from `api` and crate root
- Embedder cookbook in `lib.rs` + `api` module docs (TypeError vs InvalidInput, non_exhaustive)
- Agent-rules / PATCHLOOM.md library bullets

### Not in this PR
- #1911 closed as **not planned** (permanent): line-oriented insert default stays; no byte-exact opt-out flag

## Breaking (0.x)
`api::doc_merge` gains a fifth argument `selector: Option<&str>`. Pass `None` for previous root-merge behavior.

## Test plan
- [x] `cargo test --lib doc_merge_` / `load_text_api` / `agent_rules_documents_library`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] doctest `doc_merge` example
- [ ] CI green

Closes #1909
Closes #1910