### PR TITLE
fix: strict binary rollback, fuzzy match_count, MCP apply_fragment

### DIFF
--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -1189,6 +1189,12 @@ mod surface_core_tests {
         assert!(text.contains("Document ops"));
         assert!(text.contains("create_file"));
         assert!(text.contains("doc_set"));
+        // Morph-class apply_fragment is a first-class registry tool; hosts that
+        // bias on handshake text must see it next to replace_text.
+        assert!(
+            text.contains("apply_fragment"),
+            "full instructions must list apply_fragment: {text}"
+        );
         assert!(!text.contains("PATCHLOOM_MCP_SURFACE=core"));
     }
 

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -60,7 +60,7 @@ fn full_server_instructions() -> String {
          - Markdown ops (by heading): md_replace_section, md_upsert_bullet, \
          md_table_append, md_insert_after_heading, md_insert_after_section, md_insert_before_heading, \
          md_move_section, md_dedupe_headings, md_lint\n\
-         - Text ops: replace_text, batch_replace, search_files, apply_patch\n\
+         - Text ops: replace_text, batch_replace, search_files, apply_fragment, apply_patch\n\
          - File ops: create_file, read_file, delete_file, move_file, append_file, \
          prepend_file, fix_whitespace, batch_tidy, git_status\n",
     );

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -1420,8 +1420,10 @@ fn run_context_replace(
             }
         })
         .collect();
-    let total_matches = files.len();
-    let file_count = total_matches;
+    // Sum per-file match counts (not file count). Fuzzy/context can replace
+    // multiple matches in one file; agents branch on match_count honesty.
+    let total_matches: usize = files.iter().map(|f| f.match_count).sum();
+    let file_count = files.len();
     // Same mode/exit owner as default replace path (no hand-rolled matrix).
     replace_output(
         global,

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -213,19 +213,31 @@ fn commit_and_finalize(
 
     if let Some(err) = run_lifecycle(ctx.plan, ctx.base_cwd, ctx.cwd) {
         if ctx.strict {
-            crate::tx::rollback_strict(
-                &result.changes,
-                &result.pending,
-                &result.deletions,
-                &result.existed_before,
-            );
+            // Backup restore keeps binary / invalid-UTF-8 bytes that soft-empty
+            // pending originals cannot reconstruct via string rollback.
+            let used_backup = apply_backup_session
+                .as_ref()
+                .is_some_and(|ts| crate::backup::restore_session(ctx.cwd, ts).is_ok());
+            if !used_backup {
+                crate::tx::rollback_strict(
+                    &result.changes,
+                    &result.pending,
+                    &result.deletions,
+                    &result.existed_before,
+                );
+            }
             crate::tx::restore_collateral_files(&collateral_snapshot);
             let rollback_msg = format!(
                 "rollback: strict mode -- all changes reverted ({})",
                 err.message
             );
             if ctx.structured {
-                let ok = emit_error_json(err.kind, &rollback_msg, None, ctx.compact);
+                let ok = emit_error_json(
+                    err.kind,
+                    &rollback_msg,
+                    apply_backup_session.as_deref(),
+                    ctx.compact,
+                );
                 return Ok(exit_after_emit(ok, exit::ROLLBACK));
             }
             eprintln!("tx: {rollback_msg}");

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -228,16 +228,29 @@ pub fn execute_plan_direct(
     // Run format steps, then validation steps.
     if let Some(err) = run_lifecycle(&plan, cwd, &effective_cwd) {
         if strict {
-            rollback_strict(
-                &result.changes,
-                &result.pending,
-                &result.deletions,
-                &result.existed_before,
-            );
+            // Prefer full backup restore so soft-empty non-text originals
+            // (binary / invalid UTF-8 path ops) are not rewritten as empty
+            // files by string rollback. Fall back to pending-based rollback
+            // when no session exists.
+            let used_backup = apply_backup_session
+                .as_ref()
+                .is_some_and(|ts| crate::backup::restore_session(&effective_cwd, ts).is_ok());
+            if !used_backup {
+                rollback_strict(
+                    &result.changes,
+                    &result.pending,
+                    &result.deletions,
+                    &result.existed_before,
+                );
+            }
             #[cfg(any(feature = "cli", feature = "files"))]
             restore_collateral_files(&collateral_snapshot);
             let msg = format!("strict mode -- all changes reverted ({})", err.message);
-            return Ok(build_error_output("rollback", &msg, None));
+            return Ok(build_error_output(
+                "rollback",
+                &msg,
+                apply_backup_session.as_deref(),
+            ));
         }
         // Non-strict: writes already committed. Report applied changes so
         // agents do not see files_changed=0 while the working tree changed.

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2444,6 +2444,40 @@ fn test_replace_fuzzy_identifier_typo_json_match_mode() {
     assert_eq!(on_disk, "fn handle_request(x: i32) {}\n");
 }
 
+/// Fuzzy/context engine path must sum per-file match_count (not file count).
+#[test]
+fn test_replace_fuzzy_path_match_count_sums_multi_match() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("f.txt"), "foo\nfoo\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "replace", "foo", "--new", "bar", "--fuzzy", "f.txt", "--apply",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(
+        v["match_count"], 2,
+        "top-level match_count must sum edits, not files: {v}"
+    );
+    assert_eq!(v["files"][0]["match_count"], 2, "{v}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("f.txt")).unwrap(),
+        "bar\nbar\n"
+    );
+}
+
 /// #1736: CLI fuzzy JSON must report matched_text for agent verification.
 #[test]
 fn test_replace_fuzzy_json_reports_matched_text() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -4297,6 +4297,59 @@ fn test_tx_strict_mode_reverts_on_format_failure() {
     assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
 }
 
+/// Soft-empty binary path ops must not be wiped to 0 bytes on strict format
+/// rollback: restore from backup session, not string pending originals.
+#[test]
+fn test_tx_strict_format_fail_restores_binary_delete() {
+    let dir = TempDir::new().unwrap();
+    let bin = dir.path().join("b.bin");
+    let bytes = b"x\0y\xffbinary";
+    fs::write(&bin, bytes).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "strict": true,
+        "operations": [{
+            "op": "file.delete",
+            "path": "b.bin"
+        }],
+        "format": [{
+            "cmd": shell_exit_1()
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("plan.json")
+        .arg("--apply")
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(7),
+        "strict format fail should exit ROLLBACK: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let restored = fs::read(&bin).expect("binary must exist after strict rollback");
+    assert_eq!(
+        restored, bytes,
+        "binary bytes must be restored from backup, not wiped empty"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(
+        json.get("backup_session")
+            .and_then(|v| v.as_str())
+            .is_some(),
+        "strict lifecycle rollback JSON should include backup_session: {json}"
+    );
+}
+
 #[test]
 fn test_tx_strict_mode_reverts_on_validate_failure() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixloop Round 2 (real-world only after #2040).

1. **Strict format/validate rollback wiped binary deletes** — string rollback used empty soft-load originals; prefer `backup::restore_session` when a session exists.
2. **Fuzzy/context replace `match_count` undercounted** — top-level was `files.len()` while file entries had real multi-match counts.
3. **MCP full instructions omitted `apply_fragment`** — hosts that bias on handshake text skipped Morph-class fragment apply.

## Test plan

- [x] Integration: strict format fail restores binary delete bytes + backup_session
- [x] Integration: fuzzy path match_count sums multi-match
- [x] Unit: full server instructions list apply_fragment
- [x] `make check-fast` green