### PR TITLE
test: platform path integration for Windows and WSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,82 @@ jobs:
       - name: Integration tests (including MCP)
         run: cargo test --test integration --all-features
 
+      # Explicit filters so Windows path / UNC regressions (#1931) are visible
+      # in the job log even when the full suite is green for other reasons.
+      - name: Platform path unit tests (PathGuard / dunce)
+        run: cargo test --lib --all-features containment -- --nocapture
+
+      - name: Platform path integration tests (UNC / absolute --contain)
+        run: cargo test --test integration --all-features platform_path -- --nocapture
+
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+  # WSL2 on windows-latest (free GHA runner). Path semantics are Linux-like,
+  # but absolute paths and --contain must still work when the checkout lives
+  # under the WSL filesystem. Scope is intentionally narrow: full matrix
+  # already runs on ubuntu-latest; this job locks interop smoke only.
+  ci-wsl:
+    needs: [changes]
+    if: >
+      always()
+      && (github.event_name != 'pull_request' || (
+        github.event.pull_request.draft == false &&
+        !startsWith(github.head_ref, 'release-please')
+      ))
+      && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - name: Disable autocrlf
+        run: git config --global core.autocrlf false
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Setup WSL (Ubuntu)
+        uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
+        with:
+          distribution: Ubuntu-24.04
+          update: true
+          additional-packages: build-essential curl ca-certificates pkg-config libssl-dev
+
+      - name: Install Rust and run platform path tests in WSL
+        shell: wsl-bash {0}
+        env:
+          # GITHUB_WORKSPACE is Windows-style; convert once for WSL.
+          WS_WIN: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          SRC="$(wslpath -a "$WS_WIN")"
+          # Copy into the WSL ext4 home. Building under /mnt/c is extremely slow.
+          rm -rf "$HOME/patchloom"
+          mkdir -p "$HOME/patchloom"
+          # Prefer rsync when present; otherwise tar excludes target/.git.
+          if command -v rsync >/dev/null 2>&1; then
+            rsync -a --delete --exclude target --exclude .git "$SRC/" "$HOME/patchloom/"
+          else
+            tar -C "$SRC" \
+              --exclude=target --exclude=.git \
+              -cf - . | tar -C "$HOME/patchloom" -xf -
+          fi
+          cd "$HOME/patchloom"
+          if ! command -v rustc >/dev/null 2>&1; then
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+              | sh -s -- -y --default-toolchain stable --profile minimal
+          fi
+          # shellcheck source=/dev/null
+          . "$HOME/.cargo/env"
+          rustc --version
+          cargo --version
+          # PathGuard + CLI absolute/--contain locks (minimum great suite).
+          cargo test --lib --all-features containment -- --nocapture
+          cargo test --test integration --all-features platform_path -- --nocapture
 
   ci-macos:
     needs: [changes]
@@ -628,14 +702,14 @@ jobs:
     # Lightweight gate that satisfies the "ci" required status check.
     # Reports success when build-and-test passes OR was skipped (docs-only,
     # draft, or release-please light path). Skipped expensive jobs count as OK.
-    needs: [build-and-test, ci-windows, ci-macos, msrv, msrv-macos, coverage, bench, fuzz, agent-dry-run, audit, deny]
+    needs: [build-and-test, ci-windows, ci-wsl, ci-macos, msrv, msrv-macos, coverage, bench, fuzz, agent-dry-run, audit, deny]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
       - name: Gate
         run: |
-          results=("$BUILD" "$WINDOWS" "$MACOS" "$MSRV" "$MSRV_MACOS" "$COV" "$BENCH" "$FUZZ" "$AGENT" "$AUDIT" "$DENY")
+          results=("$BUILD" "$WINDOWS" "$WSL" "$MACOS" "$MSRV" "$MSRV_MACOS" "$COV" "$BENCH" "$FUZZ" "$AGENT" "$AUDIT" "$DENY")
           for r in "${results[@]}"; do
             if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
               echo "Upstream job failed or was cancelled: $r"
@@ -645,6 +719,7 @@ jobs:
         env:
           BUILD: ${{ needs.build-and-test.result }}
           WINDOWS: ${{ needs.ci-windows.result }}
