### PR TITLE
fix: agent honesty for patch, search, md, AST, tx (R11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-3900%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-4000%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -497,7 +497,7 @@ flowchart LR
 
 ## Status
 
-3900+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+4000+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/ast/symbol_extract.rs
+++ b/src/ast/symbol_extract.rs
@@ -111,7 +111,25 @@ fn extract_rust(node: tree_sitter_lib::Node, source: &str) -> Option<(SymbolKind
     match node.kind() {
         "function_item" => {
             let name = child_text_by_kind(node, "identifier", source)?;
-            Some((SymbolKind::Function, name.to_string()))
+            // Methods live inside impl blocks; free functions stay Function.
+            // Agents filter with --kind method (Python/TS parity).
+            let kind = {
+                let mut ancestor = node.parent();
+                let mut is_method = false;
+                while let Some(a) = ancestor {
+                    if a.kind() == "impl_item" {
+                        is_method = true;
+                        break;
+                    }
+                    ancestor = a.parent();
+                }
+                if is_method {
+                    SymbolKind::Method
+                } else {
+                    SymbolKind::Function
+                }
+            };
+            Some((kind, name.to_string()))
         }
         "struct_item" => {
             let name = child_text_by_kind(node, "type_identifier", source)?;

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -433,7 +433,7 @@ pub fn parse_kind_filter(kind_arg: &Option<String>) -> anyhow::Result<Vec<Symbol
             if !unknown.is_empty() {
                 return Err(crate::exit::InvalidInputError {
                     msg: format!(
-                        "unknown symbol kind(s): {}. Use function, method, class, struct, enum, interface, trait, type, const, variable, field, module, or property",
+                        "unknown symbol kind(s): {}. Use function, method, class, struct, enum, interface, trait, type, const, impl, or module",
                         unknown.join(", ")
                     ),
                 }
@@ -444,7 +444,8 @@ pub fn parse_kind_filter(kind_arg: &Option<String>) -> anyhow::Result<Vec<Symbol
     }
 }
 
-/// Filter symbols by kind. Returns all symbols if filter is empty.
+/// Filter symbols by kind (includes nested children, e.g. methods under impl/class).
+/// Returns all top-level symbols if filter is empty.
 pub fn filter_symbols<'a>(
     symbols: &'a [SymbolDef],
     kind_filter: &[SymbolKind],
@@ -452,10 +453,24 @@ pub fn filter_symbols<'a>(
     if kind_filter.is_empty() {
         return symbols.iter().collect();
     }
-    symbols
-        .iter()
-        .filter(|s| kind_filter.contains(&s.kind))
-        .collect()
+    let mut out = Vec::new();
+    filter_symbols_recursive(symbols, kind_filter, &mut out);
+    out
+}
+
+fn filter_symbols_recursive<'a>(
+    symbols: &'a [SymbolDef],
+    kind_filter: &[SymbolKind],
+    out: &mut Vec<&'a SymbolDef>,
+) {
+    for s in symbols {
+        if kind_filter.contains(&s.kind) {
+            out.push(s);
+        }
+        if !s.children.is_empty() {
+            filter_symbols_recursive(&s.children, kind_filter, out);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/ast/symbols/tests.rs
+++ b/src/ast/symbols/tests.rs
@@ -78,11 +78,12 @@ impl Foo {
     let names: Vec<&str> = symbols.iter().map(|s| s.name.as_str()).collect();
     assert!(names.contains(&"Foo"));
     assert!(names.contains(&"bar"));
-    // impl Foo should contain baz as a child
+    // impl Foo should contain baz as a child (Method, not free Function)
     let impl_sym = symbols.iter().find(|s| s.kind == SymbolKind::Impl).unwrap();
     assert_eq!(impl_sym.name, "Foo");
     assert_eq!(impl_sym.children.len(), 1);
     assert_eq!(impl_sym.children[0].name, "baz");
+    assert_eq!(impl_sym.children[0].kind, SymbolKind::Method);
 }
 
 #[test]
@@ -292,6 +293,28 @@ fn symbol_kind_from_str() {
     );
     assert_eq!(SymbolKind::from_str_loose("CONST"), Some(SymbolKind::Const));
     assert_eq!(SymbolKind::from_str_loose("unknown"), None);
+    // Dead aliases must not appear in parse_kind_filter help.
+    assert_eq!(SymbolKind::from_str_loose("variable"), None);
+    assert_eq!(SymbolKind::from_str_loose("field"), None);
+    assert_eq!(SymbolKind::from_str_loose("property"), None);
+}
+
+#[test]
+fn filter_symbols_includes_nested_methods() {
+    let source = r#"
+struct Foo;
+impl Foo {
+    fn bar(&self) {}
+    fn baz(&self) {}
+}
+"#;
+    let symbols = extract_symbols(source, Language::Rust);
+    let methods = filter_symbols(&symbols, &[SymbolKind::Method]);
+    let names: Vec<&str> = methods.iter().map(|s| s.name.as_str()).collect();
+    assert!(
+        names.contains(&"bar") && names.contains(&"baz"),
+        "nested methods must match --kind method, got {names:?}"
+    );
 }
 
 #[test]

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -176,6 +176,19 @@ pub(super) fn run_read(args: ReadArgs, global: &GlobalFlags) -> anyhow::Result<u
         args.path,
         args.symbol
     );
+    // Unsupported language is invalid_input (list/validate parity), not
+    // "symbol not found" which sends agents hunting alternate spellings.
+    if !lang.has_grammar() {
+        let msg = format!(
+            "Unsupported language: {} (detected from {}). \
+             Supported: Rust, Python, TypeScript, JavaScript, Go, Java, \
+             C#, Ruby, PHP, Swift, Kotlin, C, C++, HCL, XML, Protobuf, \
+             TOML, YAML, JSON, Shell.",
+            lang, args.path,
+        );
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+        return Ok(exit::FAILURE);
+    }
     let all_symbols = symbols::extract_symbols(&source, lang);
     let sym = match symbols::find_symbol(&all_symbols, &args.symbol) {
         Some(s) => s,
@@ -261,6 +274,24 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
     let mut all_valid = true;
     crate::verbose!("ast validate: checking {} files", paths.len());
 
+    // Preflight grammar paths: any binary/unreadable co-path fails closed.
+    // Soft-dropping mid-walk would report partial trees as validated OK.
+    for path in &paths {
+        let lang = resolve_lang(lang_hint, path);
+        if !lang.has_grammar() {
+            continue;
+        }
+        let display = display_path(path, &cwd);
+        if let Err(e) = crate::files::load_text_strict(path, &display)
+            && crate::exit::is_load_text_strict_fail(&e)
+        {
+            let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+            let msg = crate::exit::agent_error_message(&e);
+            global.emit_error_json_kind(Some(kind), &msg)?;
+            return Ok(exit::FAILURE);
+        }
+    }
+
     struct ValidateFileResult {
         display: String,
         result: crate::ast::validate::ValidationResult,
@@ -274,8 +305,6 @@ pub(super) fn run_validate(args: ValidateArgs, global: &GlobalFlags) -> anyhow::
             if !lang.has_grammar() {
                 return None;
             }
-            // Do not soft-drop load failures (.ok()?): binary / unreadable
-            // would become invisible "validated OK" on partial trees.
             let result = crate::ast::validate::validate_file(path, Some(lang)).ok()?;
             let display = display_path(path, &cwd);
             Some(ValidateFileResult { display, result })
@@ -377,14 +406,21 @@ pub(super) fn run_search(args: SearchArgs, global: &GlobalFlags) -> anyhow::Resu
         matches: Vec<crate::ast::search::SearchMatch>,
     }
 
-    // Fail closed on invalid S-expression before the walk soft-drops ParseError.
-    if !args.pattern
-        && let Some(sample) = paths
-            .iter()
-            .find(|p| resolve_lang(lang_hint, p).has_grammar())
+    // Fail closed on invalid S-expression / pattern compile before the walk
+    // soft-drops ParseError into no_matches.
+    if let Some(sample) = paths
+        .iter()
+        .find(|p| resolve_lang(lang_hint, p).has_grammar())
     {
         let lang = resolve_lang(lang_hint, sample);
-        if let Err(e) = crate::ast::search::search_file(sample, &args.query, Some(lang), Some(1))
+        if args.pattern {
+            if let Err(e) = crate::ast::search::compile_pattern_query(&args.query, lang) {
+                let msg = crate::exit::agent_error_message(&e);
+                global.emit_error_json_kind(Some("parse_error"), &msg)?;
+                return Ok(exit::PARSE_ERROR);
+            }
+        } else if let Err(e) =
+            crate::ast::search::search_file(sample, &args.query, Some(lang), Some(1))
             && crate::exit::is_parse_error(&e)
         {
             let msg = crate::exit::agent_error_message(&e);
@@ -570,9 +606,18 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
     let paths = resolve_target_paths(&target, &args.path, global)?;
     crate::verbose!("ast deps: scanning {} files", paths.len());
 
+    if let Err(err) = super::common::reject_sole_explicit_non_text(&paths, &args.path) {
+        let kind = crate::fallback::error_kind_str(&err).unwrap_or("invalid_input");
+        let msg = crate::exit::agent_error_message(&err);
+        global.emit_error_json_kind(Some(kind), &msg)?;
+        return Ok(exit::FAILURE);
+    }
+
     let mut any_output = false;
     let structured = global.json || global.jsonl;
     let mut structured_items: Vec<serde_json::Value> = Vec::new();
+    // Reverse deps scan cwd; empty-mask must use that scan set, not only `paths`.
+    let mut reverse_scan_files: Option<Vec<std::path::PathBuf>> = None;
 
     if args.reverse {
         // For reverse deps, scan all files and find which ones import
@@ -586,6 +631,7 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
         // Scan from the project root (cwd), not just the target's parent
         // directory, to find importers anywhere in the project.
         let all_files = collect_source_files(&cwd, global)?;
+        reverse_scan_files = Some(all_files.clone());
 
         struct ReverseHit {
             display: String,
@@ -674,7 +720,8 @@ pub(super) fn run_deps(args: DepsArgs, global: &GlobalFlags) -> anyhow::Result<u
         }
         Ok(exit::SUCCESS)
     } else {
-        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+        let mask_paths = reverse_scan_files.as_deref().unwrap_or(&paths);
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(mask_paths, &cwd) {
             global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
             return Ok(exit::FAILURE);
         }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -44,7 +44,15 @@ pub(super) fn handle_ast_list(
                 None,
             ));
         }
-        let symbols = crate::ast::symbols::extract_symbols_from_file(&target, Some(lang));
+        // Strict sole-path load (CLI list parity): binary/utf8 must not soft-empty.
+        let source = crate::files::load_text_strict(&target, &p.path).map_err(|e| {
+            if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
+                McpError::invalid_params(e.to_string(), None)
+            } else {
+                McpError::internal_error(e.to_string(), None)
+            }
+        })?;
+        let symbols = crate::ast::symbols::extract_symbols(&source, lang);
         let filtered = crate::cmd::ast::filter_symbols(&symbols, &kind_filter);
         if !filtered.is_empty() {
             for sym in &filtered {
@@ -75,6 +83,12 @@ pub(super) fn handle_ast_list(
         });
         for r in par_results {
             results.extend(r.entries);
+        }
+        // All-unreadable dirs must not soft-empty as "No symbols found".
+        if results.is_empty()
+            && let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd)
+        {
+            return Err(McpError::invalid_params(err.msg, None));
         }
     } else {
         return Err(McpError::invalid_params(
@@ -111,6 +125,18 @@ pub(super) fn handle_ast_read(
             McpError::internal_error(e.to_string(), None)
         }
     })?;
+    if !lang.has_grammar() {
+        return Err(McpError::invalid_params(
+            format!(
+                "Unsupported language: {} (detected from {}). \
+                 Supported: Rust, Python, TypeScript, JavaScript, Go, Java, \
+                 C#, Ruby, PHP, Swift, Kotlin, C, C++, HCL, XML, Protobuf, \
+                 TOML, YAML, JSON, Shell.",
+                lang, p.path,
+            ),
+            None,
+        ));
+    }
     let all_symbols = crate::ast::symbols::extract_symbols(&source, lang);
     let sym = crate::ast::symbols::find_symbol(&all_symbols, &p.symbol).ok_or_else(|| {
         McpError::invalid_params(
@@ -158,6 +184,16 @@ pub(super) fn handle_ast_rename(
 
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+    // Sole explicit non-text: fail closed (CLI rename parity), not soft empty.
+    if paths.len() == 1 {
+        let sole = &paths[0];
+        if let Err(e) = crate::files::load_text_strict(sole, &p.path)
+            && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
+        {
+            return Err(McpError::invalid_params(e.to_string(), None));
+        }
+    }
 
     // Pre-filter to files with matches (parallel, same as CLI ast rename),
     // build one AstRename op per file, then tx engine for backup/rollback (#1100).
@@ -274,6 +310,21 @@ pub(super) fn handle_ast_validate(
         }
     }
 
+    // Preflight grammar paths: any binary/unreadable co-path fails closed
+    // (CLI validate parity; soft-drop would claim partial trees validated OK).
+    for path in &paths {
+        let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
+        if !lang.has_grammar() {
+            continue;
+        }
+        let display = crate::cmd::ast::display_path(path, &cwd);
+        if let Err(e) = crate::files::load_text_strict(path, &display)
+            && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
+        {
+            return Err(McpError::invalid_params(e.to_string(), None));
+        }
+    }
+
     let results: Vec<serde_json::Value> = crate::par_process_files(&paths, None, &[], |path| {
         let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(path));
         if !lang.has_grammar() {
@@ -327,17 +378,27 @@ pub(super) fn handle_ast_search(
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
+    // Sole explicit non-text: fail closed (CLI search parity).
+    if paths.len() == 1 {
+        let sole = &paths[0];
+        if let Err(e) = crate::files::load_text_strict(sole, &p.path)
+            && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
+        {
+            return Err(McpError::invalid_params(e.to_string(), None));
+        }
+    }
+
     struct SearchFileResult {
         entries: Vec<serde_json::Value>,
     }
-    // Pre-validate pattern query compilation before entering the parallel loop.
-    // Without this, compile_pattern_query errors are silently swallowed via .ok()?,
-    // causing "No matches found" instead of a useful error message.
+    // Pre-validate pattern / S-expression before the walk soft-drops ParseError
+    // into "No matches found".
     let precompiled_query = if p.pattern {
         let validation_lang = lang_hint.unwrap_or_else(|| {
             paths
-                .first()
-                .map(|p| crate::ast::Language::from_path(p))
+                .iter()
+                .find(|path| crate::ast::Language::from_path(path).has_grammar())
+                .map(|path| crate::ast::Language::from_path(path))
                 .unwrap_or(crate::ast::Language::Rust)
         });
         Some(
@@ -346,6 +407,21 @@ pub(super) fn handle_ast_search(
             })?,
         )
     } else {
+        if let Some(sample) = paths.iter().find(|path| {
+            lang_hint
+                .unwrap_or_else(|| crate::ast::Language::from_path(path))
+                .has_grammar()
+        }) {
+            let lang = lang_hint.unwrap_or_else(|| crate::ast::Language::from_path(sample));
+            if let Err(e) = crate::ast::search::search_file(sample, &p.query, Some(lang), Some(1))
+                && crate::exit::is_parse_error(&e)
+            {
+                return Err(McpError::invalid_params(
+                    crate::exit::agent_error_message(&e),
+                    None,
+                ));
+            }
+        }
         None
     };
 
@@ -383,6 +459,9 @@ pub(super) fn handle_ast_search(
         par_results.into_iter().flat_map(|r| r.entries).collect();
 
     if all_matches.is_empty() {
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            return Err(McpError::invalid_params(err.msg, None));
+        }
         return no_results("No matches found.");
     }
     let json = serde_json::to_string_pretty(&all_matches)

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -413,7 +413,8 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             };
             let (_new, removed) = dedupe_headings_in(&original);
 
-            // Human / JSONL: one line (or item) per removed heading.
+            // Human: one line per removed heading. JSONL streams headings then
+            // a type:summary trailer with applied/backup (tidy/replace parity).
             // --json uses a single object with applied (see finalize below).
             if !removed.is_empty() {
                 if global.jsonl {
@@ -445,6 +446,22 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 #[serde(skip_serializing_if = "Option::is_none")]
                 diff: Option<String>,
             }
+            let emit_dedupe_jsonl_summary = |g: &GlobalFlags,
+                                             applied: Option<bool>,
+                                             backup: Option<String>,
+                                             diff: Option<String>|
+             -> anyhow::Result<()> {
+                g.emit_json(&serde_json::json!({
+                    "type": "summary",
+                    "ok": true,
+                    "path": path_for_json.clone(),
+                    "removed": removed_for_json.clone(),
+                    "applied": applied,
+                    "backup_session": backup,
+                    "diff": diff,
+                }))?;
+                Ok(())
+            };
             finalize_report(
                 global,
                 &cwd,
@@ -461,6 +478,8 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                                 backup_session: None,
                                 diff: None,
                             })?;
+                        } else if g.jsonl {
+                            emit_dedupe_jsonl_summary(g, Some(false), None, None)?;
                         }
                         let _ = has;
                         Ok(())
@@ -476,9 +495,11 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                                 path: path_for_json.clone(),
                                 removed: removed_for_json.clone(),
                                 applied: Some(has),
-                                backup_session: backup,
-                                diff: plain,
+                                backup_session: backup.clone(),
+                                diff: plain.clone(),
                             })?;
+                        } else if g.jsonl {
+                            emit_dedupe_jsonl_summary(g, Some(has), backup, plain)?;
                         }
                         Ok(())
                     },
@@ -493,9 +514,11 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                                 removed: removed_for_json.clone(),
                                 applied: Some(false),
                                 backup_session: None,
-                                diff: plain,
+                                diff: plain.clone(),
                             })?;
-                        } else if !diffs.is_empty() && !g.jsonl && !g.quiet {
+                        } else if g.jsonl {
+                            emit_dedupe_jsonl_summary(g, Some(false), None, plain)?;
+                        } else if !diffs.is_empty() && !g.quiet {
                             let dr = crate::diff::DiffResult {
                                 diffs: diffs.to_vec(),
                             };

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -1,3 +1,9 @@
+//! Unified-diff check/apply/merge CLI surface.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). One module owns
+//! patch check/apply/merge modes, agent JSON/JSONL honesty, and exit/kind
+//! mapping for multi-file results; do not split for LOC alone.
+
 use crate::cli::global::GlobalFlags;
 use crate::diff::{DiffResult, format_diff_result_colored};
 use crate::exit;
@@ -299,9 +305,11 @@ fn emit_error(global: &GlobalFlags, error: &str, error_kind: &str) -> anyhow::Re
     Ok(())
 }
 
