### PR TITLE
feat(mcp): list_files inventory and competitive gap docs

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -9,6 +9,7 @@
 | identifier rename | `ast rename` | `ast.rename` | `ast_rename` or plan via `execute_plan` |
 | structured set | `doc set` / `doc update` | `doc.set` / `doc.update` | `doc_set` / plan |
 | search | `search` | n/a | `search_files` |
+| list files | n/a (MCP) | n/a | `list_files` |
 | read | `read` | n/a | `read_file` |
 
 Host meta-tools (for example a host `search_tool` catalog lookup) are **not** patchloom MCP tools. Only list registered MCP tool names when summarizing patchloom usage.
@@ -17,7 +18,7 @@ Host meta-tools (for example a host `search_tool` catalog lookup) are **not** pa
 
 When patchloom MCP is connected:
 
-- Prefer `search_files` and `read_file` with paths **relative** to MCP cwd over shell `cat` / `head` / `find` / `sed` / `rg` for exploring and reading source.
+- Prefer `list_files`, `search_files`, and `read_file` with paths **relative** to MCP cwd over shell `cat` / `head` / `find` / `ls` / `sed` / `rg` (and over a second generic filesystem MCP) for explore and inventory.
 - Use shell only for build/test/run (`make`, `cargo test`, language runners) unless the user explicitly overrides.
 - MCP path containment: relative paths and absolute paths that resolve **inside** the server workspace are allowed (agents often join `server_info.cwd` + relative). `../` escapes, absolute paths outside the workspace, and escaping symlinks are rejected. Prefer relative paths in tool calls.
 
@@ -67,7 +68,7 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 
 **Context budget:** prefer `read` with a line range, `search --count` / `--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` for large result streams. Binary sole paths peel `error_kind: binary`.
 
-**MCP tool volume:** the server may expose many tools; start from this table (and `schema --tier weak|medium|strong` for plan prompts). Full inventory is the default. Small agents / tight context: set env `PATCHLOOM_MCP_SURFACE=core` so handshake registers only the minimal pack (`read_file`, `search_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info`). `PATCHLOOM_MCP_SURFACE=full` or unset keeps the full inventory. `server_info` reports `cwd`, `surface`, `tool_count`, package `version`, and MCP `protocol_version`. Handshake instructions are surface-aware (core does not list full-only tool names). `execute_plan` on core can still run full plan ops; the env reduces tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.
+**MCP tool volume:** the server may expose many tools; start from this table (and `schema --tier weak|medium|strong` for plan prompts). Full inventory is the default. Small agents / tight context: set env `PATCHLOOM_MCP_SURFACE=core` so handshake registers only the core pack (`read_file`, `search_files`, `list_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info`). Prefer core alone for list+edit (no second filesystem MCP). `PATCHLOOM_MCP_SURFACE=full` or unset keeps the full inventory. `server_info` reports `cwd`, `surface`, `tool_count`, package `version`, and MCP `protocol_version`. Handshake instructions are surface-aware (core does not list full-only tool names). `execute_plan` on core can still run full plan ops; the env reduces tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.
 
 ## Tool selection guide
 
@@ -88,6 +89,7 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |
 | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |
 | Search across files | `search_files` |
+| List/inventory files (ignore-aware, capped; prefer over FS MCP) | `list_files` |
 | Apply a unified diff patch | `apply_patch` |
 | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace`, `ast_rewrite_signature` |
 | Insert, wrap, or manage imports | `ast_insert`, `ast_wrap`, `ast_imports` |

--- a/README.md
+++ b/README.md
@@ -283,11 +283,15 @@ patchloom mcp-server
 
 MCP-capable agents call patchloom tools directly as structured JSON, with no shell quoting or command construction. The agent sends `{"path": "config.json", "selector": "version", "value": "2.0"}` instead of building `patchloom doc set config.json version '"2.0"' --apply`.
 
-Small agents that choke on large tool schemas can set `PATCHLOOM_MCP_SURFACE=core` for a 10-tool pack at handshake (default remains full inventory). See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for per-agent configuration, surface options, and the full security model.
+**Coding agents:** set `PATCHLOOM_MCP_SURFACE=core` for an 11-tool pack (`list_files`, search/read/replace, doc/md, `execute_plan`, `server_info`) so schemas stay small. Product default remains full inventory when the env is unset. Prefer Patchloom MCP alone for list+edit (no second filesystem MCP). See the [MCP setup guide](./docs/getting-started/mcp-setup.md) for Cursor / Claude / Codex paste configs and the full security model.
 
 > **Using VS Code, Cursor, or Windsurf?** The [Patchloom extension](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom) handles setup automatically: it installs the binary, runs init, and configures your editor's MCP settings.
 
 ### As a Rust library
+
+Host teams embedding Patchloom instead of a private edit stack: see the
+[embedder host case study](./docs/blog/embedder-host-case-study.md)
+(`for_agent`, peels, fuzzy refuse, apply_fragment, path-only ops).
 
 Add patchloom as a dependency (omit CLI/MCP/AST with `default-features = false`):
 

--- a/docs/blog/embedder-host-case-study.md
+++ b/docs/blog/embedder-host-case-study.md
@@ -1,0 +1,51 @@
+# Embedder host case study: prefer Patchloom library contracts
+
+> **Audience:** product teams that embed Patchloom as a Rust crate (hosts such as multi-agent CLIs) instead of reimplementing search/replace, config edits, and peels.
+> **APIs:** public surface as of 0.23+ (0.24 when released). No confidential host internals.
+
+## The problem hosts reinvent
+
+Without a shared library, agent hosts often grow a private edit stack:
+
+- fuzzy or approximate replace after exact match fails
+- multi-op batch apply with partial success
+- path containment and binary/encoding soft-skip
+- Morph-class freeform snippets with `// ... existing code ...` markers
+- ad hoc undo
+
+That glue tends to drift from CLI and MCP behavior, so the same agent prompt works in one surface and fails in another.
+
+## Prefer these Patchloom host APIs
+
+| Job | API |
+|-----|-----|
+| Agent-safe replace defaults | `ReplaceOptions::for_agent()` (`unique`, `require_change`, fuzzy floor, `allow_absent_old: false`, `refuse_suspicious_fuzzy`) |
+| Classify errors for branching | `edit_error_kind` / `error_kind_str` / peels such as `is_binary`, `is_already_exists`, `is_not_found`, `is_guard_rejected` |
+| Refuse over-wide fuzzy spans | `fuzzy_span_suspicious` / `FuzzySpanPolicy` |
+| Multi-op buffer refuse before write | `refuse_batch_if_suspicious_fuzzy` |
+| Multi-op content apply | `apply_content_edits` / `apply_content_edits_to_file` (+ span policy variant) |
+| Morph-class fragment with anchor | `apply_fragment_to_file` (markers stripped; requires after/before/old) |
+| Path-only binary/invalid UTF-8 rename/delete | library file ops with path-only honesty constructors |
+| Atomic multi-file library write | finalize-before-mutate multi-write path (`write_if_apply_many` internally) |
+| Plan/tx | `execute_plan` with optional `PathGuard` |
+
+Scale: hosts that previously maintained a few hundred to a few thousand lines of private replace/path/peel glue can delete most of it once they pin a Patchloom version that includes these exports (exact line counts vary by host; the win is one contract across CLI, MCP, and library).
+
+## Routing rules that reduce Morph / yq / FS MCP
+
+1. **Configs / multi-doc YAML / TOML / JSON:** `doc_*` / `doc set`, not text replace or yq.
+2. **Markdown structure:** `md_*`, not whole-file rewrite.
+3. **Identifiers:** `ast rename` / project rename, not fuzzy text.
+4. **Inventory:** MCP `list_files` / library walk helpers, not a second filesystem MCP.
+5. **Freeform snippet with known anchor:** `apply_fragment_to_file` / CLI `apply-fragment`.
+6. **Freeform with no anchors:** still Morph/IDE apply territory (non-goal for Patchloom).
+
+## Verify before you pin
+
+```bash
+make embedder-smoke
+make test-library-hygiene
+cargo test --lib fuzzy_span refuse_batch --all-features
+```
+
+See also [comparisons](../getting-started/comparisons.md), [MCP setup](../getting-started/mcp-setup.md), and crate docs under `patchloom::api`.

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -107,7 +107,7 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 ## By the numbers
 
 - **2,800+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
