### PR TITLE
fix: load errors keep OS detail without double-wrap

### DIFF
--- a/src/cmd/explain/mod.rs
+++ b/src/cmd/explain/mod.rs
@@ -60,9 +60,11 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         // Strict sole-path plan load (#1894).
         let content = match crate::files::load_text_strict(&full, &full.display().to_string()) {
             Ok(c) => c,
+            // load_text_strict already names the path + OS detail; do not
+            // prefix "cannot read {path}:" again (double-wrap / missing OS
+            // detail on Display; MPI 2026-07-23).
             Err(e) if crate::exit::is_io_not_found(&e) => {
-                let msg = format!("cannot read {}: {e}", full.display());
-                global.emit_error_json_kind(Some("not_found"), &msg)?;
+                global.emit_error_json_kind(Some("not_found"), &e.to_string())?;
                 return Ok(exit::FAILURE);
             }
             Err(e) if crate::exit::is_invalid_input(&e) => {
@@ -70,8 +72,7 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 return Ok(exit::FAILURE);
             }
             Err(e) => {
-                let msg = format!("cannot read {}: {e}", full.display());
-                global.emit_error_json_kind(Some("not_found"), &msg)?;
+                global.emit_error_json_kind(Some("not_found"), &e.to_string())?;
                 return Ok(exit::FAILURE);
             }
         };

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -104,10 +104,11 @@ pub(super) fn handle_ast_read(
     let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
     // Strict sole-path text load (#1894): binary / invalid UTF-8 → invalid_params.
     let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
-        if crate::exit::is_invalid_input(&e) {
+        // load_text_strict already names path + OS detail (MPI 2026-07-23).
+        if crate::exit::is_invalid_input(&e) || crate::exit::is_io_not_found(&e) {
             McpError::invalid_params(e.to_string(), None)
         } else {
-            McpError::internal_error(format!("reading {}: {e}", p.path), None)
+            McpError::internal_error(e.to_string(), None)
         }
     })?;
     let all_symbols = crate::ast::symbols::extract_symbols(&source, lang);