-/// Top-level error_kind for multi-file patch JSON when `ok` is false.
-/// Matches CLI exit codes agents already branch on (stale → exit 5 / ambiguous).
-fn patch_problem_error_kind(results: &[PatchFileResult]) -> (&'static str, String) {
+/// Top-level `error_kind`, message, and exit code for multi-file patch when `ok` is false.
+///
+/// Exit codes match the shared agent table (`classify_typed_error`):
+/// conflicts → 8, ambiguous/stale → 5, not_found/invalid_input → 1.
+fn patch_problem_kind(results: &[PatchFileResult]) -> (&'static str, String, u8) {
     let has_stale = results.iter().any(|r| r.status == "stale");
     let has_missing = results.iter().any(|r| r.status == "missing");
     let has_error = results.iter().any(|r| r.status == "error");
@@ -310,21 +318,32 @@ fn patch_problem_error_kind(results: &[PatchFileResult]) -> (&'static str, Strin
         (
             "conflicts",
             "one or more patch targets have merge conflicts".into(),
+            exit::CONFLICTS,
         )
     } else if has_stale {
         (
             "ambiguous",
             "one or more patch targets are stale (context no longer matches)".into(),
+            exit::AMBIGUOUS,
         )
     } else if has_missing && !has_error {
-        ("not_found", "one or more patch targets are missing".into())
+        (
+            "not_found",
+            "one or more patch targets are missing".into(),
+            exit::FAILURE,
+        )
     } else if has_error {
         (
             "invalid_input",
             "one or more patch targets could not be read".into(),
+            exit::FAILURE,
         )
     } else {
-        ("ambiguous", "one or more patch targets failed".into())
+        (
+            "ambiguous",
+            "one or more patch targets failed".into(),
+            exit::AMBIGUOUS,
+        )
     }
 }
 
@@ -335,24 +354,35 @@ fn emit_patch_files_output(
     applied: Option<bool>,
     backup_session: Option<String>,
 ) -> anyhow::Result<()> {
+    let (error_kind, error) = if ok {
+        (None, None)
+    } else {
+        let (k, e, _) = patch_problem_kind(results);
+        (Some(k), Some(e))
+    };
     if global.json {
-        let (error_kind, error) = if ok {
-            (None, None)
-        } else {
-            let (k, e) = patch_problem_error_kind(results);
-            (Some(k), Some(e))
-        };
         let output = PatchFilesOutput {
             ok,
             files: results.to_vec(),
             error_kind,
-            error,
+            error: error.clone(),
             applied,
-            backup_session,
+            backup_session: backup_session.clone(),
         };
         global.emit_json(&output)?;
     } else if global.jsonl {
+        // Stream per-file rows, then a summary trailer (replace/tidy/search parity)
+        // so agents get ok / error_kind / applied without scraping exit alone.
         global.emit_json_items(results)?;
+        global.emit_json(&serde_json::json!({
+            "type": "summary",
+            "ok": ok,
+            "error_kind": error_kind,
+            "error": error,
+            "applied": applied,
+            "backup_session": backup_session,
+            "file_count": results.len(),
+        }))?;
     } else if !global.quiet {
         for r in results {
             let label = match r.status {
@@ -571,8 +601,9 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 .count();
             println!("{n} file(s) would change");
         }
+        // Exit must match JSON error_kind (not_found/invalid_input → 1, not 5).
         return Ok(if any_problem {
-            exit::AMBIGUOUS
+            patch_problem_kind(&results).2
         } else if any_would_change {
             exit::CHANGES_DETECTED
         } else {
@@ -645,8 +676,20 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let has_conflicts = results.iter().any(|r| r.status == "conflict");
         // Identity / already-applied (content == original): exit 0 so agents
         // do not loop on exit 2 forever (parity with patch check).
+        // Errors use shared kind→exit (invalid_input → 1), not always ambiguous.
+        // When --allow-conflicts, derive kind from non-conflict rows so a
+        // read/stale error is not masked as conflicts (exit 8).
         return Ok(if has_errors {
-            exit::AMBIGUOUS
+            if apply_options.allow_conflicts {
+                let non_conflict: Vec<PatchFileResult> = results
+                    .iter()
+                    .filter(|r| r.status != "conflict")
+                    .cloned()
+                    .collect();
+                patch_problem_kind(&non_conflict).2
+            } else {
+                patch_problem_kind(&results).2
+            }
         } else if has_conflicts && !apply_options.allow_conflicts {
             exit::CONFLICTS
         } else if any_would_change {
@@ -672,17 +715,13 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 // The engine error from apply_patch_with_loader already includes
                 // "patch apply: <path> -- <detail>", so we add the STALE/MERGE
                 // FAILED label to match the original CLI format.
-                // Prefer typed kinds. Sole-path binary / invalid UTF-8 from
-                // load_text_strict must stay invalid_input (exit 1), not get
-                // STALE/ambiguous labels (fixrealloop 2026-07-21).
+                // Prefer shared classify_typed_error so missing targets peel
+                // not_found (exit 1), not STALE/ambiguous (exit 5). Tx already
+                // does this; sole-path binary/utf8 stay typed (fixrealloop).
                 let (exit_code, kind) = if exit::is_conflicts(&e) || msg.contains("conflict(s)") {
                     (exit::CONFLICTS, "conflicts")
-                } else if exit::is_binary(&e) {
-                    (exit::FAILURE, "binary")
-                } else if exit::is_invalid_encoding(&e) {
-                    (exit::FAILURE, "invalid_encoding")
-                } else if exit::is_invalid_input(&e) {
-                    (exit::FAILURE, "invalid_input")
+                } else if let Some((k, c)) = exit::classify_typed_error(&e) {
+                    (c, k)
                 } else {
                     // Ambiguous / stale context and remaining untyped errors.
                     (exit::AMBIGUOUS, "ambiguous")

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -533,6 +533,21 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         // actual==0 with unreadable paths must not count as a clean match
         // (assert-count 0 would otherwise pass while the scan was masked).
         if actual == 0 {
+            // All targets missing must fail closed (same as normal no-match path).
+            // assert-count 0 on a typo path must not report success / "no TODOs".
+            let all_missing = if let Some(ref files) = files_from_list {
+                crate::files::all_explicit_paths_missing(files, Some(&cwd))
+            } else {
+                crate::files::all_scan_targets_missing(global, &args.paths, Some(&cwd))?
+            };
+            if all_missing {
+                let msg = format!(
+                    "no such file or directory: {}",
+                    global.path_scope_description(&args.paths)
+                );
+                global.emit_error_json_kind(Some("not_found"), &msg)?;
+                return Ok(exit::FAILURE);
+            }
             if let Some(err) = crate::ops::file::sole_explicit_non_text_for_scan(
                 &args.paths,
                 files_from_list.as_deref(),

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -446,6 +446,7 @@ pub fn error_kind_implies_not_applied(kind: &str) -> bool {
             | "conflicts"
             | "parse_error"
             | "changes_detected"
+            | "fuzzy_span_suspicious"
     )
 }
 
@@ -704,6 +705,7 @@ mod tests {
         assert!(error_kind_implies_not_applied("guard_rejected"));
         assert!(error_kind_implies_not_applied("binary"));
         assert!(error_kind_implies_not_applied("invalid_encoding"));
+        assert!(error_kind_implies_not_applied("fuzzy_span_suspicious"));
         assert!(!error_kind_implies_not_applied("format_failed"));
     }
 

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -92,9 +92,22 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
                 }
                 let mut total = 0usize;
                 for file_path in &files {
-                    let count = ast_rename_single_file(tx, file_path, old, new, lang.as_deref());
-                    if let Ok(n) = count {
-                        total += n;
+                    // Expanded paths must pass PathGuard (MCP list/rename do;
+                    // plan/tx must not skip expanded children).
+                    if let Some(g) = tx.guard {
+                        let rel = file_path
+                            .strip_prefix(tx.cwd)
+                            .unwrap_or(file_path.as_path())
+                            .to_string_lossy();
+                        g.check_path(rel.as_ref())
+                            .map_err(crate::fallback::EditError::guard_rejected)?;
+                    }
+                    match ast_rename_single_file(tx, file_path, old, new, lang.as_deref()) {
+                        Ok(n) => total = total.saturating_add(n),
+                        // Soft miss in one file does not abort the directory walk.
+                        Err(e) if crate::exit::is_no_match(&e) => {}
+                        // Hard failures (binary, guard, IO) must not soft-succeed.
+                        Err(e) => return Err(e),
                     }
                 }
                 if total == 0 {

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -804,6 +804,14 @@ pub(crate) fn execute_and_collect(
                         .with_backup_session(backup)
                         .into());
                 }
+                // Re-emit EditError so guard_rejected / fuzzy_span_suspicious
+                // keep structured kinds after the op wrapper (not operation_failed).
+                if let Some(edit) = e.chain().find_map(|c| {
+                    c.downcast_ref::<crate::fallback::EditError>()
+                        .map(|ed| ed.kind)
+                }) {
+                    return Err(crate::fallback::EditError::new(edit, msg).into());
+                }
                 anyhow::bail!("{msg}");
             }
         }

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -381,7 +381,7 @@ pub(crate) fn compare_snapshots(
                 return VerifyResult {
                     passed: false,
                     message: format!(
-                        "verify: unknown symbol kind '{kind}' (use function, method, class, struct, enum, interface, trait, type, const, variable, field, module, or property)"
+                        "verify: unknown symbol kind '{kind}' (use function, method, class, struct, enum, interface, trait, type, const, impl, or module)"
                     ),
                 };
             }

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -587,6 +587,103 @@ fn test_ast_search_invalid_query_exits_4() {
     assert_eq!(json["error_kind"], "parse_error", "{json}");
 }
 
+/// Pattern mode must fail closed on compile errors (not soft no_matches).
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_search_invalid_pattern_exits_4() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, "fn foo() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args([
+            "--json",
+            "ast",
+            "search",
+            "--pattern",
+            "!!!not a valid pattern!!!",
+            "lib.rs",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(4),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["error_kind"], "parse_error", "{json}");
+}
+
+/// Unsupported language on read is invalid_input, not symbol no_matches.
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_read_unsupported_language_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("data.csv");
+    fs::write(&f, "a,b,c\n1,2,3\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["--json", "ast", "read", "data.csv", "SomeName"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input", "{json}");
+}
+
+/// Nested methods must match --kind method (not only top-level symbols).
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_list_kind_method_includes_impl_methods() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, "struct Foo;\nimpl Foo {\n    fn bar(&self) {}\n}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["--json", "ast", "list", "lib.rs", "--kind", "method"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains("bar"),
+        "expected nested method in list output: {text}"
+    );
+}
+
+/// Unknown kind help must not advertise dead aliases (variable/field/property).
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_list_unknown_kind_help_matches_allowlist() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, "fn foo() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["--json", "ast", "list", "lib.rs", "--kind", "variable"])
+        .output()
+        .unwrap();
+    assert_eq!(out.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(json["error_kind"], "invalid_input", "{json}");
+    let err = json["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("impl") && !err.contains("variable, field"),
+        "help must list real kinds only: {err}"
+    );
+}
+
 #[test]
 #[cfg(feature = "ast")]
 fn test_ast_refs_no_references_exits_3() {

--- a/tests/integration/md_tests.rs
+++ b/tests/integration/md_tests.rs
@@ -420,11 +420,25 @@ fn test_md_dedupe_headings_jsonl_output() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
-    assert_eq!(lines.len(), 1);
-    let json: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    // Removed heading string(s) + type:summary trailer with applied/backup.
+    assert!(
+        lines.len() >= 2,
+        "expected heading line(s) + summary, got {lines:?}"
+    );
+    let heading: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
     // JSONL dedupe-headings emits one JSON string per removed heading (not an
     // object). `.as_str()` is intentional.
-    assert_eq!(json.as_str().unwrap(), "## Dup");
+    assert_eq!(heading.as_str().unwrap(), "## Dup");
+    let summary: serde_json::Value = serde_json::from_str(lines.last().unwrap()).unwrap();
+    assert_eq!(summary["type"], "summary", "{summary}");
+    assert_eq!(summary["ok"], true, "{summary}");
+    assert_eq!(summary["applied"], true, "{summary}");
+    assert!(
+        summary["backup_session"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty()),
+        "apply must expose backup_session in JSONL summary: {summary}"
+    );
 }
 
 #[test]

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -435,9 +435,23 @@ fn test_patch_check_jsonl_output() {
         .map(|l| serde_json::from_str(l).expect("each line should be valid JSON"))
         .collect();
 
-    assert_eq!(lines.len(), 1, "should have one JSONL line per patch file");
-    assert_eq!(lines[0]["path"], "test.txt");
-    assert_eq!(lines[0]["status"], "would_change");
+    // Per-file row + type:summary trailer (applied:false for check).
+    assert!(
+        lines.len() >= 2,
+        "file row + summary expected, got {lines:?}"
+    );
+    let file_row = lines
+        .iter()
+        .find(|v| v.get("path").is_some())
+        .expect("file row");
+    assert_eq!(file_row["path"], "test.txt");
+    assert_eq!(file_row["status"], "would_change");
+    let summary = lines
+        .iter()
+        .find(|v| v.get("type").and_then(|t| t.as_str()) == Some("summary"))
+        .expect("summary trailer");
+    assert_eq!(summary["ok"], true);
+    assert_eq!(summary["applied"], false);
 }
 
 #[test]
@@ -667,7 +681,7 @@ fn test_patch_apply_on_stale_merge() {
 }
 
 #[test]
-fn test_patch_check_exits_5_on_directory_read_error() {
+fn test_patch_check_exits_1_on_directory_read_error() {
     let dir = TempDir::new().unwrap();
     let target = dir.path().join("test.txt");
     fs::create_dir(&target).unwrap();
@@ -679,6 +693,7 @@ fn test_patch_check_exits_5_on_directory_read_error() {
     )
     .unwrap();
 
+    // invalid_input / exit 1 (shared table), not ambiguous/exit 5.
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("--cwd")
@@ -687,7 +702,7 @@ fn test_patch_check_exits_5_on_directory_read_error() {
         .arg("check")
         .arg(&patch_file)
         .assert()
-        .code(5)
+        .code(1)
         .stderr(predicate::str::contains(
             "patch check: test.txt -- READ ERROR: target is not a file",
         ));
@@ -717,10 +732,11 @@ fn test_patch_check_json_reports_directory_read_error() {
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(5));
+    assert_eq!(output.status.code(), Some(1));
 
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], false);
+    assert_eq!(json["error_kind"], "invalid_input");
     assert_eq!(json["files"][0]["status"], "error");
     assert!(
         json["files"][0]["error"]
@@ -756,7 +772,7 @@ fn test_patch_check_jsonl_reports_directory_read_error() {
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(5));
+    assert_eq!(output.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&output.stderr).trim().is_empty());
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -766,14 +782,101 @@ fn test_patch_check_jsonl_reports_directory_read_error() {
         .map(|l| serde_json::from_str(l).expect("each line should be valid JSON"))
         .collect();
 
-    assert_eq!(lines.len(), 1, "should have one JSONL line per patch file");
-    assert_eq!(lines[0]["path"], "test.txt");
-    assert_eq!(lines[0]["status"], "error");
+    // Per-file row + type:summary trailer with ok/error_kind.
     assert!(
-        lines[0]["error"].as_str().unwrap().contains("not a file"),
-        "error={}",
-        lines[0]["error"]
+        lines.len() >= 2,
+        "file row + summary trailer expected, got {lines:?}"
     );
+    let file_row = lines
+        .iter()
+        .find(|v| v.get("path").is_some())
+        .expect("file row");
+    assert_eq!(file_row["path"], "test.txt");
+    assert_eq!(file_row["status"], "error");
+    assert!(
+        file_row["error"].as_str().unwrap().contains("not a file"),
+        "error={}",
+        file_row["error"]
+    );
+    let summary = lines
+        .iter()
+        .find(|v| v.get("type").and_then(|t| t.as_str()) == Some("summary"))
+        .expect("summary trailer");
+    assert_eq!(summary["ok"], false);
+    assert_eq!(summary["error_kind"], "invalid_input");
+    assert_eq!(summary["applied"], false);
+}
+
+/// Missing patch target → not_found + exit 1 (not ambiguous/exit 5).
+#[test]
+fn test_patch_check_json_missing_target_not_found_exit_1() {
+    let dir = TempDir::new().unwrap();
+    let patch_file = dir.path().join("change.patch");
+    fs::write(
+        &patch_file,
+        "--- a/missing.txt\n+++ b/missing.txt\n@@ -0,0 +1 @@\n+new line\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--json")
+        .arg("patch")
+        .arg("check")
+        .arg(&patch_file)
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(json["error_kind"], "not_found", "{json}");
+    assert_eq!(json["files"][0]["status"], "missing");
+}
+
+/// Apply when target file is gone: not_found, not STALE/ambiguous.
+#[test]
+fn test_patch_apply_missing_target_json_not_found() {
+    let dir = TempDir::new().unwrap();
+    let patch_file = dir.path().join("change.patch");
+    // Existing-file hunk (not new-file create): context requires a real target.
+    fs::write(
+        &patch_file,
+        "--- a/gone.txt\n+++ b/gone.txt\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--json")
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(json["error_kind"], "not_found", "{json}");
+    assert_eq!(json["applied"], false, "{json}");
 }
 
 #[test]
@@ -857,7 +960,7 @@ fn test_patch_malformed_file_fails() {
 // multi-file patch.  The error was masked because `has_conflicts && allow_conflicts`
 // short-circuited before checking for errors.
 #[test]
-fn test_patch_merge_check_allow_conflicts_still_exits_5_on_error() {
+fn test_patch_merge_check_allow_conflicts_still_fails_on_error() {
     let dir = TempDir::new().unwrap();
     // File A: will produce a conflict (content diverged from patch context).
     let file_a = dir.path().join("a.txt");
@@ -886,7 +989,8 @@ fn test_patch_merge_check_allow_conflicts_still_exits_5_on_error() {
     )
     .unwrap();
     // With --allow-conflicts, the conflict on a.txt is acceptable, but the
-    // error on b.txt should still produce a non-zero exit code (AMBIGUOUS=5).
+    // error on b.txt still fails. Kind is invalid_input (status error), exit 1
+    // (shared agent table), not conflicts/8 and not always ambiguous/5.
     Command::cargo_bin("patchloom")
         .unwrap()
         .arg("--cwd")
@@ -897,7 +1001,7 @@ fn test_patch_merge_check_allow_conflicts_still_exits_5_on_error() {
         .arg("--check")
         .arg("--allow-conflicts")
         .assert()
-        .code(5);
+        .code(1);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -1786,6 +1786,63 @@ fn test_search_dir_all_unreadable_not_no_matches() {
     }
 }
 
+/// --assert-count 0 must not succeed when every target path is missing.
+#[test]
+fn test_search_assert_count_zero_all_missing_not_success() {
+    let dir = TempDir::new().unwrap();
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "search",
+            "TODO",
+            "totally_missing_path/",
+            "--assert-count",
+            "0",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "not_found", "{v}");
+    assert_ne!(v["ok"], true, "must not claim assert-count success: {v}");
+}
+
+/// --assert-count N>0 on all-missing must be not_found, not changes_detected.
+#[test]
+fn test_search_assert_count_nonzero_all_missing_not_found() {
+    let dir = TempDir::new().unwrap();
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args([
+            "search",
+            "TODO",
+            "totally_missing_path/",
+            "--assert-count",
+            "5",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["error_kind"], "not_found", "{v}");
+}
+
 /// --assert-count 0 must not succeed when the scan is all-unreadable.
 #[test]
 fn test_search_assert_count_zero_all_unreadable_not_success() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -4415,12 +4415,14 @@ fn test_tx_strict_mode_reverts_on_validate_failure() {
     let file = dir.path().join("test.txt");
     fs::write(&file, "original\n").unwrap();
 
+    // Relative path + --cwd (same as format-fail restore tests): absolute
+    // plan paths can desync backup restore keys on Windows.
     let plan = serde_json::json!({
-            "version": 1,
+        "version": 1,
         "strict": true,
         "operations": [{
             "op": "replace",
-            "path": file.to_str().unwrap(),
+            "path": "test.txt",
             "old": "original",
             "new": "changed"
         }],
@@ -4432,15 +4434,28 @@ fn test_tx_strict_mode_reverts_on_validate_failure() {
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
 
-    Command::cargo_bin("patchloom")
+    let output = Command::cargo_bin("patchloom")
         .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
         .arg("tx")
-        .arg(plan_file.to_str().unwrap())
+        .arg("plan.json")
         .arg("--apply")
-        .assert()
-        .code(7); // ROLLBACK
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(7), // ROLLBACK
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 
-    assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "original\n",
+        "strict validate fail must restore original content"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixloop R11: real-world agent-branching honesty after R5–R10.

- **patch**: `error_kind` and exit codes aligned (`not_found` / `invalid_input` → exit 1, not always 5); apply missing target peels `not_found`; JSONL gets `type:summary` with `ok` / `error_kind` / `applied`
- **search**: `--assert-count` fail-closed when all scan targets are missing (no false success on assert-count 0)
- **md dedupe-headings**: JSONL summary trailer with `applied` / `backup_session`
- **AST**: pattern compile → `parse_error`; nested `--kind method`; Rust impl methods tagged Method; recursive kind filter; read unsupported language; deps sole non-text; validate load preflight; MCP list/search/rename sole-binary + S-expression fail-closed; kind help allowlist
- **tx**: re-emit `EditError` after op wrap (`guard_rejected`); PathGuard on expanded `ast.rename` directory paths; `fuzzy_span_suspicious` implies `applied: false`

## Test plan

- [x] `make check-fast`
- [x] Integration: patch check/apply missing/jsonl, search assert-count missing, md dedupe jsonl, AST method/pattern/read/kind help
- [x] Unit: filter_symbols nested methods, error_kind_implies_not_applied