### PR TITLE
test(mcp): list_files coverage after #2077

### DIFF
--- a/src/cmd/mcp/list_files.rs
+++ b/src/cmd/mcp/list_files.rs
@@ -251,4 +251,67 @@ mod tests {
         let total = report.total_matched.expect("total_matched when truncated");
         assert!(total > 1, "total_matched={total}");
     }
+
+    #[test]
+    fn include_hidden_lists_dotfiles() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        fs::write(dir.path().join(".secret"), "s\n").unwrap();
+        let global = GlobalFlags::test_default();
+        let hidden_off =
+            collect_list_files(&[".".into()], &global, dir.path(), 500, None, false).unwrap();
+        assert!(
+            !hidden_off.paths.iter().any(|p| p.contains(".secret")),
+            "hidden off must skip .secret: {:?}",
+            hidden_off.paths
+        );
+        let hidden_on =
+            collect_list_files(&[".".into()], &global, dir.path(), 500, None, true).unwrap();
+        assert!(
+            hidden_on
+                .paths
+                .iter()
+                .any(|p| p.ends_with(".secret") || p == ".secret"),
+            "include_hidden must list .secret: {:?}",
+            hidden_on.paths
+        );
+    }
+
+    #[test]
+    fn multi_root_union_sorted() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let global = GlobalFlags::test_default();
+        let report = collect_list_files(
+            &["src".into(), "vendor".into()],
+            &global,
+            dir.path(),
+            500,
+            None,
+            false,
+        )
+        .unwrap();
+        assert!(
+            report.paths.iter().any(|p| p.contains("a.rs")),
+            "src root: {:?}",
+            report.paths
+        );
+        assert!(
+            report.paths.iter().any(|p| p.contains("x.js")),
+            "vendor root: {:?}",
+            report.paths
+        );
+        assert!(
+            !report
+                .paths
+                .iter()
+                .any(|p| p == "README.md" || p.ends_with("README.md")),
+            "README is outside roots: {:?}",
+            report.paths
+        );
+        let mut sorted = report.paths.clone();
+        sorted.sort();
+        assert_eq!(report.paths, sorted);
+        assert_eq!(report.roots, vec!["src".to_string(), "vendor".to_string()]);
+    }
 }

--- a/src/cmd/mcp/list_files.rs
+++ b/src/cmd/mcp/list_files.rs
@@ -278,6 +278,19 @@ mod tests {
     }
 
     #[test]
+    fn invalid_glob_pattern_errors() {
+        let dir = TempDir::new().unwrap();
+        write_tree(dir.path());
+        let mut global = GlobalFlags::test_default();
+        // Unclosed bracket is invalid for globset.
+        global.glob = vec!["**/*[".into()];
+        let err = collect_list_files(&[".".into()], &global, dir.path(), 500, None, false)
+            .expect_err("invalid glob must fail");
+        let msg = format!("{err:#}");
+        assert!(!msg.is_empty(), "error should describe invalid glob: {msg}");
+    }
+
+    #[test]
     fn multi_root_union_sorted() {
         let dir = TempDir::new().unwrap();
         write_tree(dir.path());

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -758,6 +758,89 @@ async fn test_mcp_list_files_missing_root_is_error() {
     client.cancel().await.unwrap();
 }
 
+/// #2076: max_depth=0 is invalid_params (not unlimited).
+#[tokio::test]
+async fn test_mcp_list_files_max_depth_zero_rejected() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.txt"), "hi\n").unwrap();
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "list_files",
+        serde_json::json!({"path": ".", "max_depth": 0}),
+    )
+    .await;
+    assert!(is_error, "max_depth=0 must fail: {val}");
+    let text = val.to_string().to_lowercase();
+    assert!(
+        text.contains("max_depth") || text.contains(">= 1") || text.contains("invalid"),
+        "max_depth=0 message: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// #2076: absolute path under workspace is allowed (AllowIfContained).
+#[tokio::test]
+async fn test_mcp_list_files_allows_absolute_path_inside_workspace() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    fs::write(dir.path().join("src/a.rs"), "a\n").unwrap();
+    let abs = dir.path().join("src");
+    let abs_s = abs.to_string_lossy().to_string();
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "list_files", serde_json::json!({"path": abs_s})).await;
+    assert!(!is_error, "abs path inside workspace must work: {val}");
+    assert_eq!(val["ok"], true, "{val}");
+    let paths = val["paths"].as_array().expect("paths");
+    assert!(
+        paths
+            .iter()
+            .any(|p| p.as_str().unwrap_or("").contains("a.rs")),
+        "expected a.rs under abs src root: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// #2076: multi-root paths array unions roots.
+#[tokio::test]
+async fn test_mcp_list_files_multi_root_paths() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("a")).unwrap();
+    fs::create_dir_all(dir.path().join("b")).unwrap();
+    fs::write(dir.path().join("a/x.txt"), "x\n").unwrap();
+    fs::write(dir.path().join("b/y.txt"), "y\n").unwrap();
+    fs::write(dir.path().join("root.md"), "r\n").unwrap();
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "list_files",
+        serde_json::json!({"paths": ["a", "b"]}),
+    )
+    .await;
+    assert!(!is_error, "multi-root: {val}");
+    let joined = val["paths"]
+        .as_array()
+        .expect("paths")
+        .iter()
+        .map(|p| p.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(joined.contains("x.txt"), "{val}");
+    assert!(joined.contains("y.txt"), "{val}");
+    assert!(!joined.contains("root.md"), "outside multi-root: {val}");
+    client.cancel().await.unwrap();
+}
+
 /// #2076: list_files on core surface.
 #[tokio::test]
 async fn test_mcp_list_files_on_core_surface() {


### PR DESCRIPTION
## Summary

MPI cycle after #2077 `list_files` landed. Product docs and inventory already healthy; this batch locks remaining agent-facing edge cases.

- Unit: `include_hidden`, multi-root union + sort, invalid include globs fail closed
- MCP integration: `max_depth=0` invalid_params, AllowIfContained absolute root under workspace, multi-root `paths` array

## Gate notes

- Release **#2066** (0.24.0) remains open; **do not merge without explicit user yes**
- B-path only: #1990 human launch, #960 winget, #961 Chocolatey
- Follow-up filed: #2078 walk-time max_depth pruning (perf, optional)

## Verification

`make check-fast` green locally.