### PR TITLE
fix(mcp): server.json description within Registry 100-char limit

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -148,8 +148,15 @@ jobs:
             | .packages |= map(.version = $v)
           ' server.json > server.json.tmp
           mv server.json.tmp server.json
-          echo "server.json version fields set to ${VERSION}:"
-          jq '{name, version, packages: [.packages[] | {registryType, identifier, version}]}' server.json
+          # Official registry rejects description longer than 100 chars (422).
+          desc_len=$(jq -r '.description | length' server.json)
+          if [ "$desc_len" -gt 100 ]; then
+            echo "server.json description is ${desc_len} chars; registry max is 100" >&2
+            jq -r '.description' server.json >&2
+            exit 1
+          fi
+          echo "server.json version fields set to ${VERSION} (description ${desc_len} chars):"
+          jq '{name, version, description, packages: [.packages[] | {registryType, identifier, version}]}' server.json
 
       - name: Install mcp-publisher
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke windows-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test chocolatey-package-test pack-mcpb pack-mcpb-test git-clean clean
+.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke windows-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test chocolatey-package-test pack-mcpb pack-mcpb-test server-json-test git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -39,9 +39,9 @@ pty-test: ## Run PTY-based interactive terminal tests (serial)
 clippy: ## Run clippy linter
 	cargo clippy --all-targets --all-features -- -D warnings
 
-check: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme ## Run all checks (full CI gate)
+check: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-patchloom-md check-readme server-json-test ## Run all checks (full CI gate)
 
-check-fast: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-readme ## Fast check (skips PATCHLOOM.md sync check only; includes README count + release notes)
+check-fast: fmt-check clippy test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test verify-release-notes audit-test-hygiene check-readme server-json-test ## Fast check (skips PATCHLOOM.md sync check only; includes README count + release notes)
 
 audit-test-hygiene: ## Audit test names/comments for staleness and weak assertions after refactors (addresses post-refactor tech debt)
 	@echo "=== Suspicious test names (same file, core, outdated concepts) ==="
@@ -75,6 +75,9 @@ pack-mcpb: ## Pack mcpb/ into target/mcpb/patchloom-<version>.mcpb (Smithery / d
 
 pack-mcpb-test: ## Unit tests for scripts/pack-mcpb.sh (VERSION override + pack stamp)
 	python3 scripts/test_pack_mcpb.py
+
+server-json-test: ## Lock server.json MCP Registry constraints (description ≤100 chars)
+	python3 scripts/test_server_json.py
 
 git-clean: ## Remove known temp files that pollute `git status` (e.g. .lycheecache). Addresses #736.
 	@rm -f .lycheecache

--- a/REPO-SETUP.md
+++ b/REPO-SETUP.md
@@ -22,7 +22,7 @@ This file captures the recommended day 1 policy setup for `patchloom/patchloom`,
 
 Keep directory copy aligned with the tagged version. Automated where possible:
 
-1. **MCP Registry** — runs from Release after crates/npm; on failure: Actions → **Publish MCP Registry** → version input. `server.json` description should stay differentiation-focused (structured agent edits, not generic filesystem); version field is stamped by the publish job.
+1. **MCP Registry** — runs from Release after crates/npm; on failure: Actions → **Publish MCP Registry** → version input. `server.json` description should stay differentiation-focused (structured agent edits, not generic filesystem) and **at most 100 characters** (registry schema hard limit; longer values fail validate with 422). Version field is stamped by the publish job.
 2. **Smithery** — `publish-smithery.yml` after Release when `SMITHERY_API_KEY` is set; manual: `make pack-mcpb && bash scripts/publish-smithery.sh`.
 3. **Glama** — no API publish; after listing exists, sync from GitHub + `glama.json`. If description drifts, update via Glama UI (human session). Suggested blurb: same as `server.json` description.
 4. **Secondary marketplaces** (mcp.so, mcpservers.org, PulseMCP, awesome lists) — re-check only when deliberately listing; not release-blocking.

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -66,7 +66,7 @@ listing is live, Glama re-reads that file for ownership/indexing hints.
 3. Submit:
    - **GitHub repository URL:** `https://github.com/patchloom/patchloom`
    - **Name / display name:** `patchloom`
-   - **Description:** match `server.json` (structured agent edits: JSON/YAML/TOML, markdown, AST, dry-run, batch/tx; not a generic filesystem MCP)
+   - **Description:** match `server.json` (registry max 100 chars; structured agent edits, not a generic filesystem MCP)
 4. Wait for automated checks (license, security scan, health test). Most
    submissions complete within minutes.
 5. Confirm search finds the listing, then optional check via the

--- a/scripts/test_server_json.py
+++ b/scripts/test_server_json.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Lock server.json constraints for MCP Registry publish."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER = ROOT / "server.json"
+# Official MCP Registry rejects body.description longer than this (HTTP 422).
+MAX_DESCRIPTION = 100
+
+
+def main() -> int:
+    data = json.loads(SERVER.read_text(encoding="utf-8"))
+    desc = data.get("description")
+    if not isinstance(desc, str) or not desc.strip():
+        print("server.json description must be a non-empty string", file=sys.stderr)
+        return 1
+    if len(desc) > MAX_DESCRIPTION:
+        print(
+            f"server.json description is {len(desc)} chars; "
+            f"MCP Registry max is {MAX_DESCRIPTION}",
+            file=sys.stderr,
+        )
+        print(desc, file=sys.stderr)
+        return 1
+    name = data.get("name")
+    if name != "io.github.patchloom/patchloom":
+        print(f"unexpected server.json name: {name!r}", file=sys.stderr)
+        return 1
+    print(f"ok: description {len(desc)}/{MAX_DESCRIPTION} chars")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.patchloom/patchloom",
   "title": "Patchloom",
-  "description": "Structured file edits for AI agents: JSON/YAML/TOML by selector, markdown sections, AST renames, dry-run, batch/tx with undo. Not a generic filesystem MCP.",
+  "description": "Agent-safe structured edits: JSON/YAML/TOML/md/AST, dry-run, batch/tx. Not a filesystem MCP.",
   "repository": {
     "url": "https://github.com/patchloom/patchloom",
     "source": "github"


### PR DESCRIPTION
## Summary

Official MCP Registry rejects `server.json` `description` longer than **100** characters (HTTP 422). The competitive-batch blurb was 155 chars, so re-publishing 0.20.0 with the differentiated text failed.

## Changes

- Shorten description (still: structured agent edits, not generic filesystem MCP)
- `make server-json-test` + wire into `make check` / `check-fast`
- Publish workflow pre-check before `mcp-publisher validate`
- REPO-SETUP + mcp-setup docs note the hard limit

## Verification

- `make server-json-test` → ok (92/100)
- After merge: re-dispatch **Publish MCP Registry** for `0.20.0`

Ref #1987