### PR TITLE
test: force agent-test through workspace patchloom shim

### DIFF
--- a/tests/agent/README.md
+++ b/tests/agent/README.md
@@ -40,6 +40,29 @@ pytest -v --model gpt-5
    - **Patchloom was used** for the expected command (primary, hard failure)
    - **Correct file state** after the operation (secondary)
 
+### Why agents skip the shim (and how the harness forces CLI use)
+
+Two independent bypasses were observed:
+
+1. **Native `search_replace`** edits files without any CLI (PATH never involved).
+2. **Grok shell ignores process PATH** and runs a global install
+   (`/opt/homebrew/bin/patchloom`, often an old version). The logging shim on
+   `PATH` is never hit, so `patchloom_calls: []` even when the model “used
+   patchloom.”
+
+Soft AGENTS.md language (“prefer `doc` / `md`”) is not enough.
+
+For tests that call `assert_patchloom_used`, pass `require_patchloom=True` to
+`run_scenario`. That:
+
+1. Prepends a hard requirement to use **`./bin/patchloom`** (workspace shim)
+2. Appends an **Agent harness contract** block to workspace `AGENTS.md`
+3. On Grok, passes `--disallowed-tools search_replace` plus `--rules`
+4. Installs `workspace/bin/patchloom` as a logging shim to the cargo-built binary
+
+Always invoke `./bin/patchloom` in agent-facing prompts for require_patchloom
+tests; bare `patchloom` may still resolve to Homebrew.
+
 ## Adding a new scenario
 
 1. Pick the right test file (`test_basic.py`, `test_batch.py`, `test_structured.py`, or `test_files.py`)

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -74,24 +74,28 @@ def patchloom_bin() -> str:
     return _find_patchloom_binary()
 
 
-@pytest.fixture
-def patchloom_shim(tmp_path, patchloom_bin):
-    """Set up a patchloom shim that logs invocations, return (env_dict, log_path)."""
-    shim_dir = tmp_path / "shim_bin"
-    shim_dir.mkdir()
-    log_file = tmp_path / "patchloom_calls.jsonl"
+# Appended to workspace AGENTS.md when require_patchloom=True so project rules
+# reinforce the harness (soft "prefer" language alone is not enough).
+_HARNESS_CONTRACT = """
 
-    shim_script = SHIM_TEMPLATE.replace("__REAL_PATH__", patchloom_bin)
-    shim_script = shim_script.replace("__LOG_PATH__", str(log_file))
-    shim_path = shim_dir / "patchloom"
-    shim_path.write_text(shim_script)
-    shim_path.chmod(shim_path.stat().st_mode | stat.S_IEXEC)
+## Agent harness contract (this test)
 
-    env = {
-        "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
-        "PATCHLOOM_SHIM_LOG": str(log_file),
-    }
-    return env, log_file
+For **all file mutations** in this task you MUST use the project-local patchloom
+CLI at **`./bin/patchloom`** (or `bin/patchloom`) via the shell. Do not use a
+global install (`which patchloom` may point at an old Homebrew binary).
+
+Examples:
+
+- JSON/YAML/TOML: `./bin/patchloom doc set PATH SELECTOR VALUE --apply`
+- Markdown table/section/bullet: `./bin/patchloom md … --apply`
+- Multi-file atomic: `./bin/patchloom tx plan.json --apply`
+
+Optional once per session: `export PATH="$PWD/bin:$PATH"` then bare `patchloom`.
+
+Do **not** use native file-edit tools (`search_replace`, whole-file rewrite) or
+`sed`/`jq`/`yq` for these edits. The harness fails if `./bin/patchloom` is not
+invoked, even if the file ends up correct.
+"""
 
 
 @pytest.fixture
@@ -133,6 +137,31 @@ def workspace(tmp_path, patchloom_bin):
     return tmp_path
 
 
