### PR TITLE
deps: upgrade rmcp 2.2 → 3.0.1 for MCP 2026-07-28

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,7 +623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -949,7 +955,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -1498,7 +1504,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -1841,7 +1847,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1891,12 +1897,12 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "2.2.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14db48ee17a9ba61810ab1a9c1beb7d06d8136ae39ac25a1137f10d357af01af"
+checksum = "3797d226787327b35b0b6f9e878fe55f3af2bb4daf916c0411079885454042f0"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.23.0",
  "bytes",
  "chrono",
  "futures",
@@ -1924,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "2.2.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783d787bf21813b285f13019adc49e11af501c658890c1e519f31f937c68b7e3"
+checksum = "a8f5bc0c6851a20cd627ef4b90defb79f39a261c467de52af5d38000d7979c52"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1987,7 +1993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2044,7 +2050,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2397,7 +2403,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3096,7 +3102,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3402,7 +3408,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d25d3b32461fbd629221a7356eb48c86ad435356db0bfa93e26e8c1509c1836"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "rowan",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ dunce = "1"
 anstream = { version = "1", optional = true }
 ec4rs = { version = "1", optional = true }
 clap_complete = { version = "4", optional = true }
-rmcp = { version = "2", features = ["server", "transport-io", "macros"], optional = true }
+rmcp = { version = "3", features = ["server", "transport-io", "macros"], optional = true }
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "io-std", "macros"], optional = true }
 axum = { version = "0.8", features = ["http1", "tokio"], default-features = false, optional = true }
 axum-server = { version = "0.8", features = ["tls-rustls"], default-features = false, optional = true }
@@ -133,7 +133,7 @@ predicates = "3"
 proptest = "1"
 rcgen = "0.14"
 reqwest = { version = "0.13", features = ["rustls"], default-features = false }
-rmcp = { version = "2", features = ["client", "transport-io", "transport-child-process", "transport-streamable-http-client-reqwest"] }
+rmcp = { version = "3", features = ["client", "transport-io", "transport-child-process", "transport-streamable-http-client-reqwest"] }
 tokio = { version = "1", features = ["full"] }
 
 [[bin]]

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -186,11 +186,14 @@ impl PatchloomService {
                     let svc = ctx.service.clone();
                     let args = ctx.arguments.unwrap_or_default();
                     Box::pin(async move {
+                        // Dyn routes must return CallToolResponse (rmcp 3.x MRTR).
+                        // Individual handlers still produce CallToolResult; map via From.
                         svc.blocking(move |svc| {
                             let args_value = serde_json::Value::Object(args);
                             handle_simple_op(svc, meta, args_value, &fields)
                         })
                         .await
+                        .map(Into::into)
                     })
                 },
             ));
@@ -260,13 +263,16 @@ impl PatchloomService {
         &self,
         tool: &str,
         duration_ms: u64,
-        result: &Result<CallToolResult, McpError>,
+        result: &Result<rmcp::model::CallToolResponse, McpError>,
     ) {
         let Some(ref log_path) = self.call_log else {
             return;
         };
         let (ok, error) = match result {
-            Ok(r) => (!r.is_error.unwrap_or(false), None),
+            Ok(rmcp::model::CallToolResponse::Complete(r)) => (!r.is_error.unwrap_or(false), None),
+            // MRTR / tasks intermediate results (and future non-exhaustive variants)
+            // are not protocol failures for call-log purposes.
+            Ok(_) => (true, None),
             Err(e) => (false, Some(format!("{e}"))),
         };
         let ts = {

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -331,7 +331,12 @@ mod basic {
         let dir = tempfile::TempDir::new().unwrap();
         let client = spawn_test_client(dir.path().to_path_buf()).await;
         let info = client.peer_info().expect("peer info should be set");
-        assert_eq!(info.server_info.name, "patchloom");
+        // rmcp 3: peer_info.server_info is Option (discovery may omit identity).
+        let server = info
+            .server_info
+            .as_ref()
+            .expect("initialize handshake must provide server_info");
+        assert_eq!(server.name, "patchloom");
         client.cancel().await.unwrap();
     }
 

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -2,8 +2,8 @@
 
 use rmcp::handler::server::tool::ToolCallContext;
 use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ErrorData as McpError, ListToolsResult,
-    PaginatedRequestParams, ServerCapabilities, ServerInfo,
+    CallToolRequestParams, CallToolResponse, ErrorData as McpError, Implementation,
+    ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo,
 };
 use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ServerHandler, ServiceExt};
