### PR TITLE
test: expand platform path suite for md, patch, tx, rename

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -464,6 +464,36 @@ impl GlobalFlags {
         }
     }
 
+    /// Rewrite a CLI path argument for I/O while preserving relative spellings.
+    ///
+    /// - **Absolute:** validate (`--contain`) and return the dunce/guard form
+    ///   so backup and apply never see raw Windows `\\?\` paths (#1931).
+    /// - **Relative:** optionally validate under `--contain`, but keep the
+    ///   original string for agent JSON (`skipped` / `refused` / plan paths).
+    pub fn rewrite_user_path_arg(
+        &self,
+        cwd: &std::path::Path,
+        path: &str,
+    ) -> anyhow::Result<String> {
+        if std::path::Path::new(path).is_absolute() {
+            Ok(self
+                .normalize_io_path(cwd, path)?
+                .to_string_lossy()
+                .into_owned())
+        } else {
+            // Validate only when sandboxing; keep relative display form.
+            if self.contain {
+                self.normalize_io_path(cwd, path)?;
+            } else if path.trim().is_empty() {
+                return Err(crate::exit::InvalidInputError {
+                    msg: "path must not be empty".into(),
+                }
+                .into());
+            }
+            Ok(path.to_string())
+        }
+    }
+
     /// Build a workspace [`PathGuard`] when `--contain` is set.
     ///
     /// Uses [`AbsolutePathPolicy::AllowIfContained`]: absolute paths are OK

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -84,9 +84,9 @@ pub(crate) fn run_content_inject(
     };
 
     let cwd = global.resolve_cwd()?;
