### PR TITLE
fix: create already_exists dual-path parity and write mode matrices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1897,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3797d226787327b35b0b6f9e878fe55f3af2bb4daf916c0411079885454042f0"
+checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f5bc0c6851a20cd627ef4b90defb79f39a261c467de52af5d38000d7979c52"
+checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/docs/blog/community-launch-draft.md
+++ b/docs/blog/community-launch-draft.md
@@ -32,6 +32,10 @@ grep LIVE_NAME f.rs
 
 echo "=== agent-rules snippet ==="
 "$BIN" agent-rules --mode mcp | head -40
+
+echo "=== MCP explore (list_files in core pack since 0.24) ==="
+# stdio MCP: use your host; CLI has no list_files subcommand
+# Prefer MCP list_files / search_files over a second filesystem MCP
 ```
 
 ## Post draft (Show HN / r/mcp)
@@ -52,6 +56,7 @@ Why not generic filesystem MCP / sed / yq alone?
 - Markdown section ops and tree-sitter AST renames
 - batch/tx with undo; stable error_kind for hosts (binary, already_exists, …)
 - Library hosts: ReplaceOptions::for_agent and fuzzy_span_suspicious
+- MCP core pack includes list_files (ignore-aware inventory)
 
 Install: https://patchloom.github.io/patchloom/
 MCP Registry: io.github.patchloom/patchloom

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -71,7 +71,9 @@ fn file_write(
             }
             crate::ops::file::ensure_parent_components_are_directories(path)?;
             let force = force.unwrap_or(false);
-            if !force && path.exists() && mode != ApplyMode::Preview {
+            // Match engine path: refuse existing without force in all modes
+            // (Preview/Check/Apply). Preview must not soft-succeed (#MPI dual-path).
+            if !force && path.exists() {
                 return Err(anyhow::Error::new(crate::exit::AlreadyExistsError {
                     msg: format!(
                         "file already exists: {} (use force to overwrite)",

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2825,6 +2825,85 @@ fn file_append_write_modes_matrix() {
     }
 }
 
+/// Same Preview/Check/Apply contract as append (prepend only mutates on Apply).
+#[test]
+fn file_prepend_write_modes_matrix() {
+    for (mode, expect_applied) in [
+        (ApplyMode::Preview, false),
+        (ApplyMode::Check, false),
+        (ApplyMode::Apply, true),
+    ] {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("pre_modes.txt");
+        fs::write(&file, "base").unwrap();
+        let res = file_prepend(&file, "HEAD\n", mode, None).unwrap();
+        assert!(res.changed, "{mode:?}");
+        assert_eq!(res.applied, expect_applied, "{mode:?}");
+        let on_disk = fs::read_to_string(&file).unwrap();
+        if expect_applied {
+            assert!(
+                on_disk.starts_with("HEAD\n"),
+                "{mode:?} expected prepend, got {on_disk}"
+            );
+            assert!(on_disk.contains("base"), "{mode:?} base content retained");
+        } else {
+            assert_eq!(on_disk, "base", "{mode:?} must not write");
+            assert!(
+                res.new_content.starts_with("HEAD\n"),
+                "{mode:?} new_content should preview prepend"
+            );
+        }
+    }
+}
+
+/// New path: Preview/Check report change without creating; Apply creates.
+#[test]
+fn file_create_write_modes_matrix() {
+    for (mode, expect_applied) in [
+        (ApplyMode::Preview, false),
+        (ApplyMode::Check, false),
+        (ApplyMode::Apply, true),
+    ] {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("new_modes.txt");
+        assert!(!file.exists(), "fixture must start missing");
+        let res = file_create(&file, "body\n", false, mode, None).unwrap();
+        assert!(res.changed, "{mode:?}");
+        assert_eq!(res.applied, expect_applied, "{mode:?}");
+        if expect_applied {
+            assert!(file.exists(), "{mode:?} should create");
+            assert_eq!(fs::read_to_string(&file).unwrap(), "body\n");
+        } else {
+            assert!(!file.exists(), "{mode:?} must not create on disk");
+            assert!(
+                res.new_content.contains("body"),
+                "{mode:?} new_content should preview create"
+            );
+        }
+    }
+}
+
+/// Existing path without force: all modes refuse with already_exists (engine + no-files parity).
+#[test]
+fn file_create_existing_without_force_fails_all_modes() {
+    for mode in [ApplyMode::Preview, ApplyMode::Check, ApplyMode::Apply] {
+        let dir = TempDir::new().unwrap();
+        let file = dir.path().join("exists.txt");
+        fs::write(&file, "prior\n").unwrap();
+        let err = file_create(&file, "new\n", false, mode, None).unwrap_err();
+        assert!(
+            crate::api::is_already_exists(&err),
+            "{mode:?} expected already_exists, got kind={:?} err={err}",
+            crate::fallback::edit_error_kind(&err)
+        );
+        assert_eq!(
+            fs::read_to_string(&file).unwrap(),
+            "prior\n",
+            "{mode:?} must not overwrite without force"
+        );
+    }
+}
+
 #[test]
 fn file_append_respects_guard_and_relaxed() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

MPI rotation batch (2026-07-31 s1417).

### Dual-path fix (High)
- **no-files `file_create`:** refuse existing path without `force` for **Preview, Check, and Apply** (was Preview-only soft success). Matches engine/CLI `already_exists` behavior.

### Tests
- `file_create_existing_without_force_fails_all_modes` (engine + `--no-default-features`)
- `file_create_write_modes_matrix` (new path Preview/Check/Apply)
- `file_prepend_write_modes_matrix` (parity with append matrix)

### Deps
- `clap` 4.6.4 → 4.6.5
- `rmcp` 3.0.1 → 3.1.0

### Docs
- Community launch draft: MCP `list_files` core-pack note for 0.24+

### Gate notes
- Release **#2085** (0.25.0) left open (user-gated)
- B-path only: #1990 human post, #960 winget index lag, #961 Chocolatey moderation lag

## Test plan
- [x] `make check-fast`
- [x] `cargo test --lib --all-features write_modes_matrix`
- [x] `cargo test --lib --no-default-features file_create_existing_without_force`
- [ ] full CI on PR