### PR TITLE
fix(mcp): surface-aware handshake instructions for core pack

### DIFF
--- a/docs/plans/mcp-surface-tiers.md
+++ b/docs/plans/mcp-surface-tiers.md
@@ -23,6 +23,10 @@ Defined in `src/cmd/mcp/surface.rs` as `CORE_MCP_TOOL_NAMES` / `McpSurface`.
 
 `server_info` reports `surface` and `tool_count`.
 
+Handshake `instructions` (MCP `ServerInfo`) are surface-aware: core mode lists
+only the core tools and names `PATCHLOOM_MCP_SURFACE=core`, so agents do not
+chase full-inventory tool names that are not registered.
+
 ## Non-goals
 
 - Removing tools without a flag
@@ -35,4 +39,5 @@ Defined in `src/cmd/mcp/surface.rs` as `CORE_MCP_TOOL_NAMES` / `McpSurface`.
 - [x] Agent-rules decision table + `PATCHLOOM_MCP_SURFACE` docs
 - [x] `McpSurface` parse + filter on registry add / custom disable
 - [x] Unit + protocol tests for core list_tools and rejected full-only calls
+- [x] Surface-aware handshake `instructions` (core does not advertise full-only tools)
 - [x] mcp-setup.md host configuration

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -1145,6 +1145,84 @@ mod surface_core_tests {
         let err = surface::McpSurface::parse("tiny").unwrap_err().to_string();
         assert!(err.contains("PATCHLOOM_MCP_SURFACE"));
     }
+
+    /// Core handshake instructions must only name tools in CORE_MCP_TOOL_NAMES.
+    #[test]
+    fn core_server_instructions_list_only_core_tools() {
+        let text = super::super::transport::server_instructions(surface::McpSurface::Core);
+        for name in surface::CORE_MCP_TOOL_NAMES {
+            assert!(
+                text.contains(name),
+                "core instructions must mention registered tool {name}"
+            );
+        }
+        // Full-only tools must not appear (agent would try them and fail).
+        for banned in [
+            "create_file",
+            "delete_file",
+            "doc_diff",
+            "doc_merge",
+            "batch_tidy",
+            "apply_patch",
+            "ast_list",
+            "git_status",
+            "File ops",
+            "AST ops",
+            "md_upsert_bullet",
+        ] {
+            assert!(
+                !text.contains(banned),
+                "core instructions must not advertise full-only {banned:?}"
+            );
+        }
+        assert!(
+            text.contains("PATCHLOOM_MCP_SURFACE=core"),
+            "core instructions should name the env mode"
+        );
+    }
+
+    /// Full instructions keep the category guide (#1273) and still list non-core tools.
+    #[test]
+    fn full_server_instructions_include_full_inventory_hints() {
+        let text = super::super::transport::server_instructions(surface::McpSurface::Full);
+        assert!(text.contains("Document ops"));
+        assert!(text.contains("create_file"));
+        assert!(text.contains("doc_set"));
+        assert!(!text.contains("PATCHLOOM_MCP_SURFACE=core"));
+    }
+
+    /// Protocol: peer_info.instructions for a core service matches unit helper.
+    #[tokio::test]
+    async fn core_surface_handshake_instructions_are_core_only() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let client =
+            spawn_test_client_with_surface(dir.path().to_path_buf(), surface::McpSurface::Core)
+                .await;
+        let info = client.peer_info().expect("peer info should be set");
+        let instructions = info
+            .instructions
+            .as_deref()
+            .expect("server should have instructions");
+        assert!(
+            instructions.contains("PATCHLOOM_MCP_SURFACE=core"),
+            "handshake must advertise core mode"
+        );
+        assert!(
+            !instructions.contains("create_file"),
+            "core handshake must not list create_file"
+        );
+        assert!(
+            !instructions.contains("ast_list"),
+            "core handshake must not list ast_list"
+        );
+        for name in ["doc_set", "execute_plan", "read_file", "server_info"] {
+            assert!(
+                instructions.contains(name),
+                "core handshake must mention {name}"
+            );
+        }
+        client.cancel().await.unwrap();
+    }
 }
 
 // --- #1270: no_results returns isError: false ---

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -41,7 +41,7 @@ fn core_server_instructions() -> String {
          - md_replace_section: replace a markdown heading section\n\
          - execute_plan: multi-op atomic plans (tx)\n\
          - server_info: cwd, surface, tool_count\n\n\
-         Use doc_* for structured config; replace_text only where structure does not matter.",
+         Use doc_get/doc_set/doc_query for structured config; replace_text only where structure does not matter.",
     )
 }
 

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -11,9 +11,42 @@ use rmcp::{ServerHandler, ServiceExt};
 use crate::cli::global::GlobalFlags;
 
 use super::PatchloomService;
