### PR TITLE
docs: clarify Morph product and apply-fragment discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,7 +461,8 @@ The YAML parser changes the value at the selector path. Comments, indentation, k
 | Structural code pattern search | [ast-grep](https://github.com/ast-grep/ast-grep) | Text-only grep for shapes |
 | Identifier rename in code | Patchloom `ast rename` | Fuzzy text replace for symbols |
 | Multi-file atomic apply + undo | Patchloom `batch` / `tx` | N sequential shell edits |
-| Cloud merge of LLM snippets | Morph Fast Apply (etc.) | Patchloom for local deterministic configs |
+| Freeform snippet **with** known anchor (after/before/old) | Patchloom `apply-fragment` (strips Morph-style `// ... existing code ...` markers) | Whole-file rewrite or guessing placement |
+| Freeform snippet **without** anchors (cloud model merge) | [Morph](https://www.morphllm.com/) Fast Apply or similar | Patchloom (anchor-less Morph merge is a non-goal) |
 | Full agent product | Claude Code / Codex / Cursor | Patchloom alone |
 
 Longer write-ups: [Comparisons](docs/getting-started/comparisons.md) · [Embedder host checklist](docs/getting-started/embedder-host.md) · [MCP setup](docs/getting-started/mcp-setup.md)

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ The YAML parser changes the value at the selector path. Comments, indentation, k
 
 Longer write-ups: [Comparisons](docs/getting-started/comparisons.md) · [Embedder host checklist](docs/getting-started/embedder-host.md) · [MCP setup](docs/getting-started/mcp-setup.md)
 
-**Library hosts:** [Embedder host checklist](docs/getting-started/embedder-host.md) — dual-path `ReplaceOptions::for_agent()` (primary + fallback, includes `refuse_suspicious_fuzzy`), peels via `edit_error_kind` / `is_*` / `is_fuzzy_span_suspicious` with `#[non_exhaustive]` `_` arm, multi-op `ContentEditsResult.op_honesty`, plan/tx widest `matched_text`, optional `apply_content_edits_to_file_with_span_policy`. Custom options still use `api::fuzzy_span_suspicious` / `FuzzySpanPolicy` after fuzzy Apply.
+**Library hosts:** [Embedder host checklist](docs/getting-started/embedder-host.md): dual-path `ReplaceOptions::for_agent()` (primary + fallback, includes `refuse_suspicious_fuzzy`), peels via `edit_error_kind` / `is_*` / `is_fuzzy_span_suspicious` with `#[non_exhaustive]` `_` arm, multi-op `ContentEditsResult.op_honesty`, plan/tx widest `matched_text`, optional `apply_content_edits_to_file_with_span_policy`. Custom options still use `api::fuzzy_span_suspicious` / `FuzzySpanPolicy` after fuzzy Apply.
 
 **Context budget:** line-range `read`, `search --count` / `--files-with-matches`, one `batch`/`tx`, `--jsonl` for large streams.
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -188,6 +188,7 @@ AST tools so `list_tools` stays honest about what is callable.
 | `server_info` | Return the server's working directory so the agent can discover the root path before file operations (read-only) |
 | `read_file` | Read file contents with optional line range |
 | `replace_text` | Replace text in a text file (literal or regex). Binary and invalid UTF-8 files are skipped |
+| `apply_fragment` | Freeform fragment at a required after/before/old anchor; strips Morph-style `// ... existing code ...` markers (no cloud merge). Prefer when the agent has a snippet plus a known placement |
 | `md_upsert_bullet` | Add a bullet under a markdown heading |
 | `md_table_append` | Append a row to a markdown table |
 | `md_replace_section` | Replace a section by heading (through next same-or-higher heading) |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -227,7 +227,7 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:apply-fragment -->
 ## `apply-fragment`
 
-- **What it does:** Applies a freeform text fragment with a **required** placement anchor. Strips Morph-style lazy marker lines such as `// ... existing code ...` from `--fragment`, then inserts after/before an anchor or replaces a unique `old` span. Dry-run by default.
+- **What it does:** Applies a freeform text fragment with a **required** placement anchor. Strips Morph-style lazy marker lines such as `// ... existing code ...` from `--fragment`, then inserts after/before an anchor or replaces a unique `old` span. Dry-run by default. **Morph** here means [MorphLLM Fast Apply](https://www.morphllm.com/) (a cloud apply product); Patchloom only reuses the common marker style and does not call Morph's API.
 - **Use when:** An agent emitted a Morph-class lazy snippet but you know a unique placement (after/before/old). Prefer this over guessing without anchors.
 - **Flags:** Exactly one of `--after`, `--before`, or `--old`. Provide text via `--fragment` or `--stdin`. Default uniqueness: fail when the anchor matches more than once. Pass `--allow-non-unique` only when multi-match is intentional (plan/MCP field is `unique`, default `true`).
 - **Prefer instead:** `replace` for exact known spans; `ast replace` / `ast rename` for code structure; never a cloud Morph merge for offline deterministic hosts.


### PR DESCRIPTION
## Summary

Small discoverability polish after 0.22.0:

- **README** "When to use what": split freeform **with** anchor (`apply-fragment`) vs **without** anchors (Morph / similar cloud merge)
- **MCP setup**: list `apply_fragment` next to `replace_text`
- **Reference**: one line that Morph means MorphLLM Fast Apply (product), not a Patchloom brand

## Why

Release readers asked whether "Morph-style lazy markers" refers to a product. Agent-facing docs already covered the contract; first-touch surfaces did not.

No code changes.