### PR TITLE
fix: library peels for already_exists and CLI error_kind strings

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1332,7 +1332,8 @@ The operations below are the building blocks inside `operations`.
 | Need | API |
 |------|-----|
 | Fail-closed text replace | `ReplaceOptions.require_change` + `edit_error_kind` / `classify_error` |
-| Non-`anyhow` error kinds | `classify_error(&dyn Error)` / `classify_error_ref` (#1659); `EditErrorKind::FormatFailed` for post-write hooks; `EditErrorKind::TypeError` for multi-doc / wrong-root doc navigation (CLI `error_kind: type_error`; #1883) |
+| Non-`anyhow` error kinds | `classify_error(&dyn Error)` / `classify_error_ref` (#1659); `EditErrorKind::FormatFailed` for post-write hooks; `EditErrorKind::TypeError` for multi-doc / wrong-root doc navigation (CLI `error_kind: type_error`; #1883); `EditErrorKind::AlreadyExists` for create/rename dest-exists (#1947); `EditErrorKind::NotFound` / `Conflicts` / `ChangesDetected` for peels that previously collapsed to `OperationFailed` |
+| CLI-stable error kind strings | `api::error_kind_str(&err)` returns the same strings as CLI JSON (`already_exists`, `not_found`, `guard_rejected`, …) without scraping Display (#1948); `api::is_already_exists` for force/overwrite branches |
 | Path binary preflight | `api::is_binary_file` / `files::is_binary_file` (8 KiB NUL probe; open fail → false; #1884 / #1910); writers still enforce binary on apply |
 | Text I/O honesty | Sole path: `api::load_text` / `files::load_text_strict` (binary / invalid UTF-8 → `InvalidInput`; #1894 / #1910); walks: `try_read_text_file` / `SoftTextSkip` / `read_text_file`; tx probe `read_and_probe` (content soft, IO hard); sole helper `ops::file::sole_explicit_non_text`; multi-path `explicit_multi_path_non_text_refused`; patch file+targets Strict (#1896) |
 | Multi-doc library merge | `api::doc_merge(path, value, mode, guard, selector)` with `Some("0")` / `Some("[0]")` for document 0; root object overlay on multi-doc is `TypeError` (#1909) |

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -89,12 +89,16 @@
 //!   binary and invalid UTF-8 become `EditErrorKind::InvalidInput`
 //! - [`is_binary_file`]: cheap 8 KiB NUL preflight (open fail → `false`; use
 //!   `load_text` when you need a typed open error)
-//! - [`edit_error_kind`]: peel `TypeError` (multi-doc bare key / wrong root)
-//!   separately from `InvalidInput` (empty pattern, sole binary, …)
+//! - [`edit_error_kind`]: peel `TypeError` (multi-doc bare key / wrong root),
+//!   `AlreadyExists` (create/rename dest), `NotFound`, `Conflicts`, etc.
+//!   separately from coarse `InvalidInput` / `OperationFailed`
+//! - [`error_kind_str`]: same CLI JSON kind strings (`already_exists`, …) for
+//!   host envelopes that mirror agent JSON (#1948)
+//! - [`is_already_exists`]: bool peel for force/overwrite recovery (#1947)
 //! - [`doc_merge`]: optional `selector` for multi-doc YAML (`Some("0")`)
 //!
 //! ```rust,no_run
-//! use patchloom::api::{self, edit_error_kind, EditErrorKind, ApplyMode};
+//! use patchloom::api::{self, edit_error_kind, error_kind_str, EditErrorKind, ApplyMode};
 //! use std::path::Path;
 //!
 //! let path = Path::new("stream.yaml");
@@ -113,6 +117,13 @@
 //!     None,
 //!     Some("0"),
 //! );
+//! // Dest-exists → AlreadyExists / "already_exists" (not InvalidInput)
+//! match api::file_create(path, "x\n", false, ApplyMode::Apply, None) {
+//!     Err(e) if edit_error_kind(&e) == Some(EditErrorKind::AlreadyExists) => {
+//!         assert_eq!(error_kind_str(&e), Some("already_exists"));
+//!     }
+//!     _ => {}
+//! }
 //! ```
 //!
 //! `EditErrorKind` is `#[non_exhaustive]`; match with a wildcard arm so new
@@ -397,10 +408,10 @@ pub struct ReplaceOptions {
     pub post_write_cwd: Option<std::path::PathBuf>,
 }
 
-// Re-export structured edit errors for embedders (#1492, #1659).
+// Re-export structured edit errors for embedders (#1492, #1659, #1947, #1948).
 pub use crate::fallback::{
     EditError, EditErrorKind, classify_error, classify_error_ref, edit_error_kind, edit_error_ref,
-    find_similar_targets,
+    error_kind_str, find_similar_targets, is_already_exists,
 };
 
 /// Write policy options for controlling file write transformations.

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -6153,15 +6153,24 @@ fn fuzzy_absent_old_fails_closed_by_default() {
 
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]
-fn file_create_already_exists_is_invalid_input() {
+fn file_create_already_exists_is_already_exists() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("a.txt");
     fs::write(&file, "x\n").unwrap();
     let err = file_create(&file, "y", false, ApplyMode::Apply, None).unwrap_err();
     assert_eq!(
         crate::fallback::edit_error_kind(&err),
-        Some(EditErrorKind::InvalidInput),
-        "already-exists must peel without string scrape: {err}"
+        Some(EditErrorKind::AlreadyExists),
+        "already-exists must peel without string scrape (#1947): {err}"
+    );
+    assert!(
+        crate::fallback::is_already_exists(&err),
+        "is_already_exists must see dest-exists: {err}"
+    );
+    assert_eq!(
+        crate::fallback::error_kind_str(&err),
+        Some("already_exists"),
+        "CLI-stable kind string (#1948): {err}"
     );
     assert!(
         err.to_string().contains("already exists"),
@@ -6171,7 +6180,7 @@ fn file_create_already_exists_is_invalid_input() {
 
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]
-fn file_rename_destination_exists_is_invalid_input() {
+fn file_rename_destination_exists_is_already_exists() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("a.txt");
     let dst = dir.path().join("b.txt");
@@ -6180,10 +6189,81 @@ fn file_rename_destination_exists_is_invalid_input() {
     let err = file_rename(&file, &dst, false, ApplyMode::Apply, None).unwrap_err();
     assert_eq!(
         crate::fallback::edit_error_kind(&err),
-        Some(EditErrorKind::InvalidInput),
-        "dest exists must peel: {err}"
+        Some(EditErrorKind::AlreadyExists),
+        "dest exists must peel as AlreadyExists (#1947): {err}"
+    );
+    assert_eq!(
+        crate::fallback::error_kind_str(&err),
+        Some("already_exists"),
+        "CLI-stable kind string (#1948): {err}"
+    );
+    assert!(
+        crate::fallback::is_already_exists(&err),
+        "rename dest-exists must set is_already_exists: {err}"
     );
     assert!(err.to_string().contains("already exists"), "message: {err}");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn file_delete_missing_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("gone.txt");
+    let err = file_delete(&missing, ApplyMode::Apply, None).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NotFound),
+        "missing delete must peel as NotFound not OperationFailed: {err}"
+    );
+    assert_eq!(
+        crate::fallback::error_kind_str(&err),
+        Some("not_found"),
+        "CLI-stable not_found (#1948 sibling): {err}"
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn execute_plan_patch_merge_conflict_is_conflicts() {
+    // Real library path: on_stale merge without allow_conflicts → ConflictsError.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("test.txt");
+    fs::write(&file, "line1\ncompletely different\nline3\n").unwrap();
+    let diff =
+        "--- a/test.txt\n+++ b/test.txt\n@@ -1,3 +1,3 @@\n line1\n-old line\n+new line\n line3\n";
+    let plan = crate::plan::Plan {
+        version: 1,
+        cwd: Some(dir.path().to_string_lossy().into()),
+        write_policy: None,
+        strict: None,
+        operations: vec![crate::plan::Operation::PatchApply {
+            diff: diff.into(),
+            on_stale: crate::ops::patch::OnStale::Merge,
+            allow_conflicts: false,
+        }],
+        format: None,
+        validate: None,
+        verify: None,
+        for_each: None,
+    };
+    // Plan failures return Ok(PlanReport) with ok:false + error_kind (not Err).
+    let report = execute_plan(plan, dir.path(), None).expect("plan report");
+    assert!(!report.ok, "merge conflict plan must fail: {report:?}");
+    assert_eq!(
+        report.error_kind.as_deref(),
+        Some("conflicts"),
+        "PlanReport must carry CLI-stable conflicts kind: {report:?}"
+    );
+    // When hosts wrap the report error string as anyhow, typed peel still works
+    // if the underlying ConflictsError remains in the chain; for plan reports
+    // the string field is the primary branch point.
+    assert!(
+        report
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("conflict")),
+        "error message should mention conflict: {report:?}"
+    );
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -425,7 +425,8 @@ pub fn classify_typed_error(err: &anyhow::Error) -> Option<(&'static str, u8)> {
     {
         // Library/engine PathGuard and other EditError-only kinds (#1935).
         // Keep exit-typed arms above so already_exists / type_error stay distinct
-        // (edit_error_kind maps some exit types onto coarser EditErrorKind values).
+        // when both layers appear in a chain. EditErrorKind now peels the same
+        // honesty kinds for library hosts (#1947).
         use crate::fallback::EditErrorKind;
         match edit.kind {
             EditErrorKind::GuardRejected => Some(("guard_rejected", FAILURE)),
@@ -433,6 +434,10 @@ pub fn classify_typed_error(err: &anyhow::Error) -> Option<(&'static str, u8)> {
             EditErrorKind::AmbiguousTarget => Some(("ambiguous", AMBIGUOUS)),
             EditErrorKind::InvalidInput => Some(("invalid_input", FAILURE)),
             EditErrorKind::TypeError => Some(("type_error", FAILURE)),
+            EditErrorKind::AlreadyExists => Some(("already_exists", FAILURE)),
+            EditErrorKind::NotFound => Some(("not_found", FAILURE)),
+            EditErrorKind::Conflicts => Some(("conflicts", CONFLICTS)),
+            EditErrorKind::ChangesDetected => Some(("changes_detected", CHANGES_DETECTED)),
             EditErrorKind::ParseError => Some(("parse_error", PARSE_ERROR)),
             EditErrorKind::FormatFailed => Some(("format_failed", FAILURE)),
             EditErrorKind::SyntaxInvalid

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -116,6 +116,24 @@ pub enum EditErrorKind {
     /// "type_error"`. Distinct from [`Self::InvalidInput`] so hosts can
     /// recover with `0.key` / `[0].key` without scraping English (#1883).
     TypeError,
+    /// Create/rename destination already exists without force.
+    /// CLI JSON uses `error_kind: "already_exists"`. Distinct from
+    /// [`Self::InvalidInput`] (binary, empty path, directory target) so hosts
+    /// can hint `overwrite`/`force` without scraping English (#1947).
+    AlreadyExists,
+    /// Path not found (`std::io::ErrorKind::NotFound`). CLI JSON uses
+    /// `error_kind: "not_found"`. Distinct from generic [`Self::OperationFailed`]
+    /// so hosts can treat missing paths separately from other I/O failures.
+    NotFound,
+    /// Patch/apply produced merge conflict markers. CLI JSON uses
+    /// `error_kind: "conflicts"`. Distinct from [`Self::ConflictingEdit`]
+    /// (batch region overlap) and generic [`Self::OperationFailed`].
+    Conflicts,
+    /// Check/preview reported pending changes, or soft assert-count mismatch
+    /// (`error_kind: "changes_detected"`, exit 2). Distinct from
+    /// [`Self::OperationFailed`] so hosts can mirror CLI exit-2 semantics
+    /// without scraping English.
+    ChangesDetected,
     /// I/O or other operational failure.
     OperationFailed,
     /// Post-write format/lint hook failed (`format_failed` / #1663).
@@ -135,6 +153,10 @@ impl std::fmt::Display for EditErrorKind {
             EditErrorKind::GuardRejected => write!(f, "guard_rejected"),
             EditErrorKind::InvalidInput => write!(f, "invalid_input"),
             EditErrorKind::TypeError => write!(f, "type_error"),
+            EditErrorKind::AlreadyExists => write!(f, "already_exists"),
+            EditErrorKind::NotFound => write!(f, "not_found"),
+            EditErrorKind::Conflicts => write!(f, "conflicts"),
+            EditErrorKind::ChangesDetected => write!(f, "changes_detected"),
             EditErrorKind::OperationFailed => write!(f, "operation_failed"),
             EditErrorKind::FormatFailed => write!(f, "format_failed"),
         }
@@ -232,11 +254,13 @@ pub fn classify_error(err: &(dyn std::error::Error + 'static)) -> Option<EditErr
         if e.downcast_ref::<crate::exit::AmbiguousError>().is_some() {
             return Some(EditErrorKind::AmbiguousTarget);
         }
-        if e.downcast_ref::<crate::exit::InvalidInputError>().is_some()
-            || e.downcast_ref::<crate::exit::AlreadyExistsError>()
-                .is_some()
-        {
+        if e.downcast_ref::<crate::exit::InvalidInputError>().is_some() {
             return Some(EditErrorKind::InvalidInput);
+        }
+        if e.downcast_ref::<crate::exit::AlreadyExistsError>()
+            .is_some()
+        {
+            return Some(EditErrorKind::AlreadyExists);
         }
         if e.downcast_ref::<crate::exit::TypeErrorError>().is_some() {
             return Some(EditErrorKind::TypeError);
@@ -247,21 +271,45 @@ pub fn classify_error(err: &(dyn std::error::Error + 'static)) -> Option<EditErr
         if e.downcast_ref::<crate::exit::FormatFailedError>().is_some() {
             return Some(EditErrorKind::FormatFailed);
         }
-        // Closest library kind for hosts that only branch on EditErrorKind.
-        if e.downcast_ref::<crate::exit::ConflictsError>().is_some()
-            || e.downcast_ref::<crate::exit::ChangesDetectedError>()
-                .is_some()
+        if e.downcast_ref::<crate::exit::ConflictsError>().is_some() {
+            return Some(EditErrorKind::Conflicts);
+        }
+        if e.downcast_ref::<crate::exit::ChangesDetectedError>()
+            .is_some()
         {
-            return Some(EditErrorKind::OperationFailed);
+            return Some(EditErrorKind::ChangesDetected);
         }
         if e.downcast_ref::<std::io::Error>()
             .is_some_and(|io| io.kind() == std::io::ErrorKind::NotFound)
         {
-            return Some(EditErrorKind::OperationFailed);
+            return Some(EditErrorKind::NotFound);
         }
         current = e.source();
     }
     None
+}
+
+/// Same stable kind string CLI JSON uses (`already_exists`, `guard_rejected`, …).
+///
+/// Library hosts that mirror agent JSON envelopes should use this instead of
+/// re-implementing [`crate::exit::classify_typed_error`] or scraping Display
+/// (#1948). Returns `None` when the chain has no recognized typed kind.
+///
+/// Prefer this over matching only [`edit_error_kind`] when you need CLI-stable
+/// strings (for example `no_matches` vs Display `no_match`).
+#[must_use]
+pub fn error_kind_str(err: &anyhow::Error) -> Option<&'static str> {
+    crate::exit::classify_typed_error(err).map(|(kind, _)| kind)
+}
+
+/// Whether the error peels as dest-exists create/rename conflict.
+///
+/// True for both [`crate::exit::AlreadyExistsError`] and
+/// [`EditError`] with [`EditErrorKind::AlreadyExists`], so the bool matches
+/// what hosts get from [`edit_error_kind`] (#1947).
+#[must_use]
+pub fn is_already_exists(err: &anyhow::Error) -> bool {
+    edit_error_kind(err) == Some(EditErrorKind::AlreadyExists)
 }
 
 /// Downcast a bare `dyn Error` chain to [`EditError`] when present (#1659).
@@ -980,6 +1028,13 @@ mod tests {
         assert_eq!(EditErrorKind::ParseError.to_string(), "parse_error");
         assert_eq!(EditErrorKind::TypeError.to_string(), "type_error");
         assert_eq!(EditErrorKind::InvalidInput.to_string(), "invalid_input");
+        assert_eq!(EditErrorKind::AlreadyExists.to_string(), "already_exists");
+        assert_eq!(EditErrorKind::NotFound.to_string(), "not_found");
+        assert_eq!(EditErrorKind::Conflicts.to_string(), "conflicts");
+        assert_eq!(
+            EditErrorKind::ChangesDetected.to_string(),
+            "changes_detected"
+        );
         assert_eq!(EditErrorKind::FormatFailed.to_string(), "format_failed");
     }
 
@@ -1007,6 +1062,32 @@ mod tests {
         assert_eq!(
             classify_error(&e as &(dyn Error + 'static)),
             Some(EditErrorKind::TypeError)
+        );
+        let e = crate::exit::AlreadyExistsError {
+            msg: "exists".into(),
+        };
+        assert_eq!(
+            classify_error(&e as &(dyn Error + 'static)),
+            Some(EditErrorKind::AlreadyExists)
+        );
+        let e = crate::exit::ConflictsError {
+            msg: "conflict".into(),
+        };
+        assert_eq!(
+            classify_error(&e as &(dyn Error + 'static)),
+            Some(EditErrorKind::Conflicts)
+        );
+        let e = crate::exit::ChangesDetectedError {
+            msg: "would change".into(),
+        };
+        assert_eq!(
+            classify_error(&e as &(dyn Error + 'static)),
+            Some(EditErrorKind::ChangesDetected)
+        );
+        let e = std::io::Error::new(std::io::ErrorKind::NotFound, "gone");
+        assert_eq!(
+            classify_error(&e as &(dyn Error + 'static)),
+            Some(EditErrorKind::NotFound)
         );
     }
 
@@ -1043,7 +1124,24 @@ mod tests {
             msg: "file already exists".into(),
         }
         .into();
-        assert_eq!(edit_error_kind(&exists), Some(EditErrorKind::InvalidInput));
+        assert_eq!(
+            edit_error_kind(&exists),
+            Some(EditErrorKind::AlreadyExists),
+            "AlreadyExistsError must not collapse to InvalidInput (#1947)"
+        );
+        assert!(is_already_exists(&exists));
+        assert_eq!(error_kind_str(&exists), Some("already_exists"));
+
+        let exists_edit: anyhow::Error =
+            EditError::new(EditErrorKind::AlreadyExists, "dest taken").into();
+        assert!(
+            is_already_exists(&exists_edit),
+            "is_already_exists must match EditErrorKind::AlreadyExists too"
+        );
+        assert_eq!(
+            edit_error_kind(&exists_edit),
+            Some(EditErrorKind::AlreadyExists)
+        );
 
         let type_err: anyhow::Error = crate::exit::TypeErrorError {
             msg: "parent is an array, not an object".into(),
@@ -1067,9 +1165,27 @@ mod tests {
         let not_found = not_found.context("failed to read path");
         assert_eq!(
             edit_error_kind(&not_found),
-            Some(EditErrorKind::OperationFailed),
-            "IO NotFound should peel via classify not_found"
+            Some(EditErrorKind::NotFound),
+            "IO NotFound must peel as NotFound not OperationFailed"
         );
+        assert_eq!(error_kind_str(&not_found), Some("not_found"));
+
+        let conflicts: anyhow::Error = crate::exit::ConflictsError {
+            msg: "merge conflict".into(),
+        }
+        .into();
+        assert_eq!(edit_error_kind(&conflicts), Some(EditErrorKind::Conflicts));
+        assert_eq!(error_kind_str(&conflicts), Some("conflicts"));
+
+        let changes: anyhow::Error = crate::exit::ChangesDetectedError {
+            msg: "would change".into(),
+        }
+        .into();
+        assert_eq!(
+            edit_error_kind(&changes),
+            Some(EditErrorKind::ChangesDetected)
+        );
+        assert_eq!(error_kind_str(&changes), Some("changes_detected"));
 
         // Intermediate .context() must not hide the typed kind.
         let wrapped = invalid.context("operation 1 (replace) failed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,11 @@
 //! | Map multi-doc bare key / wrong-root merge to tool `invalid_args` | [`api::edit_error_kind`] → [`EditErrorKind::TypeError`] |
 //! | Multi-doc YAML merge into document 0 | [`api::doc_merge`](..., `Some("0")`) |
 //! | Map empty pattern / sole binary to `invalid_args` | [`EditErrorKind::InvalidInput`] |
+//! | Map create/rename dest-exists to force/overwrite recovery | [`EditErrorKind::AlreadyExists`] / [`api::is_already_exists`] |
+//! | CLI-stable kind string for host JSON envelopes | [`api::error_kind_str`] (`already_exists`, `not_found`, …) |
+//! | Map missing path I/O to not-found (not generic op fail) | [`EditErrorKind::NotFound`] |
+//! | Map patch merge conflict markers | [`EditErrorKind::Conflicts`] (distinct from batch [`EditErrorKind::ConflictingEdit`]) |
+//! | Map check/assert-count exit-2 soft failures | [`EditErrorKind::ChangesDetected`] |
 //!
 //! `EditErrorKind` is `#[non_exhaustive]`: always include a wildcard arm when matching.
 //!
@@ -290,9 +295,9 @@ pub use api::{
     EditResult, Hunk, MatchMode, PatchFile, PatchLine, PostWriteHooks, PostWriteOnFailure,
     ReplaceOptions, SearchOptions, SearchResult, WritePolicyOptions, apply_content_edits,
     apply_content_edits_with_label, apply_post_write_validator, build_context_lines,
-    classify_error, classify_error_ref, edit_error_kind, edit_error_ref, format_search_results,
-    is_binary_file, load_text, load_text_strict, merge_match_modes, parse_unified_diff,
-    run_post_write_validation, search_file, text_diff,
+    classify_error, classify_error_ref, edit_error_kind, edit_error_ref, error_kind_str,
+    format_search_results, is_already_exists, is_binary_file, load_text, load_text_strict,
+    merge_match_modes, parse_unified_diff, run_post_write_validation, search_file, text_diff,
 };
 pub use plan::Plan;
 


### PR DESCRIPTION
## Summary

- Add `EditErrorKind::AlreadyExists` so create/rename dest-exists peels separately from `InvalidInput` (binary / empty path / directory targets).
- Add `api::error_kind_str` (CLI-stable kind strings) and `api::is_already_exists` for library hosts that mirror agent JSON.
- Sibling peels: `NotFound`, `Conflicts`, and `ChangesDetected` no longer collapse to `OperationFailed`.
- Docs: embedder cookbook + reference library table.

## Why

Bline and other crate embedders could not branch on dest-exists without scraping English after 0.18 structured file peels. CLI JSON already had `already_exists`; the library surface did not.

## Test plan

- [x] `cargo test --lib --all-features already_exists` / `file_delete_missing` / `edit_error_kind_maps` / `classify_error_peels` / `execute_plan_patch_merge`
- [x] `make check-fast`
- [x] Reviewer pass (is_already_exists symmetry + coverage tightened)

Closes #1947
Closes #1948