### PR TITLE
docs: batch --help REPLACE SHAPE; integration test for --new

### DIFF
--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -22,7 +22,9 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
 /// doc.update <path> <selector> <value>
 /// doc.move <path> <from> <to>
 /// doc.delete_where <path> <selector> <predicate>
-/// replace <path> <from> <to> [--fuzzy] [--min-fuzzy-score N] [-i] …
+/// replace <path> <old> <new> [--fuzzy] [--min-fuzzy-score N] [-i] …
+///   Batch is PATH OLD NEW positionals (not CLI `replace OLD --new NEW path`).
+///   CLI/plan flags `--new`, `--old`, `--from`, `--to` are rejected with a shape hint.
 ///   Optional flags (phase 1, #1724): --fuzzy, --min-fuzzy-score, --word-boundary/-w,
 ///   --command-position, --require-change, -i/--case-insensitive, --if-exists
 /// file.create <path> <content>
@@ -58,6 +60,11 @@ pub const MAX_BATCH_OPERATIONS: usize = 10_000;
   md.insert_after_section, md.insert_before_heading (alias md.insert_before_section),
   md.move_section, md.dedupe_headings,
   md.lint_agents, tidy.fix, ast.rename, ast.replace, ast.rewrite_signature
+
+REPLACE SHAPE:
+  Batch:  replace PATH OLD NEW [--fuzzy …]
+  CLI:    patchloom replace OLD --new NEW path
+  Do not paste CLI --new into a batch line (parse error with PATH OLD NEW hint).
 
 EXAMPLES:
   printf 'doc.set config.json version "2.0"\nreplace README.md v1 v2\n' | patchloom batch

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -315,6 +315,34 @@ fn test_batch_malformed_line_fails() {
         .stderr(predicates::str::contains("unknown operation"));
 }
 
+/// CLI path: agents paste `replace OLD --new NEW path` into batch (fixrealloop/MPI).
+#[test]
+fn test_batch_replace_cli_new_flag_hints_path_old_new() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("README.md"), "hello\n").unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "batch", "-"])
+        .write_stdin("replace hello --new hi README.md\n")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(4)); // PARSE_ERROR
+    let v: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("parse_error JSON on stdout");
+    assert_eq!(v["error_kind"], "parse_error");
+    assert_eq!(v["applied"], false);
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("--new") && err.contains("PATH OLD NEW"),
+        "expected CLI --new shape hint: {v}"
+    );
+    // Must not have mutated the file
+    assert_eq!(
+        fs::read_to_string(dir.path().join("README.md")).unwrap(),
+        "hello\n"
+    );
+}
+
 /// CLI path for agent-facing batch parse hints (#1483): bare leaf → namespaced op.
 #[test]
 fn test_batch_bare_create_suggests_file_create() {


### PR DESCRIPTION
## Summary

MPI cycle after #1941/#1942:

- Document batch replace shape in `patchloom batch --help` (`REPLACE SHAPE` section)
- Rename help positionals to `<path> <old> <new>` (was `<from> <to>`, plan-shaped)
- Integration test: CLI `replace OLD --new NEW path` into batch → `error_kind: parse_error`, `applied: false`, no write

## Gate

- Release PR #1930 left unmerged (needs explicit approval)
- Dist issues #960/#961 remain external blockers
- Other perspectives: no additional product findings after mechanical greps (deps current, AGENTS/Makefile check lists match, weak-assertion greps clean)

## Test plan

- [x] `make check-fast`
- [x] `cargo test --test integration test_batch_replace_cli_new_flag`
- [x] `patchloom batch --help` shows REPLACE SHAPE