### PR TITLE
docs: fix library peels for AlreadyExists after #1950

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make pack-mcpb` | Pack `mcpb/` into `target/mcpb/patchloom-<ver>.mcpb` (Smithery / desktop). Honors `$VERSION` over Cargo.toml |
 | `make pack-mcpb-test` | Unit tests for pack version override and stamped manifest (`scripts/test_pack_mcpb.py`; skips full pack when `mcpb` CLI missing) |
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
-| `make embedder-smoke` | Pre-release host contracts (fuzzy token span with `--allow-absent-old`, nested undo list, plan `key` alias, `--contain` → `guard_rejected`). Not part of `check`; run before tagging a release |
+| `make embedder-smoke` | Pre-release host contracts (fuzzy token span with `--allow-absent-old`, nested undo list, plan `key` alias, `--contain` → `guard_rejected`, create dest-exists → `already_exists`). Not part of `check`; run before tagging a release |
 | `make fuzz` | Run fuzz tests (11 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse, containment_check, fallback_resolve, ast_parse, md_heading, replace_regex). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |
 | `make bench-mcp` | Run MCP benchmarks: per-call latency vs CLI process spawn (not part of `check`) |

--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -57,7 +57,18 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)
 - `backup::find_backup_roots(path)` — walk path and parents for roots that own `.patchloom/backups` (nearest first; #1934)
-- File create/delete/rename/append and `ast_rewrite_signature` peel via `edit_error_kind`: exists/dir/binary → `InvalidInput`, missing symbol → `NoMatch`, PathGuard → `GuardRejected` (#1935 / #1936)
+- File create/delete/rename/append and `ast_rewrite_signature` peel via `edit_error_kind` / `error_kind_str` (#1935 / #1936 / #1947 / #1948):
+| Condition | `EditErrorKind` / CLI string |
+|-----------|-----------------------------|
+| Create/rename dest exists without force | `AlreadyExists` / `already_exists` (not `InvalidInput`; use force/overwrite) |
+| Missing path I/O | `NotFound` / `not_found` |
+| Directory target / binary / empty path | `InvalidInput` / `invalid_input` |
+| PathGuard / `--contain` escape | `GuardRejected` / `guard_rejected` |
+| Patch merge conflict markers | `Conflicts` / `conflicts` (not batch `ConflictingEdit`) |
+| Check/assert-count exit-2 soft fail | `ChangesDetected` / `changes_detected` |
+| AST missing symbol | `NoMatch` / `no_matches` |
+- Bool peel: `api::is_already_exists` for force/overwrite recovery; string peel: `api::error_kind_str` for CLI-stable envelopes (#1947 / #1948).
+- New `EditErrorKind` variants must be **appended** (after the last variant) so discriminants of published kinds stay stable under cargo-semver-checks (#1955).
 - CLI: `patchloom undo --list` walks nested `.patchloom/backups` under the cwd (#1695). Bare CLI undo is dry-run (exit 2); restore needs the write apply flag (see CLI agent-rules).
 - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`
 - Multi-doc / wrong-root doc navigation peels to `EditErrorKind::TypeError` via `edit_error_kind` / `classify_error` (CLI JSON `error_kind: type_error`; #1883). Do not collapse with `InvalidInput` (empty patterns, bad options, sole binary).

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1348,7 +1348,7 @@ The operations below are the building blocks inside `operations`.
 | Apply session id for surgical undo | `EditResult.backup_session` after Apply (#1686); pair with `restore_path_from_session` |
 | Nested monorepo backup listing | `backup::list_sessions_under` + `ListSessionsOptions` (#1688) |
 | Ancestor backup root discovery | `backup::find_backup_roots(path)` walks parents for `.patchloom/backups` (#1934) |
-| File op structured kinds | `file_create` / `file_delete` / `file_rename` / `file_append`: exists/dir/binary → `InvalidInput`; PathGuard → `GuardRejected` (#1935) |
+| File op structured kinds | `file_create` / `file_delete` / `file_rename` / `file_append`: dest-exists without force → `AlreadyExists` (#1947); missing path → `NotFound`; dir/binary/empty path → `InvalidInput`; PathGuard → `GuardRejected` (#1935) |
 | AST signature rewrite kinds | `ast_rewrite_signature`: missing fn → `NoMatch`; binary → `InvalidInput`; guard → `GuardRejected` (#1936) |
 | In-memory multi-op with real diff headers | `apply_content_edits_with_label` (#1665) |
 | Surgical undo one path | `backup::restore_path_from_session(root, ts, path)` (#1660) |

--- a/scripts/embedder-smoke.sh
+++ b/scripts/embedder-smoke.sh
@@ -56,6 +56,21 @@ echo "$contain_json" | grep -q '"error_kind": "guard_rejected"' \
   || fail "contain escape must set error_kind guard_rejected: $contain_json"
 pass "CLI --contain JSON error_kind is guard_rejected (#1935)"
 
+# --- #1947: create without force peels already_exists (not invalid_input) ---
+printf 'existing\n' >"$tmpdir/ws/taken.txt"
+create_json=$("$BIN" --json --cwd "$tmpdir/ws" create taken.txt --content 'new' 2>/dev/null || true)
+echo "$create_json" | grep -q '"error_kind": "already_exists"' \
+  || echo "$create_json" | grep -q '"error_kind":"already_exists"' \
+  || fail "create dest-exists must set error_kind already_exists: $create_json"
+echo "$create_json" | grep -q '"applied": false\|"applied":false' \
+  || fail "create dest-exists must set applied:false: $create_json"
+# Must not claim invalid_input for dest-exists (hosts branch on kind for force).
+echo "$create_json" | grep -q '"error_kind": "invalid_input"' \
+  && fail "create dest-exists must not be invalid_input: $create_json"
+echo "$create_json" | grep -q '"error_kind":"invalid_input"' \
+  && fail "create dest-exists must not be invalid_input: $create_json"
+pass "CLI create dest-exists JSON error_kind is already_exists (#1947)"
+
 # --- nested undo still works after contain smoke (sessions already created) ---
 # Library-only find_backup_roots is unit-tested; CLI hosts use undo --list (#1695).
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -147,7 +147,21 @@ resort for typos in non-AST text (prose, comments), not a general rename tool.\n
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
              - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)\n\
              - `backup::find_backup_roots(path)` — walk path and parents for roots that own `.patchloom/backups` (nearest first; #1934)\n\
-             - File create/delete/rename/append and `ast_rewrite_signature` peel via `edit_error_kind`: exists/dir/binary → `InvalidInput`, missing symbol → `NoMatch`, PathGuard → `GuardRejected` (#1935 / #1936)\n\
+             - File create/delete/rename/append and `ast_rewrite_signature` peel via `edit_error_kind` \
+               / `error_kind_str` (#1935 / #1936 / #1947 / #1948):\n\
+               | Condition | `EditErrorKind` / CLI string |\n\
+               |-----------|-----------------------------|\n\
+               | Create/rename dest exists without force | `AlreadyExists` / `already_exists` (not `InvalidInput`; use force/overwrite) |\n\
+               | Missing path I/O | `NotFound` / `not_found` |\n\
+               | Directory target / binary / empty path | `InvalidInput` / `invalid_input` |\n\
+               | PathGuard / `--contain` escape | `GuardRejected` / `guard_rejected` |\n\
+               | Patch merge conflict markers | `Conflicts` / `conflicts` (not batch `ConflictingEdit`) |\n\
+               | Check/assert-count exit-2 soft fail | `ChangesDetected` / `changes_detected` |\n\
+               | AST missing symbol | `NoMatch` / `no_matches` |\n\
+             - Bool peel: `api::is_already_exists` for force/overwrite recovery; string peel: \
+               `api::error_kind_str` for CLI-stable envelopes (#1947 / #1948).\n\
+             - New `EditErrorKind` variants must be **appended** (after the last variant) so \
+               discriminants of published kinds stay stable under cargo-semver-checks (#1955).\n\
              - CLI: `patchloom undo --list` walks nested `.patchloom/backups` under the cwd (#1695). Bare CLI undo is dry-run (exit 2); restore needs the write apply flag (see CLI agent-rules).\n\
              - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`\n\
              - Multi-doc / wrong-root doc navigation peels to `EditErrorKind::TypeError` via \
@@ -1178,6 +1192,24 @@ mod tests {
         assert!(
             out.contains("EditErrorKind::TypeError"),
             "library hosts need TypeError peel docs (#1883)"
+        );
+        // #1947/#1948: dest-exists is AlreadyExists, not InvalidInput (stale #1935 bullet).
+        assert!(
+            out.contains("AlreadyExists") && out.contains("already_exists"),
+            "library hosts need AlreadyExists / already_exists peels (#1947)"
+        );
+        assert!(
+            out.contains("is_already_exists") && out.contains("error_kind_str"),
+            "library hosts need api::is_already_exists and error_kind_str (#1948)"
+        );
+        assert!(
+            !out.contains("exists/dir/binary → `InvalidInput`")
+                && !out.contains("exists/dir/binary → InvalidInput"),
+            "must not claim create dest-exists peels as InvalidInput after #1950"
+        );
+        assert!(
+            out.contains("appended") || out.contains("append"),
+            "library hosts need EditErrorKind append-only discriminant note (#1955)"
         );
         assert!(
             out.contains("is_binary_file"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,9 +124,10 @@
 //! descendant `.patchloom/backups` roots (#1688). Ancestor discovery:
 //! `backup::find_backup_roots(path)` walks parents for roots that contain
 //! `.patchloom/backups` (#1934). File create/delete/rename/append and
-//! `ast_rewrite_signature` peel via `edit_error_kind` (`InvalidInput` for
-//! exists/dir/binary, `NoMatch` for missing symbols, `GuardRejected` for
-//! PathGuard; #1935 / #1936). Fuzzy policy:
+//! `ast_rewrite_signature` peel via `edit_error_kind` (`AlreadyExists` for
+//! dest-exists without force, `NotFound` for missing path I/O, `InvalidInput`
+//! for dir/binary/empty path, `NoMatch` for missing AST symbols, `GuardRejected`
+//! for PathGuard; #1935 / #1936 / #1947). Fuzzy policy:
 //! `ReplaceOptions.min_fuzzy_score` rejects weak similarity matches (#1687).
 //! Project-wide rename: `api::ast_rename_project` (#1689). Post-Apply hooks:
 //! `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` / batch


### PR DESCRIPTION
## Summary

MPI cycle found **stale library host docs** after [#1950](https://github.com/patchloom/patchloom/pull/1950):

- agent-rules / `PATCHLOOM.md` still said file create dest-exists peels as **`InvalidInput`**
- Real peel is **`AlreadyExists` / `already_exists`** (force/overwrite recovery)
- crate `lib.rs` overview and reference inventory table repeated the stale map

## Changes

- Correct library embedder peel table (`AlreadyExists`, `NotFound`, guard, conflicts, …)
- Document `api::is_already_exists` / `api::error_kind_str` and append-only discriminants (#1955)
- `embedder-smoke`: create dest-exists JSON must be `already_exists` with `applied: false`
- AGENTS.md smoke blurb updated

## Test plan

- [x] `cargo test --lib agent_rules --all-features`
- [x] `make sync-patchloom-md` / `make check-patchloom-md`
- [x] `make embedder-smoke`
- [x] `make check-fast`

## Gate notes

- Release PR [#1951](https://github.com/patchloom/patchloom/pull/1951) green (do not merge without explicit yes)
- Dist issues #960 / #961 still external-blocked (winget moderator; Chocolatey feed lag)