### PR TITLE
docs: minimal embedder host checklist for LLM agent hosts

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -65,6 +65,8 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 - `allow_absent_old`: only then apply fuzzy when exact `old` is not in the file (#1758). Default false (fail closed).
 Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"require_change":true}`
 
+**Library host checklist (#2009):** ordered onboarding for LLM agent hosts / embedders (primary + fallback replace, peels, multi-op honesty, pre-write span policy) lives in `docs/getting-started/embedder-host.md` (linked from README and crate docs).
+
 **Library `ReplaceOptions::for_agent` (#1965 / #2005):** Rust hosts with primary + fallback replace paths should call `ReplaceOptions::for_agent()` in **both** places (not hand-copy `ReplaceOptions { ... }` twice). Preset: `unique=true`, `require_change=true`, `fuzzy=true`, `min_fuzzy_score=Some(AGENT_MIN_FUZZY_SCORE)` (`0.90`), **`allow_absent_old=false`** (fail closed), **`refuse_suspicious_fuzzy=true`** (auto-refuse over-wide fuzzy as `EditErrorKind::FuzzySpanSuspicious` / `error_kind: fuzzy_span_suspicious`; peel with `api::is_fuzzy_span_suspicious`). Overrides via struct update: replace-all → `unique: false`; deliberate approximate recovery → `allow_absent_old: true`; raw fuzzy without span refuse → `refuse_suspicious_fuzzy: false`; word-boundary rename → `fuzzy: false`, `min_fuzzy_score: None`, `word_boundary: true`. `command_position` cannot combine with fuzzy/word_boundary/regex/whole_line (typed `invalid_input`). This is **not** a host-specific recovery policy; approximate rewrite of missing `old` stays an explicit opt-in.
 
 **Fuzzy defaults fail closed when exact old is absent (#1758):**

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ match api::replace_in_content("body", "missing", "x", &opts) {
     Ok(r) => println!("changed={}", r.changed),
     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::NoMatch)),
 }
-// After fuzzy Apply: refuse over-wide spans before trust (api::fuzzy_span_suspicious)
+// for_agent auto-refuses over-wide fuzzy; custom options use api::fuzzy_span_suspicious
 // Invalid options and bad regex peel InvalidInput (CLI/tx typed errors included)
 match api::replace_in_content("body", "", "x", &ReplaceOptions::default()) {
     Err(e) => assert_eq!(edit_error_kind(&e), Some(EditErrorKind::InvalidInput)),
@@ -342,7 +342,7 @@ let _text = api::load_text(Path::new("notes.md"))?;
 
 All API types are `Send + Sync`. Beyond the `api` module, utility modules are also public: `containment` (workspace path guarding), `exec` (shell command execution), `files` (file-walking, `load_text_strict`, binary detection), `backup` (`restore_path_from_latest_backup` for post-Apply validate/revert), and `write` (atomic file writes with policy transformations). Library users needing temp dirs (e.g. agents) can use `PathGuard::builder(cwd).allow_temp_directory()` (handles /tmp on macOS); see the `containment` and `api` module rustdocs. Multi-doc bare keys and wrong-root merges peel to `EditErrorKind::TypeError` via `edit_error_kind`. Create/rename dest-exists peels to `EditErrorKind::AlreadyExists` (or `api::is_already_exists` / `api::error_kind_str` for CLI-stable `"already_exists"` strings). Fine-grained kinds also have bool peels (`is_not_found`, `is_conflicts`, `is_changes_detected`, `is_type_error`, `is_format_failed`, `is_guard_rejected`, `is_invalid_input`, `is_no_match`, `is_ambiguous`) matching `edit_error_kind`.
 
-Replace fail-closed / shell-token options: CLI `replace --require-change` and `--command-position` (also plan/MCP fields and `ReplaceOptions` on the library). Agent hosts: `ReplaceOptions::for_agent()` plus `api::fuzzy_span_suspicious` after fuzzy Apply. Library-only AST mutators: `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Host checklist: [Embedder host](docs/getting-started/embedder-host.md). Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
+Replace fail-closed / shell-token options: CLI `replace --require-change` and `--command-position` (also plan/MCP fields and `ReplaceOptions` on the library). Agent hosts: `ReplaceOptions::for_agent()` on **primary and fallback** replace paths (auto span refuse); custom options still call `api::fuzzy_span_suspicious` / `FuzzySpanPolicy` after fuzzy Apply. Library-only AST mutators: `ast_rename` / `ast_replace_in_symbol` / `ast_rename_batch` (feature `ast` + `files`), and `FunctionSigEdit::parse_rust`. Ordered host onboarding: [Embedder host checklist](docs/getting-started/embedder-host.md) (#2009). Full surface: [docs.rs/patchloom](https://docs.rs/patchloom).
 
 ## Getting started
 
@@ -465,7 +465,7 @@ The YAML parser changes the value at the selector path. Comments, indentation, k
 
 Longer write-ups: [Comparisons](docs/getting-started/comparisons.md) · [Embedder host checklist](docs/getting-started/embedder-host.md) · [MCP setup](docs/getting-started/mcp-setup.md)
 
-**Library hosts:** `ReplaceOptions::for_agent()` (includes `refuse_suspicious_fuzzy`), peels via `edit_error_kind` / `is_*` / `is_fuzzy_span_suspicious`, multi-op `ContentEditsResult.op_honesty`. Custom options still use `api::fuzzy_span_suspicious` after fuzzy Apply.
+**Library hosts:** [Embedder host checklist](docs/getting-started/embedder-host.md) — dual-path `ReplaceOptions::for_agent()` (primary + fallback, includes `refuse_suspicious_fuzzy`), peels via `edit_error_kind` / `is_*` / `is_fuzzy_span_suspicious` with `#[non_exhaustive]` `_` arm, multi-op `ContentEditsResult.op_honesty`, plan/tx widest `matched_text`, optional `apply_content_edits_to_file_with_span_policy`. Custom options still use `api::fuzzy_span_suspicious` / `FuzzySpanPolicy` after fuzzy Apply.
 
 **Context budget:** line-range `read`, `search --count` / `--files-with-matches`, one `batch`/`tx`, `--jsonl` for large streams.
 

--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -1,49 +1,111 @@
 # Embedder host checklist (Rust library)
 
-For agent runtimes that **embed** Patchloom (not only shell out to the CLI). Public API surface: [docs.rs/patchloom](https://docs.rs/patchloom).
+For **LLM agent hosts / embedders** that call Patchloom as a library (not only
+shell out to the CLI). Public API: [docs.rs/patchloom](https://docs.rs/patchloom).
 
-## Host checklist
+This is the **one-screen** ordered checklist for a first host integration.
+Bline is a real embedder that dogfooded these steps; the checklist is host-generic.
 
-1. **Shared replace policy:** call `ReplaceOptions::for_agent()` on every primary and fallback replace path (`unique`, `require_change`, fuzzy at `AGENT_MIN_FUZZY_SCORE` 0.90, `allow_absent_old: false`, `refuse_suspicious_fuzzy: true`).
-2. **Branch on peels:** use `edit_error_kind` / `error_kind_str` / bools (`is_no_match`, `is_binary`, `is_already_exists`, `is_fuzzy_span_suspicious`, …). Keep a `_` arm (`EditErrorKind` is `#[non_exhaustive]`).
-3. **Over-wide fuzzy:** with `for_agent()`, refuse is automatic (`EditErrorKind::FuzzySpanSuspicious`). For custom options, call `fuzzy_span_suspicious(old, matched_text, match_score)` (or `FuzzySpanPolicy`) before trusting Apply.
-4. **Containment:** for sandboxed agents, use `PathGuard` / workspace roots; do not let the model widen `--cwd` under CLI contain (#1832).
-5. **Undo:** after Apply, persist `EditResult.backup_session` if the host exposes undo.
+## Minimal checklist
+
+1. **PathGuard** from the workspace root (and `allow_temp_directory` if the
+   agent writes under `/tmp`). Pass `Some(&guard)` into Apply writers.
+2. **Sole-path text load:** `api::load_text` / `load_text_strict` (or
+   `is_binary_file` preflight). Peel `Binary` / `InvalidEncoding` /
+   `is_load_text_strict_fail` instead of scraping English.
+3. **Dual-path replace (primary + fallback):** call
+   `ReplaceOptions::for_agent()` in **both** places. Do not hand-copy
+   `ReplaceOptions { ... }` twice (options drift is a common footgun).
+   Preset: `unique`, `require_change`, fuzzy at `AGENT_MIN_FUZZY_SCORE` (0.90),
+   `allow_absent_old: false`, `refuse_suspicious_fuzzy: true`.
+4. **Over-wide fuzzy:** with `for_agent()`, refuse is automatic
+   (`EditErrorKind::FuzzySpanSuspicious` / `is_fuzzy_span_suspicious`). For
+   custom options, call `fuzzy_span_suspicious(old, matched_text, score)` or
+   `fuzzy_span_suspicious_with_policy` + `FuzzySpanPolicy` before trusting Apply.
+5. **On `Err`:** branch with `edit_error_kind` / `error_kind_str` / `is_*`
+   peels. Keep a `_` arm: `EditErrorKind` is `#[non_exhaustive]`.
+6. **Apply writers:** prefer `api` file_* / `replace_text` /
+   `apply_content_edits_to_file` (hardlink preserve, `backup_session`). Persist
+   `EditResult.backup_session` if the host exposes undo.
+7. **Multi-op / multi-path honesty:**
+   - Buffer multi-op: `apply_content_edits` + **`ContentEditsResult.op_honesty`**
+     (per-replace `old` + `matched_text` + `match_score`; #2006).
+   - Plan/tx multi-path: top-level **widest** `matched_text` + **min** fuzzy
+     score (#2007); pair refuse with `changes[]` / plan `old`, not unpaired
+     rollup fields.
+   - Disk multi-op with a final gate:  
+     `apply_content_edits_to_file_with_span_policy(path, edits, mode, guard, Some(&FuzzySpanPolicy::default()))`  
+     refuses over-wide fuzzy **before** write/backup (#2008).
 
 ## Minimal sketch
 
 ```rust
 use patchloom::api::{
     replace_in_content, ReplaceOptions, edit_error_kind, EditErrorKind,
-    is_fuzzy_span_suspicious,
+    is_fuzzy_span_suspicious, ApplyMode, apply_content_edits_to_file_with_span_policy,
+    ContentEdit, FuzzySpanPolicy,
 };
+use patchloom::containment::PathGuard;
+use std::path::Path;
 
+// 1) Containment (optional but recommended for sandboxed agents)
+let guard = PathGuard::builder(std::env::current_dir()?).build()?;
+
+// 2–5) Dual-path replace: same for_agent() on primary AND fallback call sites
 let opts = ReplaceOptions::for_agent();
 match replace_in_content(content, old, new, &opts) {
-    Ok(r) => Ok(r), // refuse_suspicious_fuzzy already ran for fuzzy
+    Ok(r) => { /* refuse_suspicious_fuzzy already ran for fuzzy */ }
     Err(e) => {
         if is_fuzzy_span_suspicious(&e) {
             return Err(e); // over-wide fuzzy
         }
         match edit_error_kind(&e) {
-            Some(EditErrorKind::NoMatch) => Err(e), // agent retry or skip
-            Some(EditErrorKind::Binary) => Err(e),
-            _ => Err(e),
+            Some(EditErrorKind::NoMatch) => return Err(e),
+            Some(EditErrorKind::Binary) => return Err(e),
+            Some(_) | None => return Err(e), // non_exhaustive: keep _
         }
     }
 }
+
+// 6–7) Multi-op Apply with optional pre-write span policy
+let edits = [ContentEdit::Replace {
+    old: old.into(),
+    new: new.into(),
+    options: ReplaceOptions::for_agent(),
+}];
+let policy = FuzzySpanPolicy::default();
+let _ = apply_content_edits_to_file_with_span_policy(
+    Path::new("notes.txt"),
+    &edits,
+    ApplyMode::Apply,
+    Some(&guard),
+    Some(&policy),
+)?;
 ```
 
-Approximate recovery stays an explicit override: `ReplaceOptions { allow_absent_old: true, ..ReplaceOptions::for_agent() }` (not a second constructor; #1980). To keep approximate recovery without span auto-refuse: also set `refuse_suspicious_fuzzy: false`.
+Approximate recovery stays an explicit override:
 
-## Multi-op
+```rust
+ReplaceOptions {
+    allow_absent_old: true,
+    ..ReplaceOptions::for_agent()
+}
+```
 
-`apply_content_edits` rolls up the **widest** `matched_text` and the **minimum** fuzzy score independently (may be different ops). Prefer **`ContentEditsResult.op_honesty`**: each replace entry has `old`, `matched_text`, and `match_score` for correct refuse pairing (#2006). When each replace uses `for_agent()`, over-wide fuzzy fails inside that op (all-or-nothing batch).
+(not a second constructor; #1980). To keep approximate recovery without span
+auto-refuse: also set `refuse_suspicious_fuzzy: false`.
 
-Plan/tx multi-path top-level honesty matches that worst-case rollup (#2007). For disk multi-op with a final gate (hardlink/backup write path), use `apply_content_edits_to_file_with_span_policy(path, edits, mode, guard, Some(&FuzzySpanPolicy::default()))` so refuse happens **before** write (#2008).
+## Multi-op notes
+
+`apply_content_edits` rolls up the **widest** `matched_text` and the **minimum**
+fuzzy score independently (may be different ops). Prefer **`op_honesty`** for
+refuse pairing. When each replace uses `for_agent()`, over-wide fuzzy fails
+inside that op (all-or-nothing batch). Plan/tx multi-path top-level honesty
+matches that worst-case rollup (#2007).
 
 ## Related
 
 - [Comparisons](comparisons.md) (Morph, filesystem MCP, yq, ast-grep)
 - [Library API table](../reference/README.md#library-api)
 - [Introduction: As a Rust library](../introduction.md#as-a-rust-library)
+- Crate docs cookbook table in [docs.rs/patchloom](https://docs.rs/patchloom)

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -161,6 +161,9 @@ default; hosts that need a smaller register set can track progressive surface de
              - `allow_absent_old`: only then apply fuzzy when exact `old` is not in the file (#1758). Default false (fail closed).\n\
              Example: `{\"path\":\"install.sh\",\"old\":\"pip\",\"new\":\"uv\",\
              \"command_position\":true,\"require_change\":true}`\n\n\
+             **Library host checklist (#2009):** ordered onboarding for LLM agent hosts / embedders \
+(primary + fallback replace, peels, multi-op honesty, pre-write span policy) lives in \
+`docs/getting-started/embedder-host.md` (linked from README and crate docs).\n\n\
              **Library `ReplaceOptions::for_agent` (#1965 / #2005):** Rust hosts with primary + fallback \
 replace paths should call `ReplaceOptions::for_agent()` in **both** places (not hand-copy \
 `ReplaceOptions { ... }` twice). Preset: `unique=true`, `require_change=true`, `fuzzy=true`, \
@@ -1276,8 +1279,10 @@ mod tests {
                 && out.contains("refuse_suspicious_fuzzy")
                 && out.contains("op_honesty")
                 && out.contains("apply_content_edits_to_file_with_span_policy")
-                && out.contains("widest"),
-            "library hosts need over-wide fuzzy refuse + multi-op/tx rollup docs (#1981/#2006-#2008)"
+                && out.contains("widest")
+                && out.contains("embedder-host.md")
+                && out.contains("primary + fallback"),
+            "library hosts need over-wide fuzzy refuse + multi-op/tx rollup + checklist (#1981/#2006-#2009)"
         );
         assert!(
             out.contains("Which surface to use")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,10 @@
 //! | Over-wide fuzzy auto-refuse on `for_agent` | [`ReplaceOptions::refuse_suspicious_fuzzy`] / [`EditErrorKind::FuzzySpanSuspicious`] / [`api::is_fuzzy_span_suspicious`] (#2005) |
 //! | Custom over-wide fuzzy refuse | [`api::fuzzy_span_suspicious`] / [`FuzzySpanPolicy`] (#1981) |
 //! | Multi-op per-replace honesty | [`ContentEditsResult::op_honesty`] / [`ContentEditHonesty`] (#2006) |
+//! | Plan/tx multi-path worst-case span | [`prefer_widest_matched_text`] / top-level `matched_text` (#2007) |
+//! | File multi-op pre-write span refuse | [`apply_content_edits_to_file_with_span_policy`] + [`FuzzySpanPolicy`] (#2008) |
 //! | Sole-path load failed as binary/encoding/invalid_input | [`api::is_load_text_strict_fail`] (#1963) |
+//! | Ordered host onboarding (primary + fallback + peels + multi-op) | [Embedder host checklist](docs/getting-started/embedder-host.md) (#2009) |
 //!
 //! `EditErrorKind` is `#[non_exhaustive]`: always include a wildcard arm when matching.
 //!


### PR DESCRIPTION
## Summary

Closes **#2009**: one-screen ordered embedder checklist for first-time library hosts.

- Expand `docs/getting-started/embedder-host.md` (PathGuard, dual-path `for_agent`, peels, multi-op honesty, pre-write span policy)
- Link from README library hosts, crate cookbook table, agent-rules
- Phrase locks in agent-rules tests (`embedder-host.md`, primary + fallback)

## Gate notes

- Release PR **#2011** (0.22.0) open; not merged (needs user yes)
- #1990 / #960 / #961 remain external or human-facing

## Closes

Closes #2009