### PR TITLE
fix(api): finalize-before-write and atomic multi-file apply

### DIFF
--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -254,23 +254,19 @@ pub fn md_move_section(
             })?;
 
     let policy = crate::write::WritePolicy::default();
-    // Write the destination file for cross-file moves.
-    if let Some(dest_path) = to {
-        if mode == ApplyMode::Apply {
-            super::ensure_contained(guard, dest_path)?;
-        }
-        let _ = super::write_if_apply(dest_path, &new_dest, mode, &policy, guard)?;
-    }
-    // Use generalized cross helper for source (centralized per #839).
-    let (applied, backup_session) = super::apply_cross_file_mutation(
-        path,
-        None,
-        mode,
-        guard,
-        |backup| backup.save_before_write(path),
-        || crate::write::atomic_write(path, &new_source, &policy),
-    )?;
     let dest = to.map(|p| p.to_string_lossy().to_string());
+
+    // Cross-file: one backup session covering source + dest (all-or-nothing).
+    // Same-file: single write path.
+    let (applied, backup_session) = if let Some(dest_path) = to {
+        let backup_root = path.parent().unwrap_or_else(|| Path::new("."));
+        let files: [(&Path, &str); 2] =
+            [(dest_path, new_dest.as_str()), (path, new_source.as_str())];
+        super::write_if_apply_many(&files, mode, &policy, guard, backup_root)?
+    } else {
+        super::write_if_apply(path, &new_source, mode, &policy, guard)?
+    };
+
     let mut edit =
         super::build_edit_result(&path_str, original, new_source, applied, "md.move", dest);
     edit.backup_session = backup_session;

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -683,6 +683,11 @@ pub(crate) fn absolute_for_engine(path: &Path) -> std::io::Result<std::path::Pat
 ///
 /// Used by write_if_apply and special file ops (create/delete/rename cross-file).
 /// Returns `(applied, backup_session)`.
+///
+/// Order matches tx `commit_changes` and [`crate::backup::backup_write_files`]:
+/// save → finalize (manifest) → mutate. On mutation failure, restore from the
+/// finalized session so hosts never see "Err but disk already changed with no
+/// undo handle."
 pub(crate) fn apply_mutation(
     path: &Path,
     mode: ApplyMode,
@@ -699,16 +704,25 @@ pub(crate) fn apply_mutation(
     let cwd = path.parent().unwrap_or_else(|| Path::new("."));
     let mut backup = BackupSession::new(cwd)?;
     prepare_backup(&mut backup)?;
-    perform_mutation()?;
+    // Finalize before mutation so undo can recover mid-write failure.
     let session = backup.finalize()?;
+    if let Err(e) = perform_mutation() {
+        if let Some(ref ts) = session {
+            let _ = crate::backup::restore_session(cwd, ts);
+        }
+        return Err(e);
+    }
     Ok((true, session))
 }
 
-/// Generalized cross-file mutation helper (for rename and md cross-file moves).
+/// Generalized cross-file mutation helper (for rename without tx engine).
 ///
 /// Handles guard checks and backup for src (and optional dst).
-/// Centralizes the cross-file guard and backup logic.
-/// Returns `(applied, backup_session)`.
+/// Only used on the no-`cli`/`files` library fallback path; with those
+/// features rename goes through the engine.
+///
+/// Same finalize-then-mutate order as [`apply_mutation`].
+#[cfg(not(any(feature = "cli", feature = "files")))]
 fn apply_cross_file_mutation(
     src: &Path,
     dst: Option<&Path>,
@@ -727,8 +741,13 @@ fn apply_cross_file_mutation(
     let cwd = src.parent().unwrap_or_else(|| Path::new("."));
     let mut backup = BackupSession::new(cwd)?;
     prepare_backup(&mut backup)?;
-    perform_mutation()?;
     let session = backup.finalize()?;
+    if let Err(e) = perform_mutation() {
+        if let Some(ref ts) = session {
+            let _ = crate::backup::restore_session(cwd, ts);
+        }
+        return Err(e);
+    }
     Ok((true, session))
 }
 
@@ -747,6 +766,51 @@ pub(crate) fn write_if_apply(
         |backup| backup.save_before_write(path),
         || atomic_write(path, new_content, policy),
     )
+}
+
+/// Apply several file writes under one backup session (all-or-nothing).
+///
+/// Used by multi-file library paths (`apply_patch_file`, cross-file
+/// `md_move_section`). Preflight must already have produced the new content
+/// for every path; this only guards, backs up, finalizes, then writes.
+/// On any write failure, restores the whole session.
+///
+/// `backup_root` is the project root for the session (usually the host cwd
+/// or a common parent of the files).
+pub(crate) fn write_if_apply_many(
+    files: &[(&Path, &str)],
+    mode: ApplyMode,
+    policy: &WritePolicy,
+    guard: Option<&PathGuard>,
+    backup_root: &Path,
+) -> anyhow::Result<(bool, Option<String>)> {
+    if mode != ApplyMode::Apply {
+        return Ok((false, None));
+    }
+    if files.is_empty() {
+        return Ok((false, None));
+    }
+    for (path, _) in files {
+        ensure_contained(guard, path)?;
+    }
+    let mut backup = BackupSession::new(backup_root)?;
+    for (path, _) in files {
+        backup.save_before_write(path)?;
+    }
+    let session = backup.finalize()?;
+    let write_result = (|| -> anyhow::Result<()> {
+        for (path, content) in files {
+            atomic_write(path, content, policy)?;
+        }
+        Ok(())
+    })();
+    if let Err(e) = write_result {
+        if let Some(ref ts) = session {
+            let _ = crate::backup::restore_session(backup_root, ts);
+        }
+        return Err(e);
+    }
+    Ok((true, session))
 }
 
 /// Run optional post-write hooks after a successful Apply (#1690).

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -117,6 +117,10 @@ fn patch_write(
 /// Retains direct implementation since it produces multiple `EditResult`s
 /// (one per file), which the single-op `execute_as_edit_result` adapter
 /// doesn't support.
+///
+/// **Atomic Apply:** all files are load+hunk preflighted first; on Apply a
+/// single backup session covers every path. Any write failure restores the
+/// whole batch (no half-applied multi-file patch).
 pub fn apply_patch_file(
     patch_text: &str,
     cwd: &Path,
@@ -129,7 +133,8 @@ pub fn apply_patch_file(
         })
     })?;
 
