### PR TITLE
test: GuardRejected locks, embedder smoke, 0.18 notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make pack-mcpb` | Pack `mcpb/` into `target/mcpb/patchloom-<ver>.mcpb` (Smithery / desktop). Honors `$VERSION` over Cargo.toml |
 | `make pack-mcpb-test` | Unit tests for pack version override and stamped manifest (`scripts/test_pack_mcpb.py`; skips full pack when `mcpb` CLI missing) |
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
-| `make embedder-smoke` | Pre-release host contracts (fuzzy token span, nested undo list, plan `key` alias). Not part of `check`; run before tagging a release |
+| `make embedder-smoke` | Pre-release host contracts (fuzzy token span with `--allow-absent-old`, nested undo list, plan `key` alias, `--contain` → `guard_rejected`). Not part of `check`; run before tagging a release |
 | `make fuzz` | Run fuzz tests (11 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse, containment_check, fallback_resolve, ast_parse, md_heading, replace_regex). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |
 | `make bench-mcp` | Run MCP benchmarks: per-call latency vs CLI process spawn (not part of `check`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ This is a quick-reference subset. For the complete list, see [AGENTS.md](./AGENT
 | `make clippy` | Run clippy with `-D warnings` |
 | `make check` | Full CI gate (run before every commit) |
 | `make check-fast` | Fast check (skips PATCHLOOM.md sync only; still checks README test count) |
-| `make embedder-smoke` | Pre-release host contracts (fuzzy token span, nested undo, plan key alias); not part of `check` |
+| `make embedder-smoke` | Pre-release host contracts (fuzzy token span, nested undo, plan key alias, `--contain` → `guard_rejected`); not part of `check` |
 | `make audit` | Run `cargo audit` for known vulnerabilities (also in CI) |
 | `make deny` | Run `cargo deny check` for licenses/bans/sources (`deny.toml`; also in CI) |
 | `make update-readme` | Update README.md rounded test count |
@@ -91,6 +91,9 @@ See the "Adding a new MCP tool" section in [AGENTS.md](./AGENTS.md).
 | `make fmt-check` | Run `make fmt` to auto-format, then re-run `make check`. |
 | `make clippy` | Address the specific warning shown in the output. Clippy treats all warnings as errors (`-D warnings`). |
 | `make test-mcp-no-ast` | MCP inventory/router/instructions must stay honest without the `ast` feature. Fix `surface.rs` / `handlers.rs` feature gates and re-run `make test-mcp-no-ast`. |
+| `make test-no-default` / `test-ast-only` / `test-library-hygiene` | Feature-matrix or pure-library hygiene failed. Reproduce with the same make target; often dead_code under `--no-default-features`. |
+| `make verify-release-notes` | `RELEASE_NOTES.md` is present when it should not be (or fails validation). See release-notes workflow in AGENTS.md. |
+| `make audit-test-hygiene` | Stale test names or weak assertions after a refactor. Strengthen or rename tests, then re-run. |
 | `make check-patchloom-md` | The agent-rules output changed. Run `make sync-patchloom-md` to regenerate `PATCHLOOM.md`. |
 | `make check-readme` | Test counts drifted. Run `make update-readme` to refresh `README.md`. |
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ cargo install patchloom
 scoop bucket add patchloom https://github.com/patchloom/scoop-bucket
 scoop install patchloom/patchloom
 
-# Chocolatey (Windows; first listing may wait on community moderation)
+# Chocolatey (Windows; community feed — newer versions may lag moderation)
 choco install patchloom
 ```
 
@@ -477,7 +477,7 @@ flowchart LR
 
 | Component | Status |
 |---|---|