-- **24 commands** including MCP server with 57 structured tool calls
+- **24 commands** including MCP server with 58 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
 - **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
 - **MIT OR Apache-2.0** licensed

--- a/docs/examples/mcp-core.example.json
+++ b/docs/examples/mcp-core.example.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "patchloom": {
+      "command": "patchloom",
+      "args": ["mcp-server"],
+      "env": {
+        "PATCHLOOM_MCP_SURFACE": "core"
+      }
+    }
+  }
+}

--- a/docs/getting-started/comparisons.md
+++ b/docs/getting-started/comparisons.md
@@ -14,11 +14,11 @@ Patchloom is **not** a generic filesystem MCP and **not** a drop-in replacement 
 | Multi-file atomic plan + undo | No | `tx` / `batch` + `undo` |
 | Agent-branchable `error_kind` | Weak | `binary`, `invalid_encoding`, `already_exists`, `format_failed`, … |
 
-**Use a generic filesystem MCP** for simple read/write outside structured agent workflows.
+**Use a generic filesystem MCP** only when you need pure FS ops and Patchloom is not installed.
 
-**Use Patchloom** when the agent must mutate configs, markdown structure, or multi-file plans with preview and peels.
+**Use Patchloom alone** for list + search + structured edit: MCP `list_files` covers inventory (ignore-aware, capped), so coding agents should not pair Patchloom with a second filesystem MCP for list/read/edit. Prefer `PATCHLOOM_MCP_SURFACE=core` (11 tools including `list_files`).
 
-Install notes: [MCP setup](mcp-setup.md). Registry name: `io.github.patchloom/patchloom`.
+Install notes: [MCP setup](mcp-setup.md) (Cursor / Claude / Codex paste configs with core). Registry name: `io.github.patchloom/patchloom`.
 
 ## vs yq / dasel / jq
 
@@ -34,6 +34,18 @@ Install notes: [MCP setup](mcp-setup.md). Registry name: `io.github.patchloom/pa
 
 **Use Patchloom** inside agent loops (CLI, MCP, or embedder library).
 
+### yq one-liners → Patchloom (agent cheat sheet)
+
+| Shell habit | Patchloom |
+|-------------|-----------|
+| `yq '.version' package.json` | `patchloom doc get package.json version` or MCP `doc_get` |
+| `yq -i '.version = "2.0.0"' package.json` | `patchloom doc set package.json version '"2.0.0"' --apply` (or MCP `doc_set`) |
+| `yq 'select(document_index == 0) \| .a' multi.yaml` | `patchloom doc get multi.yaml 0.a` |
+| `yq -i '.[0].image = "x"' multi.yaml` | `patchloom doc set multi.yaml 0.image x --apply` |
+| `yq '.items[] \| select(.name == "a")' f.yaml` | `patchloom doc select f.yaml items --predicate name=a` (or MCP `doc_query` / plan) |
+
+Prefer parser-backed `doc` over inventing `yq` in agent shells so peels, dry-run exit 2, and multi-doc honesty stay consistent.
+
 ## vs ast-grep (complement)
 
 [ast-grep](https://github.com/ast-grep/ast-grep) owns **structural code search and pattern rewrite** (syntax-tree patterns, codemods). Patchloom owns **host-safe apply** for configs, markdown, multi-file transactions, and agent honesty.
@@ -46,7 +58,16 @@ Install notes: [MCP setup](mcp-setup.md). Registry name: `io.github.patchloom/pa
 | Atomic multi-file apply with undo | Patchloom `tx` / `batch` |
 | After fuzzy text replace, refuse over-wide spans (library host) | Patchloom `fuzzy_span_suspicious` / batch `refuse_batch_if_suspicious_fuzzy` |
 
-Typical pipeline: discover with ast-grep → apply policy-safe writes with Patchloom.
+### Typical pipeline (ast-grep + Patchloom)
+
+1. **Discover** code shapes with ast-grep (or `patchloom ast search` when a simple structural query is enough).
+2. **Apply** with Patchloom so peels and undo stay host-safe:
+   - identifier rename: `ast rename PATH --old X --new Y --apply` or plan `ast.rename`
+   - multi-file atomic apply: `tx` / MCP `execute_plan`
+   - config/docs alongside code: `doc set` / `md replace-section` in the same plan
+3. **Do not** re-apply the same edit with raw `sed` after Patchloom already wrote.
+
+Example: ast-grep finds call sites; Patchloom `ast rename` + `tx` with `require_change` applies and fails closed if a path misses.
 
 ## vs Morph Fast Apply (and similar merge APIs)
 
@@ -79,7 +100,12 @@ Use this table when someone asks "can patchloom replace Morph for X?" Full PASS/
 | Lazy markers with **no** anchors | Not supported | Non-goal: supply after/before/old or use Morph |
 | Freeform "put method in the right place" with known anchor | `apply-fragment` or `ast` + insert | **PASS** with anchors; no free placement guess |
 
