### PR TITLE
fix: keep Permission denied and invalid_input on unreadable sole paths

### DIFF
--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -28,10 +28,11 @@ pub(super) fn setup_single_file(
     Ok((cwd, target, lang, source))
 }
 
-/// When the user names exactly one file path, fail closed as `invalid_input` for
-/// binary or invalid UTF-8 (parity with replace/search/tidy/md / #1894).
-/// Directory walks soft-skip content kinds; IO is handled by the walk
-/// (return `Ok` here so missing sole paths can soft-fail later).
+/// When the user names exactly one **file** path, fail closed as `invalid_input`
+/// for binary, invalid UTF-8, or unreadable (parity with replace/search/tidy/md
+/// / #1894). Directory walks soft-skip content kinds and report unreadable via
+/// the scan mask ("could not read N path(s)…"); do not treat a dir that happens
+/// to resolve to a single file as sole-path (#fixrealloop 2026-07-23).
 pub(super) fn reject_sole_explicit_non_text(
     paths: &[PathBuf],
     path_arg: &str,
@@ -39,7 +40,13 @@ pub(super) fn reject_sole_explicit_non_text(
     if paths.len() != 1 {
         return Ok(());
     }
-    match crate::files::load_text_strict(&paths[0], path_arg) {
+    // path_arg must name this file (not a parent directory). Otherwise the
+    // multi-file walk owns Unreadable policy.
+    let sole = &paths[0];
+    if !sole.ends_with(Path::new(path_arg)) {
+        return Ok(());
+    }
+    match crate::files::load_text_strict(sole, path_arg) {
         Ok(_) => Ok(()),
         Err(e) => {
             if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -141,14 +141,16 @@ fn read_diff_input(
 /// - Text: `Ok(content)`
 /// - Missing + `missing_as_empty`: `Ok("")` (creation / merge check)
 /// - Missing + not empty: `Err(NotFound)`
-/// - Binary / invalid UTF-8: `Err(InvalidInput)`
-/// - Other IO: `Err(Io)`
+/// - Binary / invalid UTF-8 / permission (and other non-NotFound IO from
+///   `load_text_strict`): `Err(InvalidInput)`
+/// - Residual IO: `Err(Io)`
 #[derive(Debug)]
 enum PatchTargetError {
     NotFound,
     /// Directory or non-file path (per-file check status `error`, exit 5).
     NotAFile(String),
-    /// Binary or invalid UTF-8 (fail-closed `invalid_input`, exit 1).
+    /// Binary, invalid UTF-8, or unreadable existing path (fail-closed
+    /// `invalid_input`, exit 1).
     InvalidInput(String),
     Io(String),
 }
@@ -739,6 +741,7 @@ mod tests {
     #[test]
     fn load_patch_target_unreadable_does_not_double_wrap() {
         // Sibling of #1916: load_text_strict already prefixes "failed to read".
+        // Permission is typed InvalidInput with OS detail in Display (2026-07-23).
         use std::os::unix::fs::PermissionsExt;
         let tmp = TempDir::new().unwrap();
         let file = tmp.path().join("locked.txt");
@@ -750,7 +753,7 @@ mod tests {
         }
         let err = load_patch_target(&file, "locked.txt", false).unwrap_err();
         match err {
-            PatchTargetError::Io(msg) => {
+            PatchTargetError::InvalidInput(msg) => {
                 assert_eq!(
                     msg.matches("failed to read").count(),
                     1,
@@ -760,8 +763,14 @@ mod tests {
                     msg.contains("locked.txt"),
                     "path should appear in message: {msg}"
                 );
+                assert!(
+                    msg.contains("Permission denied")
+                        || msg.contains("PermissionDenied")
+                        || msg.contains("os error"),
+                    "OS detail missing: {msg}"
+                );
             }
-            other => panic!("expected Io, got {other:?}"),
+            other => panic!("expected InvalidInput, got {other:?}"),
         }
         std::fs::set_permissions(&file, std::fs::Permissions::from_mode(0o644)).unwrap();
     }

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -63,11 +63,12 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Rea
                     msg: inv.msg.clone(),
                 });
             }
-            // Missing path and other IO.
-            let msg = e.to_string();
-            let kind = if msg.contains("No such file")
-                || msg.contains("not found")
-                || msg.contains("failed to read")
+            // Missing path and other IO. Prefer `{:#}` so anyhow cause chains
+            // keep the OS detail (Permission denied); Display alone drops it.
+            let full = format!("{e:#}");
+            let kind = if full.contains("No such file")
+                || full.contains("not found")
+                || full.contains("failed to read")
             {
                 // Prefer not_found when the path is missing.
                 if !p.exists() {
@@ -80,7 +81,13 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Rea
             };
             return Err(ReadFail {
                 kind,
-                msg: format!("{path}: {e}"),
+                // Avoid `{path}: failed to read {path}` when the load error
+                // already names the display path.
+                msg: if full.contains(path) {
+                    full
+                } else {
+                    format!("{path}: {full}")
+                },
             });
         }
     };
@@ -448,6 +455,36 @@ mod tests {
         let err = result.expect_err("directory must fail");
         assert_eq!(err.kind, "invalid_input");
         assert!(err.msg.contains("not a file"), "got: {err}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn read_one_file_unreadable_keeps_permission_detail() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("locked.txt");
+        fs::write(&path, "secret\n").unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+        if fs::read_to_string(&path).is_ok() {
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+            return;
+        }
+        let err = read_one_file(path.to_str().unwrap(), None).expect_err("mode 000 must fail");
+        let _ = fs::set_permissions(&path, fs::Permissions::from_mode(0o644));
+        assert_eq!(err.kind, "invalid_input", "got: {err:?}");
+        assert!(
+            err.msg.contains("Permission denied")
+                || err.msg.contains("PermissionDenied")
+                || err.msg.contains("os error"),
+            "OS detail missing: {}",
+            err.msg
+        );
+        assert_eq!(
+            err.msg.matches("failed to read").count(),
+            1,
+            "double-wrap: {}",
+            err.msg
+        );
     }
 
     #[test]

--- a/src/files.rs
+++ b/src/files.rs
@@ -19,7 +19,6 @@
 
 #[cfg(feature = "cli")]
 use crate::cli::global::GlobalFlags;
-use anyhow::Context;
 #[cfg(any(feature = "cli", feature = "files"))]
 use globset::{Glob, GlobSet, GlobSetBuilder};
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -101,7 +100,13 @@ pub fn classify_text_bytes(bytes: &[u8]) -> TextBytesKind {
 /// | Binary | `Err(InvalidInputError)` — `target is a binary file: {display}` |
 /// | Invalid UTF-8 | `Err(InvalidInputError)` — `target is not valid UTF-8 text: {display}` |
 /// | Not a file | `Err(InvalidInputError)` — `target is not a file: {display}` |
-/// | IO (missing, …) | `Err` with context `failed to read {display}` |
+/// | IO NotFound | `Err` with `io::Error` + context `failed to read {display}` (`is_io_not_found`) |
+/// | IO other (permission, …) | `Err(InvalidInputError)` — `failed to read {display}: {os error}` |
+///
+/// Non-NotFound IO is typed so agent JSON gets `error_kind: invalid_input` and a
+/// single complete message that includes the OS error even when callers format
+/// with `Display` / `to_string()` (which drops anyhow cause chains). NotFound
+/// stays an IO error so [`crate::exit::is_io_not_found`] keeps working.
 ///
 /// Directory walks and multi-path soft-skip must use [`read_text_file`] (or
 /// `tx::read_and_probe`), not this function.
@@ -112,7 +117,21 @@ pub fn load_text_strict(path: &Path, display: &str) -> anyhow::Result<String> {
         }
         .into());
     }
-    let bytes = std::fs::read(path).with_context(|| format!("failed to read {display}"))?;
+    let bytes = match std::fs::read(path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(anyhow::Error::new(e).context(format!("failed to read {display}")));
+        }
+        Err(e) => {
+            // Full message in InvalidInputError so Display and JSON envelopes
+            // keep "Permission denied" without requiring `{:#}` (fixrealloop
+            // 2026-07-23: CLI read / MCP read dropped the OS detail).
+            return Err(crate::exit::InvalidInputError {
+                msg: format!("failed to read {display}: {e}"),
+            }
+            .into());
+        }
+    };
     match classify_text_bytes(&bytes) {
         TextBytesKind::Text(s) => Ok(s),
         TextBytesKind::Binary => Err(crate::exit::InvalidInputError {
@@ -991,6 +1010,54 @@ mod tests {
         let err = load_text_strict(dir.path(), "dir").unwrap_err();
         assert!(crate::exit::is_invalid_input(&err), "{err:#}");
         assert!(err.to_string().contains("not a file"), "msg: {err}");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn load_text_strict_unreadable_is_invalid_input_with_os_detail() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = dir.path().join("locked.txt");
+        std::fs::write(&p, "secret\n").unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o000)).unwrap();
+        // Root (common in Docker) can still read mode-000 files.
+        if std::fs::read_to_string(&p).is_ok() {
+            std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
+            return;
+        }
+        let err = load_text_strict(&p, "locked.txt").unwrap_err();
+        let _ = std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644));
+        assert!(crate::exit::is_invalid_input(&err), "{err:#}");
+        // Display (not only {:#}) must include OS detail for agent JSON paths
+        // that use e.to_string().
+        let msg = err.to_string();
+        assert!(msg.contains("failed to read locked.txt"), "msg: {msg}");
+        assert!(
+            msg.contains("Permission denied")
+                || msg.contains("PermissionDenied")
+                || msg.contains("os error"),
+            "OS detail missing from Display: {msg}"
+        );
+        assert_eq!(
+            msg.matches("failed to read").count(),
+            1,
+            "must not double-wrap: {msg}"
+        );
+    }
+
+    #[test]
+    fn load_text_strict_missing_is_io_not_found() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let p = dir.path().join("nope.txt");
+        let err = load_text_strict(&p, "nope.txt").unwrap_err();
+        assert!(
+            crate::exit::is_io_not_found(&err),
+            "expected is_io_not_found, got: {err:#}"
+        );
+        assert!(
+            !crate::exit::is_invalid_input(&err),
+            "NotFound must not be invalid_input: {err:#}"
+        );
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -487,9 +487,13 @@ mod tests {
                 return;
             }
             let err = sole_explicit_non_text(&["locked.txt".into()], dir.path()).unwrap();
+            assert!(err.msg.contains("failed to read"), "got: {}", err.msg);
+            // OS detail must appear in Display/msg (not only via {:#} on a chain).
             assert!(
-                err.msg.contains("failed to read") || err.msg.contains("Permission"),
-                "got: {}",
+                err.msg.contains("Permission denied")
+                    || err.msg.contains("PermissionDenied")
+                    || err.msg.contains("os error"),
+                "OS detail missing: {}",
                 err.msg
             );
             // Single prefix only (not "failed to read x: failed to read x").

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -83,13 +83,18 @@ pub(crate) fn read_and_probe(
             return Ok(false);
         }
         Err(crate::files::SoftTextSkip::Unreadable) => {
-            // Re-open so NotFound / PermissionDenied stay in the error chain
-            // for exit::is_io_not_found and agent remapping.
+            // Re-open so NotFound stays in the chain for is_io_not_found, and
+            // permission/other IO become typed InvalidInput with a complete
+            // Display message (fixrealloop 2026-07-23).
             return match std::fs::read(path) {
                 Ok(_) => Err(anyhow::anyhow!("failed to read {}", path.display())),
-                Err(e) => {
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     Err(anyhow::Error::new(e).context(format!("failed to read {}", path.display())))
                 }
+                Err(e) => Err(crate::exit::InvalidInputError {
+                    msg: format!("failed to read {}: {e}", path.display()),
+                }
+                .into()),
             };
         }
     };
@@ -682,7 +687,10 @@ pub(crate) fn execute_and_collect(
                 }
                 // Keep a readable Display string for stderr/tests, and re-emit
                 // typed kinds so CLI/tx --json can map error_kind without
-                // scraping English.
+                // scraping English. Use Display (not `{:#}`): `path_err`
+                // already embeds the prior Display text into its context, so
+                // `{:#}` would double the message (fixrealloop 2026-07-23).
+                // OS detail comes from load_text_strict InvalidInput Display.
                 let msg = format!("operation {} ({}) failed: {e}", i + 1, op_label(op));
                 if crate::exit::is_io_not_found(&e) {
                     return Err(std::io::Error::new(std::io::ErrorKind::NotFound, msg).into());


### PR DESCRIPTION
## Summary

Unreadable existing files (mode 000 / permission denied) lost agent-facing honesty after the double-wrap fix stack:

- CLI `read` reported `failed to read path` **without** `Permission denied`
- CLI `doc get` had no `error_kind` on the same failure
- MCP `read_file` / plan ops used `error_kind: operation_failed` and dropped the OS detail

Root cause: `load_text_strict` wrapped non-NotFound IO only as anyhow context. `Display` / `to_string()` show the outer layer only, so permission detail disappeared unless every caller used `{:#}`.

## Changes

- `load_text_strict`: NotFound stays IO (for `is_io_not_found`); other IO becomes `InvalidInputError` with a single complete message `failed to read {display}: {os error}`
- `read` residual path uses full chain messaging without double path prefix
- tx `read_and_probe` unreadable path matches the same typing
- AST sole-path reject only when `path_arg` names the file (directory walks keep the unreadable scan mask)
- Tests: unit coverage for load/read/patch/sole unreadable; existing AST dir unreadable integration still passes

## Dogfood (post-fix)

| Surface | error_kind | Permission denied | single `failed to read` |
|---------|------------|-------------------|-------------------------|
| CLI read/doc/search/replace/append | invalid_input | yes | yes |
| MCP read_file / doc_set | invalid_input | yes | yes |

## Test plan

- [x] `make check-fast`
- [x] unit: `load_text_strict_unreadable_*`, `read_one_file_unreadable_*`, patch unreadable, sole_explicit
- [x] integration: `test_ast_rename_dir_unreadable_not_no_matches`
- [x] release binary dogfood CLI + MCP on mode-000 file

Found by `/fixrealloop testing cli and mcp` after #1924.