### PR TITLE
test(mcp): core surface env integration + honesty docs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -26,7 +26,7 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 
 **Context budget:** prefer `read` with a line range, `search --count` / `--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` for large result streams. Binary sole paths peel `error_kind: binary`.
 
-**MCP tool volume:** the server may expose many tools; start from this table (and `schema --tier weak|medium|strong` for plan prompts). Full inventory is the default. Small agents / tight context: set env `PATCHLOOM_MCP_SURFACE=core` so handshake registers only the minimal pack (`read_file`, `search_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info`). `PATCHLOOM_MCP_SURFACE=full` or unset keeps the full inventory. `server_info` reports `surface` and `tool_count`. See docs/plans/mcp-surface-tiers.md.
+**MCP tool volume:** the server may expose many tools; start from this table (and `schema --tier weak|medium|strong` for plan prompts). Full inventory is the default. Small agents / tight context: set env `PATCHLOOM_MCP_SURFACE=core` so handshake registers only the minimal pack (`read_file`, `search_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info`). `PATCHLOOM_MCP_SURFACE=full` or unset keeps the full inventory. `server_info` reports `surface` and `tool_count`. Handshake instructions are surface-aware (core does not list full-only tool names). `execute_plan` on core can still run full plan ops; the env reduces tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.
 
 ## Tool selection guide
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ patchloom mcp-server
 
 MCP-capable agents call patchloom tools directly as structured JSON, with no shell quoting or command construction. The agent sends `{"path": "config.json", "selector": "version", "value": "2.0"}` instead of building `patchloom doc set config.json version '"2.0"' --apply`.
 
-See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent configuration and the full security model.
+Small agents that choke on large tool schemas can set `PATCHLOOM_MCP_SURFACE=core` for a 10-tool pack at handshake (default remains full inventory). See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent configuration, surface options, and the full security model.
 
 > **Using VS Code, Cursor, or Windsurf?** The [Patchloom extension](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom) handles setup automatically: it installs the binary, runs init, and configures your editor's MCP settings.
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -285,6 +285,10 @@ patchloom mcp-server
 
 `server_info` includes `"surface": "core"|"full"` and `"tool_count"`. Invalid values are rejected (do not silently fall back).
 
