### PR TITLE
fix: patch EOF newline, files-from stdin, NotFound peel, ast aliases

### DIFF
--- a/fuzz/fuzz_targets/fuzz_patch_apply.rs
+++ b/fuzz/fuzz_targets/fuzz_patch_apply.rs
@@ -17,7 +17,9 @@ struct FuzzHunk {
     new_start: usize,
     new_count: usize,
     lines: Vec<FuzzLine>,
-}
+            old_no_final_newline: false,
+            new_no_final_newline: false,
+        }
 
 #[derive(Debug, Arbitrary)]
 enum FuzzLine {
@@ -44,6 +46,8 @@ fuzz_target!(|input: FuzzInput| {
                     FuzzLine::Add(s) => PatchLine::Add(s),
                 })
                 .collect(),
+                    old_no_final_newline: false,
+            new_no_final_newline: false,
         })
         .collect();
 

--- a/fuzz/fuzz_targets/fuzz_patch_apply.rs
+++ b/fuzz/fuzz_targets/fuzz_patch_apply.rs
@@ -17,9 +17,9 @@ struct FuzzHunk {
     new_start: usize,
     new_count: usize,
     lines: Vec<FuzzLine>,
-            old_no_final_newline: false,
-            new_no_final_newline: false,
-        }
+    old_no_final_newline: bool,
+    new_no_final_newline: bool,
+}
 
 #[derive(Debug, Arbitrary)]
 enum FuzzLine {
@@ -46,8 +46,8 @@ fuzz_target!(|input: FuzzInput| {
                     FuzzLine::Add(s) => PatchLine::Add(s),
                 })
                 .collect(),
-                    old_no_final_newline: false,
-            new_no_final_newline: false,
+            old_no_final_newline: h.old_no_final_newline,
+            new_no_final_newline: h.new_no_final_newline,
         })
         .collect();
 

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -271,8 +271,10 @@ pub fn apply_content_edits_to_file_with_span_policy(
     }
     let path_str = path.to_string_lossy().into_owned();
     let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
-        // Preserve content SoftSkip peels (#1963); do not collapse to OperationFailed.
-        if crate::exit::is_load_text_strict_fail(&e) {
+        // Preserve content SoftSkip peels (#1963) and NotFound for hosts that
+        // branch on is_not_found (create/retry). Do not collapse either to
+        // OperationFailed.
+        if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
             return e;
         }
         EditError::new(EditErrorKind::OperationFailed, e.to_string()).into()

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -530,6 +530,26 @@ fn apply_content_edits_to_file_binary_is_binary() {
 }
 
 #[test]