-    // Containment before existence so --contain cannot be distinguished from
-    // "missing file" for escaped paths (agent sandbox).
-    global.check_paths_contained(&cwd, [file])?;
+    // Containment + absolute-path rewrite before existence checks (#1931).
+    let file = global.rewrite_user_path_arg(&cwd, file)?;
+    let file = file.as_str();
     let path = cwd.join(file);
     if !path.exists() {
         let msg = format!("file does not exist: {file}");

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -40,7 +40,7 @@ struct CreateOutput {
     backup_session: Option<String>,
 }
 
-pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+pub fn run(mut args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!("create: file={}, force={}", args.file, args.force);
     if args.content.is_some() && args.stdin {
         let msg = "--content and --stdin cannot be combined";
@@ -59,7 +59,7 @@ pub fn run(args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
 
     let cwd = global.resolve_cwd()?;
-    global.check_paths_contained(&cwd, [&args.file])?;
+    args.file = global.rewrite_user_path_arg(&cwd, &args.file)?;
     let path = cwd.join(&args.file);
     if path.exists() && !path.is_file() {
         let msg = format!("target is not a file: {}", args.file);

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -26,10 +26,10 @@ struct DeleteOutput {
     backup_session: Option<String>,
 }
 
-pub fn run(args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+pub fn run(mut args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!("delete: file={}", args.file);
     let cwd = global.resolve_cwd()?;
-    global.check_paths_contained(&cwd, [&args.file])?;
+    args.file = global.rewrite_user_path_arg(&cwd, &args.file)?;
     let path = cwd.join(&args.file);
 
     if !path.exists() {

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -197,19 +197,39 @@ struct MdOutput {
     backup_session: Option<String>,
 }
 
+/// Keep Operation.path aligned with the rewritten CLI path (#1931).
+fn set_md_op_path(op: &mut Operation, path: String) {
+    match op {
+        Operation::MdReplaceSection { path: p, .. }
+        | Operation::MdInsertAfterHeading { path: p, .. }
+        | Operation::MdInsertAfterSection { path: p, .. }
+        | Operation::MdInsertBeforeHeading { path: p, .. }
+        | Operation::MdUpsertBullet { path: p, .. }
+        | Operation::MdDedupeHeadings { path: p, .. }
+        | Operation::MdTableAppend { path: p, .. }
+        | Operation::MdLintAgents { path: p, .. }
+        | Operation::MdMoveSection { path: p, .. } => {
+            *p = path;
+        }
+        _ => {}
+    }
+}
+
 /// Execute a single md operation through the engine, mapping "not found"
 /// errors to `exit::NO_MATCHES`.
 fn execute_md_op(
-    op: Operation,
+    mut op: Operation,
     global: &GlobalFlags,
     file: &str,
     check_msg: &str,
     apply_msg: &str,
 ) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
-    // Shared empty-path + --contain gate (engine also checks under --contain).
-    global.check_paths_contained(&cwd, [file])?;
-    let file_owned = file.to_string();
+    // Rewrite absolute paths for I/O; keep relative spellings (#1931 suite).
+    let file = global.rewrite_user_path_arg(&cwd, file)?;
+    set_md_op_path(&mut op, file.clone());
+    let file_owned = file;
+    // Callers may mention multiple paths (move-section cross-file); keep them.
     match execute_via_engine(
         op,
         global,
@@ -374,12 +394,12 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             )
         }
 
-        MdAction::DedupeHeadings { file } => {
+        MdAction::DedupeHeadings { mut file } => {
             crate::verbose!("md: dedupe-headings file={}", file);
             // Pre-read to compute removed headings for structured output,
             // then route the actual write through the engine.
             let cwd = global.resolve_cwd()?;
-            global.check_paths_contained(&cwd, [&file])?;
+            file = global.rewrite_user_path_arg(&cwd, &file)?;
             let path = cwd.join(&file);
             let original = match crate::files::load_text_strict(&path, &file) {
                 Ok(s) => s,
@@ -493,10 +513,10 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             )
         }
 
-        MdAction::LintAgents { file } => {
+        MdAction::LintAgents { mut file } => {
             crate::verbose!("md: lint-agents file={}", file);
             let cwd = global.resolve_cwd()?;
-            global.check_paths_contained(&cwd, [&file])?;
+            file = global.rewrite_user_path_arg(&cwd, &file)?;
             let path = cwd.join(&file);
             let content = match crate::files::load_text_strict(&path, &file) {
                 Ok(s) => s,
@@ -551,13 +571,17 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             }
         }
 
-        MdAction::TableAppend { file, heading, row } => {
+        MdAction::TableAppend {
+            mut file,
+            heading,
+            row,
+        } => {
             crate::verbose!("md: table-append file={}, heading={:?}", file, heading);
             // Pre-validate: distinguish "heading not found" (NO_MATCHES)
             // from "no table under heading" (error), which the engine
             // conflates into a single None.
             let cwd = global.resolve_cwd()?;
-            global.check_paths_contained(&cwd, [&file])?;
+            file = global.rewrite_user_path_arg(&cwd, &file)?;
             let path = cwd.join(&file);
             let content = match crate::files::load_text_strict(&path, &file) {
                 Ok(s) => s,
@@ -612,9 +636,9 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
 
         MdAction::MoveSection {
-            file,
+            mut file,
             heading,
-            to,
+            mut to,
             before,
             after,
         } => {
@@ -633,6 +657,11 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 return Ok(exit::FAILURE);
             }
 
+            let cwd = global.resolve_cwd()?;
+            file = global.rewrite_user_path_arg(&cwd, &file)?;
+            if let Some(dest) = to.take() {
+                to = Some(global.rewrite_user_path_arg(&cwd, &dest)?);
+            }
             let dest_file = to.as_deref().unwrap_or(&file);
             let (check_msg, apply_msg) = if dest_file != file {
                 (

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -39,7 +39,7 @@ struct RenameOutput {
     backup_session: Option<String>,
 }
 
-pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!(
         "rename: from={}, to={}, force={}",
         args.from,
@@ -47,11 +47,10 @@ pub fn run(args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         args.force
     );
     let cwd = global.resolve_cwd()?;
-    // Empty-path + --contain for all rename paths (engine-backed text and
-    // binary/case-only callback via write_dispatch). Engine-backed ops also
-    // check declared_paths in the tx engine; this early check covers the
-    // callback path that never reaches the engine (#1409).
-    global.check_paths_contained(&cwd, [args.from.as_str(), args.to.as_str()])?;
+    // Empty-path + --contain, and rewrite absolute paths so case-only / backup
+    // I/O never sees Windows \\?\ UNC forms (#1931 / platform path suite).
+    args.from = global.rewrite_user_path_arg(&cwd, &args.from)?;
+    args.to = global.rewrite_user_path_arg(&cwd, &args.to)?;
     let src = cwd.join(&args.from);
     let dst = cwd.join(&args.to);
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -641,21 +641,11 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // Fail closed before the parallel scan so --contain does not read
     // outside the workspace while computing matches (precomputed write-path
     // guard remains defense-in-depth).
-    // Absolute paths: validate (if --contain) and rewrite to dunce-simplified /
-    // guard-resolved forms so backup/apply never see Windows \\?\ UNC (#1931).
-    // Relative paths keep their agent-facing spelling in skipped/refused JSON.
+    // Absolute paths: dunce/guard rewrite so backup never sees \\?\ UNC (#1931).
+    // Relative paths keep agent-facing spelling in skipped/refused JSON.
     let mut normalized_paths = Vec::with_capacity(args.paths.len());
     for p in &args.paths {
-        if std::path::Path::new(p).is_absolute() {
-            let resolved = global.normalize_io_path(&cwd, p)?;
-            normalized_paths.push(resolved.to_string_lossy().into_owned());
-        } else {
-            if global.contain {
-                // Validate only; keep the relative path string for display.
-                global.normalize_io_path(&cwd, p)?;
-            }
-            normalized_paths.push(p.clone());
-        }
+        normalized_paths.push(global.rewrite_user_path_arg(&cwd, p)?);
     }
     args.paths = normalized_paths;
     // Sole non-text before soft-skip scan (file-backed --files-from; not stdin).

--- a/tests/integration/platform_path_tests.rs
+++ b/tests/integration/platform_path_tests.rs
@@ -285,3 +285,405 @@ mod windows_native {
             .stdout(predicate::str::contains("drive-ok"));
     }
 }
+
+// ---------------------------------------------------------------------------
+// Expansions: md / patch / tx / rename / long-path
+// ---------------------------------------------------------------------------
+
+/// Absolute path under `--contain` for md upsert-bullet (engine write path).
+#[test]
+fn contain_md_upsert_bullet_absolute_path() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("doc.md");
+    fs::write(&file, "# Intro\n\n").unwrap();
+    let abs = file
+        .canonicalize()
+        .unwrap_or_else(|_| file.clone())
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args([
+            "--contain",
+            "md",
+            "upsert-bullet",
+            &abs,
+            "--heading",
+            "Intro",
+            "--bullet",
+            "- item",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("- item"),
+        "md absolute under --contain must write: {content}"
+    );
+}
+
+/// Absolute patch *file* path under `--contain` (meta-input resolve_user_path).
+#[test]
+fn contain_patch_check_absolute_patch_file() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("t.txt");
+    fs::write(&target, "hello\n").unwrap();
+    let patch = dir.path().join("change.diff");
+    // Unified diff with relative target under --cwd.
+    let body = "\
+--- a/t.txt
++++ b/t.txt
+@@ -1 +1 @@
+-hello
++world
+";
+    fs::write(&patch, body).unwrap();
+    let abs_patch = patch
+        .canonicalize()
+        .unwrap_or_else(|_| patch.clone())
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "patch", "check", &abs_patch])
+        .assert()
+        .code(2); // changes detected in check mode
+}
+
+/// Absolute plan path for `tx` under `--contain`.
+#[test]
+fn contain_tx_absolute_plan_path() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("note.txt");
+    fs::write(&target, "alpha\n").unwrap();
+    let plan = dir.path().join("plan.json");
+    fs::write(
+        &plan,
+        r#"{
+  "version": 1,
+  "operations": [
+    {"op": "replace", "path": "note.txt", "old": "alpha", "new": "beta"}
+  ]
+}
+"#,
+    )
+    .unwrap();
+    let abs_plan = plan
+        .canonicalize()
+        .unwrap_or_else(|_| plan.clone())
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "tx", &abs_plan, "--apply"])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&target).unwrap();
+    assert!(
+        content.contains("beta"),
+        "tx absolute plan under --contain must apply: {content}"
+    );
+}
+
+/// Absolute plan path outside workspace rejected under `--contain`.
+#[test]
+fn contain_tx_rejects_absolute_plan_outside_workspace() {
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let plan = outside.path().join("evil.json");
+    fs::write(&plan, r#"{"version":1,"operations":[]}"#).unwrap();
+    let abs = plan
+        .canonicalize()
+        .unwrap_or_else(|_| plan.clone())
+        .to_string_lossy()
+        .into_owned();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "tx", &abs, "--apply"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+}
+
+/// Absolute rename under `--contain` (both from and to).
+#[test]
+fn contain_rename_absolute_paths_apply() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("old-name.txt");
+    fs::write(&src, "data\n").unwrap();
+    let dst = dir.path().join("new-name.txt");
+    let abs_src = src
+        .canonicalize()
+        .unwrap_or_else(|_| src.clone())
+        .to_string_lossy()
+        .replace('\\', "/");
+    let abs_dst = dst.to_string_lossy().replace('\\', "/");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "rename", &abs_src, &abs_dst, "--apply"])
+        .assert()
+        .code(0);
+
+    assert!(!src.exists() || !src.is_file() || fs::read_to_string(&src).is_err());
+    let content = fs::read_to_string(&dst).unwrap();
+    assert!(
+        content.contains("data"),
+        "rename absolute under --contain: {content}"
+    );
+}
+
+/// Case-only rename under `--contain` with absolute paths (Windows/macOS).
+#[test]
+fn contain_rename_case_only_absolute_paths() {
+    let dir = TempDir::new().unwrap();
+    let lower = dir.path().join("readme.md");
+    fs::write(&lower, "hello\n").unwrap();
+    let abs_from = lower
+        .canonicalize()
+        .unwrap_or_else(|_| lower.clone())
+        .to_string_lossy()
+        .replace('\\', "/");
+    // Same directory, different case of basename.
+    let mut abs_to = abs_from.clone();
+    if let Some(i) = abs_to.rfind("readme.md") {
+        abs_to.replace_range(i..i + "readme.md".len(), "README.md");
+    } else if let Some(i) = abs_to.rfind("README.md") {
+        abs_to.replace_range(i..i + "README.md".len(), "readme.md");
+    }
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "rename", &abs_from, &abs_to, "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let entries: Vec<String> = fs::read_dir(dir.path())
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.eq_ignore_ascii_case("readme.md"))
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected one readme.md entry: {entries:?}"
+    );
+}
+
+/// Deep relative escape under `--contain` still fails closed.
+#[test]
+fn contain_rejects_deep_relative_escape() {
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("a/b/c")).unwrap();
+    fs::write(dir.path().join("a/b/c/x.txt"), "in\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "read", "a/b/c/../../../../../../etc/passwd"])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("escapes")
+                .or(predicate::str::contains("rejected"))
+                .or(predicate::str::contains("workspace guard")),
+        );
+}
+
+/// Batch ops file as absolute path under `--contain`.
+#[test]
+fn contain_batch_absolute_ops_file() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("b.txt");
+    fs::write(&target, "old\n").unwrap();
+    let ops = dir.path().join("ops.txt");
+    // batch replace: PATH OLD NEW
+    fs::write(&ops, "replace b.txt old new\n").unwrap();
+    let abs_ops = ops
+        .canonicalize()
+        .unwrap_or_else(|_| ops.clone())
+        .to_string_lossy()
+        .replace('\\', "/");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "batch", &abs_ops, "--apply"])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&target).unwrap();
+    assert!(
+        content.contains("new"),
+        "batch absolute ops under --contain: {content}"
+    );
+}
+
+#[cfg(windows)]
+mod windows_expansions {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// Case-only rename with std-canonicalize (UNC) absolute paths under contain.
+    #[test]
+    fn contain_rename_case_only_std_canonicalized_paths() {
+        let dir = TempDir::new().unwrap();
+        let lower = dir.path().join("notes.txt");
+        fs::write(&lower, "body\n").unwrap();
+        let from = std::fs::canonicalize(&lower).unwrap();
+        let from_s = from.to_string_lossy().into_owned();
+        let to_s = from_s.replace("notes.txt", "NOTES.txt");
+
+        let out = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--cwd"])
+            .arg(dir.path())
+            .args(["--contain", "rename", &from_s, &to_s, "--apply"])
+            .output()
+            .unwrap();
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "stderr={} stdout={}",
+            String::from_utf8_lossy(&out.stderr),
+            String::from_utf8_lossy(&out.stdout)
+        );
+        let names: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .filter(|n| n.eq_ignore_ascii_case("notes.txt"))
+            .collect();
+        assert_eq!(names.len(), 1, "{names:?}");
+    }
+
+    /// Long path under workspace: either succeeds with simplified path, or
+    /// fails closed with a clear error (never panics / never silent wrong write).
+    #[test]
+    fn long_path_under_workspace_is_honest() {
+        let dir = TempDir::new().unwrap();
+        // Build a nested directory name that exceeds classic MAX_PATH (260)
+        // when fully joined, using a single long component where possible.
+        let mut long = dir.path().to_path_buf();
+        // ~40 * 8 = 320 chars of nesting under temp (often > 260 total).
+        for i in 0..40 {
+            long.push(format!("seg{i:02}xx"));
+        }
+        // Creating deep trees may require \\?\ on Windows.
+        let create = std::process::Command::new("cmd")
+            .args(["/C", "mkdir", &format!("\\\\?\\{}", long.display())])
+            .output();
+        if create.map(|o| !o.status.success()).unwrap_or(true) {
+            // Fallback: try std create_dir_all (works if long-path registry is on).
+            if fs::create_dir_all(&long).is_err() {
+                // Environment cannot create long paths; skip without failing CI.
+                return;
+            }
+        }
+        let file = long.join("leaf.txt");
+        let write_path = PathBuf::from(format!("\\\\?\\{}", file.display()));
+        if fs::write(&write_path, "long-ok\n").is_err() {
+            let _ = fs::write(&file, "long-ok\n");
+        }
+        if !file.exists() && !write_path.exists() {
+            return;
+        }
+
+        let abs = std::fs::canonicalize(&file)
+            .or_else(|_| std::fs::canonicalize(&write_path))
+            .unwrap_or(file.clone());
+        let s = abs.to_string_lossy().into_owned();
+
+        let out = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "--cwd"])
+            .arg(dir.path())
+            .args(["--contain", "read", &s])
+            .output()
+            .unwrap();
+
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        if out.status.success() {
+            assert!(
+                combined.contains("long-ok"),
+                "long path read success must return content: {combined}"
+            );
+        } else {
+            // Fail closed: structured failure, no panic, path mentioned.
+            assert!(
+                combined.contains("error")
+                    || combined.contains("failed")
+                    || combined.contains("path")
+                    || combined.contains("escapes"),
+                "long path failure must be actionable: {combined}"
+            );
+        }
+    }
+
+    /// Outside long path under --contain rejects (fail closed).
+    #[test]
+    fn contain_rejects_outside_long_absolute_path() {
+        let dir = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let mut long = outside.path().to_path_buf();
+        for i in 0..20 {
+            long.push(format!("out{i:02}"));
+        }
+        let _ = fs::create_dir_all(&long);
+        let file = long.join("x.txt");
+        if fs::write(&file, "x\n").is_err() {
+            return;
+        }
+        let abs = std::fs::canonicalize(&file).unwrap_or(file);
+        let s = abs.to_string_lossy().into_owned();
+
+        Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--cwd"])
+            .arg(dir.path())
+            .args(["--contain", "read", &s])
+            .assert()
+            .failure()
+            .stderr(
+                predicate::str::contains("escapes")
+                    .or(predicate::str::contains("rejected"))
+                    .or(predicate::str::contains("workspace guard")),
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #1933: expand platform path integration coverage and make more write commands rewrite absolute paths for safe I/O.

## Product

- `GlobalFlags::rewrite_user_path_arg`: absolute → dunce/guard form; relative kept for agent JSON
- Wired into replace, rename, md, create, delete, append

## Tests (`platform_path_tests`)

| Area | Coverage |
|------|----------|
| md | absolute upsert-bullet under `--contain` |
| patch | absolute patch file for `patch check` |
| tx | absolute plan apply + outside reject |
| batch | absolute ops file |
| rename | absolute from/to apply |
| case-only | absolute case rename under `--contain` |
| escape | deep `../` still rejected |
| Windows | UNC case-only rename; long-path honesty; outside long path reject |

## Validation

- `make check-fast` green
- `cargo test --test integration --all-features platform_path` (15 portable tests)