### PR TITLE
fix: jsonl honesty for read/schema/tidy; MCP search; AST empty-scan

### DIFF
--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -434,6 +434,11 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
     }
 
     if total_matches == 0 {
+        // Unreadable-masked walks must not look like pattern miss.
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+            return Ok(exit::FAILURE);
+        }
         let msg = format!("no matches for pattern in {}", args.path);
         global.emit_error_json_kind(Some("no_matches"), &msg)?;
         Ok(exit::NO_MATCHES)
@@ -491,6 +496,10 @@ pub(super) fn run_refs(args: RefsArgs, global: &GlobalFlags) -> anyhow::Result<u
     }
 
     if all_refs.is_empty() {
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+            return Ok(exit::FAILURE);
+        }
         let msg = format!("no references found for '{}' in {}", args.symbol, args.path);
         global.emit_error_json_kind(Some("no_matches"), &msg)?;
         return Ok(exit::NO_MATCHES);
@@ -641,6 +650,10 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
         }
         Ok(exit::SUCCESS)
     } else {
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+            return Ok(exit::FAILURE);
+        }
         let msg = format!("no imports found in {}", args.path);
         global.emit_error_json_kind(Some("no_matches"), &msg)?;
         Ok(exit::NO_MATCHES)

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -277,9 +277,58 @@ impl PatchloomService {
                 },
             )?;
 
+            let cwd = global
+                .resolve_cwd()
+                .map_err(|e| McpError::internal_error(format!("resolve cwd: {e}"), None))?;
+
+            // Shared CLI honesty for empty scans (missing / sole binary /
+            // unreadable-masked). Used by assert_count(actual=0) and no-match.
+            let empty_scan_hard_fail = |global: &GlobalFlags,
+                                       paths: &[String],
+                                       cwd: &std::path::Path|
+             -> Result<(), McpError> {
+                match crate::files::all_scan_targets_missing(global, paths, Some(cwd)) {
+                    Ok(true) => {
+                        return Err(McpError::invalid_params(
+                            format!(
+                                "no such file or directory: {}",
+                                global.path_scope_description(paths)
+                            ),
+                            None,
+                        ));
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        return Err(McpError::invalid_params(
+                            crate::exit::agent_error_message(&e),
+                            None,
+                        ));
+                    }
+                }
+                if let Some(err) =
+                    crate::ops::file::sole_explicit_non_text_for_scan(paths, None, cwd)
+                {
+                    let kind = crate::fallback::error_kind_str(&err).unwrap_or("invalid_input");
+                    let msg = crate::exit::agent_error_message(&err);
+                    return Err(McpError::invalid_params(format!("{kind}: {msg}"), None));
+                }
+                let scanned = crate::files::collect_file_paths_opts(paths, global, false, Some(cwd))
+                    .map_err(|e| {
+                        McpError::invalid_params(crate::exit::agent_error_message(&e), None)
+                    })?;
+                if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, cwd)
+                {
+                    return Err(McpError::invalid_params(err.msg, None));
+                }
+                Ok(())
+            };
+
             // --assert-count mode: return count comparison instead of matches.
             if let Some(expected) = p.assert_count {
                 let actual: usize = results.file_match_counts.values().sum();
+                if actual == 0 {
+                    empty_scan_hard_fail(&global, &search_args.paths, &cwd)?;
+                }
                 let matched = actual == expected;
                 let status = if matched {
                     "success"
@@ -313,33 +362,7 @@ impl PatchloomService {
                 results.has_matches()
             };
             if !has_matches {
-                // CLI honesty: missing/binary/unreadable are not soft no-matches.
-                let cwd = global.resolve_cwd().map_err(|e| {
-                    McpError::internal_error(format!("resolve cwd: {e}"), None)
-                })?;
-                if crate::files::all_scan_targets_missing(&global, &search_args.paths, Some(&cwd))
-                    .unwrap_or(false)
-                {
-                    return Err(McpError::invalid_params(
-                        format!(
-                            "no such file or directory: {}",
-                            global.path_scope_description(&search_args.paths)
-                        ),
-                        None,
-                    ));
-                }
-                if let Some(err) = crate::ops::file::sole_explicit_non_text_for_scan(
-                    &search_args.paths,
-                    None,
-                    &cwd,
-                ) {
-                    let kind = crate::fallback::error_kind_str(&err).unwrap_or("invalid_input");
-                    let msg = crate::exit::agent_error_message(&err);
-                    return Err(McpError::invalid_params(
-                        format!("{kind}: {msg}"),
-                        None,
-                    ));
-                }
+                empty_scan_hard_fail(&global, &search_args.paths, &cwd)?;
                 // True pattern miss: CLI-shaped JSON so agents can branch.
                 let body = serde_json::json!({
                     "ok": false,
@@ -353,16 +376,18 @@ impl PatchloomService {
                 )]));
             }
 
-            let cwd = global.resolve_cwd().map_err(|e| {
-                McpError::internal_error(format!("resolve cwd: {e}"), None)
-            })?;
+            // cwd already resolved for empty-scan honesty.
             let refused =
                 crate::cmd::search::explicit_binary_refused(&search_args, &global, &cwd);
+            let skipped = crate::files::scan_missing_entries(&global, &cwd, &search_args.paths)
+                .map_err(|e| {
+                    McpError::invalid_params(crate::exit::agent_error_message(&e), None)
+                })?;
             let output = crate::cmd::search::format_results(
                 results,
                 &search_args,
                 &global,
-                None,
+                skipped,
                 refused,
             )
             .map_err(|e| McpError::internal_error(format!("{e}"), None))?;

--- a/src/cmd/read.rs
+++ b/src/cmd/read.rs
@@ -189,7 +189,7 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     let multi = args.files.len() > 1;
     let mut outputs: Vec<ReadOutput> = Vec::new();
-    let mut errors: Vec<ReadFail> = Vec::new();
+    let mut errors: Vec<(String, ReadFail)> = Vec::new();
 
     for (i, path) in args.files.iter().enumerate() {
         let resolved = cwd.join(path);
@@ -215,20 +215,35 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 if !structured {
                     eprintln!("read: {e}");
                 }
-                errors.push(e);
+                errors.push((path.clone(), e));
             }
         }
     }
 
     if errors.len() == args.files.len() {
-        let msg = errors
+        let fails: Vec<ReadFail> = errors.iter().map(|(_, e)| e.clone()).collect();
+        let msg = fails
             .iter()
             .map(|e| e.msg.as_str())
             .collect::<Vec<_>>()
             .join("\n");
-        let (kind, code) = classify_read_failures(&errors);
+        let (kind, code) = classify_read_failures(&fails);
+        // All-fail: single error object (json/jsonl), not N lines.
         global.emit_error_json_kind(Some(kind), &msg)?;
         return Ok(code);
+    }
+
+    // Partial --jsonl: stream one failure object per bad path so agents that
+    // only parse stdout still see error_kind (successes already emitted).
+    if global.jsonl && !errors.is_empty() {
+        for (path, e) in &errors {
+            let _ = global.emit_json(&serde_json::json!({
+                "ok": false,
+                "path": path,
+                "error_kind": e.kind,
+                "error": e.msg,
+            }));
+        }
     }
 
     if global.json {
@@ -245,11 +260,12 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 error_kind: &'static str,
                 error: String,
             }
