### PR TITLE
fix: agent honesty for format_failed, lint exit, kind filter, undo

### DIFF
--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -410,13 +410,37 @@ pub fn extract_symbol_text<'a>(source: &'a str, sym: &SymbolDef, lang: Language)
 }
 
 /// Parse a comma-separated kind filter string into a list of `SymbolKind`s.
-pub fn parse_kind_filter(kind_arg: &Option<String>) -> Vec<SymbolKind> {
+///
+/// Unknown tokens fail closed with an error (agents inventing `functions` /
+/// `def` must not get an unfiltered list that looks filtered).
+pub fn parse_kind_filter(kind_arg: &Option<String>) -> anyhow::Result<Vec<SymbolKind>> {
     match kind_arg {
-        Some(s) => s
-            .split(',')
-            .filter_map(|k| SymbolKind::from_str_loose(k.trim()))
-            .collect(),
-        None => Vec::new(),
+        None => Ok(Vec::new()),
+        Some(s) if s.trim().is_empty() => Ok(Vec::new()),
+        Some(s) => {
+            let mut out = Vec::new();
+            let mut unknown = Vec::new();
+            for raw in s.split(',') {
+                let k = raw.trim();
+                if k.is_empty() {
+                    continue;
+                }
+                match SymbolKind::from_str_loose(k) {
+                    Some(sk) => out.push(sk),
+                    None => unknown.push(k.to_string()),
+                }
+            }
+            if !unknown.is_empty() {
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!(
+                        "unknown symbol kind(s): {}. Use function, method, class, struct, enum, interface, trait, type, const, variable, field, module, or property",
+                        unknown.join(", ")
+                    ),
+                }
+                .into());
+            }
+            Ok(out)
+        }
     }
 }
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -582,6 +582,7 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
         .with_context(|| format!("parsing backup manifest for session {timestamp}"))?;
 
     let mut restored = 0;