@@ -85,11 +85,9 @@ fn full_server_instructions() -> String {
 
 impl ServerHandler for PatchloomService {
     fn get_info(&self) -> ServerInfo {
-        let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_instructions(server_instructions(self.surface()));
-        info.server_info.name = "patchloom".into();
-        info.server_info.version = env!("CARGO_PKG_VERSION").into();
-        info
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_instructions(server_instructions(self.surface()))
+            .with_server_info(Implementation::new("patchloom", env!("CARGO_PKG_VERSION")))
     }
 
     async fn list_tools(
@@ -97,10 +95,11 @@ impl ServerHandler for PatchloomService {
         _request: Option<PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
+        // Use Default for SEP-2549/SEP-2322 optional fields (result_type, ttl_ms,
+        // cache_scope) so we stay compatible when rmcp adds more result metadata.
         Ok(ListToolsResult {
             tools: self.tool_router.list_all(),
-            next_cursor: None,
-            meta: None,
+            ..ListToolsResult::default()
         })
     }
 
@@ -108,7 +107,7 @@ impl ServerHandler for PatchloomService {
         &self,
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
-    ) -> Result<CallToolResult, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let tool_name = request.name.clone();
         crate::verbose!("mcp: tool call -> {tool_name}");
         let start = std::time::Instant::now();


### PR DESCRIPTION
## Summary

Upgrade the Model Context Protocol Rust SDK from **rmcp 2.2.0** to **3.0.1** (stable), per the [RMCP 3.0 migration guide](https://github.com/modelcontextprotocol/rust-sdk/discussions/969).

Closes #2057

## Changes

| Area | Adaptation |
|------|------------|
| `Cargo.toml` / lock | `rmcp = "3"` (server + client/dev features) |
| `ServerHandler::call_tool` | Returns `CallToolResponse` (MRTR) |
| Dyn registry routes | Map `CallToolResult` → `CallToolResponse` via `Into` |
| `list_tools` | `..ListToolsResult::default()` for `result_type` / `ttl_ms` / `cache_scope` |
| `get_info` | `Implementation::new("patchloom", version)` via `with_server_info` |
| Tests | `peer_info.server_info` is `Option` after discovery-aware peer info |

Individual `#[tool]` handlers still return `CallToolResult`; the macros/Into path wraps them for 3.x.

## Acceptance criteria

- [x] Read rmcp 3.0 changelog / migration notes
- [x] Upgrade `rmcp` (and `rmcp-macros`) in Cargo.toml
- [x] `cargo build --all-features` + MCP lib tests + `make test-mcp-no-ast` + integration MCP filter
- [x] MCP tool inventory still lists expected tools (existing inventory tests)
- [x] Document wire note in commit/PR (no CLI break; 2026-07-28 `resultType` when negotiated)

## Test plan

- [x] `make check-fast`
- [x] `cargo test --lib mcp --all-features`
- [x] `make test-mcp-no-ast`
- [x] `cargo test --test integration --all-features mcp`
- [ ] CI green

## Notes

- Not user-visible CLI. MCP hosts that negotiate protocol **2026-07-28** may see additive SDK wire fields (`resultType`, optional cache hints). Older protocol sessions keep legacy shapes (SDK clears `resultType` for them).
- Release PR **#2036** is independent and still waits on explicit human merge.