### PR TITLE
fix: multi-doc delete, stale delete patches, force rename backup

### DIFF
--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -286,7 +286,7 @@ fn replace_write(
             }
             return Err(anyhow::Error::new(crate::exit::AmbiguousError {
                 msg: format!(
-                    "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), or --allow-non-unique (apply-fragment))",
+                    "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI))",
                     crate::fallback::truncate_str(&old, 60),
                     count
                 ),
@@ -302,7 +302,7 @@ fn replace_write(
         if unique && count > 1 {
             return Err(anyhow::Error::new(crate::exit::AmbiguousError {
                 msg: format!(
-                    "ambiguous match: pattern {old:?} matches {count} times; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)"
+                    "ambiguous match: pattern {old:?} matches {count} times; tighten the pattern/anchor, use --nth (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI)"
                 ),
             }));
         }
@@ -705,7 +705,7 @@ fn replace_in_content_inner(
         }
         return Err(anyhow::Error::new(crate::exit::AmbiguousError {
             msg: format!(
-                "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), or --allow-non-unique (apply-fragment))",
+                "ambiguous match: pattern {:?} matches {} times; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI))",
                 crate::fallback::truncate_str(from, 60),
                 count
             ),
@@ -880,7 +880,7 @@ fn finalize_content_replace(
         return Err(crate::fallback::EditError::new(
             crate::fallback::EditErrorKind::AmbiguousTarget,
             format!(
-                "ambiguous match: pattern {:?} matches {} times; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)",
+                "ambiguous match: pattern {:?} matches {} times; tighten the pattern/anchor, use --nth (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI)",
                 from, count
             ),
         )

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -369,6 +369,11 @@ const FIELD_ALIASES: &[(&str, &str)] = &[
     ("key", "selector"),
     ("from", "old"),
     ("to", "new"),
+    // apply.fragment: agents copy replace_text priors (new/to/content → fragment).
+    // Applied only when the tool schema allows the canonical name.
+    ("new", "fragment"),
+    ("to", "fragment"),
+    ("content", "fragment"),
     ("ops", "operations"),
 ];
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -720,7 +720,7 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 global.emit_json(&output)?;
                 if !global.quiet {
                     eprintln!(
-                        "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)",
+                        "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI)",
                         crate::fallback::truncate_str(&args.old, 60),
                         r.match_count,
                         r.display_path,

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -646,22 +646,53 @@ fn serialize_multi_document_yaml(
         return Ok(preserve::hoist_comments(original_content, &body));
     };
 
-    let old_docs = old_value.as_array();
+    let old_docs = old_value.as_array().map(|a| a.as_slice()).unwrap_or(&[]);
     let mut out_docs: Vec<String> = Vec::with_capacity(new_docs.len());
 
-    for (i, new_doc) in new_docs.iter().enumerate() {
-        let orig_body = bodies.get(i).map(String::as_str).unwrap_or("");
-        let old_doc = old_docs.and_then(|arr| arr.get(i));
-        match old_doc {
-            Some(old_doc) if old_doc == new_doc && !orig_body.is_empty() => {
-                out_docs.push(orig_body.to_string());
+    // When document count is unchanged, pair by index (in-place field edits).
+    // When count changes (whole-doc delete/append), pair by value identity so
+    // surviving docs keep their original bodies/comments. Index pairing after
+    // `doc.delete 0` wrongly maps body[0] onto the former doc 1.
+    if old_docs.len() == new_docs.len() {
+        for (i, new_doc) in new_docs.iter().enumerate() {
+            let orig_body = bodies.get(i).map(String::as_str).unwrap_or("");
+            let old_doc = old_docs.get(i);
+            match old_doc {
+                Some(old_doc) if old_doc == new_doc && !orig_body.is_empty() => {
+                    out_docs.push(orig_body.to_string());
+                }
+                Some(old_doc) => {
+                    out_docs.push(serialize_single_yaml_document(orig_body, old_doc, new_doc)?);
+                }
+                None => {
+                    out_docs.push(serialize_value(new_doc, &FileFormat::Yaml)?);
+                }
             }
-            Some(old_doc) => {
-                out_docs.push(serialize_single_yaml_document(orig_body, old_doc, new_doc)?);
-            }
-            None => {
-                // Appended document: no original body to preserve.
-                out_docs.push(serialize_value(new_doc, &FileFormat::Yaml)?);
+        }
+    } else {
+        let mut used = vec![false; old_docs.len()];
+        for new_doc in new_docs {
+            let match_j = old_docs.iter().enumerate().find_map(|(j, old_doc)| {
+                if !used[j] && old_doc == new_doc {
+                    Some(j)
+                } else {
+                    None
+                }
+            });
+            match match_j {
+                Some(j) => {
+                    used[j] = true;
+                    let orig_body = bodies.get(j).map(String::as_str).unwrap_or("");
+                    if !orig_body.is_empty() {
+                        out_docs.push(orig_body.to_string());
+                    } else {
+                        out_docs.push(serialize_value(new_doc, &FileFormat::Yaml)?);
+                    }
+                }
+                None => {
+                    // New or edited without exact old identity: full serialize.
+                    out_docs.push(serialize_value(new_doc, &FileFormat::Yaml)?);
+                }
             }
         }
     }

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1066,6 +1066,36 @@ mod error_handling {
     }
 
     #[test]
+    fn yaml_multi_document_delete_first_preserves_surviving_comments() {
+        // Whole-doc delete must not pair body[0] onto former doc 1.
+        let yaml = "# doc A comment\nname: alpha\n---\n# doc B comment\nname: beta\n---\n# doc C comment\nname: gamma\n";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new.as_array_mut().unwrap().remove(0);
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert!(
+            result.contains("# doc B comment") && result.contains("name: beta"),
+            "surviving beta must keep its comment, got:\n{result}"
+        );
+        assert!(
+            result.contains("# doc C comment") && result.contains("name: gamma"),
+            "surviving gamma must keep its comment, got:\n{result}"
+        );
+        assert!(
+            !result.contains("# doc A comment"),
+            "deleted alpha comment must not stick to beta, got:\n{result}"
+        );
+        assert!(
+            !result.contains("name: alpha"),
+            "deleted alpha must be gone, got:\n{result}"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed.as_array().map(|a| a.len()), Some(2));
+        assert_eq!(reparsed[0]["name"], json!("beta"));
+        assert_eq!(reparsed[1]["name"], json!("gamma"));
+    }
+
+    #[test]
     fn yaml_multi_document_set_preserves_crlf_separators() {
         // Windows agent editing multi-doc k8s manifests must keep CRLF stream.
         let yaml = "---\r\na: 1\r\n---\r\nb: 2\r\n";

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -720,15 +720,53 @@ where
         } else {
             load_original(&pf.path)?
         };
-        // File deletion: result is empty string (caller handles removal).
+        // File deletion: still run hunk application so stale context fails
+        // closed (check and apply must agree). Skipping hunks always deleted
+        // even when the file was edited after the patch was made.
         if pf.is_deletion {
+            if pf.hunks.is_empty() {
+                // Pure delete marker without hunks: remove as-is.
+                results.push(PatchApplyFileResult {
+                    path: pf.path.clone(),
+                    content: String::new(),
+                    status: ApplyHunksStatus::Clean,
+                    conflicts: Vec::new(),
+                    is_creation: false,
+                    is_deletion: true,
+                });
+                continue;
+            }
+            let applied = match apply_hunks_with_options(&original, &pf.hunks, options) {
+                Ok(applied) => applied,
+                Err(msg) if msg.contains("conflict(s)") => {
+                    return Err(crate::exit::ConflictsError {
+                        msg: format!("patch apply: {} -- {msg}", pf.path),
+                    }
+                    .into());
+                }
+                Err(msg) if msg.contains("stale context") => {
+                    return Err(crate::exit::AmbiguousError {
+                        msg: format!("patch apply: {} -- {msg}", pf.path),
+                    }
+                    .into());
+                }
+                Err(msg) => {
+                    return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("patch apply: {} -- {msg}", pf.path),
+                    }));
+                }
+            };
+            // Only treat as deletion when context matched (Clean empty result).
+            // Stale/conflict already returned Err above under OnStale::Fail.
+            let is_clean_delete =
+                applied.status == ApplyHunksStatus::Clean && applied.content.is_empty();
             results.push(PatchApplyFileResult {
                 path: pf.path.clone(),
-                content: String::new(),
-                status: ApplyHunksStatus::Clean,
-                conflicts: Vec::new(),
+                content: applied.content,
+                status: applied.status,
+                conflicts: applied.conflicts,
                 is_creation: false,
-                is_deletion: true,
+                is_deletion: is_clean_delete,
             });
             continue;
         }

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -976,6 +976,51 @@ mod regression {
         );
     }
 
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn apply_deletion_patch_fails_when_content_stale() {
+        let diff = "\
+--- a/old_file.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-line one
+-line two
+";
+        let err = apply_patch_with_loader(
+            diff,
+            |_path| Ok("changed content\n".to_string()),
+            ApplyHunksOptions::default(),
+        )
+        .expect_err("stale deletion must fail closed");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("stale") || crate::exit::is_ambiguous(&err),
+            "expected stale/ambiguous, got: {msg}"
+        );
+    }
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn apply_deletion_patch_succeeds_when_context_matches() {
+        let diff = "\
+--- a/old_file.txt
++++ /dev/null
+@@ -1,2 +0,0 @@
+-line one
+-line two
+";
+        let results = apply_patch_with_loader(
+            diff,
+            |_path| Ok("line one\nline two\n".to_string()),
+            ApplyHunksOptions::default(),
+        )
+        .expect("matching deletion should apply");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].is_deletion);
+        assert_eq!(results[0].status, ApplyHunksStatus::Clean);
+        assert!(results[0].content.is_empty());
+    }
+
     #[test]
     fn hunk_context_anchors_mid_hunk_context_excluded_from_suffix() {
         // Regression: mid-hunk context between two change blocks was included

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -85,6 +85,8 @@ pub enum Operation {
         /// File to edit.
         path: String,
         /// New text or Morph-style snippet (lazy marker lines stripped).
+        /// Aliases `new`/`to`/`content` match replace_text agent priors.
+        #[serde(alias = "new", alias = "to", alias = "content")]
         fragment: String,
         /// Optional human instruction (explain only; not used for merge).
         #[serde(default)]

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -53,6 +53,25 @@ fn substitute_single_pass_preserves_utf8() {
 }
 
 #[test]
+fn apply_fragment_accepts_new_alias_for_fragment() {
+    // Agents often copy replace_text priors (`new`/`to`) onto apply.fragment.
+    let v: serde_json::Value = serde_json::json!({
+        "op": "apply.fragment",
+        "path": "f.rs",
+        "old": "anchor",
+        "new": "replacement"
+    });
+    let op: Operation = serde_json::from_value(v).expect("new should alias fragment");
+    match op {
+        Operation::ApplyFragment { fragment, old, .. } => {
+            assert_eq!(fragment, "replacement");
+            assert_eq!(old.as_deref(), Some("anchor"));
+        }
+        other => panic!("expected ApplyFragment, got {other:?}"),
+    }
+}
+
+#[test]
 fn has_lifecycle_steps_none() {
     let plan = Plan {
         version: SCHEMA_VERSION,

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -146,6 +146,16 @@ pub(crate) fn commit_changes(
             .save_before_delete(path)
             .map_err(|e| commit_error(format!("backing up {}: {e}", path.display())))?;
     }
+    // Force rename overwrite: dest may be soft-empty non-text and absent from
+    // `changes` (original == final == ""), so it would not be backed up above.
+    // `rename_or_copy` still overwrites dest; keep prior dest bytes for undo.
+    for (_, to) in renames {
+        if to.exists() {
+            backup.save_before_write(to).map_err(|e| {
+                commit_error(format!("backing up rename dest {}: {e}", to.display()))
+            })?;
+        }
+    }
 
     // Finalize before writes so undo can recover from a mid-commit failure.
     let backup_session = backup

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -251,7 +251,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
         if *unique && match_count > 1 {
             return Err(crate::exit::AmbiguousError {
                 msg: format!(
-                    "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)",
+                    "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI)",
                     crate::fallback::truncate_str(old, 60),
                     match_count,
                     p
@@ -288,7 +288,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 }
                 return Err(crate::exit::AmbiguousError {
                     msg: format!(
-                        "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), or --allow-non-unique (apply-fragment))",
+                        "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI))",
                         crate::fallback::truncate_str(old, 60),
                         match_count,
                         p
@@ -572,7 +572,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     .display();
                 return Err(crate::exit::AmbiguousError {
                     msg: format!(
-                        "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), or --allow-non-unique (apply-fragment)",
+                        "ambiguous match: pattern {:?} matches {} times in {}; tighten the pattern/anchor, use --nth (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI)",
                         crate::fallback::truncate_str(old, 60),
                         match_count,
                         rel
@@ -611,7 +611,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         .display();
                     return Err(crate::exit::AmbiguousError {
                         msg: format!(
-                            "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), or --allow-non-unique (apply-fragment))",
+                            "ambiguous match: pattern {:?} matches {} times in {}; context did not select a unique occurrence (use --nth, stronger before/after-context (replace), unique: false (plan/MCP), or --allow-non-unique (apply-fragment CLI))",
                             crate::fallback::truncate_str(old, 60),
                             match_count,
                             rel

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -238,6 +238,34 @@ fn test_patch_apply_json_stale_error_returns_error_object() {
     assert_patch_apply_error_object(&output, 5, "patch apply: test.txt -- STALE:");
 }
 
+/// Deletion patches must fail closed when file content no longer matches the
+/// hunk (check already reported stale; apply must not delete).
+#[test]
+fn test_patch_apply_stale_deletion_does_not_delete_file() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("t.txt");
+    fs::write(&file, "changed\n").unwrap();
+    let patch_file = dir.path().join("del.patch");
+    fs::write(
+        &patch_file,
+        "--- a/t.txt\n+++ /dev/null\n@@ -1,2 +0,0 @@\n-line1\n-line2\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--apply")
+        .assert()
+        .code(5); // AMBIGUOUS / stale
+    assert!(file.exists(), "stale deletion must not remove the file");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "changed\n");
+}
+
 #[test]
 fn test_patch_check_exits_2_when_would_change() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -1278,6 +1278,59 @@ fn test_tx_file_rename_fails_if_dst_exists() {
     );
 }
 
+/// Force overwrite of existing binary dest must back up dest bytes for undo.
+#[test]
+fn test_tx_file_rename_force_binary_undo_restores_dest() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("src.bin"), b"AAA\0").unwrap();
+    fs::write(dir.path().join("dst.bin"), b"BBB\0").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "file.rename",
+            "from": "src.bin",
+            "to": "dst.bin",
+            "force": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg("plan.json")
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read(dir.path().join("dst.bin")).unwrap(), b"AAA\0");
+    assert!(!dir.path().join("src.bin").exists());
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("undo")
+        .arg("--apply")
+        .assert()
+        .success();
+
+    assert_eq!(
+        fs::read(dir.path().join("src.bin")).unwrap(),
+        b"AAA\0",
+        "src restored"
+    );
+    assert_eq!(
+        fs::read(dir.path().join("dst.bin")).unwrap(),
+        b"BBB\0",
+        "prior dest bytes must be restored from backup"
+    );
+}
+
 #[test]
 fn test_tx_file_rename_force_overwrites() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Fixloop Round 3 (real-world agent paths only).

1. **Multi-doc YAML `doc.delete 0`** mis-paired bodies by index after length change (wrong comments/structure on survivors).
2. **`+++ /dev/null` patches** always deleted without hunk check; `patch check` could report stale while apply deleted.
3. **Force binary rename** overwrote dest without backing up dest bytes (undo lost prior dest).
4. **Agent priors:** `apply.fragment` accepts `new`/`to`/`content`; ambiguous messages mention `unique: false` for plan/MCP.

Rejected as non-real: mid-op EditError rewrap peel (only upfront contain hits), no-newline-at-EOF (larger design), corrupt-session undo skip (no dogfood).

## Test plan

- [x] Unit: multi-doc delete preserves surviving comments
- [x] Unit: deletion patch stale fail / match success
- [x] Unit: apply.fragment `new` alias
- [x] Integration: stale deletion does not delete file
- [x] Integration: force binary rename undo restores dest BBB
- [x] `make check-fast` green