### PR TITLE
fix: path absolutize, fuzzy refused, MCP honesty, search nth

### DIFF
--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -44,8 +44,14 @@ pub fn ast_rewrite_signature(
         )
         .into());
     }
+    let abs = super::absolute_for_engine(path).map_err(|e| {
+        EditError::new(
+            EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
     let op = Operation::AstRewriteSignature {
-        path: path.to_string_lossy().into(),
+        path: abs.to_string_lossy().into(),
         old: name.into(),
         new_signature: new_signature.map(str::to_string),
         visibility: edit.visibility.clone(),
@@ -53,7 +59,7 @@ pub fn ast_rewrite_signature(
         return_type: edit.return_type.clone(),
         lang: None,
     };
-    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    let cwd = abs.parent().unwrap_or_else(|| Path::new("."));
     super::execute_as_edit_result(op, mode, cwd, guard, "ast.rewrite_signature", None)
 }
 

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -33,13 +33,39 @@ fn load_doc_value(path: &Path) -> anyhow::Result<serde_json::Value> {
 /// falls back to direct mutation when the tx module is not compiled in.
 #[cfg(any(feature = "cli", feature = "files"))]
 fn doc_write(
-    op: Operation,
+    mut op: Operation,
     path: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action, None)
+    let abs = super::absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    rewrite_op_path(&mut op, abs.to_string_lossy().as_ref());
+    super::execute_as_edit_result(op, mode, cwd_from_path(&abs), guard, action, None)
+}
+
+/// Put absolutized path into doc/md plan ops so engine join is correct.
+#[cfg(any(feature = "cli", feature = "files"))]
+fn rewrite_op_path(op: &mut Operation, abs: &str) {
+    match op {
+        Operation::DocSet { path, .. }
+        | Operation::DocDelete { path, .. }
+        | Operation::DocMerge { path, .. }
+        | Operation::DocAppend { path, .. }
+        | Operation::DocPrepend { path, .. }
+        | Operation::DocUpdate { path, .. }
+        | Operation::DocMove { path, .. }
+        | Operation::DocEnsure { path, .. }
+        | Operation::DocDeleteWhere { path, .. } => {
+            *path = abs.into();
+        }
+        _ => {}
+    }
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -21,13 +21,38 @@ fn cwd_from_path(path: &Path) -> &Path {
 /// Unified write path for standard md operations.
 #[cfg(any(feature = "cli", feature = "files"))]
 fn md_write(
-    op: Operation,
+    mut op: Operation,
     path: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action, None)
+    let abs = super::absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    rewrite_md_op_path(&mut op, abs.to_string_lossy().as_ref());
+    super::execute_as_edit_result(op, mode, cwd_from_path(&abs), guard, action, None)
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+fn rewrite_md_op_path(op: &mut Operation, abs: &str) {
+    match op {
+        Operation::MdReplaceSection { path, .. }
+        | Operation::MdInsertAfterHeading { path, .. }
+        | Operation::MdInsertAfterSection { path, .. }
+        | Operation::MdInsertBeforeHeading { path, .. }
+        | Operation::MdUpsertBullet { path, .. }
+        | Operation::MdTableAppend { path, .. }
+        | Operation::MdMoveSection { path, .. }
+        | Operation::MdDedupeHeadings { path, .. }
+        | Operation::MdLintAgents { path, .. } => {
+            *path = abs.into();
+        }
+        _ => {}
+    }
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -24,7 +24,27 @@ pub fn apply_patch(
         on_stale: Default::default(),
         allow_conflicts: false,
     };
-    let cwd = path.parent().unwrap_or_else(|| Path::new("."));
+    // Resolve cwd so multi-component relative paths (and git-style patch
+    // paths that match the caller path) join correctly.
+    let abs = super::absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    let cwd_owned: std::path::PathBuf;
+    let cwd = if path.is_absolute() {
+        abs.parent().unwrap_or_else(|| Path::new("."))
+    } else {
+        // path "src/lib.rs" → strip components so cwd is project root and
+        // patch path "src/lib.rs" resolves once.
+        cwd_owned = abs
+            .ancestors()
+            .nth(path.components().count())
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf();
+        cwd_owned.as_path()
+    };
     patch_write(op, cwd, mode, guard)
 }
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7562,3 +7562,32 @@ fn ast_rename_batch_binary_peels_binary() {
         "batch must not collapse Binary to OperationFailed: {err:?}"
     );
 }
+
+/// Library doc_set multi-component relative path (sibling of replace absolutize).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn doc_set_relative_nested_path_does_not_double_join() {
+    use std::env;
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("cfg");
+    fs::create_dir_all(&nested).unwrap();
+    let file = nested.join("app.json");
+    fs::write(&file, r#"{"v":1}"#).unwrap();
+    let prev = env::current_dir().unwrap();
+    env::set_current_dir(dir.path()).unwrap();
+    let result = doc_set(
+        Path::new("cfg/app.json"),
+        "v",
+        serde_json::json!(2),
+        ApplyMode::Apply,
+        None,
+    );
+    let _ = env::set_current_dir(prev);
+    let r = result.expect("relative nested doc path should resolve");
+    assert!(r.changed, "{r:?}");
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains('2') || content.contains("2"),
+        "got {content}"
+    );
+}

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -55,6 +55,15 @@ pub fn tidy_with_indent(
         EolMode::Cr => "cr".to_string(),
         EolMode::Keep => "keep".to_string(),
     });
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path_owned = super::absolute_for_engine(path).map_err(|e| {
+        crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::OperationFailed,
+            format!("failed to resolve path {}: {e}", path.display()),
+        )
+    })?;
+    #[cfg(any(feature = "cli", feature = "files"))]
+    let path = path_owned.as_path();
     let op = Operation::TidyFix {
         path: path.to_string_lossy().into(),
         ensure_final_newline: Some(policy_opts.ensure_final_newline),

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -77,6 +77,9 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             require_change,
             command_position,
             fuzzy,
+            unique,
+            allow_absent_old,
+            min_fuzzy_score,
             ..
         } => {
             let target = path.as_deref().or(glob.as_deref()).unwrap_or("(all files)");
@@ -122,8 +125,17 @@ pub(super) fn describe_operation(op: &Operation) -> String {
                 ""
             };
             let fuzzy_str = if *fuzzy { ", fuzzy" } else { "" };
+            let unique_str = if *unique { ", unique" } else { "" };
+            let absent_str = if *allow_absent_old {
+                ", allow-absent-old"
+            } else {
+                ""
+            };
+            let min_fuzzy_str = min_fuzzy_score
+                .map(|s| format!(", min-fuzzy-score={s}"))
+                .unwrap_or_default();
             format!(
-                "Replace \"{old}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{wb_str}{ml_str}{ie_str}{rc_str}{cp_str}{fuzzy_str}{range_str})"
+                "Replace \"{old}\" with \"{to_str}\" in {target} ({mode_str}{nth_str}{ci_str}{wl_str}{wb_str}{ml_str}{ie_str}{rc_str}{cp_str}{fuzzy_str}{unique_str}{absent_str}{min_fuzzy_str}{range_str})"
             )
         }
         Operation::DocSet {
@@ -538,6 +550,39 @@ mod tests {
         };
         let desc = describe_operation(&op);
         assert_eq!(desc, r#"Replace "v1" with "v2" in README.md (literal)"#);
+    }
+
+    #[test]
+    fn describe_replace_surfaces_unique_fuzzy_safety_flags() {
+        let op = Operation::Replace {
+            path: Some("src/lib.rs".into()),
+            glob: None,
+            regex: false,
+            old: "foo".into(),
+            new_text: Some("bar".into()),
+            nth: None,
+            insert_before: None,
+            insert_after: None,
+            case_insensitive: false,
+            multiline: false,
+            if_exists: false,
+            whole_line: false,
+            range: None,
+            word_boundary: false,
+            before_context: None,
+            after_context: None,
+            unique: true,
+            require_change: false,
+            command_position: false,
+            fuzzy: true,
+            min_fuzzy_score: Some(0.9),
+            allow_absent_old: true,
+        };
+        let desc = describe_operation(&op);
+        assert!(desc.contains(", unique"), "got: {desc}");
+        assert!(desc.contains(", fuzzy"), "got: {desc}");
+        assert!(desc.contains(", allow-absent-old"), "got: {desc}");
+        assert!(desc.contains(", min-fuzzy-score=0.9"), "got: {desc}");
     }
 
     #[test]

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -274,7 +274,15 @@ pub(super) fn handle_ast_rename(
                 None,
             ));
         }
