### PR TITLE
fix: lint/search jsonl trailers; AST validate/search/impact honesty

### DIFF
--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -274,10 +274,18 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
             if !lang.has_grammar() {
                 return None;
             }
+            // Do not soft-drop load failures (.ok()?): binary / unreadable
+            // would become invisible "validated OK" on partial trees.
             let result = crate::ast::validate::validate_file(path, Some(lang)).ok()?;
             let display = display_path(path, &cwd);
             Some(ValidateFileResult { display, result })
         });
+
+    // Unreadable co-paths must not look like clean validate or empty grammar set.
+    if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+        global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+        return Ok(exit::FAILURE);
+    }
 
     // Directory walk can include only non-grammar files filtered inside the
     // loop, or every validate_file call can fail. Do not report success with
@@ -367,6 +375,22 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
     struct SearchFileResult {
         display: String,
         matches: Vec<crate::ast::search::SearchMatch>,
+    }
+
+    // Fail closed on invalid S-expression before the walk soft-drops ParseError.
+    if !args.pattern
+        && let Some(sample) = paths
+            .iter()
+            .find(|p| resolve_lang(lang_hint, p).has_grammar())
+    {
+        let lang = resolve_lang(lang_hint, sample);
+        if let Err(e) = crate::ast::search::search_file(sample, &args.query, Some(lang), Some(1))
+            && crate::exit::is_parse_error(&e)
+        {
+            let msg = crate::exit::agent_error_message(&e);
+            global.emit_error_json_kind(Some("parse_error"), &msg)?;
+            return Ok(exit::PARSE_ERROR);
+        }
     }
 
     let glob_matcher = crate::build_glob_matcher_from_global(global)?;
@@ -768,6 +792,10 @@ pub(super) fn run_impact(args: ImpactArgs, global: &GlobalFlags) -> anyhow::Resu
     let nodes = crate::ast::impact::compute_impact(&args.symbol, &file_pairs, args.depth);
 
     if nodes.is_empty() {
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
+            return Ok(exit::FAILURE);
+        }
         global.emit_error_json_kind(
             Some("no_matches"),
             &format!("no references found for '{}'", args.symbol),

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -289,6 +289,11 @@ pub(super) fn handle_ast_validate(
         }))
     });
 