-            let (kind, _) = classify_read_failures(&errors);
+            let fails: Vec<ReadFail> = errors.iter().map(|(_, e)| e.clone()).collect();
+            let (kind, _) = classify_read_failures(&fails);
             let report = PartialReadReport {
                 ok: false,
                 files: outputs,
-                skipped: errors.iter().map(|e| e.msg.clone()).collect(),
+                skipped: errors.iter().map(|(_, e)| e.msg.clone()).collect(),
                 error_kind: kind,
                 error: format!("partial read failure: {} path(s) failed", errors.len()),
             };
@@ -261,7 +277,7 @@ pub fn run(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
 
     // Always show errors on stderr, even with --quiet (#1179).
     if structured {
-        for error in &errors {
+        for (_, error) in &errors {
             eprintln!("read: {error}");
         }
     }

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -72,11 +72,15 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     "write_policy": schema::plan_write_policy_schema()
                 }
             });
-            let output = serde_json::to_string_pretty(&envelope)?;
             if global.quiet {
                 return Ok(exit::SUCCESS);
             }
-            println!("{output}");
+            // Honor global --json / --jsonl (pretty vs compact). Agents that
+            // always pass --jsonl break on multi-line pretty-only stdout.
+            if !global.emit_json(&envelope)? {
+                let output = serde_json::to_string_pretty(&envelope)?;
+                println!("{output}");
+            }
         }
         SchemaFormat::Prompt => {
             let prompt = match args.tier {

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -160,7 +160,19 @@ fn emit_tidy_fix_output(
         };
         global.emit_json(&output)?;
     } else if global.jsonl {
+        // Stream per-file rows, then a summary trailer so agents using --jsonl
+        // still get applied / backup_session / skipped / refused (parity JSON).
         global.emit_json_items(fix_files)?;
+        global.emit_json(&serde_json::json!({
+            "type": "summary",
+            "ok": true,
+            "files_changed": fix_files.len(),
+            "applied": applied,
+            "backup_session": backup_session,
+            "skipped": skipped,
+            "refused": refused,
+            "diff": diff_text,
+        }))?;
     }
     Ok(())
 }

