### PR TITLE
test(api): host-path fuzzy_span_suspicious after replace_in_content

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,12 +302,14 @@ let result = api::replace_text(
 )?;
 println!("{}", result.diff);
 
-// Fail closed: zero matches become EditErrorKind::NoMatch (agent hosts)
-let opts = ReplaceOptions { require_change: true, ..Default::default() };
+// Agent hosts: shared primary+fallback policy (unique, require_change, fuzzy @ 0.90)
+let opts = ReplaceOptions::for_agent();
+// Fail closed: zero matches become EditErrorKind::NoMatch
 match api::replace_in_content("body", "missing", "x", &opts) {
     Ok(r) => println!("changed={}", r.changed),
     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::NoMatch)),
 }
+// After fuzzy Apply: refuse over-wide spans before trust (api::fuzzy_span_suspicious)
 // Invalid options and bad regex peel InvalidInput (CLI/tx typed errors included)
 match api::replace_in_content("body", "", "x", &ReplaceOptions::default()) {
     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::InvalidInput)),
@@ -338,7 +340,7 @@ let _text = api::load_text(Path::new("notes.md"))?;
 
 All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking, `load_text_strict`, binary detection), `backup` (`restore_path_from_latest_backup` for post-Apply validate/revert), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS); see the `containment` and `api` module rustdocs. Multi-doc bare keys and wrong-root merges peel to `EditErrorKind::TypeError` via `edit_error_kind`. Create/rename dest-exists peels to `EditErrorKind::AlreadyExists` (or `api::is_already_exists` / `api::error_kind_str` for CLI-stable `"already_exists"` strings). Fine-grained kinds also have bool peels (`is_not_found`, `is_conflicts`, `is_changes_detected`, `is_type_error`, `is_format_failed`, `is_guard_rejected`, `is_invalid_input`, `is_no_match`, `is_ambiguous`) matching `edit_error_kind`.
 
