### PR TITLE
fix: set error_kind on patch check multi-file JSON failures

### DIFF
--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -198,6 +198,12 @@ struct PatchFileResult {
 struct PatchFilesOutput {
     ok: bool,
     files: Vec<PatchFileResult>,
+    /// Agent branch key when `ok` is false (e.g. stale check → `ambiguous`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_kind: Option<&'static str>,
+    /// Human/agent summary when `ok` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
     /// Whether bytes were written (#1812). `false` for preview/`--check`.
     #[serde(skip_serializing_if = "Option::is_none")]
     applied: Option<bool>,
@@ -273,6 +279,35 @@ fn emit_error(global: &GlobalFlags, error: &str, error_kind: &str) -> anyhow::Re
     Ok(())
 }
 
+/// Top-level error_kind for multi-file patch JSON when `ok` is false.
+/// Matches CLI exit codes agents already branch on (stale → exit 5 / ambiguous).
+fn patch_problem_error_kind(results: &[PatchFileResult]) -> (&'static str, String) {
+    let has_stale = results.iter().any(|r| r.status == "stale");
+    let has_missing = results.iter().any(|r| r.status == "missing");
+    let has_error = results.iter().any(|r| r.status == "error");
+    let has_conflict = results.iter().any(|r| r.status == "conflict");
+    if has_conflict {
+        (
+            "conflicts",
+            "one or more patch targets have merge conflicts".into(),
+        )
+    } else if has_stale {
+        (
+            "ambiguous",
+            "one or more patch targets are stale (context no longer matches)".into(),
+        )
+    } else if has_missing && !has_error {
+        ("not_found", "one or more patch targets are missing".into())
+    } else if has_error {
+        (
+            "invalid_input",
+            "one or more patch targets could not be read".into(),
+        )
+    } else {
+        ("ambiguous", "one or more patch targets failed".into())
+    }
+}
+
 fn emit_patch_files_output(
     global: &GlobalFlags,
     ok: bool,
@@ -281,9 +316,17 @@ fn emit_patch_files_output(
     backup_session: Option<String>,
 ) -> anyhow::Result<()> {
     if global.json {
+        let (error_kind, error) = if ok {
+            (None, None)
+        } else {
+            let (k, e) = patch_problem_error_kind(results);
+            (Some(k), Some(e))
+        };
         let output = PatchFilesOutput {
             ok,
             files: results.to_vec(),
+            error_kind,
+            error,
             applied,
             backup_session,
         };

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -436,6 +436,41 @@ fn test_patch_check_exits_5_when_stale() {
         .code(5);
 }
 
+/// fixrealloop: agents branch on error_kind; stale check must not leave it null.
+#[test]
+fn test_patch_check_json_stale_sets_error_kind_ambiguous() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
+
+    let patch_file = dir.path().join("stale.patch");
+    fs::write(
+        &patch_file,
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n",
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["patch", "check"])
+        .arg(&patch_file)
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(5), "stale → exit 5");
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["error_kind"], "ambiguous", "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    assert_eq!(v["files"][0]["status"], "stale", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("stale"),
+        "error summary should mention stale: {v}"
+    );
+}
+
 #[test]
 fn test_patch_check_stale_human_readable_output() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Found by **fixrealloop** (CLI + MCP dogfood):

```text
patch check --json  # after apply → stale
# before: {"ok":false,"files":[{"status":"stale"}],"applied":false}
# after:  {"ok":false,"error_kind":"ambiguous","error":"...stale...","files":[...],"applied":false}
```

Exit code was already 5 (`AMBIGUOUS`); JSON just omitted the agent branch key.

## Test plan

- [x] `make check-fast`
- [x] `test_patch_check_json_stale_sets_error_kind_ambiguous`
- [x] MCP integration suite (148 mcp_* tests green before change)
- [ ] CI green