-**Host routing (Morph MCP says "prefer edit_file"):** prefer `doc` / `md` / `ast` / `batch` when structure is known; use `replace` (+ fuzzy only when needed); never whole-file rewrite for a one-line change.
+**Host routing (Morph MCP says "prefer edit_file"):** prefer `doc` / `md` / `ast` / `batch` when structure is known; use `replace` (+ fuzzy only when needed); use `apply-fragment` only with a known after/before/old anchor; never whole-file rewrite for a one-line change.
+
+**Non-goals (do not expect Patchloom to replace Morph here):**
+
+- Anchor-less lazy snippet merge (`// ... existing code ...` with no placement)
+- Competing on cloud apply tok/s or network Fast Apply latency
 
 ## vs full coding agents (Claude Code, Codex, Cursor, Aider)
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -166,7 +166,7 @@ the registry when that would lose multi-file, batch, or read UX.
 
 Custom tools are inventoried in `CUSTOM_MCP_TOOLS_CORE` (always registered)
 and `CUSTOM_MCP_TOOLS_AST` (only when the `ast` feature is enabled). Default
-builds expose **57** tools (registry + custom). Builds without `ast` omit the
+builds expose **58** tools (registry + custom). Builds without `ast` omit the
 AST tools so `list_tools` stays honest about what is callable.
 
 | Tool | Description |
@@ -184,6 +184,7 @@ AST tools so `list_tools` stays honest about what is callable.
 | `doc_query` | Query a structured file: has, keys, len, select, or flatten (read-only) |
 | `doc_diff` | Compare two structured files (read-only) |
 | `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes. Binary and invalid UTF-8 files are skipped (read-only) |
+| `list_files` | Bounded directory inventory with the same ignore/exclude/glob rules as search (read-only). Prefer this over a second generic filesystem MCP for list/tree. Caps with `max_results` (default 500) and optional `max_depth`; reports `truncated` when capped |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
 | `server_info` | Return server identity and workspace root: `cwd`, `surface` (`full`\|`core`), `tool_count`, package `version`, and MCP `protocol_version` (read-only). Use `cwd` before relative path ops |
 | `read_file` | Read file contents with optional line range |
@@ -283,12 +284,12 @@ patchloom mcp-server
 | Value | Effect |
 |-------|--------|
 | unset or `full` | Full inventory (default; backward compatible) |
-| `core` | Only: `read_file`, `search_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info` |
+| `core` | Only: `read_file`, `search_files`, `list_files`, `replace_text`, `batch_replace`, `doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info` |
 | anything else | Server fails to start with a clear error |
 
 `server_info` includes `"surface": "core"|"full"`, `"tool_count"`, package `"version"`, MCP `"protocol_version"` (same as the initialize handshake), and when surface is full a `"recommendation"` string pointing coding agents at core. Invalid `PATCHLOOM_MCP_SURFACE` values are rejected (do not silently fall back).
 
-Handshake `instructions` match the active surface: core mode lists only the core tools (it does not advertise full-inventory names such as `create_file` or `ast_*`). Instructions also include a short **canonical name map** (CLI / plan / MCP) and an **explore rule** (prefer `search_files` / `read_file` over shell `cat` when MCP is connected).
+Handshake `instructions` match the active surface: core mode lists only the core tools (it does not advertise full-inventory names such as `create_file` or `ast_*`). Instructions also include a short **canonical name map** (CLI / plan / MCP) and an **explore rule** (prefer `list_files` / `search_files` / `read_file` over shell `cat`/`find`/`ls` and over a second generic filesystem MCP when Patchloom MCP is connected).
 
 **Note:** `execute_plan` remains on core, so multi-op plans can still run create/delete/AST-style plan ops (and plan `apply.fragment`) when the host sends a full plan. Standalone tools such as `apply_fragment`, `create_file`, and `ast_*` are full-inventory only. The env flag reduces the *tool schema* surface for small agents; it is not a capability sandbox for the plan catalog.
 
@@ -298,7 +299,11 @@ Short system-prompt rules (not the full ~50KB dump):
 patchloom agent-rules --surface core
 ```
 
-Example client env (Grok `config.toml`):
+### Coding-agent install recipes (core by default)
+
+**Coding agents should use the core pack** so tool schemas stay small. Full inventory remains the product default when the env is unset (compatibility). Set `PATCHLOOM_MCP_SURFACE=core` in the client config for Grok, Claude, Cursor, and Codex-style hosts.
+
+#### Grok / config.toml
 
 ```toml
 [mcp_servers.patchloom]
@@ -306,6 +311,55 @@ command = "patchloom"
 args = ["mcp-server"]
 env = { PATCHLOOM_MCP_SURFACE = "core" }
 ```
+
+#### Cursor (`~/.cursor/mcp.json` or project `.cursor/mcp.json`)
+
+```json
+{
+  "mcpServers": {
+    "patchloom": {
+      "command": "patchloom",
+      "args": ["mcp-server"],
+      "env": {
+        "PATCHLOOM_MCP_SURFACE": "core"
+      }
+    }
+  }
+}
+```
+
+#### Claude Desktop / Claude Code style MCP config
+
+```json
+{
+  "mcpServers": {
+    "patchloom": {
+      "command": "patchloom",
+      "args": ["mcp-server"],
+      "env": {
+        "PATCHLOOM_MCP_SURFACE": "core"
+      }
+    }
+  }
+}
+```
+
+#### Codex / generic stdio MCP
+
+```json
+{
+  "name": "patchloom",
+  "command": "patchloom",
+  "args": ["mcp-server"],
+  "env": {
+    "PATCHLOOM_MCP_SURFACE": "core"
+  }
+}
+```
+
+Do **not** also install a generic filesystem MCP only for list/read when Patchloom MCP is connected: use `list_files`, `search_files`, and `read_file` instead. Use full surface (unset env or `full`) when you need standalone AST tools or advanced md/doc tools as first-class MCP tools (`execute_plan` on core can still run plan ops).
+
+Example fragment for copy-paste: [mcp-core.example.json](../examples/mcp-core.example.json).
 
 Design notes: [mcp-surface-tiers.md](../plans/mcp-surface-tiers.md).
 

--- a/docs/plans/mcp-surface-tiers.md
+++ b/docs/plans/mcp-surface-tiers.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Full default inventory (~57 tools with AST) can overwhelm small agents (context tax on tool schemas). Competitors often ship tiny FS MCP servers.
+Full default inventory (~58 tools with AST) can overwhelm small agents (context tax on tool schemas). Competitors often ship tiny FS MCP servers.
 
 ## Decision
 
