### PR TITLE
test: strengthen multi-doc merge coverage and library docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,9 +1221,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.188"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22053b6a34f84abc97f9129e61334f40174659a1b9bd18c970b83db6a9a6348b"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "linux-raw-sys"

--- a/README.md
+++ b/README.md
@@ -322,9 +322,21 @@ api::doc_set(
     ApplyMode::Apply,
     None,
 )?;
+
+// Multi-doc YAML: merge into document 0 (selector None = root only)
+api::doc_merge(
+    Path::new("stream.yaml"),
+    serde_json::json!({"env": "prod"}),
+    ApplyMode::Apply,
+    None,
+    Some("0"),
+)?;
+
+// Sole-path text load: binary / invalid UTF-8 → EditErrorKind::InvalidInput
+let _text = api::load_text(Path::new("notes.md"))?;
 ```
 
-All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking and binary detection), `backup` (`restore_path_from_latest_backup` for post-Apply validate/revert), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS); see the `containment` and `api` module rustdocs.
+All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking, `load_text_strict`, binary detection), `backup` (`restore_path_from_latest_backup` for post-Apply validate/revert), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS); see the `containment` and `api` module rustdocs. Multi-doc bare keys and wrong-root merges peel to `EditErrorKind::TypeError` via `edit_error_kind`.
 
 Replace fail-closed / shell-token options: CLI `replace --require-change` and `--command-position` (also plan/MCP fields and `ReplaceOptions` on the library). Library-only AST mutators: `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -173,7 +173,7 @@ AST tools so `list_tools` stays honest about what is callable.
 |------|-------------|
 | `doc_set` | Set a value by selector path in a JSON, YAML, or TOML file |
 | `doc_delete` | Delete a value by selector path from a structured file |
-| `doc_merge` | Deep-merge an object into a document |
+| `doc_merge` | Deep-merge an object into a document (optional `selector`, e.g. `0` for multi-doc YAML) |
 | `doc_append` | Append a value to an array |
 | `doc_prepend` | Prepend a value to an array |
 | `doc_ensure` | Set a value only if the selector path does not exist |

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -193,17 +193,29 @@ fn doc_merge_multi_doc_selector_preserves_second_document() {
 
     assert!(result.changed);
     assert!(result.applied);
-    let on_disk = fs::read_to_string(&file).unwrap();
-    assert!(
-        on_disk.contains("c:") || on_disk.contains("c: 3"),
-        "merged key missing: {on_disk}"
-    );
-    assert!(
-        on_disk.contains("x:") || on_disk.contains("x: 9"),
-        "second document must be preserved: {on_disk}"
-    );
-    // First document should still have a/b and gain c.
+    // Prefer typed gets over weak substring contains (MPI Test Auditor).
     assert_eq!(doc_get(&file, "0.a").unwrap(), serde_json::json!(1));
+    assert_eq!(doc_get(&file, "0.b").unwrap(), serde_json::json!(2));
+    assert_eq!(doc_get(&file, "0.c").unwrap(), serde_json::json!(3));
+    assert_eq!(doc_get(&file, "1.x").unwrap(), serde_json::json!(9));
+}
+
+#[test]
+fn doc_merge_multi_doc_bracket_index_selector() {
+    // Docs claim Some("[0]") works; lock it at the library API (#1909 review).
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("stream.yaml");
+    fs::write(&file, "a: 1\n---\nx: 9\n").unwrap();
+
+    let result = doc_merge(
+        &file,
+        serde_json::json!({"c": 3}),
+        ApplyMode::Apply,
+        None,
+        Some("[0]"),
+    )
+    .unwrap();
+    assert!(result.changed);
     assert_eq!(doc_get(&file, "0.c").unwrap(), serde_json::json!(3));
     assert_eq!(doc_get(&file, "1.x").unwrap(), serde_json::json!(9));
 }


### PR DESCRIPTION
## Summary

MPI cycle after embedder API (#1913 / #1914):

- Strengthen multi-doc `api::doc_merge` tests (typed `doc_get` asserts; selector `"[0]"`)
- README library example: `doc_merge` + `load_text`
- mcp-setup: optional `selector` on `doc_merge`
- `libc` 0.2.188 → 0.2.189

### Gate notes
- Release PR **#1912** (0.17.0) left open (needs explicit merge OK)
- Dist issues **#960** / **#961** still externally blocked (no new spam comments)

## Test plan
- [x] `cargo test --lib doc_merge_` / `load_text_api`
- [x] `make check-fast`
- [ ] CI green