### PR TITLE
ci: expand WSL tests and add Windows PowerShell smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -131,10 +131,18 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
-  # WSL2 on windows-latest (free GHA runner). Path semantics are Linux-like,
-  # but absolute paths and --contain must still work when the checkout lives
-  # under the WSL filesystem. Scope is intentionally narrow: full matrix
-  # already runs on ubuntu-latest; this job locks interop smoke only.
+      # PowerShell dogfood: backslash paths, absolute paths, peels, tx, CRLF.
+      # Fixrealloop-style scenarios under pwsh (not covered by assert_cmd alone).
+      - name: Windows PowerShell smoke (create/replace/doc/tx/paths)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          pwsh -NoProfile -File scripts/windows-smoke.ps1 -Bin target\debug\patchloom.exe
+
+  # WSL2 on windows-latest (free GHA runner). Path semantics are Linux-like;
+  # checkout is copied to ext4 home (building under /mnt/c is too slow).
+  # Expanded beyond path-only smoke: full lib + integration (no clippy/fuzz/pty;
+  # those stay on ubuntu-latest). Keeps WSL interop honest for agents in WSL.
   ci-wsl:
     needs: [changes]
     if: >
@@ -145,7 +153,7 @@ jobs:
       ))
       && (needs.changes.result == 'skipped' || needs.changes.outputs.code == 'true')
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -165,7 +173,7 @@ jobs:
           update: true
           additional-packages: build-essential curl ca-certificates pkg-config libssl-dev
 
-      - name: Install Rust and run platform path tests in WSL
+      - name: Install Rust and run lib + integration tests in WSL
         shell: wsl-bash {0}
         run: |
           set -euo pipefail
@@ -191,8 +199,13 @@ jobs:
           . "$HOME/.cargo/env"
           rustc --version
           cargo --version
+          # Path-focused filters first (fast feedback on #1931-class bugs).
           cargo test --lib --all-features containment -- --nocapture
           cargo test --test integration --all-features platform_path -- --nocapture