-| CLI | Published on [crates.io](https://crates.io/crates/patchloom), [Homebrew](https://github.com/patchloom/homebrew-tap), [Scoop](https://github.com/patchloom/scoop-bucket), [Chocolatey](https://community.chocolatey.org/packages/patchloom) (`choco install patchloom`; first version under moderation), and [npm](https://www.npmjs.com/package/patchloom) (`npx patchloom`) |
+| CLI | Published on [crates.io](https://crates.io/crates/patchloom), [Homebrew](https://github.com/patchloom/homebrew-tap), [Scoop](https://github.com/patchloom/scoop-bucket), [Chocolatey](https://community.chocolatey.org/packages/patchloom) (`choco install patchloom`), and [npm](https://www.npmjs.com/package/patchloom) (`npx patchloom`). winget package under community review. |
 | MCP server | Official [MCP Registry](https://registry.modelcontextprotocol.io/) name `io.github.patchloom/patchloom` (stdio; crates.io / npm packages; see `server.json`). Local MCPB for [Smithery](https://smithery.ai/) / desktop hosts: `make pack-mcpb` (`mcpb/`). [Glama](https://glama.ai/mcp/servers) directory prep: root `glama.json` + manual **Add MCP Server** (see [MCP setup](./docs/getting-started/mcp-setup.md#glama-directory)) |
 | Editor extension | Published on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom) and [Open VSX](https://open-vsx.org/extension/patchloom/patchloom) |
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,64 @@
+# Patchloom 0.18.0
+
+Safer embedder undo discovery, structured PathGuard failures, and cleaner
+agent JSON. Seven commits since 0.17.0.
+
+## Highlights
+
+Hosts that implement undo no longer need a private parent walk:
+`backup::find_backup_roots(path)` returns project roots that own
+`.patchloom/backups`, nearest first.
+
+PathGuard and `--contain` rejections are a first-class kind. Library
+`edit_error_kind` returns `GuardRejected`, and CLI `--json` sets
+`error_kind: "guard_rejected"` (with `applied: false`). Empty paths and
+other usage errors stay `invalid_input`. Agents that only checked
+`invalid_input` for sandbox escapes should also accept `guard_rejected`.
+
+File create/delete/rename/append and `ast_rewrite_signature` peel the same
+way for exists/dir/binary (`InvalidInput`), missing symbols (`NoMatch`),
+and guard failures (`GuardRejected`). Windows PathGuard uses dunce
+canonicalize so UNC roots do not break containment. Agent JSON stops
+doubling the OS detail when context already embeds it.
+
+## New features
+
+- **`backup::find_backup_roots(path)`.** Ancestor walk for backup roots
+  (presence of `.patchloom/backups`, nearest first; uncapped, unlike
+  `list_sessions_under` depth caps). (#1934)
+- **Structured `GuardRejected` for PathGuard.** Engine, CLI `--contain`,
+  plan cwd escapes, and library file/AST writers share
+  `EditError::guard_rejected`. CLI JSON `error_kind: guard_rejected`.
+  (#1935, #1938)
+- **File and AST signature error kinds locked for hosts.** Already-exists,
+  directory targets, binary text ops, missing functions, and empty signature
+  edits peel without English scraping. (#1935, #1936)
+
+## Bug fixes
+
+- **Windows PathGuard UNC.** dunce canonicalize / simplified paths keep
+  contain and backup relative paths valid under `\\?\`. (#1931, #1932)
+- **Agent JSON no double OS detail.** When outer context already embeds
+  the OS message, the agent envelope keeps one complete string. (#1929)
+- **Platform path coverage.** Integration tests for Windows and WSL path
+  shapes (md, patch, tx, rename) reduce platform-only regressions. (#1933,
+  #1937)
+
+## Numbers
+
+| Metric | 0.17.0 | 0.18.0 |
+|--------|--------|--------|
+| Test attributes (`src/` + `tests/`) | 3,875 | 3,922 |
+| Commands | 23 | 23 |
+
+## Upgrading
+
+- From crates: `patchloom = "0.18"`
+- From npm: `npx patchloom@0.18` or pin `patchloom@0.18.0`
+- CLI binary: install from the GitHub Release installers, Homebrew tap,
+  Scoop, or Chocolatey as for 0.17.0
+
+**Agent / host note:** treat `--contain` failures as
+`error_kind: "guard_rejected"`. Prefer `edit_error_kind` /
+`classify_error` over English string matching. `find_backup_roots` is the
+supported replacement for private parent walks over `.patchloom/backups`.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -50,8 +50,9 @@ The package downloads the portable Windows zip from GitHub Releases and
 shims `patchloom.exe`. Each product release packs and pushes a new nupkg
 when `CHOCOLATEY_API_KEY` is configured. The **first** listing is subject
 to [community.chocolatey.org](https://community.chocolatey.org/packages)
-moderation (often multi-day); later version-only updates are usually
-auto-approved. If `choco install` reports the package is not found yet,
+moderation. Version `0.13.0` is approved on the public feed; newer pushes
+may lag until moderators clear them. If `choco install` reports the package
+is not found yet (or only an older version installs),
 use Scoop or the [GitHub Release](https://github.com/patchloom/patchloom/releases/latest)
 zip meanwhile.
 

--- a/scripts/embedder-smoke.sh
+++ b/scripts/embedder-smoke.sh
@@ -18,8 +18,11 @@ pass() { echo "OK: $*"; }
 # --- #1694: bare identifier typo must not nuke surrounding syntax ---
 printf 'const CONFIGURATION_VALUE_PRIMARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n' \
   >"$tmpdir/f.rs"
+# Fail-closed fuzzy requires allow_absent_old when old is a typo of the live
+# identifier (#1736 / default deny). Opt-in restores host-facing fuzzy apply.
 "$BIN" replace CONFIGURATION_VALUE_PRIMRY \
-  --new CONFIGURATION_VALUE_SECONDARY --fuzzy --apply "$tmpdir/f.rs" >/dev/null
+  --new CONFIGURATION_VALUE_SECONDARY --fuzzy --allow-absent-old --apply \
+  "$tmpdir/f.rs" >/dev/null
 got=$(cat "$tmpdir/f.rs")
 echo "$got" | grep -q 'const CONFIGURATION_VALUE_SECONDARY: i32 = 1;' \
   || fail "fuzzy typo lost const/type syntax: $got"
@@ -44,5 +47,16 @@ JSON
 "$BIN" --cwd "$tmpdir/ws" tx plan.json --apply >/dev/null
 grep -q '9090' "$tmpdir/ws/config.json" || fail "plan key alias did not apply"
 pass "plan doc.set accepts key alias (#1696/#1435)"
+
+# --- #1935: --contain path escape JSON error_kind is guard_rejected ---
+printf 'x\n' >"$tmpdir/ws/in.txt"
+contain_json=$("$BIN" --json --cwd "$tmpdir/ws" --contain read /etc/passwd 2>/dev/null || true)
+echo "$contain_json" | grep -q '"error_kind": "guard_rejected"' \
+  || echo "$contain_json" | grep -q '"error_kind":"guard_rejected"' \
+  || fail "contain escape must set error_kind guard_rejected: $contain_json"
+pass "CLI --contain JSON error_kind is guard_rejected (#1935)"
+
+# --- nested undo still works after contain smoke (sessions already created) ---
+# Library-only find_backup_roots is unit-tested; CLI hosts use undo --list (#1695).
 
 echo "embedder-smoke: all checks passed"

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -757,6 +757,11 @@ fn execute_plan_rejects_on_guard() {
     let plan = parse_plan(&plan_json).unwrap();
     let err = execute_plan(plan, dir.path(), Some(&guard)).unwrap_err();
     assert!(err.to_string().contains("path rejected by workspace guard"));
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::GuardRejected),
+        "execute_plan PathGuard must peel as GuardRejected: {err}"
+    );
     // No mutation
     assert!(fs::read_to_string(&file).unwrap().contains("content"));
 }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -433,10 +433,16 @@ mod tests {
             result.is_err(),
             "should reject plan.cwd that escapes workspace"
         );
-        let msg = result.unwrap_err().to_string();
+        let err = result.unwrap_err();
+        let msg = err.to_string();
         assert!(
             msg.contains("escapes workspace root"),
             "error should mention escape: {msg}"
+        );
+        assert_eq!(
+            crate::fallback::edit_error_kind(&err),
+            Some(crate::fallback::EditErrorKind::GuardRejected),
+            "plan cwd escape must peel as GuardRejected: {err}"
         );
     }
 


### PR DESCRIPTION
## Summary

MPI cycle after #1938: harden host contracts and prep 0.18.0 release narrative.

- Assert `execute_plan` PathGuard and plan `cwd` escape peel as `EditErrorKind::GuardRejected`
- `embedder-smoke`: CLI `--json --contain` must report `error_kind: guard_rejected`; fuzzy typo check uses `--allow-absent-old` under fail-closed defaults
- Curated `RELEASE_NOTES.md` for 0.18.0 (find_backup_roots, GuardRejected, platform/path fixes)
- README / installation chocolatey and winget status accuracy
- CONTRIBUTING troubleshooting for the remaining `make check` targets

## Test plan

- [x] `make check-fast`
- [x] `make embedder-smoke`
- [x] unit: `execute_plan_rejects_on_guard`, `execute_plan_direct_rejects_escaped_cwd_with_guard`

## Notes

- Does not close #960 / #961 (external winget/chocolatey moderation)
- Does not merge release PR #1930 (needs explicit approval)