+    // CLI parity: unreadable co-paths are not soft empty / no-grammar.
+    if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+        return Err(McpError::invalid_params(err.msg, None));
+    }
+
     if results.is_empty() {
         return Err(McpError::invalid_params(
             "No files with grammars found.",

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -554,7 +554,16 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     issues: issues.clone(),
                 })?;
             } else if global.jsonl {
+                // Stream issues, then summary with ok/error_kind (parity --json).
                 global.emit_json_items(&issues)?;
+                let dirty = !issues.is_empty();
+                global.emit_json(&serde_json::json!({
+                    "type": "summary",
+                    "ok": !dirty,
+                    "path": file,
+                    "issue_count": issues.len(),
+                    "error_kind": if dirty { Some("changes_detected") } else { None::<&str> },
+                }))?;
             } else if !global.quiet {
                 for issue in &issues {
                     match (issue.line, &issue.heading) {

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -340,12 +340,18 @@ pub(crate) fn format_results(
                 }
                 out.push('\n');
             }
-            if truncated {
+            let need_summary = truncated
+                || skipped.as_ref().is_some_and(|s| !s.is_empty())
+                || refused.as_ref().is_some_and(|r| !r.is_empty());
+            if need_summary {
                 out.push_str(&serde_json::to_string(&serde_json::json!({
                     "type": "summary",
+                    "ok": true,
                     "file_count": full_file_count,
                     "file_emitted": paths.len(),
-                    "truncated": true,
+                    "truncated": truncated,
+                    "skipped": skipped,
+                    "refused": refused,
                 }))?);
                 out.push('\n');
             }
@@ -357,15 +363,21 @@ pub(crate) fn format_results(
                 out.push_str(&serde_json::to_string(m)?);
                 out.push('\n');
             }
-            // Trailer when --max-results capped the stream (fixrealloop):
-            // agents using --jsonl cannot infer total from match lines alone.
-            if truncated {
+            // Trailer when --max-results capped the stream, or when skipped/
+            // refused would only appear under --json (agent --jsonl parity).
+            let need_summary = truncated
+                || skipped.as_ref().is_some_and(|s| !s.is_empty())
+                || refused.as_ref().is_some_and(|r| !r.is_empty());
+            if need_summary {
                 out.push_str(&serde_json::to_string(&serde_json::json!({
                     "type": "summary",
+                    "ok": true,
                     "match_count": match_count,
                     "match_emitted": emitted,
                     "file_count": results.file_match_counts.len(),
-                    "truncated": true,
+                    "truncated": truncated,
+                    "skipped": skipped,
+                    "refused": refused,
                 }))?);
                 out.push('\n');
             }

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -243,7 +243,19 @@ pub(super) fn render_issues(
         };
         global.emit_json(&output)?;
     } else if global.jsonl {
+        // Stream issues, then dirty summary so agents that only parse stdout
+        // still see error_kind / skipped / refused (parity with --json).
         global.emit_json_items(issues)?;
+        let dirty = !issues.is_empty();
+        global.emit_json(&serde_json::json!({
+            "type": "summary",
+            "ok": !dirty,
+            "issue_count": issues.len(),
+            "status": if dirty { Some("changes_detected") } else { None::<&str> },
+            "error_kind": if dirty { Some("changes_detected") } else { None::<&str> },
+            "skipped": skipped,
+            "refused": refused,
+        }))?;
     } else {
         for issue in issues {
             if let Some(line) = issue.line {

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -554,11 +554,37 @@ fn test_ast_search_no_match_exits_3() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("lib.rs");
     fs::write(&f, "fn foo() {}\n").unwrap();
-    // Query for class_declaration which does not exist in Rust
+    // Valid Rust S-expression that simply finds nothing (no structs in file).
+    // Invalid node types for the language are parse_error exit 4, not no_matches.
     patchloom_in(dir.path())
-        .args(["ast", "search", "(class_declaration) @cls", "lib.rs"])
+        .args(["ast", "search", "(struct_item) @s", "lib.rs"])
         .assert()
         .code(3);
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_search_invalid_query_exits_4() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, "fn foo() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args([
+            "--json",
+            "ast",
+            "search",
+            "(class_declaration) @cls",
+            "lib.rs",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "invalid S-expression must be parse_error"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["error_kind"], "parse_error", "{json}");
 }
 
 #[test]

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -663,18 +663,27 @@ fn test_md_lint_agents_jsonl_output() {
     assert_eq!(output.status.code(), Some(2));
     let stdout = String::from_utf8(output.stdout).unwrap();
     let lines: Vec<&str> = stdout.trim().lines().collect();
-    assert!(!lines.is_empty());
-    // Each line must be valid JSON with an "issue" string field
+    assert!(lines.len() >= 2, "issues + summary: {lines:?}");
+    let mut saw_issue = false;
+    let mut saw_summary = false;
     for line in &lines {
         let parsed: serde_json::Value = serde_json::from_str(line).unwrap();
-        let issue_val = parsed
-            .get("issue")
-            .expect("issue field missing in JSONL line");
-        assert!(
-            issue_val.is_string(),
-            "issue field should be a string: {issue_val}"
-        );
+        if parsed.get("type").and_then(|t| t.as_str()) == Some("summary") {
+            saw_summary = true;
+            assert_eq!(parsed["ok"], false, "{parsed}");
+            assert_eq!(parsed["error_kind"], "changes_detected", "{parsed}");
+        } else {
+            saw_issue = true;
+            let issue_val = parsed
+                .get("issue")
+                .expect("issue field missing in JSONL line");
+            assert!(
+                issue_val.is_string(),
+                "issue field should be a string: {issue_val}"
+            );
+        }
     }
+    assert!(saw_issue && saw_summary, "need issues + dirty summary");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1494,6 +1494,50 @@ fn test_search_files_from_missing_reported_in_json() {
     );
 }
 
+/// --jsonl with hits + missing co-path must trailer skipped (parity with --json).
+#[test]
+fn test_search_jsonl_partial_files_from_emits_skipped_summary() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hello world\n").unwrap();
+    let list = dir.path().join("list.txt");
+    fs::write(&list, "a.txt\nmissing.txt\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--jsonl", "--quiet", "--cwd"])
+        .arg(dir.path())
+        .args(["--files-from", "list.txt", "search", "hello"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    let summary = lines
+        .iter()
+        .rev()
+        .find_map(|l| {
+            let v: serde_json::Value = serde_json::from_str(l).ok()?;
+            if v.get("type").and_then(|t| t.as_str()) == Some("summary") {
+                Some(v)
+            } else {
+                None
+            }
+        })
+        .expect("jsonl search with skipped must emit type=summary trailer");
+    let skipped = summary["skipped"]
+        .as_array()
+        .expect("summary.skipped array");
+    assert!(
+        skipped.iter().any(|s| s.as_str() == Some("missing.txt")),
+        "expected missing.txt in summary.skipped: {summary}"
+    );
+}
+
 /// --max-results caps the matches array while match_count stays full.
 /// Agents need truncated=true so they do not treat matches as complete.
 #[test]

--- a/tests/integration/tidy_tests.rs
+++ b/tests/integration/tidy_tests.rs
@@ -95,13 +95,24 @@ fn test_tidy_check_jsonl_output() {
         .collect();
 
     assert!(
-        lines.len() >= 2,
-        "should have at least one JSONL line per issue"
+        lines.len() >= 3,
+        "expect issue lines + dirty summary trailer, got {lines:?}"
     );
+    let mut saw_issue = false;
+    let mut saw_summary = false;
     for line in &lines {
-        assert!(line["path"].is_string());
-        assert!(line["issue"].is_string());
+        if line.get("type").and_then(|t| t.as_str()) == Some("summary") {
+            saw_summary = true;
+            assert_eq!(line["ok"], false, "{line}");
+            assert_eq!(line["error_kind"], "changes_detected", "{line}");
+        } else {
+            saw_issue = true;
+            assert!(line["path"].is_string());
+            assert!(line["issue"].is_string());
+        }
     }
+    assert!(saw_issue, "expected issue lines");
+    assert!(saw_summary, "expected type=summary dirty trailer");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixloop R10: JSONL trailers and AST empty-scan / query honesty.

- **tidy check / md lint-agents --jsonl**: `type:summary` with `ok` / `error_kind: changes_detected`
- **search --jsonl**: summary includes `skipped` / `refused` when co-paths miss
- **AST validate**: unreadable co-paths → `invalid_input` (CLI + MCP)
- **AST search**: invalid S-expression → `parse_error` exit 4 (not soft no_matches)
- **AST impact**: unreadable-masked empty → `invalid_input`

## Test plan

- [x] `make check-fast`
- [x] Integration: tidy/md lint jsonl summary, search jsonl skipped trailer, AST invalid query exit 4