### PR TITLE
feat(api): export is_load_text_strict_fail for embedders

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -72,7 +72,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 | Patch merge conflict markers | `Conflicts` / `conflicts` (not batch `ConflictingEdit`) |
 | Check/assert-count exit-2 soft fail | `ChangesDetected` / `changes_detected` |
 | AST missing symbol | `NoMatch` / `no_matches` |
-- Bool peels (match `edit_error_kind`): `api::is_already_exists`, `is_not_found`, `is_conflicts`, `is_changes_detected`, `is_type_error`, `is_format_failed`, `is_guard_rejected`, `is_invalid_input`, `is_binary`, `is_invalid_encoding`, `is_no_match`, `is_ambiguous`; string peel: `api::error_kind_str` / one-shot `api::peel_error` (kind + message + suggestion) for CLI-stable envelopes (#1947 / #1948 / #1963 / #1964).
+- Bool peels (match `edit_error_kind`): `api::is_already_exists`, `is_not_found`, `is_conflicts`, `is_changes_detected`, `is_type_error`, `is_format_failed`, `is_guard_rejected`, `is_invalid_input`, `is_binary`, `is_invalid_encoding`, `is_load_text_strict_fail` (binary|encoding|invalid_input), `is_no_match`, `is_ambiguous`; string peel: `api::error_kind_str` / one-shot `api::peel_error` (kind + message + suggestion) for CLI-stable envelopes (#1947 / #1948 / #1963 / #1964).
 - New `EditErrorKind` variants must be **appended** (after the last variant) so discriminants of published kinds stay stable under cargo-semver-checks (#1955).
 - CLI: `patchloom undo --list` walks nested `.patchloom/backups` under the cwd (#1695). Bare CLI undo is dry-run (exit 2); restore needs the write apply flag (see CLI agent-rules).
 - `api::run_post_write_validation` / `ReplaceOptions.post_write` / `WritePolicyOptions.post_write` (#1663, #1690) maps to `format_failed` / `EditErrorKind::FormatFailed`

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -532,6 +532,8 @@ impl ReplaceOptions {
 }
 
 // Re-export structured edit errors for embedders (#1492, #1659, #1947, #1948, #1963, #1964).
+/// Re-export: binary | invalid_encoding | invalid_input from sole-path loads (#1963).
+pub use crate::exit::is_load_text_strict_fail;
 pub use crate::fallback::{
     EditError, EditErrorKind, PeeledError, classify_error, classify_error_ref, edit_error_kind,
     edit_error_ref, error_kind_str, find_similar_targets, is_already_exists, is_ambiguous,

--- a/src/ast/rename.rs
+++ b/src/ast/rename.rs
@@ -87,7 +87,7 @@ pub fn rename_in_file(
     lang_hint: Option<Language>,
 ) -> anyhow::Result<Option<RenameResult>> {
     let lang = lang_hint.unwrap_or_else(|| Language::from_path(path));
-    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let source = crate::files::load_text_strict(path, &path.display().to_string())?;
     Ok(rename_in_source(&source, old_name, new_name, lang))
 }

--- a/src/ast/replace.rs
+++ b/src/ast/replace.rs
@@ -122,7 +122,7 @@ pub fn replace_in_symbol_file(
     if !lang.has_grammar() {
         return Ok(None);
     }
-    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let source = crate::files::load_text_strict(path, &path.display().to_string())?;
     replace_in_symbol(&source, symbol_name, from, to, regex, lang)
 }

--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -110,7 +110,7 @@ pub fn search_file(
     if !lang.has_grammar() {
         return Ok(Vec::new());
     }
-    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let source = crate::files::load_text_strict(path, &path.display().to_string())?;
     search_query(&source, query_str, lang, max_results)
 }

--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -53,7 +53,7 @@ pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result
             msg: format!("no grammar available for {lang}"),
         }));
     }
-    // Strict sole-path (#1894): binary / invalid UTF-8 → InvalidInput.
+    // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let source = crate::files::load_text_strict(path, &path.display().to_string())?;
     validate_source(&source, lang).ok_or_else(|| {
         anyhow::Error::new(crate::exit::ParseErrorError {

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -173,8 +173,9 @@ resort for typos in non-AST text (prose, comments), not a general rename tool.\n
              - Bool peels (match `edit_error_kind`): `api::is_already_exists`, `is_not_found`, \
                `is_conflicts`, `is_changes_detected`, `is_type_error`, `is_format_failed`, \
                `is_guard_rejected`, `is_invalid_input`, `is_binary`, `is_invalid_encoding`, \
-               `is_no_match`, `is_ambiguous`; string peel: `api::error_kind_str` / one-shot \
-               `api::peel_error` (kind + message + suggestion) for CLI-stable envelopes \
+               `is_load_text_strict_fail` (binary|encoding|invalid_input), `is_no_match`, \
+               `is_ambiguous`; string peel: `api::error_kind_str` / one-shot `api::peel_error` \
+               (kind + message + suggestion) for CLI-stable envelopes \
                (#1947 / #1948 / #1963 / #1964).\n\
              - New `EditErrorKind` variants must be **appended** (after the last variant) so \
                discriminants of published kinds stay stable under cargo-semver-checks (#1955).\n\
@@ -1222,6 +1223,10 @@ mod tests {
         assert!(
             out.contains("ReplaceOptions::for_agent") && out.contains("AGENT_MIN_FUZZY_SCORE"),
             "library hosts need for_agent replace preset docs (#1965)"
+        );
+        assert!(
+            out.contains("is_load_text_strict_fail"),
+            "library hosts need is_load_text_strict_fail peel docs (#1963)"
         );
         assert!(
             out.contains("is_not_found")

--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -22,7 +22,7 @@ pub(super) fn setup_single_file(
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, [path_arg])?;
     let target = cwd.join(path_arg);
-    // Strict sole-path text load (#1894): binary / invalid UTF-8 → InvalidInput.
+    // Strict sole-path text load (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let source = crate::files::load_text_strict(&target, path_arg)?;
     let lang = resolve_lang(lang_arg, &target);
     Ok((cwd, target, lang, source))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,9 @@
 //! `backup::find_backup_roots(path)` walks parents for roots that contain
 //! `.patchloom/backups` (#1934). File create/delete/rename/append and
 //! `ast_rewrite_signature` peel via `edit_error_kind` (`AlreadyExists` for
-//! dest-exists without force, `NotFound` for missing path I/O, `InvalidInput`
-//! for dir/binary/empty path, `NoMatch` for missing AST symbols, `GuardRejected`
+//! dest-exists without force, `NotFound` for missing path I/O, `Binary` /
+//! `InvalidEncoding` for content SoftSkip, `InvalidInput` for dir/empty path,
+//! `NoMatch` for missing AST symbols, `GuardRejected`
 //! for PathGuard; #1935 / #1936 / #1947). Fuzzy policy:
 //! `ReplaceOptions.min_fuzzy_score` rejects weak similarity matches (#1687).
 //! Project-wide rename: `api::ast_rename_project` (#1689). Post-Apply hooks:
@@ -206,6 +207,7 @@
 //! | Unique multi-match ambiguity | [`EditErrorKind::AmbiguousTarget`] / [`api::is_ambiguous`] (JSON `ambiguous`) |
 //! | Post-write format/lint failure | [`EditErrorKind::FormatFailed`] / [`api::is_format_failed`] |
 //! | Shared agent replace policy (primary + fallback) | [`ReplaceOptions::for_agent`] / [`AGENT_MIN_FUZZY_SCORE`] (#1965) |
+//! | Sole-path load failed as binary/encoding/invalid_input | [`api::is_load_text_strict_fail`] (#1963) |
 //!
 //! `EditErrorKind` is `#[non_exhaustive]`: always include a wildcard arm when matching.
 //!
@@ -310,9 +312,9 @@ pub use api::{
     apply_post_write_validator, build_context_lines, classify_error, classify_error_ref,
     edit_error_kind, edit_error_ref, error_kind_str, format_search_results, is_already_exists,
     is_ambiguous, is_binary, is_binary_file, is_changes_detected, is_conflicts, is_format_failed,
-    is_guard_rejected, is_invalid_encoding, is_invalid_input, is_no_match, is_not_found,
-    is_type_error, load_text, load_text_strict, merge_match_modes, parse_unified_diff, peel_error,
-    run_post_write_validation, search_file, text_diff,
+    is_guard_rejected, is_invalid_encoding, is_invalid_input, is_load_text_strict_fail,
+    is_no_match, is_not_found, is_type_error, load_text, load_text_strict, merge_match_modes,
+    parse_unified_diff, peel_error, run_post_write_validation, search_file, text_diff,
 };
 pub use plan::Plan;
 


### PR DESCRIPTION
## Summary

MPI cycle 2:

- Re-export `api::is_load_text_strict_fail` / crate root (Binary | InvalidEncoding | InvalidInput)
- Document in agent-rules / embedder cookbook
- Fix stale sole-path comments still saying content SoftSkip → InvalidInput

## Validation

- `make check-fast` (local)

## Notes

- Only open product PR while release #1968 waits for user approval
- Dist #960/#961 remain backlog