### PR TITLE
fix: real-world for_each guards and CRLF append separators

### DIFF
--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -1,15 +1,20 @@
 use std::path::{Path, PathBuf};
 
+use crate::ops::replace::preferred_line_ending;
+
 /// Pure helpers for file append/prepend content computation.
 /// Used by api::file_* , plan execution (tx), and cmd/append for consistency.
-/// Centralizes the "ensure nl between existing and new" logic.
+/// Centralizes the "ensure line ending between existing and new" logic.
+///
+/// When a separator is needed, uses the file's dominant EOL (CRLF / CR / LF)
+/// so Windows CRLF files without a final newline do not gain a bare LF.
 pub fn append_content(existing: &str, append: &str) -> String {
     if append.is_empty() {
         return existing.to_string();
     }
     let mut combined = existing.to_string();
-    if !combined.is_empty() && !combined.ends_with('\n') {
-        combined.push('\n');
+    if !combined.is_empty() && !ends_with_line_ending(&combined) {
+        combined.push_str(preferred_line_ending(existing));
     }
     combined.push_str(append);
     combined
@@ -17,11 +22,16 @@ pub fn append_content(existing: &str, append: &str) -> String {
 
 pub fn prepend_content(existing: &str, prepend: &str) -> String {
     let mut combined = prepend.to_string();
-    if !combined.is_empty() && !combined.ends_with('\n') && !existing.is_empty() {
-        combined.push('\n');
+    if !combined.is_empty() && !ends_with_line_ending(&combined) && !existing.is_empty() {
+        combined.push_str(preferred_line_ending(existing));
     }
     combined.push_str(existing);
     combined
+}
+
+#[inline]
+fn ends_with_line_ending(s: &str) -> bool {
+    s.ends_with("\r\n") || s.ends_with('\n') || s.ends_with('\r')
 }
 
 /// Walk ancestors of `path` and ensure every existing component is a directory.
@@ -327,6 +337,25 @@ mod tests {
         assert!(a.contains('\n'));
         let p = prepend_content("base", "added");
         assert!(p.contains('\n'));
+    }
+
+    #[test]
+    fn append_crlf_file_without_final_newline_uses_crlf_separator() {
+        // Windows file missing final newline must not gain a bare LF.
+        let out = append_content("line1\r\nline2", "line3");
+        assert_eq!(out, "line1\r\nline2\r\nline3");
+    }
+
+    #[test]
+    fn append_crlf_file_with_final_newline_no_extra_separator() {
+        let out = append_content("line1\r\nline2\r\n", "line3");
+        assert_eq!(out, "line1\r\nline2\r\nline3");
+    }
+
+    #[test]
+    fn prepend_crlf_payload_uses_file_eol_when_payload_lacks_eol() {
+        let out = prepend_content("body\r\n", "head");
+        assert_eq!(out, "head\r\nbody\r\n");
     }
 
     #[test]

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -42,10 +42,11 @@ pub struct Plan {
     ///
     /// On MCP, use a **relative** path that stays inside the server workspace;
     /// absolute path strings and `../` escapes are rejected. Do not combine
-    /// with `for_each` (glob expansion is relative to the server root; use
-    /// workspace-relative `{path}` templates without `cwd` instead).
+    /// with `for_each` on any surface (glob expansion uses the invocation cwd;
+    /// combining with `plan.cwd` double-prefixes `{path}`). Use
+    /// workspace-relative `{path}` templates without `cwd` instead.
     /// CLI and library callers may use absolute paths when PathGuard policy
-    /// allows them.
+    /// allows them (still without `for_each`).
     pub cwd: Option<String>,
     pub write_policy: Option<crate::write::WritePolicyOverride>,
     /// When omitted from the plan, defaults to strict mode at execution time.
@@ -480,6 +481,18 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
         None => return Ok(()),
     };
 
+    // for_each globs against the invocation cwd; plan.cwd re-roots op paths
+    // after expansion, which double-prefixes workspace-relative `{path}` values
+    // (CLI/library parity with MCP which already rejected this combo).
+    if plan.cwd.as_ref().is_some_and(|c| !c.trim().is_empty()) {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: "plan.cwd cannot be combined with for_each; \
+                 omit cwd and use workspace-relative paths in for_each templates \
+                 (e.g. path \"{path}\"), or omit for_each and set cwd for a nested re-root"
+                .into(),
+        }));
+    }
+
     // 1. Collect matching files.
     let glob_set =
         crate::files::build_glob_matcher(std::slice::from_ref(&fe.glob))?.ok_or_else(|| {
@@ -558,6 +571,21 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
         .replace("{{", "\x00LBRACE\x00")
         .replace("}}", "\x00RBRACE\x00");
 
+    // Multi-match without any file placeholder multiplies fixed-path ops
+    // (e.g. append the same CHANGELOG.md once per .rs file). Fail closed when
+    // more than one file matches and the template never references a match var.
+    if matched.len() > 1 && !template_uses_match_var(&protected) {
+        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+            msg: format!(
+                "for_each matched {} files but no operation uses a file template \
+                 ({{path}}, {{item}}, {{dir}}, {{stem}}, {{ext}}, or {{name}}); \
+                 fixed-path ops would run once per match. Add a path template or \
+                 narrow the glob to a single file",
+                matched.len()
+            ),
+        }));
+    }
+
     let mut expanded = Vec::with_capacity(matched.len() * plan.operations.len());
     for file_path in &matched {
         let rel = file_path
@@ -628,6 +656,14 @@ pub fn expand_for_each(plan: &mut Plan, cwd: &std::path::Path) -> anyhow::Result
 
     plan.operations = expanded;
     Ok(())
+}
+
+/// True when the protected for_each template JSON still contains a match
+/// variable (not escaped as `{{…}}`).
+#[cfg(feature = "cli")]
+fn template_uses_match_var(protected_template: &str) -> bool {
+    const VARS: &[&str] = &["{path}", "{item}", "{dir}", "{stem}", "{ext}", "{name}"];
+    VARS.iter().any(|v| protected_template.contains(v))
 }
 
 /// Detect `"path":"{placeholder}"` (and `from`/`to`) after for_each expansion.

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -443,6 +443,55 @@ fn parse_plan_without_for_each_is_none() {
 
 #[cfg(feature = "cli")]
 #[test]
+fn for_each_rejects_plan_cwd_combination() {
+    // Glob is relative to invocation cwd; plan.cwd re-roots after expand and
+    // double-prefixes {path}. MCP already rejected this; CLI/library must too.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("nested")).unwrap();
+    std::fs::write(dir.path().join("nested/a.txt"), "x").unwrap();
+
+    let json = r#"{
+            "version": 1,
+            "cwd": "nested",
+            "for_each": { "glob": "**/*.txt" },
+            "operations": [
+                {"op": "replace", "path": "{path}", "old": "x", "new": "y"}
+            ]
+        }"#;
+    let mut plan = parse_plan(json).unwrap();
+    let err = expand_for_each(&mut plan, dir.path()).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("plan.cwd cannot be combined with for_each"),
+        "expected cwd+for_each reject, got: {msg}"
+    );
+}
+
+#[cfg(feature = "cli")]
+#[test]
+fn for_each_rejects_multi_match_without_file_template() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "fn a() {}").unwrap();
+    std::fs::write(dir.path().join("b.rs"), "fn b() {}").unwrap();
+
+    let json = r#"{
+            "version": 1,
+            "for_each": { "glob": "*.rs" },
+            "operations": [
+                {"op": "file.append", "path": "CHANGELOG.md", "content": "- touch\n"}
+            ]
+        }"#;
+    let mut plan = parse_plan(json).unwrap();
+    let err = expand_for_each(&mut plan, dir.path()).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("no operation uses a file template") && msg.contains("2 files"),
+        "expected multi-match fixed-path reject, got: {msg}"
+    );
+}
+
+#[cfg(feature = "cli")]
+#[test]
 fn for_each_escape_preserves_literal_braces() {
     // When a template value contains `{{path}}`, the doubled braces should
     // produce a literal `{path}` in the output, not get substituted.

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -7978,6 +7978,94 @@ fn test_tx_for_each_no_matches_produces_empty_plan() {
 }
 
 #[test]
+fn test_tx_for_each_rejects_plan_cwd() {
+    // CLI parity with MCP: cwd + for_each double-prefixes {path}.
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("svc/src")).unwrap();
+    fs::write(dir.path().join("svc/src/lib.rs"), "Foo\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": "svc",
+        "for_each": { "glob": "src/**/*.rs" },
+        "operations": [{
+            "op": "replace",
+            "path": "{path}",
+            "old": "Foo",
+            "new": "Bar"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "cwd+for_each must fail; stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        combined.contains("plan.cwd cannot be combined with for_each")
+            || combined.contains("invalid_input"),
+        "expected invalid_input / cwd+for_each message, got: {combined}"
+    );
+    // File must remain unchanged (no partial apply).
+    assert_eq!(
+        fs::read_to_string(dir.path().join("svc/src/lib.rs")).unwrap(),
+        "Foo\n"
+    );
+}
+
+#[test]
+fn test_tx_for_each_rejects_fixed_path_multi_match() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("a.rs"), "fn a() {}\n").unwrap();
+    fs::write(dir.path().join("b.rs"), "fn b() {}\n").unwrap();
+    fs::write(dir.path().join("CHANGELOG.md"), "# log\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "for_each": { "glob": "*.rs" },
+        "operations": [{
+            "op": "file.append",
+            "path": "CHANGELOG.md",
+            "content": "- touch\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = patchloom_in(dir.path())
+        .args(["--json", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_ne!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("file template") || stdout.contains("invalid_input"),
+        "expected fixed-path multi-match reject: {stdout}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("CHANGELOG.md")).unwrap(),
+        "# log\n",
+        "CHANGELOG must not be appended once per .rs match"
+    );
+}
+
+#[test]
 fn test_tx_for_each_escaped_braces_produce_literal() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("a.txt"), "old value\n").unwrap();


### PR DESCRIPTION
## Summary

Fixloop round (real-world only) after the 0.24.0 / empty-delete CI fix.

## Fixes

| Finding | Realistic scenario | Change |
|---------|-------------------|--------|
| `plan.cwd` + `for_each` | Agent plan re-roots under `services/api` while for_each globs workspace → double-prefixed paths / `not_found` | Reject combo in `expand_for_each` (CLI/library parity with MCP) |
| Multi-match for_each without `{path}` | Append fixed `CHANGELOG.md` once per `*.rs` match | Reject when match count > 1 and template has no file vars |
| Append on CRLF without final newline | Windows `line1\r\nline2` + append → mixed `\n` | Separator uses dominant EOL |

## Rejected (noise / intentional / multi-day)

- Md first-heading-only for duplicate titles (product: needs ambiguous API)
- Multi-doc `---` inside block scalars (CST work → not this PR)
- Shell `ast.rename` over-matching `word` nodes (needs scoped rename design)
- Host restore-swallow / hardlink truncate (separate honesty PR if still open)

## Tests

- Unit: `for_each_rejects_*`, `append_crlf_*`
- Integration: `test_tx_for_each_rejects_plan_cwd`, `test_tx_for_each_rejects_fixed_path_multi_match`