### PR TITLE
feat(mcp): PATCHLOOM_MCP_SURFACE=core|full progressive tool pack

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -26,7 +26,7 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 
 **Context budget:** prefer `read` with a line range, `search --count` / `--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` for large result streams. Binary sole paths peel `error_kind: binary`.
 
-**MCP tool volume:** the server may expose many tools; start from this table (and `schema --tier weak|medium|strong` for plan prompts). Full inventory is power-user default; hosts that need a smaller register set can track progressive surface design (docs/plans/mcp-surface-tiers.md).
+**MCP tool volume:** the server may expose many tools; start from this table (and `schema --tier weak|medium|strong` for plan prompts). Full inventory is the default. Small agents / tight context: set env `PATCHLOOM_MCP_SURFACE=core` so handshake registers only the minimal pack (`read_file`, `search_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info`). `PATCHLOOM_MCP_SURFACE=full` or unset keeps the full inventory. `server_info` reports `surface` and `tool_count`. See docs/plans/mcp-surface-tiers.md.
 
 ## Tool selection guide
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -268,6 +268,34 @@ Example inline plan (JSON):
 
 These semantics are also documented in the tool instructions returned by the MCP server and in `patchloom agent-rules --mode mcp`.
 
+## Tool surface (full vs core)
+
+By default the server registers the **full** tool inventory (registry + custom handlers, including AST when built with `ast`). Small agents that choke on large tool schemas can request a **minimal pack** at handshake:
+
+```bash
+export PATCHLOOM_MCP_SURFACE=core
+patchloom mcp-server
+```
+
+| Value | Effect |
+|-------|--------|
+| unset or `full` | Full inventory (default; backward compatible) |
+| `core` | Only: `read_file`, `search_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info` |
+| anything else | Server fails to start with a clear error |
+
+`server_info` includes `"surface": "core"|"full"` and `"tool_count"`. Invalid values are rejected (do not silently fall back).
+
+Example client env (Grok `config.toml`):
+
+```toml
+[mcp_servers.patchloom]
+command = "patchloom"
+args = ["mcp-server"]
+env = { PATCHLOOM_MCP_SURFACE = "core" }
+```
+
+Design notes: [mcp-surface-tiers.md](../plans/mcp-surface-tiers.md).
+
 ## Debugging and logging
 
 The MCP server can log every tool call to a JSONL file for debugging and performance analysis. Each line records the tool name, duration, and success/failure status.

--- a/docs/plans/mcp-surface-tiers.md
+++ b/docs/plans/mcp-surface-tiers.md
@@ -4,16 +4,24 @@
 
 Full default inventory (~56 tools with AST) can overwhelm small agents (context tax on tool schemas). Competitors often ship tiny FS MCP servers.
 
-## Decision (v1: document first, no default break)
+## Decision
 
 1. **Default remains full surface** (backward compatible).
 2. **Progressive disclosure via existing schema tiers** (`patchloom schema --tier weak|medium|strong`) for plan/prompt generation.
 3. **Agent-rules** lead with a decision table (which tool family for which task), not the full inventory first.
-4. **Future (not blocking):** optional env `PATCHLOOM_MCP_SURFACE=core|full` to register a subset at MCP handshake. Core candidate set (illustrative):
-   - `read_file`, `search_files`, `replace_text`, `batch_replace`
-   - `doc_get`, `doc_set`, `doc_query`
-   - `md_replace_section`, `execute_plan`, `server_info`
-   - AST off unless surface=full or feature-gated already
+4. **Env `PATCHLOOM_MCP_SURFACE=core|full`** registers a subset at MCP handshake (implemented).
+
+### Core pack (`PATCHLOOM_MCP_SURFACE=core`)
+
+Exactly these tools (AST off):
+
+- `read_file`, `search_files`, `replace_text`, `batch_replace`
+- `doc_get`, `doc_set`, `doc_query`
+- `md_replace_section`, `execute_plan`, `server_info`
+
+Defined in `src/cmd/mcp/surface.rs` as `CORE_MCP_TOOL_NAMES` / `McpSurface`.
+
+`server_info` reports `surface` and `tool_count`.
 
 ## Non-goals
 
