### PR TITLE
fix: undo/status/init honesty, EXDEV rename, MCP search, batch force

### DIFF
--- a/src/cmd/apply_fragment.rs
+++ b/src/cmd/apply_fragment.rs
@@ -98,8 +98,12 @@ pub fn run(args: ApplyFragmentArgs, global: &GlobalFlags) -> anyhow::Result<u8> 
         return Ok(crate::exit::FAILURE);
     }
 
+    // Parity with create/delete/rename: rewrite absolute/contain paths before plan.
+    let cwd = global.resolve_cwd()?;
+    let file = global.rewrite_user_path_arg(&cwd, &args.file)?;
+
     let op = Operation::ApplyFragment {
-        path: args.file.clone(),
+        path: file.clone(),
         fragment: raw,
         instruction: args.instruction.clone(),
         after: args.after.clone(),
@@ -113,7 +117,7 @@ pub fn run(args: ApplyFragmentArgs, global: &GlobalFlags) -> anyhow::Result<u8> 
         global,
         |phase, diff, backup| ApplyFragmentOutput {
             ok: true,
-            path: args.file.clone(),
+            path: file.clone(),
             op: "apply.fragment",
             instruction: args.instruction.clone(),
             diff,

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -1,3 +1,6 @@
+// size-waiver: accepted single-domain bulk (policy #1408). Line-oriented batch
+// parse + op dispatch for all plan ops stay one module; do not split for LOC alone.
+// Provenance: fixloop R8 (file.create/rename flag peel) crossed 1000-line alert.
 use crate::cli::global::GlobalFlags;
 use crate::exit;
 use crate::plan::{Operation, Plan};
@@ -225,11 +228,35 @@ fn parse_line(line: &str, line_num: usize) -> anyhow::Result<Operation> {
             })
         }
         "file.rename" => {
-            require_args(op, args, 2, line_num)?;
+            // Peel optional --force (CLI-shaped batch lines).
+            let mut force = false;
+            let mut path_args: Vec<String> = Vec::new();
+            for tok in args {
+                if tok == "--force" {
+                    force = true;
+                    continue;
+                }
+                if tok.starts_with("--") {
+                    return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                        msg: format!(
+                            "line {line_num}: 'file.rename' unknown flag {tok}; only --force is supported"
+                        ),
+                    }));
+                }
+                path_args.push(tok.clone());
+            }
+            if path_args.len() != 2 {
+                return Err(anyhow::Error::new(crate::exit::ParseErrorError {
+                    msg: format!(
+                        "line {line_num}: 'file.rename' requires exactly 2 arguments (from to [--force]), got {}",
+                        path_args.len()
+                    ),
+                }));
+            }
             op!(FileRename {
-                from: args[0].clone(),
-                to: args[1].clone(),
-                force: false
+                from: path_args[0].clone(),
+                to: path_args[1].clone(),
+                force
             })
         }
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -163,23 +163,33 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
 
     // 3. Keep undo backups out of git noise (pairs with `status` filtering).
