### PR TITLE
test(mcp): multi-root max_depth prune locks after #2078

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -89,7 +89,7 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |
 | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |
 | Search across files | `search_files` |
-| List/inventory files (ignore-aware, capped; prefer over FS MCP) | `list_files` |
+| List/inventory files (ignore-aware; max_depth prunes walk; prefer over FS MCP) | `list_files` |
 | Apply a unified diff patch | `apply_patch` |
 | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace`, `ast_rewrite_signature` |
 | Insert, wrap, or manage imports | `ast_insert`, `ast_wrap`, `ast_imports` |

--- a/src/cmd/agent_rules.rs
+++ b/src/cmd/agent_rules.rs
@@ -191,7 +191,7 @@ tool schema size, not the plan catalog. See docs/plans/mcp-surface-tiers.md.\n\n
              | Create, append, prepend, rename, or delete a file | `create_file`, `append_file`, `prepend_file`, `move_file`, `delete_file` |\n\
              | Find/replace text in a file | `replace_text` (one file) or `batch_replace` (same replacement across multiple files) |\n\
              | Search across files | `search_files` |\n\
-             | List/inventory files (ignore-aware, capped; prefer over FS MCP) | `list_files` |\n\
+             | List/inventory files (ignore-aware; max_depth prunes walk; prefer over FS MCP) | `list_files` |\n\
              | Apply a unified diff patch | `apply_patch` |\n\
              | List/read/rename symbols (AST-aware) | `ast_list`, `ast_read`, `ast_rename`, `ast_replace`, `ast_rewrite_signature` |\n\
              | Insert, wrap, or manage imports | `ast_insert`, `ast_wrap`, `ast_imports` |\n\

--- a/src/cmd/mcp/list_files.rs
+++ b/src/cmd/mcp/list_files.rs
@@ -346,4 +346,40 @@ mod tests {
         assert_eq!(report.paths, sorted);
         assert_eq!(report.roots, vec!["src".to_string(), "vendor".to_string()]);
     }
+
+    /// #2078: max_depth applies per walk root when multiple roots are set.
+    #[test]
+    fn multi_root_max_depth_prunes_each_root() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join("a/nested")).unwrap();
+        fs::create_dir_all(dir.path().join("b/nested")).unwrap();
+        fs::write(dir.path().join("a/top_a.txt"), "a\n").unwrap();
+        fs::write(dir.path().join("a/nested/deep_a.txt"), "da\n").unwrap();
+        fs::write(dir.path().join("b/top_b.txt"), "b\n").unwrap();
+        fs::write(dir.path().join("b/nested/deep_b.txt"), "db\n").unwrap();
+        fs::write(dir.path().join("root.md"), "r\n").unwrap();
+        let global = GlobalFlags::test_default();
+        let report = collect_list_files(
+            &["a".into(), "b".into()],
+            &global,
+            dir.path(),
+            500,
+            Some(1),
+            false,
+        )
+        .unwrap();
+        let joined = report.paths.join(" ");
+        assert!(joined.contains("top_a"), "a top: {:?}", report.paths);
+        assert!(joined.contains("top_b"), "b top: {:?}", report.paths);
+        assert!(
+            !joined.contains("deep_"),
+            "deep pruned per root: {:?}",
+            report.paths
+        );
+        assert!(
+            !joined.contains("root.md"),
+            "outside multi-root: {:?}",
+            report.paths
+        );
+    }
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -1551,6 +1551,47 @@ mod tests {
         );
     }
 
+    /// #2078: max_depth is per walk root when multiple roots are collected.
+    #[test]
+    #[cfg(feature = "cli")]
+    fn collect_file_paths_opts_depth_multi_root() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::create_dir_all(root.join("left/deep")).unwrap();
+        fs::create_dir_all(root.join("right/deep")).unwrap();
+        fs::write(root.join("left/l.txt"), "l\n").unwrap();
+        fs::write(root.join("left/deep/x.txt"), "x\n").unwrap();
+        fs::write(root.join("right/r.txt"), "r\n").unwrap();
+        fs::write(root.join("right/deep/y.txt"), "y\n").unwrap();
+        let global = GlobalFlags::test_with_cwd(root);
+        let paths = collect_file_paths_opts_depth(
+            &["left".into(), "right".into()],
+            &global,
+            false,
+            Some(root),
+            Some(1),
+        )
+        .unwrap();
+        let rels: Vec<_> = paths
+            .iter()
+            .map(|p| {
+                p.strip_prefix(root)
+                    .unwrap()
+                    .to_string_lossy()
+                    .replace('\\', "/")
+            })
+            .collect();
+        assert!(
+            rels.iter().any(|r| r.ends_with("l.txt")) && rels.iter().any(|r| r.ends_with("r.txt")),
+            "top of each root: {rels:?}"
+        );
+        assert!(
+            !rels.iter().any(|r| r.contains("deep")),
+            "deep under each root pruned: {rels:?}"
+        );
+    }
+
     #[test]
     #[cfg(feature = "cli")]
     fn collect_file_paths_opts_skips_patchloom_directory() {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -841,6 +841,40 @@ async fn test_mcp_list_files_multi_root_paths() {
     client.cancel().await.unwrap();
 }
 
+/// #2078: multi-root + max_depth prunes each root independently.
+#[tokio::test]
+async fn test_mcp_list_files_multi_root_max_depth() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("a/nested")).unwrap();
+    fs::create_dir_all(dir.path().join("b/nested")).unwrap();
+    fs::write(dir.path().join("a/top_a.txt"), "a\n").unwrap();
+    fs::write(dir.path().join("a/nested/deep_a.txt"), "da\n").unwrap();
+    fs::write(dir.path().join("b/top_b.txt"), "b\n").unwrap();
+    fs::write(dir.path().join("b/nested/deep_b.txt"), "db\n").unwrap();
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "list_files",
+        serde_json::json!({"paths": ["a", "b"], "max_depth": 1}),
+    )
+    .await;
+    assert!(!is_error, "multi-root max_depth: {val}");
+    let joined = val["paths"]
+        .as_array()
+        .expect("paths")
+        .iter()
+        .map(|p| p.as_str().unwrap_or(""))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(joined.contains("top_a"), "{val}");
+    assert!(joined.contains("top_b"), "{val}");
+    assert!(!joined.contains("deep_"), "deep pruned per root: {val}");
+    client.cancel().await.unwrap();
+}
+
 /// #2076: list_files on core surface.
 #[tokio::test]
 async fn test_mcp_list_files_on_core_surface() {


### PR DESCRIPTION
## Summary

MPI cycle after #2080 walk-time max_depth prune.

- Unit: multi-root + max_depth=1 prunes deep files under **each** root (`list_files` + `files::collect_file_paths_opts_depth`)
- MCP integration: same contract over `paths` + `max_depth`
- agent-rules / PATCHLOOM: tool guide notes max_depth walk prune

## Gate

- Release **#2066** (0.24.0) open — **do not merge without user yes**
- B-path only: #1990 / #960 / #961

## Verification

`make check-fast` green.