+Handshake `instructions` match the active surface: core mode lists only the core tools (it does not advertise full-inventory names such as `create_file` or `ast_*`).
+
+**Note:** `execute_plan` remains on core, so multi-op plans can still run create/delete/AST-style plan ops when the host sends a full plan. The env flag reduces the *tool schema* surface for small agents; it is not a capability sandbox for the plan catalog.
+
 Example client env (Grok `config.toml`):
 
 ```toml

--- a/docs/plans/mcp-surface-tiers.md
+++ b/docs/plans/mcp-surface-tiers.md
@@ -27,6 +27,11 @@ Handshake `instructions` (MCP `ServerInfo`) are surface-aware: core mode lists
 only the core tools and names `PATCHLOOM_MCP_SURFACE=core`, so agents do not
 chase full-inventory tool names that are not registered.
 
+`execute_plan` stays in the core pack so multi-op atomicity still works. Plan
+ops are not filtered by surface: a host can still send `file.create` inside a
+plan. The env flag is a **tool schema** progressive disclosure, not a plan
+capability sandbox.
+
 ## Non-goals
 
 - Removing tools without a flag

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -123,7 +123,9 @@ Small agents / tight context: set env `PATCHLOOM_MCP_SURFACE=core` so handshake 
 only the minimal pack (`read_file`, `search_files`, `replace_text`, `batch_replace`, \
 `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info`). \
 `PATCHLOOM_MCP_SURFACE=full` or unset keeps the full inventory. `server_info` reports \
-`surface` and `tool_count`. See docs/plans/mcp-surface-tiers.md.\n\n",
+`surface` and `tool_count`. Handshake instructions are surface-aware (core does not list \
+full-only tool names). `execute_plan` on core can still run full plan ops; the env reduces \
+tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.\n\n",
     );
 
     // When to use
@@ -1298,8 +1300,10 @@ mod tests {
             out.contains("PATCHLOOM_MCP_SURFACE")
                 && out.contains("core")
                 && out.contains("read_file")
-                && out.contains("execute_plan"),
-            "agent-rules must document PATCHLOOM_MCP_SURFACE=core pack (#1994)"
+                && out.contains("execute_plan")
+                && out.contains("surface-aware")
+                && out.contains("plan catalog"),
+            "agent-rules must document PATCHLOOM_MCP_SURFACE=core pack + honesty (#1994)"
         );
         assert!(
             out.contains("one-line override") || out.contains("allow_absent_old: true"),

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -1191,7 +1191,7 @@ mod surface_core_tests {
         assert!(!text.contains("PATCHLOOM_MCP_SURFACE=core"));
     }
 
-    /// Protocol: peer_info.instructions for a core service matches unit helper.
+    /// Protocol: peer_info.instructions equals `server_instructions(Core)` (no drift).
     #[tokio::test]
     async fn core_surface_handshake_instructions_are_core_only() {
         let dir = tempfile::TempDir::new().unwrap();
@@ -1203,24 +1203,15 @@ mod surface_core_tests {
             .instructions
             .as_deref()
             .expect("server should have instructions");
-        assert!(
-            instructions.contains("PATCHLOOM_MCP_SURFACE=core"),
-            "handshake must advertise core mode"
+        let expected = super::super::transport::server_instructions(surface::McpSurface::Core);
+        assert_eq!(
+            instructions, expected,
+            "handshake instructions must match server_instructions(Core) exactly"
         );
         assert!(
             !instructions.contains("create_file"),
             "core handshake must not list create_file"
         );
-        assert!(
-            !instructions.contains("ast_list"),
-            "core handshake must not list ast_list"
-        );
-        for name in ["doc_set", "execute_plan", "read_file", "server_info"] {
-            assert!(
-                instructions.contains(name),
-                "core handshake must mention {name}"
-            );
-        }
         client.cancel().await.unwrap();
     }
 }

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -621,12 +621,24 @@ fn has_mcp_http_support() -> bool {
 
 /// Spawn `patchloom mcp-server` in a tempdir and return a connected MCP client.
 async fn spawn_mcp_client(cwd: &Path) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
+    spawn_mcp_client_with_env(cwd, &[]).await
+}
+
+/// Like [`spawn_mcp_client`], but sets extra environment variables on the child
+/// (e.g. `PATCHLOOM_MCP_SURFACE=core`). Isolated per-process; safe for parallel tests.
+async fn spawn_mcp_client_with_env(
+    cwd: &Path,
+    env: &[(&str, &str)],
+) -> rmcp::service::RunningService<rmcp::RoleClient, ()> {
     use rmcp::ServiceExt;
     use rmcp::transport::TokioChildProcess;
 
     let bin = assert_cmd::cargo::cargo_bin("patchloom");
     let mut cmd = tokio::process::Command::new(bin);
     cmd.arg("mcp-server").current_dir(cwd);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
 
     let transport = TokioChildProcess::new(cmd).expect("failed to spawn patchloom mcp-server");
     ().serve(transport)

--- a/tests/integration/mcp_tests.rs
+++ b/tests/integration/mcp_tests.rs
@@ -7,6 +7,92 @@ fn test_mcp_setup_documents_search_files_modes() {
 }
 
 #[test]
+fn test_mcp_setup_documents_surface_core_honesty() {
+    let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
+    assert!(
+        doc.contains("PATCHLOOM_MCP_SURFACE"),
+        "mcp-setup must document surface env"
+    );
+    assert!(
+        doc.contains("match the active surface"),
+        "mcp-setup must document surface-aware instructions"
+    );
+    assert!(
+        doc.contains("not a capability sandbox for the plan catalog"),
+        "mcp-setup must clarify execute_plan is not sandboxed by core surface"
+    );
+}
+
+/// Invalid `PATCHLOOM_MCP_SURFACE` must fail closed at process start (#1994).
+#[cfg(feature = "mcp")]
+#[test]
+fn test_mcp_surface_invalid_env_fails_closed() {
+    if !has_mcp_support() {
+        return;
+    }
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["mcp-server"])
+        .env("PATCHLOOM_MCP_SURFACE", "tiny")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains("PATCHLOOM_MCP_SURFACE"));
+}
+
+/// Subprocess path: `from_env` + list_tools (unit tests inject surface without env).
+#[cfg(feature = "mcp")]
+#[tokio::test]
+async fn test_mcp_surface_core_env_lists_ten_tools() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let client = spawn_mcp_client_with_env(dir.path(), &[("PATCHLOOM_MCP_SURFACE", "core")]).await;
+    let tools = client.peer().list_all_tools().await.unwrap();
+    let names: std::collections::BTreeSet<_> =
+        tools.iter().map(|t| t.name.as_ref().to_string()).collect();
+    assert_eq!(names.len(), 10, "core pack is 10 tools, got {names:?}");
+    for required in [
+        "read_file",
+        "search_files",
+        "replace_text",
+        "batch_replace",
+        "doc_get",
+        "doc_set",
+        "doc_query",
+        "md_replace_section",
+        "execute_plan",
+        "server_info",
+    ] {
+        assert!(names.contains(required), "missing core tool {required}");
+    }
+    assert!(!names.contains("create_file"));
+    assert!(!names.contains("ast_list"));
+
+    let info = client.peer_info().expect("peer info");
+    let instructions = info.instructions.as_deref().unwrap_or("");
+    assert!(
+        instructions.contains("PATCHLOOM_MCP_SURFACE=core"),
+        "handshake instructions must name core surface"
+    );
+    assert!(
+        !instructions.contains("create_file"),
+        "core instructions must not advertise create_file"
+    );
+
+    let params = rmcp::model::CallToolRequestParams::new("server_info");
+    let result = client.peer().call_tool(params).await.unwrap();
+    let text = match result.content.first().unwrap() {
+        rmcp::model::ContentBlock::Text(t) => &t.text,
+        _ => panic!("expected text"),
+    };
+    let v: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(v["surface"], "core");
+    assert_eq!(v["tool_count"], 10);
+    client.cancel().await.unwrap();
+}
+
+#[test]
 fn test_mcp_setup_documents_text_file_skip_semantics() {
     let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
     assert!(doc.contains("Binary and invalid UTF-8 files are skipped"));


### PR DESCRIPTION
## Summary

MPI 2026-07-27 batch after #2015/#2016:

1. **Integration tests** for the real subprocess path:
   - `PATCHLOOM_MCP_SURFACE=core` via child env (not only `new_with_surface` inject)
   - Invalid surface fails closed with stderr containing `PATCHLOOM_MCP_SURFACE`
   - Handshake instructions + `server_info` surface/tool_count on core
2. **Unit:** handshake instructions must equal `server_instructions(Core)` (no prose drift)
3. **Honesty docs:** core is a tool-schema progressive disclosure; `execute_plan` is not a plan-catalog sandbox
4. **README:** mention `PATCHLOOM_MCP_SURFACE=core` for small agents

## Test plan

- [x] `cargo test --lib --all-features surface_core`
- [x] `cargo test --test integration --all-features test_mcp_surface`
- [x] `make check-fast`
- [ ] CI green

## Related

Ref #1994 (design already closed)
Follow-up to #2015 / #2016