-        return no_results("No matches found.");
+        // Write tool: miss is not a successful soft query (contrast ast_list/refs).
+        // Agents must see isError + no_matches, not a green tool result.
+        let body = serde_json::json!({
+            "ok": false,
+            "error_kind": "no_matches",
+            "error": "No matches found.",
+            "applied": false,
+        });
+        return exit_code_to_result(exit::NO_MATCHES, &body.to_string(), "No matches found.");
     }
 
     svc.run_ops(operations, None)
@@ -1214,5 +1222,35 @@ impl Point {
 
         let result = handle_ast_rename(&svc, params).unwrap();
         assert!(result.is_error.unwrap_or(false));
+    }
+
+    #[test]
+    fn ast_rename_missing_symbol_is_error_not_soft_success() {
+        let dir = TempDir::new().unwrap();
+        std::fs::write(dir.path().join("sample.rs"), RUST_SAMPLE).unwrap();
+
+        let svc = make_service(&dir);
+        let params = AstRenameParams {
+            path: "sample.rs".into(),
+            old: "does_not_exist_symbol".into(),
+            new: "other".into(),
+            lang: Some("rs".into()),
+        };
+
+        let result = handle_ast_rename(&svc, params).unwrap();
+        assert!(
+            result.is_error.unwrap_or(false),
+            "write miss must set isError so agents do not treat rename as applied"
+        );
+        let text = extract_text(&result);
+        assert!(
+            text.contains("no_matches") || text.contains("No matches"),
+            "got: {text}"
+        );
+        let content = std::fs::read_to_string(dir.path().join("sample.rs")).unwrap();
+        assert!(
+            content.contains("greet"),
+            "file must stay unchanged on rename miss"
+        );
     }
 }

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -483,6 +483,19 @@ pub(super) fn handle_ast_refs(
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
+    // Sole explicit non-text: fail closed (CLI parity; not soft empty).
+    if paths.len() == 1 {
+        let sole = &paths[0];
+        if let Err(e) = crate::files::load_text_strict(sole, &p.path)
+            && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
+        {
+            return Err(McpError::invalid_params(
+                crate::exit::agent_error_message(&e),
+                None,
+            ));
+        }
+    }
+
     let per_file: Vec<Vec<crate::ast::refs::SymbolRef>> =
         crate::par_process_files(&paths, None, &[], |path| {
             let display = crate::cmd::ast::display_path(path, &cwd);
@@ -496,6 +509,9 @@ pub(super) fn handle_ast_refs(
     }
 
     if all_refs.is_empty() {
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            return Err(McpError::invalid_params(err.msg, None));
+        }
         return no_results("No references found.");
     }
 
@@ -521,6 +537,19 @@ pub(super) fn handle_ast_deps(
     let global = GlobalFlags::with_cwd(&cwd);
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
+
+    // Sole explicit non-text: fail closed (CLI parity; not soft empty).
+    if paths.len() == 1 {
+        let sole = &paths[0];
+        if let Err(e) = crate::files::load_text_strict(sole, &p.path)
+            && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
+        {
+            return Err(McpError::invalid_params(
+                crate::exit::agent_error_message(&e),
+                None,
+            ));
+        }
+    }
 
     let mut results = Vec::new();
 
@@ -596,6 +625,9 @@ pub(super) fn handle_ast_deps(
     }
 
     if results.is_empty() {
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            return Err(McpError::invalid_params(err.msg, None));
+        }
         return no_results("No imports found.");
     }
     let json = serde_json::to_string_pretty(&results)
@@ -713,6 +745,19 @@ pub(super) fn handle_ast_impact(
     let paths = crate::cmd::ast::resolve_target_paths(&target, &p.path, &global)
         .map_err(|e| McpError::invalid_params(format!("{e}"), None))?;
 
+    // Sole explicit non-text: fail closed (CLI parity; not soft empty).
+    if paths.len() == 1 {
+        let sole = &paths[0];
+        if let Err(e) = crate::files::load_text_strict(sole, &p.path)
+            && (crate::exit::is_load_text_strict_fail(&e) || crate::exit::is_io_not_found(&e))
+        {
+            return Err(McpError::invalid_params(
+                crate::exit::agent_error_message(&e),
+                None,
+            ));
+        }
+    }
+
     let file_pairs: Vec<(std::path::PathBuf, String)> = paths
         .iter()
         .map(|fp| {
@@ -724,6 +769,9 @@ pub(super) fn handle_ast_impact(
     let nodes = crate::ast::impact::compute_impact(&p.symbol, &file_pairs, p.depth);
 
     if nodes.is_empty() {
+        if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&paths, &cwd) {
+            return Err(McpError::invalid_params(err.msg, None));
+        }
         return no_results(&format!("No references found for '{}'.", p.symbol));
     }
 

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -637,7 +637,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Replace the same text across multiple files in one call. Atomic: all files succeed or none change. Canonical field is files (array); singular file is accepted as an alias for one path. Optional fuzzy enables similarity fallback; when exact old is absent, refuse by default unless allow_absent_old=true (#1758). JSON reports match_mode (exact/fuzzy/anchored), optional match_score, optional matched_text, match_count per change and aggregate (#1674). IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
+        description = "Replace the same text across multiple files in one call. Engine staging is atomic for applied writes (all written files succeed or none change). Pattern misses are soft by default: matching files still apply and total misses appear in refused[]; set require_change=true to fail the whole batch if any file has no match. Canonical field is files (array); singular file is accepted as an alias for one path. Optional fuzzy enables similarity fallback; when exact old is absent, refuse by default unless allow_absent_old=true (#1758). JSON reports match_mode (exact/fuzzy/anchored), optional match_score, optional matched_text, match_count per change and aggregate (#1674). IMPORTANT: do NOT issue concurrent write calls targeting the same files; use execute_plan for multi-op atomicity. Example: {\"files\": [\"Cargo.toml\", \"README.md\"], \"old\": \"0.1.0\", \"new\": \"0.2.0\"}"
     )]
     async fn batch_replace(
         &self,
@@ -845,8 +845,14 @@ impl PatchloomService {
     ) -> Result<CallToolResult, McpError> {
         self.blocking(move |svc| {
             let global = GlobalFlags::with_cwd(svc.cwd());
-            let status = crate::cmd::status::collect_status(&[], &global)
-                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+            let status = crate::cmd::status::collect_status(&[], &global).map_err(|e| {
+                // Non-git workspace / invalid_input is agent input, not a server bug.
+                if crate::exit::is_invalid_input(&e) {
+                    McpError::invalid_params(format!("{e}"), None)
+                } else {
+                    McpError::internal_error(format!("{e}"), None)
+                }
+            })?;
             let json = serde_json::to_string_pretty(&status)
                 .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
             // Always tool success (isError=false); agents branch on ok /

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -1474,6 +1474,27 @@ fn run_context_replace(
     // multiple matches in one file; agents branch on match_count honesty.
     let total_matches: usize = files.iter().map(|f| f.match_count).sum();
     let file_count = files.len();
+    // Multi-file soft-miss: report total misses (no write) so agents see
+    // partial-apply honesty (parity with exact multi-path #1792).
+    let matched: Vec<FileReplacement> = result
+        .exec_result
+        .changes
+        .iter()
+        .map(|(abs, original, replaced)| FileReplacement {
+            path: abs.to_string_lossy().into_owned(),
+            display_path: crate::files::relative_display(abs, &cwd)
+                .to_string_lossy()
+                .into_owned(),
+            original: original.clone(),
+            replaced: replaced.clone(),
+            match_count: 1,
+            match_mode: None,
+            match_score: None,
+            matched_text: None,
+        })
+        .collect();
+    let zero_match_refused =
+        exact_zero_match_refused_from_paths(&args, global, &cwd, &file_paths, &matched);
     // Same mode/exit owner as default replace path (no hand-rolled matrix).
     replace_output(
         global,
@@ -1484,8 +1505,7 @@ fn run_context_replace(
             file_count,
             cwd: &cwd,
             skipped,
-            // Exact zero-match refused collected only on precomputed path (#1792).
-            zero_match_refused: None,
+            zero_match_refused,
         },
     )
 }

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -1618,37 +1618,64 @@ fn multi_file_match_mode_worst_case_rollup() {
 
 #[test]
 fn multi_fuzzy_total_miss_in_refused() {
-    let dir = tempfile::TempDir::new().unwrap();
+    // Unit tests cannot use cargo_bin (CARGO_BIN_EXE unset under cargo test --lib).
+    // In-process: apply fuzzy multi-file, assert partial write + exact-miss refused.
+    let dir = TempDir::new().unwrap();
     let a = dir.path().join("a.txt");
     let b = dir.path().join("b.txt");
-    std::fs::write(&a, "hello world\n").unwrap();
-    std::fs::write(&b, "unrelated content\n").unwrap();
-    let out = assert_cmd::Command::cargo_bin("patchloom")
-        .unwrap()
-        .current_dir(dir.path())
-        .args([
-            "--json",
-            "replace",
-            "hello world",
-            "--new",
-            "hi",
-            "--fuzzy",
-            "--apply",
-            "a.txt",
-            "b.txt",
-        ])
-        .assert()
-        .success()
-        .get_output()
-        .stdout
-        .clone();
-    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
-    assert_eq!(v["ok"], true);
-    let refused = v["refused"].as_array().expect("refused array");
+    fs::write(&a, "hello world\n").unwrap();
+    fs::write(&b, "unrelated content\n").unwrap();
+
+    let paths = vec![
+        a.to_string_lossy().into_owned(),
+        b.to_string_lossy().into_owned(),
+    ];
+    let mut args = make_args("hello world", "hi", paths);
+    args.fuzzy = true;
+    let global = GlobalFlags {
+        apply: true,
+        json: true,
+        quiet: true,
+        cwd: Some(dir.path().to_string_lossy().into_owned()),
+        ..GlobalFlags::test_default()
+    };
+    let code = run(args, &global).unwrap();
+    assert_eq!(code, exit::SUCCESS);
+    assert_eq!(fs::read_to_string(&a).unwrap(), "hi\n");
+    assert_eq!(fs::read_to_string(&b).unwrap(), "unrelated content\n");
+
+    // Explicit multi-path total miss lands in refused with reason no_matches.
+    let mut args_for_refused = make_args(
+        "hello world",
+        "hi",
+        vec![
+            a.to_string_lossy().into_owned(),
+            b.to_string_lossy().into_owned(),
+        ],
+    );
+    args_for_refused.fuzzy = true;
+    let matched_only_a = [FileReplacement {
+        path: a.to_string_lossy().into_owned(),
+        display_path: "a.txt".into(),
+        original: "hello world\n".into(),
+        replaced: "hi\n".into(),
+        match_count: 1,
+        match_mode: Some("exact"),
+        match_score: None,
+        matched_text: None,
+    }];
+    let refused = exact_zero_match_refused_from_paths(
+        &args_for_refused,
+        &global,
+        dir.path(),
+        &[a, b],
+        &matched_only_a,
+    )
+    .expect("refused for co-listed miss");
     assert!(
         refused
             .iter()
-            .any(|r| r["path"] == "b.txt" && r["reason"] == "no_matches"),
+            .any(|r| r.path == "b.txt" && r.reason == "no_matches"),
         "got {refused:?}"
     );
 }

--- a/src/cmd/replace_tests.rs
+++ b/src/cmd/replace_tests.rs
@@ -1615,3 +1615,40 @@ fn multi_file_match_mode_worst_case_rollup() {
     assert_eq!(mode, Some("anchored"));
     assert!(score.is_none());
 }
+
+#[test]
+fn multi_fuzzy_total_miss_in_refused() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let a = dir.path().join("a.txt");
+    let b = dir.path().join("b.txt");
+    std::fs::write(&a, "hello world\n").unwrap();
+    std::fs::write(&b, "unrelated content\n").unwrap();
+    let out = assert_cmd::Command::cargo_bin("patchloom")
+        .unwrap()
+        .current_dir(dir.path())
+        .args([
+            "--json",
+            "replace",
+            "hello world",
+            "--new",
+            "hi",
+            "--fuzzy",
+            "--apply",
+            "a.txt",
+            "b.txt",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+    assert_eq!(v["ok"], true);
+    let refused = v["refused"].as_array().expect("refused array");
+    assert!(
+        refused
+            .iter()
+            .any(|r| r["path"] == "b.txt" && r["reason"] == "no_matches"),
+        "got {refused:?}"
+    );
+}

--- a/src/ops/search.rs
+++ b/src/ops/search.rs
@@ -327,7 +327,14 @@ pub fn merge_file_results(
     }
 
     if !count_only {
-        all_matches.sort_unstable_by(|a, b| a.path.cmp(&b.path).then_with(|| a.line.cmp(&b.line)));
+        // Tie-break by column so same-line hits stay left-to-right. Agents map
+        // search index → replace --nth; unstable (path, line) alone can scramble.
+        all_matches.sort_by(|a, b| {
+            a.path
+                .cmp(&b.path)
+                .then_with(|| a.line.cmp(&b.line))
+                .then_with(|| a.column.cmp(&b.column))
+        });
     }
 
     if max_results > 0 && !count_only {
@@ -423,6 +430,46 @@ mod tests {
         let results = merge_file_results(vec![fr1, fr2], false, 0);
         assert_eq!(results.matches[0].text, "a1");
         assert_eq!(results.matches[1].text, "b1");
+    }
+
+    #[test]
+    fn merge_file_results_sorts_same_line_by_column() {
+        // Scrambled same-line hits must re-order left-to-right for --nth.
+        let fr = FileResult {
+            path_str: Arc::from("t.txt"),
+            matches: vec![
+                SearchMatch {
+                    path: Arc::from("t.txt"),
+                    line: 1,
+                    column: 7,
+                    text: "hi".into(),
+                    context_before: None,
+                    context_after: None,
+                },
+                SearchMatch {
+                    path: Arc::from("t.txt"),
+                    line: 1,
+                    column: 1,
+                    text: "hi".into(),
+                    context_before: None,
+                    context_after: None,
+                },
+                SearchMatch {
+                    path: Arc::from("t.txt"),
+                    line: 1,
+                    column: 4,
+                    text: "hi".into(),
+                    context_before: None,
+                    context_after: None,
+                },
+            ],
+            count: 3,
+        };
+        let results = merge_file_results(vec![fr], false, 0);
+        assert_eq!(
+            results.matches.iter().map(|m| m.column).collect::<Vec<_>>(),
+            vec![1, 4, 7]
+        );
     }
 
     #[test]

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -523,9 +523,11 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
         let sym_name = sym_name.trim();
         #[cfg(feature = "ast")]
         {
+            // find_symbol walks nested children (impl methods, mod items).
+            // Top-level-only matching dropped realistic method filters.
             matched.retain(|p| {
                 let syms = crate::ast::symbols::extract_symbols_from_file(p, None);
-                syms.iter().any(|s| s.name == sym_name)
+                crate::ast::symbols::find_symbol(&syms, sym_name).is_some()
             });
         }
         #[cfg(not(feature = "ast"))]

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -526,6 +526,35 @@ fn for_each_item_alias_substitutes_path() {
     );
 }
 
+#[cfg(all(feature = "cli", feature = "ast"))]
+#[test]
+fn for_each_has_symbol_matches_nested_method() {
+    // Methods live under impl; top-level-only filter would drop the file.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("svc.rs"),
+        "struct S;\nimpl S {\n    fn process_request(&self) {}\n}\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("other.rs"), "fn unrelated() {}\n").unwrap();
+
+    let json = r#"{
+            "version": 1,
+            "for_each": { "glob": "*.rs", "filter": "has_symbol(process_request)" },
+            "operations": [
+                {"op": "replace", "path": "{path}", "old": "x", "new": "y"}
+            ]
+        }"#;
+    let mut plan = parse_plan(json).unwrap();
+    expand_for_each(&mut plan, dir.path()).unwrap();
+    assert_eq!(plan.operations.len(), 1, "only the method host file");
+    let op_json = serde_json::to_string(&plan.operations[0]).unwrap();
+    assert!(
+        op_json.contains("svc.rs"),
+        "nested method filter must keep svc.rs: {op_json}"
+    );
+}
+
 #[cfg(feature = "cli")]
 #[test]
 fn for_each_unknown_path_template_is_invalid_input() {

--- a/src/tx/verify.rs
+++ b/src/tx/verify.rs
@@ -322,12 +322,14 @@ fn symbol_has_attr(source: &str, sym: &symbols::SymbolDef, attr: &str) -> bool {
         return false;
     }
     // Walk backward from the line above the definition (start_line is 1-based).
+    // Skip blank lines: hand-edited / some formatters leave a blank between
+    // `#[test]` and `fn` without attaching a prior item's attrs.
     let mut idx = sym.start_line; // 1-based cursor; first decrement lands on line above
     while idx > 1 {
         idx -= 1;
         let trimmed = lines[idx - 1].trim();
         if trimmed.is_empty() {
-            break;
+            continue;
         }
         let is_rust_attr = trimmed.starts_with("#[") || trimmed.ends_with(']');
         let is_doc = trimmed.starts_with("///") || trimmed.starts_with("//!");
@@ -750,6 +752,28 @@ fn not_a_test() {}
         assert!(
             !symbol_has_attr(source, not_a_test, "test"),
             "neighbor must not inherit #[test] from my_test"
+        );
+    }
+
+    /// Blank line between attr and item is common in hand-edited sources.
+    #[test]
+    #[cfg(feature = "ast")]
+    fn symbol_has_attr_skips_blank_between_attr_and_item() {
+        let source = r#"
+#[test]
+
+fn spaced_test() {
+    assert!(true);
+}
+"#;
+        let syms = symbols::extract_symbols(source, Language::Rust);
+        let spaced = syms
+            .iter()
+            .find(|s| s.name == "spaced_test")
+            .expect("spaced_test");
+        assert!(
+            symbol_has_attr(source, spaced, "test"),
+            "blank line must not drop #[test] for attr= filter"
         );
     }
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -4724,3 +4724,37 @@ async fn test_mcp_replace_text_sole_binary_refused() {
     );
     client.cancel().await.unwrap();
 }
+
+/// Sole binary via MCP ast_refs fails closed (not soft "No references found").
+#[tokio::test]
+#[cfg(all(feature = "mcp", feature = "ast"))]
+async fn test_mcp_ast_refs_sole_binary_is_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("x.rs"), b"fn foo() {}\x00").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_refs",
+        serde_json::json!({"path": "x.rs", "symbol": "foo"}),
+    )
+    .await;
+    assert!(
+        is_error || val["ok"] == false,
+        "sole binary ast_refs should fail: {val}"
+    );
+    let text = val.to_string().to_lowercase();
+    assert!(
+        text.contains("binary") || text.contains("nul") || text.contains("invalid"),
+        "sole binary must not soft-empty: {val}"
+    );
+    // Must not look like a clean empty search.
+    assert!(
+        !text.contains("no references found"),
+        "must not soft-empty: {val}"
+    );
+    client.cancel().await.unwrap();
+}


### PR DESCRIPTION
## Summary

Round 2 + round 3 fixloop (realistic findings only).

### Round 2 (prior)
- Absolute path join for doc/md/tidy/patch/ast write siblings of library path fix
- Multi-file fuzzy total miss lands in `refused[]`
- MCP AST sole-binary fail-closed

### Round 3 (this push)
- **CI:** multi-file fuzzy refused unit test no longer uses `cargo_bin` under `cargo test --lib`
- **Search:** same-line matches sort by column so agents map index → `replace --nth`
- **MCP `ast_rename`:** miss returns `isError` + `no_matches` (not soft success)
- **Plan `for_each`:** `has_symbol` matches nested methods (impl methods)
- **Verify `attr=`:** blank line between `#[test]` and item no longer false-green
- **Explain:** surfaces `unique`, `allow-absent-old`, `min-fuzzy-score`
- **MCP `batch_replace`:** description matches soft-miss + `require_change` (not a false Atomic claim)
- **MCP `git_status`:** non-git workspace → `invalid_params`, not `internal_error`

## Rejected (noise / multi-day / intentional)

| Finding | Why rejected |
|---------|----------------|
| Multi-file library patch / md_move atomicity | Multi-day engine work |
| `write_if_apply` finalize-after-write | Architecture; track if host reports |
| `EditResult.path` basename | Host contract; separate PR |
| Config `defaults.apply=true` | Intentional project config |
| Plan `unique` default false | Compatibility; docs only |
| Fuzzy multi-candidate first | Locked intentional |
| md duplicate-heading first match | Documented intentional |
| `parse_value` `1.0` → number | Documented heuristic; quote strings |

## Test plan

- [x] `make check-fast` local green
- [x] Unit: multi_fuzzy_total_miss_in_refused (in-process)
- [x] Unit: merge column sort, attr blank, explain flags, nested has_symbol, ast_rename miss
- [ ] CI green on PR