### PR TITLE
fix: stop double-wrapping load_text_strict IO errors

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1616,6 +1616,34 @@ fn load_text_api_rejects_binary_and_loads_utf8() {
         "is_binary_file should detect NUL probe"
     );
     assert!(!is_binary_file(&text));
+
+    // Docs claim invalid UTF-8 peels to InvalidInput (same as load_text_strict).
+    let bad = dir.path().join("bad.txt");
+    fs::write(&bad, b"hello\xffworld").unwrap();
+    let err = load_text(&bad).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput),
+        "invalid UTF-8 must be InvalidInput, got: {err}"
+    );
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("UTF-8") || msg.contains("utf-8") || msg.contains("invalid"),
+        "message should name encoding issue: {msg}"
+    );
+
+    let missing = dir.path().join("no-such.txt");
+    let err = load_text(&missing).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("failed to read"),
+        "missing path must keep load_text_strict context: {msg}"
+    );
+    assert_ne!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput),
+        "missing path is IO, not binary/UTF-8 InvalidInput: {msg}"
+    );
 }
 
 #[test]

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -839,18 +839,16 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let input_path = global.resolve_user_path(&args.input)?;
         // Strict sole-path input (#1894): binary / invalid UTF-8 → InvalidInput.
         let display = input_path.display().to_string();
+        // load_text_strict already prefixes "failed to read {display}"; do not
+        // re-wrap (same class as #1916 / patch target IO).
         crate::files::load_text_strict(&input_path, &display).map_err(|e| {
             if crate::exit::is_io_not_found(&e) {
-                std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("failed to read '{display}': {e}"),
-                )
-                .into()
+                std::io::Error::new(std::io::ErrorKind::NotFound, format!("{e:#}")).into()
             } else if crate::exit::is_invalid_input(&e) {
                 e
             } else {
                 anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("failed to read '{display}': {e}"),
+                    msg: format!("{e:#}"),
                 })
             }
         })?

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -641,11 +641,13 @@ impl PatchloomService {
                 svc.check_path(path)?;
                 let abs = svc.cwd().join(path);
                 // Strict sole-path plan load (#1894).
+                // load_text_strict already prefixes "failed to read {path}";
+                // do not re-wrap (same class as #1916).
                 let content = crate::files::load_text_strict(&abs, path).map_err(|e| {
                     if crate::exit::is_invalid_input(&e) {
                         McpError::invalid_params(e.to_string(), None)
                     } else {
-                        McpError::internal_error(format!("failed to read plan_path: {e}"), None)
+                        McpError::internal_error(format!("{e:#}"), None)
                     }
                 })?;
                 crate::plan::parse_plan_auto(&content, Some(path), None).map_err(|e| {

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -372,11 +372,17 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             } else {
                 ("parse_error", exit::PARSE_ERROR)
             };
-            emit_error(
-                global,
-                &format!("patch: failed to read '{path}': {e}"),
-                kind,
-            )?;
+            // load_text_strict (and stdin map) already include path/context in
+            // `e`; do not re-prefix "failed to read" (sibling of #1916).
+            let msg = {
+                let detail = e.to_string();
+                if detail.contains("failed to read") {
+                    format!("patch: {detail}")
+                } else {
+                    format!("patch: failed to read '{path}': {detail}")
+                }
+            };
+            emit_error(global, &msg, kind)?;
             return Ok(code);
         }
         Err(DiffReadError::StdinError(e)) => {

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -175,9 +175,11 @@ fn load_patch_target(
                 Err(PatchTargetError::InvalidInput(msg))
             }
         }
-        Err(e) => Err(PatchTargetError::Io(format!(
-            "failed to read {display}: {e}"
-        ))),
+        Err(e) => {
+            // load_text_strict already prefixes "failed to read {display}";
+            // do not double-wrap (same class as #1916 sole-path unreadable).
+            Err(PatchTargetError::Io(format!("{e:#}")))
+        }
     }
 }
 
