### PR TITLE
fix: raise did-you-mean bar for similar_targets noise

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -427,6 +427,28 @@ pub fn validate_edit_nth(
     }
 }
 
+/// Minimum Jaro-Winkler score for a did-you-mean candidate.
+///
+/// Kept in line with anchor matching (0.85). The previous 0.7 floor
+/// admitted noise like `nold` for long unrelated patterns when scanning
+/// large trees (fixrealloop stress, 2026-07-23).
+const SIMILAR_TARGET_MIN_SCORE: f64 = 0.85;
+
+/// Whether `candidate` is a plausible typo of `target` by length.
+///
+/// Jaro-Winkler can score short tokens above the floor against long
+/// strings (shared characters / prefixes). Reject extreme length skew
+/// so agents do not chase nonsense suggestions.
+fn similar_target_length_plausible(candidate: &str, target: &str) -> bool {
+    let (ca, ta) = (candidate.len(), target.len());
+    if ca == 0 || ta == 0 {
+        return false;
+    }
+    let (shorter, longer) = if ca < ta { (ca, ta) } else { (ta, ca) };
+    // Allow ~2x length difference, or a small absolute gap for short ids.
+    shorter.saturating_mul(2) >= longer || longer - shorter <= 3
+}
+
 /// Find similar text targets in file content using Jaro-Winkler similarity.
 ///
 /// Extracts identifiers and substrings from the content and returns the top
@@ -445,8 +467,11 @@ pub fn find_similar_targets(content: &str, target: &str, max_results: usize) -> 
             if !seen.insert(word.clone()) {
                 continue;
             }
+            if word == target || !similar_target_length_plausible(&word, target) {
+                continue;
+            }
             let score = strsim::jaro_winkler(&word, target);
-            if score > 0.7 && word != target {
+            if score > SIMILAR_TARGET_MIN_SCORE {
                 candidates.push((word, score));
             }
         }
@@ -460,8 +485,11 @@ pub fn find_similar_targets(content: &str, target: &str, max_results: usize) -> 
                 continue;
             }
             seen.insert(trimmed.clone());
+            if trimmed == target || !similar_target_length_plausible(&trimmed, target) {
+                continue;
+            }
             let score = strsim::jaro_winkler(&trimmed, target);
-            if score > 0.7 && trimmed != target {
+            if score > SIMILAR_TARGET_MIN_SCORE {
                 candidates.push((trimmed, score));
             }
         }
@@ -1117,6 +1145,25 @@ mod tests {
         let similar = find_similar_targets(content, "process_requst", 3);
         assert!(!similar.is_empty());
         assert!(similar.iter().any(|s| s.contains("process_request")));
+    }
+
+    #[test]
+    fn find_similar_targets_rejects_length_skew_noise() {
+        // Real multi-file no-match noise (fixrealloop stress): long invented
+        // pattern vs short tokens like "nold" can clear a loose JW floor.
+        let content = "fn nold() {}\nlet compute = 1;\nfn process_request() {}\n";
+        let similar = find_similar_targets(content, "this_string_should_not_exist_xyzzy", 5);
+        assert!(
+            similar.is_empty(),
+            "unrelated long pattern must not suggest short tokens: {similar:?}"
+        );
+        let similar = find_similar_targets(content, "completely_bogus_token_zzz", 5);
+        assert!(
+            !similar
+                .iter()
+                .any(|s| s == "compute" || s == "let" || s == "nold"),
+            "bogus pattern must not surface weak short-token hints: {similar:?}"
+        );
     }
 
     #[test]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2129,6 +2129,43 @@ fn test_replace_cli_json_no_matches_includes_similar_targets() {
 }
 
 #[test]
+fn test_replace_cli_json_no_matches_omits_weak_similar_targets() {
+    // Multi-file / large-tree no-match must not invent short-token hints
+    // for long unrelated patterns (fixrealloop stress: "did you mean: nold?").
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("a.txt");
+    fs::write(&file, "fn nold() {}\nlet compute = 1;\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace",
+            "this_string_should_not_exist_xyzzy",
+            "--new",
+            "x",
+            "a.txt",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(3));
+    let v: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("valid JSON");
+    assert_eq!(v["error_kind"], "no_matches");
+    let similar = v["similar_targets"].as_array().cloned().unwrap_or_default();
+    assert!(
+        similar.is_empty(),
+        "weak JW noise must not populate similar_targets: {v}"
+    );
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        !err.contains("did you mean"),
+        "no-match prose must omit weak did-you-mean: {v}"
+    );
+}
+
+#[test]
 fn test_replace_cli_json_error_kind_ambiguous() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("a.txt");


### PR DESCRIPTION
## Summary

- Raise `find_similar_targets` Jaro-Winkler floor from 0.7 to 0.85 (aligned with anchor matching)
- Reject extreme length skew so short tokens cannot "match" long invented patterns
- Unit + integration regression for fixrealloop stress finding (`did you mean: nold?`)

Found during fixrealloop large-repo stress: `patchloom replace 'this_string_should_not_exist_xyzzy' --new x src` returned `did you mean: nold?`. Real typos (`process_requst` → `process_request`) still suggest correctly.

## Test plan

- [x] `cargo test --lib find_similar_targets --all-features`
- [x] `cargo test --test integration test_replace_cli_json_no_matches --all-features`
- [x] `make check-fast`
- [x] Release binary: nonsense multi-file no-match has empty similar_targets; typo still suggests