### PR TITLE
test: strengthen multi-doc keys asserts and #1918 IO locks

### DIFF
--- a/src/ast/rewrite.rs
+++ b/src/ast/rewrite.rs
@@ -1222,8 +1222,11 @@ mod tests {
         let span = find_function_span(source, "f", Language::Rust).unwrap();
         let out = splice_function_signature(source, span.signature_range, "   ");
         // Empty after trim: keep original gap + body; do not invent brace glue.
-        assert!(out.contains("{"), "body brace remains: {out}");
-        assert!(!out.contains("i32{"), "got: {out}");
+        assert!(
+            out.contains("{\n    0\n}"),
+            "body brace + body must remain intact: {out}"
+        );
+        assert!(!out.contains("i32{"), "must not invent brace glue: {out}");
     }
 
     // ── find_function_span tests ──────────────────────────────────

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -978,3 +978,41 @@ fn test_batch_tidy_fix_trims_trailing_whitespace_by_default() {
         "trailing spaces must be trimmed by default"
     );
 }
+
+/// Unreadable batch input must surface one "failed to read" prefix (#1918).
+#[cfg(unix)]
+#[test]
+fn test_batch_unreadable_input_does_not_double_wrap() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = TempDir::new().unwrap();
+    let batch = dir.path().join("ops.batch");
+    fs::write(&batch, "file.create x.txt hi\n").unwrap();
+    fs::set_permissions(&batch, fs::Permissions::from_mode(0o000)).unwrap();
+    if fs::read_to_string(&batch).is_ok() {
+        fs::set_permissions(&batch, fs::Permissions::from_mode(0o644)).unwrap();
+        return;
+    }
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["batch", "ops.batch"])
+        .output()
+        .unwrap();
+    let _ = fs::set_permissions(&batch, fs::Permissions::from_mode(0o644));
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert_eq!(
+        err.matches("failed to read").count(),
+        1,
+        "must not double-wrap load_text_strict: {v}"
+    );
+}

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2917,8 +2917,11 @@ fn test_doc_keys_multi_document_root_hints_index() {
         let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
         assert_eq!(v["error_kind"], "type_error", "selector {root_sel:?}: {v}");
         let err = v["error"].as_str().unwrap_or("");
+        // Prefer multi-char guidance over bare "0" (matches any digit noise).
         assert!(
-            err.contains("array") && (err.contains("0") || err.contains("index")),
+            err.contains("top-level array")
+                && err.contains("index")
+                && (err.contains("`0`") || err.contains("[0]")),
             "expected multi-doc keys guidance for {root_sel:?}, got: {v}"
         );
     }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8895,3 +8895,41 @@ fn test_tx_json_includes_applied_field() {
     assert_eq!(v["applied"], true, "apply must set applied=true: {v}");
     assert_eq!(fs::read_to_string(&file).unwrap(), "yo\n");
 }
+
+/// Unreadable plan file must surface one "failed to read" prefix (#1918).
+#[cfg(unix)]
+#[test]
+fn test_tx_unreadable_plan_does_not_double_wrap() {
+    use std::os::unix::fs::PermissionsExt;
+    let dir = TempDir::new().unwrap();
+    let plan = dir.path().join("plan.json");
+    fs::write(&plan, r#"{"version":1,"operations":[]}"#).unwrap();
+    fs::set_permissions(&plan, fs::Permissions::from_mode(0o000)).unwrap();
+    if fs::read_to_string(&plan).is_ok() {
+        fs::set_permissions(&plan, fs::Permissions::from_mode(0o644)).unwrap();
+        return;
+    }
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["tx", "plan.json"])
+        .output()
+        .unwrap();
+    let _ = fs::set_permissions(&plan, fs::Permissions::from_mode(0o644));
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert_eq!(
+        err.matches("failed to read").count(),
+        1,
+        "must not double-wrap load_text_strict: {v}"
+    );
+}


### PR DESCRIPTION
## Summary

MPI cycle 2 (Test Auditor rotation) on `fix/improve-mpi-20260722-s3`.

**Test integrity**
- Multi-doc `doc keys` root error: drop weak `contains("0")`; require `top-level array`, `index`, and `` `0` `` / `[0]`.
- Empty function-sig splice: assert full body brace span, not bare `{`.

**#1918 regression locks**
- Integration: unreadable batch input and unreadable tx plan each emit exactly one `failed to read` (patch unit test already covered targets).

## Test plan

- [x] `make check-fast`
- [x] `cargo test --test integration double_wrap`
- [x] `cargo test --lib splice_function_signature_empty`
- [ ] CI green