-    match ensure_gitignore_patchloom(&cwd) {
-        Ok(GitignorePatchloom::Created) => {
-            report.gitignore = "created".into();
-            status!("created .gitignore with .patchloom/");
+    // Same consent as agent rules: do not silently mutate .gitignore when the
+    // user declined interactive init (no --yes / no structured auto-accept).
+    let auto_gitignore = auto_yes || structured;
+    if auto_gitignore
+        || confirm("Add .patchloom/ to .gitignore (hides undo backup sessions from git)?")
+    {
+        match ensure_gitignore_patchloom(&cwd) {
+            Ok(GitignorePatchloom::Created) => {
+                report.gitignore = "created".into();
+                status!("created .gitignore with .patchloom/");
+            }
+            Ok(GitignorePatchloom::Appended) => {
+                report.gitignore = "appended".into();
+                status!("appended .patchloom/ to .gitignore");
+            }
+            Ok(GitignorePatchloom::AlreadyPresent) => {
+                report.gitignore = "already_present".into();
+                status!(".gitignore already ignores .patchloom/");
+            }
+            Err(e) => {
+                report.gitignore = format!("error:{e}");
+                status!("could not update .gitignore: {e}");
+            }
         }
-        Ok(GitignorePatchloom::Appended) => {
-            report.gitignore = "appended".into();
-            status!("appended .patchloom/ to .gitignore");
-        }
-        Ok(GitignorePatchloom::AlreadyPresent) => {
-            report.gitignore = "already_present".into();
-            status!(".gitignore already ignores .patchloom/");
-        }
-        Err(e) => {
-            report.gitignore = format!("error:{e}");
-            status!("could not update .gitignore: {e}");
-        }
+    } else {
+        report.gitignore = "skipped_use_yes".into();
+        status!("skipped .gitignore (declined or non-interactive; re-run with --yes or --json)");
     }
 
     if !quiet && !structured {
@@ -212,6 +222,14 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         eprintln!("setup complete.");
     }
 
+    // Completions install failure is soft (we still print a manual command).
+    // Hard fail only on agent_rules/gitignore write errors.
+    let hard_fail =
+        report.agent_rules.starts_with("error") || report.gitignore.starts_with("error:");
+    // Structured JSON: ok:false on hard fail only (completions failed: is soft).
+    // Interactive decline of AGENTS.md/.gitignore is not a hard fail (exit 0).
+    let ok = !hard_fail;
+
     if structured {
         #[derive(serde::Serialize)]
         struct InitJson<'a> {
@@ -224,7 +242,7 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             mcp_available: bool,
         }
         let payload = InitJson {
-            ok: true,
+            ok,
             agent_rules: &report.agent_rules,
             agent_rules_path: report.agent_rules_path.as_deref(),
             completions: &report.completions,
@@ -233,7 +251,11 @@ pub fn run(args: InitArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         };
         global.emit_json(&payload)?;
     }
-    Ok(exit::SUCCESS)
+    if hard_fail {
+        Ok(exit::FAILURE)
+    } else {
+        Ok(exit::SUCCESS)
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -24,7 +24,7 @@ use crate::plan::Operation;
 use super::ast_tools;
 use super::params::*;
 use super::{
-    PatchloomService, doc_readonly, execute_plan_validated, exit_code_to_result, no_results,
+    PatchloomService, doc_readonly, execute_plan_validated, exit_code_to_result,
     validate_batch_size, validate_content_size, validate_param_size,
 };
 
@@ -255,8 +255,27 @@ impl PatchloomService {
             global.glob = p.globs;
             global.exclude = p.exclude_patterns;
             global.ignore_file = p.custom_ignore_filenames;
-            let results = crate::cmd::search::collect_matches(&search_args, &global)
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+            let results = crate::cmd::search::collect_matches(&search_args, &global).map_err(
+                |e| {
+                    // Prefer invalid_params for typed agent failures (bad regex,
+                    // invalid_input) so hosts do not treat them as server bugs.
+                    let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+                    let msg = crate::exit::agent_error_message(&e);
+                    if matches!(
+                        kind,
+                        "invalid_input"
+                            | "parse_error"
+                            | "guard_rejected"
+                            | "not_found"
+                            | "binary"
+                            | "invalid_encoding"
+                    ) {
+                        McpError::invalid_params(msg, None)
+                    } else {
+                        McpError::internal_error(msg, None)
+                    }
+                },
+            )?;
 
             // --assert-count mode: return count comparison instead of matches.
             if let Some(expected) = p.assert_count {
@@ -294,7 +313,44 @@ impl PatchloomService {
                 results.has_matches()
             };
             if !has_matches {
-                return no_results("No matches found.");
+                // CLI honesty: missing/binary/unreadable are not soft no-matches.
+                let cwd = global.resolve_cwd().map_err(|e| {
+                    McpError::internal_error(format!("resolve cwd: {e}"), None)
+                })?;
+                if crate::files::all_scan_targets_missing(&global, &search_args.paths, Some(&cwd))
+                    .unwrap_or(false)
+                {
+                    return Err(McpError::invalid_params(
+                        format!(
+                            "no such file or directory: {}",
+                            global.path_scope_description(&search_args.paths)
+                        ),
+                        None,
+                    ));
+                }
+                if let Some(err) = crate::ops::file::sole_explicit_non_text_for_scan(
+                    &search_args.paths,
+                    None,
+                    &cwd,
+                ) {
+                    let kind = crate::fallback::error_kind_str(&err).unwrap_or("invalid_input");
+                    let msg = crate::exit::agent_error_message(&err);
+                    return Err(McpError::invalid_params(
+                        format!("{kind}: {msg}"),
+                        None,
+                    ));
+                }
+                // True pattern miss: CLI-shaped JSON so agents can branch.
+                let body = serde_json::json!({
+                    "ok": false,
+                    "error_kind": "no_matches",
+                    "error": "No matches found.",
+                    "match_count": 0,
+                    "file_count": 0,
+                });
+                return Ok(CallToolResult::success(vec![ContentBlock::text(
+                    body.to_string(),
+                )]));
             }
 
             let cwd = global.resolve_cwd().map_err(|e| {
@@ -757,6 +813,8 @@ impl PatchloomService {
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
             let json = serde_json::to_string_pretty(&status)
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+            // Always tool success (isError=false); agents branch on ok /
+            // total_changes / error_kind like md_lint dirty envelopes.
             Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
         })
         .await

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -13,7 +13,8 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct ReplaceParams {
-    /// File path (relative to working directory).
+    /// File path (relative to working directory). Alias `file` matches CLI/batch.
+    #[serde(alias = "file")]
     pub path: String,
     /// Text to find.
     /// Alias `from` accepted because agents often emit that name (LLM prior).

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -369,6 +369,8 @@ const FIELD_ALIASES: &[(&str, &str)] = &[
     ("key", "selector"),
     ("from", "old"),
     ("to", "new"),
+    // CLI/batch use `file`; plan/MCP tools use `path`.
+    ("file", "path"),
     // apply.fragment: agents copy replace_text priors (new/to/content → fragment).
     // Applied only when the tool schema allows the canonical name.
     ("new", "fragment"),

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -311,9 +311,19 @@ fn rename_or_copy(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Resul
             fs::copy(src, dst).with_context(|| {
                 format!("cross-device copy {} -> {}", src.display(), dst.display())
             })?;
-            fs::remove_file(src).with_context(|| {
-                format!("removing source after cross-device copy: {}", src.display())
-            })?;
+            if let Err(remove_err) = fs::remove_file(src) {
+                // Best-effort rollback: drop the dest copy so we do not leave
+                // two copies after a failed apply (backup session may still
+                // recover source via undo).
+                let _ = fs::remove_file(dst);
+                return Err(remove_err).with_context(|| {
+                    format!(
+                        "removing source after cross-device copy: {}; rolled back dest {}",
+                        src.display(),
+                        dst.display()
+                    )
+                });
+            }
             Ok(())
         }
         Err(e) => Err(e.into()),

--- a/src/cmd/status.rs
+++ b/src/cmd/status.rs
@@ -21,7 +21,14 @@ pub struct StatusArgs {
 
 #[derive(Debug, Serialize)]
 pub(crate) struct StatusOutput {
+    /// True only when the tree is clean. Dirty trees set ok:false +
+    /// error_kind/status changes_detected so agents that branch on ok match
+    /// CLI exit 2 (same pattern as md lint / tx lint).
     ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_kind: Option<&'static str>,
     modified: Vec<String>,
     created: Vec<String>,
     deleted: Vec<String>,
@@ -126,9 +133,20 @@ pub(crate) fn collect_status(
     }
 
     let total_changes = modified.len() + created.len() + deleted.len();
+    let dirty = total_changes > 0;
 
     Ok(StatusOutput {
-        ok: true,
+        ok: !dirty,
+        status: if dirty {
+            Some("changes_detected")
+        } else {
+            Some("clean")
+        },
+        error_kind: if dirty {
+            Some("changes_detected")
+        } else {
+            None
+        },
         modified,
         created,
         deleted,

--- a/src/cmd/undo.rs
+++ b/src/cmd/undo.rs
@@ -185,18 +185,28 @@ pub fn run(args: UndoArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let restored = backup::restore_session(&backup_root, &timestamp)?;
     // Remove the consumed session so subsequent `undo` calls advance to
     // the next-oldest session instead of replaying the same one.
+    // Even when restored == 0 (e.g. create-only session, files already gone),
+    // the session is complete and safe to drop; do not claim applied:true.
     backup::remove_session(&backup_root, &timestamp)?;
     crate::verbose!("undo: restored {} file(s)", restored);
+    let applied = restored > 0;
+    let status = if applied { "restored" } else { "noop" };
     if !global.emit_json(&serde_json::json!({
         "ok": true,
-        "status": "restored",
-        "applied": true,
+        "status": status,
+        "applied": applied,
         "session": timestamp,
         "project_root": display_root(&cwd, &backup_root),
         "file_count": restored,
     }))? && !global.quiet
     {
-        eprintln!("restored {restored} file(s) from session {timestamp}");
+        if applied {
+            eprintln!("restored {restored} file(s) from session {timestamp}");
+        } else {
+            eprintln!(
+                "session {timestamp}: nothing to restore (already undone or files gone); session removed"
+            );
+        }
     }
 
     Ok(exit::SUCCESS)

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -359,9 +359,18 @@ fn rename_or_copy(src: &Path, dst: &Path) -> anyhow::Result<()> {
             std::fs::copy(src, dst).with_context(|| {
                 format!("cross-device copy {} -> {}", src.display(), dst.display())
             })?;
-            std::fs::remove_file(src).with_context(|| {
-                format!("removing source after cross-device copy: {}", src.display())
-            })?;
+            if let Err(remove_err) = std::fs::remove_file(src) {
+                // Best-effort rollback: drop dest copy so apply does not leave
+                // two copies when source remove fails after EXDEV copy.
+                let _ = std::fs::remove_file(dst);
+                return Err(remove_err).with_context(|| {
+                    format!(
+                        "removing source after cross-device copy: {}; rolled back dest {}",
+                        src.display(),
+                        dst.display()
+                    )
+                });
+            }
             Ok(())
         }
         Err(e) => Err(e.into()),

--- a/tests/integration/init_tests.rs
+++ b/tests/integration/init_tests.rs
@@ -204,6 +204,10 @@ fn test_init_json_without_yes_creates_agents_md() {
         dir.path().join("AGENTS.md").exists(),
         "AGENTS.md must exist after init --json without --yes"
     );
+    assert!(
+        dir.path().join(".gitignore").exists(),
+        "structured init must still write .gitignore (auto-accept)"
+    );
     let content = fs::read_to_string(dir.path().join("AGENTS.md")).unwrap();
     assert!(
         content.contains("patchloom") || content.len() > 100,
@@ -238,14 +242,19 @@ fn test_init_falls_back_to_completion_command_when_completion_dir_creation_fails
 #[test]
 fn test_init_confirm_eof_skips_agents_creation() {
     let dir = TempDir::new().unwrap();
+    // Two prompts now: AGENTS.md and .gitignore. EOF on each declines both.
     let output = run_patchloom_confirm_in_pty_with_env(
         &["init", "--cwd", dir.path().to_str().unwrap()],
-        "\u{4}",
+        "\u{4}\u{4}",
         &[("SHELL", "unknown")],
     );
 
     assert!(output.status.success());
     assert!(!dir.path().join("AGENTS.md").exists());
+    assert!(
+        !dir.path().join(".gitignore").exists(),
+        "declined gitignore must not create .gitignore"
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Create AGENTS.md? [Y/n]"));
@@ -273,12 +282,20 @@ fn test_init_noninteractive_without_yes_hints_use_yes() {
         !dir.path().join("AGENTS.md").exists(),
         "non-interactive init without --yes must not create AGENTS.md"
     );
+    assert!(
+        !dir.path().join(".gitignore").exists(),
+        "non-interactive init without --yes must not silently create .gitignore"
+    );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains("skipped AGENTS.md")
             && stderr.contains("--yes")
             && stderr.contains("--json"),
         "stderr must explain how to create rules: {stderr}"
+    );
+    assert!(
+        stderr.contains("skipped .gitignore") || stderr.contains(".gitignore"),
+        "stderr must mention gitignore skip: {stderr}"
     );
 }
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1846,7 +1846,12 @@ async fn test_mcp_status_round_trip() {
 
     let client = spawn_mcp_client(dir.path()).await;
     let (is_error, status) = call_tool_value(&client, "git_status", serde_json::json!({})).await;
-    assert!(!is_error, "status should succeed: {status}");
+    assert!(!is_error, "status tool isError should stay false: {status}");
+    assert_eq!(
+        status["ok"], false,
+        "dirty tree must set ok:false (agents branch on ok): {status}"
+    );
+    assert_eq!(status["error_kind"], "changes_detected", "{status}");
     let modified: Vec<String> = status
         .get("modified")
         .and_then(|v| v.as_array())

--- a/tests/integration/status_tests.rs
+++ b/tests/integration/status_tests.rs
@@ -90,7 +90,9 @@ fn test_status_jsonl_output() {
 
     assert_eq!(output.status.code(), Some(2));
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["ok"], true);
+    assert_eq!(json["ok"], false, "dirty tree must set ok:false: {json}");
+    assert_eq!(json["error_kind"], "changes_detected", "{json}");
+    assert_eq!(json["status"], "changes_detected", "{json}");
     assert_eq!(json["total_changes"], 1);
     assert!(
         json["created"]
@@ -119,7 +121,9 @@ fn test_status_json_output() {
         .unwrap();
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["ok"], true);
+    assert_eq!(json["ok"], false, "dirty tree must set ok:false: {json}");
+    assert_eq!(json["error_kind"], "changes_detected", "{json}");
+    assert_eq!(json["status"], "changes_detected", "{json}");
     assert_eq!(json["total_changes"], 1);
     assert!(
         json["created"]

--- a/tests/integration/undo_tests.rs
+++ b/tests/integration/undo_tests.rs
@@ -387,6 +387,54 @@ fn test_undo_json_no_sessions_sets_error_kind() {
     );
 }
 
+/// Create-only session where the created file is already gone: restore is a
+/// no-op. Must not claim applied:true (agents branch on applied for undo success).
+#[test]
+fn test_undo_apply_create_already_gone_is_noop_not_applied() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("ephemeral.txt");
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args([
+            "create",
+            "ephemeral.txt",
+            "--content",
+            "temp\n",
+            "--apply",
+            "--cwd",
+        ])
+        .arg(dir.path())
+        .assert()
+        .code(0);
+    assert!(file.exists());
+
+    // User/agent already deleted the file; undo of create would only remove it.
+    fs::remove_file(&file).unwrap();
+    assert!(!file.exists());
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "undo", "--apply", "--cwd"])
+        .arg(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(json["status"], "noop", "{json}");
+    assert_eq!(
+        json["applied"], false,
+        "noop undo must not claim applied:true: {json}"
+    );
+    assert_eq!(json["file_count"], 0, "{json}");
+}
+
 // ---------------------------------------------------------------------------
 // Non-TTY error output (#1341)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixloop R8: agent honesty for undo, status, init, plus more real-world fixes from parallel audit.

### Core (late R7 audit)
- **undo**: `applied:true` only when `restored > 0`; status `noop` when create-only session already gone
- **status**: dirty tree sets `ok:false` + `error_kind: changes_detected` (matches CLI exit 2)
- **init**: `.gitignore` no longer mutates without `--yes` / structured / confirm

### Additional (R8 hunt)
- **EXDEV rename**: roll back dest copy if source remove fails (CLI + tx)
- **batch file.rename**: peel `--force`
- **MCP search**: missing/binary fail closed; true miss returns JSON `no_matches`; typed errors as invalid_params
- **aliases**: `file`→`path` (registry + replace_text); apply-fragment path rewrite like other writers

## Test plan

- [x] `make check-fast`
- [x] Integration: undo create-gone noop, status dirty ok:false, init no gitignore without yes, MCP git_status dirty, init PTY dual confirm
- [x] Reviewer subagent on diff