### PR TITLE
fix: docs honesty and batch/MCP agent recovery (MPI)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,11 +113,12 @@ src/
   cmd/read.rs          Read file contents with optional line range
   cmd/schema.rs        Export operation schemas with tier filtering and system prompt generation
   cmd/status.rs        Show uncommitted file changes vs git HEAD
-  cmd/tx.rs            Transaction engine: execute a multi-operation plan atomically
+  cmd/tx.rs            Thin CLI entry for `tx` / plan file; engine lives under `tx/`
   cmd/explain/         Parse a tx plan and print a human-readable summary
                          (mod + describe; JSON includes schema catalog blurb per op)
   cmd/undo.rs          Restore files from backup sessions created by --apply
   cmd/init.rs          Project setup: shell completion install, AGENTS.md generation
+  tx/                  Transaction engine (stage, execute, lifecycle, replace/ast ops, output)
   config.rs            Project config file (.patchloom.toml) loading and merging
   backup.rs            Backup session management for undo safety net
   schema.rs            Intent format spec: OperationSchema, Tier, OPERATION_REGISTRY (metadata table),
@@ -133,18 +134,15 @@ src/
                        NO_MATCHES=3, PARSE_ERROR=4, AMBIGUOUS=5, VALIDATION_FAILED=6, ROLLBACK=7,
                        CONFLICTS=8, OPERATION_FAILED=9
   diff.rs              Unified diff generation using similar::TextDiff; FileDiff and DiffResult types
-  ops.rs               Shared operation helpers used by cmd/tx.rs, cmd/doc.rs, cmd/md.rs:
-                       replace (validation, replacement text, content replacement),
-                       doc (format detection, parsing, navigation, merge, update),
-                       md (heading parse, section replace, bullet upsert, table append),
-                       patch (parse, apply hunks with fuzz, loader). Each is a pub(crate) submodule.
+  ops/                 Shared operation helpers used by tx, cmd/doc, cmd/md:
+                       replace, doc, md, patch (each a pub(crate) submodule)
   write.rs             Atomic file writes via tempfile; WritePolicy applies trim, EOL, final newline
   plan/                Transaction plan format (`mod.rs`, `operation.rs`, `tests.rs`): Plan, Operation, …
-                       25 operation types including all doc/md/replace/tidy/file/patch/read/search ops.
+                       40 operation types (doc/md/replace/tidy/file/patch/read/search/ast/…).
                        VerifyCheck defines pre/post symbol verification specs (must live here, not in
                        feature-gated modules, because Plan is always compiled)
 tests/
-  integration.rs       Rust integration tests (cargo test --test integration)
+  integration/         Integration crate (`main.rs` + `*_tests.rs`; cargo test --test integration)
   agent/               Python (pytest) agent integration tests verifying AI agents use patchloom
     conftest.py        Fixtures: workspace with AGENTS.md, patchloom shim for invocation capture
     drivers/           Pluggable agent drivers (GrokDriver first, extensible)

--- a/README.md
+++ b/README.md
@@ -240,11 +240,14 @@ patchloom doc set config.yaml database.port 5432 --apply
 
 ```bash
 patchloom batch --apply <<'EOF'
-doc.set config.json version "2.0"
+doc.set config.json version '"2.0.0"'
 md.upsert_bullet AGENTS.md "Rules" "- Always test"
 replace src/main.rs "v1" "v2"
 EOF
 ```
+
+Values are JSON-first: unquoted `2.0` becomes a number. Force a string with nested
+quotes as above (Unix shells).
 
 Or use a JSON plan with format and validate lifecycle:
 
