### PR TITLE
ci: exclude glama.ai from lychee (CI timeouts)

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -30,6 +30,9 @@ exclude = [
   "patchloom\\.github\\.io",
   # npmjs.com returns 403 to many CI link-checkers (bot protection) for public packages
   "npmjs\\.com",
+  # glama.ai MCP directory/inspector timeouts from CI runners (PR #1945 flake;
+  # Links on PRs are soft-fail, but main/schedule still hard-fail)
+  "glama\\.ai",
 ]
 
 # 502/503/504: GitHub (and occasional other hosts) return gateway errors under


### PR DESCRIPTION
## Summary

Exclude `glama.ai` from lychee so main/schedule hard-fail is not blocked by known CI timeouts (same flake that red'd #1945).

PR Links remain non-blocking (#1946). Docs still mention Glama; we just stop requiring the live page from CI.

## Test plan

- [x] lychee.toml exclude added with comment
- [ ] Links workflow on this PR soft-fails if other flakes occur