@@ -15,7 +15,7 @@ Full default inventory (~57 tools with AST) can overwhelm small agents (context 
 
 Exactly these tools (AST off):
 
-- `read_file`, `search_files`, `replace_text`, `batch_replace`
+- `read_file`, `search_files`, `list_files`, `replace_text`, `batch_replace`
 - `doc_get`, `doc_set`, `doc_query`
 - `md_replace_section`, `execute_plan`, `server_info`
 

--- a/src/cmd/agent_packaging.rs
+++ b/src/cmd/agent_packaging.rs
@@ -10,6 +10,7 @@
 pub(crate) const CORE_MCP_TOOL_NAMES: &[&str] = &[
     "read_file",
     "search_files",
+    "list_files",
     "replace_text",
     "batch_replace",
     "doc_get",
@@ -43,6 +44,7 @@ fn canonical_name_map_markdown_for_surface(full_ast_tools: bool) -> &'static str
 | identifier rename | `ast rename` | `ast.rename` | `ast_rename` or plan via `execute_plan` |\n\
 | structured set | `doc set` / `doc update` | `doc.set` / `doc.update` | `doc_set` / plan |\n\
 | search | `search` | n/a | `search_files` |\n\
+| list files | n/a (MCP) | n/a | `list_files` |\n\
 | read | `read` | n/a | `read_file` |\n\
 \n\
 Host meta-tools (for example a host `search_tool` catalog lookup) are **not** \
@@ -58,6 +60,7 @@ patchloom usage.\n\n"
 | identifier rename | `ast rename` | `ast.rename` | plan via `execute_plan` only (no standalone `ast_*` on core) |\n\
 | structured set | `doc set` / `doc update` | `doc.set` / `doc.update` | `doc_set` / plan |\n\
 | search | `search` | n/a | `search_files` |\n\
+| list files | n/a (MCP) | n/a | `list_files` |\n\
 | read | `read` | n/a | `read_file` |\n\
 \n\
 Host meta-tools (for example a host `search_tool` catalog lookup) are **not** \
@@ -72,8 +75,9 @@ pub(crate) fn explore_guidance_markdown() -> &'static str {
 \n\
 When patchloom MCP is connected:\n\
 \n\
-- Prefer `search_files` and `read_file` with paths **relative** to MCP cwd over \
-shell `cat` / `head` / `find` / `sed` / `rg` for exploring and reading source.\n\
+- Prefer `list_files`, `search_files`, and `read_file` with paths **relative** to \
+MCP cwd over shell `cat` / `head` / `find` / `ls` / `sed` / `rg` (and over a \
+second generic filesystem MCP) for explore and inventory.\n\
 - Use shell only for build/test/run (`make`, `cargo test`, language runners) \
 unless the user explicitly overrides.\n\
 - MCP path containment: relative paths and absolute paths that resolve **inside** \
@@ -212,7 +216,7 @@ mod tests {
                 "core body missing tool {name} from CORE_MCP_TOOL_NAMES"
             );
         }
-        assert_eq!(CORE_MCP_TOOL_NAMES.len(), 10);
+        assert_eq!(CORE_MCP_TOOL_NAMES.len(), 11);
     }
 
     #[test]

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -79,8 +79,9 @@ pub(crate) fn generate_agent_rules(args: &AgentRulesArgs) -> String {
     if show_mcp && !show_cli {
         out.push_str(
             "You have MCP tools for file reads, edits, and searches. \
-             Use them for ALL file operations (including explore: `search_files` / \
-             `read_file`, not shell `cat`). Paths are confined to the \
+             Use them for ALL file operations (including explore: `list_files` / \
+             `search_files` / `read_file`, not shell `cat`/`find`/`ls` and not a \
+             second generic filesystem MCP). Paths are confined to the \
              server workspace (MCP rejects `../` escapes and outside symlinks).\n\n",
         );
     }
@@ -149,18 +150,25 @@ For Morph-class snippets, use `apply-fragment` with a **required** after/before/
 (lazy markers stripped; no model merge). Migration matrix: docs/plans/morph-gap-matrix.md (#2018).\n\n\
          **Context budget:** prefer `read` with a line range, `search --count` / \
 `--files-with-matches`, and one `batch`/`tx` over N full-file dumps. Use `--jsonl` \
-for large result streams. Binary sole paths peel `error_kind: binary`.\n\n\
-         **MCP tool volume:** the server may expose many tools; start from this table \
+for large result streams. Binary sole paths peel `error_kind: binary`.\n\n",
+    );
+    // Core pack list must track CORE_MCP_TOOL_NAMES (single source; #2070/#2076).
+    let core_tools = crate::cmd::agent_packaging::CORE_MCP_TOOL_NAMES
+        .iter()
+        .map(|n| format!("`{n}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    out.push_str(&format!(
+        "**MCP tool volume:** the server may expose many tools; start from this table \
 (and `schema --tier weak|medium|strong` for plan prompts). Full inventory is the default. \
 Small agents / tight context: set env `PATCHLOOM_MCP_SURFACE=core` so handshake registers \
-only the minimal pack (`read_file`, `search_files`, `replace_text`, `batch_replace`, \
-`doc_get`, `doc_set`, `doc_query`, `md_replace_section`, `execute_plan`, `server_info`). \
+only the core pack ({core_tools}). Prefer core alone for list+edit (no second filesystem MCP). \
 `PATCHLOOM_MCP_SURFACE=full` or unset keeps the full inventory. `server_info` reports \
 `cwd`, `surface`, `tool_count`, package `version`, and MCP `protocol_version`. \
 Handshake instructions are surface-aware (core does not list \
 full-only tool names). `execute_plan` on core can still run full plan ops; the env reduces \
-tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.\n\n",
-    );
+tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.\n\n"
+    ));
 
     // When to use
     if show_mcp {
@@ -183,6 +191,7 @@ tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.\n\n
              | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |\n\
              | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |\n\
              | Search across files | `search_files` |\n\
+             | List/inventory files (ignore-aware, capped; prefer over FS MCP) | `list_files` |\n\
              | Apply a unified diff patch | `apply_patch` |\n\
              | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace`, `ast_rewrite_signature` |\n\
              | Insert, wrap, or manage imports | `ast_insert`, `ast_wrap`, `ast_imports` |\n\
@@ -1385,10 +1394,16 @@ mod tests {
             out.contains("PATCHLOOM_MCP_SURFACE")
                 && out.contains("core")
                 && out.contains("read_file")
+                && out.contains("list_files")
                 && out.contains("execute_plan")
                 && out.contains("surface-aware")
-                && out.contains("plan catalog"),
-            "agent-rules must document PATCHLOOM_MCP_SURFACE=core pack + honesty (#1994)"
+                && out.contains("plan catalog")
+                && out.contains("filesystem MCP"),
+            "agent-rules must document PATCHLOOM_MCP_SURFACE=core pack + list_files (#1994/#2076)"
+        );
+        assert!(
+            out.contains("| List/inventory files") && out.contains("`list_files`"),
+            "tool selection guide must include list_files (#2076)"
         );
         assert!(
             out.contains("one-line override") || out.contains("allow_absent_old: true"),

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -837,6 +837,74 @@ impl PatchloomService {
     // are auto-generated from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
 
     #[tool(
+        description = "List files under the workspace (or given roots) with the same ignore/exclude/glob rules as search. Use this instead of a generic filesystem MCP list_dir/tree. Caps results (default max_results=500) and reports truncated+total_matched when capped. Prefer relative paths. Example: {\"path\": \"src/\", \"exclude_patterns\": [\"target/**\"], \"max_results\": 100, \"max_depth\": 3}"
+    )]
+    async fn list_files(
+        &self,
+        Parameters(p): Parameters<ListFilesParams>,
+    ) -> Result<CallToolResult, McpError> {
+        self.blocking(move |svc| {
+            if p.path.as_ref().is_some_and(|s| s.trim().is_empty()) {
+                return Err(McpError::invalid_params(
+                    "path must not be empty or whitespace-only (use paths for multi-root, or omit for workspace root)",
+                    None,
+                ));
+            }
+            if p.max_depth == Some(0) {
+                return Err(McpError::invalid_params(
+                    "max_depth must be >= 1 when set (1 = files directly under each root)",
+                    None,
+                ));
+            }
+            let roots = p.effective_paths();
+            for path in &roots {
+                svc.check_path(path)?;
+            }
+            for f in &p.custom_ignore_filenames {
+                svc.check_path(f)?;
+            }
+            // Same honesty as search: all-missing roots are typos, not empty inventory.
+            if crate::files::all_explicit_paths_missing(&roots, Some(svc.cwd())) {
+                return Err(McpError::invalid_params(
+                    format!(
+                        "no such file or directory: {}",
+                        roots.join(", ")
+                    ),
+                    None,
+                ));
+            }
+            let mut global = GlobalFlags::with_cwd_and_json(svc.cwd());
+            global.glob = p.globs;
+            global.exclude = p.exclude_patterns;
+            global.ignore_file = p.custom_ignore_filenames;
+            let report = super::list_files::collect_list_files(
+                &roots,
+                &global,
+                svc.cwd(),
+                p.max_results,
+                p.max_depth,
+                p.include_hidden,
+            )
+            .map_err(|e| {
+                let kind = crate::fallback::error_kind_str(&e).unwrap_or("invalid_input");
+                let msg = crate::exit::agent_error_message(&e);
+                if matches!(
+                    kind,
+                    "invalid_input" | "guard_rejected" | "not_found" | "binary" | "invalid_encoding"
+                ) {
+                    McpError::invalid_params(msg, None)
+                } else {
+                    McpError::internal_error(msg, None)
+                }
+            })?;
+            let json = serde_json::to_string_pretty(&report)
+                .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+            Ok(CallToolResult::success(vec![ContentBlock::text(json)]))
+        })
+        .await
+    }
+
+    #[tool(
         description = "Show uncommitted file changes vs git HEAD. Returns lists of modified, created, and deleted files. Omits .patchloom/ backup paths from --apply undo sessions. No parameters required."
     )]
     async fn git_status(

--- a/src/cmd/mcp/list_files.rs
+++ b/src/cmd/mcp/list_files.rs
@@ -1,0 +1,254 @@
+//! Bounded file inventory for MCP `list_files` (#2076).
+//!
+//! Reuses search/walk ignore and exclude rules so agents can drop a second
+//! filesystem MCP for directory listing.
+
+use crate::cli::global::GlobalFlags;
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+/// Default cap when the caller omits `max_results` (agent context budget).
+pub(crate) const DEFAULT_LIST_MAX_RESULTS: usize = 500;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListFilesReport {
+    pub ok: bool,
+    /// Paths relative to MCP cwd when under the workspace; otherwise display form.
+    pub paths: Vec<String>,
+    /// Number of paths returned (after cap).
+    pub count: usize,
+    /// True when more files matched than `max_results`.
+    pub truncated: bool,
+    /// Total matches before the cap (when truncated).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_matched: Option<usize>,
+    /// Effective walk roots (as requested).
+    pub roots: Vec<String>,
+}
+
+/// Collect a bounded inventory of files under `roots` with the same ignore /
+/// exclude / glob rules as search walks.
+pub(crate) fn collect_list_files(
+    roots: &[String],
+    global: &GlobalFlags,
+    cwd: &Path,
+    max_results: usize,
+    max_depth: Option<usize>,
+    include_hidden: bool,
+) -> anyhow::Result<ListFilesReport> {
+    let cap = if max_results == 0 {
+        DEFAULT_LIST_MAX_RESULTS
+    } else {
+        max_results
+    };
+    let mut paths =
+        crate::files::collect_file_paths_opts(roots, global, include_hidden, Some(cwd))?;
+
+    // Include globs are applied by callers of collect_file_paths_opts (search,
+    // replace, tidy), not inside the collector — mirror that here (#2076).
+    let glob_matcher = crate::files::build_glob_matcher_from_global(global)?;
+    if glob_matcher.is_some() {
+        let glob_roots = crate::files::collect_glob_roots_from_global(roots, global, Some(cwd))?;
+        paths.retain(|p| {
+            crate::files::matches_glob_with_roots(p, glob_matcher.as_ref(), &glob_roots)
+        });
+    }
+
+    // max_depth is relative to each walk root (not always cwd).
+    if let Some(depth) = max_depth {
+        let walk_roots: Vec<PathBuf> = roots
+            .iter()
+            .map(|r| {
+                if r == "." {
+                    cwd.to_path_buf()
+                } else {
+                    cwd.join(r)
+                }
+            })
+            .collect();
+        paths.retain(|p| path_depth_under_any_root(&walk_roots, p) <= depth);
+    }
+
+    // Stable order for agents.
+    paths.sort();
+
+    let total = paths.len();
+    let truncated = total > cap;
+    if truncated {
+        paths.truncate(cap);
+    }
+
+    let rel: Vec<String> = paths.iter().map(|p| display_rel(cwd, p)).collect();
+
+    Ok(ListFilesReport {
+        ok: true,
+        count: rel.len(),
+        paths: rel,
+        truncated,
+        total_matched: if truncated { Some(total) } else { None },
+        roots: roots.to_vec(),
+    })
+}
+
+/// Depth of `path` under the first walk root that contains it (file component
+/// count relative to that root). Falls back to the full path component count
+/// when no root prefix matches.
+fn path_depth_under_any_root(walk_roots: &[PathBuf], path: &Path) -> usize {
+    for root in walk_roots {
+        if let Ok(rel) = path.strip_prefix(root) {
+            return rel.components().count();
+        }
+    }
+    path.components().count()
+}
+
+fn display_rel(cwd: &Path, path: &Path) -> String {
+    match path.strip_prefix(cwd) {
+        Ok(rel) if !rel.as_os_str().is_empty() => rel.to_string_lossy().replace('\\', "/"),
+        Ok(_) => ".".into(),
+        Err(_) => path.to_string_lossy().replace('\\', "/"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_tree(dir: &Path) {
+        fs::create_dir_all(dir.join("src/nested")).unwrap();
+        fs::write(dir.join("src/a.rs"), "a\n").unwrap();
+        fs::write(dir.join("src/nested/b.rs"), "b\n").unwrap();
+        fs::write(dir.join("README.md"), "r\n").unwrap();
+        fs::create_dir_all(dir.join("vendor")).unwrap();
+        fs::write(dir.join("vendor/x.js"), "x\n").unwrap();
+        fs::write(dir.join("src/lib.ts"), "t\n").unwrap();
+    }
+
+    #[test]
+    fn lists_files_sorted_relative() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let global = GlobalFlags::test_default();
+        let report =
+            collect_list_files(&[".".into()], &global, dir.path(), 500, None, false).unwrap();
+        assert!(report.ok);
+        assert!(
+            report
+                .paths
+                .iter()
+                .any(|p| p == "README.md" || p.ends_with("README.md"))
+        );
+        assert!(report.paths.iter().any(|p| p.contains("a.rs")));
+        assert!(!report.truncated);
+        // Sorted
+        let mut sorted = report.paths.clone();
+        sorted.sort();
+        assert_eq!(report.paths, sorted);
+    }
+
+    #[test]
+    fn exclude_and_max_results_truncate() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let mut global = GlobalFlags::test_default();
+        global.exclude = vec!["vendor/**".into()];
+        let report =
+            collect_list_files(&[".".into()], &global, dir.path(), 2, None, false).unwrap();
+        assert!(!report.paths.iter().any(|p| p.contains("vendor")));
+        assert_eq!(report.count, 2);
+        assert!(report.truncated);
+        assert!(report.total_matched.unwrap() >= 3);
+    }
+
+    #[test]
+    fn max_depth_limits_nested() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let global = GlobalFlags::test_default();
+        // depth 1 under cwd: only top-level files
+        let report =
+            collect_list_files(&[".".into()], &global, dir.path(), 500, Some(1), false).unwrap();
+        assert!(
+            report.paths.iter().all(|p| !p.contains('/')),
+            "depth 1 must not include nested paths: {:?}",
+            report.paths
+        );
+        assert!(report.paths.iter().any(|p| p == "README.md"));
+    }
+
+    #[test]
+    fn max_depth_relative_to_non_dot_root() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let global = GlobalFlags::test_default();
+        // root=src, depth 1: src/a.rs and src/lib.ts but not src/nested/b.rs
+        let report =
+            collect_list_files(&["src".into()], &global, dir.path(), 500, Some(1), false).unwrap();
+        assert!(
+            report.paths.iter().any(|p| p.ends_with("a.rs")),
+            "expected a.rs under src depth 1: {:?}",
+            report.paths
+        );
+        assert!(
+            report.paths.iter().any(|p| p.ends_with("lib.ts")),
+            "expected lib.ts under src depth 1: {:?}",
+            report.paths
+        );
+        assert!(
+            !report.paths.iter().any(|p| p.contains("nested")),
+            "nested must be depth 2 under src: {:?}",
+            report.paths
+        );
+    }
+
+    #[test]
+    fn globs_filter_include() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let mut global = GlobalFlags::test_default();
+        global.glob = vec!["**/*.rs".into()];
+        let report =
+            collect_list_files(&[".".into()], &global, dir.path(), 500, None, false).unwrap();
+        assert!(
+            !report.paths.is_empty(),
+            "glob **/*.rs must match: {:?}",
+            report.paths
+        );
+        assert!(
+            report.paths.iter().all(|p| p.ends_with(".rs")),
+            "only .rs: {:?}",
+            report.paths
+        );
+        assert!(!report.paths.iter().any(|p| p.ends_with(".md")));
+        assert!(!report.paths.iter().any(|p| p.ends_with(".js")));
+        assert!(!report.paths.iter().any(|p| p.ends_with(".ts")));
+    }
+
+    #[test]
+    fn zero_max_results_uses_default_cap() {
+        assert_eq!(DEFAULT_LIST_MAX_RESULTS, 500);
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let global = GlobalFlags::test_default();
+        let report =
+            collect_list_files(&[".".into()], &global, dir.path(), 0, None, false).unwrap();
+        assert!(report.count <= DEFAULT_LIST_MAX_RESULTS);
+        assert!(!report.truncated);
+        assert!(report.total_matched.is_none());
+    }
+
+    #[test]
+    fn total_matched_when_truncated() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let global = GlobalFlags::test_default();
+        let report =
+            collect_list_files(&[".".into()], &global, dir.path(), 1, None, false).unwrap();
+        assert!(report.truncated);
+        assert_eq!(report.count, 1);
+        let total = report.total_matched.expect("total_matched when truncated");
+        assert!(total > 1, "total_matched={total}");
+    }
+}

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -38,6 +38,7 @@ use crate::plan::{Operation, Plan};
 // ---------------------------------------------------------------------------
 
 mod handlers;
+mod list_files;
 mod params;
 mod registry;
 mod surface;

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -199,6 +199,50 @@ impl SearchParams {
     }
 }
 
+/// Parameters for MCP `list_files` (bounded directory inventory; #2076).
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ListFilesParams {
+    /// Walk roots relative to working directory (defaults to workspace root).
+    /// Prefer this for multi-root lists.
+    #[serde(default)]
+    pub paths: Vec<String>,
+    /// Single walk root (LLM prior). Equivalent to `paths: [path]` when `paths`
+    /// is empty. If both are set, `paths` wins.
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Glob include patterns (same role as search `globs` / CLI `--glob`).
+    #[serde(default)]
+    pub globs: Vec<String>,
+    /// Exclude glob patterns (in addition to ignore files).
+    #[serde(default)]
+    pub exclude_patterns: Vec<String>,
+    /// Custom ignore filenames (e.g. `.agentignore`).
+    #[serde(default)]
+    pub custom_ignore_filenames: Vec<String>,
+    /// Max paths to return. Default 500 when omitted or 0 (agent context budget).
+    #[serde(default)]
+    pub max_results: usize,
+    /// Max path depth under each root (1 = only files directly under the root).
+    /// Omit for unlimited depth (still subject to max_results).
+    pub max_depth: Option<usize>,
+    /// Include hidden files (still never walks `.git` / `.patchloom`).
+    #[serde(default)]
+    pub include_hidden: bool,
+}
+
+impl ListFilesParams {
+    pub(crate) fn effective_paths(&self) -> Vec<String> {
+        if !self.paths.is_empty() {
+            self.paths.clone()
+        } else if let Some(ref path) = self.path {
+            vec![path.clone()]
+        } else {
+            vec![".".into()]
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct DocQueryParams {

--- a/src/cmd/mcp/surface.rs
+++ b/src/cmd/mcp/surface.rs
@@ -79,6 +79,11 @@ pub(super) const CUSTOM_MCP_TOOLS_CORE: &[CustomMcpTool] = &[
         kind: CustomKind::MultiFileOrScan,
     },
     CustomMcpTool {
+        name: "list_files",
+        why: "bounded directory inventory so agents need no second filesystem MCP (#2076)",
+        kind: CustomKind::MultiFileOrScan,
+    },
+    CustomMcpTool {
         name: "replace_text",
         why: "parallel multi-file scan + precomputed engine handoff",
         kind: CustomKind::MultiFileOrScan,
@@ -363,13 +368,13 @@ mod tests {
         // Core tools always; AST tools only with `ast` (matches list_tools registration).
         let registry_n = MCP_TOOL_REGISTRY.len();
         let custom_n = custom_mcp_tools().count();
-        let expected_total = if cfg!(feature = "ast") { 57 } else { 37 };
+        let expected_total = if cfg!(feature = "ast") { 58 } else { 38 };
         assert_eq!(
             registry_n + custom_n,
             expected_total,
             "registry ({registry_n}) + custom ({custom_n}) must equal total MCP tools ({expected_total})"
         );
-        assert_eq!(CUSTOM_MCP_TOOLS_CORE.len(), 13, "core custom tool count");
+        assert_eq!(CUSTOM_MCP_TOOLS_CORE.len(), 14, "core custom tool count");
         #[cfg(feature = "ast")]
         assert_eq!(CUSTOM_MCP_TOOLS_AST.len(), 20, "ast custom tool count");
         #[cfg(not(feature = "ast"))]

--- a/src/cmd/mcp/tests.rs
+++ b/src/cmd/mcp/tests.rs
@@ -84,6 +84,10 @@ mod basic {
         assert!(names.contains(&"doc_diff"), "missing doc_diff tool");
         assert!(names.contains(&"read_file"), "missing read_file tool");
         assert!(names.contains(&"search_files"), "missing search_files tool");
+        assert!(
+            names.contains(&"list_files"),
+            "missing list_files tool (#2076)"
+        );
         assert_eq!(
             descriptions.get("search_files"),
             Some(

--- a/src/cmd/mcp/transport.rs
+++ b/src/cmd/mcp/transport.rs
@@ -34,11 +34,12 @@ fn core_server_instructions() -> String {
          Prefer 'execute_plan' for multi-op or multi-file work (atomicity). \
          Per-call success does not guarantee combined success if you issue \
          conflicting parallel writes.\n\n\
-         Explore with search_files/read_file (prefer relative paths); shell cat/find/sed \
-         only for build/test unless the user overrides. MCP allows absolute paths only \
-         when they resolve inside the workspace; `../` and outside paths are rejected.\n\n\
+         Explore with list_files/search_files/read_file (prefer relative paths); shell \
+         cat/find/sed only for build/test unless the user overrides. Do not also install \
+         a generic filesystem MCP for list+edit. MCP allows absolute paths only when they \
+         resolve inside the workspace; `../` and outside paths are rejected.\n\n\
          Core tools:\n\
-         - read_file, search_files: inspect and find content\n\
+         - read_file, search_files, list_files: inspect, find, and inventory files\n\
          - replace_text, batch_replace: literal/regex text edits\n\
          - doc_get, doc_set, doc_query: parser-backed JSON/YAML/TOML by selector path\n\
          - md_replace_section: replace a markdown heading section\n\
@@ -57,8 +58,9 @@ fn core_server_instructions() -> String {
 fn full_server_instructions() -> String {
     let mut s = String::from(
         "Use these tools for ALL file operations (edits and explore). Prefer \
-         search_files/read_file over shell cat/find/sed when MCP is connected; \
-         shell for build/test/run unless the user overrides. Prefer 'execute_plan' (or tx plans) \
+         list_files/search_files/read_file over shell cat/find/ls/sed (and over a second \
+         filesystem MCP) when MCP is connected; shell for build/test/run unless the user \
+         overrides. Prefer 'execute_plan' (or tx plans) \
          for any multi-op or multi-file work to ensure atomicity and avoid races from \
          parallel calls on the same paths. Use batch_replace/batch_tidy only for uniform \
          ops across files. Per-call success does not guarantee combined success if you \
@@ -72,7 +74,7 @@ fn full_server_instructions() -> String {
          - Markdown ops (by heading): md_replace_section, md_upsert_bullet, \
          md_table_append, md_insert_after_heading, md_insert_after_section, md_insert_before_heading, \
          md_move_section, md_dedupe_headings, md_lint\n\
-         - Text ops: replace_text, batch_replace, search_files, apply_fragment, apply_patch\n\
+         - Text ops: replace_text, batch_replace, search_files, list_files, apply_fragment, apply_patch\n\
          - File ops: create_file, read_file, delete_file, move_file, append_file, \
          prepend_file, fix_whitespace, batch_tidy, git_status\n",
     );

--- a/tests/integration/mcp_tests.rs
+++ b/tests/integration/mcp_tests.rs
@@ -61,7 +61,7 @@ fn test_mcp_surface_invalid_env_fails_closed() {
 /// Subprocess path: `from_env` + list_tools (unit tests inject surface without env).
 #[cfg(feature = "mcp")]
 #[tokio::test]
-async fn test_mcp_surface_core_env_lists_ten_tools() {
+async fn test_mcp_surface_core_env_lists_eleven_tools() {
     if !has_mcp_support() {
         return;
     }
@@ -70,10 +70,11 @@ async fn test_mcp_surface_core_env_lists_ten_tools() {
     let tools = client.peer().list_all_tools().await.unwrap();
     let names: std::collections::BTreeSet<_> =
         tools.iter().map(|t| t.name.as_ref().to_string()).collect();
-    assert_eq!(names.len(), 10, "core pack is 10 tools, got {names:?}");
+    assert_eq!(names.len(), 11, "core pack is 11 tools, got {names:?}");
     for required in [
         "read_file",
         "search_files",
+        "list_files",
         "replace_text",
         "batch_replace",
         "doc_get",
@@ -107,7 +108,7 @@ async fn test_mcp_surface_core_env_lists_ten_tools() {
     };
     let v: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(v["surface"], "core");
-    assert_eq!(v["tool_count"], 10);
+    assert_eq!(v["tool_count"], 11);
     client.cancel().await.unwrap();
 }
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -605,6 +605,186 @@ async fn test_mcp_search_no_match_returns_descriptive_message() {
     client.cancel().await.unwrap();
 }
 
+/// #2076: list_files inventory with exclude + truncation honesty.
+#[tokio::test]
+async fn test_mcp_list_files_inventory_and_truncate() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("src/a.rs"), "a\n").unwrap();
+    fs::write(dir.path().join("README.md"), "r\n").unwrap();
+    fs::create_dir_all(dir.path().join("vendor")).unwrap();
+    fs::write(dir.path().join("vendor/x.js"), "x\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "list_files",
+        serde_json::json!({
+            "path": ".",
+            "exclude_patterns": ["vendor/**"],
+            "max_results": 1
+        }),
+    )
+    .await;
+    assert!(!is_error, "list_files should succeed: {val}");
+    assert_eq!(val["ok"], true, "{val}");
+    assert_eq!(val["truncated"], true, "max_results=1 must truncate: {val}");
+    assert!(
+        val["total_matched"].as_u64().unwrap_or(0) >= 2,
+        "truncated must report total_matched: {val}"
+    );
+    let paths = val["paths"].as_array().expect("paths array");
+    assert_eq!(paths.len(), 1, "{val}");
+    let joined = paths
+        .iter()
+        .map(|p| p.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(!joined.contains("vendor"), "exclude vendor/**: {val}");
+    client.cancel().await.unwrap();
+}
+
+/// #2076: list_files include globs filter results (not a no-op).
+#[tokio::test]
+async fn test_mcp_list_files_globs_filter() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("src/a.rs"), "a\n").unwrap();
+    fs::write(dir.path().join("src/b.ts"), "b\n").unwrap();
+    fs::write(dir.path().join("README.md"), "r\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "list_files",
+        serde_json::json!({
+            "path": ".",
+            "globs": ["**/*.rs"]
+        }),
+    )
+    .await;
+    assert!(!is_error, "list_files globs: {val}");
+    assert_eq!(val["ok"], true, "{val}");
+    let paths = val["paths"].as_array().expect("paths");
+    assert!(!paths.is_empty(), "expected .rs matches: {val}");
+    for p in paths {
+        let s = p.as_str().unwrap_or("");
+        assert!(s.ends_with(".rs"), "only .rs paths, got {s} in {val}");
+    }
+    client.cancel().await.unwrap();
+}
+
+/// #2076: list_files max_depth is relative to each root (not only cwd).
+#[tokio::test]
+async fn test_mcp_list_files_max_depth_under_root() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("src/nested")).unwrap();
+    fs::write(dir.path().join("src/a.rs"), "a\n").unwrap();
+    fs::write(dir.path().join("src/nested/b.rs"), "b\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "list_files",
+        serde_json::json!({
+            "path": "src",
+            "max_depth": 1
+        }),
+    )
+    .await;
+    assert!(!is_error, "list_files max_depth: {val}");
+    let paths = val["paths"].as_array().expect("paths");
+    let joined = paths
+        .iter()
+        .map(|p| p.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        joined.contains("a.rs"),
+        "depth 1 under src must include a.rs: {val}"
+    );
+    assert!(
+        !joined.contains("nested"),
+        "depth 1 under src must exclude nested/b.rs: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// #2076: list_files rejects path escape like other tools.
+#[tokio::test]
+async fn test_mcp_list_files_rejects_escape() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hi\n").unwrap();
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "list_files", serde_json::json!({"path": ".."})).await;
+    assert!(is_error, "list_files must reject .. escape: {val}");
+    client.cancel().await.unwrap();
+}
+
+/// #2076: all-missing roots hard-fail (typo honesty, parity with search).
+#[tokio::test]
+async fn test_mcp_list_files_missing_root_is_error() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hi\n").unwrap();
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "list_files",
+        serde_json::json!({"path": "does-not-exist"}),
+    )
+    .await;
+    assert!(is_error, "missing root must hard-fail: {val}");
+    let text = val.to_string().to_lowercase();
+    assert!(
+        text.contains("no such") || text.contains("not found") || text.contains("does-not-exist"),
+        "missing-root message: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// #2076: list_files on core surface.
+#[tokio::test]
+async fn test_mcp_list_files_on_core_surface() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hi\n").unwrap();
+    let client = spawn_mcp_client_with_env(dir.path(), &[("PATCHLOOM_MCP_SURFACE", "core")]).await;
+    let tools = client.peer().list_all_tools().await.unwrap();
+    let names: Vec<_> = tools.iter().map(|t| t.name.as_ref().to_string()).collect();
+    assert!(
+        names.iter().any(|n| n == "list_files"),
+        "core must include list_files: {names:?}"
+    );
+    assert_eq!(
+        names.len(),
+        11,
+        "core pack is 11 tools including list_files: {names:?}"
+    );
+    let (is_error, val) =
+        call_tool_value(&client, "list_files", serde_json::json!({"path": "."})).await;
+    assert!(!is_error, "core list_files: {val}");
+    assert_eq!(val["ok"], true);
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_search_rejects_absolute_path() {
     if !has_mcp_support() {

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -817,7 +817,7 @@ fn test_smoke_readme_command_examples() {
         "launch announcement CLI command count drifted"
     );
     assert!(
-        launch.contains("57 structured tool calls"),
+        launch.contains("58 structured tool calls"),
         "launch announcement MCP tool count drifted"
     );
     let merge_value = r#"{"settings": {"debug": true}}"#;


### PR DESCRIPTION
## Summary

Close competitive gaps so coding agents stop pairing a second filesystem MCP (or inventing yq/Morph) for work Patchloom already covers.

- **MCP `list_files`**: bounded directory inventory with the same ignore / exclude / glob rules as search. Caps (`max_results` default 500, optional `max_depth` relative to each walk root), `truncated` + `total_matched` when capped. Registered on **full** and **core** (11-tool pack). Missing roots hard-fail; `../` escapes rejected via path guard.
- **Core pack default for coding agents**: install recipes (Cursor / Claude / Codex), `docs/examples/mcp-core.example.json`, README + mcp-setup lead with core.
- **Docs**: comparisons (FS MCP, yq cheat sheet, ast-grep pipeline, Morph non-goals), embedder host case study, agent-rules tool guide + core pack list generated from `CORE_MCP_TOOL_NAMES`.

## Tests

- Unit: `list_files` (sort, exclude, max_depth under cwd and non-dot root, include globs, truncation / `total_matched`)
- MCP integration: inventory+truncate, globs, max_depth under root, escape, missing root, core surface (11 tools)
- Inventory locks: surface 58 full / 11 core, smoke counts
- `make check-fast` green locally

## Reviewer

Local reviewer: **APPROVE** (prior request-changes on globs/max_depth/agent_rules fixed). Optional follow-up only: walk-time depth pruning for large trees (not blocking).

Closes #2076