-    let mut results = Vec::new();
+    // Phase 1: preflight load + hunk apply for every file (no disk writes).
+    let mut staged: Vec<(std::path::PathBuf, String, String, String)> = Vec::new();
     for pf in &patch_files {
         let file_path = cwd.join(&pf.path);
         // Strict sole-path (#1894).
@@ -146,13 +151,24 @@ pub fn apply_patch_file(
                 })
             }
         })?;
+        staged.push((file_path, pf.path.clone(), original, new_content));
+    }
 
-        let policy = crate::write::WritePolicy::default();
-        let (applied, backup_session) =
-            super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
+    // Phase 2: one backup session + all-or-nothing write on Apply.
+    let policy = crate::write::WritePolicy::default();
+    let write_pairs: Vec<(&std::path::Path, &str)> = staged
+        .iter()
+        .map(|(p, _, _, n)| (p.as_path(), n.as_str()))
+        .collect();
+    let (applied, backup_session) =
+        super::write_if_apply_many(&write_pairs, mode, &policy, guard, cwd)?;
+
+    let mut results = Vec::with_capacity(staged.len());
+    for (_abs, display, original, new_content) in staged {
         let mut edit =
-            super::build_edit_result(&pf.path, original, new_content, applied, "patch", None);
-        edit.backup_session = backup_session;
+            super::build_edit_result(&display, original, new_content, applied, "patch", None);
+        // Same session id on every file result so hosts can undo once.
+        edit.backup_session = backup_session.clone();
         results.push(edit);
     }
     Ok(results)

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1047,6 +1047,97 @@ fn apply_patch_file_applies_multi_file_patch() {
     assert!(results.iter().all(|r| r.changed && r.applied));
     assert_eq!(fs::read_to_string(&a).unwrap(), "AAA\n");
     assert_eq!(fs::read_to_string(&b).unwrap(), "BBB\n");
+    // One shared backup session across files (atomic multi-file apply).
+    let sessions: Vec<_> = results
+        .iter()
+        .filter_map(|r| r.backup_session.clone())
+        .collect();
+    assert_eq!(sessions.len(), 2);
+    assert_eq!(sessions[0], sessions[1], "both files share one session");
+}
+
+/// Multi-file Apply must not leave a half-applied tree when a later file fails
+/// hunk preflight (stale context). Previously wrote earlier files then Err.
+#[test]
+fn apply_patch_file_stale_second_file_leaves_first_unchanged() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.txt");
+    let b = dir.path().join("b.txt");
+    fs::write(&a, "aaa\n").unwrap();
+    fs::write(&b, "bbb\n").unwrap();
+
+    let patch = "\
+--- a/a.txt\n\
++++ b/a.txt\n\
+@@ -1 +1 @@\n\
+-aaa\n\
++AAA\n\
+--- a/b.txt\n\
++++ b/b.txt\n\
+@@ -1 +1 @@\n\
+-not-the-content\n\
++BBB\n";
+
+    let err = apply_patch_file(patch, dir.path(), ApplyMode::Apply, None).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("stale") || msg.contains("patch apply"),
+        "expected hunk failure, got: {msg}"
+    );
+    assert_eq!(
+        fs::read_to_string(&a).unwrap(),
+        "aaa\n",
+        "first file must not be half-applied when later file fails preflight"
+    );
+    assert_eq!(fs::read_to_string(&b).unwrap(), "bbb\n");
+}
+
+/// Mid-write failure after a successful first write must restore all files.
+#[test]
+fn write_if_apply_many_restores_on_second_write_failure() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.txt");
+    let b = dir.path().join("b.txt");
+    fs::write(&a, "aaa\n").unwrap();
+    fs::write(&b, "bbb\n").unwrap();
+
+    let policy = crate::write::WritePolicy::default();
+    // Replace b with a directory so the second atomic_write fails after a writes.
+    fs::remove_file(&b).unwrap();
+    fs::create_dir(&b).unwrap();
+    let files: [(&std::path::Path, &str); 2] = [(&a, "AAA\n"), (&b, "BBB\n")];
+    assert!(
+        super::write_if_apply_many(&files, ApplyMode::Apply, &policy, None, dir.path()).is_err()
+    );
+    assert_eq!(
+        fs::read_to_string(&a).unwrap(),
+        "aaa\n",
+        "first write must be rolled back when later write fails"
+    );
+}
+
+/// Mutation failure after finalize must leave original content and a listable session.
+#[test]
+fn apply_mutation_restores_on_perform_failure() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("f.txt");
+    fs::write(&file, "original\n").unwrap();
+
+    let err = super::apply_mutation(
+        &file,
+        ApplyMode::Apply,
+        None,
+        |backup| backup.save_before_write(&file),
+        || anyhow::bail!("simulated write failure after backup finalize"),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("simulated write failure"));
+    assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
+    let sessions = crate::backup::list_sessions(dir.path()).unwrap();
+    assert!(
+        !sessions.is_empty(),
+        "finalize-before-mutate must leave a discoverable session for undo"
+    );
 }
 
 #[test]
