### PR TITLE
fix: real findings wrongly rejected as architecture noise

### DIFF
--- a/src/api/apply_fragment.rs
+++ b/src/api/apply_fragment.rs
@@ -66,5 +66,14 @@ pub fn apply_fragment_to_file(
         unique,
     )?;
     let cwd = abs.parent().unwrap_or_else(|| Path::new("."));
-    super::execute_as_edit_result(op, mode, cwd, guard, "apply.fragment", None)
+    let display = path.to_string_lossy();
+    super::execute_as_edit_result_with_path(
+        op,
+        mode,
+        cwd,
+        guard,
+        "apply.fragment",
+        None,
+        Some(display.as_ref()),
+    )
 }

--- a/src/api/ast_write.rs
+++ b/src/api/ast_write.rs
@@ -60,7 +60,16 @@ pub fn ast_rewrite_signature(
         lang: None,
     };
     let cwd = abs.parent().unwrap_or_else(|| Path::new("."));
-    super::execute_as_edit_result(op, mode, cwd, guard, "ast.rewrite_signature", None)
+    let display = path.to_string_lossy();
+    super::execute_as_edit_result_with_path(
+        op,
+        mode,
+        cwd,
+        guard,
+        "ast.rewrite_signature",
+        None,
+        Some(display.as_ref()),
+    )
 }
 
 /// In-memory function signature rewrite (preview/apply parity with on-disk API).

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -46,7 +46,17 @@ fn doc_write(
         )
     })?;
     rewrite_op_path(&mut op, abs.to_string_lossy().as_ref());
-    super::execute_as_edit_result(op, mode, cwd_from_path(&abs), guard, action, None)
+    // Keep caller path spelling on EditResult (not basename from parent cwd).
+    let display = path.to_string_lossy();
+    super::execute_as_edit_result_with_path(
+        op,
+        mode,
+        cwd_from_path(&abs),
+        guard,
+        action,
+        None,
+        Some(display.as_ref()),
+    )
 }
 
 /// Put absolutized path into doc/md plan ops so engine join is correct.

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -40,7 +40,16 @@ fn file_write(
     guard: Option<&PathGuard>,
     action: &'static str,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd_from_path(path), guard, action, None)
+    let display = path.to_string_lossy();
+    super::execute_as_edit_result_with_path(
+        op,
+        mode,
+        cwd_from_path(path),
+        guard,
+        action,
+        None,
+        Some(display.as_ref()),
+    )
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]
@@ -174,7 +183,16 @@ fn file_write_cross(
     action: &'static str,
     dest_path: Option<String>,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd_from_path(src), guard, action, dest_path)
+    let display = src.to_string_lossy();
+    super::execute_as_edit_result_with_path(
+        op,
+        mode,
+        cwd_from_path(src),
+        guard,
+        action,
+        dest_path,
+        Some(display.as_ref()),
+    )
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -34,7 +34,16 @@ fn md_write(
         )
     })?;
     rewrite_md_op_path(&mut op, abs.to_string_lossy().as_ref());