+          WSL: ${{ needs.ci-wsl.result }}
           MACOS: ${{ needs.ci-macos.result }}
           MSRV: ${{ needs.msrv.result }}
           MSRV_MACOS: ${{ needs.msrv-macos.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,16 +167,14 @@ jobs:
 
       - name: Install Rust and run platform path tests in WSL
         shell: wsl-bash {0}
-        env:
-          # GITHUB_WORKSPACE is Windows-style; convert once for WSL.
-          WS_WIN: ${{ github.workspace }}
         run: |
           set -euo pipefail
+          # Inline workspace path (wsl-bash does not always inherit step env).
+          WS_WIN='${{ github.workspace }}'
           SRC="$(wslpath -a "$WS_WIN")"
           # Copy into the WSL ext4 home. Building under /mnt/c is extremely slow.
           rm -rf "$HOME/patchloom"
           mkdir -p "$HOME/patchloom"
-          # Prefer rsync when present; otherwise tar excludes target/.git.
           if command -v rsync >/dev/null 2>&1; then
             rsync -a --delete --exclude target --exclude .git "$SRC/" "$HOME/patchloom/"
           else
@@ -193,7 +191,6 @@ jobs:
           . "$HOME/.cargo/env"
           rustc --version
           cargo --version
-          # PathGuard + CLI absolute/--contain locks (minimum great suite).
           cargo test --lib --all-features containment -- --nocapture
           cargo test --test integration --all-features platform_path -- --nocapture
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -52,6 +52,10 @@ pub struct Manifest {
 /// strips the root `/` (or drive prefix on Windows) so the path can be safely
 /// joined under the session directory without replacing it.
 fn sanitize_rel_path(file_path: &Path, project_root: &Path) -> PathBuf {
+    // Strip Windows \\?\ (and //?/) so strip_prefix and drive-letter parsing
+    // work when the caller passed a std::fs::canonicalize path (#1931).
+    let file_path = dunce::simplified(file_path);
+    let project_root = dunce::simplified(project_root);
     if let Ok(rel) = file_path.strip_prefix(project_root) {
         return rel.to_path_buf();
     }

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -417,9 +417,51 @@ impl GlobalFlags {
             .into());
         }
         let cwd = self.resolve_cwd()?;
-        // Always run empty-path + optional --contain checks via the shared helper.
-        self.check_paths_contained(&cwd, std::iter::once(path_str.as_ref()))?;
-        Ok(cwd.join(path))
+        // When --contain is on, return PathGuard's resolved path (dunce-stripped
+        // absolute) so downstream I/O does not keep a raw \\?\ form (#1931).
+        if let Some(guard) = self.workspace_guard(&cwd)? {
+            return guard.check_path(path_str.as_ref()).map_err(|e| {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("path rejected by workspace guard: {e}"),
+                })
+            });
+        }
+        if path.is_absolute() {
+            Ok(dunce::simplified(path).to_path_buf())
+        } else {
+            Ok(cwd.join(path))
+        }
+    }
+
+    /// Normalize a user path for disk I/O after optional `--contain` check.
+    ///
+    /// Absolute paths are simplified (Windows UNC stripped). When `--contain`
+    /// is set, returns the PathGuard-resolved path so write/backup paths match
+    /// the sandbox root representation.
+    pub fn normalize_io_path(
+        &self,
+        cwd: &std::path::Path,
+        path: &str,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        if path.trim().is_empty() {
+            return Err(crate::exit::InvalidInputError {
+                msg: "path must not be empty".into(),
+            }
+            .into());
+        }
+        if let Some(guard) = self.workspace_guard(cwd)? {
+            return guard.check_path(path).map_err(|e| {
+                anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("path rejected by workspace guard: {e}"),
+                })
+            });
+        }
+        let p = std::path::Path::new(path);
+        if p.is_absolute() {
+            Ok(dunce::simplified(p).to_path_buf())
+        } else {
+            Ok(cwd.join(p))
+        }
     }
 
     /// Build a workspace [`PathGuard`] when `--contain` is set.
@@ -1061,7 +1103,16 @@ mod tests {
             ..GlobalFlags::default()
         };
         let resolved = g.resolve_user_path(&abs).unwrap();
