### PR TITLE
docs: reference table for load_text and doc_merge selector

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1332,8 +1332,9 @@ The operations below are the building blocks inside `operations`.
 |------|-----|
 | Fail-closed text replace | `ReplaceOptions.require_change` + `edit_error_kind` / `classify_error` |
 | Non-`anyhow` error kinds | `classify_error(&dyn Error)` / `classify_error_ref` (#1659); `EditErrorKind::FormatFailed` for post-write hooks; `EditErrorKind::TypeError` for multi-doc / wrong-root doc navigation (CLI `error_kind: type_error`; #1883) |
-| Path binary preflight | `files::is_binary_file` (8 KiB NUL probe; open fail → false; #1884); writers still enforce binary on apply |
-| Text I/O honesty | Sole path: `files::load_text_strict` (binary / invalid UTF-8 → `InvalidInput`); walks: `try_read_text_file` / `SoftTextSkip` / `read_text_file`; tx probe `read_and_probe` (content soft, IO hard); sole helper `ops::file::sole_explicit_non_text`; multi-path `explicit_multi_path_non_text_refused`; patch file+targets Strict (#1894 / #1896) |
+| Path binary preflight | `api::is_binary_file` / `files::is_binary_file` (8 KiB NUL probe; open fail → false; #1884 / #1910); writers still enforce binary on apply |
+| Text I/O honesty | Sole path: `api::load_text` / `files::load_text_strict` (binary / invalid UTF-8 → `InvalidInput`; #1894 / #1910); walks: `try_read_text_file` / `SoftTextSkip` / `read_text_file`; tx probe `read_and_probe` (content soft, IO hard); sole helper `ops::file::sole_explicit_non_text`; multi-path `explicit_multi_path_non_text_refused`; patch file+targets Strict (#1896) |
+| Multi-doc library merge | `api::doc_merge(path, value, mode, guard, selector)` with `Some("0")` / `Some("[0]")` for document 0; root object overlay on multi-doc is `TypeError` (#1909) |
 | Line-oriented insert | `insert_before` / `insert_after` default (#1885): newline when payload looks like a new line or anchor is whole-line; mid-line bare stays byte-exact |
 | Shell token rename | `ReplaceOptions.command_position` / `ContentEdit::Replace` (#1666) |
 | Scoped symbol replace (literal/regex) | `ast_replace_in_symbol` + `AstReplaceInSymbolOptions.regex` (#1658) |


### PR DESCRIPTION
## Summary

Reference book polish after #1913: document `api::load_text`, `api::is_binary_file`, and multi-doc `api::doc_merge` selector in the embedder table.

Ref #1909, #1910 (already closed by #1913).

## Test plan
- [x] Docs-only table update