### PR TITLE
test: multi-surface AST insert/wrap/imports coverage

### DIFF
--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -335,6 +335,27 @@ fn test_batch_ast_insert_hints_tx_plan() {
         .stderr(predicates::str::contains("tx plan"));
 }
 
+/// #2054: wrap/imports batch lines also hint at tx/MCP (same unsupported class).
+#[test]
+fn test_batch_ast_wrap_and_imports_hint_tx_plan() {
+    let dir = TempDir::new().unwrap();
+    for line in [
+        "ast.wrap lib.rs symbols=test_a wrapper=\"mod m\"\n",
+        "ast.imports lib.rs add=use std::io;\n",
+    ] {
+        let ops = dir.path().join("ops.txt");
+        fs::write(&ops, line).unwrap();
+        patchloom_in(dir.path())
+            .arg("batch")
+            .arg(&ops)
+            .arg("--apply")
+            .assert()
+            .code(4)
+            .stderr(predicates::str::contains("not supported in batch"))
+            .stderr(predicate::str::contains("tx plan").or(predicate::str::contains("MCP")));
+    }
+}
+
 /// Nested JSON quotes keep batch doc.set values as strings (not float 2.0).
 #[test]
 fn test_batch_doc_set_version_string_not_float() {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -4440,6 +4440,95 @@ async fn test_mcp_ast_imports_list_only() {
     client.cancel().await.unwrap();
 }
 
+/// Multi-surface (#2054): MCP insert miss peels error_kind no_matches.
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_insert_missing_symbol_error_kind() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn existing() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_insert",
+        serde_json::json!({
+            "path": "lib.rs",
+            "content": "fn added() {}",
+            "after": "missing_symbol"
+        }),
+    )
+    .await;
+    assert!(is_error, "ast_insert miss must be error: {val}");
+    assert_eq!(val["error_kind"], "no_matches", "{val}");
+    assert_eq!(val["ok"], false, "{val}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("lib.rs")).unwrap(),
+        "fn existing() {}\n",
+        "file unchanged on MCP insert miss"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// Multi-surface (#2054): MCP wrap miss peels error_kind no_matches.
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_wrap_missing_symbol_error_kind() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn keep() {}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_wrap",
+        serde_json::json!({
+            "path": "lib.rs",
+            "symbols": ["gone"],
+            "wrapper": "mod m"
+        }),
+    )
+    .await;
+    assert!(is_error, "ast_wrap miss must be error: {val}");
+    assert_eq!(val["error_kind"], "no_matches", "{val}");
+    assert_eq!(val["ok"], false, "{val}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("lib.rs")).unwrap(),
+        "fn keep() {}\n",
+        "file unchanged on MCP wrap miss"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// Multi-surface (#2054): MCP imports missing path peels not_found.
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_imports_missing_file_error_kind() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_imports",
+        serde_json::json!({
+            "path": "gone.rs",
+            "add": ["use std::io;"]
+        }),
+    )
+    .await;
+    assert!(is_error, "ast_imports missing file must be error: {val}");
+    assert_eq!(val["error_kind"], "not_found", "{val}");
+    assert_eq!(val["ok"], false, "{val}");
+    client.cancel().await.unwrap();
+}
+
 // --- fixrealloop / MCP dogfood (agent-shaped replace insert + multi-doc) ---
 
 /// MCP `replace_text` insert_after is line-oriented by default (#1885).

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -6558,6 +6558,299 @@ fn test_tx_ast_replace_in_plan() {
     );
 }
 
