### PR TITLE
feat: constrained apply-fragment for Morph-class freeform jobs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -20,14 +20,15 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 | Markdown section/bullet/table | `md *` | whole-file rewrite |
 | Identifier rename in code | `ast rename` / `ast_rename_project` | fuzzy replace for symbols |
 | Find code by AST shape (pattern DSL) | ast-grep (or `ast search`) | blind text grep only |
-| Freeform code body change (known span or symbol) | `replace` exact/`ast replace` | whole-file rewrite |
-| Place new lines next to known text | `replace` + `--insert-after` / `--insert-before` | inventing full-file rewrite |
-| Lazy Morph-style markers only (`// ... existing code ...`, no anchors) | **not supported** | Morph merge APIs; use matchable `old`, AST target, or insert anchors (#2018) |
+| Freeform code body change (known span or symbol) | `replace` exact/`ast replace` / `apply-fragment --old` | whole-file rewrite |
+| Place new lines next to known text | `replace` + `--insert-after` / `--insert-before` or `apply-fragment --after/--before` | inventing full-file rewrite |
+| Morph-style snippet with markers **and** known anchor | `apply-fragment` / plan `apply.fragment` / MCP `apply_fragment` (markers stripped) | Morph cloud merge |
+| Lazy Morph-style markers only (`// ... existing code ...`, **no** anchors) | **not supported** | Morph merge APIs; supply after/before/old (#2018) |
 | Prose/typo in non-code text | `replace` (fuzzy last resort) | AST |
 | Multi-file atomic apply | `tx` / `batch` / `execute_plan` | sequential shell |
 | Host agent policy (Rust) | `ReplaceOptions::for_agent` + peels + `fuzzy_span_suspicious` | soft defaults |
 
-**Morph Fast Apply jobs:** prefer Patchloom for exact/`doc`/`md`/`ast`/`batch`/`undo` offline. There is no Morph-style model merge of incomplete snippets. Migration matrix: docs/plans/morph-gap-matrix.md.
+**Morph Fast Apply jobs:** prefer Patchloom offline for exact/`doc`/`md`/`ast`/`batch`/`undo`. For Morph-class snippets, use `apply-fragment` with a **required** after/before/old anchor (lazy markers stripped; no model merge). Migration matrix: docs/plans/morph-gap-matrix.md (#2018).
 
 **Context budget:** prefer `read` with a line range, `search --count` / `--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` for large result streams. Binary sole paths peel `error_kind: binary`.
 
@@ -480,6 +481,7 @@ dependencies[name=react].version # predicate filter
 ## Operations (from schema registry)
 
 - `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches), command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip), and fuzzy (similarity fallback when exact match fails). When exact old is absent, fuzzy refuses by default even above min_fuzzy_score; set allow_absent_old for deliberate approximate recovery (#1758). Prefer ast.rename for identifiers.
+- `apply.fragment`: Constrained freeform fragment apply (#2018). Strips Morph-style // ... existing code ... marker lines from fragment, then inserts or replaces at a required unique anchor (exactly one of after, before, old). Fail-closed: no anchor-less Morph model merge. Prefer for lazy-snippet agent output when anchors are known; use replace/ast for precise edits.
 - `file.append`: Append content to an existing file.
 - `file.prepend`: Prepend content to an existing file.
 - `file.create`: Create a new file with specified content.

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Replace fail-closed / shell-token options: CLI `replace --require-change` and `-
 |---|---|
 | `search` | Fast literal or regex search across text files (supports --glob/--exclude/--ignore-file for layered custom ignore files, --max-results, -C context, etc.) |
 | `replace` | Mechanical string replacement across text files with diff preview |
+| `apply-fragment` | Freeform fragment with required anchors (Morph markers stripped; no model merge) |
 | `append` | Append content to an existing file |
 | `prepend` | Prepend content to an existing file |
 | `create` | Create a new file with content |
@@ -495,7 +496,7 @@ flowchart LR
 
 ## Status
 
-3900+ tests across 23 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+3900+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -25,7 +25,7 @@ file.create VERSION "2.0.0"
 EOF
 ```
 
-23 commands cover structured document editing, search and replace, markdown section editing, multi-file batching, atomic transactions with rollback, diff patching, file lifecycle operations, AST-aware code operations (rename, list, read, validate across 20 languages), operation schema export, and an MCP server that exposes everything as structured tool calls for MCP-capable agents.
+24 commands cover structured document editing, search and replace, markdown section editing, multi-file batching, atomic transactions with rollback, diff patching, file lifecycle operations, AST-aware code operations (rename, list, read, validate across 20 languages), operation schema export, and an MCP server that exposes everything as structured tool calls for MCP-capable agents.
 
 ## The honest benchmark
 
@@ -99,7 +99,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 ## By the numbers
 
 - **2,800+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
-- **23 commands** including MCP server with 56 structured tool calls
+- **24 commands** including MCP server with 57 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/docs/getting-started/comparisons.md
+++ b/docs/getting-started/comparisons.md
@@ -75,8 +75,9 @@ Use this table when someone asks "can patchloom replace Morph for X?" Full PASS/
 | Config / comments | `doc set` | Not text replace |
 | Markdown section | `md replace-section` (etc.) | Not whole-file rewrite |
 | Preview / revert | default dry-run (exit 2); `undo --apply` | Backup session on apply |
-| Lazy `// ... existing code ...` with **no** anchors | Not first-class | **Gap** ([#2018](https://github.com/patchloom/patchloom/issues/2018)): supply matchable `old`, AST target, or `--insert-after` anchor. No Morph-style model merge |
-| Freeform "put method in the right place" with no anchors | Not first-class | **Gap** ([#2018](https://github.com/patchloom/patchloom/issues/2018)): use `ast list`/`read` then insert/replace with a chosen anchor |
+| Lazy `// ... existing code ...` **with** known anchor | `apply-fragment --after/--before/--old` (markers stripped) | **PASS** (#2018). No Morph-style model merge |
+| Lazy markers with **no** anchors | Not supported | Non-goal: supply after/before/old or use Morph |
+| Freeform "put method in the right place" with known anchor | `apply-fragment` or `ast` + insert | **PASS** with anchors; no free placement guess |
 
 **Host routing (Morph MCP says "prefer edit_file"):** prefer `doc` / `md` / `ast` / `batch` when structure is known; use `replace` (+ fuzzy only when needed); never whole-file rewrite for a one-line change.
 

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -2,9 +2,10 @@
 
 ## Commands
 
-Patchloom has 23 commands:
+Patchloom has 24 commands:
 
 - **search** / **replace** -- text-level find and replace across files
+- **apply-fragment** -- freeform fragment with required anchors (Morph-style markers stripped; no model merge)
 - **patch** -- apply unified diffs
 - **md** -- markdown-aware editing (sections, bullets, tables, headings)
 - **doc** -- parser-backed JSON, YAML, and TOML mutations

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -166,7 +166,7 @@ the registry when that would lose multi-file, batch, or read UX.
 
 Custom tools are inventoried in `CUSTOM_MCP_TOOLS_CORE` (always registered)
 and `CUSTOM_MCP_TOOLS_AST` (only when the `ast` feature is enabled). Default
-builds expose **56** tools (registry + custom). Builds without `ast` omit the
+builds expose **57** tools (registry + custom). Builds without `ast` omit the
 AST tools so `list_tools` stays honest about what is callable.
 
 | Tool | Description |

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -28,12 +28,13 @@ replace README.md "1.0.0" "2.0.0"
 EOF
 ```
 
-## 23 commands
+## 24 commands
 
 | Category | Command | Description |
 |----------|---------|-------------|
 | Text | `search` | Literal or regex search across files |
 | | `replace` | Mechanical string replacement with diff preview |
+| | `apply-fragment` | Freeform fragment with required anchors (Morph markers stripped) |
 | | `patch` | Preview or apply unified diffs |
 | Structured | `doc` | Parser-backed JSON, YAML, and TOML operations |
 | | `md` | Markdown section-aware operations |

--- a/docs/plans/mcp-surface-tiers.md
+++ b/docs/plans/mcp-surface-tiers.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Full default inventory (~56 tools with AST) can overwhelm small agents (context tax on tool schemas). Competitors often ship tiny FS MCP servers.
+Full default inventory (~57 tools with AST) can overwhelm small agents (context tax on tool schemas). Competitors often ship tiny FS MCP servers.
 
 ## Decision
 

--- a/docs/plans/morph-gap-matrix.md
+++ b/docs/plans/morph-gap-matrix.md
@@ -8,12 +8,12 @@
 
 | Result | Count | Meaning |
 |--------|------:|---------|
-| **PASS** | 11 | Patchloom already handles this Morph job |
+| **PASS** | 13 | Patchloom already handles this Morph job (including constrained `apply-fragment`) |
 | **PARTIAL** | 2 | Works with flags/host policy; not Morph-default UX |
-| **GAP** | 2 | Real product gap if you want Morph users to never need Morph |
+| **GAP** | 0 | Anchor-less Morph model merge remains a non-goal |
 | **N/A** | 2 | Morph product metrics (tok/s, network API); not our target |
 
-**Bottom line:** Most Morph reliability jobs (small edit, large file with a matchable span, multi-file, preview, undo, configs, peels) are already covered. Morph still wins on **lazy snippet UX** (no exact `old`) and **semantic freeform placement**. Do not train an apply model; close gaps with AST/multi-hunk routing and optional constrained anchor apply (see open issues).
+**Bottom line:** Most Morph reliability jobs are covered. M9/M16 are **PASS** when anchors are known via `apply-fragment` / `apply.fragment` (#2018). Anchor-less Morph model merge remains a non-goal.
 
 ## Sources (Morph side)
 
@@ -39,14 +39,14 @@ Legend: **PASS** / **PARTIAL** / **GAP** / **N/A**. Verified 2026-07-27 unless n
 | M6 | Config/YAML without breaking comments | `doc set` | **PASS** | Comment `# keep me` preserved; port updated |
 | M7 | Markdown section without full rewrite | `md replace-section` (and siblings) | **PASS** | Commands section replaced; Other kept |
 | M8 | Preview before write | Default dry-run (no `--apply`) | **PASS** | Exit **2**, file unchanged |
-| M9 | Lazy snippet merge (`// ... existing code ...`, no exact `old`) | None first-class | **GAP** | Expected: no Morph-style apply model. Host must supply matchable `old`, AST symbol, or insert anchors |
+| M9 | Lazy snippet merge (`// ... existing code ...`) with placement | `apply-fragment` / plan `apply.fragment` / MCP `apply_fragment` | **PASS** | Markers stripped; **requires** after/before/old. Anchor-less remains non-goal (#2018) |
 | M10 | Place new code after a known anchor | `replace ANCHOR --insert-after TEXT` (or `--insert-before`) | **PASS** | Insert after `a();` PASS |
 | M11 | Scattered multi-hunk different sites | Sequential `replace`, `batch` same file, or library `apply_content_edits*` | **PASS** | Batch two different olds same file PASS. Not one Morph lazy multi-hunk blob |
 | M12 | Identifier rename across file | `ast rename` | **PASS** | `compute` to `calculate` including call site |
 | M13 | Revert / trust after apply | `undo --list` / `undo --apply` (+ library backup APIs) | **PASS** | Restore most recent session restored content |
 | M14 | Offline / no API key | Local binary + crate | **PASS** | No network required for apply path |
 | M15 | Clear failure kinds for hosts | `--json` `error_kind` (e.g. `binary`) | **PASS** | Sole binary target returns `error_kind: binary` |
-| M16 | Semantic freeform "put this method in the right place" with no anchors | Morph model only | **GAP** | Closest: `ast` list/read + insert/replace with user-chosen symbol/anchor. No structure-aware freeform merge |
+| M16 | Freeform placement with **known** anchor (not free guess) | `apply-fragment --after/--before` or `ast` + insert | **PASS** | With anchors: constrained apply. Without anchors: still non-goal (no Morph guess) |
 | M17 | 10k+ tok/s cloud apply latency brand | N/A | **N/A** | Local apply is a different success metric (correctness + peels, not model tok/s) |
 | M18 | Host prompt: prefer specialized edit tool over str_replace/full write | `agent-rules` + comparisons + MCP descriptions | **PARTIAL** | Decision tree and Morph section exist; this matrix is the migration checklist. Keep routing sharp in agent-rules |
 
@@ -57,7 +57,7 @@ From [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast
 | Situation | Their tool | Patchloom equivalent | Result |
 |-----------|------------|----------------------|--------|
 | Small, exact replacement | native `edit` | `replace` exact | **PASS** (prefer us) |
-| Large file (500+ lines) | `morph_edit` | Exact/`ast replace` if span or symbol known | **PASS** if agent names span/symbol; **GAP** if only lazy snippet |
+| Large file (500+ lines) | `morph_edit` | Exact/`ast replace`/`apply-fragment` if span/anchor known | **PASS** if agent names span/anchor; non-goal if only lazy snippet with no anchor |
 | Multiple scattered changes | `morph_edit` | `batch` / `apply_content_edits` / multi `replace` | **PASS** |
 | Whitespace-sensitive | `morph_edit` | `--fuzzy` + span policy | **PARTIAL** (fail-closed default) |
 
@@ -79,10 +79,10 @@ From [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast
 
 ## Follow-up issues
 
-| Issue | Topic |
-|-------|--------|
-| [#2018](https://github.com/patchloom/patchloom/issues/2018) | Constrained freeform code apply (M9/M16); no Morph clone |
-| [#2019](https://github.com/patchloom/patchloom/issues/2019) | Keep matrix / comparisons / agent-rules Morph routing in sync |
+| Issue | Topic | Status |
+|-------|--------|--------|
+| [#2018](https://github.com/patchloom/patchloom/issues/2018) | Constrained freeform code apply (M9/M16); no Morph clone | Shipped: `apply-fragment` / `apply.fragment` / MCP `apply_fragment` |
+| [#2019](https://github.com/patchloom/patchloom/issues/2019) | Keep matrix / comparisons / agent-rules Morph routing in sync | Closed with matrix landing |
 
 ## How to re-run smoke scenarios
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -222,7 +222,16 @@ These are the main entry points. If you are deciding between commands, start her
 - **Prefer instead:** Use `doc` for structured data, `md` for heading aware markdown, or `patch` when you already have a unified diff.
 - **Failure behavior:** Soft pattern miss exits `3` with `error_kind: "no_matches"`; `--unique` multi-match exits `5` with `ambiguous`. All-explicit-path-missing (or all-missing `--files-from` list) exits `1` with `not_found`. Empty `--files-from` (empty list file or empty stdin) exits `1` with `invalid_input` (not pattern miss; #1796). Validation failures and invalid regex patterns use `invalid_input`.
 - **Multi-path honesty:** Explicit multi-file lists report zero-match paths under `refused[]` with `reason: no_matches` while applying matches on other paths (#1792). Missing explicit paths soft-skip under `skipped[]` on CLI (partial apply); MCP `batch_replace` hard-fails missing paths and rolls back (#1793). Under `--json`/`--jsonl`, missing-path stderr lines are suppressed when paths are already in `skipped[]` (#1797).
-- **Related:** `search`, `tx`
+- **Related:** `search`, `tx`, `apply-fragment`
+
+<!-- ref:command:apply-fragment -->
+## `apply-fragment`
+
+- **What it does:** Applies a freeform text fragment with a **required** placement anchor. Strips Morph-style lazy marker lines such as `// ... existing code ...` from `--fragment`, then inserts after/before an anchor or replaces a unique `old` span. Dry-run by default.
+- **Use when:** An agent emitted a Morph-class lazy snippet but you know a unique placement (after/before/old). Prefer this over guessing without anchors.
+- **Prefer instead:** `replace` for exact known spans; `ast replace` / `ast rename` for code structure; never a cloud Morph merge for offline deterministic hosts.
+- **Failure behavior:** Missing placement or empty fragment after strip → `invalid_input` (exit 1). Anchor miss → `no_matches` (exit 3). Multi-match with default unique → `ambiguous` (exit 5). Preview without `--apply` → exit 2 when changes would apply.
+- **Related:** `replace`, `tx` plan op `apply.fragment`, MCP `apply_fragment`, `docs/plans/morph-gap-matrix.md`
 
 <!-- ref:command:patch -->
 ## `patch`
@@ -1049,6 +1058,14 @@ The operations below are the building blocks inside `operations`.
 - **Regex insert semantics:** In regex mode, `insert_before` and `insert_after` preserve the matched text, they do not insert the raw pattern string.
 - **Optional fields:** `case_insensitive` (bool, default false), `multiline` (bool, default false), and `if_exists` (bool, default false) match the top level `replace --case-insensitive`, `--multiline`, and `--if-exists` flags. Library-aligned plan fields: `require_change` (bool, default false; hard-fails the op on zero matches when `if_exists` is false) and `command_position` (bool, default false; shell invocable rewrite).
 - **Related:** top level `replace`
+
+<!-- ref:tx-op:apply.fragment -->
+### `apply.fragment`
+
+- **What it does:** Applies a freeform fragment with a required placement anchor inside a transaction (Morph-style `// ... existing code ...` lines stripped).
+- **Use when:** Batching Morph-class freeform snippets with known after/before/old anchors.
+- **Requires:** Exactly one of `after`, `before`, or `old`. Non-empty `fragment` after marker strip. `unique` defaults true.
+- **Related:** CLI `apply-fragment`, MCP `apply_fragment`, top level `replace`
 
 <!-- ref:tx-op:doc.set -->
 ### `doc.set`

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -240,6 +240,13 @@ mod content_edits;
 mod fuzzy_span;
 pub use self::content_edits::*;
 
+// Constrained freeform fragment helpers (#2018); pure + plan desugar.
+pub use crate::ops::apply_fragment::{
+    ApplyFragmentSpec, DesugaredReplace, FragmentPlacement, build_apply_fragment_spec,
+    desugar_to_replace_fields, desugar_to_replace_operation, is_lazy_marker_line,
+    plan_apply_fragment_to_replace, strip_lazy_markers,
+};
+
 mod post_write;
 pub use self::post_write::*;
 

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -111,14 +111,16 @@ DSL; use Patchloom for host-safe apply, configs, markdown, batch/tx/undo, and pe
          | Markdown section/bullet/table | `md *` | whole-file rewrite |\n\
          | Identifier rename in code | `ast rename` / `ast_rename_project` | fuzzy replace for symbols |\n\
          | Find code by AST shape (pattern DSL) | ast-grep (or `ast search`) | blind text grep only |\n\
-         | Freeform code body change (known span or symbol) | `replace` exact/`ast replace` | whole-file rewrite |\n\
-         | Place new lines next to known text | `replace` + `--insert-after` / `--insert-before` | inventing full-file rewrite |\n\
-         | Lazy Morph-style markers only (`// ... existing code ...`, no anchors) | **not supported** | Morph merge APIs; use matchable `old`, AST target, or insert anchors (#2018) |\n\
+         | Freeform code body change (known span or symbol) | `replace` exact/`ast replace` / `apply-fragment --old` | whole-file rewrite |\n\
+         | Place new lines next to known text | `replace` + `--insert-after` / `--insert-before` or `apply-fragment --after/--before` | inventing full-file rewrite |\n\
+         | Morph-style snippet with markers **and** known anchor | `apply-fragment` / plan `apply.fragment` / MCP `apply_fragment` (markers stripped) | Morph cloud merge |\n\
+         | Lazy Morph-style markers only (`// ... existing code ...`, **no** anchors) | **not supported** | Morph merge APIs; supply after/before/old (#2018) |\n\
          | Prose/typo in non-code text | `replace` (fuzzy last resort) | AST |\n\
          | Multi-file atomic apply | `tx` / `batch` / `execute_plan` | sequential shell |\n\
          | Host agent policy (Rust) | `ReplaceOptions::for_agent` + peels + `fuzzy_span_suspicious` | soft defaults |\n\n\
-         **Morph Fast Apply jobs:** prefer Patchloom for exact/`doc`/`md`/`ast`/`batch`/`undo` offline. \
-There is no Morph-style model merge of incomplete snippets. Migration matrix: docs/plans/morph-gap-matrix.md.\n\n\
+         **Morph Fast Apply jobs:** prefer Patchloom offline for exact/`doc`/`md`/`ast`/`batch`/`undo`. \
+For Morph-class snippets, use `apply-fragment` with a **required** after/before/old anchor \
+(lazy markers stripped; no model merge). Migration matrix: docs/plans/morph-gap-matrix.md (#2018).\n\n\
          **Context budget:** prefer `read` with a line range, `search --count` / \
 `--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` \
 for large result streams. Binary sole paths peel `error_kind: binary`.\n\n\
@@ -1305,8 +1307,9 @@ mod tests {
             out.contains("Morph Fast Apply")
                 && out.contains("morph-gap-matrix")
                 && out.contains("not supported")
-                && out.contains("insert-after"),
-            "agent-rules need Morph freeform routing (no lazy marker merge; #2019)"
+                && out.contains("apply-fragment")
+                && out.contains("apply.fragment"),
+            "agent-rules need Morph freeform routing + apply-fragment (#2018/#2019)"
         );
         assert!(
             out.contains("PATCHLOOM_MCP_SURFACE")

--- a/src/cmd/apply_fragment.rs
+++ b/src/cmd/apply_fragment.rs
@@ -1,0 +1,244 @@
+//! CLI: constrained freeform fragment apply (#2018).
+
+use crate::cli::global::GlobalFlags;
+use crate::cmd::output::run_write_op;
+use crate::ops::apply_fragment::build_apply_fragment_spec;
+use crate::plan::Operation;
+use clap::Args;
+use serde::Serialize;
+
+#[derive(Debug, Args)]
+#[command(
+    name = "apply-fragment",
+    after_help = "\
+EXAMPLES:
+  # Morph-style snippet + required after-anchor (markers stripped)
+  patchloom apply-fragment src/lib.rs --after 'fn foo() {' --fragment '// ... existing code ...
+  bar();
+// ... existing code ...' --apply
+
+  # Replace a unique span with freeform new text
+  patchloom apply-fragment src/lib.rs --old 'return 0;' --fragment 'return 1;' --apply
+
+NOTES:
+  Exactly one of --after, --before, or --old is required (no anchor-less Morph merge).
+  Lazy marker lines such as // ... existing code ... are stripped from --fragment.
+  Dry-run by default (exit 2 when changes would apply). See docs/plans/morph-gap-matrix.md."
+)]
+pub struct ApplyFragmentArgs {
+    /// Path of the file to edit.
+    pub file: String,
+    /// New text or Morph-style snippet (lazy marker lines stripped).
+    #[arg(long)]
+    pub fragment: Option<String>,
+    /// Read fragment from stdin.
+    #[arg(long)]
+    pub stdin: bool,
+    /// Optional human note (not used for merge).
+    #[arg(long)]
+    pub instruction: Option<String>,
+    /// Insert cleaned fragment after this unique anchor.
+    #[arg(long)]
+    pub after: Option<String>,
+    /// Insert cleaned fragment before this unique anchor.
+    #[arg(long)]
+    pub before: Option<String>,
+    /// Replace this unique span with the cleaned fragment.
+    #[arg(long)]
+    pub old: Option<String>,
+    /// Allow non-unique anchors (default: require unique).
+    #[arg(long)]
+    pub allow_non_unique: bool,
+    #[command(flatten)]
+    pub write: crate::cli::global::WriteFlags,
+}
+
+#[derive(Debug, Serialize)]
+struct ApplyFragmentOutput {
+    ok: bool,
+    path: String,
+    op: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instruction: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    diff: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    applied: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    backup_session: Option<String>,
+}
+
+pub fn run(args: ApplyFragmentArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    if args.fragment.is_some() && args.stdin {
+        let msg = "--fragment and --stdin cannot be combined";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(crate::exit::FAILURE);
+    }
+    let raw = if let Some(f) = args.fragment {
+        f
+    } else if args.stdin {
+        std::io::read_to_string(std::io::stdin())?
+    } else {
+        let msg = "provide --fragment or --stdin";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(crate::exit::FAILURE);
+    };
+
+    let unique = !args.allow_non_unique;
+    // Validate early for agent JSON kind.
+    if let Err(e) = build_apply_fragment_spec(
+        &raw,
+        args.instruction.as_deref(),
+        args.after.as_deref(),
+        args.before.as_deref(),
+        args.old.as_deref(),
+        unique,
+    ) {
+        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
+        return Ok(crate::exit::FAILURE);
+    }
+
+    let op = Operation::ApplyFragment {
+        path: args.file.clone(),
+        fragment: raw,
+        instruction: args.instruction.clone(),
+        after: args.after.clone(),
+        before: args.before.clone(),
+        old: args.old.clone(),
+        unique,
+    };
+
+    run_write_op(
+        op,
+        global,
+        |phase, diff, backup| ApplyFragmentOutput {
+            ok: true,
+            path: args.file.clone(),
+            op: "apply.fragment",
+            instruction: args.instruction.clone(),
+            diff,
+            applied: phase.applied_flag(),
+            backup_session: backup,
+        },
+        "fragment apply would change files",
+        "applied fragment",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::global::GlobalFlags;
+    use tempfile::TempDir;
+
+    fn g_apply() -> GlobalFlags {
+        GlobalFlags {
+            apply: true,
+            ..GlobalFlags::default()
+        }
+    }
+
+    #[test]
+    fn apply_fragment_after_anchor_strips_markers() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.rs");
+        std::fs::write(&path, "fn foo() {\n  a();\n}\n").unwrap();
+        let file = path.to_string_lossy().into_owned();
+        let code = run(
+            ApplyFragmentArgs {
+                file: file.clone(),
+                fragment: Some(
+                    "// ... existing code ...\n  b();\n// ... existing code ...\n".into(),
+                ),
+                stdin: false,
+                instruction: Some("add b".into()),
+                after: Some("  a();".into()),
+                before: None,
+                old: None,
+                allow_non_unique: false,
+                write: Default::default(),
+            },
+            &g_apply(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::SUCCESS);
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(body.contains("  a();\n  b();\n"), "{body}");
+        assert!(!body.contains("existing code"), "{body}");
+    }
+
+    #[test]
+    fn apply_fragment_missing_anchor_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.rs");
+        std::fs::write(&path, "x\n").unwrap();
+        let code = run(
+            ApplyFragmentArgs {
+                file: path.to_string_lossy().into(),
+                fragment: Some("y".into()),
+                stdin: false,
+                instruction: None,
+                after: None,
+                before: None,
+                old: None,
+                allow_non_unique: false,
+                write: Default::default(),
+            },
+            &GlobalFlags::default(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::FAILURE);
+    }
+
+    #[test]
+    fn apply_fragment_preview_exit_2() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.rs");
+        std::fs::write(&path, "a\n").unwrap();
+        let code = run(
+            ApplyFragmentArgs {
+                file: path.to_string_lossy().into(),
+                fragment: Some("b\n".into()),
+                stdin: false,
+                instruction: None,
+                after: Some("a".into()),
+                before: None,
+                old: None,
+                allow_non_unique: false,
+                write: Default::default(),
+            },
+            &GlobalFlags::default(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::CHANGES_DETECTED);
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "a\n");
+    }
+
+    #[test]
+    fn apply_fragment_replace_old() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.rs");
+        std::fs::write(&path, "return 0;\n").unwrap();
+        let code = run(
+            ApplyFragmentArgs {
+                file: path.to_string_lossy().into(),
+                fragment: Some("return 1;\n".into()),
+                stdin: false,
+                instruction: None,
+                after: None,
+                before: None,
+                old: Some("return 0;".into()),
+                allow_non_unique: false,
+                write: Default::default(),
+            },
+            &g_apply(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::SUCCESS);
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            body.starts_with("return 1;"),
+            "expected replace to return 1; got {body:?}"
+        );
+    }
+}

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -27,6 +27,38 @@ pub(super) fn describe_operation(op: &Operation) -> String {
     // Rich field-level text; catalog blurb is on JSON via build_json_summary (`catalog`).
     let _ = schema::operation_description(&operation_op_name(op));
     match op {
+        Operation::ApplyFragment {
+            path,
+            fragment,
+            instruction,
+            after,
+            before,
+            old,
+            unique,
+        } => {
+            let cleaned = crate::ops::apply_fragment::strip_lazy_markers(fragment);
+            let preview: String = cleaned.chars().take(40).collect();
+            let dots = if cleaned.chars().count() > 40 {
+                "…"
+            } else {
+                ""
+            };
+            let place = if let Some(a) = after {
+                format!("after \"{a}\"")
+            } else if let Some(b) = before {
+                format!("before \"{b}\"")
+            } else if let Some(o) = old {
+                format!("replacing \"{o}\"")
+            } else {
+                "with missing placement (invalid)".into()
+            };
+            let uniq = if *unique { ", unique anchor" } else { "" };
+            let note = instruction
+                .as_deref()
+                .map(|i| format!(" (note: {i})"))
+                .unwrap_or_default();
+            format!("Apply fragment \"{preview}{dots}\" {place} in {path}{uniq}{note}")
+        }
         Operation::Replace {
             path,
             glob,

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -324,6 +324,22 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         has_strict: false,
         validations: &[FieldValidation::Path("path")],
     },
+    McpToolMeta {
+        tool_name: "apply_fragment",
+        op_name: "apply.fragment",
+        extra: Some(
+            "Morph-class freeform fragment with required placement (exactly one of after/before/old). Lazy // ... existing code ... lines are stripped; no model merge without anchors (#2018). IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+        ),
+        has_strict: false,
+        validations: &[
+            FieldValidation::Path("path"),
+            FieldValidation::ContentSize("fragment"),
+            FieldValidation::ParamSize("after"),
+            FieldValidation::ParamSize("before"),
+            FieldValidation::ParamSize("old"),
+            FieldValidation::ParamSize("instruction"),
+        ],
+    },
 ];
 
 /// Inject a `strict` boolean property (default true) into a JSON Schema object.

--- a/src/cmd/mcp/surface.rs
+++ b/src/cmd/mcp/surface.rs
@@ -376,7 +376,7 @@ mod tests {
         // Core tools always; AST tools only with `ast` (matches list_tools registration).
         let registry_n = MCP_TOOL_REGISTRY.len();
         let custom_n = custom_mcp_tools().count();
-        let expected_total = if cfg!(feature = "ast") { 56 } else { 36 };
+        let expected_total = if cfg!(feature = "ast") { 57 } else { 37 };
         assert_eq!(
             registry_n + custom_n,
             expected_total,

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -142,6 +142,7 @@ mod basic {
             "replace_text",
             "batch_replace",
             "md_move_section",
+            "apply_fragment",
         ] {
             let desc = descriptions.get(tool).copied().unwrap_or("");
             assert!(

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_rules;
 pub mod append;
+pub mod apply_fragment;
 #[cfg(feature = "ast")]
 pub mod ast;
 pub mod batch;
@@ -58,8 +59,11 @@ pub enum Command {
     /// Mechanical string replacement across text files with diff preview.
     #[command(display_order = 21)]
     Replace(replace::ReplaceArgs),
+    /// Constrained freeform fragment apply (Morph-style markers; anchors required).
+    #[command(display_order = 22, name = "apply-fragment")]
+    ApplyFragment(apply_fragment::ApplyFragmentArgs),
     /// Preview or apply unified diffs safely.
-    #[command(display_order = 22)]
+    #[command(display_order = 23)]
     Patch(patch::PatchArgs),
     /// Text-file newline, line ending, and whitespace normalization.
     #[command(display_order = 23)]
@@ -248,6 +252,11 @@ pub fn dispatch(cli: Cli) -> anyhow::Result<u8> {
             global.merge_write(&args.write);
             load_project_config(&mut global);
             replace::run(args, &global)
+        }
+        Command::ApplyFragment(args) => {
+            global.merge_write(&args.write);
+            load_project_config(&mut global);
+            apply_fragment::run(args, &global)
         }
         Command::Patch(args) => {
             global.merge_write(&args.write);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,18 +310,21 @@ pub mod write;
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use api::search_one_file;
 pub use api::{
-    AGENT_MIN_FUZZY_SCORE, ApplyMode, ContentEdit, ContentEditHonesty, ContentEditResult,
-    ContentEditsResult, EditError, EditErrorKind, EditResult, FuzzySpanPolicy, Hunk, MatchMode,
-    PatchFile, PatchLine, PeeledError, PostWriteHooks, PostWriteOnFailure, ReplaceOptions,
-    SearchOptions, SearchResult, WritePolicyOptions, apply_content_edits,
-    apply_content_edits_with_label, apply_post_write_validator, build_context_lines,
-    classify_error, classify_error_ref, edit_error_kind, edit_error_ref, error_kind_str,
-    format_search_results, fuzzy_span_suspicious, fuzzy_span_suspicious_with_policy,
-    is_already_exists, is_ambiguous, is_binary, is_binary_file, is_changes_detected, is_conflicts,
-    is_format_failed, is_fuzzy_span_suspicious, is_guard_rejected, is_invalid_encoding,
-    is_invalid_input, is_load_text_strict_fail, is_no_match, is_not_found, is_type_error,
-    load_text, load_text_strict, merge_match_modes, parse_unified_diff, peel_error,
-    prefer_widest_matched_text, run_post_write_validation, search_file, text_diff,
+    AGENT_MIN_FUZZY_SCORE, ApplyFragmentSpec, ApplyMode, ContentEdit, ContentEditHonesty,
+    ContentEditResult, ContentEditsResult, DesugaredReplace, EditError, EditErrorKind, EditResult,
+    FragmentPlacement, FuzzySpanPolicy, Hunk, MatchMode, PatchFile, PatchLine, PeeledError,
+    PostWriteHooks, PostWriteOnFailure, ReplaceOptions, SearchOptions, SearchResult,
+    WritePolicyOptions, apply_content_edits, apply_content_edits_with_label,
+    apply_post_write_validator, build_apply_fragment_spec, build_context_lines, classify_error,
+    classify_error_ref, desugar_to_replace_fields, desugar_to_replace_operation, edit_error_kind,
+    edit_error_ref, error_kind_str, format_search_results, fuzzy_span_suspicious,
+    fuzzy_span_suspicious_with_policy, is_already_exists, is_ambiguous, is_binary, is_binary_file,
+    is_changes_detected, is_conflicts, is_format_failed, is_fuzzy_span_suspicious,
+    is_guard_rejected, is_invalid_encoding, is_invalid_input, is_lazy_marker_line,
+    is_load_text_strict_fail, is_no_match, is_not_found, is_type_error, load_text,
+    load_text_strict, merge_match_modes, parse_unified_diff, peel_error,
+    plan_apply_fragment_to_replace, prefer_widest_matched_text, run_post_write_validation,
+    search_file, strip_lazy_markers, text_diff,
 };
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use api::{apply_content_edits_to_file, apply_content_edits_to_file_with_span_policy};

--- a/src/ops/apply_fragment.rs
+++ b/src/ops/apply_fragment.rs
@@ -1,0 +1,317 @@
+//! Constrained freeform fragment apply (#2018).
+//!
+//! Covers Morph-class *jobs* (lazy snippets, freeform placement) without a
+//! Morph clone: Morph-style `// ... existing code ...` markers are stripped,
+//! but **placement anchors are required** and matching is fail-closed.
+
+use crate::exit::InvalidInputError;
+
+/// Placement for a cleaned fragment. Exactly one mode must be chosen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FragmentPlacement {
+    /// Insert cleaned fragment immediately after the first unique match of `anchor`.
+    After(String),
+    /// Insert cleaned fragment immediately before the first unique match of `anchor`.
+    Before(String),
+    /// Replace the matched `old` span with the cleaned fragment.
+    Replace(String),
+}
+
+/// Validated apply-fragment request (anchors required; no free guess).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplyFragmentSpec {
+    /// Optional human note (not used for merge).
+    pub instruction: Option<String>,
+    /// Fragment after Morph marker strip.
+    pub fragment: String,
+    /// Required placement.
+    pub placement: FragmentPlacement,
+    /// Enforce a single anchor match (default true for agents).
+    pub unique: bool,
+}
+
+/// True when a line is a Morph-style lazy placeholder (not real source).
+///
+/// Recognizes common forms agents emit for Fast Apply:
+/// - `// ... existing code ...`
+/// - `// ...existing code...`
+/// - `# ... existing code ...`
+/// - `/* ... existing code ... */`
+/// - lines that are only `// ...` / `# ...` with ellipsis fillers
+pub fn is_lazy_marker_line(line: &str) -> bool {
+    let t = line.trim();
+    if t.is_empty() {
+        return false;
+    }
+    let lower = t.to_ascii_lowercase();
+    // Strip common comment wrappers for the core check.
+    let core = lower
+        .trim_start_matches("/*")
+        .trim_end_matches("*/")
+        .trim()
+        .trim_start_matches("//")
+        .trim_start_matches('#')
+        .trim_start_matches('*')
+        .trim();
+    if core.is_empty() {
+        return false;
+    }
+    // Must look like an ellipsis placeholder, not real code.
+    let has_ellipsis = core.contains("...") || core.contains('\u{2026}');
+    if !has_ellipsis {
+        return false;
+    }
+    // Morph default phrasing or pure ellipsis filler between punctuation/spaces.
+    if core.contains("existing code") || core.contains("existingcode") {
+        return true;
+    }
+    // `// ...` or `// ... ...` only (no identifiers of length >= 2 without dots)
+    let alnum: String = core.chars().filter(|c| c.is_ascii_alphanumeric()).collect();
+    alnum.is_empty() || alnum == "existingcode" || alnum == "code"
+}
+
+/// Remove Morph-style lazy marker lines; preserve other content and relative newlines.
+///
+/// Does **not** invent placement. Empty result after strip is an error at the
+/// call site (invalid_input).
+pub fn strip_lazy_markers(fragment: &str) -> String {
+    let ends_with_nl = fragment.ends_with('\n');
+    let mut out_lines: Vec<&str> = Vec::new();
+    for line in fragment.lines() {
+        if is_lazy_marker_line(line) {
+            continue;
+        }
+        out_lines.push(line);
+    }
+    let mut s = out_lines.join("\n");
+    if ends_with_nl && !s.is_empty() && !s.ends_with('\n') {
+        s.push('\n');
+    }
+    s
+}
+
+/// Build a validated spec from raw Morph-style inputs.
+///
+/// Exactly one of `after`, `before`, `old` must be `Some` and non-empty after trim.
+/// `fragment` is stripped of lazy markers and must remain non-empty.
+pub fn build_apply_fragment_spec(
+    fragment: &str,
+    instruction: Option<&str>,
+    after: Option<&str>,
+    before: Option<&str>,
+    old: Option<&str>,
+    unique: bool,
+) -> Result<ApplyFragmentSpec, InvalidInputError> {
+    let cleaned = strip_lazy_markers(fragment);
+    if cleaned.trim().is_empty() {
+        return Err(InvalidInputError {
+            msg: "apply.fragment: fragment empty after stripping lazy markers \
+(// ... existing code ...); provide real new text"
+                .into(),
+        });
+    }
+
+    // Preserve anchor whitespace (indentation is significant for exact match).
+    let after = after.filter(|s| !s.trim().is_empty()).map(str::to_string);
+    let before = before.filter(|s| !s.trim().is_empty()).map(str::to_string);
+    let old = old.filter(|s| !s.trim().is_empty()).map(str::to_string);
+
+    let n =
+        usize::from(after.is_some()) + usize::from(before.is_some()) + usize::from(old.is_some());
+    if n == 0 {
+        return Err(InvalidInputError {
+            msg: "apply.fragment: require exactly one placement anchor \
+(--after / after, --before / before, or --old / old); no Morph-style guess without anchors (#2018)"
+                .into(),
+        });
+    }
+    if n > 1 {
+        return Err(InvalidInputError {
+            msg:
+                "apply.fragment: after, before, and old are mutually exclusive; pick one placement"
+                    .into(),
+        });
+    }
+
+    let placement = if let Some(a) = after {
+        FragmentPlacement::After(a)
+    } else if let Some(b) = before {
+        FragmentPlacement::Before(b)
+    } else {
+        FragmentPlacement::Replace(old.unwrap())
+    };
+
+    Ok(ApplyFragmentSpec {
+        instruction: instruction
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string),
+        fragment: cleaned,
+        placement,
+        unique,
+    })
+}
+
+/// Desugar a validated spec into replace `old` + optional insert_after/before + new text.
+///
+/// Maps onto the existing replace write path (no parallel writer).
+pub fn desugar_to_replace_fields(spec: &ApplyFragmentSpec) -> DesugaredReplace {
+    match &spec.placement {
+        FragmentPlacement::After(anchor) => DesugaredReplace {
+            old: anchor.clone(),
+            new_text: None,
+            insert_after: Some(spec.fragment.clone()),
+            insert_before: None,
+            unique: spec.unique,
+        },
+        FragmentPlacement::Before(anchor) => DesugaredReplace {
+            old: anchor.clone(),
+            new_text: None,
+            insert_after: None,
+            insert_before: Some(spec.fragment.clone()),
+            unique: spec.unique,
+        },
+        FragmentPlacement::Replace(old) => DesugaredReplace {
+            old: old.clone(),
+            new_text: Some(spec.fragment.clone()),
+            insert_after: None,
+            insert_before: None,
+            unique: spec.unique,
+        },
+    }
+}
+
+/// Fields for building `Operation::Replace` / `replace_text` from apply.fragment.
+#[derive(Debug, Clone)]
+pub struct DesugaredReplace {
+    pub old: String,
+    pub new_text: Option<String>,
+    pub insert_after: Option<String>,
+    pub insert_before: Option<String>,
+    pub unique: bool,
+}
+
+/// Build a plan [`crate::plan::Operation::Replace`] from a validated apply.fragment spec.
+pub fn desugar_to_replace_operation(
+    path: &str,
+    spec: &ApplyFragmentSpec,
+) -> crate::plan::Operation {
+    let d = desugar_to_replace_fields(spec);
+    crate::plan::Operation::Replace {
+        glob: None,
+        path: Some(path.to_string()),
+        regex: false,
+        old: d.old,
+        new_text: d.new_text,
+        nth: None,
+        insert_before: d.insert_before,
+        insert_after: d.insert_after,
+        case_insensitive: false,
+        multiline: false,
+        if_exists: false,
+        whole_line: false,
+        range: None,
+        word_boundary: false,
+        before_context: None,
+        after_context: None,
+        unique: d.unique,
+        require_change: true,
+        command_position: false,
+        fuzzy: false,
+        min_fuzzy_score: None,
+        allow_absent_old: false,
+    }
+}
+
+/// Validate raw apply.fragment plan fields and desugar to `Operation::Replace`.
+pub fn plan_apply_fragment_to_replace(
+    path: &str,
+    fragment: &str,
+    instruction: Option<&str>,
+    after: Option<&str>,
+    before: Option<&str>,
+    old: Option<&str>,
+    unique: bool,
+) -> Result<crate::plan::Operation, InvalidInputError> {
+    let spec = build_apply_fragment_spec(fragment, instruction, after, before, old, unique)?;
+    Ok(desugar_to_replace_operation(path, &spec))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_morph_marker_lines() {
+        let raw = "// ... existing code ...\nfn new() {}\n// ... existing code ...\n";
+        let cleaned = strip_lazy_markers(raw);
+        assert_eq!(cleaned, "fn new() {}\n");
+    }
+
+    #[test]
+    fn strips_hash_and_block_markers() {
+        assert!(is_lazy_marker_line("# ... existing code ..."));
+        assert!(is_lazy_marker_line("/* ... existing code ... */"));
+        assert!(is_lazy_marker_line("  // ...existing code...  "));
+        assert!(!is_lazy_marker_line("fn main() { /* real */ }"));
+        assert!(!is_lazy_marker_line("let x = 1; // keep comment"));
+    }
+
+    #[test]
+    fn build_requires_anchor() {
+        let err = build_apply_fragment_spec("fn x() {}", None, None, None, None, true).unwrap_err();
+        assert!(err.msg.contains("placement anchor"), "{msg}", msg = err.msg);
+    }
+
+    #[test]
+    fn build_rejects_empty_after_strip() {
+        let err = build_apply_fragment_spec(
+            "// ... existing code ...\n",
+            None,
+            Some("a"),
+            None,
+            None,
+            true,
+        )
+        .unwrap_err();
+        assert!(
+            err.msg.contains("empty after stripping"),
+            "{msg}",
+            msg = err.msg
+        );
+    }
+
+    #[test]
+    fn build_after_ok() {
+        let s = build_apply_fragment_spec(
+            "// ... existing code ...\n  b();\n// ... existing code ...\n",
+            Some("add b call"),
+            Some("  a();"),
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+        assert_eq!(s.fragment.trim(), "b();");
+        assert_eq!(s.placement, FragmentPlacement::After("  a();".into()));
+        assert_eq!(s.instruction.as_deref(), Some("add b call"));
+    }
+
+    #[test]
+    fn build_mutual_exclusion() {
+        let err =
+            build_apply_fragment_spec("x", None, Some("a"), Some("b"), None, true).unwrap_err();
+        assert!(
+            err.msg.contains("mutually exclusive"),
+            "{msg}",
+            msg = err.msg
+        );
+    }
+
+    #[test]
+    fn build_replace_mode() {
+        let s = build_apply_fragment_spec("NEW", None, None, None, Some("OLD"), true).unwrap();
+        assert_eq!(s.placement, FragmentPlacement::Replace("OLD".into()));
+        assert_eq!(s.fragment, "NEW");
+    }
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1,3 +1,4 @@
+pub mod apply_fragment;
 pub mod doc;
 pub mod file;
 pub mod md;

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -324,7 +324,8 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<String> {
         | Operation::FileDelete { path, .. }
         | Operation::Read { path, .. }
         | Operation::Search { path, .. }
-        | Operation::MdLintAgents { path, .. } => vec![path.clone()],
+        | Operation::MdLintAgents { path, .. }
+        | Operation::ApplyFragment { path, .. } => vec![path.clone()],
         #[cfg(feature = "ast")]
         Operation::AstRename { path, .. }
         | Operation::AstReplace { path, .. }

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -76,6 +76,32 @@ pub enum Operation {
         #[serde(default)]
         allow_absent_old: bool,
     },
+    /// Constrained freeform fragment apply (#2018): Morph-style marker strip + required anchor.
+    ///
+    /// Exactly one of `after`, `before`, or `old` must be set. Fragment may include
+    /// `// ... existing code ...` lines (stripped). No model merge / no anchor-less guess.
+    #[serde(rename = "apply.fragment")]
+    ApplyFragment {
+        /// File to edit.
+        path: String,
+        /// New text or Morph-style snippet (lazy marker lines stripped).
+        fragment: String,
+        /// Optional human instruction (explain only; not used for merge).
+        #[serde(default)]
+        instruction: Option<String>,
+        /// Insert cleaned fragment after this unique anchor.
+        #[serde(default)]
+        after: Option<String>,
+        /// Insert cleaned fragment before this unique anchor.
+        #[serde(default)]
+        before: Option<String>,
+        /// Replace this unique span with the cleaned fragment.
+        #[serde(default)]
+        old: Option<String>,
+        /// Fail if the anchor matches more than once (default true).
+        #[serde(default = "default_true_unique")]
+        unique: bool,
+    },
     #[serde(rename = "doc.set")]
     DocSet {
         /// Path to the JSON, YAML, or TOML file.
@@ -535,6 +561,7 @@ impl Operation {
     pub fn label(&self) -> &'static str {
         match self {
             Operation::Replace { .. } => "replace",
+            Operation::ApplyFragment { .. } => "apply.fragment",
             Operation::DocSet { .. } => "doc.set",
             Operation::DocDelete { .. } => "doc.delete",
             Operation::DocMerge { .. } => "doc.merge",
@@ -596,6 +623,7 @@ impl Operation {
         matches!(
             self,
             Operation::Replace { .. }
+                | Operation::ApplyFragment { .. }
                 | Operation::MdReplaceSection { .. }
                 | Operation::MdInsertAfterHeading { .. }
                 | Operation::MdInsertAfterSection { .. }
@@ -643,4 +671,9 @@ impl Operation {
     pub fn declared_paths(&self) -> Vec<String> {
         crate::plan::declared_paths(self)
     }
+}
+
+/// Serde default for [`Operation::ApplyFragment::unique`] (agents need fail-closed uniqueness).
+fn default_true_unique() -> bool {
+    true
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -201,6 +201,21 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
         ],
     },
     OpMeta {
+        name: "apply.fragment",
+        description: "Constrained freeform fragment apply (#2018). Strips Morph-style // ... existing code ... marker lines from fragment, then inserts or replaces at a required unique anchor (exactly one of after, before, old). Fail-closed: no anchor-less Morph model merge. Prefer for lazy-snippet agent output when anchors are known; use replace/ast for precise edits.",
+        tier: Tier::Weak,
+        examples: &[
+            (
+                "Insert cleaned fragment after an anchor (Morph markers stripped)",
+                r###"{"op":"apply.fragment","path":"src/lib.rs","after":"fn foo() {","fragment":"// ... existing code ...\n    bar();\n// ... existing code ...\n"}"###,
+            ),
+            (
+                "Replace a unique span with freeform new text",
+                r###"{"op":"apply.fragment","path":"src/lib.rs","old":"return 0;","fragment":"return 1;"}"###,
+            ),
+        ],
+    },
+    OpMeta {
         name: "file.append",
         description: "Append content to an existing file.",
         tier: Tier::Weak,

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -507,6 +507,28 @@ pub(crate) fn execute_operation(op: &Operation, tx: &mut TxState<'_>) -> anyhow:
         Operation::Replace { .. } => {
             return execute_replace_op(op, tx);
         }
+        Operation::ApplyFragment {
+            path,
+            fragment,
+            instruction,
+            after,
+            before,
+            old,
+            unique,
+        } => {
+            // Desugar to Replace: Morph marker strip + required anchor (#2018).
+            let replace_op = crate::ops::apply_fragment::plan_apply_fragment_to_replace(
+                path,
+                fragment,
+                instruction.as_deref(),
+                after.as_deref(),
+                before.as_deref(),
+                old.as_deref(),
+                *unique,
+            )
+            .map_err(anyhow::Error::new)?;
+            return execute_replace_op(&replace_op, tx);
+        }
 
         Operation::DocSet { .. }
         | Operation::DocDelete { .. }

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -35,6 +35,24 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
             }
             .into()
         }),
+        Operation::ApplyFragment {
+            fragment,
+            instruction,
+            after,
+            before,
+            old,
+            unique,
+            ..
+        } => crate::ops::apply_fragment::build_apply_fragment_spec(
+            fragment,
+            instruction.as_deref(),
+            after.as_deref(),
+            before.as_deref(),
+            old.as_deref(),
+            *unique,
+        )
+        .map(|_| ())
+        .map_err(Into::into),
         // Exhaustive match ensures the compiler flags new variants that may
         // need validation constraints.
         Operation::DocSet { .. }

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -91,7 +91,7 @@ def create_driver(agent_name: str, model: str) -> AgentDriver:
 
 
 _PATCHLOOM_SUBCOMMANDS = {
-    "search", "replace", "patch", "md", "doc", "tidy",
+    "search", "replace", "apply-fragment", "patch", "md", "doc", "tidy",
     "append", "prepend", "create", "delete", "rename", "read", "status", "tx",
     "batch", "explain", "undo", "init", "completions",
     "agent-rules", "mcp-server", "schema", "ast",

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -813,11 +813,11 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains(".cursor/mcp.json"));
     assert!(launch.contains("2,800+ tests"));
     assert!(
-        launch.contains("23 commands"),
+        launch.contains("24 commands"),
         "launch announcement CLI command count drifted"
     );
     assert!(
-        launch.contains("56 structured tool calls"),
+        launch.contains("57 structured tool calls"),
         "launch announcement MCP tool count drifted"
     );
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
## Summary

Implements **#2018** (preferred design): constrained freeform fragment apply without a Morph clone.

### Design decision

- Strip Morph-style lazy marker lines (`// ... existing code ...`, `# ...`, block comments).
- Require **exactly one** placement: `after` | `before` | `old`.
- Fail closed when anchors missing/ambiguous or fragment empty after strip.
- Desugar to existing `replace` write path (no parallel writer).
- No cloud apply model; no anchor-less guess.

### Surfaces

| Surface | Name |
|---------|------|
| CLI | `patchloom apply-fragment` |
| Plan / tx | `apply.fragment` |
| MCP | `apply_fragment` |
| Library | `build_apply_fragment_spec`, `strip_lazy_markers`, `plan_apply_fragment_to_replace`, … |

### Tests

- Unit: marker strip, placement validation, mutual exclusion
- CLI: after-anchor strips markers, preview exit 2, missing anchor, replace-old
- Matrix M9/M16 updated to PASS (with anchors)

Closes #2018

## Test plan

- [x] `cargo test --lib apply_fragment --all-features`
- [x] `make check-fast`
- [ ] CI green
- [ ] Reviewer pass