### PR TITLE
fix: stop doubling OS detail in agent error JSON

### DIFF
--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -842,14 +842,13 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         // load_text_strict already prefixes "failed to read {display}"; do not
         // re-wrap (same class as #1916 / patch target IO).
         crate::files::load_text_strict(&input_path, &display).map_err(|e| {
+            let msg = crate::exit::agent_error_message(&e);
             if crate::exit::is_io_not_found(&e) {
-                std::io::Error::new(std::io::ErrorKind::NotFound, format!("{e:#}")).into()
+                std::io::Error::new(std::io::ErrorKind::NotFound, msg).into()
             } else if crate::exit::is_invalid_input(&e) {
                 e
             } else {
-                anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("{e:#}"),
-                })
+                anyhow::Error::new(crate::exit::InvalidInputError { msg })
             }
         })?
     };

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -181,7 +181,8 @@ fn load_patch_target(
         Err(e) => {
             // load_text_strict already prefixes "failed to read {display}";
             // do not double-wrap (same class as #1916 sole-path unreadable).
-            Err(PatchTargetError::Io(format!("{e:#}")))
+            // Prefer agent_error_message so embedded OS detail is not doubled.
+            Err(PatchTargetError::Io(crate::exit::agent_error_message(&e)))
         }
     }
 }

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -63,9 +63,10 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Rea
                     msg: inv.msg.clone(),
                 });
             }
-            // Missing path and other IO. Prefer `{:#}` so anyhow cause chains
-            // keep the OS detail (Permission denied); Display alone drops it.
-            let full = format!("{e:#}");
+            // Missing path and other IO. Prefer agent_error_message so embedded
+            // OS detail is kept once (Display alone drops chains; `{:#}` can
+            // double when load_text_strict already embeds the cause).
+            let full = crate::exit::agent_error_message(&e);
             let kind = if full.contains("No such file")
                 || full.contains("not found")
                 || full.contains("failed to read")

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -310,14 +310,13 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         // load_text_strict already prefixes "failed to read {display}"; do not
         // re-wrap (same class as #1916).
         crate::files::load_text_strict(plan_path, &display).map_err(|e| {
+            let msg = crate::exit::agent_error_message(&e);
             if crate::exit::is_io_not_found(&e) {
-                std::io::Error::new(std::io::ErrorKind::NotFound, format!("{e:#}")).into()
+                std::io::Error::new(std::io::ErrorKind::NotFound, msg).into()
             } else if crate::exit::is_invalid_input(&e) {
                 e
             } else {
-                anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("{e:#}"),
-                })
+                anyhow::Error::new(crate::exit::InvalidInputError { msg })
             }
         })?
     };

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -300,6 +300,28 @@ pub fn is_io_is_a_directory(err: &anyhow::Error) -> bool {
     })
 }
 
+/// Format an error for agent-facing surfaces (JSON `error`, typed msg fields).
+///
+/// Prefer [`Display`] when the outer context already embeds every cause message
+/// (common after `context(format!("…: {e}"))` on IO errors). In that case
+/// `{:#}` only doubles the OS detail (e.g. `…: No such file …: No such file …`).
+/// Otherwise use the full chain (`{:#}`) so multi-layer context stays complete.
+///
+/// [`Display`]: std::fmt::Display
+#[must_use]
+pub fn agent_error_message(err: &anyhow::Error) -> String {
+    let top = err.to_string();
+    let mut complete = true;
+    for cause in err.chain().skip(1) {
+        let c = cause.to_string();
+        if !c.is_empty() && !top.contains(&c) {
+            complete = false;
+            break;
+        }
+    }
+    if complete { top } else { format!("{err:#}") }
+}
+
 /// Build the shared JSON error envelope + exit code for agent `--json` paths.
 ///
 /// Includes `error_kind` when classifiable and `backup_session` when a