+    let mut missing: Vec<String> = Vec::new();
     for entry in &manifest.entries {
         let target = resolve_restore_path(project_root, &entry.path);
 
@@ -594,19 +595,22 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
         match entry.action {
             FileAction::Modified => {
                 let backup = session_dir.join(&entry.path);
-                if backup.exists() {
-                    if let Some(parent) = target.parent() {
-                        std::fs::create_dir_all(parent).with_context(|| {
-                            format!("creating parent dir for restore target {}", entry.path)
-                        })?;
-                    }
-                    std::fs::copy(&backup, &target)
-                        .with_context(|| format!("restoring modified file {}", entry.path))?;
-                    restored += 1;
+                if !backup.exists() {
+                    missing.push(format!("{} (modified backup blob missing)", entry.path));
+                    continue;
                 }
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent).with_context(|| {
+                        format!("creating parent dir for restore target {}", entry.path)
+                    })?;
+                }
+                std::fs::copy(&backup, &target)
+                    .with_context(|| format!("restoring modified file {}", entry.path))?;
+                restored += 1;
             }
             FileAction::Created => {
-                // File was newly created by the apply; remove it.
+                // File was newly created by the apply; remove it if still present.
+                // Already gone is fine (idempotent undo of create).
                 if target.exists() {
                     std::fs::remove_file(&target).with_context(|| {
                         format!("removing created file {} during undo", entry.path)
@@ -616,18 +620,30 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
             }
             FileAction::Deleted => {
                 let backup = session_dir.join(&entry.path);
-                if backup.exists() {
-                    if let Some(parent) = target.parent() {
-                        std::fs::create_dir_all(parent).with_context(|| {
-                            format!("creating parent dir for restore target {}", entry.path)
-                        })?;
-                    }
-                    std::fs::copy(&backup, &target)
-                        .with_context(|| format!("restoring deleted file {}", entry.path))?;
-                    restored += 1;
+                if !backup.exists() {
+                    missing.push(format!("{} (deleted backup blob missing)", entry.path));
+                    continue;
                 }
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent).with_context(|| {
+                        format!("creating parent dir for restore target {}", entry.path)
+                    })?;
+                }
+                std::fs::copy(&backup, &target)
+                    .with_context(|| format!("restoring deleted file {}", entry.path))?;
+                restored += 1;
             }
         }
+    }
+
+    if !missing.is_empty() {
+        return Err(crate::exit::InvalidInputError {
+            msg: format!(
+                "backup session {timestamp} is incomplete; not removing session. Missing: {}",
+                missing.join("; ")
+            ),
+        }
+        .into());
     }
 
     Ok(restored)
@@ -802,6 +818,44 @@ mod tests {
         let restored = restore_session(dir.path(), &ts).unwrap();
         assert_eq!(restored, 1);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "doomed content");
+    }
+
+    #[test]
+    fn restore_incomplete_session_errors_and_keeps_session() {
+        // Missing Modified backup blob must fail closed (not silently skip and
+        // delete the session), so agents can still recover via manual copy.
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("keep.txt");
+        std::fs::write(&file, "original").unwrap();
+
+        let mut session = BackupSession::new(dir.path()).unwrap();
+        session.save_before_write(&file).unwrap();
+        let ts = session.finalize().unwrap().unwrap();
+
+        // Corrupt: remove the backup blob but leave the manifest entry.
+        let backup_blob = dir
+            .path()
+            .join(".patchloom/backups")
+            .join(&ts)
+            .join("keep.txt");
+        assert!(backup_blob.exists(), "precondition: backup blob exists");
+        std::fs::remove_file(&backup_blob).unwrap();
+
+        std::fs::write(&file, "mutated").unwrap();
+        let err = restore_session(dir.path(), &ts).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("incomplete") && msg.contains("keep.txt"),
+            "expected incomplete-session error, got: {msg}"
+        );
+        // Session must remain so a second undo attempt or manual recovery works.
+        let sessions = list_sessions(dir.path()).unwrap();
+        assert!(
+            sessions.iter().any(|s| s.timestamp == ts),
+            "incomplete restore must not remove the session"
+        );
+        // Disk left as-is (mutated content not partially restored).
+        assert_eq!(std::fs::read_to_string(&file).unwrap(), "mutated");
     }
 
     #[test]

