### PR TITLE
docs: lock server_info version and protocol_version after #2060

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -61,7 +61,7 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 | Validate syntax, find refs, or analyze impact | `ast_validate`, `ast_refs`, `ast_impact`, `ast_search` |
 | Repo map, imports, or structural diff | `ast_map`, `ast_deps`, `ast_diff` |
 | Apply same operation to many files | `execute_plan` with `for_each` glob |
-| Get server version and working directory | `server_info` |
+| Get package version, MCP protocol_version, surface, tool_count, and cwd | `server_info` |
 
 **`replace_text` / plan replace flags (default false):**
 - `require_change`: error when the pattern matches zero times (fail closed).

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -185,7 +185,7 @@ AST tools so `list_tools` stays honest about what is callable.
 | `doc_diff` | Compare two structured files (read-only) |
 | `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes. Binary and invalid UTF-8 files are skipped (read-only) |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
-| `server_info` | Return the server's working directory so the agent can discover the root path before file operations (read-only) |
+| `server_info` | Return server identity and workspace root: `cwd`, `surface` (`full`\|`core`), `tool_count`, package `version`, and MCP `protocol_version` (read-only). Use `cwd` before relative path ops |
 | `read_file` | Read file contents with optional line range |
 | `replace_text` | Replace text in a text file (literal or regex). Binary and invalid UTF-8 files are skipped |
 | `apply_fragment` | Freeform fragment at a required after/before/old anchor; strips Morph-style `// ... existing code ...` markers (no cloud merge). Prefer when the agent has a snippet plus a known placement |
@@ -284,7 +284,7 @@ patchloom mcp-server
 | `core` | Only: `read_file`, `search_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info` |
 | anything else | Server fails to start with a clear error |
 
-`server_info` includes `"surface": "core"|"full"` and `"tool_count"`. Invalid values are rejected (do not silently fall back).
+`server_info` includes `"surface": "core"|"full"`, `"tool_count"`, package `"version"`, and MCP `"protocol_version"` (same as the initialize handshake). Invalid `PATCHLOOM_MCP_SURFACE` values are rejected (do not silently fall back).
 
 Handshake `instructions` match the active surface: core mode lists only the core tools (it does not advertise full-inventory names such as `create_file` or `ast_*`).
 

--- a/docs/plans/mcp-surface-tiers.md
+++ b/docs/plans/mcp-surface-tiers.md
@@ -21,7 +21,7 @@ Exactly these tools (AST off):
 
 Defined in `src/cmd/mcp/surface.rs` as `CORE_MCP_TOOL_NAMES` / `McpSurface`.
 
-`server_info` reports `surface` and `tool_count`.
+`server_info` reports `cwd`, `surface`, `tool_count`, package `version`, and MCP `protocol_version`.
 
 Handshake `instructions` (MCP `ServerInfo`) are surface-aware: core mode lists
 only the core tools and names `PATCHLOOM_MCP_SURFACE=core`, so agents do not

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -165,7 +165,7 @@ tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.\n\n
              | Validate syntax, find refs, or analyze impact | `ast_validate`, `ast_refs`, `ast_impact`, `ast_search` |\n\
              | Repo map, imports, or structural diff | `ast_map`, `ast_deps`, `ast_diff` |\n\
              | Apply same operation to many files | `execute_plan` with `for_each` glob |\n\
-             | Get server version and working directory | `server_info` |\n\n\
+             | Get package version, MCP protocol_version, surface, tool_count, and cwd | `server_info` |\n\n\
              **`replace_text` / plan replace flags (default false):**\n\
              - `require_change`: error when the pattern matches zero times (fail closed).\n\
              - `command_position`: rewrite only shell invocable tokens (`sudo`/`timeout`/`flock`/`runuser`/`setsid`/`run0`/`gosu`/`su-exec`/`tini`/`dumb-init`/`unshare`/`nsenter`/`taskset`/`systemd-run`/`firejail`/`busybox`/`chpst`/`softlimit`/`envdir`/`setlock` wrappers yes; `uv pip` no).\n\
@@ -1098,6 +1098,18 @@ mod tests {
                 && mcp.contains("no_matches")
                 && mcp.contains("truncated"),
             "MCP-only agent-rules must document replace_text flags, fuzzy fail-closed, refused[], and search truncated"
+        );
+    }
+
+    #[test]
+    fn agent_rules_mcp_documents_server_info_version_fields() {
+        let out = generate_agent_rules(&args(AgentMode::Mcp, AgentPlatform::All));
+        assert!(
+            out.contains("protocol_version")
+                && out.contains("tool_count")
+                && out.contains("server_info")
+                && out.contains("package `version`"),
+            "MCP agent-rules must document server_info version + protocol_version (#2060)"
         );
     }
 

--- a/tests/integration/mcp_tests.rs
+++ b/tests/integration/mcp_tests.rs
@@ -23,6 +23,25 @@ fn test_mcp_setup_documents_surface_core_honesty() {
     );
 }
 
+/// #2060: setup docs must list package version + protocol_version on server_info
+/// (not only cwd/surface), matching the tool payload and agent-rules.
+#[test]
+fn test_mcp_setup_documents_server_info_version_fields() {
+    let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
+    assert!(
+        doc.contains("protocol_version"),
+        "mcp-setup must document server_info protocol_version after #2060"
+    );
+    assert!(
+        doc.contains("package `version`") || doc.contains("package \"version\""),
+        "mcp-setup must document server_info package version after #2060"
+    );
+    assert!(
+        doc.contains("tool_count"),
+        "mcp-setup must keep documenting server_info tool_count"
+    );
+}
+
 /// Invalid `PATCHLOOM_MCP_SURFACE` must fail closed at process start (#1994).
 #[cfg(feature = "mcp")]
 #[test]


### PR DESCRIPTION
## Summary

After #2060, `server_info` returns package `version` and MCP `protocol_version` (plus surface/tool_count/cwd), but MCP setup and surface-tier docs still described the tool as working-directory only.

- Align `docs/getting-started/mcp-setup.md` tool table and surface note
- Align `docs/plans/mcp-surface-tiers.md`
- Clarify agent-rules tool selection row + unit lock
- Integration lock so mcp-setup cannot drop `protocol_version` / package version again
- Regenerate `PATCHLOOM.md`

## Test plan

- [x] `cargo test --lib agent_rules_mcp_documents_server_info --all-features`
- [x] `cargo test --test integration test_mcp_setup_documents_server_info --all-features`
- [x] `make check-fast`
- [x] `make check-patchloom-md`

Ref #2060 (docs lag; code already landed)