@@ -562,10 +563,10 @@ pub(super) fn handle_ast_diff(
     } else {
         // Strict sole-path (#1894): working-tree binary / invalid UTF-8.
         crate::files::load_text_strict(&target, &p.path).map_err(|e| {
-            if crate::exit::is_invalid_input(&e) {
+            if crate::exit::is_invalid_input(&e) || crate::exit::is_io_not_found(&e) {
                 McpError::invalid_params(e.to_string(), None)
             } else {
-                McpError::internal_error(format!("reading {}: {e}", p.path), None)
+                McpError::internal_error(e.to_string(), None)
             }
         })?
     };
@@ -715,10 +716,10 @@ pub(super) fn handle_ast_imports(
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
         // Strict sole-path (#1894).
         let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
-            if crate::exit::is_invalid_input(&e) {
+            if crate::exit::is_invalid_input(&e) || crate::exit::is_io_not_found(&e) {
                 McpError::invalid_params(e.to_string(), None)
             } else {
-                McpError::internal_error(format!("reading {}: {e}", p.path), None)
+                McpError::internal_error(e.to_string(), None)
             }
         })?;
         let imports = crate::ast::imports::list_imports(&source, lang);

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -488,10 +488,12 @@ impl PatchloomService {
             let abs = svc.cwd().join(&p.path);
             // Strict sole-path (#1894): binary / invalid UTF-8 → invalid_params.
             let content = crate::files::load_text_strict(&abs, &p.path).map_err(|e| {
-                if crate::exit::is_invalid_input(&e) {
+                // load_text_strict messages already include path + OS detail;
+                // do not prefix "reading {path}:" again (MPI 2026-07-23).
+                if crate::exit::is_invalid_input(&e) || crate::exit::is_io_not_found(&e) {
                     McpError::invalid_params(e.to_string(), None)
                 } else {
-                    McpError::internal_error(format!("reading {}: {e}", p.path), None)
+                    McpError::internal_error(e.to_string(), None)
                 }
             })?;
             let issues = crate::ops::md::lint_agents_content(&content);
@@ -644,10 +646,11 @@ impl PatchloomService {
                 // load_text_strict already prefixes "failed to read {path}";
                 // do not re-wrap (same class as #1916).
                 let content = crate::files::load_text_strict(&abs, path).map_err(|e| {
-                    if crate::exit::is_invalid_input(&e) {
+                    // Display already has path + OS detail (MPI 2026-07-23).
+                    if crate::exit::is_invalid_input(&e) || crate::exit::is_io_not_found(&e) {
                         McpError::invalid_params(e.to_string(), None)
                     } else {
-                        McpError::internal_error(format!("{e:#}"), None)
+                        McpError::internal_error(e.to_string(), None)
                     }
                 })?;
                 crate::plan::parse_plan_auto(&content, Some(path), None).map_err(|e| {

--- a/src/files.rs
+++ b/src/files.rs
@@ -120,7 +120,12 @@ pub fn load_text_strict(path: &Path, display: &str) -> anyhow::Result<String> {
     let bytes = match std::fs::read(path) {
         Ok(b) => b,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            return Err(anyhow::Error::new(e).context(format!("failed to read {display}")));
+            // Keep io::Error in the chain for `is_io_not_found`, and put the
+            // OS detail in the context string so Display (not only `{:#}`)
+            // includes "No such file" for agent JSON (MPI 2026-07-23: explain
+            // showed "cannot read X: failed to read X" with no OS detail).
+            let msg = format!("failed to read {display}: {e}");
+            return Err(anyhow::Error::new(e).context(msg));
         }
         Err(e) => {
             // Full message in InvalidInputError so Display and JSON envelopes
@@ -1057,6 +1062,18 @@ mod tests {
         assert!(
             !crate::exit::is_invalid_input(&err),
             "NotFound must not be invalid_input: {err:#}"
+        );
+        // Display must include OS detail (not only `{:#}`).
+        let msg = err.to_string();
+        assert!(msg.contains("failed to read nope.txt"), "msg: {msg}");
+        assert!(
+            msg.contains("No such file") || msg.contains("os error 2") || msg.contains("not found"),
+            "OS detail missing from Display: {msg}"
+        );
+        assert_eq!(
+            msg.matches("failed to read").count(),
+            1,
+            "must not double-wrap: {msg}"
         );
     }
 

--- a/tests/integration/explain_tests.rs
+++ b/tests/integration/explain_tests.rs
@@ -222,6 +222,54 @@ fn test_explain_invalid_plan_fails() {
     );
 }
 
+/// Missing plan file: not_found with a single path prefix + OS detail.
+/// MPI 2026-07-23: previously "cannot read X: failed to read X" without OS text.
+#[test]
+fn test_explain_missing_plan_is_not_found_with_os_detail() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.json");
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["explain", "nope.json"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "not_found", "{json}");
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("failed to read"),
+        "expected load_text_strict message: {json}"
+    );
+    assert!(
+        !err.contains("cannot read"),
+        "must not double-prefix cannot read: {json}"
+    );
+    assert_eq!(
+        err.matches("failed to read").count(),
+        1,
+        "must not double-wrap: {json}"
+    );
+    assert!(
+        err.contains("No such file")
+            || err.contains("os error 2")
+            || err.contains("not found")
+            || err.contains("not exist"),
+        "OS detail missing: {json}"
+    );
+    let _ = missing; // path intentionally absent
+}
+
 #[test]
 fn test_explain_stdin() {
     Command::cargo_bin("patchloom")

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -650,6 +650,54 @@ async fn test_mcp_symlink_within_cwd_allowed() {
 // Permission error integration tests (unix only)
 // ---------------------------------------------------------------------------
 
+/// Sole unreadable path is invalid_input with OS detail (not a bare
+/// "failed to read path" without Permission denied). MPI 2026-07-23 / #1925.
+#[cfg(unix)]
+#[test]
+fn test_read_sole_unreadable_is_invalid_input_with_os_detail() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("locked.txt");
+    fs::write(&file, "secret\n").unwrap();
+    fs::set_permissions(&file, fs::Permissions::from_mode(0o000)).unwrap();
+    if fs::read_to_string(&file).is_ok() {
+        fs::set_permissions(&file, fs::Permissions::from_mode(0o644)).unwrap();
+        return;
+    }
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["read", "locked.txt"])
+        .output()
+        .unwrap();
+    let _ = fs::set_permissions(&file, fs::Permissions::from_mode(0o644));
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("Permission denied")
+            || err.contains("PermissionDenied")
+            || err.contains("os error"),
+        "OS detail missing: {v}"
+    );
+    assert_eq!(
+        err.matches("failed to read").count(),
+        1,
+        "must not double-wrap: {v}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // --contain on read (read-side sandbox) (MPI cycle 18)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up honesty after #1925 (permission denied on unreadable paths):

- **explain** missing plan used `cannot read {path}: {e}` where `{e}` was only the outer `failed to read {path}` context, so agents saw a double path and no `No such file or directory`
- **load_text_strict** NotFound Display lacked OS detail unless callers used `{:#}`
- **MCP** sole-path loads prefixed `reading {path}:` on the same class of errors

## Changes

- `load_text_strict`: NotFound context string includes the OS error (chain still has `io::Error` for `is_io_not_found`)
- `explain`: emit `e.to_string()` without a second path prefix
- MCP handlers / AST tools: map NotFound to `invalid_params` with the complete message
- Integration: explain missing plan; CLI read sole-unreadable (locks #1925 for the empty test section)

## Test plan

- [x] `make check-fast`
- [x] unit `load_text_strict_missing_is_io_not_found`
- [x] integration `test_explain_missing_plan_is_not_found_with_os_detail`
- [x] integration `test_read_sole_unreadable_is_invalid_input_with_os_detail`
- [x] 148 MCP integration tests