### PR TITLE
perf(mcp): prune list_files walks at max_depth

### DIFF
--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -184,7 +184,7 @@ AST tools so `list_tools` stays honest about what is callable.
 | `doc_query` | Query a structured file: has, keys, len, select, or flatten (read-only) |
 | `doc_diff` | Compare two structured files (read-only) |
 | `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes. Binary and invalid UTF-8 files are skipped (read-only) |
-| `list_files` | Bounded directory inventory with the same ignore/exclude/glob rules as search (read-only). Prefer this over a second generic filesystem MCP for list/tree. Caps with `max_results` (default 500) and optional `max_depth`; reports `truncated` when capped |
+| `list_files` | Bounded directory inventory with the same ignore/exclude/glob rules as search (read-only). Prefer this over a second generic filesystem MCP for list/tree. Optional `max_depth` prunes the walk per root (does not enter deeper dirs). `max_results` (default 500) still counts all in-depth matches then truncates and sets `truncated` / `total_matched` |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
 | `server_info` | Return server identity and workspace root: `cwd`, `surface` (`full`\|`core`), `tool_count`, package `version`, and MCP `protocol_version` (read-only). Use `cwd` before relative path ops |
 | `read_file` | Read file contents with optional line range |

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -837,7 +837,7 @@ impl PatchloomService {
     // are auto-generated from MCP_TOOL_REGISTRY (registered in PatchloomService::new).
 
     #[tool(
-        description = "List files under the workspace (or given roots) with the same ignore/exclude/glob rules as search. Use this instead of a generic filesystem MCP list_dir/tree. Caps results (default max_results=500) and reports truncated+total_matched when capped. Prefer relative paths. Example: {\"path\": \"src/\", \"exclude_patterns\": [\"target/**\"], \"max_results\": 100, \"max_depth\": 3}"
+        description = "List files under the workspace (or given roots) with the same ignore/exclude/glob rules as search. Use this instead of a generic filesystem MCP list_dir/tree. Caps results (default max_results=500) and reports truncated+total_matched when capped. max_depth prunes the walk at each root (does not enter deeper dirs). max_results still counts all in-depth matches then truncates (total_matched remains honest). Prefer relative paths. Example: {\"path\": \"src/\", \"exclude_patterns\": [\"target/**\"], \"max_results\": 100, \"max_depth\": 3}"
     )]
     async fn list_files(
         &self,

--- a/src/cmd/mcp/list_files.rs
+++ b/src/cmd/mcp/list_files.rs
@@ -5,7 +5,7 @@
 
 use crate::cli::global::GlobalFlags;
 use serde::Serialize;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// Default cap when the caller omits `max_results` (agent context budget).
 pub(crate) const DEFAULT_LIST_MAX_RESULTS: usize = 500;
@@ -41,8 +41,17 @@ pub(crate) fn collect_list_files(
     } else {
         max_results
     };
-    let mut paths =
-        crate::files::collect_file_paths_opts(roots, global, include_hidden, Some(cwd))?;
+    // Walk-time max_depth pruning via WalkBuilder (#2078). Do not full-walk
+    // then filter: deep monorepos stay cheap when agents pass max_depth.
+    // max_results still collects all matches in-depth then caps (total_matched
+    // honesty when truncated).
+    let mut paths = crate::files::collect_file_paths_opts_depth(
+        roots,
+        global,
+        include_hidden,
+        Some(cwd),
+        max_depth,
+    )?;
 
     // Include globs are applied by callers of collect_file_paths_opts (search,
     // replace, tidy), not inside the collector — mirror that here (#2076).
@@ -52,21 +61,6 @@ pub(crate) fn collect_list_files(
         paths.retain(|p| {
             crate::files::matches_glob_with_roots(p, glob_matcher.as_ref(), &glob_roots)
         });
-    }
-
-    // max_depth is relative to each walk root (not always cwd).
-    if let Some(depth) = max_depth {
-        let walk_roots: Vec<PathBuf> = roots
-            .iter()
-            .map(|r| {
-                if r == "." {
-                    cwd.to_path_buf()
-                } else {
-                    cwd.join(r)
-                }
-            })
-            .collect();
-        paths.retain(|p| path_depth_under_any_root(&walk_roots, p) <= depth);
     }
 
     // Stable order for agents.
@@ -88,18 +82,6 @@ pub(crate) fn collect_list_files(
         total_matched: if truncated { Some(total) } else { None },
         roots: roots.to_vec(),
     })
-}
-
-/// Depth of `path` under the first walk root that contains it (file component
-/// count relative to that root). Falls back to the full path component count
-/// when no root prefix matches.
-fn path_depth_under_any_root(walk_roots: &[PathBuf], path: &Path) -> usize {
-    for root in walk_roots {
-        if let Ok(rel) = path.strip_prefix(root) {
-            return rel.components().count();
-        }
-    }
-    path.components().count()
 }
 
 fn display_rel(cwd: &Path, path: &Path) -> String {
@@ -200,6 +182,43 @@ mod tests {
             !report.paths.iter().any(|p| p.contains("nested")),
             "nested must be depth 2 under src: {:?}",
             report.paths
+        );
+    }
+
+    /// #2078: deep trees with max_depth must not surface deep files (walk prune).
+    #[test]
+    fn max_depth_prunes_very_deep_tree() {
+        let dir = TempDir::new().unwrap();
+        let mut deep = dir.path().to_path_buf();
+        for i in 0..12 {
+            deep.push(format!("d{i}"));
+            fs::create_dir_all(&deep).unwrap();
+        }
+        fs::write(deep.join("leaf.txt"), "leaf\n").unwrap();
+        fs::write(dir.path().join("top.txt"), "top\n").unwrap();
+        let global = GlobalFlags::test_default();
+        let report =
+            collect_list_files(&[".".into()], &global, dir.path(), 500, Some(1), false).unwrap();
+        assert!(
+            report
+                .paths
+                .iter()
+                .any(|p| p == "top.txt" || p.ends_with("top.txt")),
+            "top-level file: {:?}",
+            report.paths
+        );
+        assert!(
+            !report.paths.iter().any(|p| p.contains("leaf")),
+            "depth-12 leaf must be pruned: {:?}",
+            report.paths
+        );
+        // Unlimited depth still finds the leaf.
+        let deep_report =
+            collect_list_files(&[".".into()], &global, dir.path(), 500, None, false).unwrap();
+        assert!(
+            deep_report.paths.iter().any(|p| p.contains("leaf")),
+            "unlimited must find leaf: {:?}",
+            deep_report.paths
         );
     }
 

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -224,6 +224,7 @@ pub(crate) struct ListFilesParams {
     #[serde(default)]
     pub max_results: usize,
     /// Max path depth under each root (1 = only files directly under the root).
+    /// Applied during the walk: deeper directories are not entered (#2078).
     /// Omit for unlimited depth (still subject to max_results).
     pub max_depth: Option<usize>,
     /// Include hidden files (still never walks `.git` / `.patchloom`).

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -312,6 +312,7 @@ fn collect_replacements_with_list(
         false,
         Some(&cwd),
         files_from_preload,
+        None,
     )?;
     // Empty --files-from is an input error, not a pattern miss (#1796).
     // Detected here (single read of stdin) before soft no_matches handling.
@@ -773,6 +774,7 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             false,
             Some(&cwd),
             files_from_list.as_deref(),
+            None,
         )?;
         let range = parse_range_arg(args.range.as_deref())?;
         for path in &file_paths {
@@ -893,6 +895,7 @@ pub fn run(mut args: ReplaceArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             true,
             Some(&cwd),
             files_from_list.as_deref(),
+            None,
         )?;
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, &cwd) {
             global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
@@ -1269,6 +1272,7 @@ fn run_context_replace(
         false,
         Some(cwd),
         files_from_list,
+        None,
     )?;
     // Empty --files-from is input error on fuzzy/context path too (#1796).
     crate::files::ensure_files_from_nonempty(global, &file_paths)?;

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -164,6 +164,7 @@ pub(crate) fn collect_matches_with_list(
         false,
         Some(&cwd),
         files_from_preload,
+        None,
     )?;
     // Empty --files-from is invalid_input, not pattern no_matches (#1796).
     crate::files::ensure_files_from_nonempty(global, &file_paths)?;
@@ -566,6 +567,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 false,
                 Some(&cwd),
                 files_from_list.as_deref(),
+                None,
             )?;
             if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, &cwd) {
                 global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;
@@ -650,6 +652,7 @@ pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             false,
             Some(&cwd),
             files_from_list.as_deref(),
+            None,
         )?;
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, &cwd) {
             global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;

--- a/src/cmd/tidy/check.rs
+++ b/src/cmd/tidy/check.rs
@@ -165,6 +165,7 @@ pub(super) fn collect_issues_with_list(
         true,
         Some(&cwd),
         files_from_preload,
+        None,
     )?;
     // Empty --files-from must not report ok:true / zero issues (#1796).
     crate::files::ensure_files_from_nonempty(global, &file_paths)?;
@@ -311,6 +312,7 @@ pub(super) fn run_check(paths: &[String], global: &GlobalFlags) -> anyhow::Resul
             true,
             Some(&cwd),
             files_from_list.as_deref(),
+            None,
         )?;
         if let Some(err) = crate::ops::file::empty_scan_masked_by_unreadable(&scanned, &cwd) {
             global.emit_error_json_kind(Some("invalid_input"), &err.msg)?;

--- a/src/cmd/tidy/fix.rs
+++ b/src/cmd/tidy/fix.rs
@@ -265,6 +265,7 @@ pub(super) fn run_fix(
         true,
         Some(&cwd),
         files_from_list.as_deref(),
+        None,
     )?;
     // Empty --files-from is invalid_input, not a successful no-op (#1796).
     crate::files::ensure_files_from_nonempty(global, &fix_file_paths)?;

--- a/src/files.rs
+++ b/src/files.rs
@@ -312,7 +312,23 @@ pub(crate) fn collect_file_paths_opts(
     include_hidden: bool,
     root: Option<&Path>,
 ) -> anyhow::Result<Vec<PathBuf>> {
-    collect_file_paths_opts_with_list(paths, global, include_hidden, root, None)
+    collect_file_paths_opts_with_list(paths, global, include_hidden, root, None, None)
+}
+
+/// Like [`collect_file_paths_opts`], with optional walk-time [`max_depth`].
+///
+/// `max_depth` is passed to [`ignore::WalkBuilder::max_depth`] so deep trees
+/// are not entered (MCP `list_files` #2078). Semantics match component count
+/// under each walk root: `Some(1)` is files directly under each root.
+#[cfg(feature = "cli")]
+pub(crate) fn collect_file_paths_opts_depth(
+    paths: &[String],
+    global: &GlobalFlags,
+    include_hidden: bool,
+    root: Option<&Path>,
+    max_depth: Option<usize>,
+) -> anyhow::Result<Vec<PathBuf>> {
+    collect_file_paths_opts_with_list(paths, global, include_hidden, root, None, max_depth)
 }
 
 /// Like [`collect_file_paths_opts`], but accepts a pre-read `--files-from` list.
@@ -323,6 +339,7 @@ pub(crate) fn collect_file_paths_opts_with_list(
     include_hidden: bool,
     root: Option<&Path>,
     files_from_preload: Option<&[String]>,
+    max_depth: Option<usize>,
 ) -> anyhow::Result<Vec<PathBuf>> {
     let files_owned;
     let files_from: Option<&[String]> = if let Some(pre) = files_from_preload {
@@ -389,6 +406,11 @@ pub(crate) fn collect_file_paths_opts_with_list(
     }
     if include_hidden {
         builder.hidden(false);
+    }
+    // Walk-time prune: ignore crate depth is per root (depth 1 = root +
+    // immediate children). Matches list_files max_depth component count (#2078).
+    if let Some(depth) = max_depth {
+        builder.max_depth(Some(depth));
     }
     // Never enter .git or .patchloom (even when hidden files are included).
     builder.filter_entry(|e| !should_skip_walk_dirname(e.file_name()));
@@ -1472,6 +1494,63 @@ mod tests {
         );
     }
 
+    /// #2078: WalkBuilder max_depth must not enter pruned dirs (only top-level files).
+    #[test]
+    #[cfg(feature = "cli")]
+    fn collect_file_paths_opts_depth_prunes_nested() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("top.txt"), "t\n").unwrap();
+        fs::create_dir_all(root.join("a/b/c")).unwrap();
+        fs::write(root.join("a/mid.txt"), "m\n").unwrap();
+        fs::write(root.join("a/b/c/deep.txt"), "d\n").unwrap();
+
+        let global = GlobalFlags::test_with_cwd(root);
+        let shallow =
+            collect_file_paths_opts_depth(&[".".into()], &global, false, Some(root), Some(1))
+                .unwrap();
+        let shallow_rels: Vec<_> = shallow
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        assert!(
+            shallow_rels.iter().any(|r| r == "top.txt"),
+            "depth 1 includes top: {shallow_rels:?}"
+        );
+        assert!(
+            !shallow_rels
+                .iter()
+                .any(|r| r.contains("mid") || r.contains("deep")),
+            "depth 1 must not enter a/: {shallow_rels:?}"
+        );
+
+        let mid = collect_file_paths_opts_depth(&[".".into()], &global, false, Some(root), Some(2))
+            .unwrap();
+        let mid_rels: Vec<_> = mid
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        assert!(
+            mid_rels.iter().any(|r| r.ends_with("mid.txt")),
+            "depth 2 includes a/mid: {mid_rels:?}"
+        );
+        assert!(
+            !mid_rels.iter().any(|r| r.contains("deep")),
+            "depth 2 must not reach a/b/c: {mid_rels:?}"
+        );
+    }
+
     #[test]
     #[cfg(feature = "cli")]
     fn collect_file_paths_opts_skips_patchloom_directory() {
@@ -1595,6 +1674,7 @@ mod explicit_exclude_tests {
             false,
             Some(root),
             None,
+            None,
         )
         .unwrap();
         assert!(
@@ -1614,9 +1694,15 @@ mod explicit_exclude_tests {
             exclude: vec!["vendor/**".into()],
             ..GlobalFlags::test_default()
         };
-        let paths =
-            collect_file_paths_opts_with_list(&[".".into()], &global, false, Some(root), None)
-                .unwrap();
+        let paths = collect_file_paths_opts_with_list(
+            &[".".into()],
+            &global,
+            false,
+            Some(root),
+            None,
+            None,
+        )
+        .unwrap();
         assert!(
             paths.iter().any(|p| p.ends_with("app.js")),
             "app.js should remain: {paths:?}"


### PR DESCRIPTION
## Summary

Implement #2078: walk-time `max_depth` pruning for MCP `list_files`.

- `collect_file_paths_opts_with_list` accepts `max_depth: Option<usize>` and passes it to `ignore::WalkBuilder::max_depth`
- New `collect_file_paths_opts_depth` wrapper for list_files
- Search/replace/tidy callers pass `None` (unlimited walk unchanged)
- `max_results` still full in-depth count then truncate (`truncated` / `total_matched` honest)
- Docs: mcp-setup, MCP tool description, `ListFilesParams`

## Tests

- Unit: deep tree prune, depth 1/2 mid levels, existing list_files max_depth cases
- Integration: existing list_files MCP suite green
- `make check-fast` green

## Reviewer

Local reviewer: **APPROVE** (WalkBuilder depth maps 1:1; multi-root per-path; call sites complete).

Closes #2078