### PR TITLE
fix(tx): restore empty-file deletes on strict validate failure

### DIFF
--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -359,6 +359,46 @@ mod tests {
         assert!(!file.exists());
     }
 
+    /// Empty-file delete must be an effective change and restore from the
+    /// backup session (same path as non-empty deletes). Regression for the
+    /// macOS CI failure where original == final == "" omitted the path from
+    /// `changes` and strict validate rollback left the file missing.
+    #[test]
+    fn execute_empty_file_delete_is_effective_and_restorable() {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("empty.txt");
+        fs::write(&file, "").unwrap();
+
+        let global = GlobalFlags::test_default();
+        let op = Operation::FileDelete {
+            path: "empty.txt".to_string(),
+        };
+
+        let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
+        assert!(
+            result.has_changes,
+            "deleting an empty file is still a change"
+        );
+        assert!(
+            result
+                .exec_result
+                .changes
+                .iter()
+                .any(|(p, _, _)| p == &file),
+            "empty delete must appear in changes (not deletions-only)"
+        );
+        assert!(result.exec_result.deletions.contains(&file));
+
+        let session = result.commit().unwrap();
+        let ts = session.expect("empty delete must create a backup session");
+        assert!(!file.exists(), "empty file deleted after commit");
+
+        let restored = crate::backup::restore_session(dir.path(), &ts).unwrap();
+        assert!(restored >= 1);
+        assert!(file.exists(), "empty file restored from backup");
+        assert_eq!(fs::read_to_string(&file).unwrap(), "");
+    }
+
     #[test]
     fn execute_single_file_append() {
         let dir = TempDir::new().unwrap();

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -846,8 +846,13 @@ pub(crate) fn execute_and_collect(
         // A file creation with empty content still has original == final == "",
         // but must be treated as an effective change because the file does not
         // exist on disk yet (#create-empty-file).
+        // A file *deletion* of an empty file likewise has original == final ==
+        // "" and must stay in `changes` so commit/backup/strict restore use
+        // the same path as non-empty deletes (macOS CI flake on
+        // deletions-only empty restore).
         let is_new_file = !existed_before.contains(path);
-        if *original != *final_content || is_new_file {
+        let is_deleted = deletions.contains(path);
+        if *original != *final_content || is_new_file || is_deleted {
             changes.push((path.clone(), original.clone(), final_content.into_owned()));
         }
     }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -217,9 +217,18 @@ pub fn execute_plan_direct(
 
     // Snapshot non-tx files before format/validate steps so we can restore
     // collateral changes on strict rollback (#1111.7).
+    // Include deletions and renames, not only `changes`: empty-file deletes
+    // used to omit from `changes` (original == final == "") and must still
+    // be treated as tx paths so collateral walk does not re-touch them.
     #[cfg(any(feature = "cli", feature = "files"))]
     let collateral_snapshot = if strict && plan.has_lifecycle_steps() {
-        let tx_paths: HashSet<PathBuf> = result.changes.iter().map(|(p, _, _)| p.clone()).collect();
+        let mut tx_paths: HashSet<PathBuf> =
+            result.changes.iter().map(|(p, _, _)| p.clone()).collect();
+        tx_paths.extend(result.deletions.iter().cloned());
+        for (from, to) in &result.renames {
+            tx_paths.insert(from.clone());
+            tx_paths.insert(to.clone());
+        }
         snapshot_non_tx_files(&effective_cwd, &tx_paths)
     } else {
         HashMap::new()

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -5295,6 +5295,46 @@ fn test_tx_strict_mode_restores_deleted_empty_file_on_failure() {
     let file = dir.path().join("empty.txt");
     fs::write(&file, "").unwrap();
 
+    // Relative path + --cwd (same shape as test_tx_file_delete_empty_file).
+    // Absolute paths under the host temp dir use __external__ backup keys;
+    // empty deletes must still restore under strict validate failure.
+    let plan = serde_json::json!({
+            "version": 1,
+        "strict": true,
+        "operations": [{
+            "op": "file.delete",
+            "path": "empty.txt"
+        }],
+        "validate": [{
+            "cmd": shell_exit_1(),
+            "required": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .assert()
+        .code(7); // ROLLBACK
+
+    assert!(file.exists(), "deleted empty file should be restored");
+    assert_eq!(fs::read_to_string(&file).unwrap(), "");
+}
+
+/// Absolute-path empty delete (backup under `__external__/…`) must also
+/// restore on strict validate failure — the shape that failed on macOS CI.
+#[test]
+fn test_tx_strict_mode_restores_deleted_empty_file_absolute_path() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.txt");
+    fs::write(&file, "").unwrap();
+
     let plan = serde_json::json!({
             "version": 1,
         "strict": true,
@@ -5318,7 +5358,10 @@ fn test_tx_strict_mode_restores_deleted_empty_file_on_failure() {
         .assert()
         .code(7); // ROLLBACK
 
-    assert!(file.exists(), "deleted empty file should be restored");
+    assert!(
+        file.exists(),
+        "deleted empty file (absolute path) should be restored"
+    );
     assert_eq!(fs::read_to_string(&file).unwrap(), "");
 }
 


### PR DESCRIPTION
## Summary

macOS CI failed on `test_tx_strict_mode_restores_deleted_empty_file_on_failure` after the 0.24.0 release notes cleanup push.

## Cause

Deleting an **empty** file stages `original == final == ""`. The change builder only pushed paths when content differed or the path was a new create, so empty deletes lived only in `deletions`, not `changes`. Non-empty deletes worked (they appear in both).

## Fix

1. Treat paths in `deletions` as effective changes (same commit/backup path as non-empty deletes)
2. Collateral snapshot `tx_paths` includes deletions and renames
3. Integration tests: relative `--cwd` path (stable) + absolute path regression
4. Unit test: empty delete is in `changes`, creates backup, restores via `restore_session`

## Verification

- `cargo test --lib execute_empty_file_delete_is_effective_and_restorable --all-features`
- `cargo test --test integration test_tx_strict_mode_restores_deleted --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`