### PR TITLE
test: apply.fragment integration coverage and ambiguous-match hints

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -229,6 +229,7 @@ These are the main entry points. If you are deciding between commands, start her
 
 - **What it does:** Applies a freeform text fragment with a **required** placement anchor. Strips Morph-style lazy marker lines such as `// ... existing code ...` from `--fragment`, then inserts after/before an anchor or replaces a unique `old` span. Dry-run by default.
 - **Use when:** An agent emitted a Morph-class lazy snippet but you know a unique placement (after/before/old). Prefer this over guessing without anchors.
+- **Flags:** Exactly one of `--after`, `--before`, or `--old`. Provide text via `--fragment` or `--stdin`. Default uniqueness: fail when the anchor matches more than once. Pass `--allow-non-unique` only when multi-match is intentional (plan/MCP field is `unique`, default `true`).
 - **Prefer instead:** `replace` for exact known spans; `ast replace` / `ast rename` for code structure; never a cloud Morph merge for offline deterministic hosts.
 - **Failure behavior:** Missing placement or empty fragment after strip → `invalid_input` (exit 1). Anchor miss → `no_matches` (exit 3). Multi-match with default unique → `ambiguous` (exit 5). Preview without `--apply` → exit 2 when changes would apply.
 - **Related:** `replace`, `tx` plan op `apply.fragment`, MCP `apply_fragment`, `docs/plans/morph-gap-matrix.md`

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -286,7 +286,7 @@ fn replace_write(
             }
             return Err(anyhow::Error::new(crate::exit::AmbiguousError {
                 msg: format!(
-                    "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth or stronger before/after-context)",
+                    "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), or --allow-non-unique (apply-fragment))",
                     crate::fallback::truncate_str(&old, 60),
                     count
                 ),
@@ -302,7 +302,7 @@ fn replace_write(
         if unique && count > 1 {
             return Err(anyhow::Error::new(crate::exit::AmbiguousError {
                 msg: format!(
-                    "ambiguous match: pattern {old:?} matches {count} times; use --nth or add context to disambiguate"
+                    "ambiguous match: pattern {old:?} matches {count} times; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)"
                 ),
             }));
         }
@@ -705,7 +705,7 @@ fn replace_in_content_inner(
         }
         return Err(anyhow::Error::new(crate::exit::AmbiguousError {
             msg: format!(
-                "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth or stronger before/after-context)",
+                "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), or --allow-non-unique (apply-fragment))",
                 crate::fallback::truncate_str(from, 60),
                 count
             ),
@@ -880,7 +880,7 @@ fn finalize_content_replace(
         return Err(crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::AmbiguousTarget,
             format!(
-                "ambiguous match: pattern {:?} matches {} times; use --nth or add context to disambiguate",
+                "ambiguous match: pattern {:?} matches {} times; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)",
                 from, count
             ),
         )

--- a/src/cmd/apply_fragment.rs
+++ b/src/cmd/apply_fragment.rs
@@ -307,6 +307,12 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("t.rs");
         std::fs::write(&path, "dup\ndup\n").unwrap();
+        let g = GlobalFlags {
+            apply: true,
+            json: true,
+            quiet: true,
+            ..GlobalFlags::default()
+        };
         let code = run(
             ApplyFragmentArgs {
                 file: path.to_string_lossy().into(),
@@ -319,9 +325,38 @@ mod tests {
                 allow_non_unique: false,
                 write: Default::default(),
             },
-            &g_apply(),
+            &g,
         )
         .unwrap();
         assert_eq!(code, crate::exit::AMBIGUOUS);
+    }
+
+    #[test]
+    fn apply_fragment_allow_non_unique_applies_all() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.txt");
+        std::fs::write(&path, "dup\ndup\n").unwrap();
+        let code = run(
+            ApplyFragmentArgs {
+                file: path.to_string_lossy().into(),
+                fragment: Some("X".into()),
+                stdin: false,
+                instruction: None,
+                after: Some("dup".into()),
+                before: None,
+                old: None,
+                allow_non_unique: true,
+                write: Default::default(),
+            },
+            &g_apply(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::SUCCESS);
+        let body = std::fs::read_to_string(&path).unwrap();
+        // Whole-line anchors use line-oriented insert (#1885).
+        assert_eq!(
+            body, "dup\nX\ndup\nX\n",
+            "both anchors should get insert: {body:?}"
+        );
     }
 }

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -720,7 +720,7 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 global.emit_json(&output)?;
                 if !global.quiet {
                     eprintln!(
-                        "ambiguous match: pattern {:?} matches {} times in {}; use --nth or add context to disambiguate",
+                        "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)",
                         crate::fallback::truncate_str(&args.old, 60),
                         r.match_count,
                         r.display_path,

--- a/src/ops/apply_fragment.rs
+++ b/src/ops/apply_fragment.rs
@@ -359,4 +359,48 @@ mod tests {
         assert_eq!(s.placement, FragmentPlacement::Replace("OLD".into()));
         assert_eq!(s.fragment, "NEW");
     }
+
+    #[test]
+    fn desugar_after_maps_to_insert_after() {
+        let s = build_apply_fragment_spec("NEW\n", None, Some("ANCHOR"), None, None, true).unwrap();
+        let d = desugar_to_replace_fields(&s);
+        assert_eq!(d.old, "ANCHOR");
+        assert_eq!(d.insert_after.as_deref(), Some("NEW\n"));
+        assert!(d.insert_before.is_none());
+        assert!(d.new_text.is_none());
+        assert!(d.unique);
+    }
+
+    #[test]
+    fn plan_apply_fragment_to_replace_op_name() {
+        let op = plan_apply_fragment_to_replace(
+            "f.rs",
+            "// ... existing code ...\nx\n",
+            None,
+            Some("y"),
+            None,
+            None,
+            true,
+        )
+        .unwrap();
+        match op {
+            crate::plan::Operation::Replace {
+                path,
+                old,
+                insert_after,
+                new_text,
+                unique,
+                require_change,
+                ..
+            } => {
+                assert_eq!(path.as_deref(), Some("f.rs"));
+                assert_eq!(old, "y");
+                assert_eq!(insert_after.as_deref(), Some("x\n"));
+                assert!(new_text.is_none());
+                assert!(unique);
+                assert!(require_change);
+            }
+            other => panic!("expected Replace, got {other:?}"),
+        }
+    }
 }

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -251,7 +251,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         if *unique && match_count > 1 {
             return Err(crate::exit::AmbiguousError {
                 msg: format!(
-                    "ambiguous match: pattern {:?} matches {} times in {}; use --nth or add context to disambiguate",
+                    "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)",
                     crate::fallback::truncate_str(old, 60),
                     match_count,
                     p
@@ -288,7 +288,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 }
                 return Err(crate::exit::AmbiguousError {
                     msg: format!(
-                        "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth or stronger before/after-context)",
+                        "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), or --allow-non-unique (apply-fragment))",
                         crate::fallback::truncate_str(old, 60),
                         match_count,
                         p
@@ -572,7 +572,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     .display();
                 return Err(crate::exit::AmbiguousError {
                     msg: format!(
-                        "ambiguous match: pattern {:?} matches {} times in {}; use --nth or add context to disambiguate",
+                        "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)",
                         crate::fallback::truncate_str(old, 60),
                         match_count,
                         rel
@@ -611,7 +611,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         .display();
                     return Err(crate::exit::AmbiguousError {
                         msg: format!(
-                            "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth or stronger before/after-context)",
+                            "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), or --allow-non-unique (apply-fragment))",
                             crate::fallback::truncate_str(old, 60),
                             match_count,
                             rel

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -127,6 +127,74 @@ async fn test_mcp_replace_round_trip() {
     client.cancel().await.unwrap();
 }
 
+/// #2018: MCP apply_fragment strips markers and inserts after anchor.
+#[tokio::test]
+async fn test_mcp_apply_fragment_after_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("t.rs"), "fn foo() {\n  a();\n}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "apply_fragment",
+        serde_json::json!({
+            "path": "t.rs",
+            "after": "  a();",
+            "fragment": "// ... existing code ...\n  b();\n// ... existing code ...\n",
+            "instruction": "add b"
+        }),
+    )
+    .await;
+    assert!(!is_error, "apply_fragment should succeed: {val}");
+    assert_eq!(val["ok"], true, "apply_fragment ok field: {val}");
+    assert_eq!(
+        val["files_changed"], 1,
+        "apply_fragment files_changed: {val}"
+    );
+
+    let content = fs::read_to_string(dir.path().join("t.rs")).unwrap();
+    assert!(
+        content.contains("  a();\n  b();\n"),
+        "expected insert after a(); got {content:?}"
+    );
+    assert!(
+        !content.contains("existing code"),
+        "lazy markers must be stripped: {content:?}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// #2018: MCP apply_fragment without anchors fails closed.
+#[tokio::test]
+async fn test_mcp_apply_fragment_requires_anchor() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("t.rs"), "x\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "apply_fragment",
+        serde_json::json!({
+            "path": "t.rs",
+            "fragment": "y\n"
+        }),
+    )
+    .await;
+    assert!(is_error, "missing anchor must error: {val}");
+    let content = fs::read_to_string(dir.path().join("t.rs")).unwrap();
+    assert_eq!(
+        content, "x\n",
+        "file must be unchanged on invalid apply_fragment"
+    );
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_read_round_trip() {
     if !has_mcp_support() {

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -3445,3 +3445,83 @@ fn test_replace_dir_all_unreadable_not_no_matches() {
         assert_ne!(v["error_kind"], "no_matches", "{v}");
     }
 }
+
+/// #2018: CLI apply-fragment binary path (subprocess) with Morph markers + after-anchor.
+#[test]
+fn test_apply_fragment_cli_after_strips_markers() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.rs");
+    fs::write(&file, "fn foo() {\n  a();\n}\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("apply-fragment")
+        .arg(file.to_str().unwrap())
+        .arg("--after")
+        .arg("  a();")
+        .arg("--fragment")
+        .arg("// ... existing code ...\n  b();\n// ... existing code ...\n")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let body = fs::read_to_string(&file).unwrap();
+    assert!(
+        body.contains("  a();\n  b();\n"),
+        "expected insert after a(); got {body:?}"
+    );
+    assert!(
+        !body.contains("existing code"),
+        "lazy markers must be stripped: {body:?}"
+    );
+}
+
+/// #2018: CLI apply-fragment dry-run preview is exit 2 and leaves file unchanged.
+#[test]
+fn test_apply_fragment_cli_preview_exit_2() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.rs");
+    fs::write(&file, "a\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("apply-fragment")
+        .arg(file.to_str().unwrap())
+        .arg("--after")
+        .arg("a")
+        .arg("--fragment")
+        .arg("b\n")
+        .assert()
+        .code(2);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "a\n");
+}
+
+/// Ambiguous apply-fragment hint must mention --allow-non-unique (not only replace --nth).
+#[test]
+fn test_apply_fragment_cli_ambiguous_json_hint() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.txt");
+    fs::write(&file, "dup\ndup\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "apply-fragment"])
+        .arg(file.to_str().unwrap())
+        .args(["--after", "dup", "--fragment", "x", "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(5),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "ambiguous", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("allow-non-unique") || err.contains("apply-fragment"),
+        "ambiguous hint must guide apply-fragment users: {v}"
+    );
+}

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8933,3 +8933,189 @@ fn test_tx_unreadable_plan_does_not_double_wrap() {
         "must not double-wrap load_text_strict: {v}"
     );
 }
+
+/// #2018: plan op `apply.fragment` desugars through tx (markers stripped + after-anchor).
+#[test]
+fn test_tx_apply_fragment_after_strips_markers() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.rs");
+    fs::write(&file, "fn foo() {\n  a();\n}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "apply.fragment",
+            "path": portable_path_str(&file),
+            "after": "  a();",
+            "fragment": "// ... existing code ...\n  b();\n// ... existing code ...\n",
+            "instruction": "add b"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let body = fs::read_to_string(&file).unwrap();
+    assert!(
+        body.contains("  a();\n  b();\n"),
+        "expected insert after a(); got {body:?}"
+    );
+    assert!(
+        !body.contains("existing code"),
+        "lazy markers must be stripped: {body:?}"
+    );
+}
+
+/// #2018: apply.fragment without placement anchors is invalid_input (exit 1).
+#[test]
+fn test_tx_apply_fragment_requires_anchor() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.rs");
+    fs::write(&file, "x\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "apply.fragment",
+            "path": portable_path_str(&file),
+            "fragment": "y\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|_| {
+        panic!(
+            "expected JSON stdout: {}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    });
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("placement anchor") || err.contains("anchor"),
+        "message should mention anchor: {v}"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "x\n");
+}
+
+/// #2018: apply.fragment unique multi-match is ambiguous (exit 5).
+#[test]
+fn test_tx_apply_fragment_unique_ambiguous_exit_5() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.txt");
+    fs::write(&file, "dup\ndup\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "apply.fragment",
+            "path": portable_path_str(&file),
+            "after": "dup",
+            "fragment": "x"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(5); // AMBIGUOUS
+    assert_eq!(fs::read_to_string(&file).unwrap(), "dup\ndup\n");
+}
+
+/// #2018: apply.fragment old-mode replace via plan.
+#[test]
+fn test_tx_apply_fragment_replace_old() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.rs");
+    fs::write(&file, "return 0;\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "apply.fragment",
+            "path": portable_path_str(&file),
+            "old": "return 0;",
+            "fragment": "return 1;"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let body = fs::read_to_string(&file).unwrap();
+    assert!(
+        body.starts_with("return 1;"),
+        "expected replace to return 1; got {body:?}"
+    );
+}
+
+/// #2018: apply.fragment mutual exclusion of after+before is invalid_input.
+#[test]
+fn test_tx_apply_fragment_mutual_exclusion() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.rs");
+    fs::write(&file, "x\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "apply.fragment",
+            "path": portable_path_str(&file),
+            "after": "x",
+            "before": "x",
+            "fragment": "y"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("mutually exclusive"),
+        "expected mutual exclusion message: {v}"
+    );
+}


### PR DESCRIPTION
## Summary

MPI cycle on `fix/improve-mpi-20260728-s1` after pre-rotation gate (CI green, open scanning=0, only release PR #2011 + B-path issues remaining).

- **QA:** #2018 had unit/CLI lib tests but no plan/tx, MCP, or cargo-bin coverage. Add integration tests for `apply.fragment` via `tx`, MCP `apply_fragment`, and CLI `apply-fragment`, plus desugar unit locks and `--allow-non-unique`.
- **End User / Observability:** Ambiguous-match messages only mentioned replace `--nth`. Apply-fragment users need `--allow-non-unique` / tighter anchors. Updated replace and tx ambiguous hints accordingly.
- **Docs:** Reference docs for `apply-fragment` now list flags including `--allow-non-unique`.

## Test plan

- [x] `cargo test --lib ops::apply_fragment cmd::apply_fragment --all-features`
- [x] `cargo test --test integration --all-features apply_fragment`
- [x] `make check-fast`

Ref #2018