### PR TITLE
fix: doc.merge catalog blurb mentions multi-doc selector

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -427,7 +427,7 @@ dependencies[name=react].version # predicate filter
 - `tidy.fix`: Normalize whitespace in a file. When op fields are omitted, defaults match CLI tidy fix (trim trailing whitespace + ensure final newline; normalize_eol stays keep). Precedence: defaults → plan write_policy → op fields. Plan write_policy is not re-applied at commit for paths last written by tidy.fix so op fields stick (#1840, #1847).
 - `doc.set`: Set a value at a selector path in a JSON, YAML, or TOML file. Parser-backed; output is always valid.
 - `doc.delete`: Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json and MCP/tx success include changed and removed (0 on missing key; exit 0 / ok is idempotent).
-- `doc.merge`: Deep-merge a JSON object into the root of a document.
+- `doc.merge`: Deep-merge a JSON object into a document root, or into a selector path (e.g. multi-doc YAML `0` / `[0]`).
 - `doc.append`: Append a value to an array at a selector path.
 - `doc.move`: Move a value from one selector path to another within the same file.
 - `doc.ensure`: Set a value only if the selector path does not already exist.

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -277,12 +277,18 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "doc.merge",
-        description: "Deep-merge a JSON object into the root of a document.",
+        description: "Deep-merge a JSON object into a document root, or into a selector path (e.g. multi-doc YAML `0` / `[0]`).",
         tier: Tier::Medium,
-        examples: &[(
-            "Add database config",
-            r###"{"op":"doc.merge","path":"config.yaml","value":{"database":{"host":"localhost","port":5432}}}"###,
-        )],
+        examples: &[
+            (
+                "Add database config at root",
+                r###"{"op":"doc.merge","path":"config.yaml","value":{"database":{"host":"localhost","port":5432}}}"###,
+            ),
+            (
+                "Merge into multi-document YAML document 0",
+                r###"{"op":"doc.merge","path":"services.yaml","selector":"0","value":{"env":"prod"}}"###,
+            ),
+        ],
     },
     OpMeta {
         name: "doc.append",

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -215,6 +215,16 @@ mod basic {
             names.contains(&"doc.merge"),
             "medium tier must include doc.merge"
         );
+        let merge_desc =
+            crate::schema::operation_description("doc.merge").expect("doc.merge is registered");
+        assert!(
+            merge_desc.contains("selector") || merge_desc.contains("multi-doc"),
+            "doc.merge catalog must mention selector/multi-doc (explain honesty; fixrealloop): {merge_desc}"
+        );
+        assert!(
+            !merge_desc.contains("into the root of a document."),
+            "doc.merge must not claim root-only when selector is supported: {merge_desc}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

**Found by fixrealloop** (explain on multi-doc merge plan):

| Field | Before | After |
|-------|--------|-------|
| `catalog` | Deep-merge … into the **root** of a document | … into a document root, **or into a selector path** (e.g. multi-doc `0` / `[0]`) |
| `description` | Merge into 0 in f.yaml (already correct) | unchanged |

Schema registry blurb feeds `explain --json`, agent-rules catalogue, and MCP tool prose.

## Test plan
- [x] Unit assert on `operation_description("doc.merge")`
- [x] `make sync-patchloom-md` + `make check-fast`
- [x] Release binary explain on selector plan
- [ ] CI green