### PR TITLE
feat(api): path-only non-text rename, apply_fragment_to_file, honesty constructors

### DIFF
--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -36,6 +36,15 @@ Bline is a real embedder that dogfooded these steps; the checklist is host-gener
    - Disk multi-op with a final gate:  
      `apply_content_edits_to_file_with_span_policy(path, edits, mode, guard, Some(&FuzzySpanPolicy::default()))`  
      refuses over-wide fuzzy **before** write/backup (#2008).
+8. **Path-only file ops on non-text:** `file_rename` / `file_delete` succeed on
+   binary and invalid UTF-8 with byte backup and PathGuard (no OS dual-path)
+   (#2031). Append/prepend/replace still refuse non-text loads.
+9. **Morph-class freeform on disk:** `apply_fragment_to_file(path, fragment,
+   FragmentPlacement::After|Before|Replace(...), unique, mode, guard)` strips
+   lazy markers and applies via the replace path (#2032).
+10. **Host unit tests for `op_honesty`:** `ContentEditHonesty` is
+    `#[non_exhaustive]`; use `ContentEditHonesty::exact` / `::fuzzy` instead of
+    struct literals (#2033). Prefer live `apply_content_edits` for integration tests.
 
 ## Minimal sketch
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1377,7 +1377,7 @@ The operations below are the building blocks inside `operations`.
 | Apply session id for surgical undo | `EditResult.backup_session` after Apply (#1686); pair with `restore_path_from_session` |
 | Nested monorepo backup listing | `backup::list_sessions_under` + `ListSessionsOptions` (#1688) |
 | Ancestor backup root discovery | `backup::find_backup_roots(path)` walks parents for `.patchloom/backups` (#1934) |
-| File op structured kinds | `file_create` / `file_delete` / `file_rename` / `file_append`: dest-exists without force → `AlreadyExists` (#1947); missing path → `NotFound`; dir/empty path → `InvalidInput`; binary → `Binary` / invalid UTF-8 → `InvalidEncoding` (#1963); force create overwrites non-text prior (#1962); PathGuard → `GuardRejected` (#1935) |
+| File op structured kinds | `file_create` / `file_delete` / `file_rename` / `file_append`: dest-exists without force → `AlreadyExists` (#1947); missing path → `NotFound`; dir/empty path → `InvalidInput`; append/prepend on binary → `Binary` / invalid UTF-8 → `InvalidEncoding` (#1963); **path-only** `file_rename` / `file_delete` succeed on binary and invalid UTF-8 with byte backup (#2031); force create overwrites non-text prior (#1962); PathGuard → `GuardRejected` (#1935) |
 | AST signature rewrite kinds | `ast_rewrite_signature`: missing fn → `NoMatch`; binary → `Binary` (#1963); guard → `GuardRejected` (#1936) |
 | In-memory multi-op with real diff headers | `apply_content_edits_with_label` (#1665) |
 | Surgical undo one path | `backup::restore_path_from_session(root, ts, path)` (#1660) |

--- a/src/api/apply_fragment.rs
+++ b/src/api/apply_fragment.rs
@@ -1,0 +1,62 @@
+//! Library disk apply for Morph-class freeform fragments (#2032).
+
+use std::path::Path;
+
+use crate::containment::PathGuard;
+use crate::ops::apply_fragment::{
+    FragmentPlacement, build_apply_fragment_spec, desugar_to_replace_fields,
+};
+
+use super::{ApplyMode, EditResult, ReplaceOptions, replace::replace_text};
+
+/// Apply a freeform fragment at a required placement anchor on disk (#2032).
+///
+/// Strips Morph-style lazy marker lines (`// ... existing code ...`), then
+/// inserts after/before the unique anchor or replaces `old` via the same
+/// path as [`replace_text`]. Fail-closed: missing/ambiguous anchors, empty
+/// fragment after strip, PathGuard rejects.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use patchloom::api::{
+///     ApplyMode, FragmentPlacement, apply_fragment_to_file,
+/// };
+/// use std::path::Path;
+///
+/// let _ = apply_fragment_to_file(
+///     Path::new("src/lib.rs"),
+///     "// ... existing code ...\nfn new() {}\n// ... existing code ...\n",
+///     FragmentPlacement::After("fn foo() {".into()),
+///     true,
+///     ApplyMode::Apply,
+///     None,
+/// )?;
+/// # Ok::<(), anyhow::Error>(())
+/// ```
+#[cfg(any(feature = "cli", feature = "files"))]
+pub fn apply_fragment_to_file(
+    path: &Path,
+    fragment: &str,
+    placement: FragmentPlacement,
+    unique: bool,
+    mode: ApplyMode,
+    guard: Option<&PathGuard>,
+) -> anyhow::Result<EditResult> {
+    let (after, before, old) = match &placement {
+        FragmentPlacement::After(a) => (Some(a.as_str()), None, None),
+        FragmentPlacement::Before(b) => (None, Some(b.as_str()), None),
+        FragmentPlacement::Replace(o) => (None, None, Some(o.as_str())),
+    };
+    let spec = build_apply_fragment_spec(fragment, None, after, before, old, unique)?;
+    let d = desugar_to_replace_fields(&spec);
+    let opts = ReplaceOptions {
+        insert_after: d.insert_after,
+        insert_before: d.insert_before,
+        unique: d.unique,
+        require_change: true,
+        ..ReplaceOptions::default()
+    };
+    let to = d.new_text.as_deref().unwrap_or("");
+    replace_text(path, &d.old, to, &opts, mode, guard)
+}

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -52,6 +52,11 @@ pub enum ContentEdit {
 /// Hosts should call [`super::fuzzy_span_suspicious`] with this entry's `old`,
 /// `matched_text`, and `match_score` rather than rollup fields alone (rollup
 /// widest span and min score may come from different ops).
+///
+/// Prefer building this via real [`apply_content_edits`] / replace for
+/// integration tests. Downstream crates cannot use struct literals
+/// (`#[non_exhaustive]`); use [`Self::exact`] / [`Self::fuzzy`] for host
+/// refuse-glue unit tests (#2033).
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct ContentEditHonesty {
@@ -65,6 +70,40 @@ pub struct ContentEditHonesty {
     pub matched_text: Option<String>,
     /// The replace `old` string for this op (for refuse with matching old).
     pub old: String,
+}
+
+impl ContentEditHonesty {
+    /// Construct a minimal exact-match honesty row for host unit tests (#2033).
+    ///
+    /// Future fields get internal defaults; prefer live edits for integration
+    /// coverage.
+    #[must_use]
+    pub fn exact(op_index: usize, old: impl Into<String>, matched_text: impl Into<String>) -> Self {
+        Self {
+            op_index,
+            match_mode: Some(MatchMode::Exact),
+            match_score: None,
+            matched_text: Some(matched_text.into()),
+            old: old.into(),
+        }
+    }
+
+    /// Construct a minimal fuzzy-match honesty row for host unit tests (#2033).
+    #[must_use]
+    pub fn fuzzy(
+        op_index: usize,
+        old: impl Into<String>,
+        score: f64,
+        matched_text: impl Into<String>,
+    ) -> Self {
+        Self {
+            op_index,
+            match_mode: Some(MatchMode::Fuzzy),
+            match_score: Some(score),
+            matched_text: Some(matched_text.into()),
+            old: old.into(),
+        }
+    }
 }
 
 /// Result of applying a sequence of [`ContentEdit`]s to a buffer.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -247,6 +247,12 @@ pub use crate::ops::apply_fragment::{
     plan_apply_fragment_to_replace, strip_lazy_markers,
 };
 
+// Disk apply for Morph-class fragments (#2032).
+#[cfg(any(feature = "cli", feature = "files"))]
+mod apply_fragment;
+#[cfg(any(feature = "cli", feature = "files"))]
+pub use self::apply_fragment::apply_fragment_to_file;
+
 mod post_write;
 pub use self::post_write::*;
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4714,13 +4714,12 @@ fn refuse_batch_if_suspicious_fuzzy_rejects_wide_honesty() {
         match_mode: Some(MatchMode::Fuzzy),
         match_score: Some(AGENT_MIN_FUZZY_SCORE),
         matched_text: Some("process_data_and_much_more_tail".into()),
-        op_honesty: vec![ContentEditHonesty {
-            op_index: 0,
-            match_mode: Some(MatchMode::Fuzzy),
-            match_score: Some(AGENT_MIN_FUZZY_SCORE),
-            matched_text: Some("process_data_and_much_more_tail".into()),
-            old: "process_data".into(),
-        }],
+        op_honesty: vec![ContentEditHonesty::fuzzy(
+            0,
+            "process_data",
+            AGENT_MIN_FUZZY_SCORE,
+            "process_data_and_much_more_tail",
+        )],
     };
     let err = refuse_batch_if_suspicious_fuzzy(&batch, &FuzzySpanPolicy::default())
         .expect_err("wide fuzzy honesty must refuse before write");
@@ -7000,27 +6999,51 @@ fn file_append_binary_is_binary() {
 
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]
-fn file_rename_binary_is_binary() {
-    // Text-oriented rename refuses binary sources so embedders can fall back to
-    // std::fs::rename after branching on Binary (#1935 / #1963).
+fn file_rename_binary_path_only_succeeds() {
+    // Path-only rename: binary must move without host OS fallback (#2031).
     let dir = TempDir::new().unwrap();
     let bin = dir.path().join("b.bin");
     let bin_dst = dir.path().join("c.bin");
-    fs::write(&bin, b"x\x00y").unwrap();
-    let err = file_rename(&bin, &bin_dst, false, ApplyMode::Apply, None).unwrap_err();
-    assert_eq!(
-        crate::fallback::edit_error_kind(&err),
-        Some(EditErrorKind::Binary),
-        "binary rename must peel Binary (#1963): {err}"
-    );
-    assert!(crate::fallback::is_binary(&err), "is_binary peel: {err}");
-    assert_eq!(crate::fallback::error_kind_str(&err), Some("binary"));
+    let bytes = b"x\x00y".as_slice();
+    fs::write(&bin, bytes).unwrap();
+    let r = file_rename(&bin, &bin_dst, false, ApplyMode::Apply, None)
+        .expect("binary rename must succeed as path-only (#2031)");
+    assert!(r.applied);
+    assert_eq!(r.action, "rename");
+    assert!(!bin.exists(), "source must be gone after rename");
+    assert!(bin_dst.exists());
+    assert_eq!(fs::read(&bin_dst).unwrap(), bytes);
     assert!(
-        err.to_string().to_ascii_lowercase().contains("binary"),
-        "message: {err}"
+        r.backup_session.is_some(),
+        "path-only rename must still create backup"
     );
-    assert!(bin.exists());
-    assert!(!bin_dst.exists());
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn file_rename_invalid_utf8_path_only_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("bad.txt");
+    let dst = dir.path().join("ok.txt");
+    // Invalid UTF-8 without NUL (not binary probe) still must path-rename.
+    fs::write(&src, b"hello\xffworld").unwrap();
+    let r = file_rename(&src, &dst, false, ApplyMode::Apply, None)
+        .expect("invalid UTF-8 rename must succeed (#2031)");
+    assert!(r.applied);
+    assert!(!src.exists());
+    assert_eq!(fs::read(&dst).unwrap(), b"hello\xffworld");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn file_delete_binary_path_only_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let bin = dir.path().join("b.bin");
+    fs::write(&bin, b"x\x00y").unwrap();
+    let r = file_delete(&bin, ApplyMode::Apply, None).expect("binary delete (#2031)");
+    assert!(r.applied);
+    assert!(!bin.exists());
+    assert!(r.backup_session.is_some());
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -7236,4 +7259,113 @@ fn ast_rewrite_signature_empty_edit_is_invalid_input() {
         Some(EditErrorKind::InvalidInput),
         "empty edit fields: {err}"
     );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_fragment_to_file_after_strips_markers() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.rs");
+    fs::write(&path, "fn foo() {\n  a();\n}\n").unwrap();
+    let fragment = "// ... existing code ...\n  bar();\n// ... existing code ...\n";
+    let r = apply_fragment_to_file(
+        &path,
+        fragment,
+        FragmentPlacement::After("fn foo() {".into()),
+        true,
+        ApplyMode::Apply,
+        None,
+    )
+    .expect("apply_fragment_to_file after (#2032)");
+    assert!(r.applied);
+    assert!(r.changed);
+    let body = fs::read_to_string(&path).unwrap();
+    assert!(body.contains("bar();"), "body: {body}");
+    assert!(!body.contains("existing code"), "markers stripped: {body}");
+    assert!(r.backup_session.is_some());
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_fragment_to_file_requires_unique_anchor() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.rs");
+    fs::write(&path, "x\nx\n").unwrap();
+    let err = apply_fragment_to_file(
+        &path,
+        "y\n",
+        FragmentPlacement::After("x".into()),
+        true,
+        ApplyMode::Preview,
+        None,
+    )
+    .expect_err("ambiguous after must fail closed");
+    assert!(
+        crate::fallback::is_ambiguous(&err)
+            || crate::fallback::edit_error_kind(&err) == Some(EditErrorKind::AmbiguousTarget),
+        "ambiguous peel: {err}"
+    );
+    assert_eq!(fs::read_to_string(&path).unwrap(), "x\nx\n");
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_fragment_to_file_empty_after_strip_invalid() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.rs");
+    fs::write(&path, "fn foo() {}\n").unwrap();
+    let err = apply_fragment_to_file(
+        &path,
+        "// ... existing code ...\n",
+        FragmentPlacement::After("fn foo() {}".into()),
+        true,
+        ApplyMode::Apply,
+        None,
+    )
+    .expect_err("empty fragment after strip");
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput),
+        "empty strip: {err}"
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_fragment_to_file_replace_old() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("t.rs");
+    fs::write(&path, "return 0;\n").unwrap();
+    let r = apply_fragment_to_file(
+        &path,
+        "return 1;\n",
+        FragmentPlacement::Replace("return 0;".into()),
+        true,
+        ApplyMode::Apply,
+        None,
+    )
+    .expect("replace old");
+    assert!(r.applied);
+    let body = fs::read_to_string(&path).unwrap();
+    assert!(
+        body.starts_with("return 1;"),
+        "replace old result: {body:?}"
+    );
+}
+
+#[test]
+fn content_edit_honesty_constructors_for_hosts() {
+    let exact = ContentEditHonesty::exact(0, "old", "old");
+    assert_eq!(exact.op_index, 0);
+    assert_eq!(exact.old, "old");
+    assert_eq!(exact.matched_text.as_deref(), Some("old"));
+    assert_eq!(exact.match_mode, Some(MatchMode::Exact));
+    assert!(exact.match_score.is_none());
+
+    let fuzzy = ContentEditHonesty::fuzzy(1, "a", 0.91, "aaaa");
+    assert_eq!(fuzzy.op_index, 1);
+    assert_eq!(fuzzy.match_mode, Some(MatchMode::Fuzzy));
+    assert_eq!(fuzzy.match_score, Some(0.91));
+    assert_eq!(fuzzy.matched_text.as_deref(), Some("aaaa"));
+    assert_eq!(fuzzy.old, "a");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,7 +327,10 @@ pub use api::{
     search_file, strip_lazy_markers, text_diff,
 };
 #[cfg(any(feature = "cli", feature = "files"))]
-pub use api::{apply_content_edits_to_file, apply_content_edits_to_file_with_span_policy};
+pub use api::{
+    apply_content_edits_to_file, apply_content_edits_to_file_with_span_policy,
+    apply_fragment_to_file,
+};
 pub use plan::Plan;
 
 #[cfg(any(feature = "cli", feature = "files"))]

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -1,5 +1,7 @@
 //! File create/append/prepend/delete/rename for the tx engine.
-use super::{TxState, read_file_content, read_file_content_for_force_create};
+use super::{
+    TxState, read_file_content, read_file_content_for_force_create, read_file_content_for_path_op,
+};
 use crate::plan::Operation;
 
 // op_to_doc_mutation moved to plan.rs as the single source of truth for
@@ -194,8 +196,13 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 return Ok(0);
             }
 
-            // Read source content into pending (validates it exists).
-            let content = read_file_content(tx.pending, tx.existed_before, &src_path)?.to_string();
+            // Read source into pending (validates it exists). Soft-load binary /
+            // invalid UTF-8 as empty text snapshot (#2031): path rename is
+            // recorded in `tx.renames` so commit uses `fs::rename` (bytes stay
+            // intact). Hard fail only for missing / not-a-file (above) and
+            // unreadable IO that is not a content SoftSkip.
+            let content = read_file_content_for_path_op(tx.pending, tx.existed_before, &src_path)?
+                .to_string();
 
             // Check destination does not already exist (unless force or
             // case-only rename on case-insensitive FS).
@@ -213,9 +220,10 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
 
             // If destination exists on disk, load it into pending first so
             // existed_before is populated and commit uses atomic_write (not
-            // atomic_create_new which would fail on existing files).
+            // atomic_create_new which would fail on existing files). Soft-load
+            // non-text dest the same way as source (#2031 force overwrite).
             if (*force || case_only) && !tx.pending.contains_key(&dst_path) && dst_path.exists() {
-                let _ = read_file_content(tx.pending, tx.existed_before, &dst_path)?;
+                let _ = read_file_content_for_path_op(tx.pending, tx.existed_before, &dst_path)?;
             }
 
             // Record renames so commit can use fs::rename and preserve hardlinks

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -85,6 +85,36 @@ pub(crate) fn read_file_content_for_force_create<'a>(
     }
 }
 
+/// Soft-load for path-only ops (rename source / force dest) (#2031).
+///
+/// Binary / invalid UTF-8 become an empty text snapshot so staging does not
+/// fail; commit still uses `fs::rename` when `tx.renames` records the pair
+/// (bytes on disk are never rewritten as empty). Missing paths and other
+/// load failures still hard-fail.
+pub(crate) fn read_file_content_for_path_op<'a>(
+    pending: &'a mut HashMap<PathBuf, (String, String)>,
+    existed_before: &mut HashSet<PathBuf>,
+    path: &Path,
+) -> anyhow::Result<&'a str> {
+    match pending.entry(path.to_path_buf()) {
+        Entry::Occupied(entry) => Ok(&entry.into_mut().1),
+        Entry::Vacant(entry) => {
+            let display = path.display().to_string();
+            let content = match crate::files::load_text_strict(path, &display) {
+                Ok(s) => s,
+                Err(e) if crate::exit::is_binary(&e) || crate::exit::is_invalid_encoding(&e) => {
+                    String::new()
+                }
+                Err(e) => return Err(e),
+            };
+            if path.exists() {
+                existed_before.insert(path.to_path_buf());
+            }
+            Ok(&entry.insert((content.clone(), content)).1)
+        }
+    }
+}
+
 /// Soft content load for multi-path scans (#1894 / SoftTextSkip).
 ///
 /// Returns `Ok(true)` if the file is text (content stored in pending),

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -194,6 +194,11 @@ pub(crate) fn commit_changes(
             } else if renamed_to.contains(path.as_path()) {
                 // Dest exists after rename; rewrite final content in place so
                 // multi-hardlinked siblings stay in sync (nlink > 1 path).
+                // Path-only renames of binary / invalid UTF-8 stage empty
+                // text (#2031). Do not clobber the just-moved inode with "".
+                if new_content.is_empty() {
+                    continue;
+                }
                 injected_write_failure(path)?;
                 atomic_write(path, new_content, &noop_policy)?;
             } else {


### PR DESCRIPTION
## Summary

Bline host follow-ups after 0.22:

- **#2031:** `file_rename` / `file_delete` path-only for binary and invalid UTF-8 (byte backup, PathGuard, no host OS dual-path). Soft-load staging + skip empty rewrite of pure rename dest after `fs::rename`.
- **#2032:** `api::apply_fragment_to_file` for Morph-class snippets (marker strip + required placement + replace Apply path).
- **#2033:** `ContentEditHonesty::exact` / `::fuzzy` constructors for downstream unit tests under `#[non_exhaustive]`.

## Closes

Closes #2031
Closes #2032
Closes #2033

## Test plan

- [x] `make check-fast`
- [x] Unit: binary/invalid-UTF-8 rename, binary delete, fragment after/old/ambiguous/empty-strip, honesty constructors
- [x] Hardlink rename engine tests still pass