### PR TITLE
feat(api): EditResult.style_changed and special-node file_delete

### DIFF
--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -43,11 +43,17 @@ Bline is a real embedder that dogfooded these steps; the checklist is host-gener
      refuses over-wide fuzzy **before** write/backup (#2008).
 8. **Path-only file ops on non-text:** `file_rename` / `file_delete` succeed on
    binary and invalid UTF-8 with byte backup and PathGuard (no OS dual-path)
-   (#2031). Append/prepend/replace still refuse non-text loads.
-9. **Morph-class freeform on disk:** `apply_fragment_to_file(path, fragment,
+   (#2031). `file_delete` also unlinks FIFO/socket/device and symlinks (link
+   only; never follows); directories stay refused (#2087). Append/prepend/replace
+   still refuse non-text loads.
+9. **Doc presentation honesty:** library `EditResult.style_changed` (and
+   `is_style_changed`) mirrors CLI/MCP when YAML block-sequence layout
+   collapses; values can still be correct (#2088). Warn hosts/agents; do not
+   treat as failure.
+10. **Morph-class freeform on disk:** `apply_fragment_to_file(path, fragment,
    FragmentPlacement::After|Before|Replace(...), unique, mode, guard)` strips
    lazy markers and applies via the replace path (#2032).
-10. **Host unit tests for `op_honesty`:** `ContentEditHonesty` is
+11. **Host unit tests for `op_honesty`:** `ContentEditHonesty` is
     `#[non_exhaustive]`; use `ContentEditHonesty::exact` / `::fuzzy` instead of
     struct literals (#2033). Prefer live `apply_content_edits` for integration tests.
 

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -101,15 +101,25 @@ fn file_write(
         }
         Operation::FileDelete { .. } => {
             let path_str = path.to_string_lossy();
-            if !path.exists() {
+            // path_entry_exists includes dangling symlinks (#2087).
+            if !crate::ops::file::path_entry_exists(path) {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     format!("file not found: {}", path.display()),
                 )
                 .into());
             }
-            // Delete may remove non-UTF-8; only require text when we need a snapshot.
-            let original = crate::files::load_text_strict(path, &path_str).unwrap_or_default();
+            // Regular files, symlinks (unlink only), FIFO/socket/device ok;
+            // real directories refuse (#2087).
+            crate::ops::file::ensure_unlinkable_not_directory(path, path_str.as_ref())?;
+            // Delete may remove non-UTF-8 / special nodes; soft snapshot only
+            // for regular text files.
+            let original = if crate::ops::file::is_regular_file_for_backup(path) {
+                crate::files::load_text_strict(path, &path_str).unwrap_or_default()
+            } else {
+                String::new()
+            };
+            // Preview/Check: report would-delete without unlinking (#2087 DryRun).
             let (applied, backup_session) = if mode == ApplyMode::Apply {
                 super::apply_mutation(
                     path,
@@ -122,6 +132,7 @@ fn file_write(
                     },
                 )?
             } else {
+                super::ensure_contained(guard, path)?;
                 (false, None)
             };
             {
@@ -281,7 +292,14 @@ pub fn file_create(
     file_write(op, path, mode, guard, "create")
 }
 
-/// Delete a file.
+/// Delete a file, symlink, FIFO, socket, or device node under PathGuard (#2087).
+///
+/// **Directories are refused** (use a host-side recursive delete if needed).
+/// **Symlinks** are unlinked without following the target. Regular-file content
+/// is backed up for undo; special nodes get an empty backup marker (restore
+/// recreates an empty regular file, not the original node type).
+///
+/// DryRun / Preview / Check report would-delete without unlinking.
 pub fn file_delete(
     path: &Path,
     mode: ApplyMode,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -330,6 +330,13 @@ pub struct EditResult {
     /// `None` for Preview/Check, no-ops, or when nothing was backed up.
     /// Use with [`crate::backup::restore_path_from_session`] for surgical undo (#1686).
     pub backup_session: Option<String>,
+    /// Presentation/layout shifted while values may still be correct (#2088).
+    ///
+    /// True for doc writers when YAML block-sequence indent (or similar)
+    /// collapses relative to the original text. Same meaning as CLI/MCP/plan
+    /// `style_changed`. Default `false` for non-doc ops. **Not a failure:**
+    /// hosts should warn, not refuse, when this is true.
+    pub style_changed: bool,
 }
 
 /// Result of an in-memory content edit (no file path, no applied flag).
@@ -872,6 +879,12 @@ pub(crate) fn build_edit_result(
 ) -> EditResult {
     let diff = make_diff(path_str, &original, &new_content);
     let changed = original != new_content;
+    // Doc writers: same presentation honesty as CLI/MCP/plan (#2088).
+    let style_changed = if action.starts_with("doc.") {
+        doc_style_changed(path_str, &original, &new_content)
+    } else {
+        false
+    };
     EditResult {
         path: path_str.to_string(),
         original_content: original,
@@ -887,7 +900,21 @@ pub(crate) fn build_edit_result(
         match_score: None,
         matched_text: None,
         backup_session: None,
+        style_changed,
     }
+}
+
+/// Presentation honesty for library doc writes (#2088).
+fn doc_style_changed(path_str: &str, original: &str, new_content: &str) -> bool {
+    let Ok(fmt) = crate::ops::doc::detect_format(path_str) else {
+        return false;
+    };
+    crate::ops::doc::presentation_style_changed(original, new_content, &fmt)
+}
+
+/// True when [`EditResult::style_changed`] is set (#2088).
+pub fn is_style_changed(result: &EditResult) -> bool {
+    result.style_changed
 }
 
 /// Map fallback match strategy to public [`MatchMode`] (#1662).
@@ -1096,6 +1123,7 @@ fn execution_result_to_edit_result(
     let mut edit = build_edit_result(&path_str, original, new_content, applied, action, dest_path);
     edit.removed = removed;
     edit.backup_session = backup_session;
+    // build_edit_result already sets style_changed for doc.* actions (#2088).
     // Thread replace honesty from the engine (#1674 / #1662 / #1736).
     if let Some(meta) = replace_meta {
         edit.match_mode = Some(meta.mode);

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7290,6 +7290,146 @@ fn file_delete_binary_path_only_succeeds() {
     assert!(r.backup_session.is_some());
 }
 
+/// FIFO delete under PathGuard (#2087).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_delete_fifo_under_guard_succeeds() {
+    use std::process::Command as StdCommand;
+
+    let dir = TempDir::new().unwrap();
+    let fifo = dir.path().join("pipe.fifo");
+    // mkfifo via shell — std has no portable mkfifo helper.
+    let status = StdCommand::new("mkfifo")
+        .arg(&fifo)
+        .status()
+        .expect("mkfifo available on unix CI");
+    assert!(status.success(), "mkfifo must create {fifo:?}");
+    assert!(fifo.exists());
+
+    let guard = crate::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .expect("guard");
+    let r = file_delete(&fifo, ApplyMode::Apply, Some(&guard)).expect("FIFO delete (#2087)");
+    assert!(r.applied);
+    assert!(!fifo.exists(), "FIFO must be unlinked");
+    assert!(
+        r.backup_session.is_some(),
+        "special-node delete still creates a backup session"
+    );
+
+    // DryRun must not remove a FIFO.
+    let fifo2 = dir.path().join("pipe2.fifo");
+    assert!(
+        StdCommand::new("mkfifo")
+            .arg(&fifo2)
+            .status()
+            .unwrap()
+            .success()
+    );
+    let preview = file_delete(&fifo2, ApplyMode::Preview, Some(&guard)).expect("preview");
+    assert!(!preview.applied);
+    assert!(fifo2.exists(), "preview must not unlink FIFO");
+}
+
+/// Symlink delete unlinks the link only, never the target (#2087).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_delete_symlink_unlinks_link_not_target() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("target.txt");
+    let link = dir.path().join("link.txt");
+    fs::write(&target, "keep me\n").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let r = file_delete(&link, ApplyMode::Apply, None).expect("symlink delete");
+    assert!(r.applied);
+    assert!(!link.exists(), "symlink must be gone");
+    assert!(target.exists(), "target must remain");
+    assert_eq!(fs::read_to_string(&target).unwrap(), "keep me\n");
+}
+
+/// Dangling symlink is still unlinkable (#2087 path_entry_exists).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_delete_dangling_symlink_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let link = dir.path().join("dangling");
+    std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+    assert!(
+        crate::ops::file::path_entry_exists(&link),
+        "dangling link must count as an entry"
+    );
+    assert!(!link.exists(), "Path::exists follows and reports false");
+    let r = file_delete(&link, ApplyMode::Apply, None).expect("dangling symlink delete");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+}
+
+/// Symlink to a directory: unlink the link, leave the real dir (#2087).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_delete_symlink_to_directory() {
+    let dir = TempDir::new().unwrap();
+    let real_dir = dir.path().join("realdir");
+    fs::create_dir(&real_dir).unwrap();
+    fs::write(real_dir.join("inside.txt"), "x\n").unwrap();
+    let link = dir.path().join("linkdir");
+    std::os::unix::fs::symlink(&real_dir, &link).unwrap();
+    let r = file_delete(&link, ApplyMode::Apply, None).expect("symlink-to-dir delete");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+    assert!(real_dir.is_dir());
+    assert_eq!(
+        fs::read_to_string(real_dir.join("inside.txt")).unwrap(),
+        "x\n"
+    );
+}
+
+/// Library doc_set surfaces style_changed when YAML sequence indent collapses (#2088).
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn doc_set_style_changed_on_yaml_sequence_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("cfg.yaml");
+    // Indented block sequence; emitter often collapses indent on rewrite.
+    fs::write(&file, "env:\n  - name: FEATURE_FLAG\n    value: off\n").unwrap();
+    let r = doc_set(
+        &file,
+        "env.0.value",
+        serde_json::json!("on"),
+        ApplyMode::Apply,
+        None,
+    )
+    .expect("doc_set");
+    assert!(r.applied);
+    assert!(r.changed);
+    assert!(
+        r.style_changed,
+        "expected style_changed when YAML sequence presentation drifts; new=\n{}",
+        r.new_content
+    );
+    assert!(crate::api::is_style_changed(&r));
+
+    // Same presentation after second apply of same structure → typically false
+    // when re-serializing already-collapsed form.
+    let r2 = doc_set(
+        &file,
+        "env.0.value",
+        serde_json::json!("on2"),
+        ApplyMode::Apply,
+        None,
+    )
+    .expect("second doc_set");
+    assert!(r2.applied);
+    // Non-doc op leaves style_changed false.
+    let txt = dir.path().join("n.txt");
+    fs::write(&txt, "a\n").unwrap();
+    let cr = file_create(&txt, "b\n", true, ApplyMode::Apply, None).expect("create");
+    assert!(!cr.style_changed);
+}
+
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]
 fn file_rename_force_binary_over_existing() {

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -178,8 +178,18 @@ impl BackupSession {
                 std::fs::create_dir_all(parent)
                     .with_context(|| format!("creating backup dir for {rel_str}"))?;
             }
-            std::fs::copy(file_path, &backup_path)
-                .with_context(|| format!("backing up {rel_str} before delete"))?;
+            // Regular files: full byte backup. Symlinks / FIFO / socket / device:
+            // empty marker only (fs::copy on FIFO blocks; symlink copy follows
+            // target). Restore recreates an empty regular file — hosts that
+            // need the special node type recreated must re-create it themselves
+            // (#2087).
+            if crate::ops::file::is_regular_file_for_backup(file_path) {
+                std::fs::copy(file_path, &backup_path)
+                    .with_context(|| format!("backing up {rel_str} before delete"))?;
+            } else {
+                std::fs::write(&backup_path, b"")
+                    .with_context(|| format!("writing empty backup marker for {rel_str}"))?;
+            }
         }
 
         self.entries.push(ManifestEntry {

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -32,14 +32,16 @@ pub fn run(mut args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     args.file = global.rewrite_user_path_arg(&cwd, &args.file)?;
     let path = cwd.join(&args.file);
 
-    if !path.exists() {
+    // path_entry_exists includes dangling symlinks (Path::exists does not).
+    if !crate::ops::file::path_entry_exists(&path) {
         let msg = format!("file not found: {}", args.file);
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
-    if !path.is_file() {
-        let msg = format!("target is not a file: {}", args.file);
-        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+    // Allow regular files, symlinks (unlink only), FIFO/socket/device;
+    // refuse real directories only (#2087).
+    if let Err(e) = crate::ops::file::ensure_unlinkable_not_directory(&path, &args.file) {
+        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
         return Ok(crate::exit::FAILURE);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,8 @@
 //! | Map invalid UTF-8 content | [`EditErrorKind::InvalidEncoding`] / [`api::is_invalid_encoding`] |
 //! | Force create over binary/unreadable prior | [`api::file_create`](..., `force: true`) (#1962) |
 //! | Path-only rename/delete non-text (byte backup, no OS dual-path) | [`api::file_rename`] / [`api::file_delete`] (#2031) |
+//! | Delete FIFO/socket/device/symlink under PathGuard | [`api::file_delete`] (dirs still refused; #2087) |
+//! | YAML presentation drift on library writes | [`EditResult::style_changed`] / [`api::is_style_changed`] (#2088) |
 //! | Morph-class freeform on disk | [`api::apply_fragment_to_file`] + [`FragmentPlacement`] (#2032) |
 //! | Host unit-test honesty rows (`#[non_exhaustive]`) | [`ContentEditHonesty::exact`] / [`ContentEditHonesty::fuzzy`] (#2033) |
 //! | Map create/rename dest-exists to force/overwrite recovery | [`EditErrorKind::AlreadyExists`] / [`api::is_already_exists`] |
@@ -324,8 +326,8 @@ pub use api::{
     fuzzy_span_suspicious_with_policy, is_already_exists, is_ambiguous, is_binary, is_binary_file,
     is_changes_detected, is_conflicts, is_format_failed, is_fuzzy_span_suspicious,
     is_guard_rejected, is_invalid_encoding, is_invalid_input, is_lazy_marker_line,
-    is_load_text_strict_fail, is_no_match, is_not_found, is_type_error, load_text,
-    load_text_strict, merge_match_modes, parse_unified_diff, peel_error,
+    is_load_text_strict_fail, is_no_match, is_not_found, is_style_changed, is_type_error,
+    load_text, load_text_strict, merge_match_modes, parse_unified_diff, peel_error,
     plan_apply_fragment_to_replace, prefer_widest_matched_text, refuse_batch_if_suspicious_fuzzy,
     run_post_write_validation, search_file, strip_lazy_markers, text_diff,
 };

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -34,6 +34,56 @@ fn ends_with_line_ending(s: &str) -> bool {
     s.ends_with("\r\n") || s.ends_with('\n') || s.ends_with('\r')
 }
 
+/// True when the path exists as a directory entry (including dangling symlinks).
+///
+/// Prefer this over `Path::exists()` for delete/unlink: `exists()` follows
+/// links and reports false for broken symlinks that `remove_file` can still
+/// unlink (#2087).
+pub fn path_entry_exists(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok()
+}
+
+/// True when `path` is a real directory (not a symlink to a directory).
+///
+/// Symlinks are unlinkable even when their target is a directory (#2087).
+pub fn is_real_directory(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) => {
+            let ft = meta.file_type();
+            ft.is_dir() && !ft.is_symlink()
+        }
+        Err(_) => false,
+    }
+}
+
+/// Refuse delete/rename targets that are real directories.
+///
+/// Allows regular files, symlinks (unlink the link only), FIFOs, sockets,
+/// and device nodes. Hosts use this so `file_delete` does not dual-path
+/// through `std::fs::remove_file` for special nodes (#2087).
+pub fn ensure_unlinkable_not_directory(
+    path: &Path,
+    display: &str,
+) -> Result<(), crate::exit::InvalidInputError> {
+    if is_real_directory(path) {
+        return Err(crate::exit::InvalidInputError {
+            msg: format!("target is not a file: {display}"),
+        });
+    }
+    Ok(())
+}
+
+/// True when the path is a regular file suitable for byte backup via `fs::copy`.
+///
+/// Symlinks, FIFOs, sockets, and devices return false so callers write an empty
+/// backup marker instead of blocking on FIFO open or copying through a link (#2087).
+pub fn is_regular_file_for_backup(path: &Path) -> bool {
+    match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta.file_type().is_file(),
+        Err(_) => false,
+    }
+}
+
 /// Walk ancestors of `path` and ensure every existing component is a directory.
 ///
 /// Missing parents are fine (`create_dir_all` creates them on apply). An
@@ -337,6 +387,29 @@ mod tests {
         assert!(a.contains('\n'));
         let p = prepend_content("base", "added");
         assert!(p.contains('\n'));
+    }
+
+    #[test]
+    fn real_directory_detected_not_file() {
+        let dir = TempDir::new().unwrap();
+        assert!(is_real_directory(dir.path()));
+        let f = dir.path().join("f.txt");
+        fs::write(&f, "x").unwrap();
+        assert!(!is_real_directory(&f));
+        assert!(is_regular_file_for_backup(&f));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlink_is_unlinkable_not_real_directory() {
+        let dir = TempDir::new().unwrap();
+        let target = dir.path().join("t");
+        let link = dir.path().join("l");
+        fs::write(&target, "x").unwrap();
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        assert!(!is_real_directory(&link));
+        assert!(!is_regular_file_for_backup(&link));
+        ensure_unlinkable_not_directory(&link, "l").unwrap();
     }
 
     #[test]

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -113,16 +113,18 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
 
         Operation::FileDelete { path } => {
             let file_path = tx.cwd.join(path);
-            if file_path.exists() && !file_path.is_file() {
-                return Err(crate::exit::InvalidInputError {
-                    msg: format!("target is not a file: {path}"),
-                }
-                .into());
+            // Allow regular files, symlinks (unlink only), FIFO/socket/device.
+            // Refuse real directories only (#2087). Use path_entry_exists so
+            // dangling symlinks are still unlinkable (Path::exists follows).
+            if crate::ops::file::path_entry_exists(&file_path) {
+                crate::ops::file::ensure_unlinkable_not_directory(&file_path, path)?;
             }
             let created_in_tx = match tx.pending.get(&file_path) {
-                Some((original, _)) => original.is_empty() && !file_path.exists(),
+                Some((original, _)) => {
+                    original.is_empty() && !crate::ops::file::path_entry_exists(&file_path)
+                }
                 None => {
-                    if !file_path.exists() {
+                    if !crate::ops::file::path_entry_exists(&file_path) {
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::NotFound,
                             format!("file not found: {path}"),
@@ -131,8 +133,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                     }
                     tx.existed_before.insert(file_path.clone());
                     // Soft text load for rollback snapshot: binary / invalid
-                    // UTF-8 / unreadable → empty pair (#1163 / #1894 SoftSkip).
-                    if let Some(content) = crate::files::read_text_file(&file_path) {
+                    // UTF-8 / unreadable / special node → empty pair
+                    // (#1163 / #1894 SoftSkip / #2087).
+                    if crate::ops::file::is_regular_file_for_backup(&file_path)
+                        && let Some(content) = crate::files::read_text_file(&file_path)
+                    {
                         tx.pending
                             .insert(file_path.clone(), (content.clone(), content));
                     } else {

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -237,7 +237,8 @@ pub(crate) fn commit_changes(
             if renamed_from.contains(path.as_path()) {
                 continue;
             }
-            if path.exists() {
+            // path_entry_exists includes dangling symlinks (#2087).
+            if crate::ops::file::path_entry_exists(path) {
                 std::fs::remove_file(path)
                     .with_context(|| format!("deleting {}", path.display()))?;
             }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -4328,12 +4328,14 @@ fn test_tx_strict_mode_reverts_on_format_failure() {
     let file = dir.path().join("test.txt");
     fs::write(&file, "original\n").unwrap();
 
+    // Relative path + --cwd (avoids __external__ absolute-path restore races
+    // on macOS CI where /var vs /private/var can leave the wrong entry).
     let plan = serde_json::json!({
             "version": 1,
         "strict": true,
         "operations": [{
             "op": "replace",
-            "path": file.to_str().unwrap(),
+            "path": "test.txt",
             "old": "original",
             "new": "changed"
         }],
@@ -4346,8 +4348,10 @@ fn test_tx_strict_mode_reverts_on_format_failure() {
 
     Command::cargo_bin("patchloom")
         .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
         .arg("tx")
-        .arg(plan_file.to_str().unwrap())
+        .arg(&plan_file)
         .arg("--apply")
         .assert()
         .code(7); // ROLLBACK


### PR DESCRIPTION
## Summary

Library host honesty for bline 0.24 upgrade remaining dual paths.

Closes #2088
Closes #2087

## Changes

### #2088 `style_changed` on `EditResult`
- New field + `api::is_style_changed`
- Set for `doc.*` actions via `presentation_style_changed`
- Test: YAML block-sequence indent collapse

### #2087 special-node `file_delete`
- Unlink regular files, symlinks (including dangling), FIFO/socket/device
- Refuse real directories only
- Empty backup marker for non-regular (no FIFO block on `fs::copy`)
- CLI + tx engine + library fallback share helpers
- Tests: FIFO+guard+preview, symlink target safe, symlink-to-dir, dangling

## Decision notes

Posted on both issues: full path-op for #2087 (not peel-only); small honesty field for #2088.

## Reviewer

Approve with nits; dangling existence + stricter style assert addressed in this PR.

## Verification

- `cargo test --lib --all-features file_delete_`
- `cargo test --lib --all-features doc_set_style`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `make check-fast` (pre-nit; re-ran targeted after nits)