--- a/tests/integration/read_tests.rs
+++ b/tests/integration/read_tests.rs
@@ -359,6 +359,50 @@ fn test_read_multiple_files_jsonl() {
     assert!(j2["content"].as_str().unwrap().contains("second"));
 }
 
+/// Partial multi-path --jsonl must emit structured failure lines with error_kind
+/// so agents that only parse stdout do not miss failed paths.
+#[test]
+fn test_read_jsonl_partial_failure_emits_error_lines() {
+    let dir = TempDir::new().unwrap();
+    let existing = dir.path().join("ok.txt");
+    fs::write(&existing, "hello\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--jsonl")
+        .arg("read")
+        .arg(existing.to_str().unwrap())
+        .arg(nonexistent_path("missing-jsonl-partial"))
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    let lines: Vec<&str> = std::str::from_utf8(&output.stdout)
+        .unwrap()
+        .lines()
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert!(
+        lines.len() >= 2,
+        "expect success line + failure line, got: {lines:?}"
+    );
+    let ok_line: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert!(
+        ok_line["content"].as_str().unwrap_or("").contains("hello"),
+        "{ok_line}"
+    );
+    let fail_line: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    assert_eq!(fail_line["ok"], false, "{fail_line}");
+    assert_eq!(fail_line["error_kind"], "not_found", "{fail_line}");
+    assert!(
+        fail_line["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("missing-jsonl-partial"),
+        "{fail_line}"
+    );
+}
+
 #[test]
 fn test_read_partial_failure_returns_failure() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/schema_tests.rs
+++ b/tests/integration/schema_tests.rs
@@ -323,3 +323,25 @@ fn test_schema_ast_rename_path_description_mentions_directory() {
 // ---------------------------------------------------------------------------
 // md --check produces stdout output (#544)
 // ---------------------------------------------------------------------------
+
+#[test]
+fn test_schema_jsonl_global_flag_is_single_line() {
+    // Agents often pass --jsonl globally; format=json must still emit one compact line.
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--jsonl", "schema", "--format", "json"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        1,
+        "schema --jsonl must be one JSON line, got {} lines",
+        lines.len()
+    );
+    let parsed: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    assert_eq!(parsed["ok"], true);
+    assert!(parsed["operations"].is_array());
+}

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -198,12 +198,29 @@ fn test_tidy_fix_jsonl_output() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert!(!lines.is_empty(), "expected at least one JSONL line");
+    assert!(
+        lines.len() >= 2,
+        "expected file row(s) + summary trailer, got: {lines:?}"
+    );
+    let mut saw_path = false;
+    let mut saw_summary = false;
     for line in &lines {
         let v: serde_json::Value =
             serde_json::from_str(line).expect("each JSONL line should be valid JSON");
-        assert!(v["path"].is_string());
+        if v.get("type").and_then(|t| t.as_str()) == Some("summary") {
+            saw_summary = true;
+            assert_eq!(v["ok"], true, "{v}");
+            assert!(v.get("applied").is_some(), "summary needs applied: {v}");
+        } else {
+            saw_path = true;
+            assert!(v["path"].is_string(), "{v}");
+        }
     }
+    assert!(saw_path, "expected at least one path row");
+    assert!(
+        saw_summary,
+        "expected type=summary trailer for agent honesty"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixloop R9: agent stdout honesty for JSONL and empty-scan paths.

- **read --jsonl**: partial failures stream `{ok:false,error_kind,...}` per path
- **schema --format json**: uses `emit_json` so `--jsonl` is one compact line
- **tidy fix --jsonl**: `type:summary` trailer with `applied` / `backup_session` / skipped / refused
- **MCP search**: shared empty-scan hard-fail (missing/binary/unreadable); pass `skipped` on hits
- **AST search/refs/deps**: `empty_scan_masked_by_unreadable` before `no_matches`

## Test plan

- [x] `make check-fast`
- [x] Integration: read jsonl partial, schema jsonl single line, tidy fix jsonl summary