-    super::execute_as_edit_result(op, mode, cwd_from_path(&abs), guard, action, None)
+    let display = path.to_string_lossy();
+    super::execute_as_edit_result_with_path(
+        op,
+        mode,
+        cwd_from_path(&abs),
+        guard,
+        action,
+        None,
+        Some(display.as_ref()),
+    )
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -960,6 +960,8 @@ mod prefer_widest_tests {
 /// For cross-file operations (rename, move) pass `dest_path` to report the
 /// destination; single-file operations pass `None`.
 #[cfg(any(feature = "cli", feature = "files"))]
+/// Thin wrapper for tests / callers that do not need a display-path override.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn execute_as_edit_result(
     op: crate::plan::Operation,
     mode: ApplyMode,
@@ -968,13 +970,29 @@ pub(crate) fn execute_as_edit_result(
     action: &'static str,
     dest_path: Option<String>,
 ) -> anyhow::Result<EditResult> {
+    execute_as_edit_result_with_path(op, mode, cwd, guard, action, dest_path, None)
+}
+
+/// Like [`execute_as_edit_result`], but forces [`EditResult::path`] to
+/// `display_path` when set so hosts that join on the caller path do not get a
+/// basename-only result from parent-as-cwd relative_display.
+#[cfg(any(feature = "cli", feature = "files"))]
+pub(crate) fn execute_as_edit_result_with_path(
+    op: crate::plan::Operation,
+    mode: ApplyMode,
+    cwd: &Path,
+    guard: Option<&PathGuard>,
+    action: &'static str,
+    dest_path: Option<String>,
+    display_path: Option<&str>,
+) -> anyhow::Result<EditResult> {
     let global = mode_to_global_flags(mode);
     let options = crate::tx::engine::ExecuteOptions::from_global(cwd, &global, guard);
     let result = crate::tx::engine::stage(crate::tx::engine::WriteRequest {
         source: crate::tx::engine::WriteSource::Operations(vec![op]),
         options,
     })?;
-    execution_result_to_edit_result(result, mode, cwd, action, dest_path)
+    execution_result_to_edit_result(result, mode, cwd, action, dest_path, display_path)
 }
 
 /// Map `ApplyMode` to `GlobalFlags` with the appropriate apply/check settings.
@@ -999,6 +1017,7 @@ fn execution_result_to_edit_result(
     cwd: &Path,
     action: &'static str,
     dest_path: Option<String>,
+    display_path: Option<&str>,
 ) -> anyhow::Result<EditResult> {
     let has_changes = result.has_changes;
     let removed: usize = result
@@ -1043,6 +1062,12 @@ fn execution_result_to_edit_result(
             // No changes at all (e.g., replace with no matches + if_exists).
             (String::new(), String::new(), String::new())
         };
+    // Prefer caller spelling when provided (parent-as-cwd collapses multi-
+    // component relatives to basename via relative_display).
+    let path_str = display_path
+        .map(str::to_string)
+        .filter(|s| !s.is_empty())
+        .unwrap_or(path_str);
 
     // Commit for Apply mode; capture backup session for embedder undo (#1686).
     let (applied, backup_session) = if mode == ApplyMode::Apply && has_changes {

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -45,7 +45,8 @@ pub fn apply_patch(
             .to_path_buf();
         cwd_owned.as_path()
     };
-    patch_write(op, cwd, mode, guard)
+    let display = path.to_string_lossy();
+    patch_write(op, cwd, mode, guard, Some(display.as_ref()))
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -54,8 +55,9 @@ fn patch_write(
     cwd: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
+    display_path: Option<&str>,
 ) -> anyhow::Result<EditResult> {
-    super::execute_as_edit_result(op, mode, cwd, guard, "patch", None)
+    super::execute_as_edit_result_with_path(op, mode, cwd, guard, "patch", None, display_path)
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]
@@ -64,6 +66,7 @@ fn patch_write(
     cwd: &Path,
     mode: ApplyMode,
     guard: Option<&PathGuard>,
+    _display_path: Option<&str>,
 ) -> anyhow::Result<EditResult> {
     use crate::ops;
 

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -162,7 +162,16 @@ fn replace_write(
     _fuzzy: bool,
 ) -> anyhow::Result<EditResult> {
     let cwd = path.parent().unwrap_or_else(|| Path::new("."));
-    super::execute_as_edit_result(op, mode, cwd, guard, "replace", None)
+    let display = path.to_string_lossy();
+    super::execute_as_edit_result_with_path(
+        op,
+        mode,
+        cwd,
+        guard,
+        "replace",
+        None,
+        Some(display.as_ref()),
+    )
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]
@@ -221,7 +230,7 @@ fn replace_write(
         } else {
             None
         };
-        let replacement = ops::replace::replacement_text(
+        let replacement = ops::replace::replacement_text_ci(
             &old,
             &direct_to,
             &insert_before,
@@ -229,6 +238,7 @@ fn replace_write(
             compiled_re.is_some(),
             is_regex,
             &original,
+            case_insensitive,
         );
 
         let parsed_range = range.as_deref().map(|r| {
@@ -632,7 +642,7 @@ fn replace_in_content_inner(
     } else {
         None
     };
-    let replacement = ops::replace::replacement_text(
+    let replacement = ops::replace::replacement_text_ci(
         from,
         &direct_to,
         &opts.insert_before,
@@ -640,6 +650,7 @@ fn replace_in_content_inner(
         compiled_re.is_some(),
         is_regex,
         content,
+        opts.case_insensitive,
     );
 
     let parsed_range = opts.range;

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -6190,6 +6190,35 @@ fn replace_text_exact_disk_multi_match_count() {
 }
 
 // ---------------------------------------------------------------------------
+
+/// Engine parent-cwd must not collapse multi-component caller paths to basename.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn edit_result_path_preserves_caller_relative() {
+    let dir = TempDir::new().unwrap();
+    let nested = dir.path().join("src");
+    fs::create_dir(&nested).unwrap();
+    let file = nested.join("lib.rs");
+    fs::write(&file, "fn old() {}\n").unwrap();
+    // Absolute multi-component path (do not chdir: process-global, races tests).
+    let r = replace_text(
+        &file,
+        "old",
+        "new",
+        &ReplaceOptions::default(),
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(
+        r.path.contains("src") && r.path.contains("lib.rs"),
+        "EditResult.path must keep multi-component path, not basename only; got {:?}",
+        r.path
+    );
+    // Without display_path override this collapsed to "lib.rs" via parent cwd.
+    assert_ne!(r.path, "lib.rs");
+}
+
 // Agent-host APIs #1686–#1690
 // ---------------------------------------------------------------------------
 

--- a/src/api/tidy.rs
+++ b/src/api/tidy.rs
@@ -98,7 +98,16 @@ fn tidy_write(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     let cwd = path.parent().unwrap_or_else(|| Path::new("."));
-    super::execute_as_edit_result(op, mode, cwd, guard, "tidy", None)
+    let display = path.to_string_lossy();
+    super::execute_as_edit_result_with_path(
+        op,
+        mode,
+        cwd,
+        guard,
+        "tidy",
+        None,
+        Some(display.as_ref()),
+    )
 }
 
 #[cfg(not(any(feature = "cli", feature = "files")))]

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -6,7 +6,6 @@ use crate::diff::render_diffs_colored;
 use crate::exit;
 use crate::ops::replace::{
     compile_replace_regex, count_nth_candidates, replace_content, replace_whole_lines,
-    replacement_text,
 };
 use crate::tx::engine::WriteSource;
 use clap::Args;
@@ -340,12 +339,13 @@ fn collect_replacements_with_list(
     let new_opt = args.new.clone();
     let use_match_anchor = args.regex || args.case_insensitive || args.word_boundary;
     let regex_mode = args.regex;
+    let case_insensitive = args.case_insensitive;
 
     let cwd_ref = &cwd;
     let mut replacements: Vec<FileReplacement> =
         crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let content = crate::files::read_text_file_logged(path, "replace", quiet)?;
-            let replacement = replacement_text(
+            let replacement = crate::ops::replace::replacement_text_ci(
                 from,
                 &new_opt,
                 &insert_before,
@@ -353,6 +353,7 @@ fn collect_replacements_with_list(
                 use_match_anchor,
                 regex_mode,
                 &content,
+                case_insensitive,
             );
             let (replaced, count) = if command_position {
                 let (out, n) =

--- a/src/files.rs
+++ b/src/files.rs
@@ -446,8 +446,24 @@ pub(crate) fn collect_file_paths_opts_with_list(
     });
     let mut paths = collected.into_inner().expect("all walkers done");
 
+    // Explicit file path args must not be dropped by exclude. Config like
+    // exclude.globs = ["vendor/**"] is for walks; a targeted
+    // `replace … vendor/pkg/x.js` must still hit that file. Directory roots
+    // keep exclude for their contents. --files-from already skips exclude.
+    let explicit_files: Vec<PathBuf> = effective
+        .iter()
+        .map(|p| resolve(p))
+        .filter(|p| p.is_file())
+        .collect();
+
     // Apply runtime exclude patterns (shared helper for parity with with_ignores).
     apply_exclude_globs(&mut paths, &global.exclude, root)?;
+
+    for f in explicit_files {
+        if !paths.iter().any(|p| p == &f) {
+            paths.push(f);
+        }
+    }
     Ok(paths)
 }
 
@@ -1551,6 +1567,63 @@ mod tests {
             paths,
             vec![PathBuf::from("/project/src/main.rs")],
             "vendor/** with root should exclude vendor files"
+        );
+    }
+}
+
+#[cfg(all(test, feature = "cli"))]
+mod explicit_exclude_tests {
+    use super::*;
+    use crate::cli::global::GlobalFlags;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn explicit_file_arg_not_dropped_by_exclude_glob() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::create_dir(root.join("vendor")).unwrap();
+        let file = root.join("vendor/x.js");
+        fs::write(&file, "foo\n").unwrap();
+        let global = GlobalFlags {
+            exclude: vec!["vendor/**".into()],
+            ..GlobalFlags::test_default()
+        };
+        let paths = collect_file_paths_opts_with_list(
+            &["vendor/x.js".into()],
+            &global,
+            false,
+            Some(root),
+            None,
+        )
+        .unwrap();
+        assert!(
+            paths.iter().any(|p| p.ends_with("x.js")),
+            "explicit file must survive exclude: {paths:?}"
+        );
+    }
+
+    #[test]
+    fn directory_root_still_honors_exclude() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        fs::create_dir(root.join("vendor")).unwrap();
+        fs::write(root.join("vendor/x.js"), "foo\n").unwrap();
+        fs::write(root.join("app.js"), "foo\n").unwrap();
+        let global = GlobalFlags {
+            exclude: vec!["vendor/**".into()],
+            ..GlobalFlags::test_default()
+        };
+        let paths =
+            collect_file_paths_opts_with_list(&[".".into()], &global, false, Some(root), None)
+                .unwrap();
+        assert!(
+            paths.iter().any(|p| p.ends_with("app.js")),
+            "app.js should remain: {paths:?}"
+        );
+        assert!(
+            !paths.iter().any(|p| p.to_string_lossy().contains("vendor")),
+            "vendor walk contents still excluded: {paths:?}"
         );
     }
 }

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -219,6 +219,48 @@ pub fn normalize_line_insert(
     }
 }
 
+/// Like [`normalize_line_insert`], but whole-line detection honors case-insensitive
+/// anchors (CLI `-i` / plan `case_insensitive`) so `Debug` + insert after `debug`
+/// becomes a sibling line, not `Debugnote`.
+pub fn normalize_line_insert_ci(
+    file_content: &str,
+    anchor: &str,
+    insert_content: &str,
+    side: InsertSide,
+    case_insensitive: bool,
+) -> String {
+    if !case_insensitive {
+        return normalize_line_insert(file_content, anchor, insert_content, side);
+    }
+    let eol = preferred_line_ending(file_content);
+    match side {
+        InsertSide::After => {
+            if starts_with_line_ending(insert_content) || ends_with_line_ending(anchor) {
+                return insert_content.to_string();
+            }
+            if looks_like_new_line_payload(insert_content)
+                || anchor_is_whole_line_ci(file_content, anchor, true)
+            {
+                format!("{eol}{insert_content}")
+            } else {
+                insert_content.to_string()
+            }
+        }
+        InsertSide::Before => {
+            if ends_with_line_ending(insert_content) || starts_with_line_ending(anchor) {
+                return insert_content.to_string();
+            }
+            if looks_like_new_line_payload(insert_content)
+                || anchor_is_whole_line_ci(file_content, anchor, true)
+            {
+                format!("{insert_content}{eol}")
+            } else {
+                insert_content.to_string()
+            }
+        }
+    }
+}
+
 /// Dominant line ending in `content` for line-oriented insert separators.
 ///
 /// Prefer CRLF when present, else bare CR, else LF. Empty content uses LF.
@@ -256,20 +298,64 @@ fn looks_like_new_line_payload(insert_content: &str) -> bool {
 /// Accepts LF, CRLF, and bare CR as line boundaries so whole-line bare
 /// inserts on Windows-style files still line-orient (#1885 follow-up).
 pub fn anchor_is_whole_line(file_content: &str, anchor: &str) -> bool {
+    anchor_is_whole_line_ci(file_content, anchor, false)
+}
+
+/// Like [`anchor_is_whole_line`]; when `case_insensitive`, compare with
+/// ASCII case folding so `-i debug` matches a whole line `Debug`.
+pub fn anchor_is_whole_line_ci(file_content: &str, anchor: &str, case_insensitive: bool) -> bool {
     if anchor.is_empty() || file_content.is_empty() {
         return false;
     }
-    let bytes = file_content.as_bytes();
-    let mut any = false;
-    for (i, _) in file_content.match_indices(anchor) {
-        any = true;
-        let before_ok = i == 0 || is_line_boundary_byte(bytes[i - 1]);
-        let end = i + anchor.len();
-        let after_ok =
-            end == file_content.len() || bytes.get(end).copied().is_some_and(is_line_boundary_byte);
-        if !(before_ok && after_ok) {
-            return false;
+    if !case_insensitive {
+        let bytes = file_content.as_bytes();
+        let mut any = false;
+        for (i, _) in file_content.match_indices(anchor) {
+            any = true;
+            let before_ok = i == 0 || is_line_boundary_byte(bytes[i - 1]);
+            let end = i + anchor.len();
+            let after_ok = end == file_content.len()
+                || bytes.get(end).copied().is_some_and(is_line_boundary_byte);
+            if !(before_ok && after_ok) {
+                return false;
+            }
         }
+        return any;
+    }
+    // Case-insensitive: scan line contents (ASCII fold). Non-ASCII case
+    // folding is not required for typical agent/CLI patterns.
+    let needle = anchor.to_ascii_lowercase();
+    let mut any = false;
+    let mut start = 0usize;
+    let bytes = file_content.as_bytes();
+    while start <= file_content.len() {
+        let rest = &file_content[start..];
+        let line_end = rest
+            .find(['\n', '\r'])
+            .map(|i| start + i)
+            .unwrap_or(file_content.len());
+        let line = &file_content[start..line_end];
+        if line.to_ascii_lowercase() == needle {
+            any = true;
+            // whole line by construction (line == match span)
+        } else if !line.is_empty() {
+            // Mid-line occurrence of the pattern is not whole-line.
+            let lower = line.to_ascii_lowercase();
+            if lower.contains(&needle) && lower != needle {
+                return false;
+            }
+        }
+        if line_end >= file_content.len() {
+            break;
+        }
+        // Advance past one line ending (CRLF, LF, or bare CR).
+        let mut next = line_end;
+        if file_content[next..].starts_with("\r\n") {
+            next += 2;
+        } else if matches!(bytes.get(next), Some(b'\n' | b'\r')) {
+            next += 1;
+        }
+        start = next;
     }
     any
 }
@@ -293,6 +379,30 @@ pub fn replacement_text(
     regex_mode: bool,
     file_content: &str,
 ) -> String {
+    replacement_text_ci(
+        from,
+        to,
+        insert_before,
+        insert_after,
+        use_match_anchor,
+        regex_mode,
+        file_content,
+        false,
+    )
+}
+
+/// Like [`replacement_text`] with case-insensitive whole-line insert detection.
+#[allow(clippy::too_many_arguments)]
+pub fn replacement_text_ci(
+    from: &str,
+    to: &Option<String>,
+    insert_before: &Option<String>,
+    insert_after: &Option<String>,
+    use_match_anchor: bool,
+    regex_mode: bool,
+    file_content: &str,
+    case_insensitive: bool,
+) -> String {
     let anchor = if use_match_anchor { "${0}" } else { from };
 
     // When a regex is compiled internally (case_insensitive / word_boundary)
@@ -303,7 +413,13 @@ pub fn replacement_text(
     if let Some(text) = insert_before {
         // Normalize against the literal `from` pattern (not ${0}) so whole-line
         // detection sees the real anchor text in the file.
-        let normalized = normalize_line_insert(file_content, from, text, InsertSide::Before);
+        let normalized = normalize_line_insert_ci(
+            file_content,
+            from,
+            text,
+            InsertSide::Before,
+            case_insensitive,
+        );
         let safe = if needs_escape {
             normalized.replace('$', "$$")
         } else {
@@ -313,7 +429,13 @@ pub fn replacement_text(
     }
 
     if let Some(text) = insert_after {
-        let normalized = normalize_line_insert(file_content, from, text, InsertSide::After);
+        let normalized = normalize_line_insert_ci(
+            file_content,
+            from,
+            text,
+            InsertSide::After,
+            case_insensitive,
+        );
         let safe = if needs_escape {
             normalized.replace('$', "$$")
         } else {

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -227,6 +227,30 @@ mod replace_tests {
         }
 
         #[test]
+        fn anchor_is_whole_line_ci_case_insensitive_matches_on_disk_casing() {
+            assert!(anchor_is_whole_line_ci("Debug\n", "debug", true));
+            assert!(!anchor_is_whole_line_ci("Debug\n", "debug", false));
+            let out = normalize_line_insert_ci("Debug\n", "debug", "note", InsertSide::After, true);
+            assert_eq!(out, "\nnote");
+            let full = replacement_text_ci(
+                "debug",
+                &None,
+                &None,
+                &Some("note".into()),
+                true,
+                false,
+                "Debug\n",
+                true,
+            );
+            // ${0} + \nnote expands later; template must include line-oriented insert
+            assert!(full.contains("note"), "got {full}");
+            assert!(
+                full.starts_with("${0}") || full.contains('\n'),
+                "got {full}"
+            );
+        }
+
+        #[test]
         fn normalize_line_insert_after_midline_stays_byte_exact() {
             let file = "prefix foo suffix\n";
             let out = normalize_line_insert(file, "foo", "X", InsertSide::After);

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -7,7 +7,7 @@ use super::execute::{TxState, read_and_probe, read_file_content};
 use crate::api::MatchMode;
 use crate::ops::replace::{
     InsertSide, compile_replace_regex, context_filtered_span_with_re, expand_match_anchor_template,
-    normalize_line_insert, replace_content, replace_whole_lines, replacement_text,
+    normalize_line_insert, replace_content, replace_whole_lines, replacement_text_ci,
 };
 use crate::plan::Operation;
 use crate::tx::output::merge_match_modes;
@@ -223,7 +223,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             Err(e) => return Err(e),
         };
         // Per-file content so whole-line anchor detection is accurate (#1885).
-        let replacement = replacement_text(
+        let replacement = replacement_text_ci(
             old,
             new_text,
             insert_before,
@@ -231,6 +231,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             use_regex,
             regex_mode,
             content,
+            *case_insensitive,
         );
         let (replaced, match_count) = if *command_position {
             let to = new_text.as_deref().unwrap_or("");
@@ -543,7 +544,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 .get(&file_path)
                 .map(|(_, c)| c.clone())
                 .expect("read_and_probe guarantees entry exists in pending");
-            let replacement = replacement_text(
+            let replacement = replacement_text_ci(
                 old,
                 new_text,
                 insert_before,
@@ -551,6 +552,7 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 use_regex,
                 regex_mode,
                 &content,
+                *case_insensitive,
             );
             let (replaced, match_count) = if *command_position {
                 let to = new_text.as_deref().unwrap_or("");


### PR DESCRIPTION
## Summary

Re-audit of fixloop R3 Reject column after user catch on multi-file / write_if_apply (fixed in #2071).

These were labeled noise or "later" without a never-happen argument. Concrete repros:

| Finding | Repro | Fix |
|---------|-------|-----|
| exclude drops explicit file | `.patchloom.toml` `exclude.globs=["vendor/**"]` + `replace … vendor/x.js` → exit 3 `no_matches` | Keep explicit file args after exclude (walks still exclude) |
| `-i` whole-line insert | `Debug` + `replace -i debug --insert-after note` → `Debugnote` | `replacement_text_ci` / `anchor_is_whole_line_ci` |
| EditResult.path basename | `replace_text(Path::new("src/lib.rs"), …)` → path `"lib.rs"` | `execute_as_edit_result_with_path` preserves caller spelling |

Still Reject (intentional / never-happen): plan `unique` default false (compat), fuzzy multi-candidate first (locked test), md first duplicate heading (documented), parse_value `1.0` number heuristic (documented).

## Test plan

- [x] `make check-fast`
- [x] Dogfood: exclude explicit apply; `-i` insert → `Debug\nnote\n`
- [x] Unit: explicit exclude, directory exclude, CI whole-line, EditResult path