### PR TITLE
refactor: share rename_or_copy and path classify

### DIFF
--- a/docs/plans/write-pipeline.md
+++ b/docs/plans/write-pipeline.md
@@ -76,7 +76,44 @@ Binary / case-only renames cannot use the UTF-8 tx engine. They use
 | tidy fix | `stage_for_write(Operations)` | `finalize_report` via `tidy_fix_output` hooks |
 | patch apply | `stage_for_write(Operations)` | `finalize_report` hooks |
 | md dedupe-headings | `stage_for_write` | `finalize_report` (`--json` object with `removed`+`applied`; JSONL one string per heading) |
-| rename binary/case-only | n/a | `execute_write` / `finalize_callback_write` |
+| rename binary/case-only / special-node plain apply | n/a | `execute_write` / `finalize_callback_write` (path-only; no UTF-8 engine) |
+
+## Layer map (why the tree is not a hodgepodge)
+
+Patchloom looks multi-entry on purpose. Agents hit three surfaces; the
+shared core is what keeps them honest:
+
+```
+ops/*          pure content + path helpers (no CLI, no plan)
+  ↑
+tx/execute     Operation → staged pending / renames / deletions
+  ↑
+tx/engine      stage + commit (backup, rename_or_copy, restore)
+  ↑
+api/*          library EditResult + PathGuard (uses engine when `files`)
+cmd/*          clap + write_mode finalize (uses engine or direct rename)
+cmd/mcp        tools → same Operation / engine path
+```
+
+**Rules of thumb when adding code:**
+
+1. **Content math** (append EOL, YAML style, selector eval) → `ops/`.
+2. **Path entry kind** (file vs dir vs symlink vs FIFO) →
+   `ops::file::classify_path_entry` / `rename_or_copy`, not ad hoc
+   `exists()` + `is_file()` for unlink/rename.
+3. **Presentation honesty** (YAML sequence indent) →
+   `ops::doc::style_changed_for_path` / `presentation_style_changed` once;
+   do not re-open `detect_format` in CLI/tx/api separately.
+4. **Mode / exit codes** → only `write_mode.rs` (never a third matrix).
+5. **CLI direct rename** (binary, case-only, plain special-node) is not a
+   second product; it is the non-UTF-8 path of the same rename contract.
+6. **No-default-features** stubs under `api/*` are intentional thin
+   fallbacks for library builds without the `files` engine; prefer
+   extending the engine path when both exist.
+
+Large modules with `size-waiver` (fallback, yaml_splice, shell_token) stay
+large **when they are one domain**. Split only on a real second subsystem
+(AGENTS.md module-size policy / closed #1408).
 
 ## Adding a write command
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -881,7 +881,7 @@ pub(crate) fn build_edit_result(
     let changed = original != new_content;
     // Doc writers: same presentation honesty as CLI/MCP/plan (#2088).
     let style_changed = if action.starts_with("doc.") {
-        doc_style_changed(path_str, &original, &new_content)
+        crate::ops::doc::style_changed_for_path(path_str, &original, &new_content)
     } else {
         false
     };
@@ -902,14 +902,6 @@ pub(crate) fn build_edit_result(
         backup_session: None,
         style_changed,
     }
-}
-
-/// Presentation honesty for library doc writes (#2088).
-fn doc_style_changed(path_str: &str, original: &str, new_content: &str) -> bool {
-    let Ok(fmt) = crate::ops::doc::detect_format(path_str) else {
-        return false;
-    };
-    crate::ops::doc::presentation_style_changed(original, new_content, &fmt)
 }
 
 /// True when [`EditResult::style_changed`] is set (#2088).

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -32,17 +32,20 @@ pub fn run(mut args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     args.file = global.rewrite_user_path_arg(&cwd, &args.file)?;
     let path = cwd.join(&args.file);
 
-    // path_entry_exists includes dangling symlinks (Path::exists does not).
-    if !crate::ops::file::path_entry_exists(&path) {
-        let msg = format!("file not found: {}", args.file);
-        global.emit_error_json_kind(Some("not_found"), &msg)?;
-        return Ok(crate::exit::FAILURE);
-    }
-    // Allow regular files, symlinks (unlink only), FIFO/socket/device;
-    // refuse real directories only (#2087).
-    if let Err(e) = crate::ops::file::ensure_unlinkable_not_directory(&path, &args.file) {
-        global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
-        return Ok(crate::exit::FAILURE);
+    // One classify: dangling ok; real directories refuse; no follow (#2087).
+    use crate::ops::file::{PathEntryKind, classify_path_entry};
+    match classify_path_entry(&path) {
+        PathEntryKind::Missing => {
+            let msg = format!("file not found: {}", args.file);
+            global.emit_error_json_kind(Some("not_found"), &msg)?;
+            return Ok(crate::exit::FAILURE);
+        }
+        PathEntryKind::RealDirectory => {
+            let msg = format!("target is not a file: {}", args.file);
+            global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+            return Ok(crate::exit::FAILURE);
+        }
+        PathEntryKind::RegularFile | PathEntryKind::Special => {}
     }
 
     let op = Operation::FileDelete {

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -855,11 +855,11 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     .changes
                     .iter()
                     .any(|(path, original, new_text)| {
-                        let display = path.to_string_lossy();
-                        let Ok(fmt) = detect_format(display.as_ref()) else {
-                            return false;
-                        };
-                        crate::ops::doc::presentation_style_changed(original, new_text, &fmt)
+                        crate::ops::doc::style_changed_for_path(
+                            &path.to_string_lossy(),
+                            original,
+                            new_text,
+                        )
                     });
             crate::cmd::write_mode::finalize_execution_result(
                 global,

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -3,7 +3,6 @@ use crate::cmd::output::execute_via_engine;
 use crate::cmd::write_dispatch::{WriteMessages, execute_write};
 use crate::exit;
 use crate::plan::Operation;
-use anyhow::Context;
 use clap::Args;
 use serde::Serialize;
 use std::fs;
@@ -54,15 +53,15 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let src = cwd.join(&args.from);
     let dst = cwd.join(&args.to);
 
-    // Pre-validation for CLI-specific checks.
-    // path_entry_exists includes dangling symlinks; is_file() would refuse
-    // special nodes and FIFO open can hang (#2087 / #2091).
-    if !crate::ops::file::path_entry_exists(&src) {
+    // Pre-validation: one classify per path (dangling ok; no FIFO open) (#2087 / #2091).
+    use crate::ops::file::{PathEntryKind, classify_path_entry};
+    let src_kind = classify_path_entry(&src);
+    if src_kind == PathEntryKind::Missing {
         let msg = format!("source file not found: {}", args.from);
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
-    if crate::ops::file::is_real_directory(&src) {
+    if src_kind == PathEntryKind::RealDirectory {
         let msg = format!("source is not a file: {}", args.from);
         global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(crate::exit::FAILURE);
@@ -71,7 +70,8 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         global.emit_error_json_kind(Some("invalid_input"), &e.msg)?;
         return Ok(crate::exit::FAILURE);
     }
-    if crate::ops::file::path_entry_exists(&dst) && crate::ops::file::is_real_directory(&dst) {
+    let dst_kind = classify_path_entry(&dst);
+    if dst_kind == PathEntryKind::RealDirectory {
         let msg = format!("destination is not a file: {}", args.to);
         global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(crate::exit::FAILURE);
@@ -109,7 +109,7 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::SUCCESS);
     }
 
-    if !args.force && !is_case_only_change && crate::ops::file::path_entry_exists(&dst) {
+    if !args.force && !is_case_only_change && dst_kind.exists() {
         let msg = format!(
             "destination already exists: {} (use --force to overwrite)",
             args.to
@@ -121,7 +121,7 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // Special nodes (symlink / FIFO / socket / device): never open for binary
     // probe (FIFO hang) or text load (symlink target rewrite via atomic_write).
     // Path-only rename via fs::rename or engine empty soft-load (#2091).
-    let is_special = !crate::ops::file::is_regular_file_for_backup(&src);
+    let is_special = !src_kind.is_regular_file();
     if is_special {
         if is_case_only_change {
             return run_direct_rename(&args, global, &cwd, &src, &dst, DirectRenameKind::CaseOnly);
@@ -309,7 +309,7 @@ fn run_direct_rename(
                 fs::create_dir_all(parent)?;
             }
             let session = backup.finalize()?;
-            rename_or_copy(src, dst)?;
+            crate::ops::file::rename_or_copy(src, dst)?;
             Ok(session)
         },
         WriteMessages {
@@ -318,53 +318,6 @@ fn run_direct_rename(
             post_confirm: Some(&post_msg),
         },
     )
-}
-
-/// Rename a file, falling back to copy+delete when the source and destination
-/// are on different filesystems (where `fs::rename` would fail).
-fn rename_or_copy(src: &std::path::Path, dst: &std::path::Path) -> anyhow::Result<()> {
-    match fs::rename(src, dst) {
-        Ok(()) => Ok(()),
-        Err(e) if is_cross_device(&e) => {
-            // Only remove dest on rollback if we created it; force overwrite
-            // must not delete the pre-existing dest (backup holds prior bytes).
-            let dest_existed = crate::ops::file::path_entry_exists(dst);
-            fs::copy(src, dst).with_context(|| {
-                format!("cross-device copy {} -> {}", src.display(), dst.display())
-            })?;
-            if let Err(remove_err) = fs::remove_file(src) {
-                if !dest_existed {
-                    let _ = fs::remove_file(dst);
-                }
-                return Err(remove_err).with_context(|| {
-                    format!(
-                        "removing source after cross-device copy: {} -> {}",
-                        src.display(),
-                        dst.display()
-                    )
-                });
-            }
-            Ok(())
-        }
-        Err(e) => Err(e.into()),
-    }
-}
-
-/// Check if an I/O error is a cross-device link error.
-fn is_cross_device(e: &std::io::Error) -> bool {
-    #[cfg(unix)]
-    {
-        e.raw_os_error() == Some(libc::EXDEV)
-    }
-    #[cfg(windows)]
-    {
-        e.raw_os_error() == Some(17)
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        let _ = e;
-        false
-    }
 }
 
 #[cfg(test)]

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -99,6 +99,17 @@ pub fn presentation_style_changed(original: &str, new_text: &str, format: &FileF
     }
 }
 
+/// Path-based presentation honesty for library, plan/tx, and CLI doc writes.
+///
+/// Single entry for surfaces that know a path string but not a pre-parsed
+/// [`FileFormat`]. Unknown/unsupported formats return false (no false alarms).
+pub fn style_changed_for_path(path: &str, original: &str, new_text: &str) -> bool {
+    let Ok(fmt) = detect_format(path) else {
+        return false;
+    };
+    presentation_style_changed(original, new_text, &fmt)
+}
+
 /// Indent levels of every block-sequence entry line (`- …`), for style compare.
 fn yaml_block_sequence_indents(text: &str) -> Vec<usize> {
     text.lines()

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -34,26 +34,72 @@ fn ends_with_line_ending(s: &str) -> bool {
     s.ends_with("\r\n") || s.ends_with('\n') || s.ends_with('\r')
 }
 
+/// Directory-entry classification from one `symlink_metadata` call (#2087 / #2091).
+///
+/// Prefer this when a call site needs existence **and** kind (rename/delete
+/// prechecks) so it does not re-stat the same path three times.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathEntryKind {
+    /// No directory entry (or unreadable metadata).
+    Missing,
+    /// Regular file (`FileType::is_file`, not a symlink).
+    RegularFile,
+    /// Real directory (not a symlink to a directory).
+    RealDirectory,
+    /// Symlink, FIFO, socket, device, or other non-regular entry.
+    Special,
+}
+
+impl PathEntryKind {
+    #[inline]
+    pub fn exists(self) -> bool {
+        !matches!(self, Self::Missing)
+    }
+
+    #[inline]
+    pub fn is_regular_file(self) -> bool {
+        matches!(self, Self::RegularFile)
+    }
+
+    #[inline]
+    pub fn is_real_directory(self) -> bool {
+        matches!(self, Self::RealDirectory)
+    }
+}
+
+/// Classify a path with a single `symlink_metadata` (does not follow links).
+pub fn classify_path_entry(path: &Path) -> PathEntryKind {
+    match std::fs::symlink_metadata(path) {
+        Err(_) => PathEntryKind::Missing,
+        Ok(meta) => {
+            let ft = meta.file_type();
+            // Symlinks report is_dir/is_file false for the link itself on Unix;
+            // real directories are never symlinks.
+            if ft.is_dir() && !ft.is_symlink() {
+                PathEntryKind::RealDirectory
+            } else if ft.is_file() {
+                PathEntryKind::RegularFile
+            } else {
+                PathEntryKind::Special
+            }
+        }
+    }
+}
+
 /// True when the path exists as a directory entry (including dangling symlinks).
 ///
 /// Prefer this over `Path::exists()` for delete/unlink: `exists()` follows
 /// links and reports false for broken symlinks that `remove_file` can still
-/// unlink (#2087).
+/// unlink (#2087). When you also need kind, use [`classify_path_entry`] once.
 pub fn path_entry_exists(path: &Path) -> bool {
-    std::fs::symlink_metadata(path).is_ok()
+    classify_path_entry(path).exists()
 }
 
 /// True when `path` is a real directory (not a symlink to a directory).
 ///
 /// Symlinks are unlinkable even when their target is a directory (#2087).
 pub fn is_real_directory(path: &Path) -> bool {
-    match std::fs::symlink_metadata(path) {
-        Ok(meta) => {
-            let ft = meta.file_type();
-            ft.is_dir() && !ft.is_symlink()
-        }
-        Err(_) => false,
-    }
+    classify_path_entry(path).is_real_directory()
 }
 
 /// Refuse delete/rename targets that are real directories.
@@ -65,7 +111,7 @@ pub fn ensure_unlinkable_not_directory(
     path: &Path,
     display: &str,
 ) -> Result<(), crate::exit::InvalidInputError> {
-    if is_real_directory(path) {
+    if classify_path_entry(path).is_real_directory() {
         return Err(crate::exit::InvalidInputError {
             msg: format!("target is not a file: {display}"),
         });
@@ -78,9 +124,56 @@ pub fn ensure_unlinkable_not_directory(
 /// Symlinks, FIFOs, sockets, and devices return false so callers write an empty
 /// backup marker instead of blocking on FIFO open or copying through a link (#2087).
 pub fn is_regular_file_for_backup(path: &Path) -> bool {
-    match std::fs::symlink_metadata(path) {
-        Ok(meta) => meta.file_type().is_file(),
-        Err(_) => false,
+    classify_path_entry(path).is_regular_file()
+}
+
+/// Rename a path, falling back to copy+delete across devices.
+///
+/// Shared by CLI direct-rename and tx commit (#2091 dedup). Force overwrite
+/// must not delete a pre-existing dest on partial failure (backup holds bytes).
+/// Uses [`path_entry_exists`] so dangling dest entries count as present.
+pub fn rename_or_copy(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    use anyhow::Context;
+
+    match std::fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if is_cross_device_rename_error(&e) => {
+            let dest_existed = path_entry_exists(dst);
+            std::fs::copy(src, dst).with_context(|| {
+                format!("cross-device copy {} -> {}", src.display(), dst.display())
+            })?;
+            if let Err(remove_err) = std::fs::remove_file(src) {
+                if !dest_existed {
+                    let _ = std::fs::remove_file(dst);
+                }
+                return Err(remove_err).with_context(|| {
+                    format!(
+                        "removing source after cross-device copy: {} -> {}",
+                        src.display(),
+                        dst.display()
+                    )
+                });
+            }
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn is_cross_device_rename_error(e: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        e.raw_os_error() == Some(libc::EXDEV)
+    }
+    #[cfg(windows)]
+    {
+        // ERROR_NOT_SAME_DEVICE
+        e.raw_os_error() == Some(17)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = e;
+        false
     }
 }
 
@@ -393,10 +486,19 @@ mod tests {
     fn real_directory_detected_not_file() {
         let dir = TempDir::new().unwrap();
         assert!(is_real_directory(dir.path()));
+        assert_eq!(
+            classify_path_entry(dir.path()),
+            PathEntryKind::RealDirectory
+        );
         let f = dir.path().join("f.txt");
         fs::write(&f, "x").unwrap();
         assert!(!is_real_directory(&f));
         assert!(is_regular_file_for_backup(&f));
+        assert_eq!(classify_path_entry(&f), PathEntryKind::RegularFile);
+        assert_eq!(
+            classify_path_entry(&dir.path().join("missing")),
+            PathEntryKind::Missing
+        );
     }
 
     #[cfg(unix)]
@@ -409,7 +511,19 @@ mod tests {
         std::os::unix::fs::symlink(&target, &link).unwrap();
         assert!(!is_real_directory(&link));
         assert!(!is_regular_file_for_backup(&link));
+        assert_eq!(classify_path_entry(&link), PathEntryKind::Special);
         ensure_unlinkable_not_directory(&link, "l").unwrap();
+    }
+
+    #[test]
+    fn rename_or_copy_moves_regular_file() {
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("a.txt");
+        let dst = dir.path().join("b.txt");
+        fs::write(&src, "payload\n").unwrap();
+        rename_or_copy(&src, &dst).unwrap();
+        assert!(!src.exists());
+        assert_eq!(fs::read_to_string(&dst).unwrap(), "payload\n");
     }
 
     #[test]

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -169,21 +169,19 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 .into());
             }
             // Special nodes (symlinks, FIFO, …) are renameable; only real
-            // directories are refused. path_entry_exists includes dangling
-            // symlinks that Path::exists() misses (#2087 / #2091).
+            // directories are refused. One classify per path (#2087 / #2091).
             // Keep "source"/"destination" wording (not generic "target") for
             // agent/CLI error matching.
-            if crate::ops::file::path_entry_exists(&src_path)
-                && crate::ops::file::is_real_directory(&src_path)
-            {
+            use crate::ops::file::{PathEntryKind, classify_path_entry};
+            let src_kind = classify_path_entry(&src_path);
+            let dst_kind = classify_path_entry(&dst_path);
+            if src_kind == PathEntryKind::RealDirectory {
                 return Err(crate::exit::InvalidInputError {
                     msg: format!("source is not a file: {from}"),
                 }
                 .into());
             }
-            if crate::ops::file::path_entry_exists(&dst_path)
-                && crate::ops::file::is_real_directory(&dst_path)
-            {
+            if dst_kind == PathEntryKind::RealDirectory {
                 return Err(crate::exit::InvalidInputError {
                     msg: format!("destination is not a file: {to}"),
                 }
@@ -223,8 +221,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             if !force && !case_only {
                 let dst_exists = (tx.pending.contains_key(&dst_path)
                     && !tx.deletions.contains(&dst_path))
-                    || (!tx.deletions.contains(&dst_path)
-                        && crate::ops::file::path_entry_exists(&dst_path));
+                    || (!tx.deletions.contains(&dst_path) && dst_kind.exists());
                 if dst_exists {
                     return Err(crate::exit::AlreadyExistsError {
                         msg: format!("destination already exists: {to} (use force to overwrite)"),
@@ -237,10 +234,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // existed_before is populated and commit uses atomic_write (not
             // atomic_create_new which would fail on existing files). Soft-load
             // non-text / special-node dest the same way as source (#2031 / #2091).
-            if (*force || case_only)
-                && !tx.pending.contains_key(&dst_path)
-                && crate::ops::file::path_entry_exists(&dst_path)
-            {
+            if (*force || case_only) && !tx.pending.contains_key(&dst_path) && dst_kind.exists() {
                 let _ = read_file_content_for_path_op(tx.pending, tx.existed_before, &dst_path)?;
             }
 
@@ -259,11 +253,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             // Case-only renames (readme.md → README.md) must also record the
             // pair. On case-insensitive FS, write-dest + delete-src removes the
             // only inode. CLI bypasses the engine (#1167); plan/MCP must not.
-            // path_entry_exists: dangling symlinks / special nodes need the
-            // fs::rename record so commit does not materialize empty files.
-            let src_on_disk = crate::ops::file::path_entry_exists(&src_path);
+            // Dangling / special sources need the fs::rename record so commit
+            // does not materialize empty files.
+            let src_on_disk = src_kind.exists();
             let src_is_rename_dest = tx.renames.iter().any(|(_, to)| to == &src_path);
-            let dst_on_disk = crate::ops::file::path_entry_exists(&dst_path);
+            let dst_on_disk = dst_kind.exists();
             if case_only {
                 if src_on_disk || src_is_rename_dest {
                     tx.renames.push((src_path.clone(), dst_path.clone()));
@@ -279,9 +273,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
 
             // Delete source (same logic as file.delete for tx-created files).
             let created_in_tx = match tx.pending.get(&src_path) {
-                Some((original, _)) => {
-                    original.is_empty() && !crate::ops::file::path_entry_exists(&src_path)
-                }
+                Some((original, _)) => original.is_empty() && !src_kind.exists(),
                 None => false,
             };
             if created_in_tx {

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -95,28 +95,38 @@ pub(crate) fn read_file_content_for_force_create<'a>(
 /// empty: never open/follow them (FIFO hang; symlink rewrite would mutate the
 /// target via [`crate::write::atomic_write`] resolve). Missing paths and other
 /// load failures still hard-fail.
+///
+/// Uses one [`classify_path_entry`](crate::ops::file::classify_path_entry) so
+/// existence, directory refuse, and regular-vs-special do not re-stat thrice.
 pub(crate) fn read_file_content_for_path_op<'a>(
     pending: &'a mut HashMap<PathBuf, (String, String)>,
     existed_before: &mut HashSet<PathBuf>,
     path: &Path,
 ) -> anyhow::Result<&'a str> {
+    use crate::ops::file::{PathEntryKind, classify_path_entry};
+
     match pending.entry(path.to_path_buf()) {
         Entry::Occupied(entry) => Ok(&entry.into_mut().1),
         Entry::Vacant(entry) => {
             let display = path.display().to_string();
-            // path_entry_exists includes dangling symlinks (#2087 / #2091).
-            if !crate::ops::file::path_entry_exists(path) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("file not found: {display}"),
-                )
-                .into());
+            let kind = classify_path_entry(path);
+            match kind {
+                PathEntryKind::Missing => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("file not found: {display}"),
+                    )
+                    .into());
+                }
+                PathEntryKind::RealDirectory => {
+                    return Err(crate::exit::InvalidInputError {
+                        msg: format!("target is not a file: {display}"),
+                    }
+                    .into());
+                }
+                PathEntryKind::RegularFile | PathEntryKind::Special => {}
             }
-            crate::ops::file::ensure_unlinkable_not_directory(path, &display)?;
-            let content = if !crate::ops::file::is_regular_file_for_backup(path) {
-                // Symlink / FIFO / socket / device: empty path-only snapshot.
-                String::new()
-            } else {
+            let content = if kind.is_regular_file() {
                 match crate::files::load_text_strict(path, &display) {
                     Ok(s) => s,
                     Err(e)
@@ -126,6 +136,9 @@ pub(crate) fn read_file_content_for_path_op<'a>(
                     }
                     Err(e) => return Err(e),
                 }
+            } else {
+                // Symlink / FIFO / socket / device: empty path-only snapshot.
+                String::new()
             };
             existed_before.insert(path.to_path_buf());
             Ok(&entry.insert((content.clone(), content)).1)

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -190,7 +190,7 @@ pub(crate) fn commit_changes(
                 std::fs::create_dir_all(parent)
                     .with_context(|| format!("creating directory {}", parent.display()))?;
             }
-            rename_or_copy(from, to)?;
+            crate::ops::file::rename_or_copy(from, to)?;
         }
 
         for (path, _, new_content) in changes {
@@ -351,52 +351,6 @@ fn detect_pure_renames(
         }
     }
     pairs
-}
-
-/// Rename a file, falling back to copy+delete across devices.
-fn rename_or_copy(src: &Path, dst: &Path) -> anyhow::Result<()> {
-    match std::fs::rename(src, dst) {
-        Ok(()) => Ok(()),
-        Err(e) if is_cross_device(&e) => {
-            // Only remove dest on rollback if we created it; force overwrite
-            // must not delete the pre-existing dest (backup holds prior bytes).
-            let dest_existed = dst.exists();
-            std::fs::copy(src, dst).with_context(|| {
-                format!("cross-device copy {} -> {}", src.display(), dst.display())
-            })?;
-            if let Err(remove_err) = std::fs::remove_file(src) {
-                if !dest_existed {
-                    let _ = std::fs::remove_file(dst);
-                }
-                return Err(remove_err).with_context(|| {
-                    format!(
-                        "removing source after cross-device copy: {} -> {}",
-                        src.display(),
-                        dst.display()
-                    )
-                });
-            }
-            Ok(())
-        }
-        Err(e) => Err(e.into()),
-    }
-}
-
-fn is_cross_device(e: &std::io::Error) -> bool {
-    #[cfg(unix)]
-    {
-        e.raw_os_error() == Some(libc::EXDEV)
-    }
-    #[cfg(windows)]
-    {
-        // ERROR_NOT_SAME_DEVICE
-        e.raw_os_error() == Some(17)
-    }
-    #[cfg(not(any(unix, windows)))]
-    {
-        let _ = e;
-        false
-    }
 }
 
 #[cfg(test)]

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -144,13 +144,9 @@ pub struct TxChange {
     pub style_changed: bool,
 }
 
-/// Presentation honesty for a path write (#2070).
+/// Presentation honesty for a path write (#2070 / single helper in ops::doc).
 fn path_style_changed(path: &Path, original: &str, new_text: &str) -> bool {
-    let display = path.to_string_lossy();
-    let Ok(fmt) = crate::ops::doc::detect_format(display.as_ref()) else {
-        return false;
-    };
-    crate::ops::doc::presentation_style_changed(original, new_text, &fmt)
+    crate::ops::doc::style_changed_for_path(&path.to_string_lossy(), original, new_text)
 }
 
 /// A search match in the tx output.


### PR DESCRIPTION
## Summary

Design hygiene so recent special-node and honesty work does not read like a hodgepodge of one-off patches.

### Code
- **One `rename_or_copy`** in `ops::file` (was duplicated CLI vs tx commit; dest existence was inconsistent).
- **`PathEntryKind` / `classify_path_entry`**: one `symlink_metadata` for existence + kind; CLI rename/delete and path soft-load reuse it.
- **One `style_changed_for_path`** in `ops::doc` for library, plan/tx, and CLI (was three near-identical wrappers).

### Docs
- [`docs/plans/write-pipeline.md`](docs/plans/write-pipeline.md) **Layer map**: ops → tx → api/cmd/mcp, with rules for where content math, path kind, honesty, and write mode live.

### Intentionally not changed
- Large single-domain modules with size-waivers (fallback, yaml_splice, shell_token): policy #1408, split only on a real second subsystem.
- CLI direct rename (binary/case-only/plain special): not a second product; non-UTF-8 path of the same contract.
- Multi-surface tests (library vs tx write-policy): different stacks, keep.
- `no-default-features` thin api stubs: intentional library builds without the engine.

## Test plan
- [x] lib: ops::file, file_rename_, cmd::rename/delete, style_changed
- [x] integration force-directory + symlink write-policy
- [x] clippy -D warnings