+/// Multi-surface (#2054): plan `ast.insert` apply path (cargo-bin).
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_insert_in_plan() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn existing() {}\n").unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.insert",
+            "path": "lib.rs",
+            "content": "fn added() { 1 }",
+            "after": "existing"
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["tx", "plan.json", "--apply"])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    assert!(
+        content.contains("fn added()"),
+        "insert should land after existing: {content}"
+    );
+    assert!(
+        content.find("fn existing").unwrap() < content.find("fn added").unwrap(),
+        "added after existing: {content}"
+    );
+}
+
+/// Multi-surface (#2054): missing after-symbol is no_matches (exit 3).
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_insert_missing_after_no_matches() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn existing() {}\n").unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.insert",
+            "path": "lib.rs",
+            "content": "fn added() {}",
+            "after": "missing_symbol"
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(3)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "no_matches", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("missing_symbol") || err.contains("not found"),
+        "error should name missing symbol: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("lib.rs")).unwrap(),
+        "fn existing() {}\n",
+        "file must be unchanged on fail-closed insert"
+    );
+}
+
+/// Multi-surface (#2054): bad insert position is invalid_input (exit 1).
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_insert_bad_position_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn existing() {}\n").unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.insert",
+            "path": "lib.rs",
+            "content": "fn x() {}",
+            "after": "existing",
+            "position": "middle"
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("position") || err.contains("start") || err.contains("end"),
+        "error should mention valid positions: {err}"
+    );
+}
+
+/// Multi-surface (#2054): plan `ast.wrap` apply path.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_wrap_in_plan() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("lib.rs"),
+        "fn test_a() {}\nfn test_b() {}\n",
+    )
+    .unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.wrap",
+            "path": "lib.rs",
+            "symbols": ["test_a", "test_b"],
+            "wrapper": "mod tests"
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["tx", "plan.json", "--apply"])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(dir.path().join("lib.rs")).unwrap();
+    assert!(
+        content.contains("mod tests"),
+        "wrapper should appear: {content}"
+    );
+    assert!(
+        content.contains("fn test_a"),
+        "wrapped symbol should remain: {content}"
+    );
+}
+
+/// Multi-surface (#2054): wrap missing symbol is no_matches.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_wrap_missing_symbol_no_matches() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("lib.rs"), "fn keep() {}\n").unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.wrap",
+            "path": "lib.rs",
+            "symbols": ["gone"],
+            "wrapper": "mod m"
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(3)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "no_matches", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("gone") || err.contains("not found"),
+        "error should name missing symbol: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("lib.rs")).unwrap(),
+        "fn keep() {}\n",
+        "file must be unchanged on fail-closed wrap"
+    );
+}
+
+/// Multi-surface (#2054): plan `ast.imports` add apply path.
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_imports_add_in_plan() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("main.rs"), "use std::io;\n\nfn main() {}\n").unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.imports",
+            "path": "main.rs",
+            "add": ["use std::collections::HashMap;"]
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["tx", "plan.json", "--apply"])
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(dir.path().join("main.rs")).unwrap();
+    assert!(
+        content.contains("use std::collections::HashMap"),
+        "import should be added: {content}"
+    );
+    assert!(
+        content.contains("use std::io"),
+        "existing import should remain: {content}"
+    );
+}
+
+/// Multi-surface (#2054): imports on missing path peels not_found (fail-closed).
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_imports_missing_file_not_found() {
+    let dir = TempDir::new().unwrap();
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.imports",
+            "path": "gone.rs",
+            "add": ["use std::io;"]
+        }]
+    });
+    fs::write(
+        dir.path().join("plan.json"),
+        serde_json::to_string(&plan).unwrap(),
+    )
+    .unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--json", "tx", "plan.json", "--apply"])
+        .assert()
+        .code(1)
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["error_kind"], "not_found", "{v}");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["applied"], false, "{v}");
+}
+
 #[test]
 fn test_tx_replace_word_boundary_in_plan() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Multi-surface test matrix for plan-only AST write ops.

Closes #2054

- **tx / cargo-bin:** apply happy path for `ast.insert`, `ast.wrap`, `ast.imports`
- **fail-closed:** insert/wrap missing symbol → `error_kind: no_matches` exit 3; insert bad position → `invalid_input`; imports missing path → `not_found`
- **MCP:** same kinds on miss paths; file unchanged where applicable
- **batch:** wrap/imports unsupported lines hint tx/MCP (insert already covered)

## Test plan

- [x] `make check-fast`
- [x] Targeted integration tests for all new cases
- [x] Reviewer pass (APPROVE; minor wrap parity asserts applied)