### PR TITLE
fix: fail-closed positions, for_each empty, patch merge exit, MCP honesty

### DIFF
--- a/src/ast/group.rs
+++ b/src/ast/group.rs
@@ -19,14 +19,27 @@ pub enum GroupPosition {
 /// Parse a plan/CLI position string into [`GroupPosition`].
 ///
 /// Shared by library AST ops and the tx engine so `after:` parsing cannot
-/// diverge (#1376).
-pub fn parse_group_position(s: Option<&str>) -> GroupPosition {
+/// diverge (#1376). Unknown tokens fail closed (agents inventing `start` /
+/// `top` / `before:X` must not silently land at FirstSymbol).
+pub fn parse_group_position(s: Option<&str>) -> anyhow::Result<GroupPosition> {
     match s {
-        Some("end") => GroupPosition::End,
+        None | Some("") | Some("first-symbol") | Some("first") => Ok(GroupPosition::FirstSymbol),
+        Some("end") => Ok(GroupPosition::End),
         Some(raw) if let Some(name) = raw.strip_prefix("after:") => {
-            GroupPosition::After(name.to_string())
+            if name.is_empty() {
+                return Err(crate::exit::InvalidInputError {
+                    msg: "ast.group position after: requires a symbol name".into(),
+                }
+                .into());
+            }
+            Ok(GroupPosition::After(name.to_string()))
         }
-        _ => GroupPosition::FirstSymbol,
+        Some(other) => Err(crate::exit::InvalidInputError {
+            msg: format!(
+                "unknown ast.group position {other:?}; use end, first-symbol, first, or after:NAME"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -229,7 +242,13 @@ pub fn group_symbols(
             if let Some(sym) = find_symbol(&mod_symbols, sym_name) {
                 sym.end_line.min(modified_lines.len())
             } else {
-                modified_lines.len()
+                // Fail closed: missing anchor must not silently place at EOF
+                // (parity with ast.move).
+                return Err(anyhow::Error::new(crate::exit::NoMatchError {
+                    msg: format!(
+                        "ast.group position after:{sym_name}: symbol not found in remaining file"
+                    ),
+                }));
             }
         }
     };
@@ -289,21 +308,28 @@ mod tests {
     #[test]
     fn parse_group_position_variants() {
         assert!(matches!(
-            parse_group_position(None),
+            parse_group_position(None).unwrap(),
             GroupPosition::FirstSymbol
         ));
         assert!(matches!(
-            parse_group_position(Some("end")),
+            parse_group_position(Some("end")).unwrap(),
             GroupPosition::End
         ));
         assert!(matches!(
-            parse_group_position(Some("after:Foo")),
+            parse_group_position(Some("after:Foo")).unwrap(),
             GroupPosition::After(ref name) if name == "Foo"
         ));
         assert!(matches!(
-            parse_group_position(Some("unknown")),
+            parse_group_position(Some("first-symbol")).unwrap(),
             GroupPosition::FirstSymbol
         ));
+        let err = parse_group_position(Some("start")).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown"),
+            "start is not a group position: {err}"
+        );
+        let err = parse_group_position(Some("top")).unwrap_err();
+        assert!(err.to_string().contains("unknown"), "{err}");
     }
 
     #[test]

--- a/src/ast/move_symbols.rs
+++ b/src/ast/move_symbols.rs
@@ -23,19 +23,37 @@ pub struct MoveResult {
 }
 
 /// Parse a position string into a MovePosition.
-pub fn parse_position(s: Option<&str>) -> MovePosition {
+///
+/// Unknown tokens fail closed so agents inventing `top` / `first` do not
+/// silently append at end.
+pub fn parse_position(s: Option<&str>) -> anyhow::Result<MovePosition> {
     match s {
-        Some("start") => MovePosition::Start,
-        Some(s) => {
-            if let Some(name) = s.strip_prefix("after:") {
-                MovePosition::After(name.to_string())
-            } else if let Some(name) = s.strip_prefix("before:") {
-                MovePosition::Before(name.to_string())
-            } else {
-                MovePosition::End
+        None | Some("") | Some("end") => Ok(MovePosition::End),
+        Some("start") => Ok(MovePosition::Start),
+        Some(raw) if let Some(name) = raw.strip_prefix("after:") => {
+            if name.is_empty() {
+                return Err(crate::exit::InvalidInputError {
+                    msg: "ast.move position after: requires a symbol name".into(),
+                }
+                .into());
             }
+            Ok(MovePosition::After(name.to_string()))
         }
-        None => MovePosition::End,
+        Some(raw) if let Some(name) = raw.strip_prefix("before:") => {
+            if name.is_empty() {
+                return Err(crate::exit::InvalidInputError {
+                    msg: "ast.move position before: requires a symbol name".into(),
+                }
+                .into());
+            }
+            Ok(MovePosition::Before(name.to_string()))
+        }
+        Some(other) => Err(crate::exit::InvalidInputError {
+            msg: format!(
+                "unknown ast.move position {other:?}; use start, end, after:NAME, or before:NAME"
+            ),
+        }
+        .into()),
     }
 }
 
@@ -433,16 +451,27 @@ mod tests {
 
     #[test]
     fn parse_position_variants() {
-        assert!(matches!(parse_position(None), MovePosition::End));
-        assert!(matches!(parse_position(Some("end")), MovePosition::End));
-        assert!(matches!(parse_position(Some("start")), MovePosition::Start));
+        assert!(matches!(parse_position(None).unwrap(), MovePosition::End));
         assert!(matches!(
-            parse_position(Some("after:foo")),
+            parse_position(Some("end")).unwrap(),
+            MovePosition::End
+        ));
+        assert!(matches!(
+            parse_position(Some("start")).unwrap(),
+            MovePosition::Start
+        ));
+        assert!(matches!(
+            parse_position(Some("after:foo")).unwrap(),
             MovePosition::After(ref s) if s == "foo"
         ));
         assert!(matches!(
-            parse_position(Some("before:bar")),
+            parse_position(Some("before:bar")).unwrap(),
             MovePosition::Before(ref s) if s == "bar"
         ));
+        let err = parse_position(Some("top")).unwrap_err();
+        assert!(
+            err.to_string().contains("unknown"),
+            "top must fail closed: {err}"
+        );
     }
 }

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -211,11 +211,11 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
             op!(FilePrepend { path, content })
         }
         "file.create" => {
-            let (path, content) = path_and_joined_content(op, args, line_num)?;
+            let (path, content, force) = path_and_joined_content_create(op, args, line_num)?;
             op!(FileCreate {
                 path,
                 content,
-                force: None
+                force: if force { Some(true) } else { None }
             })
         }
         "file.delete" => {
@@ -745,6 +745,39 @@ fn path_and_joined_content(
         args[1..].join(" ")
     };
     Ok((path, expand_content_escapes(&raw)))
+}
+
+/// Like [`path_and_joined_content`], but peels optional `--force` so CLI-shaped
+/// batch lines do not write the flag into file content.
+fn path_and_joined_content_create(
+    op: &str,
+    args: &[String],
+    line_num: usize,
+) -> anyhow::Result<(String, String, bool)> {
+    if args.is_empty() {
+        return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+            msg: format!("line {line_num}: '{op}' requires a path argument, got 0"),
+        }));
+    }
+    let path = args[0].clone();
+    let mut force = false;
+    let mut content_parts: Vec<&str> = Vec::new();
+    for tok in args.iter().skip(1) {
+        if tok == "--force" {
+            force = true;
+            continue;
+        }
+        if tok.starts_with("--") {
+            return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                msg: format!(
+                    "line {line_num}: '{op}' unknown flag {tok}; only --force is supported before content"
+                ),
+            }));
+        }
+        content_parts.push(tok.as_str());
+    }
+    let raw = content_parts.join(" ");
+    Ok((path, expand_content_escapes(&raw), force))
 }
 
 /// Expand common escapes in batch file content (`\n` `\t` `\r` `\\` `\"`).

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -257,6 +257,23 @@ pub(super) fn handle_ast_validate(
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
+    // Sole explicit path without grammar: invalid_input (CLI parity).
+    if paths.len() == 1 {
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(&paths[0]));
+        if !lang.has_grammar() {
+            return Err(McpError::invalid_params(
+                format!(
+                    "Unsupported language: {} (detected from {}). \
+                     Supported: Rust, Python, TypeScript, JavaScript, Go, Java, \
+                     C#, Ruby, PHP, Swift, Kotlin, C, C++, HCL, XML, Protobuf, \
+                     TOML, YAML, JSON, Shell.",
+                    lang, p.path,
+                ),
+                None,
+            ));
+        }
+    }
+
     let results: Vec<serde_json::Value> = crate::par_process_files(&paths, None, &[], |path| {
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
         if !lang.has_grammar() {
@@ -273,11 +290,22 @@ pub(super) fn handle_ast_validate(
     });
 
     if results.is_empty() {
-        return no_results("No files with grammars found.");
+        return Err(McpError::invalid_params(
+            "No files with grammars found.",
+            None,
+        ));
     }
+    let any_invalid = results
+        .iter()
+        .any(|r| r.get("valid") == Some(&serde_json::json!(false)));
     let json = serde_json::to_string_pretty(&results)
         .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
-    Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    // CLI exits 1 when invalid; hosts that only check isError must see failure.
+    if any_invalid {
+        Ok(CallToolResult::error(vec![ContentBlock::text(json)]))
+    } else {
+        Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+    }
 }
 
 pub(super) fn handle_ast_search(
@@ -990,6 +1018,10 @@ impl Point {
         };
 
         let result = handle_ast_validate(&svc, params).unwrap();
+        assert!(
+            result.is_error.is_some_and(|v| v),
+            "invalid syntax must set isError so agents do not treat as clean"
+        );
         let text = extract_text(&result);
         assert!(text.contains("\"valid\": false"));
     }

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -499,12 +499,17 @@ impl PatchloomService {
             let issues = crate::ops::md::lint_agents_content(&content);
             // Envelope matches CLI `md lint-agents --json` (#1854 / #1859).
             // Always tool success (isError=false); agents branch on ok / issue_count.
-            let envelope = serde_json::json!({
+            let mut envelope = serde_json::json!({
                 "ok": issues.is_empty(),
                 "path": p.path,
                 "issue_count": issues.len(),
                 "issues": issues,
             });
+            // CLI md lint-agents --json sets error_kind when dirty; agents
+            // branch the same way across surfaces.
+            if !issues.is_empty() {
+                envelope["error_kind"] = serde_json::json!("changes_detected");
+            }
             let json = serde_json::to_string_pretty(&envelope)
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
             Ok(CallToolResult::success(vec![ContentBlock::text(json)]))

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -374,6 +374,8 @@ const FIELD_ALIASES: &[(&str, &str)] = &[
     ("new", "fragment"),
     ("to", "fragment"),
     ("content", "fragment"),
+    // md.upsert_bullet: CLI --content alias; only when schema allows bullet.
+    ("content", "bullet"),
     ("ops", "operations"),
 ];
 

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -587,6 +587,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         };
         let mut results = Vec::new();
         let mut all_ok = true;
+        let mut any_would_change = false;
         for pf in &patch_files {
             let file_path = cwd.join(&pf.path);
             // Merge check: missing target → empty; binary/utf8 → typed kinds.
@@ -621,6 +622,11 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     if applied.status == ApplyHunksStatus::Conflict {
                         all_ok = false;
                     }
+                    // Clean means apply without fuzz, not "no content change".
+                    // Compare content for identity (new-file create is Clean).
+                    if applied.content != original {
+                        any_would_change = true;
+                    }
                     results.push(patch_file_result(&pf.path, &applied));
                 }
                 Err(msg) => {
@@ -637,13 +643,16 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         emit_patch_files_output(global, all_ok, &results, Some(false), None)?;
         let has_errors = results.iter().any(|r| r.status == "error");
         let has_conflicts = results.iter().any(|r| r.status == "conflict");
+        // Identity / already-applied (content == original): exit 0 so agents
+        // do not loop on exit 2 forever (parity with patch check).
         return Ok(if has_errors {
             exit::AMBIGUOUS
         } else if has_conflicts && !apply_options.allow_conflicts {
             exit::CONFLICTS
-        } else {
-            // Preview/check mode: report that changes would be applied.
+        } else if any_would_change {
             exit::CHANGES_DETECTED
+        } else {
+            exit::SUCCESS
         });
     }
 
@@ -701,11 +710,12 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             on_check: |g: &GlobalFlags, _has: bool, diffs: &[crate::diff::FileDiff]| {
                 let files = build_file_results(diffs, "would_change");
                 let changed = files.len();
-                if changed > 0 {
+                // Always emit JSON on --check (even empty) so agents parse stdout.
+                if g.json || g.jsonl || changed > 0 {
                     emit_patch_files_output(g, true, &files, Some(false), None)?;
-                    if !(g.json || g.jsonl || g.quiet) {
-                        println!("{changed} file(s) would change");
-                    }
+                }
+                if changed > 0 && !(g.json || g.jsonl || g.quiet) {
+                    println!("{changed} file(s) would change");
                 }
                 Ok(())
             },

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -690,8 +690,9 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // Context / pure fuzzy: route through the tx engine where the
     // context_filtered_offset and fallback chain live (#1668).
+    // Pass files_from_list so --files-from - is not re-read empty.
     if args.fuzzy || args.before_context.is_some() || args.after_context.is_some() {
-        return run_context_replace(args, global, &cwd, skipped);
+        return run_context_replace(args, global, &cwd, skipped, files_from_list.as_deref());
     }
 
     // Phase 1: Parallel file scan to identify files with matches (includes identity).
@@ -1247,18 +1248,27 @@ fn run_context_replace(
     global: &GlobalFlags,
     cwd: &std::path::Path,
     skipped: Option<Vec<String>>,
+    files_from_list: Option<&[String]>,
 ) -> anyhow::Result<u8> {
     use crate::plan::Operation;
 
     // Expand directories the same way as the default replace scan so
     // `patchloom replace --fuzzy OLD --new NEW src/` works (not only
     // single-file paths). Empty roots default to `.` via collect.
+    // Use preloaded files_from_list so --files-from - works (exact path
+    // already read stdin once).
     let paths = if args.paths.is_empty() {
         vec![".".to_string()]
     } else {
         args.paths.clone()
     };
-    let file_paths = crate::collect_file_paths_opts(&paths, global, false, Some(cwd))?;
+    let file_paths = crate::collect_file_paths_opts_with_list(
+        &paths,
+        global,
+        false,
+        Some(cwd),
+        files_from_list,
+    )?;
     // Empty --files-from is input error on fuzzy/context path too (#1796).
     crate::files::ensure_files_from_nonempty(global, &file_paths)?;
     if file_paths.is_empty() {

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -384,12 +384,18 @@ pub(crate) fn run_parsed_plan(
         && let Err(e) = crate::plan::expand_for_each(&mut plan, &base_cwd)
     {
         let msg = e.to_string();
+        // Zero matches is no_matches (exit 3); other expand failures stay parse_error.
+        let (kind, code) = if crate::exit::is_no_match(&e) {
+            ("no_matches", exit::NO_MATCHES)
+        } else {
+            ("parse_error", exit::PARSE_ERROR)
+        };
         if structured {
-            let ok = emit_error_json("parse_error", &msg, None, compact);
-            return Ok(exit_after_emit(ok, exit::PARSE_ERROR));
+            let ok = emit_error_json(kind, &msg, None, compact);
+            return Ok(exit_after_emit(ok, code));
         }
         eprintln!("tx: {msg}");
-        return Ok(exit::PARSE_ERROR);
+        return Ok(code);
     }
 
     // Symbol verify needs AST. Without the feature, reject so agents do not

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -538,9 +538,11 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
     }
 
     if matched.is_empty() {
-        // No files matched; clear operations (nothing to do).
-        plan.operations.clear();
-        return Ok(());
+        // Fail closed: typo globs / wrong cwd must not look like a successful
+        // empty apply. Agents branch on exit 0 as "batch done".
+        return Err(anyhow::Error::new(crate::exit::NoMatchError {
+            msg: "for_each matched zero files (check glob, cwd, exclude, and filter)".into(),
+        }));
     }
 
     // 4. Serialize template operations once, then substitute per file.

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -227,6 +227,8 @@ pub enum Operation {
     MdUpsertBullet {
         path: String,
         heading: String,
+        /// Bullet text. Alias `content` matches CLI `--content` / other md ops.
+        #[serde(alias = "content")]
         bullet: String,
     },
     #[serde(rename = "md.table_append")]

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -213,8 +213,14 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
             let pos = match position.as_deref() {
+                None | Some("") | Some("end") => crate::ast::insert::InsertPosition::End,
                 Some("start") => crate::ast::insert::InsertPosition::Start,
-                _ => crate::ast::insert::InsertPosition::End,
+                Some(other) => {
+                    return Err(crate::exit::InvalidInputError {
+                        msg: format!("unknown ast.insert position {other:?}; use start or end"),
+                    }
+                    .into());
+                }
             };
             let result = crate::ast::insert::insert_code(
                 file_content,
@@ -332,7 +338,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 .as_deref()
                 .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs));
-            let pos = crate::ast::group::parse_group_position(position.as_deref());
+            let pos = crate::ast::group::parse_group_position(position.as_deref())?;
             let spec = crate::ast::group::GroupSpec {
                 module: module.clone(),
                 symbols: sym_names.clone(),
@@ -370,7 +376,7 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 .as_deref()
                 .map(crate::ast::Language::from_name_or_ext)
                 .unwrap_or_else(|| crate::ast::Language::from_path(&abs_source));
-            let pos = crate::ast::move_symbols::parse_position(position.as_deref());
+            let pos = crate::ast::move_symbols::parse_position(position.as_deref())?;
             let result = crate::ast::move_symbols::move_symbols(
                 &source_content,
                 &target_content,

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -3251,8 +3251,11 @@ async fn test_mcp_ast_validate_syntax_error() {
         serde_json::json!({"path": "bad.rs"}),
     )
     .await;
-    // ast_validate returns success with errors in the response body
-    assert!(!is_error, "ast_validate should not be a tool error: {val}");
+    // Syntax errors must set isError so hosts that only check the flag fail closed.
+    assert!(
+        is_error,
+        "ast_validate syntax error must be a tool error: {val}"
+    );
     let results = val.as_array().expect("ast_validate should return array");
     assert!(
         results.iter().any(|r| r["valid"] == false),

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7607,13 +7607,23 @@ fn test_tx_for_each_no_matches_produces_empty_plan() {
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
 
-    // No matching files means no operations, success with no changes
-    patchloom_in(dir.path())
-        .arg("tx")
+    // Zero for_each matches fail closed (not silent success) so typo globs
+    // do not look like a completed multi-file apply.
+    let output = patchloom_in(dir.path())
+        .args(["--json", "tx"])
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
-        .assert()
-        .code(0);
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "for_each empty must be no_matches; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(json["error_kind"], "no_matches", "{json}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixloop R7: more agent honesty / fail-closed fixes.

- **AST positions** (group/move/insert): unknown tokens fail closed; group `after:` missing symbol is no_matches
- **for_each** zero matches: exit 3 `no_matches` (not silent empty success)
- **batch file.create**: peel `--force`; reject unknown `--` flags (no content pollution)
- **patch merge check**: exit 0 when content unchanged; always emit JSON on empty check
- **MCP**: md_lint `error_kind`; ast_validate `isError` on syntax errors; unsupported language invalid_params
- **md.upsert_bullet** `content` alias; **fuzzy/context replace** reuses preloaded `--files-from` (stdin safe)

## Test plan

- [x] `make check-fast`
- [x] Unit: position parsers, merge_check new file, ast_validate isError
- [x] Integration: for_each empty no_matches, MCP validate syntax error