### PR TITLE
fix: agent honesty for context insert, applied, verify, MCP paths

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -505,7 +505,7 @@ dependencies[name=react].version # predicate filter
 - `doc.prepend`: Prepend a value to the beginning of an array at a selector path.
 - `doc.update`: Set a new value at every location matching a selector. Use wildcards (items[*].enabled) or selector predicates (items[name=foo].v). Not a separate --where flag; the filter is part of the selector string.
 - `doc.delete_where`: Delete array elements matching a key=value predicate via --predicate (CLI) or the predicate field (plans). For scalar arrays use .=x, _=x, or value=x. Different from doc.update, which filters inside the selector path. CLI --json and MCP/tx success include changed and removed (0 when no elements match; exit 0 / ok is idempotent).
-- `search`: Search for text across files with optional regex, context, and count assertion. Supports advanced layered ignores: literal (vs regex), globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.
+- `search`: Search for text across files. Pattern is regex by default (set literal:true for fixed strings). Optional context and count assertion. Supports layered ignores: literal, globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.
 - `read`: Read file contents with optional line range.
 - `md.dedupe_headings`: Remove later whole sections whose heading text+level already appeared (heading and body until next same-or-higher heading; unique second-section content is discarded).
 - `md.lint_agents`: Lint an AGENTS.md file for common issues.

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -256,17 +256,20 @@ fn replace_write(
             && !is_regex
             && (before_context.is_some() || after_context.is_some())
         {
-            if let Some(target_offset) = ops::replace::context_filtered_offset(
+            if let Some((target_offset, match_end)) = ops::replace::context_filtered_span_with_re(
                 &original,
                 &old,
+                compiled_re.as_ref(),
                 before_context.as_deref(),
                 after_context.as_deref(),
             ) {
+                let matched = &original[target_offset..match_end];
+                let piece = ops::replace::expand_match_anchor_template(&replacement, matched);
                 let ctx_content = format!(
                     "{}{}{}",
                     &original[..target_offset],
-                    &replacement,
-                    &original[target_offset + old.len()..],
+                    piece,
+                    &original[match_end..],
                 );
                 let policy = crate::write::WritePolicy::default();
                 let (applied, backup_session) =
@@ -677,17 +680,20 @@ fn replace_in_content_inner(
         && !is_regex
         && (opts.before_context.is_some() || opts.after_context.is_some())
     {
-        if let Some(target_offset) = ops::replace::context_filtered_offset(
+        if let Some((target_offset, match_end)) = ops::replace::context_filtered_span_with_re(
             content,
             from,
+            compiled_re.as_ref(),
             opts.before_context.as_deref(),
             opts.after_context.as_deref(),
         ) {
+            let matched = &content[target_offset..match_end];
+            let piece = ops::replace::expand_match_anchor_template(&replacement, matched);
             let ctx_content = format!(
                 "{}{}{}",
                 &content[..target_offset],
-                replacement,
-                &content[target_offset + from.len()..],
+                piece,
+                &content[match_end..],
             );
             let diff = super::make_diff("<content>", content, &ctx_content);
             return Ok(ContentEditResult {
@@ -698,9 +704,9 @@ fn replace_in_content_inner(
                 match_count: 1,
                 match_mode: Some(MatchMode::Anchored),
                 match_score: None,
-                // Exact span at the context-picked offset (equals `from`; hosts
-                // still get a non-null matched_text on Anchored like fuzzy #1736).
-                matched_text: Some(from.to_string()),
+                // Exact span at the context-picked offset (hosts still get a
+                // non-null matched_text on Anchored like fuzzy #1736).
+                matched_text: Some(matched.to_string()),
             });
         }
         return Err(anyhow::Error::new(crate::exit::AmbiguousError {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -534,7 +534,14 @@ pub fn restore_path_from_session(
         FileAction::Modified => {
             let backup = session_dir.join(&entry.path);
             if !backup.exists() {
-                return Ok(false);
+                // Entry listed but blob gone: fail closed (not "path not in session").
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!(
+                        "backup session {session_timestamp} is incomplete for {}; modified backup blob missing",
+                        entry.path
+                    ),
+                }
+                .into());
             }
             if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent).with_context(|| {
@@ -557,7 +564,13 @@ pub fn restore_path_from_session(
         FileAction::Deleted => {
             let backup = session_dir.join(&entry.path);
             if !backup.exists() {
-                return Ok(false);
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!(
+                        "backup session {session_timestamp} is incomplete for {}; deleted backup blob missing",
+                        entry.path
+                    ),
+                }
+                .into());
             }
             if let Some(parent) = target.parent() {
                 std::fs::create_dir_all(parent).with_context(|| {
@@ -581,24 +594,43 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
     let manifest: Manifest = serde_json::from_str(&content)
         .with_context(|| format!("parsing backup manifest for session {timestamp}"))?;
 
-    let mut restored = 0;
+    // Phase 1: validate all entries and required blobs before any mutation so
+    // a missing blob cannot leave a half-undone tree.
     let mut missing: Vec<String> = Vec::new();
     for entry in &manifest.entries {
-        let target = resolve_restore_path(project_root, &entry.path);
-
-        // Validate that path components never escape upward. This catches both
-        // internal paths (`../../etc/passwd`) and crafted external prefixes
-        // (`__external__/../../../etc/shadow`) that abuse the prefix to skip
-        // validation. The `__external__/` prefix itself counts as a Normal
-        // component (+1 depth), so legitimate external paths pass.
         validate_restore_path(&entry.path)?;
+        match entry.action {
+            FileAction::Modified | FileAction::Deleted => {
+                let backup = session_dir.join(&entry.path);
+                if !backup.exists() {
+                    let kind = match entry.action {
+                        FileAction::Modified => "modified",
+                        FileAction::Deleted => "deleted",
+                        FileAction::Created => unreachable!(),
+                    };
+                    missing.push(format!("{} ({kind} backup blob missing)", entry.path));
+                }
+            }
+            FileAction::Created => {}
+        }
+    }
+    if !missing.is_empty() {
+        return Err(crate::exit::InvalidInputError {
+            msg: format!(
+                "backup session {timestamp} is incomplete; not removing session. Missing: {}",
+                missing.join("; ")
+            ),
+        }
+        .into());
+    }
+
+    // Phase 2: apply restores only after every required blob exists.
+    let mut restored = 0;
+    for entry in &manifest.entries {
+        let target = resolve_restore_path(project_root, &entry.path);
         match entry.action {
             FileAction::Modified => {
                 let backup = session_dir.join(&entry.path);
-                if !backup.exists() {
-                    missing.push(format!("{} (modified backup blob missing)", entry.path));
-                    continue;
-                }
                 if let Some(parent) = target.parent() {
                     std::fs::create_dir_all(parent).with_context(|| {
                         format!("creating parent dir for restore target {}", entry.path)
@@ -620,10 +652,6 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
             }
             FileAction::Deleted => {
                 let backup = session_dir.join(&entry.path);
-                if !backup.exists() {
-                    missing.push(format!("{} (deleted backup blob missing)", entry.path));
-                    continue;
-                }
                 if let Some(parent) = target.parent() {
                     std::fs::create_dir_all(parent).with_context(|| {
                         format!("creating parent dir for restore target {}", entry.path)
@@ -634,16 +662,6 @@ pub fn restore_session(project_root: &Path, timestamp: &str) -> anyhow::Result<u
                 restored += 1;
             }
         }
-    }
-
-    if !missing.is_empty() {
-        return Err(crate::exit::InvalidInputError {
-            msg: format!(
-                "backup session {timestamp} is incomplete; not removing session. Missing: {}",
-                missing.join("; ")
-            ),
-        }
-        .into());
     }
 
     Ok(restored)

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -72,8 +72,9 @@ pub(super) fn run_list(args: ListArgs, global: &GlobalFlags) -> anyhow::Result<u
                  TOML, YAML, JSON, Shell.",
                 lang, args.path,
             );
-            global.emit_error_json_kind(Some("no_matches"), &msg)?;
-            return Ok(exit::NO_MATCHES);
+            // invalid_input: not an empty symbol set (agents must not widen search).
+            global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+            return Ok(exit::FAILURE);
         }
         let symbols = symbols::extract_symbols(&source, lang);
         let filtered = filter_symbols(&symbols, &kind_filter);
@@ -251,8 +252,9 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
                  TOML, YAML, JSON, Shell.",
                 lang, args.path,
             );
-            global.emit_error_json_kind(Some("no_matches"), &msg)?;
-            return Ok(exit::NO_MATCHES);
+            // invalid_input: not an empty symbol set (agents must not widen search).
+            global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+            return Ok(exit::FAILURE);
         }
     }
 

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -330,10 +330,11 @@ pub(super) fn describe_operation(op: &Operation) -> String {
         Operation::Search {
             path,
             pattern,
-            regex,
+            literal,
             ..
         } => {
-            let mode = if *regex { "regex" } else { "literal" };
+            // Default (literal=false) is regex to match CLI/MCP behavior.
+            let mode = if *literal { "literal" } else { "regex" };
             format!("Search for \"{pattern}\" in {path} ({mode})")
         }
         Operation::Read { path, lines } => match lines {

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -33,17 +33,16 @@ pub(super) fn handle_ast_list(
     if target.is_file() {
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&target));
         if !lang.has_grammar() {
-            return exit_code_to_result(
-                exit::NO_MATCHES,
-                &format!(
+            return Err(McpError::invalid_params(
+                format!(
                     "Unsupported language: {} (detected from {}). \
                      Supported: Rust, Python, TypeScript, JavaScript, Go, Java, \
                      C#, Ruby, PHP, Swift, Kotlin, C, C++, HCL, XML, Protobuf, \
                      TOML, YAML, JSON, Shell.",
                     lang, p.path,
                 ),
-                "",
-            );
+                None,
+            ));
         }
         let symbols = crate::ast::symbols::extract_symbols_from_file(&target, Some(lang));
         let filtered = crate::cmd::ast::filter_symbols(&symbols, &kind_filter);

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -136,9 +136,12 @@ impl PatchloomService {
         log_flag: Option<String>,
         surface: surface::McpSurface,
     ) -> anyhow::Result<Self> {
+        // Allow absolute paths inside the workspace: agents often copy
+        // server_info.cwd + relative into an absolute path. Outside workspace
+        // still fails closed via PathGuard resolution.
         let path_guard = crate::containment::PathGuard::new(
             cwd.clone(),
-            crate::containment::AbsolutePathPolicy::Reject,
+            crate::containment::AbsolutePathPolicy::AllowIfContained,
         )
         .map_err(|e| {
             anyhow::Error::new(crate::exit::InvalidInputError {

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -233,8 +233,8 @@ pub(crate) struct BatchReplaceParams {
     #[serde(default)]
     pub files: Vec<String>,
     /// Single file (LLM prior). Equivalent to `files: [file]` when `files` is empty.
-    /// If both are set, `files` wins.
-    #[serde(default)]
+    /// If both are set, `files` wins. Alias `path` matches replace_text priors.
+    #[serde(default, alias = "path")]
     pub file: Option<String>,
     /// Text to find in each file.
     /// Alias `from` accepted because agents often emit that name (LLM prior).
@@ -291,8 +291,8 @@ pub(crate) struct BatchTidyParams {
     #[serde(default)]
     pub files: Vec<String>,
     /// Single file (LLM prior). Equivalent to `files: [file]` when `files` is empty.
-    /// If both are set, `files` wins.
-    #[serde(default)]
+    /// If both are set, `files` wins. Alias `path` matches other tools.
+    #[serde(default, alias = "path")]
     pub file: Option<String>,
     /// Roll back all writes when format/validate lifecycle steps fail.
     #[serde(default = "default_strict_true")]

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -536,12 +536,19 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 #[derive(Serialize)]
                 struct MdLintOutput {
                     ok: bool,
+                    #[serde(skip_serializing_if = "Option::is_none")]
+                    error_kind: Option<&'static str>,
                     path: String,
                     issue_count: usize,
                     issues: Vec<crate::ops::md::LintIssue>,
                 }
                 global.emit_json(&MdLintOutput {
                     ok: issues.is_empty(),
+                    error_kind: if issues.is_empty() {
+                        None
+                    } else {
+                        Some("changes_detected")
+                    },
                     path: file.clone(),
                     issue_count: issues.len(),
                     issues: issues.clone(),

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -286,10 +286,12 @@ fn inject_stale_label(msg: &str, label: &str) -> String {
 fn emit_error(global: &GlobalFlags, error: &str, error_kind: &str) -> anyhow::Result<()> {
     // Include error_kind so agents can branch (ambiguous=stale, conflicts=merge
     // conflicts) without scraping the English STALE/MERGE FAILED label.
+    // applied:false matches replace/create error parity (#1835).
     if !global.emit_json(&serde_json::json!({
         "ok": false,
         "error": error,
         "error_kind": error_kind,
+        "applied": false,
     }))? && !global.quiet
     {
         eprintln!("{error}");

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -231,9 +231,13 @@ pub fn delete_at_selector(
         return Ok(false);
     }
     let (parent_path, last) = split_last(segments);
+    // Soft no-match only when a key is missing. Type/invalid errors (e.g. bare
+    // key under multi-doc array root, nested metadata.name) must propagate so
+    // agents get type_error instead of silent "already gone".
     let parent = match navigate_mut(root, parent_path, false) {
         Ok(p) => p,
-        Err(_) => return Ok(false),
+        Err(e) if crate::exit::is_no_match(&e) => return Ok(false),
+        Err(e) => return Err(e),
     };
     match last {
         selector::Segment::Key(k) => {
@@ -769,6 +773,19 @@ mod tests {
             "expected multi-doc index hint, got: {msg}"
         );
         assert_eq!(root, original);
+    }
+
+    #[test]
+    fn delete_at_selector_array_root_nested_key_is_type_error() {
+        // Nested bare path (metadata.name) must not soft-succeed as "already gone".
+        let mut root = json!([{"metadata": {"name": "a"}}, {"metadata": {"name": "b"}}]);
+        let original = root.clone();
+        let err = delete_at_selector(&mut root, &segs("metadata.name")).unwrap_err();
+        assert!(
+            crate::exit::is_type_error(&err),
+            "expected type_error not soft false, got: {err}"
+        );
+        assert_eq!(root, original, "must not mutate on type error");
     }
 
     #[test]

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -549,29 +549,41 @@ fn context_fragment_score(content_fragment: &str, ctx_fragment: &str) -> f64 {
 /// For `after_context`, the first N lines following the match are compared,
 /// plus the same-line suffix after a single-line match.
 /// Tie-breaking: first occurrence (lowest byte offset) wins on equal scores.
-pub fn context_filtered_offset(
+/// Expand a replace template that may contain `${0}` / `$$` (match-anchor form
+/// used for case_insensitive / word_boundary inserts) against the matched text.
+pub fn expand_match_anchor_template(template: &str, matched: &str) -> String {
+    // Reuse regex::Captures::expand so $$ and ${0} match replace_content.
+    let Ok(re) = Regex::new(&format!("^{}$", regex::escape(matched))) else {
+        return template.replace("${0}", matched);
+    };
+    match re.captures(matched) {
+        Some(caps) => expand_regex_replacement(&caps, template),
+        None => template.replace("${0}", matched),
+    }
+}
+
+/// Context disambiguation over precomputed match spans `(start, end)`.
+/// Prefer this when matches come from a regex (case_insensitive / word_boundary).
+pub fn context_filtered_span(
     content: &str,
-    old: &str,
+    matches: &[(usize, usize)],
+    old_for_line_count: &str,
     before_context: Option<&str>,
     after_context: Option<&str>,
-) -> Option<usize> {
+) -> Option<(usize, usize)> {
     if before_context.is_none() && after_context.is_none() {
         return None;
     }
-
-    let offsets: Vec<usize> = content.match_indices(old).map(|(i, _)| i).collect();
-    if offsets.len() < 2 {
-        return None; // single match: no disambiguation needed
+    if matches.len() < 2 {
+        return None;
     }
 
     let lines: Vec<&str> = content.lines().collect();
-    // Build a map: byte-offset-of-line-start -> line-index
     let mut line_starts: Vec<usize> = Vec::with_capacity(lines.len());
     let mut off = 0;
     for line in &lines {
         line_starts.push(off);
         off += line.len();
-        // skip the newline character(s)
         if content.as_bytes().get(off) == Some(&b'\r') {
             off += 1;
         }
@@ -588,23 +600,20 @@ pub fn context_filtered_offset(
     };
 
     const MAX_CONTEXT_LINES: usize = 3;
-    let old_line_count = old.lines().count().max(1);
-    let single_line_old = old_line_count == 1 && !old.contains('\n');
+    let old_line_count = old_for_line_count.lines().count().max(1);
+    let single_line_old = old_line_count == 1 && !old_for_line_count.contains('\n');
 
-    let mut best: Option<(usize, f64)> = None;
-    for &match_off in &offsets {
+    let mut best: Option<(usize, usize, f64)> = None;
+    for &(match_off, match_end) in matches {
         let match_line = line_index_at(match_off);
         let mut score = 0.0f64;
         let mut checks = 0u32;
 
         if let Some(before) = before_context {
             let ctx_lines: Vec<&str> = before.lines().collect();
-            // Take up to MAX_CONTEXT_LINES from the end (nearest to match first).
             let start = ctx_lines.len().saturating_sub(MAX_CONTEXT_LINES);
             let ctx_tail = &ctx_lines[start..];
             for (i, ctx_line) in ctx_tail.iter().rev().enumerate() {
-                // Nearest before-context fragment also scores the same-line
-                // prefix (agents pass anchors that sit on the match line).
                 if i == 0 && single_line_old && match_line < lines.len() {
                     let line = lines[match_line];
                     let col = match_off
@@ -634,10 +643,8 @@ pub fn context_filtered_offset(
             let n = ctx_lines.len().min(MAX_CONTEXT_LINES);
             let end_line = match_line + old_line_count;
             for (i, ctx_line) in ctx_lines[..n].iter().enumerate() {
-                // Same-line suffix for nearest after-context fragment.
                 if i == 0 && single_line_old && match_line < lines.len() {
                     let line = lines[match_line];
-                    let match_end = match_off.saturating_add(old.len());
                     let col = match_end
                         .saturating_sub(line_starts[match_line])
                         .min(line.len());
@@ -660,12 +667,68 @@ pub fn context_filtered_offset(
             }
         }
 
-        if checks > 0 && score > 0.0 && best.is_none_or(|(_, s)| score > s) {
-            best = Some((match_off, score));
+        if checks > 0 && score > 0.0 && best.is_none_or(|(_, _, s)| score > s) {
+            best = Some((match_off, match_end, score));
         }
     }
 
-    best.map(|(off, _)| off)
+    best.map(|(s, e, _)| (s, e))
+}
+
+pub fn context_filtered_offset(
+    content: &str,
+    old: &str,
+    before_context: Option<&str>,
+    after_context: Option<&str>,
+) -> Option<usize> {
+    context_filtered_offset_with_re(content, old, None, before_context, after_context)
+}
+
+/// Like [`context_filtered_offset`], but when `compiled_re` is set uses regex
+/// match spans (word_boundary / case_insensitive) instead of literal indices.
+pub fn context_filtered_offset_with_re(
+    content: &str,
+    old: &str,
+    compiled_re: Option<&Regex>,
+    before_context: Option<&str>,
+    after_context: Option<&str>,
+) -> Option<usize> {
+    context_filtered_span_with_re(content, old, compiled_re, before_context, after_context)
+        .map(|(s, _)| s)
+}
+
+/// Return `(start, end)` of the context-selected match.
+pub fn context_filtered_span_with_re(
+    content: &str,
+    old: &str,
+    compiled_re: Option<&Regex>,
+    before_context: Option<&str>,
+    after_context: Option<&str>,
+) -> Option<(usize, usize)> {
+    if before_context.is_none() && after_context.is_none() {
+        return None;
+    }
+
+    let matches: Vec<(usize, usize)> = match compiled_re {
+        Some(re) => {
+            let content_len = content.len();
+            re.find_iter(content)
+                .filter(|m| !(m.start() == content_len && m.end() == content_len))
+                .map(|m| (m.start(), m.end()))
+                .collect()
+        }
+        None => {
+            if old.is_empty() {
+                Vec::new()
+            } else {
+                content
+                    .match_indices(old)
+                    .map(|(i, s)| (i, i + s.len()))
+                    .collect()
+            }
+        }
+    };
+    context_filtered_span(content, &matches, old, before_context, after_context)
 }
 
 /// Whole-line replacement: when a line matches the pattern, the entire line

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -1042,3 +1042,42 @@ mod nth_count_tests {
         );
     }
 }
+
+mod expand_match_anchor_tests {
+    use crate::ops::replace::{
+        compile_replace_regex, context_filtered_span_with_re, expand_match_anchor_template,
+    };
+
+    #[test]
+    fn expand_match_anchor_template_expands_group_zero() {
+        assert_eq!(
+            expand_match_anchor_template("${0} // mark", "foo"),
+            "foo // mark"
+        );
+    }
+
+    #[test]
+    fn expand_match_anchor_template_preserves_escaped_dollars() {
+        // User insert "$price" is escaped to "$$price" in replacement_text.
+        assert_eq!(
+            expand_match_anchor_template("${0}$$price", "id"),
+            "id$price"
+        );
+    }
+
+    #[test]
+    fn context_filtered_span_with_re_word_boundary_skips_substrings() {
+        let content = "valid\nid here\nvalid again\nid two\n";
+        let re = compile_replace_regex("id", false, false, false, true)
+            .unwrap()
+            .expect("word boundary re");
+        let span = context_filtered_span_with_re(content, "id", Some(&re), None, Some("two"));
+        let (s, e) = span.expect("should pick whole-word id near 'two'");
+        assert_eq!(&content[s..e], "id");
+        // Must not land inside "valid"
+        assert!(
+            !content[..s].ends_with("val"),
+            "must not pick substring of valid"
+        );
+    }
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -438,9 +438,12 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "search",
-        description: "Search for text across files with optional regex, context, and count assertion. Supports advanced layered ignores: literal (vs regex), globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.",
+        description: "Search for text across files. Pattern is regex by default (set literal:true for fixed strings). Optional context and count assertion. Supports layered ignores: literal, globs (include), exclude_patterns, custom_ignore_filenames, max_results, before_context/after_context.",
         tier: Tier::Strong,
-        examples: &[],
+        examples: &[(
+            "Literal search (agents: always set literal:true for fixed strings)",
+            r###"{"op":"search","path":".","pattern":"TODO","literal":true}"###,
+        )],
     },
     OpMeta {
         name: "read",

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -505,8 +505,10 @@ pub(crate) fn build_tx_output_with_meta(
     TxOutput {
         ok,
         status: status.to_string(),
-        // success = committed apply; changes_detected/no_matches = dry-run
-        applied: status == "success",
+        // Only claim applied when a real commit mutated files. Status
+        // "success" is also used for dry-run no-ops and lint-only clean
+        // plans; agents branch on applied for undo.
+        applied: status == "success" && (modified + created + deleted_count + renamed_count > 0),
         files_changed: modified,
         files_created: created,
         files_deleted: deleted_count,
@@ -572,7 +574,7 @@ pub(crate) fn build_full_tx_output(
     }
     // Lint-only (or any plan with lint issues): match CLI md lint-agents
     // exit 2 / ok:false so agents branching on ok/exit do not treat dirty
-    // AGENTS.md as clean.
+    // AGENTS.md as clean. Clear applied: lint never writes.
     if matches!(status, "success" | "changes_detected") {
         let lint_issues: usize = output.lints.iter().map(|l| l.issue_count).sum();
         if lint_issues > 0 {
@@ -582,6 +584,15 @@ pub(crate) fn build_full_tx_output(
             output.error = Some(format!(
                 "lint found {lint_issues} issue(s); see lints[] for details"
             ));
+            // Lint does not mutate files; never claim applied.
+            if output.files_changed
+                + output.files_created
+                + output.files_deleted
+                + output.files_renamed
+                == 0
+            {
+                output.applied = false;
+            }
         }
     }
     output
@@ -1232,7 +1243,8 @@ mod tests {
             },
         );
         assert!(!preview.applied, "preview must set applied=false");
-        let applied = build_tx_output_with_meta(
+        // success with zero mutations is a no-op / dry-run identity: applied=false
+        let noop = build_tx_output_with_meta(
             "success",
             true,
             Path::new("/tmp"),
@@ -1244,7 +1256,33 @@ mod tests {
                 renames: &[],
             },
         );
-        assert!(applied.applied, "success must set applied=true");
+        assert!(
+            !noop.applied,
+            "success with no file mutations must set applied=false"
+        );
+        let mut existed = HashSet::new();
+        existed.insert(PathBuf::from("/tmp/a.txt"));
+        let changes = vec![(
+            PathBuf::from("/tmp/a.txt"),
+            "old".to_string(),
+            "new".to_string(),
+        )];
+        let applied = build_tx_output_with_meta(
+            "success",
+            true,
+            Path::new("/tmp"),
+            TxOutputMetaInputs {
+                changes: &changes,
+                deletions: &Default::default(),
+                existed_before: &existed,
+                replace_match_meta: &Default::default(),
+                renames: &[],
+            },
+        );
+        assert!(
+            applied.applied,
+            "success with real file mutations must set applied=true"
+        );
         let err = build_error_output("invalid_input", "nope", None);
         assert!(!err.applied, "pure error must set applied=false");
     }

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -6,8 +6,8 @@
 use super::execute::{TxState, read_and_probe, read_file_content};
 use crate::api::MatchMode;
 use crate::ops::replace::{
-    InsertSide, compile_replace_regex, context_filtered_offset, normalize_line_insert,
-    replace_content, replace_whole_lines, replacement_text,
+    InsertSide, compile_replace_regex, context_filtered_span_with_re, expand_match_anchor_template,
+    normalize_line_insert, replace_content, replace_whole_lines, replacement_text,
 };
 use crate::plan::Operation;
 use crate::tx::output::merge_match_modes;
@@ -270,17 +270,20 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 && !regex_mode
                 && (before_context.is_some() || after_context.is_some())
             {
-                if let Some(target_offset) = context_filtered_offset(
+                if let Some((target_offset, match_end)) = context_filtered_span_with_re(
                     content,
                     old,
+                    compiled_re.as_ref(),
                     before_context.as_deref(),
                     after_context.as_deref(),
                 ) {
+                    let matched = &content[target_offset..match_end];
+                    let piece = expand_match_anchor_template(&replacement, matched);
                     let new_content = format!(
                         "{}{}{}",
                         &content[..target_offset],
-                        replacement,
-                        &content[target_offset + old.len()..],
+                        piece,
+                        &content[match_end..],
                     );
                     tx.write_file(&file_path, new_content);
                     record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);
@@ -588,17 +591,20 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                     && !regex_mode
                     && (before_context.is_some() || after_context.is_some())
                 {
-                    if let Some(target_offset) = context_filtered_offset(
+                    if let Some((target_offset, match_end)) = context_filtered_span_with_re(
                         &content,
                         old,
+                        compiled_re.as_ref(),
                         before_context.as_deref(),
                         after_context.as_deref(),
                     ) {
+                        let matched = &content[target_offset..match_end];
+                        let piece = expand_match_anchor_template(&replacement, matched);
                         let new_content = format!(
                             "{}{}{}",
                             &content[..target_offset],
-                            replacement,
-                            &content[target_offset + old.len()..],
+                            piece,
+                            &content[match_end..],
                         );
                         tx.write_file(&file_path, new_content);
                         record_replace_match(tx, &file_path, MatchMode::Anchored, None, 1, None);

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -376,6 +376,15 @@ pub(crate) fn compare_snapshots(
 ) -> VerifyResult {
     match check {
         VerifyCheck::SymbolCount { kind, attr } => {
+            // Unknown kinds produce empty snapshots (0==0 would pass). Fail closed.
+            if symbols::parse_kind_filter(&Some(kind.clone())).is_err() {
+                return VerifyResult {
+                    passed: false,
+                    message: format!(
+                        "verify: unknown symbol kind '{kind}' (use function, method, class, struct, enum, interface, trait, type, const, variable, field, module, or property)"
+                    ),
+                };
+            }
             let label = if let Some(a) = attr {
                 format!("{kind} (attr={a})")
             } else {
@@ -458,9 +467,11 @@ pub(crate) fn compare_snapshots(
         VerifyCheck::Named { check } if check == "no_orphans" => {
             check_no_orphans(before, after, cwd)
         }
-        _ => VerifyResult {
-            passed: true,
-            message: "unknown check (skipped)".to_string(),
+        VerifyCheck::Named { check } => VerifyResult {
+            passed: false,
+            message: format!(
+                "unknown verify check '{check}' (supported: unique_names, no_orphans)"
+            ),
         },
     }
 }

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -519,7 +519,7 @@ fn test_ast_list_unsupported_file_reports_language() {
     patchloom_in(dir.path())
         .args(["ast", "list", "data.csv"])
         .assert()
-        .code(3) // NO_MATCHES
+        .code(1) // FAILURE / invalid_input (not empty-symbol no_matches)
         .stderr(predicates::str::contains("Unsupported language"))
         .stderr(predicates::str::contains("Rust"));
 }
@@ -537,7 +537,7 @@ fn test_ast_list_unsupported_quiet_suppresses_stderr() {
         .args(["ast", "list", "data.csv"])
         .output()
         .unwrap();
-    assert_eq!(output.status.code(), Some(3));
+    assert_eq!(output.status.code(), Some(1)); // invalid_input / FAILURE
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.is_empty(),
@@ -1008,7 +1008,7 @@ fn test_ast_list_whitespace_only_path_rejected() {
 
 #[cfg(feature = "ast")]
 #[test]
-fn test_ast_validate_unsupported_language_is_no_matches() {
+fn test_ast_validate_unsupported_language_is_invalid_input() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("notes.txt"), "not source code\n").unwrap();
 
@@ -1019,13 +1019,13 @@ fn test_ast_validate_unsupported_language_is_no_matches() {
 
     assert_eq!(
         output.status.code(),
-        Some(3),
-        "unsupported language must not exit 0; stdout={}",
+        Some(1),
+        "unsupported language is invalid_input (not empty-symbol no_matches); stdout={}",
         String::from_utf8_lossy(&output.stdout)
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
-    assert_eq!(json["error_kind"], "no_matches");
+    assert_eq!(json["error_kind"], "invalid_input");
     assert!(
         json["error"]
             .as_str()


### PR DESCRIPTION
## Summary

Fixloop R6: real-world agent/CLI contract bugs.

- **Context insert + -i/-w**: expand `${0}` and use regex match spans (no literal `${0}` corruption; no substring picks for word-boundary)
- **applied**: only true when success actually mutated files; lint-only plans clear applied
- **verify**: unknown named checks and unknown kinds fail closed (no skip-as-pass / 0=0 green)
- **MCP**: `AllowIfContained` so agents can pass absolute paths inside workspace from `server_info.cwd`; `batch_replace`/`batch_tidy` accept `path` alias
- **search honesty**: explain + schema catalogue say default is regex
- **md lint / patch JSON**: `error_kind` + `applied:false` parity
- **undo**: two-phase restore (no half-undone tree); path restore fails on missing blob
- **doc delete** nested multi-doc type_error; **ast** unsupported language is `invalid_input` not `no_matches`

## Test plan

- [x] `make check-fast`
- [x] Unit: expand_match_anchor, word-boundary context span, nested multi-doc delete, applied success/noop
- [x] Integration: unsupported language exit/kind; existing lint/format suites green