@@ -681,6 +683,37 @@ mod tests {
         )
         .unwrap();
         assert_eq!(code, exit::CONFLICTS);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_patch_target_unreadable_does_not_double_wrap() {
+        // Sibling of #1916: load_text_strict already prefixes "failed to read".
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("locked.txt");
+        std::fs::write(&file, "secret\n").unwrap();
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o000)).unwrap();
+        if std::fs::read_to_string(&file).is_ok() {
+            std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
+            return;
+        }
+        let err = load_patch_target(&file, "locked.txt", false).unwrap_err();
+        match err {
+            PatchTargetError::Io(msg) => {
+                assert_eq!(
+                    msg.matches("failed to read").count(),
+                    1,
+                    "must not double-wrap load_text_strict context: {msg}"
+                );
+                assert!(
+                    msg.contains("locked.txt"),
+                    "path should appear in message: {msg}"
+                );
+            }
+            other => panic!("expected Io, got {other:?}"),
+        }
+        std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
     }
 
     #[cfg(unix)]

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -143,6 +143,7 @@ fn read_diff_input(
 /// - Missing + not empty: `Err(NotFound)`
 /// - Binary / invalid UTF-8: `Err(InvalidInput)`
 /// - Other IO: `Err(Io)`
+#[derive(Debug)]
 enum PatchTargetError {
     NotFound,
     /// Directory or non-file path (per-file check status `error`, exit 5).

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -307,18 +307,16 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             .ok_or_else(|| anyhow::anyhow!("internal error: plan path missing"))?;
         // Strict sole-path plan load (#1894): binary / invalid UTF-8 → InvalidInput.
         let display = plan_path.display().to_string();
+        // load_text_strict already prefixes "failed to read {display}"; do not
+        // re-wrap (same class as #1916).
         crate::files::load_text_strict(plan_path, &display).map_err(|e| {
             if crate::exit::is_io_not_found(&e) {
-                std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("failed to read plan file '{display}': {e}"),
-                )
-                .into()
+                std::io::Error::new(std::io::ErrorKind::NotFound, format!("{e:#}")).into()
             } else if crate::exit::is_invalid_input(&e) {
                 e
             } else {
                 anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("failed to read plan file '{display}': {e}"),
+                    msg: format!("{e:#}"),
                 })
             }
         })?

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1157,6 +1157,54 @@ async fn test_mcp_doc_merge_round_trip() {
     client.cancel().await.unwrap();
 }
 
+/// Multi-doc YAML merge via MCP must honor `selector` (parity with CLI/API #1909).
+#[tokio::test]
+async fn test_mcp_doc_merge_multi_doc_selector() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("stream.yaml"), "a: 1\nb: 2\n---\nx: 9\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_merge",
+        serde_json::json!({
+            "path": "stream.yaml",
+            "selector": "0",
+            "value": {"c": 3}
+        }),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "doc_merge multi-doc selector should succeed: {val}"
+    );
+    assert_eq!(val["ok"], true, "doc_merge ok: {val}");
+    assert_eq!(val["files_changed"], 1, "doc_merge files_changed: {val}");
+
+    // MCP doc_get returns the bare JSON value (see test_mcp_doc_get_reads_value).
+    let (is_error, got) = call_tool_value(
+        &client,
+        "doc_get",
+        serde_json::json!({"path": "stream.yaml", "selector": "0.c"}),
+    )
+    .await;
+    assert!(!is_error, "doc_get 0.c: {got}");
+    assert_eq!(got, 3, "merged c into doc 0: {got}");
+
+    let (is_error, got) = call_tool_value(
+        &client,
+        "doc_get",
+        serde_json::json!({"path": "stream.yaml", "selector": "1.x"}),
+    )
+    .await;
+    assert!(!is_error, "doc_get 1.x: {got}");
+    assert_eq!(got, 9, "doc 1 must remain: {got}");
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_doc_delete_round_trip() {
     if !has_mcp_support() {


### PR DESCRIPTION
## Summary

MPI cycle 2026-07-22 (session branch `fix/improve-mpi-20260722-s2`).

**Bug (sibling of #1916):** Several sole-path loaders call `load_text_strict`, which already prefixes `failed to read {display}`, then wrap again with `failed to read …: {e}`. Agent-facing JSON becomes:

```text
failed to read t.txt: failed to read t.txt: Permission denied
```

**Fixed surfaces:**

- `cmd/patch` target load + diff IO emit
- `cmd/batch` input file
- `cmd/tx` plan file
- MCP `execute_plan` `plan_path`

**Tests:**

- Unit: patch unreadable target has exactly one `failed to read`
- API: `load_text` invalid UTF-8 + missing path contracts
- Integration: MCP `doc_merge` multi-doc `selector` parity with CLI/API (#1909)

## Test plan

- [x] `make check-fast`
- [x] `cargo test --lib load_patch_target_unreadable`
- [x] `cargo test --test integration test_mcp_doc_merge_multi_doc_selector`
- [ ] CI green

Ref #1916 (same class; already closed for sole_explicit_non_text)