--- a/src/cmd/ast/common.rs
+++ b/src/cmd/ast/common.rs
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn parse_kind_filter_works() {
-        let filter = parse_kind_filter(&Some("function,struct".to_string()));
+        let filter = parse_kind_filter(&Some("function,struct".to_string())).unwrap();
         assert_eq!(filter.len(), 2);
         assert!(filter.contains(&SymbolKind::Function));
         assert!(filter.contains(&SymbolKind::Struct));
@@ -239,8 +239,18 @@ mod tests {
 
     #[test]
     fn parse_kind_filter_empty() {
-        let filter = parse_kind_filter(&None);
+        let filter = parse_kind_filter(&None).unwrap();
         assert!(filter.is_empty());
+    }
+
+    #[test]
+    fn parse_kind_filter_unknown_fails_closed() {
+        let err = parse_kind_filter(&Some("functions,def".to_string())).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("unknown symbol kind") && msg.contains("functions"),
+            "expected unknown kind error, got: {msg}"
+        );
     }
 
     #[test]

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -36,7 +36,7 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
     global.check_paths_contained(&cwd, [args.path.as_str()])?;
     let target = cwd.join(&args.path);
 
-    let kind_filter = parse_kind_filter(&args.kind);
+    let kind_filter = parse_kind_filter(&args.kind)?;
     let lang_hint = args.lang.as_deref();
     crate::verbose!(
         "ast list: target={}, kind_filter={:?}",

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -25,7 +25,8 @@ pub(super) fn handle_ast_list(
     let cwd = svc.cwd().to_path_buf();
     let target = cwd.join(&p.path);
     let lang_hint = p.lang.as_deref().map(crate::cmd::ast::lang_from_str);
-    let kind_filter = crate::cmd::ast::parse_kind_filter(&p.kind);
+    let kind_filter = crate::cmd::ast::parse_kind_filter(&p.kind)
+        .map_err(|e| McpError::invalid_params(crate::exit::agent_error_message(&e), None))?;
 
     let mut results = Vec::new();
 

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -515,11 +515,11 @@ pub(crate) struct AstReplaceParams {
 pub(crate) struct AstRewriteSignatureParams {
     /// File containing the function (relative to working directory).
     pub path: String,
-    /// Function name to rewrite. Alias `name` accepted for agents.
-    #[serde(alias = "name")]
+    /// Function name to rewrite. Aliases `name`/`from` accepted for agents.
+    #[serde(alias = "name", alias = "from")]
     pub old: String,
-    /// Full replacement signature text (optional).
-    #[serde(default)]
+    /// Full replacement signature text (optional). Alias `to` for agents.
+    #[serde(default, alias = "to")]
     pub new_signature: Option<String>,
     /// New visibility (e.g. "pub", "pub(crate)", or "").
     #[serde(default)]

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -4,7 +4,8 @@ use crate::exit;
 use crate::plan::{self, Plan};
 use crate::tx::{
     CommitError, TxArgs, TxExecResult, TxOutput, build_applied_with_error_output,
-    build_error_output, build_full_tx_output, format_error_with_backup_hint, run_lifecycle,
+    build_error_output, build_full_tx_output, exit_code_from_tx_output,
+    format_error_with_backup_hint, run_lifecycle,
 };
 use crate::write::run_format_command;
 
@@ -276,7 +277,7 @@ fn commit_and_finalize(
             output.backup_session = apply_backup_session;
         }
         let ok = emit_output_json(&output, ctx.compact);
-        return Ok(exit_after_emit(ok, exit::SUCCESS));
+        return Ok(exit_after_emit(ok, exit_code_from_tx_output(&output)));
     }
     print_human_replace_honesty(result, ctx.cwd, global.quiet);
     if global.show_status() {
@@ -288,7 +289,12 @@ fn commit_and_finalize(
         let total = result.changes.len() + extra_deletions;
         eprintln!("applied: {total} file(s) affected");
     }
-    Ok(exit::SUCCESS)
+    let lint_issues: usize = result.tx_lints.iter().map(|l| l.issue_count).sum();
+    if lint_issues > 0 {
+        Ok(exit::CHANGES_DETECTED)
+    } else {
+        Ok(exit::SUCCESS)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -573,14 +579,19 @@ pub(crate) fn run_parsed_plan(
             if structured {
                 let output = build_full_tx_output("success", &mut result, &cwd);
                 let ok = emit_output_json(&output, compact);
-                return Ok(exit_after_emit(ok, exit::SUCCESS));
+                return Ok(exit_after_emit(ok, exit_code_from_tx_output(&output)));
+            }
+            // Lint-only check still has no file changes but issues in lints[].
+            let lint_issues: usize = result.tx_lints.iter().map(|l| l.issue_count).sum();
+            if lint_issues > 0 {
+                return Ok(exit::CHANGES_DETECTED);
             }
             return Ok(exit::SUCCESS);
         }
         if structured {
             let output = build_full_tx_output("changes_detected", &mut result, &cwd);
             let ok = emit_output_json(&output, compact);
-            return Ok(exit_after_emit(ok, exit::CHANGES_DETECTED));
+            return Ok(exit_after_emit(ok, exit_code_from_tx_output(&output)));
         } else if !global.quiet {
             println!(
                 "{} file(s) would change",
@@ -625,11 +636,7 @@ pub(crate) fn run_parsed_plan(
     if structured {
         let output = build_full_tx_output(preview_status, &mut result, &cwd);
         let ok = emit_output_json(&output, compact);
-        let planned = if result.no_effective_changes {
-            exit::SUCCESS
-        } else {
-            exit::CHANGES_DETECTED
-        };
+        let planned = exit_code_from_tx_output(&output);
         // Continue into confirm path only when primary emit succeeded and
         // should_apply; otherwise return planned/failure exit now.
         if !ok {
@@ -663,7 +670,12 @@ pub(crate) fn run_parsed_plan(
     if !result.no_effective_changes {
         Ok(exit::CHANGES_DETECTED)
     } else {
-        Ok(exit::SUCCESS)
+        let lint_issues: usize = result.tx_lints.iter().map(|l| l.issue_count).sum();
+        if lint_issues > 0 {
+            Ok(exit::CHANGES_DETECTED)
+        } else {
+            Ok(exit::SUCCESS)
+        }
     }
 }
 

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -396,25 +396,30 @@ pub fn structured_error_payload(err: &anyhow::Error) -> (serde_json::Value, u8) 
         output["backup_session"] = serde_json::Value::String(bs.to_string());
     }
     let written = format_failed_written_files(err);
-    if !written.is_empty() {
+    // Write landed if we have written paths, or a backup session (callback
+    // renames / soft-empty path-only ops attach backup with empty written[]).
+    let write_landed = !written.is_empty() || format_failed_backup_session(err).is_some();
+    if write_landed {
         // Canonical with other mutators (#1831 / #1788): agents branch on
         // `applied`. Keep `write_applied` as a deprecated alias for one release.
         output["applied"] = serde_json::Value::Bool(true);
         output["write_applied"] = serde_json::Value::Bool(true);
-        output["files_changed"] = serde_json::Value::Number(written.len().into());
-        output["files"] = serde_json::Value::Array(
-            written
-                .into_iter()
-                .map(|path| serde_json::json!({ "path": path }))
-                .collect(),
-        );
+        if !written.is_empty() {
+            output["files_changed"] = serde_json::Value::Number(written.len().into());
+            output["files"] = serde_json::Value::Array(
+                written
+                    .into_iter()
+                    .map(|path| serde_json::json!({ "path": path }))
+                    .collect(),
+            );
+        }
     } else if kind.is_some_and(error_kind_implies_not_applied)
         || matches!(kind, Some("format_failed"))
     {
         // Pre-write failures never mutate disk (#1835): agents branch on
         // `applied` alone. Also cover not_found / already_exists / parse_error
-        // (CLI emit_error_json_kind parity). format_failed with no written
-        // paths is applied:false (write did not land).
+        // (CLI emit_error_json_kind parity). format_failed with no write
+        // evidence is applied:false.
         output["applied"] = serde_json::Value::Bool(false);
     }
     (output, code)
@@ -547,6 +552,10 @@ mod tests {
         assert_eq!(code, FAILURE);
         assert_eq!(payload["error_kind"], "format_failed");
         assert_eq!(payload["backup_session"], "123_0");
+        assert_eq!(
+            payload["applied"], true,
+            "backup_session means write landed even without written_files: {payload}"
+        );
         assert!(
             payload["error"]
                 .as_str()

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -379,11 +379,12 @@ pub enum Operation {
     AstRewriteSignature {
         /// Source file containing the function.
         path: String,
-        /// Function name to rewrite (aliases `name` for agents).
-        #[serde(alias = "name")]
+        /// Function name to rewrite (aliases `name`/`from` for agents).
+        #[serde(alias = "name", alias = "from")]
         old: String,
         /// Full replacement signature text (replaces the signature span).
-        #[serde(default)]
+        /// Alias `to` matches rename/replace agent priors for the new text.
+        #[serde(default, alias = "to")]
         new_signature: Option<String>,
         /// New visibility (e.g. `"pub"`, `"pub(crate)"`, or `""` for private).
         #[serde(default)]

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -71,6 +71,30 @@ fn ast_rename_accepts_from_to_aliases() {
     }
 }
 
+#[cfg(feature = "ast")]
+#[test]
+fn ast_rewrite_signature_accepts_from_to_aliases() {
+    let v: serde_json::Value = serde_json::json!({
+        "op": "ast.rewrite_signature",
+        "path": "src/lib.rs",
+        "from": "process",
+        "to": "fn process(x: i32) -> String"
+    });
+    let op: Operation = serde_json::from_value(v).expect("from/to aliases");
+    match op {
+        Operation::AstRewriteSignature {
+            old, new_signature, ..
+        } => {
+            assert_eq!(old, "process");
+            assert_eq!(
+                new_signature.as_deref(),
+                Some("fn process(x: i32) -> String")
+            );
+        }
+        other => panic!("expected AstRewriteSignature, got {other:?}"),
+    }
+}
+
 #[test]
 fn apply_fragment_accepts_new_alias_for_fragment() {
     // Agents often copy replace_text priors (`new`/`to`) onto apply.fragment.

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -570,6 +570,20 @@ pub(crate) fn build_full_tx_output(
             .unwrap_or("no matches");
         output.error = Some(detail.to_string());
     }
+    // Lint-only (or any plan with lint issues): match CLI md lint-agents
+    // exit 2 / ok:false so agents branching on ok/exit do not treat dirty
+    // AGENTS.md as clean.
+    if matches!(status, "success" | "changes_detected") {
+        let lint_issues: usize = output.lints.iter().map(|l| l.issue_count).sum();
+        if lint_issues > 0 {
+            output.ok = false;
+            output.status = "changes_detected".to_string();
+            output.error_kind = Some("changes_detected".to_string());
+            output.error = Some(format!(
+                "lint found {lint_issues} issue(s); see lints[] for details"
+            ));
+        }
+    }
     output
 }
 
@@ -667,10 +681,12 @@ pub(crate) fn build_applied_with_error_output(
 /// Map a `TxOutput` (PlanReport) to the traditional exit code for CLI/MCP compat.
 pub fn exit_code_from_tx_output(report: &TxOutput) -> u8 {
     if report.ok {
-        if report.status == "no_matches" {
-            exit::NO_MATCHES
-        } else {
-            exit::SUCCESS
+        // Preview/check with mutations keeps ok:true (not an error) but exit 2.
+        // Lint issues force ok:false + error_kind=changes_detected (handled below).
+        match report.status.as_str() {
+            "no_matches" => exit::NO_MATCHES,
+            "changes_detected" => exit::CHANGES_DETECTED,
+            _ => exit::SUCCESS,
         }
     } else {
         match report.error_kind.as_deref() {
@@ -887,6 +903,15 @@ mod tests {
         assert_eq!(
             exit_code_from_tx_output(&ok_output("success")),
             exit::SUCCESS
+        );
+    }
+
+    #[test]
+    fn exit_code_ok_changes_detected() {
+        // Dry-run/check with file changes: ok:true, status changes_detected, exit 2.
+        assert_eq!(
+            exit_code_from_tx_output(&ok_output("changes_detected")),
+            exit::CHANGES_DETECTED
         );
     }
 

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -165,7 +165,12 @@ pub(crate) fn snapshot_symbols(files: &[PathBuf], check: &VerifyCheck) -> Symbol
 
     let (kind_filter, attr_filter) = match check {
         VerifyCheck::SymbolCount { kind, attr } => {
-            (parse_kind_filter(&Some(kind.clone())), attr.clone())
+            // Unknown kinds must not become an empty filter (empty = all symbols).
+            // Fail closed: return empty snapshot (total 0) instead of fail-open.
+            match parse_kind_filter(&Some(kind.clone())) {
+                Ok(f) => (f, attr.clone()),
+                Err(_) => return result,
+            }
         }
         VerifyCheck::Named { check } if check == "unique_names" || check == "no_orphans" => {
             // For named checks, capture all symbols
@@ -240,7 +245,11 @@ pub(crate) fn snapshot_symbols_from_pending(
 
     let (kind_filter, attr_filter) = match check {
         VerifyCheck::SymbolCount { kind, attr } => {
-            (parse_kind_filter(&Some(kind.clone())), attr.clone())
+            // Unknown kinds must not become an empty filter (empty = all symbols).
+            match parse_kind_filter(&Some(kind.clone())) {
+                Ok(f) => (f, attr.clone()),
+                Err(_) => return result,
+            }
         }
         VerifyCheck::Named { check } if check == "unique_names" || check == "no_orphans" => {
             (Vec::new(), None)

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -36,12 +36,15 @@ fn test_batch_md_lint_agents() {
         .output()
         .unwrap();
 
-    assert!(
-        output.status.success(),
-        "stderr: {}",
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "lint issues must exit 2, stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(json["error_kind"], "changes_detected", "{json}");
     let lints = json["lints"].as_array().unwrap();
     assert_eq!(lints.len(), 1);
     assert!(lints[0]["issue_count"].as_u64().unwrap() >= 1);

--- a/tests/integration/rename_tests.rs
+++ b/tests/integration/rename_tests.rs
@@ -937,6 +937,17 @@ fn test_rename_format_failure_json_error_kind() {
         parsed["error_kind"], "format_failed",
         "rename --format failure should set error_kind: {parsed}"
     );
+    assert_eq!(
+        parsed["applied"], true,
+        "write landed before format failure must set applied:true: {parsed}"
+    );
+    assert!(
+        parsed
+            .get("backup_session")
+            .and_then(|v| v.as_str())
+            .is_some(),
+        "backup_session required for undo after format_failed: {parsed}"
+    );
     // Rename still applied before format failure.
     assert!(!dir.path().join("a.txt").exists());
     assert_eq!(

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2597,12 +2597,18 @@ fn test_tx_md_lint_agents_reports_issues() {
         .output()
         .unwrap();
 
-    assert!(
-        output.status.success(),
-        "stderr: {}",
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "lint issues must exit CHANGES_DETECTED (2), stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false, "lint issues must set ok:false: {json}");
+    assert_eq!(
+        json["error_kind"], "changes_detected",
+        "lint issues must set error_kind: {json}"
+    );
     let lints = json["lints"].as_array().unwrap();
     assert_eq!(lints.len(), 1);
     assert!(lints[0]["issue_count"].as_u64().unwrap() >= 2);


### PR DESCRIPTION
## Summary

Fixloop R5: agent/CLI contract honesty for real-world branching.

- **format_failed + backup_session**: set `applied:true` so agents undo after callback renames even when `written_files` is empty
- **md.lint-agents in tx/batch**: `ok:false`, `error_kind: changes_detected`, exit 2 (was exit 0 / ok true with dirty AGENTS.md)
- **parse_kind_filter**: unknown kinds fail closed (CLI/MCP) instead of silent unfiltered list; verify path returns empty snapshot (not all-symbols fail-open)
- **ast.rewrite_signature**: accept `from`/`to` aliases matching rename/replace priors
- **undo incomplete session**: missing Modified/Deleted backup blobs error and keep session for recovery
- **exit_code_from_tx_output**: map `status: changes_detected` with `ok:true` to exit 2 (preview/check)

## Test plan

- [x] `make check-fast` (fmt, clippy, lib, integration, pty, README, server.json)
- [x] Unit: `parse_kind_filter_unknown_fails_closed`, incomplete restore, format_failed applied, rewrite from/to, exit_code_ok_changes_detected
- [x] Integration: `test_tx_md_lint_agents_reports_issues`, `test_batch_md_lint_agents`, `test_rename_format_failure_json_error_kind`