### PR TITLE
fix: real-world agent path bugs (case rename, MCP op, YAML CRLF, files-from)

### DIFF
--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -1392,11 +1392,33 @@ mod registry_schema_sync {
                 tool.tool_name
             );
             if let Some(example) = operation_example_json(tool.op_name) {
+                // MCP descriptions strip plan `"op"` (unknown field on tools).
                 assert!(
-                    desc.contains(example),
-                    "{}: description must include schema example JSON",
+                    !desc.contains("\"op\""),
+                    "{}: MCP description must not teach forbidden op field",
                     tool.tool_name
                 );
+                // Still include example payload fields from the plan example.
+                if let Ok(serde_json::Value::Object(map)) =
+                    serde_json::from_str::<serde_json::Value>(example)
+                {
+                    for (k, v) in map.iter().filter(|(k, _)| *k != "op") {
+                        let needle = format!("\"{k}\":");
+                        assert!(
+                            desc.contains(&needle),
+                            "{}: description missing example field {k} (from {example}): {desc}",
+                            tool.tool_name
+                        );
+                        if let Some(s) = v.as_str() {
+                            assert!(
+                                desc.contains(s)
+                                    || desc.contains(&serde_json::to_string(v).unwrap()),
+                                "{}: description missing example value for {k}",
+                                tool.tool_name
+                            );
+                        }
+                    }
+                }
             }
             if let Some(extra) = tool.extra {
                 assert!(

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -132,6 +132,15 @@ pub(crate) fn collect_matches(
     args: &SearchArgs,
     global: &GlobalFlags,
 ) -> anyhow::Result<SearchResults> {
+    collect_matches_with_list(args, global, None)
+}
+
+/// Like [`collect_matches`], with a pre-read `--files-from` list (stdin once).
+pub(crate) fn collect_matches_with_list(
+    args: &SearchArgs,
+    global: &GlobalFlags,
+    files_from_preload: Option<&[String]>,
+) -> anyhow::Result<SearchResults> {
     crate::verbose!(
         "search: pattern={:?} literal={} paths={:?}",
         args.pattern,
@@ -149,7 +158,13 @@ pub(crate) fn collect_matches(
         args.case_insensitive,
         args.multiline,
     )?;
-    let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+    let file_paths = crate::files::collect_file_paths_opts_with_list(
+        &args.paths,
+        global,
+        false,
+        Some(&cwd),
+        files_from_preload,
+    )?;
     // Empty --files-from is invalid_input, not pattern no_matches (#1796).
     crate::files::ensure_files_from_nonempty(global, &file_paths)?;
     let glob_roots = crate::collect_glob_roots_from_global(&args.paths, global, Some(&cwd))?;
@@ -187,6 +202,16 @@ pub(crate) fn explicit_binary_refused(
     global: &GlobalFlags,
     cwd: &std::path::Path,
 ) -> Option<Vec<SearchRefused>> {
+    explicit_binary_refused_with_list(args, global, cwd, None)
+}
+
+/// Like [`explicit_binary_refused`], with a pre-read `--files-from` list.
+pub(crate) fn explicit_binary_refused_with_list(
+    args: &SearchArgs,
+    global: &GlobalFlags,
+    cwd: &std::path::Path,
+    files_from_preload: Option<&[String]>,
+) -> Option<Vec<SearchRefused>> {
     let explicit = if global.files_from.is_some() {
         // Match replace: files-from counts as explicit list.
         true
@@ -199,16 +224,19 @@ pub(crate) fn explicit_binary_refused(
     if !explicit {
         return None;
     }
-    // Prefer caller-resolved files_from when available is not plumbed; re-read
-    // file lists (stdin lists are sole-hard-failed earlier when len == 1).
-    let path_strings: Vec<String> = if global.files_from.is_some() {
-        global.read_files_from().ok().flatten().unwrap_or_default()
+    // Prefer caller-resolved list so `--files-from -` is not re-read (empty).
+    let owned;
+    let path_strings: &[String] = if let Some(pre) = files_from_preload {
+        pre
+    } else if global.files_from.is_some() {
+        owned = global.read_files_from().ok().flatten().unwrap_or_default();
+        &owned
     } else {
-        args.paths.clone()
+        &args.paths
     };
     // Shared helper: binary / invalid_utf8 / unreadable (len < 2 → None;
     // sole is invalid_input via sole_explicit_non_text_for_scan).
-    let shared = crate::ops::file::explicit_multi_path_non_text_refused(&path_strings, cwd)?;
+    let shared = crate::ops::file::explicit_multi_path_non_text_refused(path_strings, cwd)?;
     let mut refused: Vec<SearchRefused> = shared
         .into_iter()
         .map(|r| SearchRefused {
@@ -458,8 +486,9 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     let cwd = global.resolve_cwd()?;
-    // Sole non-text before soft-skip scan (file-backed --files-from; not stdin).
-    let files_from_list = global.files_from_for_sole_scan()?;
+    // Read --files-from once (including stdin `-`). Re-reading stdin is empty
+    // and would skip sole-binary / refused honesty and empty-scan masks.
+    let files_from_list = global.read_files_from()?;
     if let Some(err) = crate::ops::file::sole_explicit_non_text_for_scan(
         &args.paths,
         files_from_list.as_deref(),
@@ -472,9 +501,17 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
         return Ok(exit::FAILURE);
     }
-    let results = collect_matches(&args, global)?;
-    let skipped = crate::files::scan_missing_entries(global, &cwd, &args.paths)?;
-    let refused = explicit_binary_refused(&args, global, &cwd);
+    let results = collect_matches_with_list(&args, global, files_from_list.as_deref())?;
+    let skipped = if files_from_list.is_some() {
+        // Use preloaded list (stdin cannot be re-read).
+        Ok(files_from_list
+            .as_ref()
+            .and_then(|files| crate::files::explicit_paths_missing_entries(&cwd, files)))
+    } else {
+        crate::files::scan_missing_entries(global, &cwd, &args.paths)
+    }?;
+    let refused =
+        explicit_binary_refused_with_list(&args, global, &cwd, files_from_list.as_deref());
 
     // --assert-count mode: succeed only if total count equals N.
     // JSON matches MCP search_files: ok == matched; mismatch sets
@@ -496,7 +533,13 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 }
                 return Ok(exit::FAILURE);
             }
-            let scanned = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+            let scanned = crate::files::collect_file_paths_opts_with_list(
+                &args.paths,
+                global,
+                false,
+                Some(&cwd),
+                files_from_list.as_deref(),
+            )?;
             if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, &cwd) {
                 global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
                 return Ok(exit::FAILURE);
@@ -546,7 +589,12 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     };
     if !has_matches {
         let cwd = global.resolve_cwd()?;
-        if crate::files::all_scan_targets_missing(global, &args.paths, Some(&cwd))? {
+        let all_missing = if let Some(ref files) = files_from_list {
+            crate::files::all_explicit_paths_missing(files, Some(&cwd))
+        } else {
+            crate::files::all_scan_targets_missing(global, &args.paths, Some(&cwd))?
+        };
+        if all_missing {
             let msg = format!(
                 "no such file or directory: {}",
                 global.path_scope_description(&args.paths)
@@ -569,7 +617,13 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::FAILURE);
         }
         // Multi-path / dir walk: unreadable may have masked the scan (#1894).
-        let scanned = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+        let scanned = crate::files::collect_file_paths_opts_with_list(
+            &args.paths,
+            global,
+            false,
+            Some(&cwd),
+            files_from_list.as_deref(),
+        )?;
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, &cwd) {
             global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
             return Ok(exit::FAILURE);

--- a/src/files.rs
+++ b/src/files.rs
@@ -301,6 +301,10 @@ pub(crate) fn ensure_files_from_nonempty(
 /// `ignore::WalkBuilder` (respects `.gitignore`).  When `root` is `Some`,
 /// paths are joined with it before walking.  Tidy commands set
 /// `include_hidden = true` so dotfiles are checked.
+///
+/// Pass `files_from_preload` when the caller already read `--files-from`
+/// (including stdin `-`). Stdin can only be consumed once; re-reading yields
+/// an empty list and breaks sole-binary / refused honesty.
 #[cfg(feature = "cli")]
 pub(crate) fn collect_file_paths_opts(
     paths: &[String],
@@ -308,11 +312,32 @@ pub(crate) fn collect_file_paths_opts(
     include_hidden: bool,
     root: Option<&Path>,
 ) -> anyhow::Result<Vec<PathBuf>> {
-    if let Some(files) = global.read_files_from()? {
+    collect_file_paths_opts_with_list(paths, global, include_hidden, root, None)
+}
+
+/// Like [`collect_file_paths_opts`], but accepts a pre-read `--files-from` list.
+#[cfg(feature = "cli")]
+pub(crate) fn collect_file_paths_opts_with_list(
+    paths: &[String],
+    global: &GlobalFlags,
+    include_hidden: bool,
+    root: Option<&Path>,
+    files_from_preload: Option<&[String]>,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let files_owned;
+    let files_from: Option<&[String]> = if let Some(pre) = files_from_preload {
+        Some(pre)
+    } else if global.files_from.is_some() {
+        files_owned = global.read_files_from()?;
+        files_owned.as_deref()
+    } else {
+        None
+    };
+    if let Some(files) = files_from {
         // --files-from entries must honor --contain (paths may escape even when
         // CLI positional paths were empty or in-workspace).
         if let Some(r) = root {
-            global.check_paths_contained(r, &files)?;
+            global.check_paths_contained(r, files)?;
         }
         return Ok(files
             .iter()

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -132,14 +132,19 @@ pub fn serialize_value_preserving(
 /// `Mapping::remove()` can leave trailing whitespace on lines and may
 /// drop the final newline. This trims each line's trailing spaces and
 /// ensures the output ends with exactly one newline.
+///
+/// Line endings match the input (`detect_eol`) so Windows CRLF YAML is not
+/// rewritten to LF by the CST preserve path.
 fn cleanup_yaml_cst_whitespace(text: &str) -> String {
+    let eol = crate::write::detect_eol(text);
     let mut result: String = text
         .lines()
         .map(|line| line.trim_end())
         .collect::<Vec<_>>()
-        .join("\n");
-    if !result.ends_with('\n') {
-        result.push('\n');
+        .join(eol);
+    // Ensure a final newline (LF or CRLF matching input).
+    if result.is_empty() || !result.ends_with('\n') {
+        result.push_str(eol);
     }
     result
 }
@@ -220,9 +225,10 @@ fn fix_yaml_block_indentation(text: &str) -> String {
         result.push(line.to_string());
     }
 
-    let mut out = result.join("\n");
+    let eol = crate::write::detect_eol(text);
+    let mut out = result.join(eol);
     if text.ends_with('\n') && !out.ends_with('\n') {
-        out.push('\n');
+        out.push_str(eol);
     }
     out
 }
@@ -566,26 +572,31 @@ pub(crate) fn split_multi_document_yaml(content: &str) -> (bool, Vec<String>) {
 }
 
 /// Reassemble multi-document YAML from body strings.
-fn join_multi_document_yaml(leading_marker: bool, docs: &[String]) -> String {
+///
+/// `eol` is the dominant line ending from the original stream so separators
+/// stay CRLF on Windows manifests (mixed EOL confuses diffs and some tools).
+fn join_multi_document_yaml(leading_marker: bool, docs: &[String], eol: &str) -> String {
     let mut out = String::new();
     if leading_marker {
-        out.push_str("---\n");
+        out.push_str("---");
+        out.push_str(eol);
     }
     for (i, doc) in docs.iter().enumerate() {
         if i > 0 {
             if !out.ends_with('\n') {
-                out.push('\n');
+                out.push_str(eol);
             }
-            out.push_str("---\n");
+            out.push_str("---");
+            out.push_str(eol);
         }
         let body = doc.trim_end_matches(['\n', '\r']);
         if !body.is_empty() {
             out.push_str(body);
-            out.push('\n');
+            out.push_str(eol);
         }
     }
     if out.is_empty() {
-        out.push('\n');
+        out.push_str(eol);
     }
     out
 }
@@ -655,7 +666,8 @@ fn serialize_multi_document_yaml(
         }
     }
 
-    Ok(join_multi_document_yaml(leading_marker, &out_docs))
+    let eol = crate::write::detect_eol(original_content);
+    Ok(join_multi_document_yaml(leading_marker, &out_docs, eol))
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1066,6 +1066,27 @@ mod error_handling {
     }
 
     #[test]
+    fn yaml_multi_document_set_preserves_crlf_separators() {
+        // Windows agent editing multi-doc k8s manifests must keep CRLF stream.
+        let yaml = "---\r\na: 1\r\n---\r\nb: 2\r\n";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new[0]["a"] = json!(9);
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert!(
+            result.contains("\r\n"),
+            "multi-doc write must preserve CRLF separators, got: {result:?}"
+        );
+        assert!(
+            !result.replace("\r\n", "").contains('\n'),
+            "must not mix bare LF into CRLF multi-doc stream: {result:?}"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed[0]["a"], json!(9));
+        assert_eq!(reparsed[1]["b"], json!(2));
+    }
+
+    #[test]
     fn yaml_multi_document_set_second_doc_preserves_first() {
         let yaml = "---\nname: alpha\nversion: 1\n---\nname: beta\nversion: 2\n";
         let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
@@ -1386,6 +1407,30 @@ mod yaml_cst_cleanup {
             !result.ends_with("\n\n"),
             "double final newline: {:?}",
             &result[result.len().saturating_sub(4)..]
+        );
+    }
+
+    #[test]
+    fn yaml_cst_set_preserves_crlf_line_endings() {
+        // Real Windows path: doc set on CRLF YAML with comments uses CST preserve.
+        let yaml = "server:\r\n  port: 8080\r\n  # keep me\r\n  host: localhost\r\n";
+        let old = json!({"server": {"port": 8080, "host": "localhost"}});
+        let new = json!({"server": {"port": 9090, "host": "localhost"}});
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert!(
+            result.contains("\r\n"),
+            "CST preserve path must keep CRLF, got: {result:?}"
+        );
+        assert!(result.contains("9090"), "updated port missing: {result:?}");
+        assert!(
+            result.contains("# keep me"),
+            "comment must be preserved: {result:?}"
+        );
+        // Dominant EOL should remain CRLF (no mixed bare LF after strip).
+        let without_crlf = result.replace("\r\n", "");
+        assert!(
+            !without_crlf.contains('\n'),
+            "must not introduce bare LF into CRLF file: {result:?}"
         );
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -774,6 +774,11 @@ fn ast_registry_iter() -> impl Iterator<Item = &'static OpMeta> {
 /// Format: `<OpMeta.description>[ extra][ Example: <first example JSON>]`
 /// MCP-only guidance (concurrency, etc.) belongs in `extra`, not a full
 /// duplicate of the registry prose (#1383).
+///
+/// Plan registry examples include `"op":"doc.set"`. Standalone MCP tools inject
+/// `op` themselves and reject unknown fields, so the example is rewritten
+/// without `op` (agents that copy the plan-shaped example otherwise get
+/// `unknown field(s): op`).
 pub fn mcp_tool_description(op_name: &str, extra: Option<&str>) -> String {
     let base = operation_description(op_name).unwrap_or("Patchloom operation.");
     let mut out = base.to_string();
@@ -786,9 +791,23 @@ pub fn mcp_tool_description(op_name: &str, extra: Option<&str>) -> String {
     }
     if let Some(example) = operation_example_json(op_name) {
         out.push_str(" Example: ");
-        out.push_str(example);
+        out.push_str(&mcp_example_without_op(example));
     }
     out
+}
+
+/// Strip the plan `"op"` discriminator from an example JSON object for MCP
+/// tool descriptions. Plan catalogue examples keep `op`; standalone MCP tools
+/// do not accept it.
+fn mcp_example_without_op(example: &str) -> String {
+    match serde_json::from_str::<serde_json::Value>(example) {
+        Ok(serde_json::Value::Object(mut map)) => {
+            map.remove("op");
+            serde_json::to_string(&serde_json::Value::Object(map))
+                .unwrap_or_else(|_| example.to_string())
+        }
+        _ => example.to_string(),
+    }
 }
 
 /// Build a compact agent-facing operations catalogue from the registry.

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -131,8 +131,28 @@ mod basic {
         let base = operation_description("doc.set").unwrap();
         assert!(desc.contains(base));
         assert!(desc.contains("EXTRA_FRAGMENT"));
-        if let Some(ex) = operation_example_json("doc.set") {
-            assert!(desc.contains(ex));
+        // Example must be present but without plan `"op"` (MCP rejects it).
+        assert!(
+            desc.contains("\"path\":\"package.json\""),
+            "description should include example fields: {desc}"
+        );
+        assert!(
+            !desc.contains("\"op\""),
+            "MCP tool description must not teach forbidden op field: {desc}"
+        );
+    }
+
+    #[test]
+    fn mcp_tool_description_strips_op_from_all_registry_examples() {
+        for meta in OPERATION_REGISTRY.iter() {
+            let desc = mcp_tool_description(meta.name, None);
+            if operation_example_json(meta.name).is_some() {
+                assert!(
+                    !desc.contains("\"op\""),
+                    "{} MCP description must not include plan op field: {desc}",
+                    meta.name
+                );
+            }
         }
     }
 

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -237,14 +237,20 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // commit's rename_or_copy replaces the dest entry while keeping the
             // source inode (and its hardlink siblings). Skipping the record falls
             // back to create-dest + delete-src and splits hardlinks (#1746).
-            if !case_only {
-                let src_on_disk = src_path.exists() && src_path.is_file();
-                let src_is_rename_dest = tx.renames.iter().any(|(_, to)| to == &src_path);
-                // Non-force with an on-disk dest is rejected earlier. Force may
-                // overwrite; non-force only records when dest is not on disk.
-                if (src_on_disk || src_is_rename_dest) && (*force || !dst_path.exists()) {
+            //
+            // Case-only renames (readme.md → README.md) must also record the
+            // pair. On case-insensitive FS, write-dest + delete-src removes the
+            // only inode. CLI bypasses the engine (#1167); plan/MCP must not.
+            let src_on_disk = src_path.exists() && src_path.is_file();
+            let src_is_rename_dest = tx.renames.iter().any(|(_, to)| to == &src_path);
+            if case_only {
+                if src_on_disk || src_is_rename_dest {
                     tx.renames.push((src_path.clone(), dst_path.clone()));
                 }
+            } else if (src_on_disk || src_is_rename_dest) && (*force || !dst_path.exists()) {
+                // Non-force with an on-disk dest is rejected earlier. Force may
+                // overwrite; non-force only records when dest is not on disk.
+                tx.renames.push((src_path.clone(), dst_path.clone()));
             }
 
             // Write content to destination.

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -555,6 +555,74 @@ fn rename_deleted_source_is_rejected() {
     );
 }
 
+/// Case-only rename (readme.md → README.md) must stage `tx.renames` so commit
+/// uses `fs::rename`. Without that, write-dest + delete-src removes the only
+/// inode on case-insensitive filesystems (macOS APFS); agents hit this via
+/// plan/MCP while CLI bypasses the engine (#1167).
+#[test]
+fn case_only_rename_records_tx_renames() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("readme.md");
+    std::fs::write(&file, "hello content\n").unwrap();
+
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+    let op = Operation::FileRename {
+        from: "readme.md".into(),
+        to: "README.md".into(),
+        force: false,
+    };
+    execute_file_op(&op, &mut tx).expect("case-only rename should stage");
+    drop(tx);
+    assert!(
+        !f.renames.is_empty(),
+        "case-only rename must record tx.renames for fs::rename; got empty"
+    );
+    assert_eq!(
+        f.renames[0].0.file_name().and_then(|n| n.to_str()),
+        Some("readme.md")
+    );
+    assert_eq!(
+        f.renames[0].1.file_name().and_then(|n| n.to_str()),
+        Some("README.md")
+    );
+}
+
+/// End-to-end: plan/tx case-only rename must leave content on disk (not delete).
+#[test]
+fn case_only_rename_plan_apply_preserves_content() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("readme.md");
+    std::fs::write(&src, "hello content\n").unwrap();
+
+    let plan = crate::plan::Plan {
+        version: crate::plan::SCHEMA_VERSION,
+        cwd: None,
+        operations: vec![Operation::FileRename {
+            from: "readme.md".into(),
+            to: "README.md".into(),
+            force: false,
+        }],
+        write_policy: None,
+        strict: None,
+        format: None,
+        validate: None,
+        verify: None,
+        for_each: None,
+    };
+    let report = crate::tx::execute_plan_direct(plan, dir.path(), None).expect("plan ok");
+    assert!(
+        report.ok,
+        "case-only rename plan should succeed: {report:?}"
+    );
+
+    // Content must still exist under either spelling (case-insensitive FS).
+    let content = std::fs::read_to_string(dir.path().join("README.md"))
+        .or_else(|_| std::fs::read_to_string(&src))
+        .expect("file must still exist after case-only rename");
+    assert_eq!(content, "hello content\n");
+}
+
 /// Regression: files loaded for Read/Search operations should not be
 /// modified by write policy (e.g. ensure_final_newline) (#1108).
 #[test]

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -51,6 +51,63 @@ fn test_files_from_stdin_restricts_search() {
     );
 }
 
+/// Sole binary via `--files-from -` must hard-fail as `binary`, not soft
+/// `no_matches` (stdin is single-shot; sole scan must use the first read).
+#[test]
+fn test_files_from_stdin_sole_binary_is_binary_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("b.bin"), b"x\0y").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--files-from")
+        .arg("-")
+        .arg("--json")
+        .arg("search")
+        .arg("foo")
+        .write_stdin("b.bin\n")
+        .output()
+        .unwrap();
+
+    assert_ne!(output.status.code(), Some(0), "sole binary must fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"error_kind\": \"binary\"")
+            || stdout.contains("\"error_kind\":\"binary\""),
+        "expected binary error_kind, got: {stdout}"
+    );
+}
+
+/// Multi-path `--files-from -` must report co-listed binary in `refused[]`.
+#[test]
+fn test_files_from_stdin_multi_reports_refused_binary() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hello\n").unwrap();
+    fs::write(dir.path().join("b.bin"), b"x\0y").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--files-from")
+        .arg("-")
+        .arg("--json")
+        .arg("search")
+        .arg("hello")
+        .write_stdin("a.txt\nb.bin\n")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "text match should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("refused") && stdout.contains("b.bin") && stdout.contains("binary"),
+        "expected refused binary for co-listed stdin path, got: {stdout}"
+    );
+}
+
 #[test]
 fn test_files_from_nonexistent_path_fails() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixloop Round 1 with a strict real-world filter (no theoretical defense-in-depth).

Four agent-facing bugs fixed with test-first coverage:

1. **Case-only rename data loss (plan/MCP)** — `file.rename` `readme.md` → `README.md` staged write-dest + delete-src without `tx.renames`. On macOS APFS that deletes the only inode. CLI already bypassed the engine; plan/MCP did not.
2. **MCP tool examples teach forbidden `op`** — registry descriptions append plan JSON with `"op":"doc.set"`. Standalone tools inject `op` and reject unknown fields, so agents copying the Example get `unknown field(s): op`.
3. **YAML CRLF rewritten to LF** — CST cleanup and multi-doc join used `.lines()` + `join("\n")`. Windows `doc set` on comment-preserving CRLF YAML (and multi-doc k8s streams) lost CRLF.
4. **`--files-from -` honesty** — stdin is single-shot; sole binary was soft `no_matches` and multi-list omitted `refused[]` because a second `read_files_from` saw empty stdin.

## Test plan

- [x] Unit: case-only rename records `tx.renames` + plan apply preserves content
- [x] Unit: MCP descriptions strip `"op"` for all registry tools
- [x] Unit: YAML CST set + multi-doc set preserve CRLF
- [x] Integration: stdin sole binary `error_kind: binary`; multi reports `refused[]`
- [x] Dogfood on macOS: plan rename, CRLF doc set, files-from stdin
- [x] `make check-fast` green

## Rejected as noise

- TX unique-before-context vs API unique-after-context (surface inconsistency, not data loss)
- Bare-CR line index panics, saturating counters, theoretical TOCTOU