### PR TITLE
fix: rename empty rewrite only for soft path-only sources

### DIFF
--- a/src/api/apply_fragment.rs
+++ b/src/api/apply_fragment.rs
@@ -3,18 +3,17 @@
 use std::path::Path;
 
 use crate::containment::PathGuard;
-use crate::ops::apply_fragment::{
-    FragmentPlacement, build_apply_fragment_spec, desugar_to_replace_fields,
-};
+use crate::ops::apply_fragment::{FragmentPlacement, plan_apply_fragment_to_replace};
 
-use super::{ApplyMode, EditResult, ReplaceOptions, replace::replace_text};
+use super::{ApplyMode, EditResult};
 
 /// Apply a freeform fragment at a required placement anchor on disk (#2032).
 ///
 /// Strips Morph-style lazy marker lines (`// ... existing code ...`), then
 /// inserts after/before the unique anchor or replaces `old` via the same
-/// path as [`replace_text`]. Fail-closed: missing/ambiguous anchors, empty
-/// fragment after strip, PathGuard rejects.
+/// plan desugar path as CLI/MCP (`plan_apply_fragment_to_replace` → tx).
+/// Fail-closed: missing/ambiguous anchors, empty fragment after strip,
+/// PathGuard rejects.
 ///
 /// # Example
 ///
@@ -48,15 +47,16 @@ pub fn apply_fragment_to_file(
         FragmentPlacement::Before(b) => (None, Some(b.as_str()), None),
         FragmentPlacement::Replace(o) => (None, None, Some(o.as_str())),
     };
-    let spec = build_apply_fragment_spec(fragment, None, after, before, old, unique)?;
-    let d = desugar_to_replace_fields(&spec);
-    let opts = ReplaceOptions {
-        insert_after: d.insert_after,
-        insert_before: d.insert_before,
-        unique: d.unique,
-        require_change: true,
-        ..ReplaceOptions::default()
-    };
-    let to = d.new_text.as_deref().unwrap_or("");
-    replace_text(path, &d.old, to, &opts, mode, guard)
+    let path_str = path.to_string_lossy();
+    let op = plan_apply_fragment_to_replace(
+        path_str.as_ref(),
+        fragment,
+        None,
+        after,
+        before,
+        old,
+        unique,
+    )?;
+    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    super::execute_as_edit_result(op, mode, cwd, guard, "apply.fragment", None)
 }

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -436,6 +436,32 @@ mod tests {
         );
     }
 
+    /// Rename then clear body must still write empty (not skip as soft non-text).
+    #[test]
+    fn execute_rename_then_clear_writes_empty() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+        let global = GlobalFlags::test_default();
+        let plan = crate::plan::parse_plan(
+            r#"{"ops":[
+              {"op":"file.rename","from":"a.txt","to":"b.txt"},
+              {"op":"replace","path":"b.txt","old":"hello\n","new":""}
+            ]}"#,
+        )
+        .unwrap();
+        let result =
+            execute_operations(plan.operations, test_options(dir.path(), &global)).unwrap();
+        result.commit().unwrap();
+        let b = dir.path().join("b.txt");
+        assert!(!dir.path().join("a.txt").exists());
+        assert!(b.exists());
+        assert_eq!(
+            fs::read_to_string(&b).unwrap(),
+            "",
+            "rename-then-clear must leave empty file, not source body"
+        );
+    }
+
     /// Rename then replace in one plan must still share the hardlink inode.
     #[cfg(unix)]
     #[test]

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -194,9 +194,15 @@ pub(crate) fn commit_changes(
             } else if renamed_to.contains(path.as_path()) {
                 // Dest exists after rename; rewrite final content in place so
                 // multi-hardlinked siblings stay in sync (nlink > 1 path).
-                // Path-only renames of binary / invalid UTF-8 stage empty
-                // text (#2031). Do not clobber the just-moved inode with "".
-                if new_content.is_empty() {
+                // Soft-loaded binary/invalid-UTF-8 renames stage empty text on
+                // both ends (#2031). Skip rewrite only when every rename
+                // source for this dest also had empty staged *original*
+                // (path-only soft snapshot or empty file). If a source had
+                // non-empty original and dest final is empty, still write
+                // (rename-then-clear).
+                if new_content.is_empty()
+                    && rename_source_originals_empty(path, &rename_pairs, changes)
+                {
                     continue;
                 }
                 injected_write_failure(path)?;
@@ -243,6 +249,34 @@ pub(crate) fn commit_changes(
     }
 
     Ok(backup_session)
+}
+
+/// True when every rename source of `dest` has empty staged original content
+/// (or is missing from `changes`, treated as empty). Used to skip empty
+/// rewrite after path-only non-text rename (#2031) without dropping
+/// rename-then-clear of non-empty text.
+fn rename_source_originals_empty(
+    dest: &Path,
+    rename_pairs: &[(PathBuf, PathBuf)],
+    changes: &[(PathBuf, String, String)],
+) -> bool {
+    let mut saw_source = false;
+    for (from, to) in rename_pairs {
+        if to.as_path() != dest {
+            continue;
+        }
+        saw_source = true;
+        let orig = changes
+            .iter()
+            .find(|(p, _, _)| p == from)
+            .map(|(_, o, _)| o.as_str())
+            .unwrap_or("");
+        if !orig.is_empty() {
+            return false;
+        }
+    }
+    // No matching rename source → do not skip (safe default: write).
+    saw_source
 }
 
 /// Detect pure renames staged as create-dest + delete-src with identical


### PR DESCRIPTION
## Summary

Follow-up to #2035 (reviewer Issue 1 + 2):

1. **Commit empty rewrite guard:** only skip `atomic_write` on rename dest when final content is empty **and** every rename source had empty staged original (soft non-text path-only rename). Rename-then-clear of non-empty text still writes empty.
2. **apply_fragment_to_file:** use `plan_apply_fragment_to_replace` + `execute_as_edit_result` (same op shape as plan/MCP; insert uses `new_text: None`).

## Test plan

- [x] `execute_rename_then_clear_writes_empty`
- [x] path_only binary/invalid-UTF-8 rename + hardlink rename tests
- [x] `apply_fragment_to_file_*` unit tests

Ref #2031 #2032