### PR TITLE
test: rename binary/encoding peels away from invalid_input

### DIFF
--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -732,7 +732,7 @@ fn test_tx_append_rejects_binary_file() {
 }
 
 #[test]
-fn test_replace_sole_binary_target_is_invalid_input() {
+fn test_replace_sole_binary_target_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("only.bin"), b"hello\x00world").unwrap();
 
@@ -758,10 +758,10 @@ fn test_replace_sole_binary_target_is_invalid_input() {
     );
 }
 
-/// Sole explicit invalid UTF-8 must be invalid_input, not pattern no_matches
-/// (soft-skip misreported as a miss; fixrealloop 2026-07-21).
+/// Sole explicit invalid UTF-8 must be `invalid_encoding`, not pattern no_matches
+/// (soft-skip misreported as a miss; fixrealloop 2026-07-21 / #1963).
 #[test]
-fn test_replace_sole_invalid_utf8_is_invalid_input() {
+fn test_replace_sole_invalid_utf8_is_invalid_encoding() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("bad.txt"), b"hello \xff world\n").unwrap();
 
@@ -801,7 +801,7 @@ fn test_replace_sole_invalid_utf8_is_invalid_input() {
 
 /// Sole tidy check on invalid UTF-8 must not report vacuous clean (exit 0).
 #[test]
-fn test_tidy_check_sole_invalid_utf8_is_invalid_input() {
+fn test_tidy_check_sole_invalid_utf8_is_invalid_encoding() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("bad.txt"), b"line  \xff\n").unwrap();
 
@@ -824,7 +824,7 @@ fn test_tidy_check_sole_invalid_utf8_is_invalid_input() {
 }
 
 #[test]
-fn test_tidy_check_sole_binary_is_invalid_input() {
+fn test_tidy_check_sole_binary_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("only.bin"), b"a\x00b  \n").unwrap();
 
@@ -841,7 +841,7 @@ fn test_tidy_check_sole_binary_is_invalid_input() {
 }
 
 #[test]
-fn test_tidy_fix_sole_binary_is_invalid_input() {
+fn test_tidy_fix_sole_binary_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("only.bin"), b"a\x00b  \n").unwrap();
 
@@ -906,7 +906,7 @@ fn test_tidy_multi_path_binary_refused() {
 }
 
 #[test]
-fn test_md_sole_binary_is_invalid_input_not_no_matches() {
+fn test_md_sole_binary_is_binary_error_kind_not_no_matches() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("only.bin"), b"hello\x00# H\n").unwrap();
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -4467,7 +4467,7 @@ async fn test_mcp_execute_plan_insert_after_line_oriented() {
     client.cancel().await.unwrap();
 }
 
-/// Sole binary path via MCP replace_text is invalid_input / binary, not silent.
+/// Sole binary path via MCP replace_text peels binary, not silent.
 #[tokio::test]
 async fn test_mcp_replace_text_sole_binary_refused() {
     if !has_mcp_support() {

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -965,9 +965,9 @@ fn test_patch_apply_json_applied_true() {
     );
 }
 
-/// Patch *file* (diff input) that is binary is invalid_input (#1896).
+/// Patch *file* (diff input) that is binary peels `error_kind: binary` (#1896 / #1963).
 #[test]
-fn test_patch_diff_file_binary_is_invalid_input() {
+fn test_patch_diff_file_binary_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("t.txt"), "hello\n").unwrap();
     fs::write(
@@ -998,9 +998,9 @@ fn test_patch_diff_file_binary_is_invalid_input() {
     );
 }
 
-/// Patch check on invalid UTF-8 *target* is invalid_input (#1896).
+/// Patch check on invalid UTF-8 *target* peels `invalid_encoding` (#1896 / #1963).
 #[test]
-fn test_patch_check_invalid_utf8_target_is_invalid_input() {
+fn test_patch_check_invalid_utf8_target_is_invalid_encoding() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("bad.txt"), b"line one\xff\nline two\n").unwrap();
     fs::write(
@@ -1028,9 +1028,9 @@ fn test_patch_check_invalid_utf8_target_is_invalid_input() {
     assert!(err.contains("UTF-8") || err.contains("utf"), "{v}");
 }
 
-/// Patch check on binary *target* is invalid_input (#1896).
+/// Patch check on binary *target* peels `error_kind: binary` (#1896 / #1963).
 #[test]
-fn test_patch_check_binary_target_is_invalid_input() {
+fn test_patch_check_binary_target_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("bin_line.bin"), b"line one\x00line two\n").unwrap();
     fs::write(
@@ -1061,10 +1061,10 @@ fn test_patch_check_binary_target_is_invalid_input() {
     );
 }
 
-/// Binary target must refuse with invalid_input (exit 1), not STALE/ambiguous.
+/// Binary target must refuse with `error_kind: binary` (exit 1), not STALE/ambiguous.
 /// Engine already load_text_strict; CLI error mapping was wrong (fixrealloop).
 #[test]
-fn test_patch_apply_binary_target_is_invalid_input() {
+fn test_patch_apply_binary_target_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("bin_line.bin"), b"line one\x00line two\n").unwrap();
     fs::write(

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -272,10 +272,10 @@ fn test_read_multiple_files_json_partial_failure_reports_skipped() {
     );
 }
 
-/// Sole explicit binary path must be invalid_input, not ok:true with NULs
-/// (parity with search/replace/tidy; MPI 2026-07-20).
+/// Sole explicit binary path must be `error_kind: binary`, not ok:true with NULs
+/// (parity with search/replace/tidy; MPI 2026-07-20 / #1963).
 #[test]
-fn test_read_sole_explicit_binary_is_invalid_input() {
+fn test_read_sole_explicit_binary_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     let bin_file = dir.path().join("data.bin");
     fs::write(&bin_file, b"hello\x00world").unwrap();
@@ -299,9 +299,9 @@ fn test_read_sole_explicit_binary_is_invalid_input() {
     assert!(err.contains("binary"), "expected binary guidance, got: {v}");
 }
 
-/// Multi-path read: text succeeds; binary co-path goes to skipped with invalid_input.
+/// Multi-path read: text succeeds; binary co-path goes to skipped with binary reason.
 #[test]
-fn test_read_multi_path_binary_skipped_invalid_input() {
+fn test_read_multi_path_binary_skipped_surfaces_binary() {
     let dir = TempDir::new().unwrap();
     let text = dir.path().join("ok.txt");
     let bin_file = dir.path().join("data.bin");

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1057,10 +1057,10 @@ fn test_search_skips_binary_files() {
     );
 }
 
-/// Sole explicit binary path must be invalid_input, not pattern no_matches
-/// (parity with replace; agents otherwise retry forever). MPI 2026-07-19.
+/// Sole explicit binary path must be `error_kind: binary`, not pattern no_matches
+/// (parity with replace; agents otherwise retry forever). MPI 2026-07-19 / #1963.
 #[test]
-fn test_search_sole_explicit_binary_is_invalid_input() {
+fn test_search_sole_explicit_binary_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     let bin_file = dir.path().join("data.bin");
     fs::write(&bin_file, b"needle\x00in binary").unwrap();
@@ -1084,10 +1084,10 @@ fn test_search_sole_explicit_binary_is_invalid_input() {
     assert!(err.contains("binary"), "expected binary guidance, got: {v}");
 }
 
-/// Sole explicit invalid UTF-8 must be invalid_input, not soft-skip no_matches.
-/// fixrealloop 2026-07-21.
+/// Sole explicit invalid UTF-8 must be `invalid_encoding`, not soft-skip no_matches.
+/// fixrealloop 2026-07-21 / #1963.
 #[test]
-fn test_search_sole_invalid_utf8_is_invalid_input() {
+fn test_search_sole_invalid_utf8_is_invalid_encoding() {
     let dir = TempDir::new().unwrap();
     let bad = dir.path().join("bad.txt");
     fs::write(&bad, b"needle \xff here\n").unwrap();
@@ -1225,9 +1225,9 @@ fn test_search_sole_unreadable_is_invalid_input() {
     }
 }
 
-/// Sole binary via --files-from is invalid_input (not pattern no_matches).
+/// Sole binary via --files-from is `error_kind: binary` (not pattern no_matches).
 #[test]
-fn test_search_files_from_sole_binary_is_invalid_input() {
+fn test_search_files_from_sole_binary_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("data.bin"), b"x\x00y").unwrap();
     fs::write(dir.path().join("list.txt"), "data.bin\n").unwrap();

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -327,9 +327,9 @@ fn test_tidy_check_sole_unreadable_is_invalid_input() {
     }
 }
 
-/// Sole binary via --files-from is invalid_input (not vacuous clean/tidy).
+/// Sole binary via --files-from is `error_kind: binary` (not vacuous clean/tidy).
 #[test]
-fn test_tidy_check_files_from_sole_binary_is_invalid_input() {
+fn test_tidy_check_files_from_sole_binary_is_binary_error_kind() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("data.bin"), b"x\x00y").unwrap();
     fs::write(dir.path().join("list.txt"), "data.bin\n").unwrap();


### PR DESCRIPTION
## Summary

fixrealloop dogfood after the Binary/InvalidEncoding honesty stack found integration tests that **assert** `error_kind: binary` / `invalid_encoding` while **names and comments** still said `invalid_input`.

Rename tests and comments for audit honesty (no product behavior change).

## Verification

- `cargo test --test integration --all-features binary_error_kind`
- `cargo test --test integration --all-features invalid_encoding`
- Runtime dogfood rounds 1–4: product peels/exits correct; harness false reds only

## Dogfood note

Multi-surface release binary scenarios (file peels, replace, search, md, ast, batch, tx, contain, fuzzy, patch, undo, tidy, init) found **no product regressions**. Round-1 “fails” were harness `|| true` zeroing exit codes and wrong CLI shapes (`--selector` vs positional).