### PR TITLE
docs: document server-json-test gate and refresh patch deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,9 @@ The `cli` feature (clap + command implementations) is enabled by default. Use `d
 | `make test-library-hygiene` | Enforce pure-library embedder set: clippy + tests under `--no-default-features --features "ast,files"` (catches dead_code, hygiene for #800 #802) |
 | `make test-mcp-no-ast` | Lib tests with `mcp,cli,files` and no `ast` (MCP inventory/router/instructions honesty) |
 | `make clippy` | Run `cargo clippy --all-targets --all-features -- -D warnings` |
-| `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, test-mcp-no-ast, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme |
-| `make check-fast` | Fast check: same as `check` minus `check-patchloom-md` (still runs `check-readme` so test-count drift fails locally before CI) |
+| `make check` | Run fmt-check, clippy, test, test-no-default, test-ast-only, test-mcp-no-ast, test-library-hygiene, integration-test, pty-test, verify-release-notes, audit-test-hygiene, check-patchloom-md, check-readme, server-json-test |
+| `make check-fast` | Fast check: same as `check` minus `check-patchloom-md` (still runs `check-readme` and `server-json-test` so test-count and MCP Registry description drift fail locally before CI) |
+| `make server-json-test` | Lock `server.json` MCP Registry constraints (description ≤100 chars; part of `check`) |
 | `make update-readme` | Update README.md rounded test count (only changes when hundreds digit changes) |
 | `make check-readme` | Verify README.md rounded test count is accurate (part of `check`) |
 | `make sync-patchloom-md` | Regenerate PATCHLOOM.md from `patchloom agent-rules` output |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd patchloom
 make check
 ```
 
-`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast + library-hygiene), integration tests, PTY tests, release notes verification, test hygiene audit, and generated-doc freshness checks (`check-patchloom-md`, `check-readme`). While iterating locally, `make check-fast` is almost the same but skips only `check-patchloom-md` (still runs `check-readme` so a drifted README test badge fails before CI).
+`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast + library-hygiene), integration tests, PTY tests, release notes verification, test hygiene audit, generated-doc freshness checks (`check-patchloom-md`, `check-readme`), and `server-json-test` (MCP Registry `server.json` description ≤100 chars). While iterating locally, `make check-fast` is almost the same but skips only `check-patchloom-md` (still runs `check-readme` and `server-json-test`).
 
 ## Issues and triage
 
@@ -97,6 +97,7 @@ See the "Adding a new MCP tool" section in [AGENTS.md](./AGENTS.md).
 | `make audit-test-hygiene` | Stale test names or weak assertions after a refactor. Strengthen or rename tests, then re-run. |
 | `make check-patchloom-md` | The agent-rules output changed. Run `make sync-patchloom-md` to regenerate `PATCHLOOM.md`. |
 | `make check-readme` | Test counts drifted. Run `make update-readme` to refresh `README.md`. |
+| `make server-json-test` | `server.json` description exceeds MCP Registry max (100 chars) or name drift. Shorten the description and re-run. |
 
 ## License
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
+checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
 dependencies = [
  "clap",
 ]
@@ -2109,9 +2109,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -2123,14 +2123,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2200,13 +2200,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Patchloom is a single-binary CLI that gives AI coding agents safe, structured fi
 
 **Not a generic filesystem MCP.** Default MCP filesystem servers read/write files as text. Patchloom adds dry-run previews, parser-backed config and markdown edits, AST ops, multi-file `batch`/`tx` with undo, and stable `error_kind` peels for hosts. Full coding agents (Claude Code, Codex, Cursor) own the loop; Patchloom is the **tool layer** they (or a Rust embedder) call.
 
-![Patchloom demo: 6 edits across 4 files in JSON, YAML, and TOML — one command, comments preserved](demo/demo.gif)
+![Patchloom demo: 6 edits across 4 files in JSON, YAML, and TOML: one command, comments preserved](demo/demo.gif)
 
 ```bash
 # Edit a YAML value by selector without breaking comments or formatting
@@ -177,7 +177,7 @@ cargo install patchloom
 scoop bucket add patchloom https://github.com/patchloom/scoop-bucket
 scoop install patchloom/patchloom
 
