### PR TITLE
docs: finalize curated release notes for 0.18.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,57 +1,75 @@
 # Patchloom 0.18.0
 
-Safer embedder undo discovery, structured PathGuard failures, and cleaner
-agent JSON. Seven commits since 0.17.0.
+Clearer sandbox and host errors for agents and embedders, a public
+backup-root helper for undo UIs, and several agent-facing CLI JSON and
+batch-parse improvements. Eleven commits since 0.17.0.
 
 ## Highlights
 
-Hosts that implement undo no longer need a private parent walk:
+Library hosts no longer need a private parent walk to find undo data:
 `backup::find_backup_roots(path)` returns project roots that own
 `.patchloom/backups`, nearest first.
 
-PathGuard and `--contain` rejections are a first-class kind. Library
+PathGuard and CLI `--contain` rejections are a first-class kind. Library
 `edit_error_kind` returns `GuardRejected`, and CLI `--json` sets
 `error_kind: "guard_rejected"` (with `applied: false`). Empty paths and
 other usage errors stay `invalid_input`. Agents that only checked
 `invalid_input` for sandbox escapes should also accept `guard_rejected`.
 
-File create/delete/rename/append and `ast_rewrite_signature` peel the same
-way for exists/dir/binary (`InvalidInput`), missing symbols (`NoMatch`),
-and guard failures (`GuardRejected`). Windows PathGuard uses dunce
-canonicalize so UNC roots do not break containment. Agent JSON stops
-doubling the OS detail when context already embeds it.
+File create, delete, rename, and append (and AST signature rewrites) peel
+the same way for already-exists, directory targets, binary text ops
+(`InvalidInput`), missing symbols (`NoMatch`), and guard failures
+(`GuardRejected`). On Windows, PathGuard uses dunce canonicalize so UNC
+roots do not break containment. Agent JSON keeps a single complete OS
+detail string when the outer context already embeds it.
 
 ## New features
 
-- **`backup::find_backup_roots(path)`.** Ancestor walk for backup roots
-  (presence of `.patchloom/backups`, nearest first; uncapped, unlike
-  `list_sessions_under` depth caps). (#1934)
+- **`backup::find_backup_roots(path)`.** Walks ancestors for directories that
+  contain `.patchloom/backups` and returns them nearest-first (uncapped,
+  unlike depth-limited session listing). For hosts that build undo UIs or
+  nested monorepo workflows. (#1934, #1938)
 - **Structured `GuardRejected` for PathGuard.** Engine, CLI `--contain`,
-  plan cwd escapes, and library file/AST writers share
-  `EditError::guard_rejected`. CLI JSON `error_kind: guard_rejected`.
+  plan `cwd` escapes, and library file/AST writers share
+  `EditError::guard_rejected`. CLI JSON uses `error_kind: guard_rejected`.
   (#1935, #1938)
-- **File and AST signature error kinds locked for hosts.** Already-exists,
-  directory targets, binary text ops, missing functions, and empty signature
-  edits peel without English scraping. (#1935, #1936)
+- **Stable file and AST signature error kinds for hosts.** Already-exists,
+  directory targets, binary text ops, missing functions, and empty
+  signature edits peel without scraping English messages. (#1935, #1936)
 
 ## Bug fixes
 
-- **`tidy check --json` sets `error_kind: changes_detected` when issues exist.**
-  Agents can branch like search `--assert-count` (exit 2 unchanged). (#1940)
+- **`tidy check --json` sets `error_kind: changes_detected` when issues
+  exist.** Exit code 2 is unchanged; agents can switch on kind the same
+  way as search `--assert-count`. (#1940)
+- **Windows PathGuard under UNC.** dunce canonicalize / simplified paths
+  keep contain and backup relative paths valid when roots look like
+  `\\?\...`. (#1931, #1932)
+- **Agent JSON no longer doubles OS detail.** When the outer context
+  already includes the OS message, the envelope keeps one complete
+  string. (#1929)
+- **Did-you-mean noise on multi-file no-match.** Long invented patterns
+  no longer suggest short unrelated tokens (for example `nold`). Real
+  typos such as `process_requst` → `process_request` still suggest.
+  Score floor raised and length skew filtered. (#1941)
+- **Batch replace CLI shape hints.** Pasting CLI
+  `replace OLD --new NEW path` into a batch line is rejected with an
+  explicit `PATH OLD NEW` message (including plan-shaped `--from` /
+  `--to`). `batch --help` documents the shape. (#1942, #1943)
 
-- **Windows PathGuard UNC.** dunce canonicalize / simplified paths keep
-  contain and backup relative paths valid under `\\?\`. (#1931, #1932)
-- **Agent JSON no double OS detail.** When outer context already embeds
-  the OS message, the agent envelope keeps one complete string. (#1929)
-- **Platform path coverage.** Integration tests for Windows and WSL path
-  shapes (md, patch, tx, rename) reduce platform-only regressions. (#1933,
-  #1937)
+## Tests
+
+- Broader platform path coverage for Windows and WSL (md, patch, tx,
+  rename). (#1933, #1937)
+- Embedder smoke covers fuzzy typo apply, nested monorepo `undo --list`,
+  plan `key` alias, and `--contain` → `guard_rejected`. (#1939)
 
 ## Numbers
 
 | Metric | 0.17.0 | 0.18.0 |
 |--------|--------|--------|
-| Test attributes (`src/` + `tests/`) | 3,875 | 3,922 |
+| Test attributes (`src/` + `tests/`) | 3,875 | 3,928 |
+| Unit-ish (`src/`) | 2,624 | 2,652 |
 | Commands | 23 | 23 |
 
 ## Upgrading
@@ -61,7 +79,8 @@ doubling the OS detail when context already embeds it.
 - CLI binary: install from the GitHub Release installers, Homebrew tap,
   Scoop, or Chocolatey as for 0.17.0
 
-**Agent / host note:** treat `--contain` failures as
+**Agent / host note:** treat `--contain` and PathGuard failures as
 `error_kind: "guard_rejected"`. Prefer `edit_error_kind` /
-`classify_error` over English string matching. `find_backup_roots` is the
-supported replacement for private parent walks over `.patchloom/backups`.
+`classify_error` over English string matching. Use `find_backup_roots`
+instead of a private parent walk over `.patchloom/backups`. Batch
+replace lines stay `replace PATH OLD NEW` (not CLI `--new`).


### PR DESCRIPTION
## Summary

Final curated `RELEASE_NOTES.md` for the 0.18.0 release (applied to the
GitHub Release body by the host job, not the release-please PR body).

Covers all commits since `patchloom-v0.17.0`, including #1940–#1943 polish
that landed after the first notes draft.

## Test plan

- [x] `make verify-release-notes`
- [x] Test attribute counts via script (3,928 total; 2,652 in src/)