-Replace fail-closed / shell-token options: CLI `replace --require-change` and `--command-position` (also plan/MCP fields and `ReplaceOptions` on the library). Library-only AST mutators: `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
+Replace fail-closed / shell-token options: CLI `replace --require-change` and `--command-position` (also plan/MCP fields and `ReplaceOptions` on the library). Agent hosts: `ReplaceOptions::for_agent()` plus `api::fuzzy_span_suspicious` after fuzzy Apply. Library-only AST mutators: `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
 
 ## Getting started
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -618,6 +618,7 @@ These are meaningful command-specific modes that change how a top-level command 
 - **What it does:** When the exact pattern has zero matches, try similarity/anchor fallback (same chain as before/after context). Plan ops and MCP `replace_text` accept `fuzzy: true`. Pure fuzzy (no context) works on disk library, single-path tx, **glob** plan ops, and CLI (including directory roots expanded like ordinary replace).
 - **Use when:** Agent edits may have whitespace or small typos but should still land with honest `match_mode` / `match_score` / `matched_text` in library results and CLI/MCP JSON (#1669, #1736). Multi-file CLI replace, plan/tx, and content_edits all roll up worst-case confidence (`fuzzy` > `anchored` > `exact`) so mixed batches never under-report fuzzy. Aggregate `match_score` is the **minimum** fuzzy score across paths/ops (lowest confidence), not the first fuzzy hit.
 - **Default safety (#1758):** When exact `old` is **absent**, Similarity/fuzzy **refuses to write** by default (even above `min_fuzzy_score`) and reports the best candidate. Set `--allow-absent-old` / `allow_absent_old` only for deliberate approximate recovery. Anchored matches (explicit context) still apply.
+- **After Apply (#1981):** library hosts should call `api::fuzzy_span_suspicious(old, matched_text, match_score)` (or `FuzzySpanPolicy`) before treating a fuzzy success as trusted. Default: refuse when matched is wider than `max(4 * old_chars, old_chars + 40)`, or score is in `[0.90, 0.95)` and ratio `> 2`. Do not rely on score alone.
 - **Prefer instead:** Exact replace when the target string is known; `ast rename` for code identifiers.
 
 <!-- ref:replace-mode:min-fuzzy-score -->
@@ -640,8 +641,9 @@ These are meaningful command-specific modes that change how a top-level command 
 
 - **What it does:** Shared constructor for coding-agent hosts so primary and fallback replace paths use one policy (#1965): `unique=true`, `require_change=true`, `fuzzy=true`, `min_fuzzy_score=Some(0.90)` (`AGENT_MIN_FUZZY_SCORE`), **`allow_absent_old=false`**.
 - **Use when:** Embedding patchloom in an agent runtime with more than one replace call site. Prefer `ReplaceOptions::for_agent()` over hand-copied `ReplaceOptions { ... }` blocks that can drift.
+- **After fuzzy Apply:** call `api::fuzzy_span_suspicious` on `matched_text` / `match_score` before trust (#1981). Pair with `for_agent` so floor + refuse policy stay aligned.
 - **Overrides:** Struct update: replace-all → `unique: false`; deliberate approximate recovery → `allow_absent_old: true`; word-boundary rename → `fuzzy: false`, `min_fuzzy_score: None`, `word_boundary: true`.
-- **Not:** A host-specific recovery preset with `allow_absent_old: true`. Fail-closed missing-`old` remains the library default; recovery stays an explicit override.
+- **Not:** A host-specific recovery preset with `allow_absent_old: true`. Fail-closed missing-`old` remains the library default; recovery stays an explicit override (#1980 closed not planned).
 - **Prefer instead:** `ReplaceOptions::default()` only for non-agent / soft no-match library callers.
 
 <!-- ref:create-mode:stdin -->

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3129,6 +3129,12 @@ fn fuzzy_span_suspicious_default_policy() {
     // 45 ASCII matched: chars refuse (45>44), bytes would allow (45==45).
     assert!(!fuzzy_span_suspicious("café", Some("café"), Some(0.99)));
     assert!(fuzzy_span_suspicious("café", Some(&"x".repeat(45)), None));
+    // NaN score: comparisons fail closed (near-floor band never fires).
+    assert!(!fuzzy_span_suspicious(
+        old10,
+        Some(over_double),
+        Some(f64::NAN)
+    ));
 }
 
 #[test]
@@ -6443,6 +6449,45 @@ fn replace_in_content_fuzzy_near_collision_reports_matched_text() {
     assert!(
         r.new_content.contains("compute_digest"),
         "replacement should apply to the matched span"
+    );
+    // #1981 host path: token-scale identifier fuzzy is not over-wide.
+    assert!(
+        !crate::api::fuzzy_span_suspicious("compute_cheksum", Some(matched), r.match_score),
+        "near-collision identifier span must not trip default refuse policy: {matched:?}"
+    );
+}
+
+/// #1981: host refuse helper after a real fuzzy `replace_in_content` Apply.
+#[test]
+fn replace_in_content_fuzzy_host_refuses_over_wide_matched_text() {
+    // Live file has a short identifier; fuzzy old is a typo of a long line
+    // that is not present. With allow_absent_old the engine may still land
+    // on the short identifier (token scale) — that is not over-wide.
+    // The over-wide case is asserted with the public helper on a synthetic
+    // function-body span (same shape hosts see after a bad fuzzy).
+    let old = "process_data";
+    let wide = "fn process_data() {\n    // lots of body\n    do_work();\n    more();\n}\n";
+    assert!(
+        crate::api::fuzzy_span_suspicious(old, Some(wide), Some(crate::api::AGENT_MIN_FUZZY_SCORE)),
+        "function-body span vs short identifier must be suspicious under default policy"
+    );
+    // Real engine path: identifier typo (not a substring of the live name)
+    // stays token-scale and is trusted under the default refuse policy.
+    let content = "fn process_data() {}\n";
+    let opts = ReplaceOptions {
+        fuzzy: true,
+        allow_absent_old: true,
+        min_fuzzy_score: Some(0.90),
+        require_change: true,
+        ..Default::default()
+    };
+    let r = replace_in_content(content, "proess_data", "process_items", &opts)
+        .expect("fuzzy typo must apply");
+    assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
+    let matched = r.matched_text.as_deref().expect("fuzzy matched_text");
+    assert!(
+        !crate::api::fuzzy_span_suspicious("proess_data", Some(matched), r.match_score),
+        "token-scale fuzzy Apply must not look over-wide: {matched:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

MPI cycle after #1981/#1984 on main. Hardens host contract for over-wide fuzzy refuse:

- `replace_in_content` fuzzy near-collision also asserts `fuzzy_span_suspicious` is false (token-scale trust)
- New test: real fuzzy typo Apply is not over-wide; synthetic function-body span is
- NaN score never trips the near-floor band
- README library example uses `ReplaceOptions::for_agent()` and names `fuzzy_span_suspicious`
- Reference docs for fuzzy / for_agent call out post-Apply refuse (#1981)

## Pre-rotation gate

- Only open product issue backlog: #960/#961 external dist (B-path)
- **Release PR #1983** (`chore(main): release patchloom 0.21.0`) is open — **not merged** (needs explicit user yes)

## Test plan

- [x] `cargo test --lib fuzzy_span`
- [x] `cargo test --lib replace_in_content_fuzzy_host_refuses`
- [x] `cargo test --lib replace_in_content_fuzzy_near_collision`
- [x] `make check-fast`