+use super::surface::McpSurface;
 
-/// Server instructions for agents; AST category omitted when `ast` is disabled.
-fn server_instructions() -> String {
+/// Server instructions for agents.
+///
+/// Must match the active [`McpSurface`]: core mode must not advertise tools
+/// that were not registered at handshake (#1994 honesty / review follow-up).
+/// AST category is also omitted when the `ast` feature is disabled (full only).
+pub(super) fn server_instructions(surface: McpSurface) -> String {
+    match surface {
+        McpSurface::Core => core_server_instructions(),
+        McpSurface::Full => full_server_instructions(),
+    }
+}
+
+/// Instructions when `PATCHLOOM_MCP_SURFACE=core` (exactly [`super::surface::CORE_MCP_TOOL_NAMES`]).
+fn core_server_instructions() -> String {
+    String::from(
+        "This server is running with PATCHLOOM_MCP_SURFACE=core (minimal tool pack). \
+         Only the tools below are registered; do not call others. Restart with \
+         PATCHLOOM_MCP_SURFACE=full (or unset) for the full inventory.\n\n\
+         Prefer 'execute_plan' for multi-op or multi-file work (atomicity). \
+         Per-call success does not guarantee combined success if you issue \
+         conflicting parallel writes.\n\n\
+         Core tools:\n\
+         - read_file, search_files: inspect and find content\n\
+         - replace_text, batch_replace: literal/regex text edits\n\
+         - doc_get, doc_set, doc_query: parser-backed JSON/YAML/TOML by selector path\n\
+         - md_replace_section: replace a markdown heading section\n\
+         - execute_plan: multi-op atomic plans (tx)\n\
+         - server_info: cwd, surface, tool_count\n\n\
+         Use doc_* for structured config; replace_text only where structure does not matter.",
+    )
+}
+
+/// Full-inventory instructions; AST category omitted when `ast` is disabled.
+fn full_server_instructions() -> String {
     let mut s = String::from(
         "Use these tools for ALL file operations. Prefer 'execute_plan' (or tx plans) \
          for any multi-op or multi-file work to ensure atomicity and avoid races from \
@@ -53,7 +86,7 @@ fn server_instructions() -> String {
 impl ServerHandler for PatchloomService {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_instructions(server_instructions());
+            .with_instructions(server_instructions(self.surface()));
         info.server_info.name = "patchloom".into();
         info.server_info.version = env!("CARGO_PKG_VERSION").into();
         info


### PR DESCRIPTION
## Summary

When `PATCHLOOM_MCP_SURFACE=core`, MCP handshake `ServerInfo.instructions` previously still listed the full tool inventory (create_file, AST ops, batch_tidy, …). Agents follow those names and get unknown-tool errors.

This makes instructions match the registered surface:

- **core:** only the 10 core tools + note that the pack is minimal
- **full:** unchanged category guide (#1273), including AST when the feature is on

## Test plan

- [x] `cargo test --lib --all-features surface_core_tests`
- [x] `cargo test --lib --features "mcp,cli,files" --no-default-features surface_core_tests`
- [x] `mcp_instructions_contain_tool_categories` (full path)
- [x] `make check-fast`
- [ ] CI green on this PR

## Related

Ref #1994 (surface design; already closed)
Follow-up to #2015 reviewer soft finding (surface-aware server_instructions)