### PR TITLE
fix: load_text_strict helper, md binary emit, Windows validate flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3800%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-3900%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -473,7 +473,7 @@ flowchart LR
 
 ## Status
 
-3800+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3900+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ api::doc_merge(
     Some("0"),
 )?;
 
-// Sole-path text load: binary / invalid UTF-8 → EditErrorKind::InvalidInput
+// Sole-path text load: binary → EditErrorKind::Binary; invalid UTF-8 → InvalidEncoding
 let _text = api::load_text(Path::new("notes.md"))?;
 ```
 

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -131,10 +131,7 @@ pub fn ast_rename(
     let path_str = path.to_string_lossy().into_owned();
     let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
         // Preserve Binary / InvalidEncoding / InvalidInput peels (#1963).
-        if crate::exit::is_binary(&e)
-            || crate::exit::is_invalid_encoding(&e)
-            || crate::exit::is_invalid_input(&e)
-        {
+        if crate::exit::is_load_text_strict_fail(&e) {
             return e;
         }
         EditError::new(EditErrorKind::OperationFailed, e.to_string()).into()
@@ -197,10 +194,7 @@ pub fn ast_replace_in_symbol(
     let path_str = path.to_string_lossy().into_owned();
     let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
         // Preserve Binary / InvalidEncoding / InvalidInput peels (#1963).
-        if crate::exit::is_binary(&e)
-            || crate::exit::is_invalid_encoding(&e)
-            || crate::exit::is_invalid_input(&e)
-        {
+        if crate::exit::is_load_text_strict_fail(&e) {
             return e;
         }
         EditError::new(EditErrorKind::OperationFailed, e.to_string()).into()

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -163,10 +163,7 @@ pub fn apply_content_edits_to_file(
     let path_str = path.to_string_lossy().into_owned();
     let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
         // Preserve content SoftSkip peels (#1963); do not collapse to OperationFailed.
-        if crate::exit::is_binary(&e)
-            || crate::exit::is_invalid_encoding(&e)
-            || crate::exit::is_invalid_input(&e)
-        {
+        if crate::exit::is_load_text_strict_fail(&e) {
             return e;
         }
         EditError::new(EditErrorKind::OperationFailed, e.to_string()).into()

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -62,14 +62,7 @@ fn file_write(
             let original = if path.exists() {
                 match crate::files::load_text_strict(path, &path_str) {
                     Ok(s) => s,
-                    Err(e)
-                        if force
-                            && (crate::fallback::is_binary(&e)
-                                || crate::fallback::is_invalid_encoding(&e)
-                                || crate::exit::is_invalid_input(&e)) =>
-                    {
-                        String::new()
-                    }
+                    Err(e) if force && crate::exit::is_load_text_strict_fail(&e) => String::new(),
                     Err(e) => return Err(e),
                 }
             } else {

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -63,7 +63,7 @@ fn patch_write(
         // Apply to the first file in the patch.
         let pf = &patch_files[0];
         let file_path = cwd.join(&pf.path);
-        // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+        // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
         let original = crate::files::load_text_strict(&file_path, &pf.path)?;
 
         let new_content = ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -467,6 +467,37 @@ fn file_create_force_overwrites_invalid_utf8_prior() {
 }
 
 #[test]
+#[cfg(unix)]
+fn file_create_force_binary_preserves_hardlinks() {
+    // #1962: force overwrite of binary prior must not unlink+recreate (nlink stays).
+    use std::os::unix::fs::MetadataExt;
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("blob.bin");
+    let link = dir.path().join("blob-link.bin");
+    fs::write(&file, b"a\0b").unwrap();
+    std::fs::hard_link(&file, &link).unwrap();
+    let nlink_before = fs::metadata(&file).unwrap().nlink();
+    assert!(nlink_before >= 2, "hardlink setup: nlink={nlink_before}");
+    let guard = PathGuard::builder(dir.path().to_path_buf())
+        .allow_temp_directory()
+        .build()
+        .unwrap();
+    let result = file_create(&file, "text\n", true, ApplyMode::Apply, Some(&guard)).unwrap();
+    assert!(result.applied);
+    assert_eq!(fs::read_to_string(&file).unwrap(), "text\n");
+    assert_eq!(
+        fs::read_to_string(&link).unwrap(),
+        "text\n",
+        "hardlink sibling must see same content"
+    );
+    let nlink_after = fs::metadata(&file).unwrap().nlink();
+    assert!(
+        nlink_after >= 2,
+        "force create must preserve hardlinks, nlink before={nlink_before} after={nlink_after}"
+    );
+}
+
+#[test]
 fn load_text_binary_peel_error_helper() {
     let dir = TempDir::new().unwrap();
     let bin = dir.path().join("x.bin");

--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -50,10 +50,7 @@ pub(super) fn reject_sole_explicit_non_text(
     match crate::files::load_text_strict(sole, path_arg) {
         Ok(_) => Ok(()),
         Err(e) => {
-            if crate::fallback::is_binary(&e)
-                || crate::fallback::is_invalid_encoding(&e)
-                || crate::exit::is_invalid_input(&e)
-            {
+            if crate::exit::is_load_text_strict_fail(&e) {
                 Err(e)
             } else {
                 Ok(())

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -873,7 +873,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         std::io::read_to_string(std::io::stdin())?
     } else {
         let input_path = global.resolve_user_path(&args.input)?;
-        // Strict sole-path input (#1894): binary / invalid UTF-8 → InvalidInput.
+        // Strict sole-path input (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
         let display = input_path.display().to_string();
         // load_text_strict already prefixes "failed to read {display}"; do not
         // re-wrap (same class as #1916 / patch target IO).
@@ -881,10 +881,7 @@ pub fn run(args: BatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let msg = crate::exit::agent_error_message(&e);
             if crate::exit::is_io_not_found(&e) {
                 std::io::Error::new(std::io::ErrorKind::NotFound, msg).into()
-            } else if crate::exit::is_binary(&e)
-                || crate::exit::is_invalid_encoding(&e)
-                || crate::exit::is_invalid_input(&e)
-            {
+            } else if crate::exit::is_load_text_strict_fail(&e) {
                 e
             } else {
                 anyhow::Error::new(crate::exit::InvalidInputError { msg })

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -247,7 +247,7 @@ impl DocAction {
 }
 
 fn load_file(path: &str) -> anyhow::Result<serde_json::Value> {
-    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let content = crate::files::load_text_strict(std::path::Path::new(path), path)?;
     let format = detect_format(path)?;
     parse_doc(&content, &format).with_context(|| format!("parsing {path}"))

--- a/src/cmd/explain/mod.rs
+++ b/src/cmd/explain/mod.rs
@@ -67,11 +67,7 @@ pub fn run(args: ExplainArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 global.emit_error_json_kind(Some("not_found"), &e.to_string())?;
                 return Ok(exit::FAILURE);
             }
-            Err(e)
-                if crate::exit::is_binary(&e)
-                    || crate::exit::is_invalid_encoding(&e)
-                    || crate::exit::is_invalid_input(&e) =>
-            {
+            Err(e) if crate::exit::is_load_text_strict_fail(&e) => {
                 let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
                 let msg = crate::exit::agent_error_message(&e);
                 global.emit_error_json_kind(Some(kind), &msg)?;

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -105,11 +105,7 @@ pub(super) fn handle_ast_read(
     // Strict sole-path text load (#1894): binary / invalid UTF-8 → invalid_params.
     let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
         // load_text_strict already names path + OS detail (MPI 2026-07-23).
-        if crate::exit::is_binary(&e)
-            || crate::exit::is_invalid_encoding(&e)
-            || crate::exit::is_invalid_input(&e)
-            || crate::exit::is_io_not_found(&e)
-        {
+        if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
             McpError::invalid_params(e.to_string(), None)
         } else {
             McpError::internal_error(e.to_string(), None)
@@ -567,11 +563,7 @@ pub(super) fn handle_ast_diff(
     } else {
         // Strict sole-path (#1894): working-tree binary / invalid UTF-8.
         crate::files::load_text_strict(&target, &p.path).map_err(|e| {
-            if crate::exit::is_binary(&e)
-                || crate::exit::is_invalid_encoding(&e)
-                || crate::exit::is_invalid_input(&e)
-                || crate::exit::is_io_not_found(&e)
-            {
+            if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
                 McpError::invalid_params(e.to_string(), None)
             } else {
                 McpError::internal_error(e.to_string(), None)
@@ -724,11 +716,7 @@ pub(super) fn handle_ast_imports(
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
         // Strict sole-path (#1894).
         let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
-            if crate::exit::is_binary(&e)
-                || crate::exit::is_invalid_encoding(&e)
-                || crate::exit::is_invalid_input(&e)
-                || crate::exit::is_io_not_found(&e)
-            {
+            if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
                 McpError::invalid_params(e.to_string(), None)
             } else {
                 McpError::internal_error(e.to_string(), None)

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -490,11 +490,7 @@ impl PatchloomService {
             let content = crate::files::load_text_strict(&abs, &p.path).map_err(|e| {
                 // load_text_strict messages already include path + OS detail;
                 // do not prefix "reading {path}:" again (MPI 2026-07-23).
-                if crate::exit::is_binary(&e)
-                    || crate::exit::is_invalid_encoding(&e)
-                    || crate::exit::is_invalid_input(&e)
-                    || crate::exit::is_io_not_found(&e)
-                {
+                if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
                     McpError::invalid_params(e.to_string(), None)
                 } else {
                     McpError::internal_error(e.to_string(), None)
@@ -651,11 +647,7 @@ impl PatchloomService {
                 // do not re-wrap (same class as #1916).
                 let content = crate::files::load_text_strict(&abs, path).map_err(|e| {
                     // Display already has path + OS detail (MPI 2026-07-23).
-                    if crate::exit::is_binary(&e)
-                    || crate::exit::is_invalid_encoding(&e)
-                    || crate::exit::is_invalid_input(&e)
-                    || crate::exit::is_io_not_found(&e)
-                {
+                    if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
                         McpError::invalid_params(e.to_string(), None)
                     } else {
                         McpError::internal_error(e.to_string(), None)

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -403,13 +403,13 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let path = cwd.join(&file);
             let original = match crate::files::load_text_strict(&path, &file) {
                 Ok(s) => s,
-                Err(e) => {
-                    if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
-                        global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
-                        return Ok(exit::FAILURE);
-                    }
-                    return Err(e).with_context(|| format!("reading {file}"));
+                Err(e) if crate::exit::is_load_text_strict_fail(&e) => {
+                    let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+                    let msg = crate::exit::agent_error_message(&e);
+                    global.emit_error_json_kind(Some(kind), &msg)?;
+                    return Ok(exit::FAILURE);
                 }
+                Err(e) => return Err(e).with_context(|| format!("reading {file}")),
             };
             let (_new, removed) = dedupe_headings_in(&original);
 
@@ -520,13 +520,13 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let path = cwd.join(&file);
             let content = match crate::files::load_text_strict(&path, &file) {
                 Ok(s) => s,
-                Err(e) => {
-                    if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
-                        global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
-                        return Ok(exit::FAILURE);
-                    }
-                    return Err(e).with_context(|| format!("reading {file}"));
+                Err(e) if crate::exit::is_load_text_strict_fail(&e) => {
+                    let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+                    let msg = crate::exit::agent_error_message(&e);
+                    global.emit_error_json_kind(Some(kind), &msg)?;
+                    return Ok(exit::FAILURE);
                 }
+                Err(e) => return Err(e).with_context(|| format!("reading {file}")),
             };
             let issues = lint_agents_content(&content);
 
@@ -585,13 +585,13 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let path = cwd.join(&file);
             let content = match crate::files::load_text_strict(&path, &file) {
                 Ok(s) => s,
-                Err(e) => {
-                    if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
-                        global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
-                        return Ok(exit::FAILURE);
-                    }
-                    return Err(e).with_context(|| format!("reading {file}"));
+                Err(e) if crate::exit::is_load_text_strict_fail(&e) => {
+                    let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+                    let msg = crate::exit::agent_error_message(&e);
+                    global.emit_error_json_kind(Some(kind), &msg)?;
+                    return Ok(exit::FAILURE);
                 }
+                Err(e) => return Err(e).with_context(|| format!("reading {file}")),
             };
             match find_section(&content, &heading) {
                 None => {

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -677,11 +677,7 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // the same path walk so --files-from - is only read once (#1796).
     let (mut replacements, zero_match_refused) = match collect_replacements(&args, global) {
         Ok(r) => r,
-        Err(e)
-            if crate::exit::is_binary(&e)
-                || crate::exit::is_invalid_encoding(&e)
-                || crate::exit::is_invalid_input(&e) =>
-        {
+        Err(e) if crate::exit::is_load_text_strict_fail(&e) => {
             let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
             let msg = crate::exit::agent_error_message(&e);
             global.emit_error_json_kind(Some(kind), &msg)?;

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -305,7 +305,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let plan_path = plan_path
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("internal error: plan path missing"))?;
-        // Strict sole-path plan load (#1894): binary / invalid UTF-8 → InvalidInput.
+        // Strict sole-path plan load (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
         let display = plan_path.display().to_string();
         // load_text_strict already prefixes "failed to read {display}"; do not
         // re-wrap (same class as #1916).
@@ -313,10 +313,7 @@ pub fn run(args: TxArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             let msg = crate::exit::agent_error_message(&e);
             if crate::exit::is_io_not_found(&e) {
                 std::io::Error::new(std::io::ErrorKind::NotFound, msg).into()
-            } else if crate::exit::is_binary(&e)
-                || crate::exit::is_invalid_encoding(&e)
-                || crate::exit::is_invalid_input(&e)
-            {
+            } else if crate::exit::is_load_text_strict_fail(&e) {
                 e
             } else {
                 anyhow::Error::new(crate::exit::InvalidInputError { msg })

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -710,11 +710,14 @@ mod edge_cases {
     fn validation_pass_with_large_stderr_output() {
         let dir = TempDir::new().unwrap();
 
+        // Windows CI can be slow to spawn PowerShell even with -NoProfile;
+        // 10s timed out on GHA (exit 7 ROLLBACK). Keep a larger budget there.
+        let timeout_secs = if cfg!(windows) { 60 } else { 10 };
         let plan_json = serde_json::json!({
             "version": 1,
             "operations": [],
             "validate": [
-                {"cmd": shell_stderr_spam(), "required": true, "timeout": 10}
+                {"cmd": shell_stderr_spam(), "required": true, "timeout": timeout_secs}
             ]
         });
 

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -243,6 +243,17 @@ pub fn is_invalid_encoding(err: &anyhow::Error) -> bool {
         .any(|cause| cause.downcast_ref::<InvalidEncodingError>().is_some())
 }
 
+/// True when [`crate::files::load_text_strict`] (or an equivalent sole-path load)
+/// failed with a typed content or argument error that hosts should branch on
+/// without collapsing to a generic op failure (#1963).
+///
+/// Matches [`BinaryError`], [`InvalidEncodingError`], and [`InvalidInputError`].
+/// Does **not** match IO NotFound (use [`is_io_not_found`]).
+#[must_use]
+pub fn is_load_text_strict_fail(err: &anyhow::Error) -> bool {
+    is_binary(err) || is_invalid_encoding(err) || is_invalid_input(err)
+}
+
 /// Typed error for post-write `--format` / format-step failures that map to
 /// exit [`FAILURE`] (1) with JSON `error_kind: "format_failed"`.
 ///
@@ -709,6 +720,27 @@ mod tests {
             classify_typed_error(&wrapped),
             Some(("invalid_input", FAILURE))
         );
+    }
+
+    #[test]
+    fn is_load_text_strict_fail_covers_content_and_invalid_input() {
+        let bin: anyhow::Error = BinaryError {
+            msg: "binary".into(),
+        }
+        .into();
+        assert!(is_load_text_strict_fail(&bin));
+        assert!(!is_io_not_found(&bin));
+        let enc: anyhow::Error = InvalidEncodingError { msg: "utf8".into() }.into();
+        assert!(is_load_text_strict_fail(&enc));
+        let inv: anyhow::Error = InvalidInputError {
+            msg: "not a file".into(),
+        }
+        .into();
+        assert!(is_load_text_strict_fail(&inv));
+        let missing: anyhow::Error =
+            std::io::Error::new(std::io::ErrorKind::NotFound, "gone").into();
+        assert!(!is_load_text_strict_fail(&missing));
+        assert!(is_io_not_found(&missing));
     }
 
     #[test]

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -129,8 +129,9 @@ pub enum EditErrorKind {
     FormatFailed,
     /// Create/rename destination already exists without force.
     /// CLI JSON uses `error_kind: "already_exists"`. Distinct from
-    /// [`Self::InvalidInput`] (binary, empty path, directory target) so hosts
-    /// can hint `overwrite`/`force` without scraping English (#1947).
+    /// [`Self::InvalidInput`] (empty path, directory target) and content SoftSkip
+    /// ([`Self::Binary`] / [`Self::InvalidEncoding`]) so hosts can hint
+    /// `overwrite`/`force` without scraping English (#1947 / #1963).
     /// Appended after [`Self::FormatFailed`] so 0.18.0 discriminants stay stable.
     AlreadyExists,
     /// Path not found (`std::io::ErrorKind::NotFound`). CLI JSON uses

--- a/src/files.rs
+++ b/src/files.rs
@@ -7,8 +7,7 @@
 //!
 //! # Text I/O honesty (#1894)
 //!
-//! - **Strict sole-path:** [`load_text_strict`] — binary / invalid UTF-8 →
-//!   `InvalidInputError` (CLI, MCP/tx sole path, library `api::*`).
+//! - **Strict sole-path:** [`load_text_strict`] — binary → `BinaryError`, invalid UTF-8 → `InvalidEncodingError` (CLI, MCP/tx sole path, library `api::*`).
 //! - **Soft content skip (walks):** [`try_read_text_file`] / [`read_text_file`] —
 //!   binary / invalid UTF-8 → [`SoftTextSkip`] (content not agent-editable).
 //! - **Unreadable is not content SoftSkip:** open/read IO is

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -120,10 +120,7 @@ pub fn sole_explicit_non_text(paths: &[String], cwd: &Path) -> Option<anyhow::Er
     match crate::files::load_text_strict(&path, display) {
         Ok(_) => None,
         Err(e) => {
-            if crate::fallback::is_binary(&e)
-                || crate::fallback::is_invalid_encoding(&e)
-                || crate::exit::is_invalid_input(&e)
-            {
+            if crate::exit::is_load_text_strict_fail(&e) {
                 Some(e)
             } else {
                 // load_text_strict already prefixes "failed to read {display}";

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -74,13 +74,7 @@ pub(crate) fn read_file_content_for_force_create<'a>(
             let display = path.display().to_string();
             let content = match crate::files::load_text_strict(path, &display) {
                 Ok(s) => s,
-                Err(e)
-                    if crate::fallback::is_binary(&e)
-                        || crate::fallback::is_invalid_encoding(&e)
-                        || crate::exit::is_invalid_input(&e) =>
-                {
-                    String::new()
-                }
+                Err(e) if crate::exit::is_load_text_strict_fail(&e) => String::new(),
                 Err(e) => return Err(e),
             };
             if path.exists() {


### PR DESCRIPTION
## Summary

MPI cycle 1 improvements (QA / Developer / Spec / Adversarial):

1. **`exit::is_load_text_strict_fail`** – shared peel for Binary | InvalidEncoding | InvalidInput so remappers cannot drop content SoftSkip kinds
2. **md sole-path** – emit `error_kind` via `error_kind_str` for binary/encoding (not only InvalidInput downcast)
3. **DRY** remappers (api, cmd, mcp, tx force soft-load, sole_explicit) onto the helper
4. **Windows flake** – larger timeout for `validation_pass_with_large_stderr_output` (GHA PowerShell spawn)
5. **Docs** – stale binary→InvalidInput in README / files / comments

## Validation

- `make check-fast`

## Gate notes

- Release PR #1968 (0.20.0) open – **not merged** (needs explicit user approval)
- #960 winget / #961 chocolatey remain dist backlog (comments updated)