### PR TITLE
fix: EXDEV rename force-dest safe rollback

### DIFF
--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -552,6 +552,25 @@ mod basic {
     }
 
     #[test]
+    fn parse_line_file_rename_force_flag() {
+        let op = parse_line("file.rename old.txt new.txt --force", 1).unwrap();
+        assert!(
+            matches!(op, Operation::FileRename { ref from, ref to, force: true }
+            if from == "old.txt" && to == "new.txt"),
+            "got {op:?}"
+        );
+        let op = parse_line("file.rename --force a b", 1).unwrap();
+        assert!(matches!(
+            op,
+            Operation::FileRename {
+                ref from,
+                ref to,
+                force: true
+            } if from == "a" && to == "b"
+        ));
+    }
+
+    #[test]
     fn full_batch_parse() {
         let input = r#"
 # Update versions across the project

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -308,17 +308,19 @@ fn rename_or_copy(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Resul
     match fs::rename(src, dst) {
         Ok(()) => Ok(()),
         Err(e) if is_cross_device(&e) => {
+            // Only remove dest on rollback if we created it; force overwrite
+            // must not delete the pre-existing dest (backup holds prior bytes).
+            let dest_existed = dst.exists();
             fs::copy(src, dst).with_context(|| {
                 format!("cross-device copy {} -> {}", src.display(), dst.display())
             })?;
             if let Err(remove_err) = fs::remove_file(src) {
-                // Best-effort rollback: drop the dest copy so we do not leave
-                // two copies after a failed apply (backup session may still
-                // recover source via undo).
-                let _ = fs::remove_file(dst);
+                if !dest_existed {
+                    let _ = fs::remove_file(dst);
+                }
                 return Err(remove_err).with_context(|| {
                     format!(
-                        "removing source after cross-device copy: {}; rolled back dest {}",
+                        "removing source after cross-device copy: {} -> {}",
                         src.display(),
                         dst.display()
                     )

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -356,16 +356,19 @@ fn rename_or_copy(src: &Path, dst: &Path) -> anyhow::Result<()> {
     match std::fs::rename(src, dst) {
         Ok(()) => Ok(()),
         Err(e) if is_cross_device(&e) => {
+            // Only remove dest on rollback if we created it; force overwrite
+            // must not delete the pre-existing dest (backup holds prior bytes).
+            let dest_existed = dst.exists();
             std::fs::copy(src, dst).with_context(|| {
                 format!("cross-device copy {} -> {}", src.display(), dst.display())
             })?;
             if let Err(remove_err) = std::fs::remove_file(src) {
-                // Best-effort rollback: drop dest copy so apply does not leave
-                // two copies when source remove fails after EXDEV copy.
-                let _ = std::fs::remove_file(dst);
+                if !dest_existed {
+                    let _ = std::fs::remove_file(dst);
+                }
                 return Err(remove_err).with_context(|| {
                     format!(
-                        "removing source after cross-device copy: {}; rolled back dest {}",
+                        "removing source after cross-device copy: {} -> {}",
                         src.display(),
                         dst.display()
                     )


### PR DESCRIPTION
## Summary

Reviewer follow-up for #2047 High finding:

- On EXDEV copy+delete, only remove dest on rollback if dest did **not** exist before the copy (force overwrite keeps dest; backup holds prior bytes)
- Unit test for batch `file.rename ... --force`

## Test plan

- [x] `cargo test --lib parse_line_file_rename`
- [x] `cargo check --all-features`