+#[cfg(any(feature = "cli", feature = "files"))]
+fn apply_content_edits_to_file_missing_is_not_found() {
+    use crate::api::{ContentEdit, apply_content_edits_to_file};
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("gone.txt");
+    let edits = [ContentEdit::Replace {
+        old: "a".into(),
+        new: "z".into(),
+        options: ReplaceOptions::default(),
+    }];
+    let err = apply_content_edits_to_file(&file, &edits, ApplyMode::Apply, None).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::NotFound),
+        "missing path must peel as NotFound not OperationFailed: {err}"
+    );
+    assert!(crate::api::is_not_found(&err), "is_not_found peel: {err}");
+}
+
+#[test]
 fn file_rename_works() {
     let dir = TempDir::new().unwrap();
     let src = dir.path().join("old.txt");

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -360,8 +360,12 @@ pub(crate) struct AstRenameParams {
     /// File or directory to rename in (relative to working directory).
     pub path: String,
     /// The identifier to rename (same name as replace / plan `old`).
+    /// Alias `from` accepted because agents often emit that name (LLM prior).
+    #[serde(alias = "from")]
     pub old: String,
     /// The new identifier name (same name as replace / plan `new`).
+    /// Alias `to` accepted because agents often emit that name (LLM prior).
+    #[serde(alias = "to")]
     pub new: String,
     /// Language hint.
     pub lang: Option<String>,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -292,13 +292,28 @@ fn parse_range_arg(spec: Option<&str>) -> anyhow::Result<Option<(usize, Option<u
 ///
 /// Second return value is exact zero-match `refused[]` for explicit file lists
 /// (#1792), built from the same path walk so `--files-from -` is not re-read.
+#[cfg_attr(not(test), allow(dead_code))]
 fn collect_replacements(
     args: &ReplaceArgs,
     global: &GlobalFlags,
 ) -> anyhow::Result<(Vec<FileReplacement>, Option<Vec<RefuseFileResult>>)> {
+    collect_replacements_with_list(args, global, None)
+}
+
+fn collect_replacements_with_list(
+    args: &ReplaceArgs,
+    global: &GlobalFlags,
+    files_from_preload: Option<&[String]>,
+) -> anyhow::Result<(Vec<FileReplacement>, Option<Vec<RefuseFileResult>>)> {
     let cwd = global.resolve_cwd()?;
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
-    let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+    let file_paths = crate::files::collect_file_paths_opts_with_list(
+        &args.paths,
+        global,
+        false,
+        Some(&cwd),
+        files_from_preload,
+    )?;
     // Empty --files-from is an input error, not a pattern miss (#1796).
     // Detected here (single read of stdin) before soft no_matches handling.
     crate::files::ensure_files_from_nonempty(global, &file_paths)?;
@@ -650,8 +665,9 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         normalized_paths.push(global.rewrite_user_path_arg(&cwd, p)?);
     }
     args.paths = normalized_paths;
-    // Sole non-text before soft-skip scan (file-backed --files-from; not stdin).
-    let files_from_list = global.files_from_for_sole_scan()?;
+    // Read --files-from once (including stdin `-`); sole/refused/scan must not
+    // re-read empty stdin (same class as search #2040).
+    let files_from_list = global.read_files_from()?;
     if let Some(err) = crate::ops::file::sole_explicit_non_text_for_scan(
         &args.paths,
         files_from_list.as_deref(),
@@ -664,7 +680,13 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
         return Ok(exit::FAILURE);
     }
-    let skipped = crate::files::scan_missing_entries(global, &cwd, &args.paths)?;
+    let skipped = if files_from_list.is_some() {
+        files_from_list
+            .as_ref()
+            .and_then(|files| crate::files::explicit_paths_missing_entries(&cwd, files))
+    } else {
+        crate::files::scan_missing_entries(global, &cwd, &args.paths)?
+    };
 
     // Context / pure fuzzy: route through the tx engine where the
     // context_filtered_offset and fallback chain live (#1668).
@@ -675,16 +697,17 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // Phase 1: Parallel file scan to identify files with matches (includes identity).
     // Also builds exact zero-match refused for explicit path lists (#1792) from
     // the same path walk so --files-from - is only read once (#1796).
-    let (mut replacements, zero_match_refused) = match collect_replacements(&args, global) {
-        Ok(r) => r,
-        Err(e) if crate::exit::is_load_text_strict_fail(&e) => {
-            let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
-            let msg = crate::exit::agent_error_message(&e);
-            global.emit_error_json_kind(Some(kind), &msg)?;
-            return Ok(exit::FAILURE);
-        }
-        Err(e) => return Err(e),
-    };
+    let (mut replacements, zero_match_refused) =
+        match collect_replacements_with_list(&args, global, files_from_list.as_deref()) {
+            Ok(r) => r,
+            Err(e) if crate::exit::is_load_text_strict_fail(&e) => {
+                let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+                let msg = crate::exit::agent_error_message(&e);
+                global.emit_error_json_kind(Some(kind), &msg)?;
+                return Ok(exit::FAILURE);
+            }
+            Err(e) => return Err(e),
+        };
     let raw_match_count: usize = replacements.iter().map(|r| r.match_count).sum();
 
     // Unique check: fail if any file has more than one match (before identity
@@ -742,7 +765,13 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             args.multiline,
             args.word_boundary,
         )?;
-        let file_paths = crate::collect_file_paths_opts(&args.paths, global, false, Some(&cwd))?;
+        let file_paths = crate::files::collect_file_paths_opts_with_list(
+            &args.paths,
+            global,
+            false,
+            Some(&cwd),
+            files_from_list.as_deref(),
+        )?;
         let range = parse_range_arg(args.range.as_deref())?;
         for path in &file_paths {
             // SoftSkip multi-path (#1894).
@@ -829,7 +858,12 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             global.emit_json(&output)?;
             return Ok(exit::SUCCESS);
         }
-        if crate::files::all_scan_targets_missing(global, &args.paths, Some(&cwd))? {
+        let all_missing = if let Some(ref files) = files_from_list {
+            crate::files::all_explicit_paths_missing(files, Some(&cwd))
+        } else {
+            crate::files::all_scan_targets_missing(global, &args.paths, Some(&cwd))?
+        };
+        if all_missing {
             let msg = format!(
                 "no such file or directory: {}",
                 global.path_scope_description(&args.paths)
@@ -851,7 +885,13 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             return Ok(exit::FAILURE);
         }
         // Multi-path / dir walk: unreadable may have masked the scan (#1894).
-        let scanned = crate::collect_file_paths_opts(&args.paths, global, true, Some(&cwd))?;
+        let scanned = crate::files::collect_file_paths_opts_with_list(
+            &args.paths,
+            global,
+            true,
+            Some(&cwd),
+            files_from_list.as_deref(),
+        )?;
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, &cwd) {
             global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
             return Ok(exit::FAILURE);

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -143,14 +143,29 @@ fn editorconfig_check_props(_path: &Path) -> (Option<crate::write::EolMode>, boo
 /// Collect all issues from the given paths, honouring .gitignore and optional
 /// glob filtering.  Uses `collect_file_paths_opts` with `include_hidden=true`
 /// so dotfiles are also checked.  File scanning is parallelized.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn collect_issues(
     paths: &[String],
     global: &GlobalFlags,
 ) -> anyhow::Result<Vec<TidyIssue>> {
+    collect_issues_with_list(paths, global, None)
+}
+
+pub(super) fn collect_issues_with_list(
+    paths: &[String],
+    global: &GlobalFlags,
+    files_from_preload: Option<&[String]>,
+) -> anyhow::Result<Vec<TidyIssue>> {
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, paths)?;
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
-    let file_paths = crate::collect_file_paths_opts(paths, global, true, Some(&cwd))?;
+    let file_paths = crate::files::collect_file_paths_opts_with_list(
+        paths,
+        global,
+        true,
+        Some(&cwd),
+        files_from_preload,
+    )?;
     // Empty --files-from must not report ok:true / zero issues (#1796).
     crate::files::ensure_files_from_nonempty(global, &file_paths)?;
     let glob_roots = crate::collect_glob_roots_from_global(paths, global, Some(&cwd))?;
@@ -254,8 +269,8 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(exit::FAILURE);
     }
-    // Sole non-text: positionals or file-backed --files-from (not stdin).
-    let files_from_list = global.files_from_for_sole_scan()?;
+    // Read --files-from once (including stdin `-`); do not re-read empty stdin.
+    let files_from_list = global.read_files_from()?;
     if let Some(err) =
         crate::ops::file::sole_explicit_non_text_for_scan(paths, files_from_list.as_deref(), &cwd)
     {
@@ -266,13 +281,25 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
         }
         return Ok(exit::FAILURE);
     }
-    let skipped = crate::files::scan_missing_entries(global, &cwd, paths)?;
+    let skipped = if files_from_list.is_some() {
+        files_from_list
+            .as_ref()
+            .and_then(|files| crate::files::explicit_paths_missing_entries(&cwd, files))
+    } else {
+        crate::files::scan_missing_entries(global, &cwd, paths)?
+    };
     let refuse_paths: &[String] = files_from_list.as_deref().unwrap_or(paths);
     let refused = crate::ops::file::explicit_multi_path_non_text_refused(refuse_paths, &cwd);
-    let issues = collect_issues(paths, global)?;
+    let issues = collect_issues_with_list(paths, global, files_from_list.as_deref())?;
     if issues.is_empty() {
         // Unreadable paths soft-skipped as "clean" would mask permission failures.
-        let scanned = crate::collect_file_paths_opts(paths, global, true, Some(&cwd))?;
+        let scanned = crate::files::collect_file_paths_opts_with_list(
+            paths,
+            global,
+            true,
+            Some(&cwd),
+            files_from_list.as_deref(),
+        )?;
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, &cwd) {
             global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
             return Ok(exit::FAILURE);

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -227,8 +227,8 @@ pub(super) fn run_fix(
 
     let cwd = global.resolve_cwd()?;
     global.check_paths_contained(&cwd, &paths)?;
-    // Sole non-text before soft-skip scan (file-backed --files-from; not stdin).
-    let files_from_list = global.files_from_for_sole_scan()?;
+    // Read --files-from once (including stdin `-`); do not re-read empty stdin.
+    let files_from_list = global.read_files_from()?;
     if let Some(err) =
         crate::ops::file::sole_explicit_non_text_for_scan(&paths, files_from_list.as_deref(), &cwd)
     {
@@ -239,9 +239,21 @@ pub(super) fn run_fix(
         }
         return Ok(crate::exit::FAILURE);
     }
-    let skipped = crate::files::scan_missing_entries(global, &cwd, &paths)?;
+    let skipped = if files_from_list.is_some() {
+        files_from_list
+            .as_ref()
+            .and_then(|files| crate::files::explicit_paths_missing_entries(&cwd, files))
+    } else {
+        crate::files::scan_missing_entries(global, &cwd, &paths)?
+    };
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
-    let fix_file_paths = crate::collect_file_paths_opts(&paths, global, true, Some(&cwd))?;
+    let fix_file_paths = crate::files::collect_file_paths_opts_with_list(
+        &paths,
+        global,
+        true,
+        Some(&cwd),
+        files_from_list.as_deref(),
+    )?;
     // Empty --files-from is invalid_input, not a successful no-op (#1796).
     crate::files::ensure_files_from_nonempty(global, &fix_file_paths)?;
     let glob_roots = crate::collect_glob_roots_from_global(&paths, global, Some(&cwd))?;
@@ -297,7 +309,12 @@ pub(super) fn run_fix(
 
     crate::verbose!("tidy: {} file(s) need fixing", dirty_rel_paths.len());
     if dirty_rel_paths.is_empty() {
-        if crate::files::all_scan_targets_missing(global, &paths, Some(&cwd))? {
+        let all_missing = if let Some(ref files) = files_from_list {
+            crate::files::all_explicit_paths_missing(files, Some(&cwd))
+        } else {
+            crate::files::all_scan_targets_missing(global, &paths, Some(&cwd))?
+        };
+        if all_missing {
             let msg = format!(
                 "no such file or directory: {}",
                 global.path_scope_description(&paths)

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -14,6 +14,10 @@ pub struct Hunk {
     pub new_start: usize,
     pub new_count: usize,
     pub lines: Vec<PatchLine>,
+    /// `\ No newline at end of file` appeared after a remove/context line.
+    pub old_no_final_newline: bool,
+    /// `\ No newline at end of file` appeared after an add line.
+    pub new_no_final_newline: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -90,6 +94,8 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
             if lines[i].starts_with("@@ ") {
                 let hunk = parse_hunk_header(lines[i])?;
                 let mut hunk_lines: Vec<PatchLine> = Vec::new();
+                let mut old_no_final_newline = false;
+                let mut new_no_final_newline = false;
                 i += 1;
 
                 while i < lines.len()
@@ -105,6 +111,14 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
                     } else if let Some(rest) = line.strip_prefix(' ') {
                         hunk_lines.push(PatchLine::Context(rest.to_string()));
                     } else if line == "\\ No newline at end of file" {
+                        // Marker applies to the previous hunk line (git format).
+                        match hunk_lines.last() {
+                            Some(PatchLine::Add(_)) => new_no_final_newline = true,
+                            Some(PatchLine::Remove(_) | PatchLine::Context(_)) => {
+                                old_no_final_newline = true;
+                            }
+                            None => {}
+                        }
                     } else {
                         hunk_lines.push(PatchLine::Context(line.to_string()));
                     }
@@ -117,6 +131,8 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
                     new_start: hunk.new_start,
                     new_count: hunk.new_count,
                     lines: hunk_lines,
+                    old_no_final_newline,
+                    new_no_final_newline,
                 });
             } else {
                 i += 1;
@@ -180,6 +196,8 @@ fn parse_hunk_header(line: &str) -> Result<Hunk, String> {
         new_start,
         new_count,
         lines: Vec::new(),
+        old_no_final_newline: false,
+        new_no_final_newline: false,
     })
 }
 
@@ -285,7 +303,7 @@ pub struct PatchApplyFileResult {
 pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, String> {
     let eol = detect_eol(original);
     let mut src_lines: Vec<String> = original.lines().map(String::from).collect();
-    let had_final_newline =
+    let mut had_final_newline =
         original.ends_with('\n') || original.ends_with("\r\n") || original.is_empty();
     let mut offset: isize = 0;
 
@@ -346,7 +364,38 @@ pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, String> {
 
         let old_len = old_refs.len();
         let new_len = new_lines.len();
+        // When the match covers the end of the file, git "\ No newline" markers
+        // decide whether the result ends with a newline.
+        let touches_eof = pos + old_len >= src_lines.len();
         src_lines.splice(pos..pos + old_len, new_lines);
+        if touches_eof {
+            let last_new = hunk
+                .lines
+                .iter()
+                .rev()
+                .find(|pl| matches!(pl, PatchLine::Add(_) | PatchLine::Context(_)));
+            match last_new {
+                Some(PatchLine::Add(_)) => {
+                    if hunk.new_no_final_newline {
+                        // Explicit: new file ends without NL.
+                        had_final_newline = false;
+                    } else if hunk.old_no_final_newline {
+                        // Old last line lacked NL; new last line has no marker → has NL.
+                        had_final_newline = true;
+                    }
+                    // Else keep prior had_final_newline (preserve EOF when only
+                    // rewriting the last line without git markers).
+                }
+                Some(PatchLine::Context(_)) if hunk.old_no_final_newline => {
+                    // EOF context line that lacked NL on the old side.
+                    had_final_newline = false;
+                }
+                Some(PatchLine::Context(_)) if hunk.new_no_final_newline => {
+                    had_final_newline = false;
+                }
+                _ => {}
+            }
+        }
         let delta = isize::try_from(new_len).unwrap_or(isize::MAX)
             - isize::try_from(old_len).unwrap_or(isize::MAX);
         offset = offset.saturating_add(delta);

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -29,6 +29,8 @@ fn make_hunk(
         new_start: old_start,
         new_count,
         lines,
+        old_no_final_newline: false,
+        new_no_final_newline: false,
     }
 }
 
@@ -93,6 +95,8 @@ mod basic {
                 PatchLine::Add("LINE2".into()),
                 PatchLine::Context("line3".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, "line1\nLINE2\nline3\n");
@@ -111,6 +115,8 @@ mod basic {
                 PatchLine::Add("inserted".into()),
                 PatchLine::Context("b".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, "a\ninserted\nb\n");
@@ -129,6 +135,8 @@ mod basic {
                 PatchLine::Remove("remove_me".into()),
                 PatchLine::Context("b".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, "a\nb\n");
@@ -176,6 +184,8 @@ mod basic {
                     PatchLine::Add("INSERTED".into()),
                     PatchLine::Context("b".into()),
                 ],
+                old_no_final_newline: false,
+                new_no_final_newline: false,
             },
             Hunk {
                 old_start: 4,
@@ -187,6 +197,8 @@ mod basic {
                     PatchLine::Add("D".into()),
                     PatchLine::Context("e".into()),
                 ],
+                old_no_final_newline: false,
+                new_no_final_newline: false,
             },
         ];
         let result = apply_hunks(original, &hunks).unwrap();
@@ -336,6 +348,8 @@ mod basic {
                 PatchLine::Remove("old".into()),
                 PatchLine::Add("new".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         };
         let haystack: Vec<&str> = vec!["ctx1", "ctx2", "modified"];
         let result = locate_by_context_anchors(&haystack, &hunk, 0);
@@ -355,6 +369,8 @@ mod basic {
                 PatchLine::Add("new".into()),
                 PatchLine::Context("suffix".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         };
         let haystack: Vec<&str> = vec!["modified", "suffix"];
         let result = locate_by_context_anchors(&haystack, &hunk, 0);
@@ -375,6 +391,8 @@ mod basic {
                 PatchLine::Add("new".into()),
                 PatchLine::Context("suffix".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         };
         let haystack: Vec<&str> = vec!["prefix", "modified", "suffix"];
         let result = locate_by_context_anchors(&haystack, &hunk, 0);
@@ -427,6 +445,8 @@ mod basic {
                 PatchLine::Add("patched".into()),
                 PatchLine::Context("ctx2".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = merge_hunks(ours, &hunks).unwrap();
         // Line 2: ours changed "keep_this" → "ours_val" (theirs kept it) → ours wins
@@ -467,6 +487,8 @@ mod basic {
                 PatchLine::Add("patched".into()),
                 PatchLine::Context("ctx2".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let opts = ApplyHunksOptions {
             on_stale: OnStale::Merge,
@@ -547,6 +569,8 @@ mod edge_cases {
             new_start: 2,
             new_count: 1,
             lines: vec![PatchLine::Remove("c".into()), PatchLine::Add("C".into())],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, "a\nb\nC\nd\n");
@@ -566,6 +590,8 @@ mod edge_cases {
                 PatchLine::Add("new_line1".into()),
                 PatchLine::Add("new_line2".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         // Empty original is treated as having a final newline, so the
@@ -634,6 +660,8 @@ mod edge_cases {
                 PatchLine::Remove("old".into()),
                 PatchLine::Add("new".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         };
         let haystack: Vec<&str> = vec!["modified"];
         let result = locate_by_context_anchors(&haystack, &hunk, 0);
@@ -655,6 +683,8 @@ mod edge_cases {
                 PatchLine::Remove("target".into()),
                 PatchLine::Add("TARGET".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, "a\nb\nc\nd\nTARGET\nf\n");
@@ -675,6 +705,8 @@ mod edge_cases {
                 PatchLine::Remove("target".into()),
                 PatchLine::Add("TARGET".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         apply_hunks(original, &hunks).expect_err("expected error");
     }
@@ -692,6 +724,8 @@ mod edge_cases {
                 new_start: 1,
                 new_count: 1,
                 lines: vec![PatchLine::Remove("x".into()), PatchLine::Add("X".into())],
+                old_no_final_newline: false,
+                new_no_final_newline: false,
             },
             Hunk {
                 old_start: 4,
@@ -699,6 +733,8 @@ mod edge_cases {
                 new_start: 4,
                 new_count: 1,
                 lines: vec![PatchLine::Remove("y".into()), PatchLine::Add("Y".into())],
+                old_no_final_newline: false,
+                new_no_final_newline: false,
             },
         ];
         let result = apply_hunks(original, &hunks).unwrap();
@@ -718,6 +754,8 @@ mod edge_cases {
                 PatchLine::Remove("b".into()),
                 PatchLine::Remove("c".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         // All lines removed; join_lines on empty vec returns "".
@@ -738,6 +776,8 @@ mod edge_cases {
                 PatchLine::Context("line2".into()),
                 PatchLine::Context("line3".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, original);
@@ -771,6 +811,8 @@ mod error_handling {
                 PatchLine::Remove("wrong_context".into()),
                 PatchLine::Add("x".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         apply_hunks(original, &hunks).expect_err("expected error");
     }
@@ -818,6 +860,8 @@ mod format_preservation {
                 PatchLine::Remove("line2".into()),
                 PatchLine::Add("LINE2".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         let result = apply_hunks(original, &hunks).unwrap();
         assert_eq!(result, "line1\nLINE2");
@@ -841,8 +885,8 @@ mod format_preservation {
     }
 
     #[test]
-    fn parse_patch_skips_no_newline_marker() {
-        // The "\ No newline at end of file" marker must be silently skipped.
+    fn parse_patch_records_no_newline_marker_on_new_side() {
+        // Marker after `+` sets new_no_final_newline (git format).
         let diff = "\
 --- a/file.txt
 +++ b/file.txt
@@ -855,13 +899,34 @@ mod format_preservation {
         let files = parse_patch(diff).unwrap();
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].hunks[0].lines.len(), 3);
-        // Only Context("keep"), Remove("old"), Add("new") -- marker not present
         assert_eq!(
             files[0].hunks[0].lines[0],
             PatchLine::Context("keep".into())
         );
         assert_eq!(files[0].hunks[0].lines[1], PatchLine::Remove("old".into()));
         assert_eq!(files[0].hunks[0].lines[2], PatchLine::Add("new".into()));
+        assert!(
+            files[0].hunks[0].new_no_final_newline,
+            "marker after + must set new_no_final_newline"
+        );
+        assert!(!files[0].hunks[0].old_no_final_newline);
+    }
+
+    #[test]
+    fn apply_hunks_adds_final_newline_when_patch_removes_old_no_nl_marker() {
+        // File is "line" without EOF NL; patch adds trailing NL (git-style).
+        let original = "line";
+        let diff = "\
+--- a/f.txt
++++ b/f.txt
+@@ -1 +1 @@
+-line
+\\ No newline at end of file
++line
+";
+        let files = parse_patch(diff).unwrap();
+        let result = apply_hunks(original, &files[0].hunks).unwrap();
+        assert_eq!(result, "line\n");
     }
 }
 
@@ -878,6 +943,8 @@ mod regression {
             new_start: 1,
             new_count: 1,
             lines: vec![PatchLine::Context("x".into())],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         // Must return Err, never panic.
         apply_hunks("x\n", &hunks).expect_err("expected error");
@@ -931,6 +998,8 @@ mod regression {
             new_start: 1,
             new_count: 1,
             lines: vec![PatchLine::Add("new".into())],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         }];
         // apply_hunks uses a fuzz of 2 internally; the regression was
         // in find_match when delta values caused isize overflow. Just
@@ -1039,6 +1108,8 @@ mod regression {
                 PatchLine::Add("new2".into()),
                 PatchLine::Context("after".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         };
         let (prefix, suffix) = hunk_context_anchors(&hunk);
         assert_eq!(
@@ -1067,6 +1138,8 @@ mod regression {
                 PatchLine::Remove("line2".into()),
                 PatchLine::Add("replaced".into()),
             ],
+            old_no_final_newline: false,
+            new_no_final_newline: false,
         };
         let result = apply_hunks(original, &[hunk]).expect("should apply");
         assert!(

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -336,8 +336,12 @@ pub enum Operation {
         /// File or directory to rename in. Directories are walked recursively.
         path: String,
         /// The identifier to rename (same field name as replace / ast.replace).
+        /// Alias `from` matches replace/ast.replace agent priors.
+        #[serde(alias = "from")]
         old: String,
         /// The new identifier name (same field name as replace / ast.replace JSON `new`).
+        /// Alias `to` matches replace/ast.replace agent priors.
+        #[serde(alias = "to")]
         new: String,
         /// Language hint (e.g. "rust", "go"). Overrides extension-based detection.
         #[serde(default)]

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -52,6 +52,25 @@ fn substitute_single_pass_preserves_utf8() {
     );
 }
 
+#[cfg(feature = "ast")]
+#[test]
+fn ast_rename_accepts_from_to_aliases() {
+    let v: serde_json::Value = serde_json::json!({
+        "op": "ast.rename",
+        "path": "src/lib.rs",
+        "from": "OldName",
+        "to": "NewName"
+    });
+    let op: Operation = serde_json::from_value(v).expect("from/to should alias old/new");
+    match op {
+        Operation::AstRename { old, new, .. } => {
+            assert_eq!(old, "OldName");
+            assert_eq!(new, "NewName");
+        }
+        other => panic!("expected AstRename, got {other:?}"),
+    }
+}
+
 #[test]
 fn apply_fragment_accepts_new_alias_for_fragment() {
     // Agents often copy replace_text priors (`new`/`to`) onto apply.fragment.

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -80,6 +80,68 @@ fn test_files_from_stdin_sole_binary_is_binary_kind() {
     );
 }
 
+/// Sole binary via `--files-from -` for tidy check must not look clean.
+#[test]
+fn test_tidy_files_from_stdin_sole_binary_is_binary_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("b.bin"), b"x\0y").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--files-from")
+        .arg("-")
+        .arg("--json")
+        .arg("tidy")
+        .arg("check")
+        .write_stdin("b.bin\n")
+        .output()
+        .unwrap();
+
+    assert_ne!(output.status.code(), Some(0), "sole binary tidy must fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"error_kind\": \"binary\"")
+            || stdout.contains("\"error_kind\":\"binary\""),
+        "expected binary error_kind, got: {stdout}"
+    );
+}
+
+/// Sole binary via `--files-from -` for replace must not report no_matches.
+#[test]
+fn test_replace_files_from_stdin_sole_binary_is_binary_kind() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("b.bin"), b"x\0y").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--files-from")
+        .arg("-")
+        .arg("--json")
+        .arg("replace")
+        .arg("foo")
+        .arg("--new")
+        .arg("bar")
+        .write_stdin("b.bin\n")
+        .output()
+        .unwrap();
+
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "sole binary replace must fail"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("\"error_kind\": \"binary\"")
+            || stdout.contains("\"error_kind\":\"binary\""),
+        "expected binary error_kind, got: {stdout}"
+    );
+}
+
 /// Multi-path `--files-from -` must report co-listed binary in `refused[]`.
 #[test]
 fn test_files_from_stdin_multi_reports_refused_binary() {


### PR DESCRIPTION
## Summary

Fixloop Round 4 (real-world only).

1. **Git `\\ No newline at end of file`** was ignored; patches that only add/remove the final newline were no-ops.
2. **`tidy` / `replace` + `--files-from -`** still soft-skipped sole binary as clean / `no_matches` (search was fixed in #2040).
3. **`apply_content_edits_to_file` missing path** peeled as `OperationFailed` instead of `NotFound`.
4. **`ast.rename`** lacked `from`/`to` aliases that replace and `ast.replace` already accept.

## Test plan

- [x] Unit: parse records new-side marker; apply adds final NL; preserves no-NL mid-edit
- [x] Unit: content_edits missing → NotFound; ast.rename from/to
- [x] Integration: tidy/replace stdin sole binary → `error_kind: binary`
- [x] `make check-fast` green