@@ -252,7 +255,7 @@ Or use a JSON plan with format and validate lifecycle:
 {
   "version": 1,
   "operations": [
-    { "op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0" },
+    { "op": "doc.set", "path": "config.json", "selector": "version", "value": "2.0.0" },
     { "op": "md.upsert_bullet", "path": "AGENTS.md", "heading": "Rules", "bullet": "- Always test" },
     { "op": "replace", "path": "src/main.rs", "old": "v1", "new": "v2" }
   ],
@@ -287,7 +290,7 @@ Add patchloom as a dependency (omit CLI/MCP/AST with `default-features = false`)
 
 ```toml
 [dependencies]
-patchloom = { default-features = false }
+patchloom = { version = "0.22", default-features = false }
 ```
 
 ```rust

--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -45,12 +45,13 @@ Every write command supports four modes:
 
 | Flag | Behavior | Use case |
 |------|----------|----------|
-| `--diff` (default) | Print a unified diff of what would change | Preview before applying |
+| default (preview) | Show what would change without writing (exit 2 when changes would occur) | Dry-run before `--apply` |
+| `--diff` | Attach/print a unified diff (combinable with `--apply`) | Prefer explicit diff text |
 | `--check` | Exit 0 if clean, exit 2 if changes detected | CI pipelines, dry-run validation |
 | `--apply` | Write changes to disk | Actual mutation |
 | `--confirm` | Show the diff, then prompt before writing | Interactive preview-then-apply |
 
-These modes are mutually exclusive. Patchloom is safe by default: nothing is written unless you pass `--apply` or confirm an interactive prompt.
+`--apply` / `--check` / `--confirm` conflict with each other; `--diff` may combine with `--apply`. Patchloom is safe by default: nothing is written unless you pass `--apply` or confirm an interactive prompt.
 
 ## Write safety on disk
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -116,14 +116,14 @@ Rust tools. Disable default features to omit CLI (clap), MCP server, and AST:
 
 ```toml
 [dependencies]
-patchloom = { default-features = false }
+patchloom = { version = "0.22", default-features = false }
 ```
 
 To add AST support without CLI/MCP (LLM agent embedders typically use
 `ast` + `files` for plan execution and AST file mutators):
 
 ```toml
-patchloom = { default-features = false, features = ["ast", "files"] }
+patchloom = { version = "0.22", default-features = false, features = ["ast", "files"] }
 ```
 
 See the [crate documentation](https://docs.rs/patchloom) for the full API

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -63,7 +63,7 @@ Patchloom is also a Rust library. Add it as a dependency to embed structured fil
 
 ```toml
 [dependencies]
-patchloom = { default-features = false }
+patchloom = { version = "0.22", default-features = false }
 ```
 
 The `api` module exposes doc, replace, markdown, file, patch, multi-op content

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -42,7 +42,7 @@ Patchloom write commands default to preview mode. The canonical semantics live i
 - **Use when:** You want a single-command preview-then-apply workflow instead of running the command twice.
 - **Prefer instead:** Use `--apply` when scripting (no interactive prompt), or `--diff` when you only want the preview.
 
-`--diff`, `--apply`, `--check`, and `--confirm` are mutually exclusive. Passing more than one is rejected with an error. When none is specified, `--diff` is the default. When `--confirm` is used and stdin is not a TTY, the command shows the diff without prompting (same as `--diff`).
+`--apply` and `--check` conflict with each other (and with `--confirm`). `--diff` is **not** exclusive: you can pass `--diff --apply` to print a unified diff after a successful write. When none of `--apply`, `--check`, or interactive confirm is used, the default is **preview** (show what would change without writing; exit 2 when changes would occur). When `--confirm` is used and stdin is not a TTY, the command shows the preview without prompting.
 
 ### Write policy flags
 

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -70,9 +70,10 @@ REPLACE SHAPE:
   Do not paste CLI --new into a batch line (parse error with PATH OLD NEW hint).
 
 EXAMPLES:
-  printf 'doc.set config.json version "2.0"\nreplace README.md v1 v2\n' | patchloom batch
+  # Force string values with nested JSON quotes (bare 2.0 becomes a number).
+  printf 'doc.set config.json version '"'"'"2.0.0"'"'"'\nreplace README.md v1 v2\n' | patchloom batch
   patchloom batch --apply <<'EOF'
-  doc.set package.json version "3.0.0"
+  doc.set package.json version '"3.0.0"'
   replace README.md "v1.0" "v3.0"
   replace src/main.rs "proccess" "process" --fuzzy --min-fuzzy-score 0.80
   EOF"#)]
@@ -418,6 +419,18 @@ fn batch_unsupported_hint(op: &str) -> Option<&'static str> {
         "status" | "git_status" => Some("not supported in batch; use `patchloom status`"),
         "undo" => Some("not supported in batch; use `patchloom undo`"),
         "explain" => Some("not supported in batch; use `patchloom explain`"),
+        // Plan/MCP-only write ops (no batch line form): steer agents to tx.
+        "apply.fragment" | "apply_fragment" | "apply-fragment" => {
+            Some("not supported in batch; use a tx plan (`apply.fragment`) or MCP `apply_fragment`")
+        }
+        "ast.insert"
+        | "ast.wrap"
+        | "ast.imports"
+        | "ast.group"
+        | "ast.move"
+        | "ast.extract_to_file"
+        | "ast.split"
+        | "ast.reorder" => Some("not supported in batch; use a tx plan or MCP ast_* tools"),
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,17 +21,16 @@
 //!
 //! ```toml
 //! [dependencies]
-//! patchloom = { default-features = false }
+//! patchloom = { version = "0.22", default-features = false }
 //! ```
 //!
 //! Or with AST support:
 //!
 //! ```toml
-//! patchloom = { default-features = false, features = ["ast"] }
+//! patchloom = { version = "0.22", default-features = false, features = ["ast"] }
 //! ```
 //!
-//! (Update the version number in these examples when the next release-please
-//! PR bumps the crate version. See the release checklist.)
+//! (Keep the version in sync with Cargo.toml / release-please. See the release checklist.)
 //!
 //! This gives you the [`api`] module (primary editing interface), [`ops`],
 //! and utility modules:

--- a/tests/integration/agent_rules_tests.rs
+++ b/tests/integration/agent_rules_tests.rs
@@ -135,9 +135,7 @@ fn test_agents_doc_project_inventory_matches_repo_state() {
         "AGENTS.md should describe the current agent-rules implementation location"
     );
     assert!(
-        agents.contains(
-            "25 operation types including all doc/md/replace/tidy/file/patch/read/search ops"
-        ),
+        agents.contains("40 operation types (doc/md/replace/tidy/file/patch/read/search/ast/…)."),
         "AGENTS.md should describe the current tx operation count"
     );
 }

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -318,6 +318,71 @@ fn test_batch_malformed_line_fails() {
         .stderr(predicates::str::contains("unknown operation"));
 }
 