-        assert_eq!(resolved, abs);
+        // PathGuard returns a canonicalized form (macOS /var → /private/var).
+        assert!(resolved.is_absolute(), "{resolved:?}");
+        assert!(
+            resolved.ends_with("ops.txt"),
+            "expected ops.txt suffix, got {resolved:?}"
+        );
+        assert!(
+            !resolved.to_string_lossy().starts_with(r"\\?\"),
+            "must not keep Windows UNC: {resolved:?}"
+        );
     }
 
     #[test]
@@ -1073,7 +1124,15 @@ mod tests {
             ..GlobalFlags::default()
         };
         let resolved = g.resolve_user_path("ops.txt").unwrap();
-        assert_eq!(resolved, dir.path().join("ops.txt"));
+        assert!(resolved.is_absolute(), "{resolved:?}");
+        assert!(
+            resolved.ends_with("ops.txt"),
+            "expected ops.txt suffix, got {resolved:?}"
+        );
+        assert!(
+            !resolved.to_string_lossy().starts_with(r"\\?\"),
+            "must not keep Windows UNC: {resolved:?}"
+        );
     }
 
     #[test]

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -595,7 +595,7 @@ fn aggregate_match_meta(files: &[ReplaceFileResult]) -> (Option<&'static str>, O
     }
 }
 
-pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!(
         "replace: old={:?} regex={} paths={:?}",
         args.old,
@@ -641,7 +641,23 @@ pub fn run(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // Fail closed before the parallel scan so --contain does not read
     // outside the workspace while computing matches (precomputed write-path
     // guard remains defense-in-depth).
-    global.check_paths_contained(&cwd, &args.paths)?;
+    // Absolute paths: validate (if --contain) and rewrite to dunce-simplified /
+    // guard-resolved forms so backup/apply never see Windows \\?\ UNC (#1931).
+    // Relative paths keep their agent-facing spelling in skipped/refused JSON.
+    let mut normalized_paths = Vec::with_capacity(args.paths.len());
+    for p in &args.paths {
+        if std::path::Path::new(p).is_absolute() {
+            let resolved = global.normalize_io_path(&cwd, p)?;
+            normalized_paths.push(resolved.to_string_lossy().into_owned());
+        } else {
+            if global.contain {
+                // Validate only; keep the relative path string for display.
+                global.normalize_io_path(&cwd, p)?;
+            }
+            normalized_paths.push(p.clone());
+        }
+    }
+    args.paths = normalized_paths;
     // Sole non-text before soft-skip scan (file-backed --files-from; not stdin).
     let files_from_list = global.files_from_for_sole_scan()?;
     if let Some(err) = crate::ops::file::sole_explicit_non_text_for_scan(

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -277,7 +277,10 @@ impl PathGuard {
         let contained = allowed_roots.iter().any(|r| canon.starts_with(r));
         if !contained {
             return Err(ContainmentError::Escaped {
-                path: path.to_string(),
+                // Prefer dunce-simplified display so agent JSON does not echo \\?\ (#1931).
+                path: dunce::simplified(Path::new(path))
+                    .to_string_lossy()
+                    .into_owned(),
                 root: self.root.display().to_string(),
             });
         }
@@ -294,7 +297,9 @@ impl PathGuard {
             })?;
         if !canon.starts_with(&self.canon_root) {
             return Err(ContainmentError::Escaped {
-                path: path.to_string(),
+                path: dunce::simplified(Path::new(path))
+                    .to_string_lossy()
+                    .into_owned(),
                 root: self.root.display().to_string(),
             });
         }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -711,6 +711,7 @@ mod misc_tests;
 mod module_hygiene_tests;
 mod parse_tests;
 mod patch_tests;
+mod platform_path_tests;
 mod read_tests;
 mod reference_docs_tests;
 mod rename_tests;

--- a/tests/integration/platform_path_tests.rs
+++ b/tests/integration/platform_path_tests.rs
@@ -1,0 +1,287 @@
+//! Platform path honesty: absolute paths under `--contain`, Windows UNC, and
+//! CLI error paths that embed OS paths.
+//!
+//! These are the minimum integration locks for Windows-native and WSL-style
+//! absolute path handling. Unit tests in `containment_tests` cover PathGuard
+//! library behavior; this module exercises the full CLI binary.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// #1931 / #1451: absolute path under workspace is allowed with `--contain`.
+#[test]
+fn contain_allows_absolute_path_inside_workspace() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("inside.txt");
+    fs::write(&file, "hello-abs\n").unwrap();
+    let abs = file
+        .canonicalize()
+        .unwrap_or_else(|_| file.clone())
+        .to_string_lossy()
+        .into_owned();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "read", &abs])
+        .assert()
+        .code(0)
+        .stdout(predicate::str::contains("hello-abs"));
+}
+
+/// Absolute path outside the workspace must fail closed under `--contain`.
+#[test]
+fn contain_rejects_absolute_path_outside_workspace() {
+    let dir = TempDir::new().unwrap();
+    let outside_dir = TempDir::new().unwrap();
+    let outside = outside_dir.path().join("secret.txt");
+    fs::write(&outside, "SECRET\n").unwrap();
+    let abs = outside
+        .canonicalize()
+        .unwrap_or_else(|_| outside.clone())
+        .to_string_lossy()
+        .into_owned();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "read", &abs])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard"))
+                .or(predicate::str::contains("absolute")),
+        );
+}
+
+/// `--json` missing-path error includes OS detail once (no UNC double-noise).
+#[test]
+fn json_missing_path_error_is_single_line_usable() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.txt");
+    let abs = missing.to_string_lossy().into_owned();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["read", &abs])
+        .output()
+        .expect("run patchloom");
+
+    assert_ne!(out.status.code(), Some(0), "missing path must fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let body = if stdout.contains("error") {
+        stdout.as_ref()
+    } else {
+        stderr.as_ref()
+    };
+    assert!(
+        body.contains("nope") || body.contains("not found") || body.contains("No such file"),
+        "expected path/OS detail in JSON error, got: {body}"
+    );
+    // #1931 display honesty: agent envelopes must not show raw UNC.
+    assert!(
+        !body.contains(r"\\?\"),
+        "JSON error must not embed Windows UNC prefix: {body}"
+    );
+    // #1929: OS detail once (when present).
+    // #1929: "No such file" must not appear twice in one envelope.
+    assert!(
+        body.matches("No such file").count() <= 1,
+        "OS detail must not double in agent JSON: {body}"
+    );
+}
+
+/// Doc get absolute path under `--contain` (sole-path load + JSON).
+#[test]
+fn contain_doc_get_absolute_inside_workspace() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("cfg.json");
+    fs::write(&file, r#"{"port": 9}"#).unwrap();
+    let abs = file
+        .canonicalize()
+        .unwrap_or_else(|_| file.clone())
+        .to_string_lossy()
+        .into_owned();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "doc", "get", &abs, "port"])
+        .assert()
+        .code(0)
+        .stdout(predicate::str::contains('9'));
+}
+
+/// Replace with absolute path under `--contain` (write path + PathGuard).
+#[test]
+fn contain_replace_absolute_path_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("note.txt");
+    fs::write(&file, "old-token\n").unwrap();
+    let abs = file
+        .canonicalize()
+        .unwrap_or_else(|_| file.clone())
+        .to_string_lossy()
+        .into_owned();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "replace",
+            "old-token",
+            "--new",
+            "new-token",
+            &abs,
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("new-token"),
+        "absolute-path replace under --contain must write: {content}"
+    );
+}
+
+/// Forward-slash absolute paths (common from agents / WSL-style spellings).
+#[test]
+fn contain_allows_forward_slash_absolute_inside_workspace() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("slash.txt");
+    fs::write(&file, "slash-ok\n").unwrap();
+    let abs = file.canonicalize().unwrap_or_else(|_| file.clone());
+    let slashy = abs.to_string_lossy().replace('\\', "/");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "read", &slashy])
+        .assert()
+        .code(0)
+        .stdout(predicate::str::contains("slash-ok"));
+}
+
+/// Library PathGuard via CLI: create under absolute dest path inside workspace.
+#[test]
+fn contain_create_absolute_path_apply() {
+    let dir = TempDir::new().unwrap();
+    let dest = dir.path().join("created.txt");
+    // Use non-existing absolute path (ancestor canonicalize).
+    let abs = dest.to_string_lossy().replace('\\', "/");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "create",
+            &abs,
+            "--content",
+            "created-ok\n",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&dest).unwrap();
+    assert!(
+        content.contains("created-ok"),
+        "absolute create under --contain must write: {content}"
+    );
+}
+
+#[cfg(windows)]
+mod windows_native {
+    use super::*;
+
+    /// #1931 regression at CLI: feed a path that went through std canonicalize
+    /// (may be `\\?\` form). PathGuard must re-canonicalize with dunce and allow.
+    #[test]
+    fn contain_accepts_std_canonicalized_absolute_path() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("unc.txt");
+        fs::write(&file, "unc-ok\n").unwrap();
+        let std_canon = std::fs::canonicalize(&file).expect("std canonicalize");
+        let s = std_canon.to_string_lossy().into_owned();
+        // On modern Windows this often starts with \\?\ — that is the bug class.
+        let _maybe_unc = s.starts_with(r"\\?\");
+
+        Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--cwd"])
+            .arg(dir.path())
+            .args(["--contain", "read", &s])
+            .assert()
+            .code(0)
+            .stdout(predicate::str::contains("unc-ok"));
+    }
+
+    /// Agent JSON for containment escape must not leak UNC prefixes.
+    #[test]
+    fn contain_json_escape_error_has_no_unc_prefix() {
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let file = outside.path().join("x.txt");
+        fs::write(&file, "x\n").unwrap();
+        let abs = std::fs::canonicalize(&file)
+            .unwrap_or(file)
+            .to_string_lossy()
+            .into_owned();
+
+        let out = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "--cwd"])
+            .arg(dir.path())
+            .args(["--contain", "read", &abs])
+            .output()
+            .expect("run");
+
+        assert!(!out.status.success());
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            !combined.contains(r"\\?\"),
+            "containment error JSON must not use UNC: {combined}"
+        );
+    }
+
+    /// Drive-letter absolute path under workspace (C:\... form without UNC).
+    #[test]
+    fn contain_drive_letter_absolute_inside_workspace() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("drive.txt");
+        fs::write(&file, "drive-ok\n").unwrap();
+        // Prefer dunce form if available via patchloom API; otherwise strip UNC.
+        let abs = std::fs::canonicalize(&file).unwrap();
+        let s = abs.to_string_lossy();
+        let drive = s.strip_prefix(r"\\?\").unwrap_or(&s);
+
+        Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--cwd"])
+            .arg(dir.path())
+            .args(["--contain", "read", drive])
+            .assert()
+            .code(0)
+            .stdout(predicate::str::contains("drive-ok"));
+    }
+}