@@ -1245,6 +1336,10 @@ fn md_move_section_cross_file_writes_dest() {
     assert!(
         dst_content.contains("# Move"),
         "section should be inserted into destination"
+    );
+    assert!(
+        result.backup_session.is_some(),
+        "cross-file move must report one backup session covering both files"
     );
 }
 


### PR DESCRIPTION
## Summary

Real-world library host honesty findings from fixloop R3 that were incorrectly deferred as "multi-day architecture."

1. **`write_if_apply` / `apply_mutation`**: finalize backup **before** mutate (match tx `commit_changes` / `backup_write_files`). On mutation failure, restore from the session so hosts never get `Err` with disk already changed and no undo handle.

2. **`apply_patch_file`**: preflight load+hunks for every file, then one `write_if_apply_many` session. No half-applied multi-file patch. Shared `backup_session` on every `EditResult`.

3. **Cross-file `md_move_section`**: dest + source written under one backup session (all-or-nothing).

## Test plan

- [x] `make check-fast`
- [x] `apply_mutation_restores_on_perform_failure`
- [x] `write_if_apply_many_restores_on_second_write_failure`
- [x] `apply_patch_file_stale_second_file_leaves_first_unchanged`
- [x] `apply_patch_file_applies_multi_file_patch` (shared session)
- [x] `md_move_section_cross_file_writes_dest` (session present)