### PR TITLE
test: lock init noninteractive skip remediation

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -401,6 +401,7 @@ Patchloom can be used as a Rust library (disable default `cli` feature for small
 - **Notable flags:**
   - `-y, --yes`: Skip confirmation prompts and auto-accept all actions (agent rules + shell completions install).
   - With global `--json` / `--jsonl`: agent-rules create/append is auto-accepted without `-y` so agent bootstrap does not report `ok: true` with `agent_rules: skipped` (#1833). Shell completion install still requires `-y` / interactive confirm.
+  - Without `-y` and without `--json`/`--jsonl`, a non-interactive decline does not write `AGENTS.md` and reports `agent_rules: skipped_use_yes` (stderr names `--yes` / `--json`).
 - **Prefer instead:** `agent-rules` if you only need the rules text, or `completions` if you only need shell completions.
 - **Related:** `agent-rules`, `completions`, `mcp-server`, `status`, `undo`
 

--- a/tests/integration/init_tests.rs
+++ b/tests/integration/init_tests.rs
@@ -249,7 +249,37 @@ fn test_init_confirm_eof_skips_agents_creation() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Create AGENTS.md? [Y/n]"));
-    assert!(stdout.contains("skipped AGENTS.md"));
+    assert!(
+        stdout.contains("skipped AGENTS.md")
+            && stdout.contains("--yes")
+            && stdout.contains("--json"),
+        "decline must name remediation flags: {stdout}"
+    );
+}
+
+/// Non-TTY plain `init` (no --yes) declines confirm and must not look like a silent no-op (#1922 / fixrealloop).
+#[test]
+fn test_init_noninteractive_without_yes_hints_use_yes() {
+    let dir = TempDir::new().unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["init", "--cwd"])
+        .arg(dir.path())
+        .env("SHELL", "unknown")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(
+        !dir.path().join("AGENTS.md").exists(),
+        "non-interactive init without --yes must not create AGENTS.md"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("skipped AGENTS.md")
+            && stderr.contains("--yes")
+            && stderr.contains("--json"),
+        "stderr must explain how to create rules: {stderr}"
+    );
 }
 
 #[cfg(feature = "mcp")]


### PR DESCRIPTION
## Summary

MPI cycle 2026-07-23 on `fix/improve-mpi-20260723` (after #1922 init messaging).

- Integration: non-TTY `init` without `--yes` must print remediation (`--yes` / `--json`) and not create `AGENTS.md`.
- PTY decline path: same remediation substring lock.
- Reference docs: document `agent_rules: skipped_use_yes` for noninteractive decline.

## Test plan

- [x] `make check-fast`
- [x] `test_init_noninteractive_without_yes_hints_use_yes`
- [x] `test_init_confirm_eof_skips_agents_creation`
- [ ] CI green