### PR TITLE
fix(cli): AST sole-path Binary/InvalidEncoding error_kind emit

### DIFF
--- a/src/cmd/ast/mutate.rs
+++ b/src/cmd/ast/mutate.rs
@@ -226,8 +226,10 @@ pub(super) fn run_replace(args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Re
     let target = cwd.join(&args.path);
     // Strict sole-path preflight (#1894); engine also loads via load_text_strict.
     if let Err(e) = crate::files::load_text_strict(&target, &args.path) {
-        if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
-            global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
+        if crate::exit::is_load_text_strict_fail(&e) {
+            let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+            let msg = crate::exit::agent_error_message(&e);
+            global.emit_error_json_kind(Some(kind), &msg)?;
             return Ok(exit::FAILURE);
         }
         return Err(e);

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -54,13 +54,13 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
         // Strict sole-path (#1894): binary / invalid UTF-8 before language miss.
         let source = match crate::files::load_text_strict(&target, &args.path) {
             Ok(s) => s,
-            Err(e) => {
-                if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
-                    global.emit_error_json_kind(Some("invalid_input"), &inv.msg)?;
-                    return Ok(exit::FAILURE);
-                }
-                return Err(e);
+            Err(e) if crate::exit::is_load_text_strict_fail(&e) => {
+                let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+                let msg = crate::exit::agent_error_message(&e);
+                global.emit_error_json_kind(Some(kind), &msg)?;
+                return Ok(exit::FAILURE);
             }
+            Err(e) => return Err(e),
         };
         let lang = resolve_lang(lang_hint, &target);
         crate::verbose!("ast list: detected language={lang} for {}", args.path);

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -57,22 +57,10 @@ fn read_one_file(path: &str, lines: Option<LineRange>) -> Result<ReadOutput, Rea
     let content = match crate::files::load_text_strict(p, path) {
         Ok(s) => s,
         Err(e) => {
-            if crate::exit::is_binary(&e) {
+            if crate::exit::is_load_text_strict_fail(&e) {
                 return Err(ReadFail {
-                    kind: "binary",
-                    msg: e.to_string(),
-                });
-            }
-            if crate::exit::is_invalid_encoding(&e) {
-                return Err(ReadFail {
-                    kind: "invalid_encoding",
-                    msg: e.to_string(),
-                });
-            }
-            if let Some(inv) = e.downcast_ref::<crate::exit::InvalidInputError>() {
-                return Err(ReadFail {
-                    kind: "invalid_input",
-                    msg: inv.msg.clone(),
+                    kind: crate::fallback::error_kind_str(&e).unwrap_or("invalid_input"),
+                    msg: crate::exit::agent_error_message(&e),
                 });
             }
             // Missing path and other IO. Prefer agent_error_message so embedded


### PR DESCRIPTION
## Summary

MPI cycle 3 (Spec / Adversarial residual of #1963):

- `ast list` / query sole-path and `ast replace` preflight emit
  `binary` / `invalid_encoding` via `is_load_text_strict_fail` +
  `error_kind_str` (same as md/read/search)
- Simplify `read` sole-path fail mapping onto the shared helper

## Validation

- `make check-fast`