### PR TITLE
fix: path-only rename for symlinks and special nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-4000%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-4100%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -508,7 +508,7 @@ flowchart LR
 
 ## Status
 
-4000+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+4100+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -43,9 +43,12 @@ Bline is a real embedder that dogfooded these steps; the checklist is host-gener
      refuses over-wide fuzzy **before** write/backup (#2008).
 8. **Path-only file ops on non-text:** `file_rename` / `file_delete` succeed on
    binary and invalid UTF-8 with byte backup and PathGuard (no OS dual-path)
-   (#2031). `file_delete` also unlinks FIFO/socket/device and symlinks (link
-   only; never follows); directories stay refused (#2087). Append/prepend/replace
-   still refuse non-text loads.
+   (#2031). Both also handle FIFO/socket/device and symlinks (including
+   dangling and symlink-to-dir) as directory-entry moves/unlinks without
+   following the target; directories stay refused (#2087, #2091). Soft-loading a
+   symlink as text then writing would rewrite the **target**; rename uses an
+   empty path-only snapshot so write policies never mutate the link target.
+   Append/prepend/replace still refuse non-text loads.
 9. **Doc presentation honesty:** library `EditResult.style_changed` (and
    `is_style_changed`) mirrors CLI/MCP when YAML block-sequence layout
    collapses; values can still be correct (#2088). Warn hosts/agents; do not

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -298,7 +298,7 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:delete -->
 ## `delete`
 
-- **What it does:** Removes a file. Directory targets are rejected in all modes. When combined with `--confirm` and `--json` or `--jsonl`, the structured output includes `applied: true|false` so callers can tell whether the prompt was accepted.
+- **What it does:** Removes a file, symlink, FIFO, socket, or device node. Directory targets are rejected in all modes. Symlinks are unlinked without following the target (including dangling links and symlink-to-dir). When combined with `--confirm` and `--json` or `--jsonl`, the structured output includes `applied: true|false` so callers can tell whether the prompt was accepted.
 - **Use when:** A file should disappear outright and no other atomic edits are needed. For AI agents deleting a single file, native delete tools are typically faster; use `file.delete` inside `tx` plans when bundling with other edits.
 - **Failure behavior:** Missing file exits `1` with `error_kind: "not_found"`; directory targets use `invalid_input`. Pre-write failures under `--json`/`--jsonl` set `applied: false`.
 - **Prefer instead:** Use `tx file.delete` when the removal must be bundled atomically with other changes.
@@ -307,9 +307,9 @@ These are the main entry points. If you are deciding between commands, start her
 <!-- ref:command:rename -->
 ## `rename`
 
-- **What it does:** Moves (renames) a file from one path to another. Source and destination must both be file paths, not directories. When combined with `--confirm` and `--json` or `--jsonl`, the structured output includes `applied: true|false` so callers can tell whether the prompt was accepted.
+- **What it does:** Moves (renames) a file, symlink, FIFO, socket, or device node from one path to another. Real directories are refused. Symlinks (including dangling and symlink-to-dir) are moved as directory entries without following the target, so write policies never rewrite the link target. When combined with `--confirm` and `--json` or `--jsonl`, the structured output includes `applied: true|false` so callers can tell whether the prompt was accepted.
 - **Use when:** A file needs to be relocated and no other atomic edits are needed. Use `file.rename` inside `tx` plans when bundling with other edits.
-- **Failure behavior:** Missing source exits `1` with `error_kind: "not_found"`; destination exists without `--force` uses `already_exists`; non-file paths use `invalid_input`. Pre-write failures under `--json`/`--jsonl` set `applied: false`.
+- **Failure behavior:** Missing source exits `1` with `error_kind: "not_found"`; destination exists without `--force` uses `already_exists`; real directories use `invalid_input`. Pre-write failures under `--json`/`--jsonl` set `applied: false`.
 - **Prefer instead:** Use `tx file.rename` when the rename must be bundled atomically with other changes.
 - **Related:** `create`, `delete`, `tx file.rename`
 
@@ -1237,7 +1237,7 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:file.rename -->
 ### `file.rename`
 
-- **What it does:** Renames (moves) a file inside a transaction.
+- **What it does:** Renames (moves) a file, symlink, or special node inside a transaction. Path-only for non-regular files so symlink targets are never rewritten by write policy.
 - **Use when:** File renames should roll back if later format or validation steps fail. More efficient than `read` + `file.create` + `file.delete` as a single operation.
 - **Related:** top level `rename`
 

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -315,7 +315,14 @@ pub fn file_delete(
     file_write(op, path, mode, guard, "delete")
 }
 
-/// Rename (move) a file.
+/// Rename (move) a file, symlink, FIFO, socket, or device node (#2091).
+///
+/// **Directories are refused.** Symlinks (including dangling and symlink-to-dir)
+/// are moved as directory entries without following the target. Soft-loading
+/// symlink text and rewriting would mutate the target via `atomic_write`;
+/// special nodes use an empty path-only snapshot so write policies never
+/// rewrite the link target. Regular-file content is soft-loaded for
+/// preview/diff; binary / invalid UTF-8 still path-rename (#2031).
 pub fn file_rename(
     src: &Path,
     dst: &Path,

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7387,6 +7387,81 @@ fn file_delete_symlink_to_directory() {
     );
 }
 
+/// Rename moves the symlink entry only; never rewrites the target (#2091).
+///
+/// Regression: soft-loading symlink text then atomic_write resolved the link
+/// and mutated the target when write policy (or engine rewrite) applied.
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_rename_symlink_does_not_mutate_target() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("target.txt");
+    let link = dir.path().join("link.txt");
+    let moved = dir.path().join("moved-link.txt");
+    // No final newline: a write-policy rewrite would add one if it followed the link.
+    fs::write(&target, "hello").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let r = file_rename(&link, &moved, false, ApplyMode::Apply, None).expect("symlink rename");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+    assert!(
+        moved.is_symlink(),
+        "dest must remain a symlink, not a regular file"
+    );
+    assert_eq!(
+        fs::read_link(&moved).unwrap(),
+        target,
+        "symlink target path must be unchanged"
+    );
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        "hello",
+        "target content must not gain a trailing newline or other rewrite"
+    );
+}
+
+/// Dangling symlink rename succeeds via path_entry_exists (#2091).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_rename_dangling_symlink_succeeds() {
+    let dir = TempDir::new().unwrap();
+    let link = dir.path().join("dangling");
+    let dest = dir.path().join("renamed-dangle");
+    std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+    assert!(!link.exists(), "Path::exists follows and reports false");
+    let r = file_rename(&link, &dest, false, ApplyMode::Apply, None).expect("dangling rename");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+    assert!(
+        crate::ops::file::path_entry_exists(&dest),
+        "dangling link must move to dest"
+    );
+    assert!(dest.is_symlink());
+}
+
+/// Symlink-to-directory is renameable (move the link, leave the real dir) (#2091).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_rename_symlink_to_directory() {
+    let dir = TempDir::new().unwrap();
+    let real_dir = dir.path().join("realdir");
+    fs::create_dir(&real_dir).unwrap();
+    fs::write(real_dir.join("inside.txt"), "x\n").unwrap();
+    let link = dir.path().join("linkdir");
+    let dest = dir.path().join("linkdir2");
+    std::os::unix::fs::symlink(&real_dir, &link).unwrap();
+    let r = file_rename(&link, &dest, false, ApplyMode::Apply, None).expect("symlink-dir rename");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+    assert!(dest.is_symlink());
+    assert!(real_dir.is_dir());
+    assert_eq!(
+        fs::read_to_string(real_dir.join("inside.txt")).unwrap(),
+        "x\n"
+    );
+}
+
 /// Library doc_set surfaces style_changed when YAML sequence indent collapses (#2088).
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -328,7 +328,7 @@ fn rename_or_copy(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Resul
         Err(e) if is_cross_device(&e) => {
             // Only remove dest on rollback if we created it; force overwrite
             // must not delete the pre-existing dest (backup holds prior bytes).
-            let dest_existed = dst.exists();
+            let dest_existed = crate::ops::file::path_entry_exists(dst);
             fs::copy(src, dst).with_context(|| {
                 format!("cross-device copy {} -> {}", src.display(), dst.display())
             })?;

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -55,23 +55,25 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let dst = cwd.join(&args.to);
 
     // Pre-validation for CLI-specific checks.
-    if !src.exists() {
+    // path_entry_exists includes dangling symlinks; is_file() would refuse
+    // special nodes and FIFO open can hang (#2087 / #2091).
+    if !crate::ops::file::path_entry_exists(&src) {
         let msg = format!("source file not found: {}", args.from);
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
-    if !src.is_file() {
-        let msg = format!("source is not a file: {}", args.from);
-        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+    if let Err(e) = crate::ops::file::ensure_unlinkable_not_directory(&src, &args.from) {
+        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
         return Ok(crate::exit::FAILURE);
     }
     if let Err(e) = crate::ops::file::ensure_parent_components_are_directories(&dst) {
         global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
         return Ok(crate::exit::FAILURE);
     }
-    if dst.exists() && !dst.is_file() {
-        let msg = format!("destination is not a file: {}", args.to);
-        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+    if crate::ops::file::path_entry_exists(&dst)
+        && let Err(e) = crate::ops::file::ensure_unlinkable_not_directory(&dst, &args.to)
+    {
+        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
         return Ok(crate::exit::FAILURE);
     }
 
@@ -107,7 +109,7 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::SUCCESS);
     }
 
-    if !args.force && !is_case_only_change && dst.exists() {
+    if !args.force && !is_case_only_change && crate::ops::file::path_entry_exists(&dst) {
         let msg = format!(
             "destination already exists: {} (use --force to overwrite)",
             args.to
@@ -116,19 +118,35 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(crate::exit::FAILURE);
     }
 
-    // Binary files can't go through the tx engine (it reads as UTF-8 text).
-    // Use a direct fs::rename (or copy+delete) for binary renames.
-    // Only read the first 8 KiB instead of the entire file to avoid
-    // unnecessary memory allocation on large binaries.
-    let is_binary = {
-        use std::io::Read;
-        let mut file = fs::File::open(&src)?;
-        let mut buf = [0u8; 8192];
-        let n = file.read(&mut buf)?;
-        crate::files::is_binary(&buf[..n])
-    };
-    if is_binary {
-        return run_direct_rename(&args, global, &cwd, &src, &dst, DirectRenameKind::Binary);
+    // Special nodes (symlink / FIFO / socket / device): never open for binary
+    // probe (FIFO hang) or text load (symlink target rewrite via atomic_write).
+    // Path-only rename via fs::rename or engine empty soft-load (#2091).
+    let is_special = !crate::ops::file::is_regular_file_for_backup(&src);
+    if is_special {
+        if is_case_only_change {
+            return run_direct_rename(&args, global, &cwd, &src, &dst, DirectRenameKind::CaseOnly);
+        }
+        let policy = crate::write::policy_from_flags(global, None);
+        if (global.apply || global.confirm) && policy.is_noop() && !global.respect_editorconfig {
+            return run_direct_rename(&args, global, &cwd, &src, &dst, DirectRenameKind::Plain);
+        }
+        // Preview / --check / write-policy: engine stages empty content +
+        // records tx.renames so commit only renames the directory entry.
+    } else {
+        // Binary files can't go through the tx engine (it reads as UTF-8 text).
+        // Use a direct fs::rename (or copy+delete) for binary renames.
+        // Only read the first 8 KiB instead of the entire file to avoid
+        // unnecessary memory allocation on large binaries.
+        let is_binary = {
+            use std::io::Read;
+            let mut file = fs::File::open(&src)?;
+            let mut buf = [0u8; 8192];
+            let n = file.read(&mut buf)?;
+            crate::files::is_binary(&buf[..n])
+        };
+        if is_binary {
+            return run_direct_rename(&args, global, &cwd, &src, &dst, DirectRenameKind::Binary);
+        }
     }
 
     // Case-only renames on case-insensitive filesystems (e.g. macOS APFS)

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -62,18 +62,18 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
-    if let Err(e) = crate::ops::file::ensure_unlinkable_not_directory(&src, &args.from) {
-        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
+    if crate::ops::file::is_real_directory(&src) {
+        let msg = format!("source is not a file: {}", args.from);
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
     if let Err(e) = crate::ops::file::ensure_parent_components_are_directories(&dst) {
         global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
         return Ok(crate::exit::FAILURE);
     }
-    if crate::ops::file::path_entry_exists(&dst)
-        && let Err(e) = crate::ops::file::ensure_unlinkable_not_directory(&dst, &args.to)
-    {
-        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
+    if crate::ops::file::path_entry_exists(&dst) && crate::ops::file::is_real_directory(&dst) {
+        let msg = format!("destination is not a file: {}", args.to);
+        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@
 //! | Force create over binary/unreadable prior | [`api::file_create`](..., `force: true`) (#1962) |
 //! | Path-only rename/delete non-text (byte backup, no OS dual-path) | [`api::file_rename`] / [`api::file_delete`] (#2031) |
 //! | Delete FIFO/socket/device/symlink under PathGuard | [`api::file_delete`] (dirs still refused; #2087) |
+//! | Rename symlink/FIFO/dangling (path-only; never rewrites link target) | [`api::file_rename`] (#2091) |
 //! | YAML presentation drift on library writes | [`EditResult::style_changed`] / [`api::is_style_changed`] (#2088) |
 //! | Morph-class freeform on disk | [`api::apply_fragment_to_file`] + [`FragmentPlacement`] (#2032) |
 //! | Host unit-test honesty rows (`#[non_exhaustive]`) | [`ContentEditHonesty::exact`] / [`ContentEditHonesty::fuzzy`] (#2033) |

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -171,11 +171,23 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // Special nodes (symlinks, FIFO, …) are renameable; only real
             // directories are refused. path_entry_exists includes dangling
             // symlinks that Path::exists() misses (#2087 / #2091).
-            if crate::ops::file::path_entry_exists(&src_path) {
-                crate::ops::file::ensure_unlinkable_not_directory(&src_path, from)?;
+            // Keep "source"/"destination" wording (not generic "target") for
+            // agent/CLI error matching.
+            if crate::ops::file::path_entry_exists(&src_path)
+                && crate::ops::file::is_real_directory(&src_path)
+            {
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("source is not a file: {from}"),
+                }
+                .into());
             }
-            if crate::ops::file::path_entry_exists(&dst_path) {
-                crate::ops::file::ensure_unlinkable_not_directory(&dst_path, to)?;
+            if crate::ops::file::path_entry_exists(&dst_path)
+                && crate::ops::file::is_real_directory(&dst_path)
+            {
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!("destination is not a file: {to}"),
+                }
+                .into());
             }
             crate::ops::file::ensure_parent_components_are_directories(&dst_path)?;
 

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -168,17 +168,14 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 )
                 .into());
             }
-            if src_path.exists() && !src_path.is_file() {
-                return Err(crate::exit::InvalidInputError {
-                    msg: format!("source is not a file: {from}"),
-                }
-                .into());
+            // Special nodes (symlinks, FIFO, …) are renameable; only real
+            // directories are refused. path_entry_exists includes dangling
+            // symlinks that Path::exists() misses (#2087 / #2091).
+            if crate::ops::file::path_entry_exists(&src_path) {
+                crate::ops::file::ensure_unlinkable_not_directory(&src_path, from)?;
             }
-            if dst_path.exists() && !dst_path.is_file() {
-                return Err(crate::exit::InvalidInputError {
-                    msg: format!("destination is not a file: {to}"),
-                }
-                .into());
+            if crate::ops::file::path_entry_exists(&dst_path) {
+                crate::ops::file::ensure_unlinkable_not_directory(&dst_path, to)?;
             }
             crate::ops::file::ensure_parent_components_are_directories(&dst_path)?;
 
@@ -214,7 +211,8 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             if !force && !case_only {
                 let dst_exists = (tx.pending.contains_key(&dst_path)
                     && !tx.deletions.contains(&dst_path))
-                    || (!tx.deletions.contains(&dst_path) && dst_path.exists());
+                    || (!tx.deletions.contains(&dst_path)
+                        && crate::ops::file::path_entry_exists(&dst_path));
                 if dst_exists {
                     return Err(crate::exit::AlreadyExistsError {
                         msg: format!("destination already exists: {to} (use force to overwrite)"),
@@ -226,8 +224,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // If destination exists on disk, load it into pending first so
             // existed_before is populated and commit uses atomic_write (not
             // atomic_create_new which would fail on existing files). Soft-load
-            // non-text dest the same way as source (#2031 force overwrite).
-            if (*force || case_only) && !tx.pending.contains_key(&dst_path) && dst_path.exists() {
+            // non-text / special-node dest the same way as source (#2031 / #2091).
+            if (*force || case_only)
+                && !tx.pending.contains_key(&dst_path)
+                && crate::ops::file::path_entry_exists(&dst_path)
+            {
                 let _ = read_file_content_for_path_op(tx.pending, tx.existed_before, &dst_path)?;
             }
 
@@ -246,13 +247,16 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // Case-only renames (readme.md → README.md) must also record the
             // pair. On case-insensitive FS, write-dest + delete-src removes the
             // only inode. CLI bypasses the engine (#1167); plan/MCP must not.
-            let src_on_disk = src_path.exists() && src_path.is_file();
+            // path_entry_exists: dangling symlinks / special nodes need the
+            // fs::rename record so commit does not materialize empty files.
+            let src_on_disk = crate::ops::file::path_entry_exists(&src_path);
             let src_is_rename_dest = tx.renames.iter().any(|(_, to)| to == &src_path);
+            let dst_on_disk = crate::ops::file::path_entry_exists(&dst_path);
             if case_only {
                 if src_on_disk || src_is_rename_dest {
                     tx.renames.push((src_path.clone(), dst_path.clone()));
                 }
-            } else if (src_on_disk || src_is_rename_dest) && (*force || !dst_path.exists()) {
+            } else if (src_on_disk || src_is_rename_dest) && (*force || !dst_on_disk) {
                 // Non-force with an on-disk dest is rejected earlier. Force may
                 // overwrite; non-force only records when dest is not on disk.
                 tx.renames.push((src_path.clone(), dst_path.clone()));
@@ -263,7 +267,9 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
 
             // Delete source (same logic as file.delete for tx-created files).
             let created_in_tx = match tx.pending.get(&src_path) {
-                Some((original, _)) => original.is_empty() && !src_path.exists(),
+                Some((original, _)) => {
+                    original.is_empty() && !crate::ops::file::path_entry_exists(&src_path)
+                }
                 None => false,
             };
             if created_in_tx {

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -85,11 +85,15 @@ pub(crate) fn read_file_content_for_force_create<'a>(
     }
 }
 
-/// Soft-load for path-only ops (rename source / force dest) (#2031).
+/// Soft-load for path-only ops (rename source / force dest) (#2031 / #2091).
 ///
 /// Binary / invalid UTF-8 become an empty text snapshot so staging does not
 /// fail; commit still uses `fs::rename` when `tx.renames` records the pair
-/// (bytes on disk are never rewritten as empty). Missing paths and other
+/// (bytes on disk are never rewritten as empty).
+///
+/// **Special nodes** (symlinks, FIFOs, sockets, devices) also soft-load as
+/// empty: never open/follow them (FIFO hang; symlink rewrite would mutate the
+/// target via [`crate::write::atomic_write`] resolve). Missing paths and other
 /// load failures still hard-fail.
 pub(crate) fn read_file_content_for_path_op<'a>(
     pending: &'a mut HashMap<PathBuf, (String, String)>,
@@ -100,16 +104,30 @@ pub(crate) fn read_file_content_for_path_op<'a>(
         Entry::Occupied(entry) => Ok(&entry.into_mut().1),
         Entry::Vacant(entry) => {
             let display = path.display().to_string();
-            let content = match crate::files::load_text_strict(path, &display) {
-                Ok(s) => s,
-                Err(e) if crate::exit::is_binary(&e) || crate::exit::is_invalid_encoding(&e) => {
-                    String::new()
-                }
-                Err(e) => return Err(e),
-            };
-            if path.exists() {
-                existed_before.insert(path.to_path_buf());
+            // path_entry_exists includes dangling symlinks (#2087 / #2091).
+            if !crate::ops::file::path_entry_exists(path) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("file not found: {display}"),
+                )
+                .into());
             }
+            crate::ops::file::ensure_unlinkable_not_directory(path, &display)?;
+            let content = if !crate::ops::file::is_regular_file_for_backup(path) {
+                // Symlink / FIFO / socket / device: empty path-only snapshot.
+                String::new()
+            } else {
+                match crate::files::load_text_strict(path, &display) {
+                    Ok(s) => s,
+                    Err(e)
+                        if crate::exit::is_binary(&e) || crate::exit::is_invalid_encoding(&e) =>
+                    {
+                        String::new()
+                    }
+                    Err(e) => return Err(e),
+                }
+            };
+            existed_before.insert(path.to_path_buf());
             Ok(&entry.insert((content.clone(), content)).1)
         }
     }

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -150,7 +150,8 @@ pub(crate) fn commit_changes(
     // `changes` (original == final == ""), so it would not be backed up above.
     // `rename_or_copy` still overwrites dest; keep prior dest bytes for undo.
     for (_, to) in renames {
-        if to.exists() {
+        // path_entry_exists: dangling dest / special nodes still need backup.
+        if crate::ops::file::path_entry_exists(to) {
             backup.save_before_write(to).map_err(|e| {
                 commit_error(format!("backing up rename dest {}: {e}", to.display()))
             })?;

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -1198,6 +1198,53 @@ fn test_tx_file_rename_moves_file() {
     );
 }
 
+/// Symlink rename must not rewrite the target even when CLI write policy is set (#2091).
+#[cfg(unix)]
+#[test]
+fn test_tx_file_rename_symlink_does_not_mutate_target_with_write_policy() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("target.txt");
+    let link = dir.path().join("link.txt");
+    // No trailing newline: a target rewrite via atomic_write would add one.
+    fs::write(&target, "hello").unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {"op": "file.rename", "from": "link.txt", "to": "moved-link.txt"}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .arg("--ensure-final-newline")
+        .assert()
+        .code(0);
+
+    let moved = dir.path().join("moved-link.txt");
+    assert!(
+        std::fs::symlink_metadata(&link).is_err(),
+        "source symlink entry must be gone"
+    );
+    assert!(
+        moved.is_symlink(),
+        "dest must stay a symlink after rename with write policy"
+    );
+    assert_eq!(
+        fs::read_to_string(&target).unwrap(),
+        "hello",
+        "target must not gain a trailing newline from rename write policy"
+    );
+}
+
 /// file.rename JSON must report one `renamed` change (not create+delete).
 #[test]
 fn test_tx_file_rename_json_action_renamed() {


### PR DESCRIPTION
## Summary

MPI cycle fix after #2087 special-node delete: `file.rename` / CLI `rename` / plan `file.rename` soft-loaded symlink targets as text and could rewrite the **target** under write policy (`atomic_write` resolves links). Dangling links and symlink-to-dir were refused incorrectly; FIFO open for binary probe could hang.

## Changes

- Soft-load non-regular sources as empty path-only snapshots (`read_file_content_for_path_op`)
- Record `tx.renames` via `path_entry_exists` so commit uses `fs::rename` only
- CLI precheck: `path_entry_exists` + real-directory refuse (preserve source/destination wording)
- Library, CLI, and integration tests (symlink + write policy, dangling, symlink-to-dir)
- Docs: embedder-host, reference, lib.rs host table

## Test plan

- [x] `cargo test --lib --all-features file_rename_`
- [x] Integration rename directory + symlink write-policy tests
- [x] `make check-fast`

Closes #2091