### PR TITLE
docs: MorphLLM naming and apply-fragment onboarding paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Replace fail-closed / shell-token options: CLI `replace --require-change` and `-
 |---|---|
 | `search` | Fast literal or regex search across text files (supports --glob/--exclude/--ignore-file for layered custom ignore files, --max-results, -C context, etc.) |
 | `replace` | Mechanical string replacement across text files with diff preview |
-| `apply-fragment` | Freeform fragment with required anchors (Morph markers stripped; no model merge) |
+| `apply-fragment` | Freeform fragment with required anchors ([MorphLLM](https://www.morphllm.com/)-style markers stripped; no cloud merge) |
 | `append` | Append content to an existing file |
 | `prepend` | Prepend content to an existing file |
 | `create` | Create a new file with content |

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -5,7 +5,7 @@
 Patchloom has 24 commands:
 
 - **search** / **replace** -- text-level find and replace across files
-- **apply-fragment** -- freeform fragment with required anchors (Morph-style markers stripped; no model merge)
+- **apply-fragment** -- freeform fragment with required anchors ([MorphLLM](https://www.morphllm.com/)-style `// ... existing code ...` markers stripped; no cloud model merge)
 - **patch** -- apply unified diffs
 - **md** -- markdown-aware editing (sections, bullets, tables, headings)
 - **doc** -- parser-backed JSON, YAML, and TOML mutations

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -288,7 +288,7 @@ patchloom mcp-server
 
 Handshake `instructions` match the active surface: core mode lists only the core tools (it does not advertise full-inventory names such as `create_file` or `ast_*`).
 
-**Note:** `execute_plan` remains on core, so multi-op plans can still run create/delete/AST-style plan ops when the host sends a full plan. The env flag reduces the *tool schema* surface for small agents; it is not a capability sandbox for the plan catalog.
+**Note:** `execute_plan` remains on core, so multi-op plans can still run create/delete/AST-style plan ops (and plan `apply.fragment`) when the host sends a full plan. Standalone tools such as `apply_fragment`, `create_file`, and `ast_*` are full-inventory only. The env flag reduces the *tool schema* surface for small agents; it is not a capability sandbox for the plan catalog.
 
 Example client env (Grok `config.toml`):
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -51,6 +51,19 @@ The output shows a unified diff. When it looks correct, apply:
 patchloom replace 'old_function' --new 'new_function' src/ --apply
 ```
 
+If an agent emitted a freeform snippet with MorphLLM-style
+`// ... existing code ...` markers **and** you know a unique anchor,
+use `apply-fragment` (markers stripped; placement required) instead of
+rewriting the whole file. See [Comparisons: Morph](comparisons.md).
+
+```bash
+patchloom apply-fragment src/lib.rs \
+  --after 'fn foo() {' \
+  --fragment '// ... existing code ...
+  bar();
+// ... existing code ...' --apply
+```
+
 ## Step 3: Edit structured config
 
 Read a value from a JSON file:

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -34,7 +34,7 @@ EOF
 |----------|---------|-------------|
 | Text | `search` | Literal or regex search across files |
 | | `replace` | Mechanical string replacement with diff preview |
-| | `apply-fragment` | Freeform fragment with required anchors (Morph markers stripped) |
+| | `apply-fragment` | Freeform fragment with required anchors ([MorphLLM](https://www.morphllm.com/)-style markers stripped; no cloud merge) |
 | | `patch` | Preview or apply unified diffs |
 | Structured | `doc` | Parser-backed JSON, YAML, and TOML operations |
 | | `md` | Markdown section-aware operations |


### PR DESCRIPTION
## Summary

MPI follow-through after #2030 Morph discoverability:

- **Introduction / concepts / README command table:** name MorphLLM with product link on `apply-fragment`
- **Quickstart:** short `apply-fragment` example after replace (markers + required anchor)
- **MCP setup:** core pack still omits standalone `apply_fragment`; `execute_plan` can still run plan `apply.fragment`

## MPI gate

- Open product issues: none (only #1990 human post, #960/#961 external dist)
- Mechanical: machete clean, outdated clean, deny clean, 0 bare `is_ok` asserts, open scanning 0
- Other perspectives: no-op on mature 0.22 surface

## Test plan

- [x] `make check-readme`
- Docs only (no code)