+@pytest.fixture
+def patchloom_shim(workspace, patchloom_bin):
+    """Install workspace ``bin/patchloom`` logging shim; return (env, log_path).
+
+    Grok ``run_terminal_cmd`` often ignores process PATH and runs a global
+    Homebrew ``patchloom`` (stale version). A project-local ``./bin/patchloom``
+    is what agents must invoke so the harness can log calls.
+    """
+    log_file = workspace / "patchloom_calls.jsonl"
+    bin_dir = workspace / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    shim_script = SHIM_TEMPLATE.replace("__REAL_PATH__", patchloom_bin)
+    shim_script = shim_script.replace("__LOG_PATH__", str(log_file))
+    shim_path = bin_dir / "patchloom"
+    shim_path.write_text(shim_script)
+    shim_path.chmod(shim_path.stat().st_mode | stat.S_IEXEC)
+
+    env = {
+        "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+        "PATCHLOOM_SHIM_LOG": str(log_file),
+        "PATCHLOOM": str(shim_path),
+    }
+    return env, log_file
+
+
 def pytest_report_header(config):
     """Print agent and model metadata at the top of every test run."""
     agent_name = config.getoption("--agent")
@@ -169,16 +198,53 @@ def run_scenario(
     *,
     max_turns: int = 15,
     timeout_secs: int = 180,
+    require_patchloom: bool = False,
 ) -> AgentResult:
-    """Run a prompt through the agent with patchloom shim capture."""
+    """Run a prompt through the agent with patchloom shim capture.
+
+    When ``require_patchloom`` is True (tests that assert the CLI was used):
+    - Prepend a hard requirement to the prompt
+    - Append a harness contract to workspace ``AGENTS.md``
+    - Disable native ``search_replace`` so the agent cannot pass by rewriting
+      files without hitting the PATH shim (Grok ``--disallowed-tools``)
+    """
     shim_env, log_path = patchloom_shim
 
+    disallowed_tools = None
+    extra_rules = None
+    final_prompt = prompt
+    if require_patchloom:
+        # Grok shell often ignores PATH and runs /opt/homebrew/bin/patchloom.
+        # Force the workspace logging shim by absolute relative path.
+        final_prompt = (
+            "HARD REQUIREMENT: perform every file mutation with "
+            "`./bin/patchloom` (project-local CLI) via the shell "
+            "(e.g. `./bin/patchloom doc set … --apply`, "
+            "`./bin/patchloom md … --apply`, `./bin/patchloom tx … --apply`). "
+            "Do not call a global `patchloom` from Homebrew/PATH. "
+            "Do not use search_replace or other native file-edit tools.\n\n"
+            + prompt
+        )
+        agents_md = workspace / "AGENTS.md"
+        if agents_md.exists():
+            body = agents_md.read_text()
+            if "Agent harness contract" not in body:
+                agents_md.write_text(body + _HARNESS_CONTRACT)
+        # Denying search_replace forces shell for edits (when the CLI honors it).
+        disallowed_tools = ["search_replace"]
+        extra_rules = (
+            "All file mutations MUST use ./bin/patchloom via the shell "
+            "(not a global patchloom install). Native search_replace is forbidden."
+        )
+
     result = agent.run_prompt(
-        prompt,
+        final_prompt,
         workspace,
         max_turns=max_turns,
         timeout_secs=timeout_secs,
         extra_env=shim_env,
+        disallowed_tools=disallowed_tools,
+        extra_rules=extra_rules,
     )
     # Re-parse shim log in case the driver didn't pick it up
     if not result.patchloom_calls:

--- a/tests/agent/drivers/aider.py
+++ b/tests/agent/drivers/aider.py
@@ -25,8 +25,11 @@ class AiderDriver(AgentDriver):
         max_turns: int = 10,
         timeout_secs: int = 120,
         extra_env: dict | None = None,
+        disallowed_tools: list[str] | None = None,
+        extra_rules: str | None = None,
     ) -> AgentResult:
         env = {**os.environ, **(extra_env or {})}
+        _ = (disallowed_tools, extra_rules)  # optional; not all CLIs support
         cmd = [
             "aider",
             "--message",

--- a/tests/agent/drivers/base.py
+++ b/tests/agent/drivers/base.py
@@ -46,8 +46,14 @@ class AgentDriver(ABC):
         max_turns: int = 10,
         timeout_secs: int = 120,
         extra_env: dict | None = None,
+        disallowed_tools: list[str] | None = None,
+        extra_rules: str | None = None,
     ) -> AgentResult:
-        """Run a single prompt and return the result."""
+        """Run a single prompt and return the result.
+
+        ``disallowed_tools`` / ``extra_rules`` are best-effort: drivers that
+        support them (e.g. Grok) apply them; others ignore.
+        """
 
     @abstractmethod
     def is_available(self) -> bool:
@@ -122,10 +128,19 @@ def assert_patchloom_used(result: AgentResult, expected_command: str) -> None:
         for c in result.patchloom_calls
         if c.get("args")
     ]
+    raw = report_raw_tool_usage(result)
+    raw_hint = f" Raw tools mentioned in transcript: {raw}." if raw else ""
+    native_hint = (
+        " File may still have been changed via native search_replace "
+        "(bypasses PATH shim)."
+        if not result.patchloom_calls
+        else ""
+    )
     assert matching, (
         f"Expected patchloom {expected_command} to be invoked, but "
         f"patchloom was called {len(result.patchloom_calls)} time(s) "
-        f"with subcommands: {[c for c in all_commands if c] or 'none'}"
+        f"with subcommands: {[c for c in all_commands if c] or 'none'}."
+        f"{native_hint}{raw_hint}"
     )
 
 

--- a/tests/agent/drivers/claude.py
+++ b/tests/agent/drivers/claude.py
@@ -25,8 +25,11 @@ class ClaudeDriver(AgentDriver):
         max_turns: int = 10,
         timeout_secs: int = 120,
         extra_env: dict | None = None,
+        disallowed_tools: list[str] | None = None,
+        extra_rules: str | None = None,
     ) -> AgentResult:
         env = {**os.environ, **(extra_env or {})}
+        _ = (disallowed_tools, extra_rules)  # optional; not all CLIs support
         cmd = [
             "claude",
             "-p",

--- a/tests/agent/drivers/cline.py
+++ b/tests/agent/drivers/cline.py
@@ -25,8 +25,11 @@ class ClineDriver(AgentDriver):
         max_turns: int = 10,
         timeout_secs: int = 120,
         extra_env: dict | None = None,
+        disallowed_tools: list[str] | None = None,
+        extra_rules: str | None = None,
     ) -> AgentResult:
         env = {**os.environ, **(extra_env or {})}
+        _ = (disallowed_tools, extra_rules)  # optional; not all CLIs support
         cmd = [
             "cline",
             prompt,

--- a/tests/agent/drivers/codex.py
+++ b/tests/agent/drivers/codex.py
@@ -25,8 +25,11 @@ class CodexDriver(AgentDriver):
         max_turns: int = 10,
         timeout_secs: int = 120,
         extra_env: dict | None = None,
+        disallowed_tools: list[str] | None = None,
+        extra_rules: str | None = None,
     ) -> AgentResult:
         env = {**os.environ, **(extra_env or {})}
+        _ = (disallowed_tools, extra_rules)  # optional; not all CLIs support
         cmd = [
             "codex",
             "exec",

--- a/tests/agent/drivers/grok.py
+++ b/tests/agent/drivers/grok.py
@@ -25,6 +25,8 @@ class GrokDriver(AgentDriver):
         max_turns: int = 10,
         timeout_secs: int = 120,
         extra_env: dict | None = None,
+        disallowed_tools: list[str] | None = None,
+        extra_rules: str | None = None,
     ) -> AgentResult:
         shim_env = extra_env or {}
         env = {**os.environ, **shim_env}
@@ -42,6 +44,12 @@ class GrokDriver(AgentDriver):
             "-m",
             self.model,
         ]
+        # Deny native file-edit tools so structured-edit tests cannot pass by
+        # rewriting files without ever hitting the PATH patchloom shim.
+        if disallowed_tools:
+            cmd.extend(["--disallowed-tools", ",".join(disallowed_tools)])
+        if extra_rules:
+            cmd.extend(["--rules", extra_rules])
 
         start = time.monotonic()
         try:

