### PR TITLE
fix(api): surface backup restore on mutation failure; hardlink write recovery

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -707,12 +707,30 @@ pub(crate) fn apply_mutation(
     // Finalize before mutation so undo can recover mid-write failure.
     let session = backup.finalize()?;
     if let Err(e) = perform_mutation() {
-        if let Some(ref ts) = session {
-            let _ = crate::backup::restore_session(cwd, ts);
-        }
-        return Err(e);
+        return Err(mutation_err_after_backup(cwd, session.as_deref(), e));
     }
     Ok((true, session))
+}
+
+/// On mutation failure after finalize: restore the session, and always
+/// surface restore outcome + session id so hosts can undo or report
+/// half-applied state (do not swallow restore errors with `let _ =`).
+fn mutation_err_after_backup(
+    backup_root: &Path,
+    session: Option<&str>,
+    mutation_err: anyhow::Error,
+) -> anyhow::Error {
+    let Some(ts) = session else {
+        return mutation_err;
+    };
+    match crate::backup::restore_session(backup_root, ts) {
+        Ok(_) => mutation_err.context(format!(
+            "mutation failed after backup finalize; restored session {ts} (undo still available)"
+        )),
+        Err(re) => mutation_err.context(format!(
+            "mutation failed after backup finalize; restore of session {ts} also failed: {re}"
+        )),
+    }
 }
 
 /// Generalized cross-file mutation helper (for rename without tx engine).
@@ -743,10 +761,7 @@ fn apply_cross_file_mutation(
     prepare_backup(&mut backup)?;
     let session = backup.finalize()?;
     if let Err(e) = perform_mutation() {
-        if let Some(ref ts) = session {
-            let _ = crate::backup::restore_session(cwd, ts);
-        }
-        return Err(e);
+        return Err(mutation_err_after_backup(cwd, session.as_deref(), e));
     }
     Ok((true, session))
 }
@@ -805,10 +820,11 @@ pub(crate) fn write_if_apply_many(
         Ok(())
     })();
     if let Err(e) = write_result {
-        if let Some(ref ts) = session {
-            let _ = crate::backup::restore_session(backup_root, ts);
-        }
-        return Err(e);
+        return Err(mutation_err_after_backup(
+            backup_root,
+            session.as_deref(),
+            e,
+        ));
     }
     Ok((true, session))
 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1131,7 +1131,15 @@ fn apply_mutation_restores_on_perform_failure() {
         || anyhow::bail!("simulated write failure after backup finalize"),
     )
     .unwrap_err();
-    assert!(err.to_string().contains("simulated write failure"));
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("simulated write failure"),
+        "mutation error must remain visible: {msg}"
+    );
+    assert!(
+        msg.contains("restored session") || msg.contains("backup finalize"),
+        "hosts must see restore outcome + session, got: {msg}"
+    );
     assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
     let sessions = crate::backup::list_sessions(dir.path()).unwrap();
     assert!(

--- a/src/write.rs
+++ b/src/write.rs
@@ -754,7 +754,7 @@ fn write_preserving_hardlinks(
         .parent()
         .context("cannot determine parent directory of target path")?;
 
-    // Stage complete payload first so we do not begin truncating the shared
+    // Stage complete payload first so we do not begin mutating the shared
     // inode until the full content exists on disk (best-effort durability).
     let mut tmp = NamedTempFile::new_in(parent)
         .with_context(|| format!("failed to create tempfile in {}", parent.display()))?;
@@ -763,9 +763,11 @@ fn write_preserving_hardlinks(
     // Best-effort; some filesystems/OS combinations do not support sync_all.
     let _ = tmp.as_file().sync_all();
 
+    // Prefer write + set_len over truncate-first so a failed mid-write can
+    // still recover the shared inode from the staged temp (hosts with
+    // package layouts / multi-hardlinked configs).
     let mut file = std::fs::OpenOptions::new()
         .write(true)
-        .truncate(true)
         .open(path)
         .with_context(|| {
             format!(
@@ -773,10 +775,21 @@ fn write_preserving_hardlinks(
                 path.display()
             )
         })?;
-    file.write_all(bytes)
-        .with_context(|| format!("failed to write hardlinked path {}", path.display()))?;
-    let _ = file.sync_all();
+    let write_result = (|| -> anyhow::Result<()> {
+        file.write_all(bytes)
+            .with_context(|| format!("failed to write hardlinked path {}", path.display()))?;
+        file.set_len(bytes.len() as u64).with_context(|| {
+            format!("failed to set length on hardlinked path {}", path.display())
+        })?;
+        let _ = file.sync_all();
+        Ok(())
+    })();
     drop(file);
+    if let Err(e) = write_result {
+        // Best-effort restore shared inode from the staged full payload.
+        let _ = std::fs::copy(tmp.path(), path);
+        return Err(e);
+    }
 
     if let Some(perms) = original_perms {
         std::fs::set_permissions(path, perms)


### PR DESCRIPTION
## Summary

Fixloop round 2 (real-world host write honesty).

## Fixes

1. **Library mutation failure after backup finalize**  
   `apply_mutation` / `write_if_apply_many` used `let _ = restore_session(...)`, dropping restore outcome. Hosts only saw the original write error with no session context when restore also failed.  
   Now chains: restored session id, or restore-also-failed + session id.

2. **Hardlink-preserving write mid-failure**  
   Truncate-then-write left multi-linked inodes half-written with no recovery from the staged temp.  
   Now write + `set_len`, and on error best-effort `copy` from the staged full payload.

## Tests

- Extended `apply_mutation_restores_on_perform_failure` for restore/session text in `{err:#}`
- Existing hardlink suite + `write_if_apply_many_restores_on_second_write_failure` still green