+          # Full lib + integration subset (no --test pty: expectrl PTY matrix is
+          # covered on ubuntu/macos; WSL job budget is for path + CLI honesty).
+          cargo test --lib --all-features
+          cargo test --test integration --all-features
 
   ci-macos:
     needs: [changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,12 @@ jobs:
           fi
           # shellcheck source=/dev/null
           . "$HOME/.cargo/env"
+          # Example-plan smoke tests (02-multi-file-batch, 05-strict-mode) run
+          # cargo fmt as a format step; minimal profile omits rustfmt.
+          rustup component add rustfmt
           rustc --version
           cargo --version
+          cargo fmt --version
           # Path-focused filters first (fast feedback on #1931-class bugs).
           cargo test --lib --all-features containment -- --nocapture
           cargo test --test integration --all-features platform_path -- --nocapture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,7 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make pack-mcpb-test` | Unit tests for pack version override and stamped manifest (`scripts/test_pack_mcpb.py`; skips full pack when `mcpb` CLI missing) |
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
 | `make embedder-smoke` | Pre-release host contracts (fuzzy token span with `--allow-absent-old`, nested undo list, plan `key` alias, `--contain` → `guard_rejected`, create dest-exists → `already_exists`). Not part of `check`; run before tagging a release |
+| `make windows-smoke` | Windows/PowerShell dogfood (`scripts/windows-smoke.ps1`: backslash paths, absolute paths, peels, tx, CRLF). Not part of `check`; runs in CI `ci-windows`. Requires `pwsh` |
 | `make fuzz` | Run fuzz tests (11 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse, containment_check, fallback_resolve, ast_parse, md_heading, replace_regex). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |
 | `make bench-mcp` | Run MCP benchmarks: per-call latency vs CLI process spawn (not part of `check`) |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test chocolatey-package-test pack-mcpb pack-mcpb-test git-clean clean
+.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke windows-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test chocolatey-package-test pack-mcpb pack-mcpb-test git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -133,6 +133,15 @@ agent-test: build ## Run agent integration tests (requires LLM API key). Use MOD
 
 embedder-smoke: build ## Pre-release host contracts (fuzzy token span, nested undo list, plan key alias)
 	bash scripts/embedder-smoke.sh target/debug/patchloom
+
+windows-smoke: build ## Windows/PowerShell dogfood (create/replace/doc/tx/paths). Requires pwsh + Windows-style binary.
+	@if command -v pwsh >/dev/null 2>&1; then \
+		pwsh -NoProfile -File scripts/windows-smoke.ps1 -Bin target/debug/patchloom; \
+	elif command -v powershell >/dev/null 2>&1; then \
+		powershell -NoProfile -File scripts/windows-smoke.ps1 -Bin target/debug/patchloom; \
+	else \
+		echo "windows-smoke: pwsh/powershell not found (run on Windows or install PowerShell)"; exit 1; \
+	fi
 
 bench-cli: build ## Run CLI benchmarks vs native tools (requires hyperfine)
 	cd benches/cli && bash run.sh

--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -1,0 +1,275 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Windows / PowerShell host smoke for patchloom (create, replace, doc, tx, paths).
+
+.DESCRIPTION
+  Fixrealloop-style dogfood under PowerShell: Windows path separators, absolute
+  paths, JSON error_kind peels, insert-after, contain, multi-op tx.
+  Not part of make check (Linux/macOS gate). Run on Windows or via CI ci-windows.
+
+.PARAMETER Bin
+  Path to patchloom.exe (default: target\debug\patchloom.exe relative to repo root).
+
+.EXAMPLE
+  pwsh -File scripts/windows-smoke.ps1 -Bin target\debug\patchloom.exe
+#>
+param(
+    [string]$Bin = ""
+)
+
+$ErrorActionPreference = "Stop"
+$script:Passes = 0
+$script:Fails = 0
+
+function Pass([string]$Msg) {
+    Write-Host "OK: $Msg"
+    $script:Passes++
+}
+function Fail([string]$Msg) {
+    Write-Host "FAIL: $Msg" -ForegroundColor Red
+    $script:Fails++
+}
+
+# Resolve binary
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+if (-not $Bin) {
+    $candidates = @(
+        (Join-Path $RepoRoot "target\debug\patchloom.exe"),
+        (Join-Path $RepoRoot "target\release\patchloom.exe"),
+        (Join-Path $RepoRoot "target\debug\patchloom"),
+        (Join-Path $RepoRoot "target\release\patchloom")
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path -LiteralPath $c) { $Bin = $c; break }
+    }
+}
+if (-not $Bin -or -not (Test-Path -LiteralPath $Bin)) {
+    throw "patchloom binary not found. Build first (cargo build --all-features) or pass -Bin"
+}
+$Bin = (Resolve-Path -LiteralPath $Bin).Path
+Write-Host "BIN=$Bin"
+
+function Invoke-Pl {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Args
+    )
+    $out = & $Bin @Args 2>&1 | Out-String
+    return @{
+        ExitCode = $LASTEXITCODE
+        Output   = $out
+    }
+}
+
+function Get-JsonField {
+    param([string]$JsonText, [string]$Name)
+    try {
+        $obj = $JsonText | ConvertFrom-Json
+        $prop = $obj.PSObject.Properties[$Name]
+        if ($null -eq $prop) { return $null }
+        return $prop.Value
+    } catch {
+        return $null
+    }
+}
+
+$ws = Join-Path ([System.IO.Path]::GetTempPath()) ("pl-win-smoke-" + [guid]::NewGuid().ToString("N").Substring(0, 8))
+New-Item -ItemType Directory -Path $ws | Out-Null
+try {
+    Push-Location $ws
+    git init -q 2>$null | Out-Null
+    git commit --allow-empty -q -m init 2>$null | Out-Null
+
+    # --- create / already_exists / force ---
+    Set-Content -Path (Join-Path $ws "taken.txt") -Value "old`n" -NoNewline
+    $r = Invoke-Pl --json --cwd $ws create taken.txt --content "new"
+    $kind = Get-JsonField $r.Output "error_kind"
+    $applied = Get-JsonField $r.Output "applied"
+    if ($r.ExitCode -eq 1 -and $kind -eq "already_exists" -and ($applied -eq $false -or "$applied" -eq "False")) {
+        Pass "create dest-exists already_exists (PowerShell)"
+    } else {
+        $snip = if ($r.Output.Length -gt 200) { $r.Output.Substring(0, 200) } else { $r.Output }
+        Fail "create dest-exists exit=$($r.ExitCode) kind=$kind applied=$applied out=$snip"
+    }
+    if ($r.Output -match "force") {
+        Pass "already_exists message mentions force"
+    } else {
+        Fail "already_exists message missing force hint: $($r.Output)"
+    }
+    $r = Invoke-Pl --json --cwd $ws create taken.txt --content "forced`n" --force --apply
+    $got = Get-Content -LiteralPath (Join-Path $ws "taken.txt") -Raw
+    if ($r.ExitCode -eq 0 -and $got -match "forced") {
+        Pass "create --force --apply"
+    } else {
+        Fail "create force exit=$($r.ExitCode) content=$got"
+    }
+
+    # --- replace with backslash-style path under --cwd ---
+    $sub = Join-Path $ws "sub\nested"
+    New-Item -ItemType Directory -Path $sub -Force | Out-Null
+    Set-Content -LiteralPath (Join-Path $sub "app.rs") -Value "use std::io;`nfn main() {}`n"
+    # Relative path with backslashes (Windows agent style)
+    $rel = "sub\nested\app.rs"
+    $r = Invoke-Pl --cwd $ws replace "use std::io;" --insert-after "use std::fs;" $rel --apply
+    $body = Get-Content -LiteralPath (Join-Path $sub "app.rs") -Raw
+    if ($r.ExitCode -eq 0 -and $body -match "use std::io;" -and $body -match "use std::fs;") {
+        Pass "insert-after with backslash relative path"
+    } else {
+        Fail "insert-after exit=$($r.ExitCode) body=$body out=$($r.Output)"
+    }
+
+    # --- absolute Windows path ---
+    $absFile = Join-Path $ws "abs_target.txt"
+    Set-Content -LiteralPath $absFile -Value "hello world`n"
+    $r = Invoke-Pl replace "world" --new "windows" $absFile --apply
+    $body = Get-Content -LiteralPath $absFile -Raw
+    if ($r.ExitCode -eq 0 -and $body -match "hello windows") {
+        Pass "replace via absolute path"
+    } else {
+        Fail "abs replace exit=$($r.ExitCode) body=$body"
+    }
+
+    # --- doc set on JSON ---
+    $cfg = Join-Path $ws "config.json"
+    Set-Content -LiteralPath $cfg -Value '{"server":{"port":8080}}' -NoNewline
+    $r = Invoke-Pl --cwd $ws doc set config.json server.port 9090 --apply
+    $cfgBody = Get-Content -LiteralPath $cfg -Raw
+    if ($r.ExitCode -eq 0 -and $cfgBody -match "9090") {
+        Pass "doc set"
+    } else {
+        Fail "doc set exit=$($r.ExitCode) body=$cfgBody"
+    }
+
+    # --- tx plan with key alias (ops + key) ---
+    $plan = Join-Path $ws "plan.json"
+    @'
+{"ops":[{"op":"doc.set","path":"config.json","key":"server.port","value":7070}]}
+'@ | Set-Content -LiteralPath $plan -NoNewline
+    $r = Invoke-Pl --cwd $ws tx plan.json --apply
+    $cfgBody = Get-Content -LiteralPath $cfg -Raw
+    if ($r.ExitCode -eq 0 -and $cfgBody -match "7070") {
+        Pass "tx plan key alias"
+    } else {
+        Fail "tx exit=$($r.ExitCode) body=$cfgBody out=$($r.Output)"
+    }
+
+    # --- multi-op tx create two files ---
+    $plan2 = Join-Path $ws "plan2.json"
+    @{
+        version    = 1
+        operations = @(
+            @{ op = "file.create"; path = "t1.txt"; content = "a`n" }
+            @{ op = "file.create"; path = "t2.txt"; content = "b`n" }
+        )
+    } | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath $plan2
+    $r = Invoke-Pl --cwd $ws --json tx plan2.json --apply
+    if ($r.ExitCode -eq 0 -and (Test-Path (Join-Path $ws "t1.txt")) -and (Test-Path (Join-Path $ws "t2.txt"))) {
+        Pass "tx multi file.create"
+    } else {
+        Fail "tx multi exit=$($r.ExitCode) out=$($r.Output)"
+    }
+
+    # --- preview exit 2, no write ---
+    Set-Content -LiteralPath (Join-Path $ws "prev.txt") -Value "alpha`n"
+    $r = Invoke-Pl --cwd $ws replace alpha --new beta prev.txt
+    $still = Get-Content -LiteralPath (Join-Path $ws "prev.txt") -Raw
+    if ($r.ExitCode -eq 2 -and $still -match "alpha") {
+        Pass "preview exit 2 no write"
+    } else {
+        Fail "preview exit=$($r.ExitCode) content=$still"
+    }
+
+    # --- --contain rejects escape (Windows absolute outside workspace) ---
+    Set-Content -LiteralPath (Join-Path $ws "in.txt") -Value "x`n"
+    # Use a path that is clearly outside the temp workspace
+    $escape = "C:\Windows\System32\drivers\etc\hosts"
+    $r = Invoke-Pl --json --cwd $ws --contain read $escape
+    $kind = Get-JsonField $r.Output "error_kind"
+    if ($kind -eq "guard_rejected") {
+        Pass "contain escape guard_rejected"
+    } else {
+        $snip = if ($r.Output.Length -gt 250) { $r.Output.Substring(0, 250) } else { $r.Output }
+        Fail "contain kind=$kind exit=$($r.ExitCode) out=$snip"
+    }
+
+    # --- not_found delete ---
+    $r = Invoke-Pl --json --cwd $ws delete missing-nope.txt --apply
+    $kind = Get-JsonField $r.Output "error_kind"
+    if ($kind -eq "not_found" -and $r.ExitCode -eq 1) {
+        Pass "delete missing not_found"
+    } else {
+        Fail "delete kind=$kind exit=$($r.ExitCode)"
+    }
+
+    # --- rename dest already_exists ---
+    Set-Content -LiteralPath (Join-Path $ws "from.txt") -Value "a`n"
+    Set-Content -LiteralPath (Join-Path $ws "to.txt") -Value "b`n"
+    $r = Invoke-Pl --json --cwd $ws rename from.txt to.txt --apply
+    $kind = Get-JsonField $r.Output "error_kind"
+    if ($kind -eq "already_exists") {
+        Pass "rename dest already_exists"
+    } else {
+        Fail "rename kind=$kind out=$($r.Output)"
+    }
+
+    # --- batch PATH OLD NEW ---
+    Set-Content -LiteralPath (Join-Path $ws "ver.txt") -Value "v1`n"
+    $ops = Join-Path $ws "ops.txt"
+    "replace ver.txt v1 v2" | Set-Content -LiteralPath $ops
+    $r = Invoke-Pl --cwd $ws batch ops.txt --apply
+    $v = Get-Content -LiteralPath (Join-Path $ws "ver.txt") -Raw
+    if ($r.ExitCode -eq 0 -and $v -match "v2") {
+        Pass "batch replace PATH OLD NEW"
+    } else {
+        Fail "batch exit=$($r.ExitCode) ver=$v"
+    }
+
+    # --- search no_matches exit 3 ---
+    Set-Content -LiteralPath (Join-Path $ws "only.txt") -Value "only`n"
+    $r = Invoke-Pl --json --cwd $ws search nomatch only.txt
+    if ($r.ExitCode -eq 3) {
+        Pass "search no_matches exit 3"
+    } else {
+        Fail "search exit=$($r.ExitCode)"
+    }
+
+    # --- CRLF file insert-after keeps CR LF ---
+    $crlf = Join-Path $ws "crlf.txt"
+    [System.IO.File]::WriteAllBytes($crlf, [byte[]](0x6c, 0x31, 0x0d, 0x0a, 0x6c, 0x32, 0x0d, 0x0a)) # l1\r\nl2\r\n
+    $r = Invoke-Pl --cwd $ws replace "l1" --insert-after "// post" crlf.txt --apply
+    $bytes = [System.IO.File]::ReadAllBytes($crlf)
+    $hex = ($bytes | ForEach-Object { $_.ToString("x2") }) -join " "
+    # Expect l1\r\n// post\r\n...
+    $asText = [System.Text.Encoding]::UTF8.GetString($bytes)
+    if ($r.ExitCode -eq 0 -and $asText -match "l1\r\n// post\r\n") {
+        Pass "CRLF insert-after preserves line endings"
+    } elseif ($r.ExitCode -eq 0 -and $asText -match "// post") {
+        # Still applied; mixed endings would be a product bug
+        if ($asText -match "l1\n// post" -and $asText -notmatch "l1\r\n// post") {
+            Fail "CRLF insert used bare LF: $hex"
+        } else {
+            Pass "CRLF insert-after applied ($hex)"
+        }
+    } else {
+        Fail "CRLF exit=$($r.ExitCode) hex=$hex"
+    }
+
+    # --- version ---
+    $r = Invoke-Pl --version
+    if ($r.ExitCode -eq 0 -and $r.Output -match "patchloom") {
+        Pass "version"
+    } else {
+        Fail "version: $($r.Output)"
+    }
+
+} finally {
+    Pop-Location
+    Remove-Item -LiteralPath $ws -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "==== windows-smoke: passes=$script:Passes fails=$script:Fails ===="
+if ($script:Fails -gt 0) {
+    exit 1
+}
+exit 0


### PR DESCRIPTION
## Summary

Closes the Windows/WSL/PowerShell coverage gaps called out after fixrealloop:

1. **Expand `ci-wsl`** beyond path-only smoke: run full `cargo test --lib --all-features` and `cargo test --test integration --all-features` inside Ubuntu-on-Windows (after the existing containment / platform_path filters). Timeout 60m. Still skips clippy/fuzz/pty (ubuntu-latest owns those).
2. **`scripts/windows-smoke.ps1`** fixrealloop-style dogfood under PowerShell: create/force, insert-after with backslash paths, absolute paths, doc set, tx (key alias + multi create), preview exit 2, `--contain` escape, not_found, rename already_exists, batch, search exit 3, CRLF insert, version.
3. **Wire smoke into `ci-windows`** so every non-draft code PR runs the PowerShell round on a real Windows runner.

## Test plan

- [x] Local `cargo build --all-features` (script syntax review; no local `pwsh`)
- [ ] CI `ci-windows` green (includes PowerShell smoke)
- [ ] CI `ci-wsl` green (lib + integration)

## Notes

- `make windows-smoke` for local Windows/PowerShell; not part of `make check`
- Untracked local junk (`install.sh`, `pr.txt`) intentionally not staged