-# Chocolatey (Windows; community feed — newer versions may lag moderation)
+# Chocolatey (Windows; community feed; newer versions may lag moderation)
 choco install patchloom
 ```
 

--- a/docs/blog/community-launch-draft.md
+++ b/docs/blog/community-launch-draft.md
@@ -1,4 +1,4 @@
-# Community launch pack (draft — do not post until a release ships)
+# Community launch pack (draft: do not post until a release ships)
 
 > **Status:** draft for maintainers. Post only after an explicit release tag / user-approved release PR merge. Do not publish stale version claims.
 

--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -4,11 +4,11 @@ For agent runtimes that **embed** Patchloom (not only shell out to the CLI). Pub
 
 ## Host checklist
 
-1. **Shared replace policy** — call `ReplaceOptions::for_agent()` on every primary and fallback replace path (`unique`, `require_change`, fuzzy at `AGENT_MIN_FUZZY_SCORE` 0.90, `allow_absent_old: false`).
-2. **Branch on peels** — use `edit_error_kind` / `error_kind_str` / bools (`is_no_match`, `is_binary`, `is_already_exists`, …). Do not treat all failures as one string.
-3. **After fuzzy Apply** — call `fuzzy_span_suspicious(old, matched_text, match_score)` (or `FuzzySpanPolicy`) before treating the write as trusted. Patchloom does **not** auto-refuse over-wide spans; the host must.
-4. **Containment** — for sandboxed agents, use `PathGuard` / workspace roots; do not let the model widen `--cwd` under CLI contain (#1832).
-5. **Undo** — after Apply, persist `EditResult.backup_session` if the host exposes undo.
+1. **Shared replace policy:** call `ReplaceOptions::for_agent()` on every primary and fallback replace path (`unique`, `require_change`, fuzzy at `AGENT_MIN_FUZZY_SCORE` 0.90, `allow_absent_old: false`).
+2. **Branch on peels:** use `edit_error_kind` / `error_kind_str` / bools (`is_no_match`, `is_binary`, `is_already_exists`, …). Do not treat all failures as one string.
+3. **After fuzzy Apply:** call `fuzzy_span_suspicious(old, matched_text, match_score)` (or `FuzzySpanPolicy`) before treating the write as trusted. Patchloom does **not** auto-refuse over-wide spans; the host must.
+4. **Containment:** for sandboxed agents, use `PathGuard` / workspace roots; do not let the model widen `--cwd` under CLI contain (#1832).
+5. **Undo:** after Apply, persist `EditResult.backup_session` if the host exposes undo.
 
 ## Minimal sketch
 
@@ -47,4 +47,4 @@ Approximate recovery stays an explicit override: `ReplaceOptions { allow_absent_
 
 - [Comparisons](comparisons.md) (Morph, filesystem MCP, yq, ast-grep)
 - [Library API table](../reference/README.md#library-api)
-- [Introduction — As a Rust library](../introduction.md#as-a-rust-library)
+- [Introduction: As a Rust library](../introduction.md#as-a-rust-library)

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -243,7 +243,7 @@ For any work involving more than one edit (especially on the same file or relate
 
 - One `execute_plan` call = atomic execution of a mixed plan (doc.set + md.replace_section + create + replace + ...).
 - Plans support `strict: true` (default) for full rollback on format/validate failures.
-- Plans can include `write_policy`, `format` steps, `validate` steps — same as CLI `tx`.
+- Plans can include `write_policy`, `format` steps, `validate` steps: same as CLI `tx`.
 
 Example inline plan (JSON):
 

--- a/docs/plans/mcp-surface-tiers.md
+++ b/docs/plans/mcp-surface-tiers.md
@@ -4,7 +4,7 @@
 
 Full default inventory (~56 tools with AST) can overwhelm small agents (context tax on tool schemas). Competitors often ship tiny FS MCP servers.
 
-## Decision (v1 — document first, no default break)
+## Decision (v1: document first, no default break)
 
 1. **Default remains full surface** (backward compatible).
 2. **Progressive disclosure via existing schema tiers** (`patchloom schema --tier weak|medium|strong`) for plan/prompt generation.


### PR DESCRIPTION
## Summary

MPI cycle after 0.21.0:

- Document `make server-json-test` in AGENTS.md and CONTRIBUTING.md (part of `check` / `check-fast` since #2000; docs lagged).
- Patch bumps: `clap_complete` 4.6.8, `schemars` 1.2.2.
- Replace em dashes in human-facing competitive/embedder docs and README alt text (project style rule).

## Gate

Open issues remaining are external/human only (#1990 post, #960 winget, #961 Chocolatey feed).

## Verification

- `make check-fast` green
- `make embedder-smoke` green
- `make server-json-test` ok