### PR TITLE
docs: competitive batch (comparisons, agent routing, MCP listings copy)

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -9,6 +9,25 @@
 
 **Apply write safety:** all Apply paths share one writer. Symlinks are resolved so the link entry is not replaced (#1230). On Unix, files with multiple hard links (`nlink > 1`) are updated in place so sibling paths stay in sync (#1733); single-link files use temp+rename. CLI `rename` and plan `file.rename` (including force overwrite) use `fs::rename` so multi-hardlinked sources keep their shared inode (#1739, #1746).
 
+## Which surface to use
+
+Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when the edit is structured or multi-file. Prefer **ast-grep** (or similar) for **structural code search / pattern codemods** when you need a syntax-tree pattern DSL; use Patchloom for host-safe apply, configs, markdown, batch/tx/undo, and peels.
+
+| If the task is… | Prefer | Avoid |
+|---|---|---|
+| JSON/YAML/TOML key mutate | `doc set` / plan `doc.*` / MCP `doc_set` | regex replace on structured files |
+| Multi-document YAML | selector `0.key` or `[0].key` | bare key on stream root |
+| Markdown section/bullet/table | `md *` | whole-file rewrite |
+| Identifier rename in code | `ast rename` / `ast_rename_project` | fuzzy replace for symbols |
+| Find code by AST shape (pattern DSL) | ast-grep (or `ast search`) | blind text grep only |
+| Prose/typo in non-code text | `replace` (fuzzy last resort) | AST |
+| Multi-file atomic apply | `tx` / `batch` / `execute_plan` | sequential shell |
+| Host agent policy (Rust) | `ReplaceOptions::for_agent` + peels + `fuzzy_span_suspicious` | soft defaults |
+
+**Context budget:** prefer `read` with a line range, `search --count` / `--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` for large result streams. Binary sole paths peel `error_kind: binary`.
+
+**MCP tool volume:** the server may expose many tools; start from this table (and `schema --tier weak|medium|strong` for plan prompts). Full inventory is power-user default; hosts that need a smaller register set can track progressive surface design (docs/plans/mcp-surface-tiers.md).
+
 ## Tool selection guide
 
 | Task pattern | Tool to use |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 
 Patchloom is a single-binary CLI that gives AI coding agents safe, structured file editing on any operating system. It edits JSON, YAML, and TOML by selector (not regex), preserves comments, understands code structure across 20 languages, batches multiple file edits into one tool call, and works identically on Linux, macOS, and Windows.
 
+**Not a generic filesystem MCP.** Default MCP filesystem servers read/write files as text. Patchloom adds dry-run previews, parser-backed config and markdown edits, AST ops, multi-file `batch`/`tx` with undo, and stable `error_kind` peels for hosts. Full coding agents (Claude Code, Codex, Cursor) own the loop; Patchloom is the **tool layer** they (or a Rust embedder) call.
+
 ![Patchloom demo: 6 edits across 4 files in JSON, YAML, and TOML — one command, comments preserved](demo/demo.gif)
 
 ```bash
@@ -41,7 +43,7 @@ file.create VERSION "2.0.0"
 EOF
 ```
 
-**[Why Patchloom?](#why-patchloom)** | **[Install](#install)** | **[Quick start](#quick-start)** | **[Commands](#commands)** | **[Comparison](#how-patchloom-compares)** | **[Architecture](#how-it-works-with-your-ai-agent)** | **[Status](#status)**
+**[Why Patchloom?](#why-patchloom)** | **[Install](#install)** | **[Quick start](#quick-start)** | **[Commands](#commands)** | **[Comparison](#how-patchloom-compares)** | **[When to use what](#when-to-use-what)** | **[Architecture](#how-it-works-with-your-ai-agent)** | **[Status](#status)**
 
 ---
 
@@ -340,7 +342,7 @@ let _text = api::load_text(Path::new("notes.md"))?;
 
 All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking, `load_text_strict`, binary detection), `backup` (`restore_path_from_latest_backup` for post-Apply validate/revert), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS); see the `containment` and `api` module rustdocs. Multi-doc bare keys and wrong-root merges peel to `EditErrorKind::TypeError` via `edit_error_kind`. Create/rename dest-exists peels to `EditErrorKind::AlreadyExists` (or `api::is_already_exists` / `api::error_kind_str` for CLI-stable `"already_exists"` strings). Fine-grained kinds also have bool peels (`is_not_found`, `is_conflicts`, `is_changes_detected`, `is_type_error`, `is_format_failed`, `is_guard_rejected`, `is_invalid_input`, `is_no_match`, `is_ambiguous`) matching `edit_error_kind`.
 
-Replace fail-closed / shell-token options: CLI `replace --require-change` and `--command-position` (also plan/MCP fields and `ReplaceOptions` on the library). Agent hosts: `ReplaceOptions::for_agent()` plus `api::fuzzy_span_suspicious` after fuzzy Apply. Library-only AST mutators: `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
+Replace fail-closed / shell-token options: CLI `replace --require-change` and `--command-position` (also plan/MCP fields and `ReplaceOptions` on the library). Agent hosts: `ReplaceOptions::for_agent()` plus `api::fuzzy_span_suspicious` after fuzzy Apply. Library-only AST mutators: `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Host checklist: [Embedder host](docs/getting-started/embedder-host.md). Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
 
 ## Getting started
 
@@ -448,6 +450,24 @@ The YAML parser changes the value at the selector path. Comments, indentation, k
 | **Stale context risk** | `patch apply` uses fuzz matching to handle context drift |
 
 **When to keep using native tools:** Single-file reads, simple text search, single-file text replacement where comments don't matter. Patchloom's agent-rules tell agents exactly when to use each approach.
+
+## When to use what
+
+| Need | Prefer | Prefer something else |
+|------|--------|------------------------|
+| JSON/YAML/TOML by path | Patchloom `doc` | Generic filesystem MCP / blind text replace |
+| Multi-doc YAML stream | Patchloom selectors (`0.key`) | Bare key on stream root |
+| Structural code pattern search | [ast-grep](https://github.com/ast-grep/ast-grep) | Text-only grep for shapes |
+| Identifier rename in code | Patchloom `ast rename` | Fuzzy text replace for symbols |
+| Multi-file atomic apply + undo | Patchloom `batch` / `tx` | N sequential shell edits |
+| Cloud merge of LLM snippets | Morph Fast Apply (etc.) | Patchloom for local deterministic configs |
+| Full agent product | Claude Code / Codex / Cursor | Patchloom alone |
+
+Longer write-ups: [Comparisons](docs/getting-started/comparisons.md) · [Embedder host checklist](docs/getting-started/embedder-host.md) · [MCP setup](docs/getting-started/mcp-setup.md)
+
+**Library hosts:** `ReplaceOptions::for_agent()`, peels via `edit_error_kind` / `is_*`, and after fuzzy Apply `api::fuzzy_span_suspicious` (Patchloom does not auto-refuse over-wide spans).
+
+**Context budget:** line-range `read`, `search --count` / `--files-with-matches`, one `batch`/`tx`, `--jsonl` for large streams.
 
 ## How it works with your AI agent
 

--- a/REPO-SETUP.md
+++ b/REPO-SETUP.md
@@ -17,6 +17,16 @@ This file captures the recommended day 1 policy setup for `patchloom/patchloom`,
 | Smithery | `mcpb/` + `make pack-mcpb` + `.github/workflows/publish-smithery.yml` | Local stdio MCPB (`patchloom/patchloom`). Pack stamps version from `$VERSION` (CI) or Cargo.toml; runtime uses PATH binary or `npx -y patchloom@ver mcp-server`. Workflow pins `@anthropic-ai/mcpb@2.1.2`. Publish soft-skips without `SMITHERY_API_KEY` (from `smithery auth login` → `smithery auth whoami --full`). Manual: `make pack-mcpb && SMITHERY_API_KEY=… bash scripts/publish-smithery.sh` (REST API; avoids CLI 400). Tests: `make pack-mcpb-test` |
 | Glama MCP directory | root `glama.json` (`maintainers`) + manual web submit | [Glama FAQ](https://glama.ai/mcp/faq): **Add MCP Server** with `https://github.com/patchloom/patchloom`. No public API token; requires Glama account. After listing, Glama indexes from the GitHub repo + `glama.json`. See `docs/getting-started/mcp-setup.md` |
 | Release secrets | add `HOMEBREW_TAP_TOKEN`, `CARGO_REGISTRY_TOKEN`, (for Chocolatey) `CHOCOLATEY_API_KEY`, and (for Smithery) `SMITHERY_API_KEY` | `HOMEBREW_TAP_TOKEN` must push to both `homebrew-tap` and `scoop-bucket` (classic PAT `public_repo` is enough for public org repos). Prefer OIDC over `NPM_TOKEN` for npm. Chocolatey key from https://community.chocolatey.org/account (API Keys). MCP Registry needs no extra secret when using OIDC. Smithery is soft-skip without the secret |
+
+## After each release (MCP directory hygiene)
+
+Keep directory copy aligned with the tagged version. Automated where possible:
+
+1. **MCP Registry** — runs from Release after crates/npm; on failure: Actions → **Publish MCP Registry** → version input. `server.json` description should stay differentiation-focused (structured agent edits, not generic filesystem); version field is stamped by the publish job.
+2. **Smithery** — `publish-smithery.yml` after Release when `SMITHERY_API_KEY` is set; manual: `make pack-mcpb && bash scripts/publish-smithery.sh`.
+3. **Glama** — no API publish; after listing exists, sync from GitHub + `glama.json`. If description drifts, update via Glama UI (human session). Suggested blurb: same as `server.json` description.
+4. **Secondary marketplaces** (mcp.so, mcpservers.org, PulseMCP, awesome lists) — re-check only when deliberately listing; not release-blocking.
+5. **GitHub repo description / topics / homepage** — optional re-check after major messaging changes (`gh api repos/patchloom/patchloom`).
 | Security reporting | commit `SECURITY.md` now, then enable GitHub private vulnerability reporting after the repo becomes public | private Free org repos do not expose GitHub private vulnerability reporting yet |
 | Branch protection | Protect `main` once the repo is public or on a plan that supports private branch protection | required before accepting outside patches |
 | Public repo metadata | commit `LICENSE`, `README.md`, `CONTRIBUTING.md`, and issue templates in the bootstrap | keep the repo legible from day one |

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,8 @@
 - [Installation](getting-started/installation.md)
 - [Quickstart](getting-started/quickstart.md)
 - [Core Concepts](getting-started/concepts.md)
+- [Comparisons](getting-started/comparisons.md)
+- [Embedder host checklist](getting-started/embedder-host.md)
 - [MCP Setup](getting-started/mcp-setup.md)
 - [Editor Extension](getting-started/editor-extension.md)
 
@@ -17,3 +19,4 @@
 # Blog
 
 - [Launch Announcement](blog/launch-announcement.md)
+- [Community launch pack (draft)](blog/community-launch-draft.md)

--- a/docs/blog/community-launch-draft.md
+++ b/docs/blog/community-launch-draft.md
@@ -1,0 +1,72 @@
+# Community launch pack (draft — do not post until a release ships)
+
+> **Status:** draft for maintainers. Post only after an explicit release tag / user-approved release PR merge. Do not publish stale version claims.
+
+## Demo script (temp dir)
+
+```bash
+REPO=$(git rev-parse --show-toplevel)
+BIN="${REPO}/target/release/patchloom"
+# or: BIN=$(which patchloom)
+S=$(mktemp -d /tmp/patchloom-demo-XXXXXX)
+cd "$S"
+printf 'port: 1\n# keep me\n' > app.yaml
+printf 'name: a\n---\nname: b\n' > stream.yaml
+
+echo "=== dry-run (expect changes, no write) ==="
+"$BIN" doc set app.yaml port 5432   # exit 2 typical without --apply
+cat app.yaml
+
+echo "=== apply structured YAML ==="
+"$BIN" doc set app.yaml port 5432 --apply
+cat app.yaml
+
+echo "=== multi-doc selector ==="
+"$BIN" doc set stream.yaml 0.name A --apply
+"$BIN" doc get stream.yaml 0.name
+
+echo "=== fail-closed fuzzy (exact old absent) ==="
+printf 'const LIVE_NAME: i32 = 1;\n' > f.rs
+"$BIN" --json replace LIVE_NAAME --new X --fuzzy --apply f.rs || true
+grep LIVE_NAME f.rs
+
+echo "=== agent-rules snippet ==="
+"$BIN" agent-rules --mode mcp | head -40
+```
+
+## Post draft (Show HN / r/mcp)
+
+Title options:
+
+- Show HN: Patchloom – structured file edits for AI agents (not another filesystem MCP)
+- Patchloom: dry-run, peels, and parser-backed JSON/YAML/TOML for agent tool loops
+
+Body (plain text; no em dashes):
+
+```
+Patchloom is a single binary (CLI + MCP + Rust library) for agent-safe file edits.
+
+Why not generic filesystem MCP / sed / yq alone?
+- Dry-run by default (preview / exit 2 when changes would apply)
+- Parser-backed JSON, YAML, TOML (comments, multi-doc honesty)
+- Markdown section ops and tree-sitter AST renames
+- batch/tx with undo; stable error_kind for hosts (binary, already_exists, …)
+- Library hosts: ReplaceOptions::for_agent and fuzzy_span_suspicious
+
+Install: https://patchloom.github.io/patchloom/
+MCP Registry: io.github.patchloom/patchloom
+Repo: https://github.com/patchloom/patchloom
+
+Would love feedback from people wiring agents to config-heavy repos.
+```
+
+## Channels (after release)
+
+- [ ] Hacker News Show HN
+- [ ] r/mcp
+- [ ] Optional: r/ClaudeAI / r/ClaudeCode if rules allow tooling posts
+- [ ] Update Glama listing description if manual form needed
+
+## Related issues
+
+- Comparison docs, README positioning, directory audit (competitive research batch)

--- a/docs/getting-started/comparisons.md
+++ b/docs/getting-started/comparisons.md
@@ -1,0 +1,79 @@
+# Comparisons and when to use what
+
+Patchloom is **not** a generic filesystem MCP and **not** a drop-in replacement for full coding agents. Use this page to choose tools.
+
+## vs official / generic MCP filesystem
+
+| Capability | Generic filesystem MCP | Patchloom |
+|------------|------------------------|-----------|
+| Read / write / list files | Yes | Yes (`read`, create, delete, …) |
+| Dry-run / preview before write | Rare | Default dry-run; exit **2** when changes would apply |
+| JSON / YAML / TOML by selector | No (text edit) | `doc` (parser-backed; multi-doc YAML honesty) |
+| Markdown section / table / bullet | No | `md` |
+| AST rename / symbol ops | No | `ast` |
+| Multi-file atomic plan + undo | No | `tx` / `batch` + `undo` |
+| Agent-branchable `error_kind` | Weak | `binary`, `invalid_encoding`, `already_exists`, `format_failed`, … |
+
+**Use a generic filesystem MCP** for simple read/write outside structured agent workflows.
+
+**Use Patchloom** when the agent must mutate configs, markdown structure, or multi-file plans with preview and peels.
+
+Install notes: [MCP setup](mcp-setup.md). Registry name: `io.github.patchloom/patchloom`.
+
+## vs yq / dasel / jq
+
+| Capability | yq / dasel | Patchloom |
+|------------|------------|-----------|
+| Selector mutate JSON/YAML/TOML | Yes | Yes (`doc`) |
+| Same tool for md / AST / replace / tx | No | Yes |
+| Agent JSON + exit codes | Shell stderr | Stable `error_kind`, dry-run exit 2 |
+| Multi-document YAML stream honesty | Limited | Bare-key type_error; `0.key` / `[0]` |
+| MCP + Rust library host contracts | No | MCP + `ReplaceOptions::for_agent` |
+
+**Use yq/dasel** in human scripts and one-off shell.
+
+**Use Patchloom** inside agent loops (CLI, MCP, or embedder library).
+
+## vs ast-grep (complement)
+
+[ast-grep](https://github.com/ast-grep/ast-grep) owns **structural code search and pattern rewrite** (syntax-tree patterns, codemods). Patchloom owns **host-safe apply** for configs, markdown, multi-file transactions, and agent honesty.
+
+| Task | Prefer |
+|------|--------|
+| Find every call matching a code shape | ast-grep (or `ast search` / project tools) |
+| Rename a symbol with project-aware AST | Patchloom `ast rename` / `ast_rename_project` |
+| Set `database.port` in YAML without losing comments | Patchloom `doc set` |
+| Atomic multi-file apply with undo | Patchloom `tx` / `batch` |
+| After fuzzy text replace, refuse over-wide spans (library host) | Patchloom `fuzzy_span_suspicious` |
+
+Typical pipeline: discover with ast-grep → apply policy-safe writes with Patchloom.
+
+## vs Morph Fast Apply (and similar merge APIs)
+
+[Morph](https://www.morphllm.com/) (Fast Apply) is a **cloud apply model**: the agent emits a short snippet (often with `// ... existing code ...` markers); Morph merges into the file at high token rates. That optimizes whole-file rewrites inside full agent loops.
+
+| | Morph Fast Apply | Patchloom |
+|--|------------------|-----------|
+| Execution | Network API | Local binary / library |
+| Determinism | Model merge | Parser / exact / controlled fuzzy |
+| Configs / multi-doc YAML / md sections | Not the product focus | Core |
+| Dry-run exit codes + peels | N/A | Core |
+| Offline / air-gapped | No | Yes |
+
+**Interop (no integration required):** a host may use Morph (or IDE apply) for freeform code and Patchloom for structured configs, plans, and peels. Patchloom does **not** depend on paid apply APIs for its core path.
+
+## vs full coding agents (Claude Code, Codex, Cursor, Aider)
+
+Those products own the **agent loop**. Patchloom is a **tool layer** (CLI / MCP / library) they can call. Do not install Patchloom expecting to replace the agent; install it so the agent edits structure safely.
+
+## Context budget tips
+
+Agents pay for tokens on every tool result. Prefer:
+
+- `read` with a **line range** instead of dumping huge files
+- `search` with `--count` / `--files-with-matches` (and limits when available) before full content
+- `batch` / `tx` / multi-op content edits instead of N sequential replaces
+- `--jsonl` when streaming many results
+- Soft-skip binary paths; sole binary targets return `error_kind: binary`
+
+See also [Core concepts](concepts.md) and [agent-rules](../../PATCHLOOM.md) output from `patchloom agent-rules`.

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -26,6 +26,18 @@ Patchloom has 23 commands:
 
 For feature-by-feature `Use when` guidance on commands, operations, and notable modes, see the [reference guide](../reference/README.md).
 
+For tool choice vs filesystem MCP, yq, ast-grep, and Morph, see [Comparisons](comparisons.md).
+
+## Context budget (agents)
+
+Tool results cost model tokens. Prefer:
+
+- `read` with a **line range** instead of dumping large files
+- `search --count` / `--files-with-matches` before full content
+- `batch` / `tx` / multi-op plans instead of N sequential replaces
+- `--jsonl` for streaming many results
+- Treating sole binary / invalid UTF-8 as peels (`error_kind`), not soft no-match
+
 ## Write modes
 
 Every write command supports four modes:

--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -1,0 +1,50 @@
+# Embedder host checklist (Rust library)
+
+For agent runtimes that **embed** Patchloom (not only shell out to the CLI). Public API surface: [docs.rs/patchloom](https://docs.rs/patchloom).
+
+## Host checklist
+
+1. **Shared replace policy** — call `ReplaceOptions::for_agent()` on every primary and fallback replace path (`unique`, `require_change`, fuzzy at `AGENT_MIN_FUZZY_SCORE` 0.90, `allow_absent_old: false`).
+2. **Branch on peels** — use `edit_error_kind` / `error_kind_str` / bools (`is_no_match`, `is_binary`, `is_already_exists`, …). Do not treat all failures as one string.
+3. **After fuzzy Apply** — call `fuzzy_span_suspicious(old, matched_text, match_score)` (or `FuzzySpanPolicy`) before treating the write as trusted. Patchloom does **not** auto-refuse over-wide spans; the host must.
+4. **Containment** — for sandboxed agents, use `PathGuard` / workspace roots; do not let the model widen `--cwd` under CLI contain (#1832).
+5. **Undo** — after Apply, persist `EditResult.backup_session` if the host exposes undo.
+
+## Minimal sketch
+
+```rust
+use patchloom::api::{
+    replace_in_content, ReplaceOptions, fuzzy_span_suspicious,
+    edit_error_kind, EditErrorKind, MatchMode, AGENT_MIN_FUZZY_SCORE,
+};
+
+let opts = ReplaceOptions::for_agent();
+match replace_in_content(content, old, new, &opts) {
+    Ok(r) => {
+        if r.match_mode == Some(MatchMode::Fuzzy)
+            && fuzzy_span_suspicious(old, r.matched_text.as_deref(), r.match_score)
+        {
+            // Host refuse: do not commit this buffer / surface to the model
+            return Err(/* host policy */);
+        }
+        Ok(r)
+    }
+    Err(e) => match edit_error_kind(&e) {
+        Some(EditErrorKind::NoMatch) => { /* agent retry or skip */ Err(e) }
+        Some(EditErrorKind::Binary) => { /* peel */ Err(e) }
+        _ => Err(e),
+    },
+}
+```
+
+Approximate recovery stays an explicit override: `ReplaceOptions { allow_absent_old: true, ..ReplaceOptions::for_agent() }` (not a second constructor; #1980).
+
+## Multi-op
+
+`apply_content_edits` rolls up the **widest** `matched_text` and the **minimum** fuzzy score independently. Prefer per-op checks with the matching `old` when possible.
+
+## Related
+
+- [Comparisons](comparisons.md) (Morph, filesystem MCP, yq, ast-grep)
+- [Library API table](../reference/README.md#library-api)
+- [Introduction — As a Rust library](../introduction.md#as-a-rust-library)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -131,8 +131,8 @@ surface (`ReplaceOptions::for_agent`, `fuzzy_span_suspicious`, `require_change`,
 `command_position`, `ast_rename_batch`, `find_files_with_symbol`, `classify_error`,
 `restore_path_from_session`, `run_post_write_validation`, `match_mode`) and the
 [introduction](../introduction.md#as-a-rust-library) for a quick overview.
-Embedder tables live under [Library API](../reference/README.md#library-api)
-in the reference.
+Host checklist: [Embedder host](embedder-host.md). Embedder tables live under
+[Library API](../reference/README.md#library-api) in the reference.
 
 ## Shell completions
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -66,7 +66,7 @@ listing is live, Glama re-reads that file for ownership/indexing hints.
 3. Submit:
    - **GitHub repository URL:** `https://github.com/patchloom/patchloom`
    - **Name / display name:** `patchloom`
-   - **Description:** short summary matching `server.json` / the README MCP line
+   - **Description:** match `server.json` (structured agent edits: JSON/YAML/TOML, markdown, AST, dry-run, batch/tx; not a generic filesystem MCP)
 4. Wait for automated checks (license, security scan, health test). Most
    submissions complete within minutes.
 5. Confirm search finds the listing, then optional check via the

--- a/docs/plans/mcp-surface-tiers.md
+++ b/docs/plans/mcp-surface-tiers.md
@@ -1,0 +1,28 @@
+# Design: MCP progressive disclosure / minimal tool pack (#1994)
+
+## Problem
+
+Full default inventory (~56 tools with AST) can overwhelm small agents (context tax on tool schemas). Competitors often ship tiny FS MCP servers.
+
+## Decision (v1 — document first, no default break)
+
+1. **Default remains full surface** (backward compatible).
+2. **Progressive disclosure via existing schema tiers** (`patchloom schema --tier weak|medium|strong`) for plan/prompt generation.
+3. **Agent-rules** lead with a decision table (which tool family for which task), not the full inventory first.
+4. **Future (not blocking):** optional env `PATCHLOOM_MCP_SURFACE=core|full` to register a subset at MCP handshake. Core candidate set (illustrative):
+   - `read_file`, `search_files`, `replace_text`, `batch_replace`
+   - `doc_get`, `doc_set`, `doc_query`
+   - `md_replace_section`, `execute_plan`, `server_info`
+   - AST off unless surface=full or feature-gated already
+
+## Non-goals
+
+- Removing tools without a flag
+- Cloud apply models
+- Changing registry MCP package name
+
+## Implementation status
+
+- Decision recorded here (#1994)
+- Agent-rules decision tree ships with competitive-docs batch
+- Code for `PATCHLOOM_MCP_SURFACE` deferred until a host requests it

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.patchloom/patchloom",
   "title": "Patchloom",
-  "description": "AI agent file editing via MCP: JSON/YAML/TOML, AST renames, markdown, batch.",
+  "description": "Structured file edits for AI agents: JSON/YAML/TOML by selector, markdown sections, AST renames, dry-run, batch/tx with undo. Not a generic filesystem MCP.",
   "repository": {
     "url": "https://github.com/patchloom/patchloom",
     "source": "github"

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -97,6 +97,32 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
          use `fs::rename` so multi-hardlinked sources keep their shared inode (#1739, #1746).\n\n",
     );
 
+    // Decision tree before full inventory (competitive research / agent routing).
+    out.push_str(
+        "## Which surface to use\n\n\
+         Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when \
+the edit is structured or multi-file. Prefer **ast-grep** (or similar) for \
+**structural code search / pattern codemods** when you need a syntax-tree pattern \
+DSL; use Patchloom for host-safe apply, configs, markdown, batch/tx/undo, and peels.\n\n\
+         | If the task is… | Prefer | Avoid |\n\
+         |---|---|---|\n\
+         | JSON/YAML/TOML key mutate | `doc set` / plan `doc.*` / MCP `doc_set` | regex replace on structured files |\n\
+         | Multi-document YAML | selector `0.key` or `[0].key` | bare key on stream root |\n\
+         | Markdown section/bullet/table | `md *` | whole-file rewrite |\n\
+         | Identifier rename in code | `ast rename` / `ast_rename_project` | fuzzy replace for symbols |\n\
+         | Find code by AST shape (pattern DSL) | ast-grep (or `ast search`) | blind text grep only |\n\
+         | Prose/typo in non-code text | `replace` (fuzzy last resort) | AST |\n\
+         | Multi-file atomic apply | `tx` / `batch` / `execute_plan` | sequential shell |\n\
+         | Host agent policy (Rust) | `ReplaceOptions::for_agent` + peels + `fuzzy_span_suspicious` | soft defaults |\n\n\
+         **Context budget:** prefer `read` with a line range, `search --count` / \
+`--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` \
+for large result streams. Binary sole paths peel `error_kind: binary`.\n\n\
+         **MCP tool volume:** the server may expose many tools; start from this table \
+(and `schema --tier weak|medium|strong` for plan prompts). Full inventory is power-user \
+default; hosts that need a smaller register set can track progressive surface design \
+(docs/plans/mcp-surface-tiers.md).\n\n",
+    );
+
     // When to use
     if show_mcp {
         out.push_str(
@@ -1239,6 +1265,13 @@ mod tests {
         assert!(
             out.contains("fuzzy_span_suspicious") && out.contains("FuzzySpanPolicy"),
             "library hosts need over-wide fuzzy refuse helper docs (#1981)"
+        );
+        assert!(
+            out.contains("Which surface to use")
+                && out.contains("ast-grep")
+                && out.contains("Context budget")
+                && out.contains("Multi-document YAML"),
+            "agent-rules need decision tree + ast-grep complement + context tips (#1992/#1993/#1996)"
         );
         assert!(
             out.contains("one-line override") || out.contains("allow_absent_old: true"),


### PR DESCRIPTION
## Summary

Implements competitive-research issues that need **no human marketplace login, no release merge, and no public posts**.

| Issue | Disposition |
|-------|-------------|
| #1988 | Comparisons page (FS MCP, yq, ast-grep, Morph) |
| #1989 | README positioning + when-to-use table |
| #1991 | Embedder host checklist (library; Bline-shaped) |
| #1992 | Agent-rules decision tree |
| #1993 | Context budget in concepts + agent-rules |
| #1995 | Morph vs Patchloom in comparisons |
| #1996 | ast-grep complement language |
| #1997 | GitHub description/homepage/topics (API) |
| #1998 | crates/docs host checklist + install links |
| #1987 | Partial: `server.json` description + REPO-SETUP re-publish checklist (Glama UI / secondary markets still human) |
| #1990 | Draft only: `docs/blog/community-launch-draft.md` (do not post until release) |
| #1994 | Design doc only: `docs/plans/mcp-surface-tiers.md` (no default inventory break) |

## Test plan

- [x] `cargo test --lib agent_rules`
- [x] `make sync-patchloom-md`
- [x] `make check-readme`

Closes #1988
Closes #1989
Closes #1991
Closes #1992
Closes #1993
Closes #1995
Closes #1996
Closes #1997
Closes #1998