### PR TITLE
test: lock md/AST and embedder-smoke binary peels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make pack-mcpb` | Pack `mcpb/` into `target/mcpb/patchloom-<ver>.mcpb` (Smithery / desktop). Honors `$VERSION` over Cargo.toml |
 | `make pack-mcpb-test` | Unit tests for pack version override and stamped manifest (`scripts/test_pack_mcpb.py`; skips full pack when `mcpb` CLI missing) |
 | `make agent-test` | Run agent integration tests (requires LLM API key, not part of `check`). Use `MODEL=X` to switch LLM (e.g. `make agent-test MODEL=sxs-gpt-5-4`) |
-| `make embedder-smoke` | Pre-release host contracts (fuzzy token span with `--allow-absent-old`, nested undo list, plan `key` alias, `--contain` → `guard_rejected`, create/rename dest-exists → `already_exists`, delete missing → `not_found`). Not part of `check`; run before tagging a release |
+| `make embedder-smoke` | Pre-release host contracts (fuzzy token span with `--allow-absent-old`, nested undo list, plan `key` alias, `--contain` → `guard_rejected`, create/rename dest-exists → `already_exists`, delete missing → `not_found`, sole binary → `binary`, invalid UTF-8 → `invalid_encoding`). Not part of `check`; run before tagging a release |
 | `make windows-smoke` | Windows/PowerShell dogfood (`scripts/windows-smoke.ps1`: backslash paths, absolute paths, peels, tx, CRLF). Not part of `check`; runs in CI `ci-windows`. Requires `pwsh` |
 | `make fuzz` | Run fuzz tests (11 targets: selector parse, patch parse, patch apply, batch tokenize, selector eval, doc parse, containment_check, fallback_resolve, ast_parse, md_heading, replace_regex). Requires nightly, not part of `check`. Use `FUZZ_TIME=N` for seconds per target |
 | `make bench-cli` | Run CLI benchmarks vs native tools (requires `hyperfine`, not part of `check`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ This is a quick-reference subset. For the complete list, see [AGENTS.md](./AGENT
 | `make clippy` | Run clippy with `-D warnings` |
 | `make check` | Full CI gate (run before every commit) |
 | `make check-fast` | Fast check (skips PATCHLOOM.md sync only; still checks README test count) |
-| `make embedder-smoke` | Pre-release host contracts (fuzzy token span, nested undo, plan key alias, `--contain` → `guard_rejected`, create/rename dest-exists → `already_exists`, delete missing → `not_found`); not part of `check` |
+| `make embedder-smoke` | Pre-release host contracts (fuzzy token span, nested undo, plan key alias, `--contain` → `guard_rejected`, create/rename dest-exists → `already_exists`, delete missing → `not_found`, sole binary → `binary`, invalid UTF-8 → `invalid_encoding`); not part of `check` |
 | `make windows-smoke` | Windows/PowerShell dogfood (`scripts/windows-smoke.ps1`; backslash paths, peels, tx, CRLF). Not part of `check`; runs in CI `ci-windows`. Requires `pwsh` |
 | `make audit` | Run `cargo audit` for known vulnerabilities (also in CI) |
 | `make deny` | Run `cargo deny check` for licenses/bans/sources (`deny.toml`; also in CI) |

--- a/scripts/embedder-smoke.sh
+++ b/scripts/embedder-smoke.sh
@@ -95,6 +95,35 @@ echo "$delete_json" | grep -q '"error_kind":"operation_failed"' \
   && fail "delete missing must not be operation_failed: $delete_json"
 pass "CLI delete missing JSON error_kind is not_found"
 
+# --- #1963 / #1972: sole binary peels binary (not no_matches / operation_failed) ---
+printf 'x\0y' >"$tmpdir/ws/blob.md"
+printf 'x\0y' >"$tmpdir/ws/blob.txt"
+bin_json=$("$BIN" --json --cwd "$tmpdir/ws" read blob.txt 2>/dev/null || true)
+echo "$bin_json" | grep -q '"error_kind": "binary"' \
+  || echo "$bin_json" | grep -q '"error_kind":"binary"' \
+  || fail "read sole binary must set error_kind binary: $bin_json"
+echo "$bin_json" | grep -q '"error_kind": "no_matches"' \
+  && fail "read sole binary must not be no_matches: $bin_json"
+echo "$bin_json" | grep -q '"error_kind":"no_matches"' \
+  && fail "read sole binary must not be no_matches: $bin_json"
+md_bin=$("$BIN" --json --cwd "$tmpdir/ws" md dedupe-headings blob.md 2>/dev/null || true)
+echo "$md_bin" | grep -q '"error_kind": "binary"' \
+  || echo "$md_bin" | grep -q '"error_kind":"binary"' \
+  || fail "md sole binary must set error_kind binary: $md_bin"
+pass "CLI sole binary JSON error_kind is binary (#1963/#1972)"
+
+# --- #1963: sole invalid UTF-8 peels invalid_encoding ---
+printf 'hello \xff world' >"$tmpdir/ws/bad.txt"
+enc_json=$("$BIN" --json --cwd "$tmpdir/ws" read bad.txt 2>/dev/null || true)
+echo "$enc_json" | grep -q '"error_kind": "invalid_encoding"' \
+  || echo "$enc_json" | grep -q '"error_kind":"invalid_encoding"' \
+  || fail "read invalid UTF-8 must set invalid_encoding: $enc_json"
+echo "$enc_json" | grep -q '"error_kind": "binary"' \
+  && fail "invalid UTF-8 must not be binary: $enc_json"
+echo "$enc_json" | grep -q '"error_kind":"binary"' \
+  && fail "invalid UTF-8 must not be binary: $enc_json"
+pass "CLI sole invalid UTF-8 JSON error_kind is invalid_encoding (#1963)"
+
 # --- nested undo still works after contain smoke (sessions already created) ---
 # Library-only find_backup_roots is unit-tested; CLI hosts use undo --list (#1695).
 

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -1075,11 +1075,11 @@ fn test_ast_validate_ok_rust_still_succeeds() {
     assert_eq!(arr[0]["valid"], true);
 }
 
-/// Sole explicit binary AST paths must be invalid_input, not no_matches /
-/// unsupported-language / missing-symbol (NUL is valid UTF-8).
+/// Sole explicit binary AST paths must be `error_kind: binary`, not
+/// no_matches / unsupported-language / missing-symbol (NUL is valid UTF-8).
 #[cfg(feature = "ast")]
 #[test]
-fn test_ast_sole_binary_is_invalid_input() {
+fn test_ast_sole_binary_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("blob.bin"), b"hello\x00world").unwrap();
 
@@ -1088,6 +1088,9 @@ fn test_ast_sole_binary_is_invalid_input() {
         vec!["--json", "ast", "validate", "blob.bin"],
         vec![
             "--json", "ast", "rename", "blob.bin", "--old", "foo", "--new", "bar",
+        ],
+        vec![
+            "--json", "ast", "replace", "blob.bin", "foo", "--old", "a", "--new", "b",
         ],
     ] {
         let output = patchloom_in(dir.path()).args(&args).output().unwrap();
@@ -1107,6 +1110,39 @@ fn test_ast_sole_binary_is_invalid_input() {
                 .contains("binary"),
             "args={args:?} json={json}"
         );
+    }
+}
+
+/// Sole-path AST invalid UTF-8 peels as `invalid_encoding` (#1963 / #1974).
+#[cfg(feature = "ast")]
+#[test]
+fn test_ast_sole_invalid_encoding_error_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bad.rs"), b"fn foo() { \xff }\n").unwrap();
+
+    for args in [
+        vec!["--json", "ast", "list", "bad.rs"],
+        vec!["--json", "ast", "validate", "bad.rs"],
+        vec![
+            "--json", "ast", "rename", "bad.rs", "--old", "foo", "--new", "bar",
+        ],
+        vec![
+            "--json", "ast", "replace", "bad.rs", "foo", "--old", "a", "--new", "b",
+        ],
+    ] {
+        let output = patchloom_in(dir.path()).args(&args).output().unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "args={args:?} stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(
+            json["error_kind"], "invalid_encoding",
+            "args={args:?} json={json}"
+        );
+        assert_eq!(json["ok"], false, "args={args:?} json={json}");
     }
 }
 

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -1485,3 +1485,109 @@ fn test_md_replace_section_format_failure_json_error_kind() {
         "md replace must still write before format failure"
     );
 }
+
+/// Sole-path md commands must peel binary (NUL) as `error_kind: binary`
+/// for engine paths and pre-load paths (#1894 / #1972).
+#[test]
+fn test_md_sole_binary_is_binary_error_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("blob.md"), b"hello\x00world").unwrap();
+
+    let cases: &[(&[&str], &str)] = &[
+        (
+            &[
+                "--json",
+                "md",
+                "replace-section",
+                "blob.md",
+                "--heading",
+                "H",
+                "--content",
+                "new",
+            ],
+            "binary",
+        ),
+        (&["--json", "md", "dedupe-headings", "blob.md"], "binary"),
+        (&["--json", "md", "lint-agents", "blob.md"], "binary"),
+        (
+            &[
+                "--json",
+                "md",
+                "table-append",
+                "blob.md",
+                "--heading",
+                "H",
+                "--row",
+                "a|b",
+            ],
+            "binary",
+        ),
+        (
+            &[
+                "--json",
+                "md",
+                "insert-after-heading",
+                "blob.md",
+                "--heading",
+                "H",
+                "--content",
+                "x",
+            ],
+            "binary",
+        ),
+    ];
+
+    for (args, kind) in cases {
+        let output = patchloom_in(dir.path()).args(*args).output().unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "args={args:?} stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(json["error_kind"], *kind, "args={args:?} json={json}");
+        assert_eq!(json["ok"], false, "args={args:?} json={json}");
+        let err = json["error"].as_str().unwrap_or("").to_lowercase();
+        assert!(
+            err.contains("binary"),
+            "args={args:?} expected binary guidance: {json}"
+        );
+    }
+}
+
+/// Sole-path md commands must peel invalid UTF-8 as `invalid_encoding` (#1963).
+#[test]
+fn test_md_sole_invalid_encoding_error_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("bad.md"), b"hello \xff world").unwrap();
+
+    for args in [
+        vec![
+            "--json",
+            "md",
+            "replace-section",
+            "bad.md",
+            "--heading",
+            "H",
+            "--content",
+            "new",
+        ],
+        vec!["--json", "md", "dedupe-headings", "bad.md"],
+        vec!["--json", "md", "lint-agents", "bad.md"],
+    ] {
+        let output = patchloom_in(dir.path()).args(&args).output().unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "args={args:?} stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(
+            json["error_kind"], "invalid_encoding",
+            "args={args:?} json={json}"
+        );
+        assert_eq!(json["ok"], false, "args={args:?} json={json}");
+    }
+}


### PR DESCRIPTION
## Summary

MPI cycle after Binary/InvalidEncoding honesty (#1969–#1974). Behavior was already correct; this PR locks CLI + pre-release host contracts so remapper regressions fail before release.

- Integration: sole-path `md` (engine + pre-load) and `ast` list/validate/rename/replace peel `error_kind: binary` and `invalid_encoding`
- Rename stale AST test that asserted binary while named `invalid_input`
- `make embedder-smoke`: read/md sole binary → `binary`; read invalid UTF-8 → `invalid_encoding`
- AGENTS/CONTRIBUTING embedder-smoke descriptions

## Verification

- `cargo test --test integration --all-features sole_binary_is_binary_error_kind`
- `cargo test --test integration --all-features sole_invalid_encoding_error_kind`
- `make embedder-smoke`
- `make check-fast` (exit 0)

## Gate note

Release PR #1968 (0.20.0) remains open; do not merge without explicit yes. Dist #960/#961 external only.