### PR TITLE
fix: use dunce::canonicalize for PathGuard (Windows UNC)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,6 +1444,7 @@ dependencies = [
  "axum-server",
  "clap",
  "clap_complete",
+ "dunce",
  "ec4rs",
  "expectrl",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,8 @@ similar = { version = "3", features = ["text"] }
 strsim = "0.11"
 tempfile = "3"
 anyhow = "1"
+# Strip Windows \\?\ UNC prefix from canonicalize results (PathGuard starts_with + display).
+dunce = "1"
 anstream = { version = "1", optional = true }
 ec4rs = { version = "1", optional = true }
 clap_complete = { version = "4", optional = true }

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -77,8 +77,9 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // Same-file no-op check. On case-insensitive filesystems (macOS APFS),
-    // canonicalize() treats case differences as identical. Allow the rename
+    // canonicalize treats case differences as identical. Allow the rename
     // when only the case differs so users can change filename casing (#1167).
+    // Use safe_canonicalize (dunce) so Windows UNC prefixes do not diverge.
     let is_case_only_change = src != dst
         && src.parent() == dst.parent()
         && src.file_name().map(|n| n.to_ascii_lowercase())
@@ -86,7 +87,10 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     if !is_case_only_change
         && (src == dst
             || matches!(
-                (src.canonicalize(), dst.canonicalize()),
+                (
+                    crate::containment::safe_canonicalize(&src),
+                    crate::containment::safe_canonicalize(&dst)
+                ),
                 (Ok(ref s), Ok(ref d)) if s == d
             ))
     {

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -53,6 +53,21 @@
 
 use std::path::{Component, Path, PathBuf};
 
+/// Canonicalize a path without the Windows `\\?\` UNC prefix when safe.
+///
+/// On Windows, [`std::fs::canonicalize`] returns paths like
+/// `\\?\C:\Users\...`. Those break [`Path::starts_with`] when compared to a
+/// non-UNC root (or vice versa) and look wrong in agent-facing display.
+/// [`dunce::canonicalize`] strips the prefix when the path is shorter than
+/// `MAX_PATH` and has no special characters. On non-Windows this is a
+/// transparent passthrough to `std::fs::canonicalize`.
+///
+/// Prefer this for PathGuard roots, containment checks, and any path that may
+/// be compared with `starts_with` or shown in error messages.
+pub fn safe_canonicalize(path: &Path) -> std::io::Result<PathBuf> {
+    dunce::canonicalize(path)
+}
+
 /// Policy for handling absolute paths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AbsolutePathPolicy {
@@ -216,7 +231,7 @@ impl PathGuard {
                 AbsolutePathPolicy::AllowAdditionalRoots(extra) => {
                     let mut allowed = vec![self.canon_root.clone()];
                     for r in extra {
-                        if let Ok(c) = r.canonicalize() {
+                        if let Ok(c) = safe_canonicalize(r) {
                             allowed.push(c);
                         }
                     }
@@ -308,12 +323,10 @@ impl PathGuard {
         root: PathBuf,
         policy: AbsolutePathPolicy,
     ) -> Result<Self, ContainmentError> {
-        let canon_root = root
-            .canonicalize()
-            .map_err(|e| ContainmentError::Canonicalize {
-                path: root.display().to_string(),
-                source: e,
-            })?;
+        let canon_root = safe_canonicalize(&root).map_err(|e| ContainmentError::Canonicalize {
+            path: root.display().to_string(),
+            source: e,
+        })?;
         Ok(Self {
             root,
             canon_root,
@@ -429,6 +442,9 @@ fn normalize_lexical(path: &Path) -> PathBuf {
 
 /// Canonicalize a path, or if it doesn't exist, canonicalize the nearest
 /// existing ancestor and append the remaining components.
+///
+/// Uses [`safe_canonicalize`] (dunce) so Windows UNC prefixes do not break
+/// containment `starts_with` checks against the PathGuard root.
 fn canonicalize_or_ancestor(path: &Path) -> std::io::Result<PathBuf> {
     // Normalize `..` and `.` lexically first so the ancestor walk never
     // encounters components that `file_name()` would silently skip.
@@ -436,7 +452,7 @@ fn canonicalize_or_ancestor(path: &Path) -> std::io::Result<PathBuf> {
     let path = normalized.as_path();
 
     if path.exists() {
-        return path.canonicalize();
+        return safe_canonicalize(path);
     }
     // Walk up to the nearest existing ancestor.
     let mut ancestor = path;
@@ -448,7 +464,7 @@ fn canonicalize_or_ancestor(path: &Path) -> std::io::Result<PathBuf> {
                 if let Some(file_name) = ancestor.file_name() {
                     tail_components.push(file_name.to_os_string());
                 }
-                let canon_ancestor = p.canonicalize()?;
+                let canon_ancestor = safe_canonicalize(p)?;
                 // Rebuild the path by appending tail components in reverse.
                 let mut result = canon_ancestor;
                 for c in tail_components.into_iter().rev() {
@@ -462,7 +478,7 @@ fn canonicalize_or_ancestor(path: &Path) -> std::io::Result<PathBuf> {
                 }
                 ancestor = p;
             }
-            None => return path.canonicalize(),
+            None => return safe_canonicalize(path),
         }
     }
 }
@@ -476,489 +492,5 @@ const _: () = {
 };
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-
-    #[test]
-    fn relative_path_within_workspace() {
-        let dir = tempfile::TempDir::new().unwrap();
-        fs::write(dir.path().join("file.txt"), "ok").unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        guard.check_path("file.txt").unwrap();
-    }
-
-    #[test]
-    fn relative_path_with_safe_parent_traversal() {
-        let dir = tempfile::TempDir::new().unwrap();
-        fs::create_dir_all(dir.path().join("src")).unwrap();
-        fs::write(dir.path().join("Cargo.toml"), "ok").unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        // src/../Cargo.toml stays within workspace
-        guard.check_path("src/../Cargo.toml").unwrap();
-    }
-
-    #[test]
-    fn relative_path_escaping_workspace() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        let err = guard.check_path("../../etc/passwd").unwrap_err();
-        assert!(matches!(err, ContainmentError::Escaped { .. }));
-    }
-
-    #[test]
-    fn absolute_path_with_allow_if_contained() {
-        let dir = tempfile::TempDir::new().unwrap();
-        fs::write(dir.path().join("inside.txt"), "ok").unwrap();
-        let guard = PathGuard::new(
-            dir.path().to_path_buf(),
-            AbsolutePathPolicy::AllowIfContained,
-        )
-        .unwrap();
-        let abs = dir.path().join("inside.txt");
-        guard.check_path(abs.to_str().unwrap()).unwrap();
-    }
-
-    /// Return an absolute path string that is guaranteed outside any temp dir.
-    fn outside_absolute_path() -> &'static str {
-        #[cfg(unix)]
-        {
-            "/etc/passwd"
-        }
-        #[cfg(windows)]
-        {
-            "C:\\Windows\\System32\\notepad.exe"
-        }
-    }
-
-    #[test]
-    fn absolute_path_outside_workspace_with_allow_if_contained() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(
-            dir.path().to_path_buf(),
-            AbsolutePathPolicy::AllowIfContained,
-        )
-        .unwrap();
-        let err = guard.check_path(outside_absolute_path()).unwrap_err();
-        assert!(matches!(err, ContainmentError::Escaped { .. }));
-    }
-
-    #[test]
-    fn absolute_path_with_reject_policy() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        let err = guard.check_path(outside_absolute_path()).unwrap_err();
-        assert!(matches!(err, ContainmentError::AbsolutePath(_)));
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn symlink_escaping_workspace() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let link = dir.path().join("escape");
-        std::os::unix::fs::symlink("/tmp", &link).unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        let err = guard.check_path("escape").unwrap_err();
-        assert!(matches!(err, ContainmentError::Escaped { .. }));
-    }
-
-    #[test]
-    fn nonexistent_file_in_existing_directory() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        let result = guard.check_path("new_file.txt");
-        assert!(
-            result.is_ok(),
-            "non-existent file with safe ancestor should be allowed"
-        );
-    }
-
-    #[test]
-    fn empty_path() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        // Empty string resolves to cwd itself, which is contained.
-        guard.check_path("").unwrap();
-    }
-
-    #[test]
-    fn single_parent_rejected() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        guard.check_path("..").expect_err("expected error");
-    }
-
-    #[test]
-    fn deep_traversal_rejected() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        guard
-            .check_path("a/b/../../../escape")
-            .expect_err("expected error");
-    }
-
-    #[test]
-    fn dot_relative_path_allowed() {
-        let dir = tempfile::TempDir::new().unwrap();
-        fs::create_dir_all(dir.path().join("foo")).unwrap();
-        fs::write(dir.path().join("foo/bar.json"), "{}").unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        guard.check_path("./foo/bar.json").unwrap();
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn new_file_through_symlink_dir_rejected() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let link = dir.path().join("link_dir");
-        std::os::unix::fs::symlink("/tmp", &link).unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        let err = guard.check_path("link_dir/new_file.txt").unwrap_err();
-        assert!(
-            matches!(err, ContainmentError::Escaped { .. }),
-            "new file through symlink escaping workspace should be rejected"
-        );
-    }
-
-    #[test]
-    fn check_path_returns_canonicalized_path() {
-        let dir = tempfile::TempDir::new().unwrap();
-        fs::write(dir.path().join("test.txt"), "ok").unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        let resolved = guard.check_path("test.txt").unwrap();
-        // The returned path should be absolute (canonicalized).
-        assert!(resolved.is_absolute());
-        assert!(resolved.ends_with("test.txt"));
-    }
-
-    #[test]
-    fn root_and_canon_root_accessors() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        assert_eq!(guard.root(), dir.path());
-        assert!(guard.canon_root().is_absolute());
-    }
-
-    #[test]
-    fn new_with_nonexistent_root_returns_canonicalize_error() {
-        let err = PathGuard::new(
-            PathBuf::from("/nonexistent_patchloom_test_dir_xyz"),
-            AbsolutePathPolicy::Reject,
-        )
-        .unwrap_err();
-        assert!(matches!(err, ContainmentError::Canonicalize { .. }));
-        let msg = err.to_string();
-        assert!(
-            msg.contains("failed to canonicalize"),
-            "expected canonicalize message, got: {msg}"
-        );
-    }
-
-    #[test]
-    fn error_display_absolute_path() {
-        let err = ContainmentError::AbsolutePath("/etc/passwd".to_string());
-        let msg = err.to_string();
-        assert!(
-            msg.contains("absolute paths are not allowed") && msg.contains("/etc/passwd"),
-            "unexpected message: {msg}"
-        );
-    }
-
-    #[test]
-    fn error_display_escaped() {
-        let err = ContainmentError::Escaped {
-            path: "../../secret".to_string(),
-            root: "/home/user".to_string(),
-        };
-        let msg = err.to_string();
-        assert!(
-            msg.contains("escapes workspace")
-                && msg.contains("../../secret")
-                && msg.contains("/home/user"),
-            "unexpected message: {msg}"
-        );
-    }
-
-    #[test]
-    fn parent_escape_error_includes_workspace_root() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        let err = guard.check_path("../escape.txt").unwrap_err();
-        let msg = err.to_string();
-        let root_disp = dir.path().display().to_string();
-        assert!(
-            msg.contains("escapes") && msg.contains(&root_disp),
-            "escape error must name workspace root {root_disp:?}, got: {msg}"
-        );
-        assert!(
-            !msg.contains("(workspace: )"),
-            "must not print empty workspace root: {msg}"
-        );
-    }
-
-    #[test]
-    fn error_source_canonicalize_returns_inner_error() {
-        use std::error::Error;
-        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
-        let err = ContainmentError::Canonicalize {
-            path: "test".to_string(),
-            source: io_err,
-        };
-        // strengthened (was bare is_some); expect gives context on failure
-        let _src = err
-            .source()
-            .expect("Canonicalize error must carry inner io source");
-        let msg = err.to_string();
-        assert!(msg.contains("failed to canonicalize"), "got: {msg}");
-    }
-
-    #[test]
-    fn error_source_non_canonicalize_returns_none() {
-        use std::error::Error;
-        let err = ContainmentError::AbsolutePath("/x".to_string());
-        assert!(err.source().is_none());
-        let err2 = ContainmentError::Escaped {
-            path: "..".to_string(),
-            root: "/r".to_string(),
-        };
-        assert!(err2.source().is_none());
-    }
-
-    #[test]
-    fn allow_additional_roots_allows_temp_and_extra() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let temp = std::env::temp_dir();
-        let guard = PathGuard::new(
-            dir.path().to_path_buf(),
-            AbsolutePathPolicy::AllowAdditionalRoots(vec![temp.clone()]),
-        )
-        .unwrap();
-        // absolute in extra root should work
-        let tmp_file = temp.join("patchloom_test_extra.txt");
-        // create it
-        std::fs::write(&tmp_file, "ok").unwrap();
-        let res = guard.check_path(tmp_file.to_str().unwrap());
-        res.unwrap();
-        // clean
-        let _ = std::fs::remove_file(&tmp_file);
-    }
-
-    #[test]
-    fn allow_additional_roots_still_rejects_outside() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(
-            dir.path().to_path_buf(),
-            AbsolutePathPolicy::allow_workspace_and_temp_dir(),
-        )
-        .unwrap();
-        let err = guard.check_path("/etc/passwd").unwrap_err();
-        assert!(matches!(err, ContainmentError::Escaped { .. }));
-    }
-
-    #[test]
-    fn builder_allows_temp() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::builder(dir.path().to_path_buf())
-            .allow_temp_directory()
-            .build()
-            .unwrap();
-        // should allow temp
-        let temp = std::env::temp_dir().join("patchloom_builder_test.txt");
-        std::fs::write(&temp, "ok").unwrap();
-        guard.check_path(temp.to_str().unwrap()).unwrap();
-        let _ = std::fs::remove_file(&temp);
-    }
-
-    /// Regression test for #781: literal `/tmp/...` (common spelling from agents/LLMs)
-    /// must be allowed by `allow_temp_directory()` even on macOS where
-    /// std::env::temp_dir() is under /var/folders and /tmp symlinks to /private/tmp.
-    #[cfg(unix)]
-    #[test]
-    fn builder_allows_literal_tmp_path_unix() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::builder(dir.path().to_path_buf())
-            .allow_temp_directory()
-            .build()
-            .unwrap();
-
-        // Use a unique name under the conventional /tmp to simulate real usage
-        // (host experiment-mode paths, agent-generated paths, etc.).
-        let tmp_path = format!("/tmp/patchloom_781_test_{}.txt", std::process::id());
-        let _ = std::fs::remove_file(&tmp_path);
-        std::fs::write(&tmp_path, "data for 781").unwrap();
-        let res = guard.check_path(&tmp_path);
-        assert!(
-            res.is_ok(),
-            "literal /tmp path must be allowed: {:?}",
-            res.err()
-        );
-        let _ = std::fs::remove_file(&tmp_path);
-    }
-
-    /// Non-existing file under /tmp must still be allowed (via ancestor canonicalization).
-    #[cfg(unix)]
-    #[test]
-    fn builder_allows_nonexistent_under_literal_tmp() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::builder(dir.path().to_path_buf())
-            .allow_temp_directory()
-            .build()
-            .unwrap();
-
-        let tmp_path = format!("/tmp/patchloom_781_nonexist_{}.txt", std::process::id());
-        // do not create it
-        let res = guard.check_path(&tmp_path);
-        assert!(
-            res.is_ok(),
-            "non-existing /tmp path must be allowed via ancestor: {:?}",
-            res.err()
-        );
-    }
-
-    #[test]
-    fn allow_workspace_and_temp_dir_allows_std_temp() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(
-            dir.path().to_path_buf(),
-            AbsolutePathPolicy::allow_workspace_and_temp_dir(),
-        )
-        .unwrap();
-        let temp = std::env::temp_dir().join("patchloom_awtd_std.txt");
-        std::fs::write(&temp, "ok").unwrap();
-        guard.check_path(temp.to_str().unwrap()).unwrap();
-        let _ = std::fs::remove_file(&temp);
-    }
-
-    /// #781: allow_workspace_and_temp_dir must also cover literal /tmp.
-    #[cfg(unix)]
-    #[test]
-    fn allow_workspace_and_temp_dir_allows_literal_tmp() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(
-            dir.path().to_path_buf(),
-            AbsolutePathPolicy::allow_workspace_and_temp_dir(),
-        )
-        .unwrap();
-
-        let tmp_path = format!("/tmp/patchloom_781_awtd_{}.txt", std::process::id());
-        let _ = std::fs::remove_file(&tmp_path);
-        std::fs::write(&tmp_path, "data").unwrap();
-        guard.check_path(&tmp_path).unwrap();
-        let _ = std::fs::remove_file(&tmp_path);
-    }
-
-    #[test]
-    fn would_allow_works() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-        assert!(guard.would_allow("foo.txt"));
-        assert!(!guard.would_allow("../escape"));
-    }
-
-    /// Basic coverage for the helper (addresses review note for direct test of system_temp...).
-    #[test]
-    fn system_temp_directory_roots_contains_expected_entries() {
-        let roots = system_temp_directory_roots();
-        // Always at least the std one
-        assert!(!roots.is_empty());
-        // On unix we explicitly add the conventional ones
-        #[cfg(unix)]
-        {
-            assert!(roots.iter().any(
-                |r| r == std::path::Path::new("/tmp") || r == std::path::Path::new("/var/tmp")
-            ));
-            // std env temp is present
-            let stdt = std::env::temp_dir();
-            assert!(roots.iter().any(|r| r == &stdt));
-        }
-    }
-
-    /// Regression for coverage: paths using ../ to escape an *allowed additional root*
-    /// (e.g. literal /tmp on macOS) must still be rejected after canonicalization.
-    /// This was not explicitly asserted in prior temp-allow tests.
-    #[cfg(unix)]
-    #[test]
-    fn allow_temp_rejects_escape_from_tmp_via_parent() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let guard = PathGuard::builder(dir.path().to_path_buf())
-            .allow_temp_directory()
-            .build()
-            .unwrap();
-
-        let escape_path = "/tmp/../etc/passwd";
-        let err = guard.check_path(escape_path).unwrap_err();
-        assert!(
-            matches!(err, ContainmentError::Escaped { .. }),
-            "expected Escaped for escape from /tmp root via .., got {:?}",
-            err
-        );
-    }
-
-    /// Regression: `..` components in non-existent absolute paths must not be
-    /// silently dropped during ancestor canonicalization. `Path::file_name()`
-    /// returns `None` for `..`, so the old code skipped those components,
-    /// making a path like `workspace/nonexistent/../../outside/secret.txt`
-    /// appear to be `workspace/nonexistent/outside/secret.txt` (inside).
-    #[test]
-    fn dotdot_in_nonexistent_absolute_path_rejected() {
-        let base = tempfile::TempDir::new().unwrap();
-        let workspace = base.path().join("workspace");
-        let outside = base.path().join("outside");
-        fs::create_dir(&workspace).unwrap();
-        fs::create_dir(&outside).unwrap();
-        fs::write(outside.join("secret.txt"), "sensitive").unwrap();
-
-        let guard =
-            PathGuard::new(workspace.clone(), AbsolutePathPolicy::AllowIfContained).unwrap();
-
-        // workspace/nonexistent/../../outside/secret.txt
-        // resolves lexically to: base/outside/secret.txt (outside workspace)
-        let escape = workspace
-            .join("nonexistent")
-            .join("..")
-            .join("..")
-            .join("outside")
-            .join("secret.txt");
-
-        let result = guard.check_path(escape.to_str().unwrap());
-        assert!(
-            matches!(result, Err(ContainmentError::Escaped { .. })),
-            "path with .. through non-existent dir should be rejected, got: {:?}",
-            result,
-        );
-    }
-
-    /// Same bypass with AllowAdditionalRoots policy.
-    #[test]
-    fn dotdot_in_nonexistent_path_rejected_with_additional_roots() {
-        let base = tempfile::TempDir::new().unwrap();
-        let workspace = base.path().join("workspace");
-        let extra_root = base.path().join("extra");
-        let outside = base.path().join("outside");
-        fs::create_dir(&workspace).unwrap();
-        fs::create_dir(&extra_root).unwrap();
-        fs::create_dir(&outside).unwrap();
-        fs::write(outside.join("data.txt"), "sensitive").unwrap();
-
-        let guard = PathGuard::new(
-            workspace.clone(),
-            AbsolutePathPolicy::AllowAdditionalRoots(vec![extra_root]),
-        )
-        .unwrap();
-
-        // extra uses nonexistent to escape via ..
-        let escape = workspace
-            .join("nonexistent")
-            .join("..")
-            .join("..")
-            .join("outside")
-            .join("data.txt");
-
-        let result = guard.check_path(escape.to_str().unwrap());
-        assert!(
-            matches!(result, Err(ContainmentError::Escaped { .. })),
-            "dotdot escape via additional-roots should be rejected, got: {:?}",
-            result,
-        );
-    }
-}
+#[path = "containment_tests.rs"]
+mod tests;

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -1,0 +1,579 @@
+use super::*;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[test]
+fn relative_path_within_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(dir.path().join("file.txt"), "ok").unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    guard.check_path("file.txt").unwrap();
+}
+
+#[test]
+fn relative_path_with_safe_parent_traversal() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("Cargo.toml"), "ok").unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    // src/../Cargo.toml stays within workspace
+    guard.check_path("src/../Cargo.toml").unwrap();
+}
+
+#[test]
+fn relative_path_escaping_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let err = guard.check_path("../../etc/passwd").unwrap_err();
+    assert!(matches!(err, ContainmentError::Escaped { .. }));
+}
+
+#[test]
+fn absolute_path_with_allow_if_contained() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(dir.path().join("inside.txt"), "ok").unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let abs = dir.path().join("inside.txt");
+    guard.check_path(abs.to_str().unwrap()).unwrap();
+}
+
+/// Return an absolute path string that is guaranteed outside any temp dir.
+fn outside_absolute_path() -> &'static str {
+    #[cfg(unix)]
+    {
+        "/etc/passwd"
+    }
+    #[cfg(windows)]
+    {
+        "C:\\Windows\\System32\\notepad.exe"
+    }
+}
+
+#[test]
+fn absolute_path_outside_workspace_with_allow_if_contained() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let err = guard.check_path(outside_absolute_path()).unwrap_err();
+    assert!(matches!(err, ContainmentError::Escaped { .. }));
+}
+
+#[test]
+fn absolute_path_with_reject_policy() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let err = guard.check_path(outside_absolute_path()).unwrap_err();
+    assert!(matches!(err, ContainmentError::AbsolutePath(_)));
+}
+
+#[cfg(unix)]
+#[test]
+fn symlink_escaping_workspace() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let link = dir.path().join("escape");
+    std::os::unix::fs::symlink("/tmp", &link).unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let err = guard.check_path("escape").unwrap_err();
+    assert!(matches!(err, ContainmentError::Escaped { .. }));
+}
+
+#[test]
+fn nonexistent_file_in_existing_directory() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let result = guard.check_path("new_file.txt");
+    assert!(
+        result.is_ok(),
+        "non-existent file with safe ancestor should be allowed"
+    );
+}
+
+#[test]
+fn empty_path() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    // Empty string resolves to cwd itself, which is contained.
+    guard.check_path("").unwrap();
+}
+
+#[test]
+fn single_parent_rejected() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    guard.check_path("..").expect_err("expected error");
+}
+
+#[test]
+fn deep_traversal_rejected() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    guard
+        .check_path("a/b/../../../escape")
+        .expect_err("expected error");
+}
+
+#[test]
+fn dot_relative_path_allowed() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("foo")).unwrap();
+    fs::write(dir.path().join("foo/bar.json"), "{}").unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    guard.check_path("./foo/bar.json").unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn new_file_through_symlink_dir_rejected() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let link = dir.path().join("link_dir");
+    std::os::unix::fs::symlink("/tmp", &link).unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let err = guard.check_path("link_dir/new_file.txt").unwrap_err();
+    assert!(
+        matches!(err, ContainmentError::Escaped { .. }),
+        "new file through symlink escaping workspace should be rejected"
+    );
+}
+
+#[test]
+fn check_path_returns_canonicalized_path() {
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(dir.path().join("test.txt"), "ok").unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let resolved = guard.check_path("test.txt").unwrap();
+    // The returned path should be absolute (canonicalized).
+    assert!(resolved.is_absolute());
+    assert!(resolved.ends_with("test.txt"));
+    // PathGuard root and resolved path must agree under starts_with (#1931).
+    assert!(
+        resolved.starts_with(guard.canon_root()),
+        "resolved {resolved:?} must start with canon_root {:?}",
+        guard.canon_root()
+    );
+}
+
+#[test]
+fn root_and_canon_root_accessors() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    assert_eq!(guard.root(), dir.path());
+    assert!(guard.canon_root().is_absolute());
+}
+
+#[test]
+fn safe_canonicalize_existing_dir() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let canon = safe_canonicalize(dir.path()).unwrap();
+    assert!(canon.is_absolute());
+    assert!(canon.exists());
+}
+
+#[test]
+fn safe_canonicalize_nonexistent_returns_error() {
+    let result = safe_canonicalize(Path::new("/nonexistent/patchloom_dunce_xyz"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn path_guard_canon_root_has_no_windows_unc_prefix() {
+    // #1931: std::fs::canonicalize on Windows yields \\?\ paths that break
+    // starts_with when compared to non-UNC absolutes. dunce strips them.
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "ok").unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let root_s = guard.canon_root().to_string_lossy();
+    assert!(
+        !root_s.starts_with(r"\\?\"),
+        "canon_root must not use UNC prefix, got: {root_s}"
+    );
+    let resolved = guard.check_path("f.txt").unwrap();
+    let res_s = resolved.to_string_lossy();
+    assert!(
+        !res_s.starts_with(r"\\?\"),
+        "check_path result must not use UNC prefix, got: {res_s}"
+    );
+    // Absolute path under AllowIfContained must still contain.
+    let abs = dir.path().join("f.txt");
+    let guard_abs = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let abs_resolved = guard_abs
+        .check_path(abs.to_str().expect("utf-8 temp path"))
+        .expect("absolute under workspace must be allowed");
+    assert!(
+        abs_resolved.starts_with(guard_abs.canon_root()),
+        "abs resolved {abs_resolved:?} vs root {:?}",
+        guard_abs.canon_root()
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_safe_canonicalize_preserves_drive_letter() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let canon = safe_canonicalize(dir.path()).unwrap();
+    let s = canon.to_string_lossy();
+    assert!(
+        s.len() >= 3
+            && s.as_bytes()[0].is_ascii_alphabetic()
+            && s.as_bytes()[1] == b':'
+            && (s.as_bytes()[2] == b'\\' || s.as_bytes()[2] == b'/'),
+        "expected drive letter path, got: {s}"
+    );
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_mixed_unc_and_plain_still_contain() {
+    // Simulate the embedder failure mode: root built from dunce, check
+    // path from std canonicalize (or the reverse). Both paths through
+    // PathGuard must use the same helper so starts_with works.
+    let dir = tempfile::TempDir::new().unwrap();
+    fs::write(dir.path().join("inside.txt"), "x").unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    // Absolute path as Windows would spell it without going through our API.
+    let abs = dir.path().join("inside.txt");
+    let std_canon = std::fs::canonicalize(&abs).unwrap();
+    // Even if the raw string has UNC, PathGuard re-canonicalizes with dunce.
+    let s = std_canon.to_string_lossy();
+    let ok = guard.check_path(s.as_ref());
+    assert!(
+        ok.is_ok(),
+        "PathGuard must accept std-canonicalized absolute path {s}: {ok:?}"
+    );
+}
+
+#[test]
+fn new_with_nonexistent_root_returns_canonicalize_error() {
+    let err = PathGuard::new(
+        PathBuf::from("/nonexistent_patchloom_test_dir_xyz"),
+        AbsolutePathPolicy::Reject,
+    )
+    .unwrap_err();
+    assert!(matches!(err, ContainmentError::Canonicalize { .. }));
+    let msg = err.to_string();
+    assert!(
+        msg.contains("failed to canonicalize"),
+        "expected canonicalize message, got: {msg}"
+    );
+}
+
+#[test]
+fn error_display_absolute_path() {
+    let err = ContainmentError::AbsolutePath("/etc/passwd".to_string());
+    let msg = err.to_string();
+    assert!(
+        msg.contains("absolute paths are not allowed") && msg.contains("/etc/passwd"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn error_display_escaped() {
+    let err = ContainmentError::Escaped {
+        path: "../../secret".to_string(),
+        root: "/home/user".to_string(),
+    };
+    let msg = err.to_string();
+    assert!(
+        msg.contains("escapes workspace")
+            && msg.contains("../../secret")
+            && msg.contains("/home/user"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[test]
+fn parent_escape_error_includes_workspace_root() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    let err = guard.check_path("../escape.txt").unwrap_err();
+    let msg = err.to_string();
+    let root_disp = dir.path().display().to_string();
+    assert!(
+        msg.contains("escapes") && msg.contains(&root_disp),
+        "escape error must name workspace root {root_disp:?}, got: {msg}"
+    );
+    assert!(
+        !msg.contains("(workspace: )"),
+        "must not print empty workspace root: {msg}"
+    );
+}
+
+#[test]
+fn error_source_canonicalize_returns_inner_error() {
+    use std::error::Error;
+    let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+    let err = ContainmentError::Canonicalize {
+        path: "test".to_string(),
+        source: io_err,
+    };
+    // strengthened (was bare is_some); expect gives context on failure
+    let _src = err
+        .source()
+        .expect("Canonicalize error must carry inner io source");
+    let msg = err.to_string();
+    assert!(msg.contains("failed to canonicalize"), "got: {msg}");
+}
+
+#[test]
+fn error_source_non_canonicalize_returns_none() {
+    use std::error::Error;
+    let err = ContainmentError::AbsolutePath("/x".to_string());
+    assert!(err.source().is_none());
+    let err2 = ContainmentError::Escaped {
+        path: "..".to_string(),
+        root: "/r".to_string(),
+    };
+    assert!(err2.source().is_none());
+}
+
+#[test]
+fn allow_additional_roots_allows_temp_and_extra() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let temp = std::env::temp_dir();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowAdditionalRoots(vec![temp.clone()]),
+    )
+    .unwrap();
+    // absolute in extra root should work
+    let tmp_file = temp.join("patchloom_test_extra.txt");
+    // create it
+    std::fs::write(&tmp_file, "ok").unwrap();
+    let res = guard.check_path(tmp_file.to_str().unwrap());
+    res.unwrap();
+    // clean
+    let _ = std::fs::remove_file(&tmp_file);
+}
+
+#[test]
+fn allow_additional_roots_still_rejects_outside() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::allow_workspace_and_temp_dir(),
+    )
+    .unwrap();
+    let err = guard.check_path("/etc/passwd").unwrap_err();
+    assert!(matches!(err, ContainmentError::Escaped { .. }));
+}
+
+#[test]
+fn builder_allows_temp() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::builder(dir.path().to_path_buf())
+        .allow_temp_directory()
+        .build()
+        .unwrap();
+    // should allow temp
+    let temp = std::env::temp_dir().join("patchloom_builder_test.txt");
+    std::fs::write(&temp, "ok").unwrap();
+    guard.check_path(temp.to_str().unwrap()).unwrap();
+    let _ = std::fs::remove_file(&temp);
+}
+
+/// Regression test for #781: literal `/tmp/...` (common spelling from agents/LLMs)
+/// must be allowed by `allow_temp_directory()` even on macOS where
+/// std::env::temp_dir() is under /var/folders and /tmp symlinks to /private/tmp.
+#[cfg(unix)]
+#[test]
+fn builder_allows_literal_tmp_path_unix() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::builder(dir.path().to_path_buf())
+        .allow_temp_directory()
+        .build()
+        .unwrap();
+
+    // Use a unique name under the conventional /tmp to simulate real usage
+    // (host experiment-mode paths, agent-generated paths, etc.).
+    let tmp_path = format!("/tmp/patchloom_781_test_{}.txt", std::process::id());
+    let _ = std::fs::remove_file(&tmp_path);
+    std::fs::write(&tmp_path, "data for 781").unwrap();
+    let res = guard.check_path(&tmp_path);
+    assert!(
+        res.is_ok(),
+        "literal /tmp path must be allowed: {:?}",
+        res.err()
+    );
+    let _ = std::fs::remove_file(&tmp_path);
+}
+
+/// Non-existing file under /tmp must still be allowed (via ancestor canonicalization).
+#[cfg(unix)]
+#[test]
+fn builder_allows_nonexistent_under_literal_tmp() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::builder(dir.path().to_path_buf())
+        .allow_temp_directory()
+        .build()
+        .unwrap();
+
+    let tmp_path = format!("/tmp/patchloom_781_nonexist_{}.txt", std::process::id());
+    // do not create it
+    let res = guard.check_path(&tmp_path);
+    assert!(
+        res.is_ok(),
+        "non-existing /tmp path must be allowed via ancestor: {:?}",
+        res.err()
+    );
+}
+
+#[test]
+fn allow_workspace_and_temp_dir_allows_std_temp() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::allow_workspace_and_temp_dir(),
+    )
+    .unwrap();
+    let temp = std::env::temp_dir().join("patchloom_awtd_std.txt");
+    std::fs::write(&temp, "ok").unwrap();
+    guard.check_path(temp.to_str().unwrap()).unwrap();
+    let _ = std::fs::remove_file(&temp);
+}
+
+/// #781: allow_workspace_and_temp_dir must also cover literal /tmp.
+#[cfg(unix)]
+#[test]
+fn allow_workspace_and_temp_dir_allows_literal_tmp() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::allow_workspace_and_temp_dir(),
+    )
+    .unwrap();
+
+    let tmp_path = format!("/tmp/patchloom_781_awtd_{}.txt", std::process::id());
+    let _ = std::fs::remove_file(&tmp_path);
+    std::fs::write(&tmp_path, "data").unwrap();
+    guard.check_path(&tmp_path).unwrap();
+    let _ = std::fs::remove_file(&tmp_path);
+}
+
+#[test]
+fn would_allow_works() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    assert!(guard.would_allow("foo.txt"));
+    assert!(!guard.would_allow("../escape"));
+}
+
+/// Basic coverage for the helper (addresses review note for direct test of system_temp...).
+#[test]
+fn system_temp_directory_roots_contains_expected_entries() {
+    let roots = system_temp_directory_roots();
+    // Always at least the std one
+    assert!(!roots.is_empty());
+    // On unix we explicitly add the conventional ones
+    #[cfg(unix)]
+    {
+        assert!(roots.iter().any(
+            |r| r == std::path::Path::new("/tmp") || r == std::path::Path::new("/var/tmp")
+        ));
+        // std env temp is present
+        let stdt = std::env::temp_dir();
+        assert!(roots.iter().any(|r| r == &stdt));
+    }
+}
+
+/// Regression for coverage: paths using ../ to escape an *allowed additional root*
+/// (e.g. literal /tmp on macOS) must still be rejected after canonicalization.
+/// This was not explicitly asserted in prior temp-allow tests.
+#[cfg(unix)]
+#[test]
+fn allow_temp_rejects_escape_from_tmp_via_parent() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::builder(dir.path().to_path_buf())
+        .allow_temp_directory()
+        .build()
+        .unwrap();
+
+    let escape_path = "/tmp/../etc/passwd";
+    let err = guard.check_path(escape_path).unwrap_err();
+    assert!(
+        matches!(err, ContainmentError::Escaped { .. }),
+        "expected Escaped for escape from /tmp root via .., got {:?}",
+        err
+    );
+}
+
+/// Regression: `..` components in non-existent absolute paths must not be
+/// silently dropped during ancestor canonicalization. `Path::file_name()`
+/// returns `None` for `..`, so the old code skipped those components,
+/// making a path like `workspace/nonexistent/../../outside/secret.txt`
+/// appear to be `workspace/nonexistent/outside/secret.txt` (inside).
+#[test]
+fn dotdot_in_nonexistent_absolute_path_rejected() {
+    let base = tempfile::TempDir::new().unwrap();
+    let workspace = base.path().join("workspace");
+    let outside = base.path().join("outside");
+    fs::create_dir(&workspace).unwrap();
+    fs::create_dir(&outside).unwrap();
+    fs::write(outside.join("secret.txt"), "sensitive").unwrap();
+
+    let guard = PathGuard::new(workspace.clone(), AbsolutePathPolicy::AllowIfContained).unwrap();
+
+    // workspace/nonexistent/../../outside/secret.txt
+    // resolves lexically to: base/outside/secret.txt (outside workspace)
+    let escape = workspace
+        .join("nonexistent")
+        .join("..")
+        .join("..")
+        .join("outside")
+        .join("secret.txt");
+
+    let result = guard.check_path(escape.to_str().unwrap());
+    assert!(
+        matches!(result, Err(ContainmentError::Escaped { .. })),
+        "path with .. through non-existent dir should be rejected, got: {:?}",
+        result,
+    );
+}
+
+/// Same bypass with AllowAdditionalRoots policy.
+#[test]
+fn dotdot_in_nonexistent_path_rejected_with_additional_roots() {
+    let base = tempfile::TempDir::new().unwrap();
+    let workspace = base.path().join("workspace");
+    let extra_root = base.path().join("extra");
+    let outside = base.path().join("outside");
+    fs::create_dir(&workspace).unwrap();
+    fs::create_dir(&extra_root).unwrap();
+    fs::create_dir(&outside).unwrap();
+    fs::write(outside.join("data.txt"), "sensitive").unwrap();
+
+    let guard = PathGuard::new(
+        workspace.clone(),
+        AbsolutePathPolicy::AllowAdditionalRoots(vec![extra_root]),
+    )
+    .unwrap();
+
+    // extra uses nonexistent to escape via ..
+    let escape = workspace
+        .join("nonexistent")
+        .join("..")
+        .join("..")
+        .join("outside")
+        .join("data.txt");
+
+    let result = guard.check_path(escape.to_str().unwrap());
+    assert!(
+        matches!(result, Err(ContainmentError::Escaped { .. })),
+        "dotdot escape via additional-roots should be rejected, got: {:?}",
+        result,
+    );
+}

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -176,7 +176,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             if !case_only
                 && (src_path == dst_path
                     || matches!(
-                        (src_path.canonicalize(), dst_path.canonicalize()),
+                        (
+                            crate::containment::safe_canonicalize(&src_path),
+                            crate::containment::safe_canonicalize(&dst_path)
+                        ),
                         (Ok(ref s), Ok(ref d)) if s == d
                     ))
             {

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -101,8 +101,9 @@ pub fn execute_plan_direct(
         // workspace root (MCP and library callers both honor plan.cwd when
         // contained; escapes must fail closed).
         if plan.cwd.is_some() {
-            let canon_cwd = effective_cwd
-                .canonicalize()
+            // Must use the same canonicalize as PathGuard (dunce) so Windows
+            // UNC prefixes do not break starts_with against canon_root (#1931).
+            let canon_cwd = crate::containment::safe_canonicalize(&effective_cwd)
                 .unwrap_or_else(|_| effective_cwd.clone());
             if !canon_cwd.starts_with(g.canon_root()) {
                 return Err(crate::exit::InvalidInputError {

--- a/src/tx/md_op.rs
+++ b/src/tx/md_op.rs
@@ -141,7 +141,10 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
             let same_file = to.is_none()
                 || source_path == dest_path
                 || matches!(
-                    (source_path.canonicalize(), dest_path.canonicalize()),
+                    (
+                        crate::containment::safe_canonicalize(&source_path),
+                        crate::containment::safe_canonicalize(&dest_path)
+                    ),
                     (Ok(ref s), Ok(ref d)) if s == d
                 );
             let source_content =

--- a/src/write.rs
+++ b/src/write.rs
@@ -686,7 +686,8 @@ pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> 
     // with a regular file, destroying the symlink and leaving the target unchanged.
     let resolved;
     let write_path = if path.is_symlink() {
-        resolved = std::fs::canonicalize(path)
+        // dunce: strip Windows \\?\ so display and multi-link checks stay clean.
+        resolved = crate::containment::safe_canonicalize(path)
             .with_context(|| format!("failed to resolve symlink {}", path.display()))?;
         resolved.as_path()
     } else {


### PR DESCRIPTION
## Summary

On Windows, `std::fs::canonicalize` returns `\\?\` UNC paths. PathGuard containment uses `starts_with` against the workspace root; mixing UNC and non-UNC forms fails containment or confuses display.

## Change

- Depend on `dunce` 1.x
- Public `containment::safe_canonicalize` (passthrough on Unix)
- Use it for PathGuard construction, `canonicalize_or_ancestor`, additional roots, plan cwd vs guard checks, symlink resolve in atomic write, rename same-file equality (CLI + tx + md move)
- Co-locate tests in `containment_tests.rs`
- Tests: no UNC prefix on canon_root/check_path; AllowIfContained absolute; Windows drive letter; mixed std-canon absolute still accepted

## Validation

- `make check-fast` green
- `cargo deny check licenses` ok (dunce)

Closes #1931