### PR TITLE
fix: sole unreadable path error without double-wrap

### DIFF
--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -128,8 +128,10 @@ pub fn sole_explicit_non_text(
                     msg: inv.msg.clone(),
                 })
             } else {
+                // load_text_strict already prefixes "failed to read {display}";
+                // do not double-wrap (fixrealloop: "failed to read x: failed to read x").
                 Some(crate::exit::InvalidInputError {
-                    msg: format!("failed to read {display}: {e}"),
+                    msg: format!("{e:#}"),
                 })
             }
         }
@@ -488,6 +490,18 @@ mod tests {
             assert!(
                 err.msg.contains("failed to read") || err.msg.contains("Permission"),
                 "got: {}",
+                err.msg
+            );
+            // Single prefix only (not "failed to read x: failed to read x").
+            let failed_count = err.msg.matches("failed to read").count();
+            assert_eq!(
+                failed_count, 1,
+                "unreadable error must not double-wrap load_text_strict context: {}",
+                err.msg
+            );
+            assert!(
+                err.msg.contains("locked.txt"),
+                "path should appear once in message: {}",
                 err.msg
             );
             fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();


### PR DESCRIPTION
## Summary

**Found by fixrealloop** (sole mode-000 path):

```
# before
{"error":"failed to read t.txt: failed to read t.txt","error_kind":"invalid_input"}

# after
{"error":"failed to read t.txt: Permission denied (os error 13)","error_kind":"invalid_input"}
```

`load_text_strict` already adds `failed to read {display}` via `with_context`. `sole_explicit_non_text` was prefixing again. Use the error chain as-is (`{e:#}`).

## Test plan
- [x] Unit test asserts exactly one `failed to read` in the message
- [x] `make check-fast`
- [x] Reproduced on release binary before/after
- [ ] CI green