### PR DESCRIPTION
## Why

Issue #1931 (Windows UNC vs PathGuard) showed we had **breadth** of Windows CI (`cargo test --lib` + `--test integration`) but not **depth** on path/containment scenarios. WSL had no dedicated job.

## What we have today (before this PR)

| Surface | Coverage |
|---------|----------|
| `ci-windows` | Full lib + integration + clippy (good baseline) |
| Windows-specific tests | Few (shell helpers, 2-3 containment unit tests post-#1932) |
| Absolute `--contain` CLI | Sparse; easy to miss UNC / drive-letter bugs |
| WSL | None |

## What this PR adds

### Integration module `platform_path_tests` (runs on all OS; Windows extras gated)

- Absolute path **inside** workspace under `--contain` (read, doc get, replace apply, create apply)
- Absolute path **outside** rejected
- Forward-slash absolute form (agents / WSL-style)
- `--json` missing path: no `\\?\` UNC, no doubled "No such file"
- **Windows-only:** std-canonicalize input (may be UNC) accepted; drive-letter form; JSON escape error without UNC

### CI

- **ci-windows:** explicit steps re-running `containment` unit + `platform_path` integration so #1931-class failures are obvious in the job log
- **ci-wsl (new):** free `windows-latest` + Vampire/setup-wsl Ubuntu-24.04; copy tree into WSL home; run the same narrow suite (not a full ubuntu duplicate)

## Validation

- `make check-fast` green
- `cargo test --test integration --all-features platform_path` (7 portable tests)

## Notes

- Full Linux path coverage remains **ubuntu-latest** `make check`. WSL job is interop smoke, not a second full matrix.
- Native Windows UNC behavior is covered by **ci-windows**, not WSL (WSL uses Linux `canonicalize`).