@@ -23,6 +31,8 @@ Full default inventory (~56 tools with AST) can overwhelm small agents (context 
 
 ## Implementation status
 
-- Decision recorded here (#1994)
-- Agent-rules decision tree ships with competitive-docs batch
-- Code for `PATCHLOOM_MCP_SURFACE` deferred until a host requests it
+- [x] Design decision recorded
+- [x] Agent-rules decision table + `PATCHLOOM_MCP_SURFACE` docs
+- [x] `McpSurface` parse + filter on registry add / custom disable
+- [x] Unit + protocol tests for core list_tools and rejected full-only calls
+- [x] mcp-setup.md host configuration

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -118,9 +118,12 @@ DSL; use Patchloom for host-safe apply, configs, markdown, batch/tx/undo, and pe
 `--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` \
 for large result streams. Binary sole paths peel `error_kind: binary`.\n\n\
          **MCP tool volume:** the server may expose many tools; start from this table \
-(and `schema --tier weak|medium|strong` for plan prompts). Full inventory is power-user \
-default; hosts that need a smaller register set can track progressive surface design \
-(docs/plans/mcp-surface-tiers.md).\n\n",
+(and `schema --tier weak|medium|strong` for plan prompts). Full inventory is the default. \
+Small agents / tight context: set env `PATCHLOOM_MCP_SURFACE=core` so handshake registers \
+only the minimal pack (`read_file`, `search_files`, `replace_text`, `batch_replace`, \
+`doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info`). \
+`PATCHLOOM_MCP_SURFACE=full` or unset keeps the full inventory. `server_info` reports \
+`surface` and `tool_count`. See docs/plans/mcp-surface-tiers.md.\n\n",
     );
 
     // When to use
@@ -1290,6 +1293,13 @@ mod tests {
                 && out.contains("Context budget")
                 && out.contains("Multi-document YAML"),
             "agent-rules need decision tree + ast-grep complement + context tips (#1992/#1993/#1996)"
+        );
+        assert!(
+            out.contains("PATCHLOOM_MCP_SURFACE")
+                && out.contains("core")
+                && out.contains("read_file")
+                && out.contains("execute_plan"),
+            "agent-rules must document PATCHLOOM_MCP_SURFACE=core pack (#1994)"
         );
         assert!(
             out.contains("one-line override") || out.contains("allow_absent_old: true"),

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -765,7 +765,12 @@ impl PatchloomService {
         Parameters(_p): Parameters<EmptyParams>,
     ) -> Result<CallToolResult, McpError> {
         let cwd = self.cwd().to_string_lossy().to_string();
-        let info = serde_json::json!({ "cwd": cwd });
+        let info = serde_json::json!({
+            "cwd": cwd,
+            // Surface active at handshake (PATCHLOOM_MCP_SURFACE).
+            "surface": self.surface().as_str(),
+            "tool_count": self.surface().expected_tool_count(),
+        });
         let json = serde_json::to_string_pretty(&info)
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
         Ok(CallToolResult::success(vec![ContentBlock::text(json)]))

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -114,10 +114,28 @@ pub struct PatchloomService {
     /// Optional path for logging MCP tool calls as JSONL.
     /// Set via `--log <path>` or `PATCHLOOM_MCP_LOG` env var.
     call_log: Option<PathBuf>,
+    /// Active tool inventory (`PATCHLOOM_MCP_SURFACE`).
+    surface: surface::McpSurface,
 }
 
 impl PatchloomService {
+    /// Build a service using `PATCHLOOM_MCP_SURFACE` from the environment.
+    ///
+    /// Unset or `full` registers the full inventory. `core` registers only
+    /// [`surface::CORE_MCP_TOOL_NAMES`] (see `docs/plans/mcp-surface-tiers.md`).
     pub fn new(cwd: PathBuf, log_flag: Option<String>) -> anyhow::Result<Self> {
+        let surface = surface::McpSurface::from_env().map_err(|e| {
+            anyhow::Error::new(crate::exit::InvalidInputError { msg: e.to_string() })
+        })?;
+        Self::new_with_surface(cwd, log_flag, surface)
+    }
+
+    /// Build a service with an explicit surface (tests and hosts that inject config).
+    pub(crate) fn new_with_surface(
+        cwd: PathBuf,
+        log_flag: Option<String>,
+        surface: surface::McpSurface,
+    ) -> anyhow::Result<Self> {
         let path_guard = crate::containment::PathGuard::new(
             cwd.clone(),
             crate::containment::AbsolutePathPolicy::Reject,
@@ -137,6 +155,9 @@ impl PatchloomService {
         // its input schema from the corresponding Operation variant and uses
         // the generic `handle_simple_op` dispatcher.
         for meta in MCP_TOOL_REGISTRY {
+            if !surface.allows(meta.tool_name) {
+                continue;
+            }
             let mut schema = crate::schema::operation_variant_schema(meta.op_name)?;
             if meta.has_strict {
                 schema = inject_strict_into_schema(schema);
@@ -172,11 +193,32 @@ impl PatchloomService {
             ));
         }
 
+        // Hand-written tools are always built by #[tool_router]; drop any that
+        // are outside the active surface (core pack excludes most custom tools).
+        if surface != surface::McpSurface::Full {
+            let to_remove: Vec<String> = tool_router
+                .list_all()
+                .into_iter()
+                .map(|t| t.name.to_string())
+                .filter(|name| !surface.allows(name))
+                .collect();
+            for name in to_remove {
+                tool_router.remove_route(&name);
+            }
+        }
+
         Ok(Self {
             tool_router,
             path_guard,
             call_log,
+            surface,
         })
+    }
+
+    /// Active MCP tool surface (`full` or `core`).
+    #[must_use]
+    pub(crate) fn surface(&self) -> surface::McpSurface {
+        self.surface
     }
 
     /// Validate a path for both syntactic containment and symlink resolution.

--- a/src/cmd/mcp/surface.rs
+++ b/src/cmd/mcp/surface.rs
@@ -249,6 +249,98 @@ pub(super) fn custom_tool_names() -> impl Iterator<Item = &'static str> {
     custom_mcp_tools().map(|t| t.name)
 }
 
+// ---------------------------------------------------------------------------
+// Progressive surface (PATCHLOOM_MCP_SURFACE) — #1994
+// ---------------------------------------------------------------------------
+
+/// Env var hosts set for a smaller MCP register set at handshake.
+pub(super) const MCP_SURFACE_ENV: &str = "PATCHLOOM_MCP_SURFACE";
+
+/// Tools registered when [`McpSurface::Core`] is active.
+///
+/// Keep this list small and agent-default: read/search/replace, doc get/set/query,
+/// one markdown write, plans, and server metadata. AST stays full-only.
+///
+/// Documented in `docs/plans/mcp-surface-tiers.md` and agent-rules.
+pub(super) const CORE_MCP_TOOL_NAMES: &[&str] = &[
+    "read_file",
+    "search_files",
+    "replace_text",
+    "batch_replace",
+    "doc_get",
+    "doc_set",
+    "doc_query",
+    "md_replace_section",
+    "execute_plan",
+    "server_info",
+];
+
+/// Which tool inventory the MCP server registers.
+///
+/// Default is [`McpSurface::Full`] (backward compatible). Hosts that want a
+/// smaller schema for small agents set `PATCHLOOM_MCP_SURFACE=core`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum McpSurface {
+    /// All registry + custom tools for the build features (default).
+    #[default]
+    Full,
+    /// Minimal pack: [`CORE_MCP_TOOL_NAMES`] only (no AST).
+    Core,
+}
+
+impl McpSurface {
+    /// Parse `PATCHLOOM_MCP_SURFACE` (unset/`full` → Full, `core` → Core).
+    pub(super) fn from_env() -> anyhow::Result<Self> {
+        match std::env::var(MCP_SURFACE_ENV) {
+            Err(std::env::VarError::NotPresent) => Ok(Self::Full),
+            Err(e) => Err(anyhow::anyhow!("failed to read {MCP_SURFACE_ENV}: {e}")),
+            Ok(raw) => Self::parse(&raw),
+        }
+    }
+
+    /// Parse a surface string (case-insensitive). Empty means full.
+    pub(super) fn parse(raw: &str) -> anyhow::Result<Self> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "" | "full" => Ok(Self::Full),
+            "core" => Ok(Self::Core),
+            other => Err(anyhow::anyhow!(
+                "invalid {MCP_SURFACE_ENV}={other:?}; expected \"core\" or \"full\""
+            )),
+        }
+    }
+
+    /// Wire / server_info string value.
+    #[must_use]
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Core => "core",
+        }
+    }
+
+    /// Whether `tool_name` is registered on this surface.
+    #[must_use]
+    pub(super) fn allows(self, tool_name: &str) -> bool {
+        match self {
+            Self::Full => true,
+            Self::Core => CORE_MCP_TOOL_NAMES.contains(&tool_name),
+        }
+    }
+
+    /// Expected `list_tools` count for this surface under current features.
+    #[must_use]
+    pub(super) fn expected_tool_count(self) -> usize {
+        match self {
+            Self::Full => {
+                let registry_n = super::registry::MCP_TOOL_REGISTRY.len();
+                let custom_n = custom_mcp_tools().count();
+                registry_n + custom_n
+            }
+            Self::Core => CORE_MCP_TOOL_NAMES.len(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::registry::MCP_TOOL_REGISTRY;
@@ -317,5 +409,64 @@ mod tests {
         } else {
             assert!(!names.iter().any(|n| n.starts_with("ast_")));
         }
+    }
+
+    #[test]
+    fn mcp_surface_parse_core_full_and_reject_unknown() {
+        assert_eq!(McpSurface::parse("").unwrap(), McpSurface::Full);
+        assert_eq!(McpSurface::parse("full").unwrap(), McpSurface::Full);
+        assert_eq!(McpSurface::parse("FULL").unwrap(), McpSurface::Full);
+        assert_eq!(McpSurface::parse("core").unwrap(), McpSurface::Core);
+        assert_eq!(McpSurface::parse(" Core ").unwrap(), McpSurface::Core);
+        let err = McpSurface::parse("minimal").unwrap_err().to_string();
+        assert!(
+            err.contains(MCP_SURFACE_ENV) && err.contains("core"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn core_mcp_tool_names_are_unique_and_exist_in_full_inventory() {
+        let mut seen = BTreeSet::new();
+        for name in CORE_MCP_TOOL_NAMES {
+            assert!(seen.insert(*name), "duplicate core tool: {name}");
+        }
+        let registry: BTreeSet<_> = MCP_TOOL_REGISTRY.iter().map(|t| t.tool_name).collect();
+        let custom: BTreeSet<_> = custom_tool_names().collect();
+        for name in CORE_MCP_TOOL_NAMES {
+            assert!(
+                registry.contains(name) || custom.contains(name),
+                "core tool {name} missing from registry and custom inventory"
+            );
+            // Core must not depend on AST-only tools.
+            assert!(
+                !name.starts_with("ast_"),
+                "core surface must not include AST tool {name}"
+            );
+        }
+        assert_eq!(
+            McpSurface::Core.expected_tool_count(),
+            CORE_MCP_TOOL_NAMES.len()
+        );
+        assert_eq!(
+            McpSurface::Full.expected_tool_count(),
+            MCP_TOOL_REGISTRY.len() + custom_mcp_tools().count()
+        );
+        // Sanity: core is much smaller than full with default features.
+        assert!(
+            McpSurface::Core.expected_tool_count() < McpSurface::Full.expected_tool_count(),
+            "core pack must be a strict subset of full"
+        );
+    }
+
+    #[test]
+    fn core_surface_allows_only_core_names() {
+        assert!(McpSurface::Core.allows("doc_set"));
+        assert!(McpSurface::Core.allows("server_info"));
+        assert!(!McpSurface::Core.allows("doc_diff"));
+        assert!(!McpSurface::Core.allows("ast_list"));
+        assert!(!McpSurface::Core.allows("create_file"));
+        assert!(McpSurface::Full.allows("ast_list"));
+        assert!(McpSurface::Full.allows("create_file"));
     }
 }

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -7,8 +7,16 @@ use rmcp::ServiceExt;
 async fn spawn_test_client(
     cwd: std::path::PathBuf,
 ) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
+    spawn_test_client_with_surface(cwd, surface::McpSurface::Full).await
+}
+
+/// Spawn with an explicit MCP surface (avoids env races in parallel tests).
+async fn spawn_test_client_with_surface(
+    cwd: std::path::PathBuf,
+    surface: surface::McpSurface,
+) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
     let (server_transport, client_transport) = tokio::io::duplex(16384);
-    let service = PatchloomService::new(cwd, None).unwrap();
+    let service = PatchloomService::new_with_surface(cwd, None, surface).unwrap();
     tokio::spawn(async move {
         let server = service.serve(server_transport).await.unwrap();
         server.waiting().await.unwrap();
@@ -1006,6 +1014,25 @@ mod server_info_tests {
     }
 
     #[tokio::test]
+    async fn server_info_reports_full_surface_by_default() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client = spawn_test_client(dir.path().to_path_buf()).await;
+        let params = rmcp::model::CallToolRequestParams::new("server_info");
+        let result = client.peer().call_tool(params).await.unwrap();
+        let text = match result.content.first().unwrap() {
+            rmcp::model::ContentBlock::Text(t) => &t.text,
+            _ => panic!("expected text"),
+        };
+        let info: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(info["surface"], "full");
+        assert_eq!(
+            info["tool_count"].as_u64().unwrap() as usize,
+            surface::McpSurface::Full.expected_tool_count()
+        );
+        client.cancel().await.unwrap();
+    }
+
+    #[tokio::test]
     async fn server_info_handles_unicode_path() {
         let base = tempfile::TempDir::new().unwrap();
         let unicode_dir = base.path().join("проект_工作区");
@@ -1034,6 +1061,89 @@ mod server_info_tests {
             "cwd should preserve unicode characters"
         );
         client.cancel().await.unwrap();
+    }
+}
+
+// --- PATCHLOOM_MCP_SURFACE=core (#1994) ---
+
+mod surface_core_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn core_surface_lists_only_core_tools() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client =
+            spawn_test_client_with_surface(dir.path().to_path_buf(), surface::McpSurface::Core)
+                .await;
+        let tools = client.peer().list_all_tools().await.unwrap();
+        let names: std::collections::BTreeSet<_> =
+            tools.iter().map(|t| t.name.as_ref().to_string()).collect();
+        let expected: std::collections::BTreeSet<_> = surface::CORE_MCP_TOOL_NAMES
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        assert_eq!(
+            names, expected,
+            "core list_tools must equal CORE_MCP_TOOL_NAMES"
+        );
+        assert_eq!(names.len(), surface::McpSurface::Core.expected_tool_count());
+        // Full-only tools must be absent.
+        assert!(!names.contains("create_file"));
+        assert!(!names.contains("doc_diff"));
+        assert!(!names.contains("ast_list"));
+        assert!(!names.contains("batch_tidy"));
+        client.cancel().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn core_surface_server_info_reports_core() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client =
+            spawn_test_client_with_surface(dir.path().to_path_buf(), surface::McpSurface::Core)
+                .await;
+        let params = rmcp::model::CallToolRequestParams::new("server_info");
+        let result = client.peer().call_tool(params).await.unwrap();
+        let text = match result.content.first().unwrap() {
+            rmcp::model::ContentBlock::Text(t) => &t.text,
+            _ => panic!("expected text"),
+        };
+        let info: serde_json::Value = serde_json::from_str(text).unwrap();
+        assert_eq!(info["surface"], "core");
+        assert_eq!(
+            info["tool_count"].as_u64().unwrap() as usize,
+            surface::CORE_MCP_TOOL_NAMES.len()
+        );
+        client.cancel().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn core_surface_rejects_full_only_tool_call() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client =
+            spawn_test_client_with_surface(dir.path().to_path_buf(), surface::McpSurface::Core)
+                .await;
+        let params = rmcp::model::CallToolRequestParams::new("create_file");
+        let err = client
+            .peer()
+            .call_tool(params)
+            .await
+            .expect_err("create_file must not be callable on core surface");
+        let msg = err.to_string();
+        assert!(
+            msg.to_lowercase().contains("create_file")
+                || msg.to_lowercase().contains("not found")
+                || msg.to_lowercase().contains("unknown")
+                || msg.to_lowercase().contains("disabled"),
+            "unexpected error: {msg}"
+        );
+        client.cancel().await.unwrap();
+    }
+
+    #[test]
+    fn invalid_surface_env_is_invalid_input() {
+        // Parse path (no env mutation): invalid values fail closed.
+        let err = surface::McpSurface::parse("tiny").unwrap_err().to_string();
+        assert!(err.contains("PATCHLOOM_MCP_SURFACE"));
     }
 }
 


### PR DESCRIPTION
## Summary

Implements progressive MCP tool disclosure from `docs/plans/mcp-surface-tiers.md` (#1994 design).

| Env | Tools |
|-----|--------|
| unset / `full` | Full inventory (~56 with AST) — **default** |
| `core` | `read_file`, `search_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info` |
| other | Server start fails with clear error |

`server_info` returns `surface` and `tool_count`.

## Tests

- Unit: parse core/full/invalid; core names unique and present in inventory
- Protocol: core list_tools exact set; create_file rejected; server_info surface field
- Full list_tools regression still passes
- `make check-fast` green

## Docs

- agent-rules / PATCHLOOM.md
- docs/getting-started/mcp-setup.md
- docs/plans/mcp-surface-tiers.md marked implemented

## Closes

Implements deferred code from closed design issue #1994 (no reopen required).