@@ -312,7 +334,7 @@ pub fn structured_error_payload(err: &anyhow::Error) -> (serde_json::Value, u8) 
     };
     let mut output = serde_json::json!({
         "ok": false,
-        "error": format!("{err:#}")
+        "error": agent_error_message(err)
     });
     if let Some(k) = kind {
         output["error_kind"] = serde_json::Value::String(k.to_string());
@@ -521,6 +543,59 @@ mod tests {
         assert_eq!(
             p["applied"], false,
             "pre-write not_found must set applied:false: {p}"
+        );
+    }
+
+    #[test]
+    fn agent_error_message_avoids_double_os_when_context_embeds_cause() {
+        // Mirrors load_text_strict NotFound: context already includes `{e}`.
+        let io = std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory");
+        let msg = format!("failed to read missing.txt: {io}");
+        let err = anyhow::Error::new(io).context(msg);
+        let agent = agent_error_message(&err);
+        assert!(
+            agent.contains("failed to read missing.txt"),
+            "path context missing: {agent}"
+        );
+        assert!(agent.contains("No such file"), "OS detail missing: {agent}");
+        assert_eq!(
+            agent.matches("No such file").count(),
+            1,
+            "OS detail must not double under agent_error_message: {agent}"
+        );
+        // {:#} still doubles — that is what we are avoiding.
+        let raw = format!("{err:#}");
+        assert!(
+            raw.matches("No such file").count() >= 2,
+            "test premise: raw {{:#}} should double: {raw}"
+        );
+        let (payload, _) = structured_error_payload(&err);
+        let json_err = payload["error"].as_str().unwrap_or("");
+        assert_eq!(
+            json_err.matches("No such file").count(),
+            1,
+            "structured_error_payload must not double OS detail: {json_err}"
+        );
+    }
+
+    #[test]
+    fn agent_error_message_keeps_multi_layer_chain_when_causes_add_info() {
+        let root = std::io::Error::new(std::io::ErrorKind::NotFound, "No such file or directory");
+        let err = anyhow::Error::new(root)
+            .context("failed to read plan.yaml")
+            .context("operation 1 (doc.get) failed");
+        let agent = agent_error_message(&err);
+        assert!(
+            agent.contains("operation 1"),
+            "outer context missing: {agent}"
+        );
+        assert!(
+            agent.contains("failed to read plan.yaml"),
+            "middle context missing: {agent}"
+        );
+        assert!(
+            agent.contains("No such file"),
+            "root OS detail missing: {agent}"
         );
     }
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -1075,6 +1075,17 @@ mod tests {
             1,
             "must not double-wrap: {msg}"
         );
+        // Agent JSON / {:#} consumers must not double the OS detail either.
+        let agent = crate::exit::agent_error_message(&err);
+        let os_hits = agent
+            .matches("No such file")
+            .count()
+            .max(agent.matches("os error 2").count())
+            .max(agent.matches("not found").count());
+        assert_eq!(
+            os_hits, 1,
+            "agent_error_message must keep OS detail once: {agent}"
+        );
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -130,8 +130,9 @@ pub fn sole_explicit_non_text(
             } else {
                 // load_text_strict already prefixes "failed to read {display}";
                 // do not double-wrap (fixrealloop: "failed to read x: failed to read x").
+                // Prefer agent_error_message so embedded OS detail is not doubled.
                 Some(crate::exit::InvalidInputError {
-                    msg: format!("{e:#}"),
+                    msg: crate::exit::agent_error_message(&e),
                 })
             }
         }


### PR DESCRIPTION
## Summary

When a missing path is loaded via `load_text_strict`, the context string already includes the OS detail for Display completeness. Agent JSON used `format!("{err:#}")`, which re-appended the same cause and produced doubled messages such as `No such file or directory (os error 2): No such file or directory (os error 2)`.

## Change

- Add `exit::agent_error_message`: prefer Display when every cause is already embedded in the top message; otherwise keep the full `{:#}` chain for multi-layer context.
- Use it in `structured_error_payload` and sole-path load consumers (`read`, `tx`, `batch`, `patch`, `ops/file`).
- Unit tests cover no-double OS detail and multi-layer chain preservation.

## Validation

- `make check-fast` green
- Dogfood: `read`, `doc get`, `explain` on missing paths show a single OS detail under `--json`