+/// Plan-only AST ops should steer agents to tx/MCP, not bare "unknown".
+#[test]
+fn test_batch_ast_insert_hints_tx_plan() {
+    let dir = TempDir::new().unwrap();
+    let ops = dir.path().join("ops.txt");
+    fs::write(&ops, "ast.insert lib.rs after foo \"fn bar() {}\"\n").unwrap();
+
+    patchloom_in(dir.path())
+        .arg("batch")
+        .arg(&ops)
+        .arg("--apply")
+        .assert()
+        .code(4)
+        .stderr(predicates::str::contains("not supported in batch"))
+        .stderr(predicates::str::contains("tx plan"));
+}
+
+/// Nested JSON quotes keep batch doc.set values as strings (not float 2.0).
+#[test]
+fn test_batch_doc_set_version_string_not_float() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.json");
+    fs::write(&file, "{\"version\":\"1.0.0\"}\n").unwrap();
+    let ops = dir.path().join("ops.txt");
+    // File form: "\"2.0\"" → after strip → \"2.0\" JSON string (not float).
+    fs::write(&ops, "doc.set config.json version \"\\\"2.0\\\"\"\n").unwrap();
+
+    patchloom_in(dir.path())
+        .arg("batch")
+        .arg(&ops)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert_eq!(
+        v["version"], "2.0",
+        "must remain a string, not number 2.0: {v}"
+    );
+    assert!(v["version"].is_string(), "version must be JSON string: {v}");
+}
+
+/// Bare `"2.0"` becomes a JSON number (documented footgun).
+#[test]
+fn test_batch_doc_set_version_bare_2_0_becomes_number() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.json");
+    fs::write(&file, "{\"version\":\"1.0.0\"}\n").unwrap();
+    let ops = dir.path().join("ops.txt");
+    fs::write(&ops, "doc.set config.json version \"2.0\"\n").unwrap();
+
+    patchloom_in(dir.path())
+        .arg("batch")
+        .arg(&ops)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert!(
+        v["version"].is_number(),
+        "bare 2.0 becomes JSON number (use nested quotes for string): {v}"
+    );
+}
+
 /// CLI path: agents paste `replace OLD --new NEW path` into batch (fixrealloop/MPI).
 #[test]
 fn test_batch_replace_cli_new_flag_hints_path_old_new() {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2837,6 +2837,61 @@ async fn test_mcp_append_file_missing_file_returns_error() {
 }
 
 #[tokio::test]
+async fn test_mcp_prepend_file_round_trip() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.txt");
+    fs::write(&file, "line two\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "prepend_file",
+        serde_json::json!({"path": "data.txt", "content": "line one\n"}),
+    )
+    .await;
+    assert!(!is_error, "prepend_file should succeed: {val}");
+    assert_eq!(val["ok"], true, "prepend ok field: {val}");
+    assert_eq!(val["files_changed"], 1, "prepend files_changed: {val}");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "line one\nline two\n",
+        "content should be prepended"
+    );
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_prepend_file_missing_file_returns_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "prepend_file",
+        serde_json::json!({"path": "nonexistent.txt", "content": "data\n"}),
+    )
+    .await;
+    assert!(
+        is_error,
+        "prepend_file should fail when file does not exist: {val}"
+    );
+    // Prefer structured kind when present (agent branching parity with tx).
+    if let Some(kind) = val.get("error_kind") {
+        assert_eq!(
+            kind, "not_found",
+            "prepend missing should peel not_found: {val}"
+        );
+    }
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_md_move_section_round_trip() {
     if !has_mcp_support() {
         return;


### PR DESCRIPTION
## Summary

MPI cycle batch for copy-paste/docs honesty and agent recovery surfaces.

- Batch/README: nested quotes for string versions; lock float `"2.0"` footgun
- Write-mode docs: `--diff` not exclusive; default is preview
- Library install snippets: require `version = "0.22"`
- AGENTS.md project map: real `tx/` / `ops/` / 40 operations
- Batch: plan-only AST ops and `apply.fragment` hint to tx/MCP
- MCP: `prepend_file` round-trip + missing file

Follow-up filed for multi-surface AST write matrix (insert/wrap/imports).

## Test plan

- [x] `make check-fast`
- [x] New batch/MCP integration tests