### PR TITLE
fix: realistic host peels and relative library path join

### DIFF
--- a/src/api/apply_fragment.rs
+++ b/src/api/apply_fragment.rs
@@ -47,7 +47,15 @@ pub fn apply_fragment_to_file(
         FragmentPlacement::Before(b) => (None, Some(b.as_str()), None),
         FragmentPlacement::Replace(o) => (None, None, Some(o.as_str())),
     };
-    let path_str = path.to_string_lossy();
+    // Absolutize so parent-cwd + full path does not double-join relatives
+    // (doc example Path::new("src/lib.rs")).
+    let abs = super::absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let path_str = abs.to_string_lossy();
     let op = plan_apply_fragment_to_replace(
         path_str.as_ref(),
         fragment,
@@ -57,6 +65,6 @@ pub fn apply_fragment_to_file(
         old,
         unique,
     )?;
-    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    let cwd = abs.parent().unwrap_or_else(|| Path::new("."));
     super::execute_as_edit_result(op, mode, cwd, guard, "apply.fragment", None)
 }

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -130,8 +130,9 @@ pub fn ast_rename(
     ensure_contained(guard, path)?;
     let path_str = path.to_string_lossy().into_owned();
     let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
-        // Preserve Binary / InvalidEncoding / InvalidInput peels (#1963).
-        if crate::exit::is_load_text_strict_fail(&e) {
+        // Preserve Binary / InvalidEncoding / InvalidInput (#1963) and
+        // NotFound so hosts can peel is_not_found (parity with content_edits).
+        if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
             return e;
         }
         EditError::new(EditErrorKind::OperationFailed, e.to_string()).into()
@@ -193,8 +194,8 @@ pub fn ast_replace_in_symbol(
     ensure_contained(guard, path)?;
     let path_str = path.to_string_lossy().into_owned();
     let original = crate::files::load_text_strict(path, &path_str).map_err(|e| {
-        // Preserve Binary / InvalidEncoding / InvalidInput peels (#1963).
-        if crate::exit::is_load_text_strict_fail(&e) {
+        // Preserve Binary / InvalidEncoding / InvalidInput (#1963) and NotFound.
+        if crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e) {
             return e;
         }
         EditError::new(EditErrorKind::OperationFailed, e.to_string()).into()
@@ -506,7 +507,24 @@ pub fn ast_rename_batch(
                 });
             }
             Err(e) => {
+                // Prefer typed EditError; else peel load_text_strict kinds so
+                // Binary/InvalidEncoding/NotFound survive batch results.
                 let edit_err = e.downcast::<EditError>().unwrap_or_else(|e| {
+                    if let Some(kind) = crate::fallback::edit_error_kind(&e) {
+                        return EditError::new(kind, e.to_string());
+                    }
+                    if crate::exit::is_load_text_strict_fail(&e) {
+                        if crate::fallback::is_binary(&e) {
+                            return EditError::new(EditErrorKind::Binary, e.to_string());
+                        }
+                        if crate::fallback::is_invalid_encoding(&e) {
+                            return EditError::new(EditErrorKind::InvalidEncoding, e.to_string());
+                        }
+                        return EditError::new(EditErrorKind::InvalidInput, e.to_string());
+                    }
+                    if crate::exit::is_io_not_found(&e) {
+                        return EditError::new(EditErrorKind::NotFound, e.to_string());
+                    }
                     EditError::new(EditErrorKind::OperationFailed, e.to_string())
                 });
                 let is_no_match = edit_err.kind == EditErrorKind::NoMatch;

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -19,6 +19,18 @@ fn cwd_from_path(path: &Path) -> &Path {
     path.parent().unwrap_or_else(|| Path::new("."))
 }
 
+/// Absolutize for engine handoff; map IO errors to OperationFailed.
+#[cfg(any(feature = "cli", feature = "files"))]
+fn abs_path(path: &Path) -> anyhow::Result<std::path::PathBuf> {
+    super::absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+        .into()
+    })
+}
+
 /// Unified write path for standard file operations.
 #[cfg(any(feature = "cli", feature = "files"))]
 fn file_write(
@@ -239,6 +251,10 @@ pub fn file_create(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path_owned = abs_path(path)?;
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path = path_owned.as_path();
     let op = Operation::FileCreate {
         path: path.to_string_lossy().into(),
         content: content.into(),
@@ -253,6 +269,10 @@ pub fn file_delete(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path_owned = abs_path(path)?;
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path = path_owned.as_path();
     let op = Operation::FileDelete {
         path: path.to_string_lossy().into(),
     };
@@ -267,6 +287,14 @@ pub fn file_rename(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let src_owned = abs_path(src)?;
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let dst_owned = abs_path(dst)?;
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let src = src_owned.as_path();
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let dst = dst_owned.as_path();
     let op = Operation::FileRename {
         from: src.to_string_lossy().into(),
         to: dst.to_string_lossy().into(),
@@ -286,6 +314,10 @@ pub fn file_append(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path_owned = abs_path(path)?;
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path = path_owned.as_path();
     let op = Operation::FileAppend {
         path: path.to_string_lossy().into(),
         content: content.into(),
@@ -302,6 +334,10 @@ pub fn file_prepend(
     mode: ApplyMode,
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path_owned = abs_path(path)?;
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path = path_owned.as_path();
     let op = Operation::FilePrepend {
         path: path.to_string_lossy().into(),
         content: content.into(),

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,5 +1,8 @@
 //! Public library API for embedding patchloom in Rust applications.
 //!
+//! size-waiver: accepted single-domain bulk (policy #1408). Library facade
+//! (re-exports, engine bridge, path absolutize, shared helpers) is one unit.
+//!
 //! This module provides a clean, CLI-independent interface to patchloom's
 //! editing operations. Functions accept `&Path`/`&str` parameters and return
 //! `Result<EditResult>`, with no dependency on `clap` or process arguments.
@@ -657,6 +660,23 @@ fn make_diff(path: &str, old: &str, new: &str) -> String {
         diffs: vec![file_diff],
     };
     format_diff_result(&result)
+}
+
+/// Absolutize a library caller path before engine handoff.
+///
+/// Engine staging does `cwd.join(op_path)`. Library helpers historically set
+/// `cwd = path.parent()` and put the full path string in the op. Multi-component
+/// relatives then double-join (`src/lib.rs` → `src/src/lib.rs`). Absolute paths
+/// join correctly because `Path::join` keeps an absolute second component.
+///
+/// Callers should put the returned path into the plan op and pass its parent
+/// (or `.`) as engine cwd.
+pub(crate) fn absolute_for_engine(path: &Path) -> std::io::Result<std::path::PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
 }
 
 /// Generalized helper for Apply-mode mutations that need backup + guard.

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -86,9 +86,16 @@ pub fn replace_text(
         return Ok(result);
     }
 
+    // Absolutize so parent-cwd + full path does not double-join relatives.
+    let abs = super::absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
     let op = Operation::Replace {
         glob: None,
-        path: Some(path.to_string_lossy().into()),
+        path: Some(abs.to_string_lossy().into()),
         regex: opts.regex,
         old: from.into(),
         new_text: Some(to.into()),
@@ -111,7 +118,7 @@ pub fn replace_text(
         min_fuzzy_score: opts.min_fuzzy_score,
         allow_absent_old: opts.allow_absent_old,
     };
-    let mut result = replace_write(op, path, mode, guard, opts.fuzzy)?;
+    let mut result = replace_write(op, &abs, mode, guard, opts.fuzzy)?;
     // if_exists intentionally softens zero-match (Ok unchanged). require_change
     // must not override that: both true means if_exists wins (#1492 docs).
     if opts.require_change && !opts.if_exists && !result.changed && result.match_count == 0 {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7498,3 +7498,67 @@ fn content_edit_honesty_constructors_for_hosts() {
     assert_eq!(fuzzy.matched_text.as_deref(), Some("aaaa"));
     assert_eq!(fuzzy.old, "a");
 }
+
+/// Prove library multi-component relative path (fixloop).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn replace_text_relative_nested_path_does_not_double_join() {
+    use std::env;
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("src");
+    fs::create_dir_all(&nested).unwrap();
+    let file = nested.join("lib.rs");
+    fs::write(&file, "fn old() {}\n").unwrap();
+    let prev = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    let result = replace_text(
+        Path::new("src/lib.rs"),
+        "old",
+        "new",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        None,
+    );
+    let _ = env::set_current_dir(prev);
+    let r = result.expect("relative nested path should resolve");
+    assert!(r.changed, "expected change: {:?}", r);
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(content.contains("fn new"), "got {content}");
+}
+
+/// Missing path peels NotFound (not OperationFailed) for library hosts.
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_missing_path_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("nope.rs");
+    let err = ast_rename(&missing, "foo", "bar", ApplyMode::Preview, None).unwrap_err();
+    assert!(
+        crate::api::is_not_found(&err),
+        "expected not_found peel, got kind={:?} err={err}",
+        crate::fallback::edit_error_kind(&err)
+    );
+}
+
+/// Batch remapper preserves Binary peel from sole-path load.
+#[cfg(all(feature = "ast", any(feature = "cli", feature = "files")))]
+#[test]
+fn ast_rename_batch_binary_peels_binary() {
+    let dir = TempDir::new().unwrap();
+    let bin = dir.path().join("x.rs");
+    fs::write(&bin, b"fn foo() {}\0").unwrap();
+    let opts = AstRenameBatchOptions {
+        mode: ApplyMode::Preview,
+        continue_on_no_match: true,
+        fail_fast: false,
+        ..Default::default()
+    };
+    let results = ast_rename_batch(&[&bin], "foo", "bar", &opts, None).unwrap();
+    assert_eq!(results.len(), 1);
+    let err = results[0].result.as_ref().unwrap_err();
+    assert_eq!(
+        err.kind,
+        EditErrorKind::Binary,
+        "batch must not collapse Binary to OperationFailed: {err:?}"
+    );
+}

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -361,21 +361,6 @@ impl PatchloomService {
             } else {
                 results.has_matches()
             };
-            if !has_matches {
-                empty_scan_hard_fail(&global, &search_args.paths, &cwd)?;
-                // True pattern miss: CLI-shaped JSON so agents can branch.
-                let body = serde_json::json!({
-                    "ok": false,
-                    "error_kind": "no_matches",
-                    "error": "No matches found.",
-                    "match_count": 0,
-                    "file_count": 0,
-                });
-                return Ok(CallToolResult::success(vec![ContentBlock::text(
-                    body.to_string(),
-                )]));
-            }
-
             // cwd already resolved for empty-scan honesty.
             let refused =
                 crate::cmd::search::explicit_binary_refused(&search_args, &global, &cwd);
@@ -383,6 +368,32 @@ impl PatchloomService {
                 .map_err(|e| {
                     McpError::invalid_params(crate::exit::agent_error_message(&e), None)
                 })?;
+            if !has_matches {
+                empty_scan_hard_fail(&global, &search_args.paths, &cwd)?;
+                // True pattern miss: include refused/skipped like CLI so agents
+                // know binary co-paths were not searched as text.
+                let mut body = serde_json::json!({
+                    "ok": false,
+                    "error_kind": "no_matches",
+                    "error": "No matches found.",
+                    "match_count": 0,
+                    "file_count": 0,
+                });
+                if let Some(ref r) = refused
+                    && !r.is_empty()
+                {
+                    body["refused"] = serde_json::to_value(r).unwrap_or_default();
+                }
+                if let Some(ref s) = skipped
+                    && !s.is_empty()
+                {
+                    body["skipped"] = serde_json::to_value(s).unwrap_or_default();
+                }
+                return Ok(CallToolResult::success(vec![ContentBlock::text(
+                    body.to_string(),
+                )]));
+            }
+
             let output = crate::cmd::search::format_results(
                 results,
                 &search_args,

--- a/src/cmd/schema.rs
+++ b/src/cmd/schema.rs
@@ -72,12 +72,9 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     "write_policy": schema::plan_write_policy_schema()
                 }
             });
-            if global.quiet {
-                return Ok(exit::SUCCESS);
-            }
-            // Honor global --json / --jsonl (pretty vs compact). Agents that
-            // always pass --jsonl break on multi-line pretty-only stdout.
-            if !global.emit_json(&envelope)? {
+            // Global --json/--jsonl still emit under --quiet (structured only).
+            // Quiet suppresses human pretty-print, not agent envelopes.
+            if !global.emit_json(&envelope)? && !global.quiet {
                 let output = serde_json::to_string_pretty(&envelope)?;
                 println!("{output}");
             }
@@ -87,16 +84,14 @@ pub fn run(args: SchemaArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 Some(t) => schema::system_prompt_for_tier(t)?,
                 None => schema::system_prompt_for_tier(Tier::Strong)?,
             };
-            if global.quiet {
-                return Ok(exit::SUCCESS);
-            }
-            // Global --json/--jsonl must not print raw markdown (agents
-            // call `json.loads` on stdout). Parity with agent-rules.
+            // Quiet + --json still emits the envelope; quiet alone suppresses
+            // raw markdown prompt text.
             if !global.emit_json(&serde_json::json!({
                 "ok": true,
                 "format": "prompt",
                 "content": prompt,
-            }))? {
+            }))? && !global.quiet
+            {
                 print!("{prompt}");
             }
         }

--- a/src/ops/doc/query.rs
+++ b/src/ops/doc/query.rs
@@ -87,10 +87,15 @@ pub enum QueryKeysResult {
 /// Get the keys of an object at a selector path.
 ///
 /// When the selector matches multiple values, returns keys of the first match.
+/// Bare object keys at an array root (multi-doc YAML) return
+/// [`crate::exit::TypeErrorError`] like [`query_get`] / [`query_has`].
 pub fn query_keys(root: &serde_json::Value, selector: &str) -> anyhow::Result<QueryKeysResult> {
     let segments = selector::parse_anyhow(selector)?;
     let results = selector::eval(root, &segments);
     if results.is_empty() {
+        if let Some(hint) = array_root_bare_key_hint(root, &segments) {
+            return Err(crate::exit::TypeErrorError { msg: hint }.into());
+        }
         return Ok(QueryKeysResult::NoMatch);
     }
     match results[0].as_object() {
@@ -111,10 +116,14 @@ pub enum QueryLenResult {
 /// Get the length of an array or object at a selector path.
 ///
 /// When the selector matches multiple values, returns the length of the first match.
+/// Bare object keys at an array root return type_error like [`query_get`].
 pub fn query_len(root: &serde_json::Value, selector: &str) -> anyhow::Result<QueryLenResult> {
     let segments = selector::parse_anyhow(selector)?;
     let results = selector::eval(root, &segments);
     if results.is_empty() {
+        if let Some(hint) = array_root_bare_key_hint(root, &segments) {
+            return Err(crate::exit::TypeErrorError { msg: hint }.into());
+        }
         return Ok(QueryLenResult::NoMatch);
     }
     let target = results[0];
@@ -303,6 +312,31 @@ mod tests {
             query_keys(&doc, "nonexistent").unwrap(),
             QueryKeysResult::NoMatch
         ));
+    }
+
+    #[test]
+    fn keys_bare_key_at_array_root_is_type_error() {
+        let doc = serde_json::json!([{"a": 1}, {"b": 2}]);
+        let err = query_keys(&doc, "a").expect_err("bare key at array root");
+        assert!(
+            crate::fallback::is_type_error(&err),
+            "expected type_error, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("0.a") || msg.contains("[0].a"),
+            "hint missing index form: {msg}"
+        );
+    }
+
+    #[test]
+    fn len_bare_key_at_array_root_is_type_error() {
+        let doc = serde_json::json!([{"a": 1}, {"b": 2}]);
+        let err = query_len(&doc, "a").expect_err("bare key at array root");
+        assert!(
+            crate::fallback::is_type_error(&err),
+            "expected type_error, got: {err}"
+        );
     }
 
     // -- query_len --

--- a/tests/integration/schema_tests.rs
+++ b/tests/integration/schema_tests.rs
@@ -345,3 +345,19 @@ fn test_schema_jsonl_global_flag_is_single_line() {
     assert_eq!(parsed["ok"], true);
     assert!(parsed["operations"].is_array());
 }
+
+#[test]
+fn test_schema_quiet_with_global_json_still_emits() {
+    // Agents often pass --json --quiet together; structured stdout must remain.
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--quiet", "schema", "--format", "json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).expect("json under --quiet");
+    assert_eq!(v["ok"], true);
+    assert!(v["operations"].is_array());
+}


### PR DESCRIPTION
## Summary

Fixloop round with **real-world-only** triage. Six accepted host/agent honesty bugs; speculative noise rejected.

## Fixes

| Issue | Realistic repro |
|-------|-----------------|
| Library relative multi-component path double-join | `replace_text(Path::new("src/lib.rs"), …)` from project root looked up `src/src/lib.rs` |
| `ast_rename` / `ast_replace_in_symbol` missing path → OperationFailed | Hosts cannot peel `is_not_found` |
| `ast_rename_batch` collapsed Binary/InvalidEncoding | Batch remapper lost load peels |
| `doc keys` / `len` bare multi-doc key → soft no_matches | Agents treat shape error as missing field |
| MCP `search_files` no_matches omitted `refused[]` | Binary co-paths looked fully searched |
| `schema --json --quiet` empty stdout | Agents often pass both flags |

## Rejected (noise)

- Nested status `.patchloom` filtering (gitignore/init covers common cases)
- Speculative defense-in-depth and saturating counters
- Theoretical races on single-threaded CLI

## Validation

- `make check-fast` green
- Red/green tests for relative path, keys/len type_error, ast peels, schema quiet+json