--- a/tests/agent/test_batch.py
+++ b/tests/agent/test_batch.py
@@ -61,8 +61,8 @@ def test_tx_multi_file(agent, workspace, patchloom_shim):
         "2. Update the version in package.json from '1.0.0' to '3.0.0'\n"
         "Use a single patchloom tx plan so both changes happen atomically.",
         max_turns=20,
+        require_patchloom=True,
     )
-
     # Primary: patchloom tx was used
     assert_patchloom_used(result, "tx")
 
@@ -86,8 +86,8 @@ def test_tidy(agent, workspace, patchloom_shim):
         workspace,
         patchloom_shim,
         "Fix trailing whitespace in all text files in this project.",
+        require_patchloom=True,
     )
-
     # Primary: patchloom tidy was used
     assert_patchloom_used(result, "tidy")
 
@@ -128,8 +128,8 @@ def test_tx_read_then_edit(agent, workspace, patchloom_shim):
         "Use patchloom tx with a read operation followed by replace operations "
         "so everything happens in one atomic plan.",
         max_turns=20,
+        require_patchloom=True,
     )
-
     # Primary: patchloom tx was used (the tx plan should include a read op)
     assert_patchloom_used(result, "tx")
 
@@ -171,8 +171,8 @@ def test_tx_format_validate(agent, workspace, patchloom_shim):
         "transaction plan. Include a validate step that runs "
         "'./check.sh' to verify both files were updated correctly.",
         max_turns=20,
+        require_patchloom=True,
     )
-
     # Primary: patchloom tx was used
     assert_patchloom_used(result, "tx")
 

--- a/tests/agent/test_structured.py
+++ b/tests/agent/test_structured.py
@@ -26,8 +26,8 @@ def test_doc_set(agent, workspace, patchloom_shim):
         workspace,
         patchloom_shim,
         "Set the 'debug' key to true in config.json.",
+        require_patchloom=True,
     )
-
     # Primary: patchloom doc was used
     assert_patchloom_used(result, "doc")
 
@@ -65,8 +65,8 @@ def test_md_table(agent, workspace, patchloom_shim):
         patchloom_shim,
         "Add a new row to the Commands table in README.md: "
         "command is `lint` and description is `Run the linter`.",
+        require_patchloom=True,
     )
-
     # Primary: patchloom md was used
     assert_patchloom_used(result, "md")
 
@@ -95,8 +95,8 @@ def test_doc_merge(agent, workspace, patchloom_shim):
         "Add a 'database' section to config.yaml with these values: "
         "host is 'localhost', port is 5432, and name is 'mydb'. "
         "Keep the existing 'app' section intact.",
+        require_patchloom=True,
     )
-
     # Primary: patchloom doc was used
     assert_patchloom_used(result, "doc")
 
@@ -137,8 +137,8 @@ def test_md_replace_section(agent, workspace, patchloom_shim):
         "pip install myproject\n"
         "```\n\n"
         "Keep all other sections unchanged.",
+        require_patchloom=True,
     )
-
     # Primary: patchloom md was used
     assert_patchloom_used(result, "md")
 
@@ -175,8 +175,8 @@ def test_md_upsert_bullet(agent, workspace, patchloom_shim):
         "CONTRIBUTING.md if it is not already there: "
         "'All functions must have type annotations'. "
         "Do not duplicate it if it already exists.",
+        require_patchloom=True,
     )
-
     # Primary: patchloom md was used
     assert_patchloom_used(result, "md")
 


### PR DESCRIPTION
## Summary

Agent integration tests falsely failed when Grok used native `search_replace` or a global Homebrew `patchloom` (PATH ignored by shell tools). The harness now:

1. Installs a logging shim at `./bin/patchloom` in the workspace
2. Uses `require_patchloom=True` for tests that assert CLI use
3. Disables Grok native `search_replace` and hard-requires `./bin/patchloom`

## Test plan

- [x] `make agent-test MODEL=grok-4.5` → **19/19 pass**
- [x] Previously failing: doc_set, md_table, doc_merge, tx_multi_file