### PR TITLE
fix: real-world create/tx/mcp/patch honesty gaps

### DIFF
--- a/src/api/post_write.rs
+++ b/src/api/post_write.rs
@@ -100,7 +100,16 @@ pub fn run_post_write_validation_with_session(
                     }
                 }
             }
-            return Err(e);
+            // KeepWithError: write already landed. Attach session + path so
+            // library hosts can branch on applied and undo (CLI/tx parity).
+            let msg = e
+                .downcast_ref::<FormatFailedError>()
+                .map(|f| f.msg.clone())
+                .unwrap_or_else(|| e.to_string());
+            return Err(FormatFailedError::new(msg)
+                .with_backup_session(backup_session.map(str::to_owned))
+                .with_written_files(vec![path.display().to_string()])
+                .into());
         }
     }
     Ok(())

--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -60,8 +60,13 @@ pub fn replace_text(
         let original = crate::files::load_text_strict(path, &display)?;
         let content_result = replace_in_content(&original, from, to, opts)?;
         let policy = crate::write::WritePolicy::default();
-        let (applied, backup_session) =
-            super::write_if_apply(path, &content_result.new_content, mode, &policy, guard)?;
+        // Soft no-op (if_exists miss, identity): do not write or create a
+        // backup. Parity with the engine path that gates on has_changes.
+        let (applied, backup_session) = if content_result.changed {
+            super::write_if_apply(path, &content_result.new_content, mode, &policy, guard)?
+        } else {
+            (false, None)
+        };
         let path_str = path.to_string_lossy();
         let mut result = super::build_edit_result(
             &path_str,

--- a/src/cmd/create.rs
+++ b/src/cmd/create.rs
@@ -61,7 +61,12 @@ pub fn run(mut args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     args.file = global.rewrite_user_path_arg(&cwd, &args.file)?;
     let path = cwd.join(&args.file);
-    if path.exists() && !path.is_file() {
+    // path_entry_exists / classify: dangling symlinks are present directory
+    // entries (Path::exists follows and returns false). Match delete/rename
+    // honesty so preview and apply agree on already_exists (#fixloop).
+    use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
+    let entry = classify_path_entry(&path);
+    if entry == PathEntryKind::RealDirectory {
         let msg = format!("target is not a file: {}", args.file);
         global.emit_error_json_kind(Some("invalid_input"), &msg)?;
         return Ok(crate::exit::FAILURE);
@@ -74,7 +79,7 @@ pub fn run(mut args: CreateArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     }
     // Catch exists before the engine so --json gets error_kind (apply and
     // preview). --force continues into FileCreate overwrite.
-    if !args.force && path.exists() {
+    if !args.force && path_entry_exists(&path) {
         let msg = format!(
             "file already exists: {} (use --force to overwrite)",
             args.file
@@ -538,5 +543,48 @@ mod tests {
         assert_eq!(code, exit::SUCCESS);
         // applied_flag() must surface Apply as applied:true (parity with delete).
         assert!(file.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_dangling_symlink_preview_already_exists() {
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("dangle.txt");
+        std::os::unix::fs::symlink("missing-target", &link).unwrap();
+
+        let args = CreateArgs {
+            file: link.to_string_lossy().into_owned(),
+            content: Some("hi\n".into()),
+            stdin: false,
+            force: false,
+            write: Default::default(),
+        };
+        let global = GlobalFlags::test_with_cwd(dir.path());
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE, "dangling entry must be already_exists");
+        assert!(link.symlink_metadata().unwrap().file_type().is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn create_force_replaces_dangling_symlink() {
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("dangle.txt");
+        std::os::unix::fs::symlink("missing-target", &link).unwrap();
+
+        let args = CreateArgs {
+            file: link.to_string_lossy().into_owned(),
+            content: Some("hi\n".into()),
+            stdin: false,
+            force: true,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::SUCCESS);
+        assert!(link.is_file());
+        assert!(!link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read_to_string(&link).unwrap(), "hi\n");
     }
 }

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -453,12 +453,17 @@ impl PatchloomService {
             // which is case-sensitive and exact-only. Fuzzy typo recovery and
             // context anchors would get false "pattern not found" warnings while
             // the engine still applies successfully (#1751).
+            // Also skip insert_before/insert_after: validate_edit_nth treats a
+            // missing `new` as delete (`to=""`), which false-flags structured
+            // files (package.json anchors) while the real insert succeeds.
             let validation_warnings = if !p.regex
                 && !p.case_insensitive
                 && !p.word_boundary
                 && !p.fuzzy
                 && p.before_context.is_none()
                 && p.after_context.is_none()
+                && p.insert_before.is_none()
+                && p.insert_after.is_none()
             {
                 let abs = svc.cwd().join(&p.path);
                 // Soft-or-preflight (#1894): skip non-text; engine still Strict.

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -393,8 +393,21 @@ fn exit_code_to_result(code: u8, output: &str, fallback: &str) -> Result<CallToo
 /// Execute a read-only doc operation directly (no subprocess).
 fn doc_readonly(action: &crate::cmd::doc::DocAction) -> Result<CallToolResult, McpError> {
     let (output, code) =
-        crate::cmd::doc::execute_with_mode(action, crate::cmd::doc::OutputMode::Json)
-            .map_err(|e| McpError::internal_error(format!("{e}"), None))?;
+        match crate::cmd::doc::execute_with_mode(action, crate::cmd::doc::OutputMode::Json) {
+            Ok(v) => v,
+            // Typed agent errors (type_error on multi-doc bare key, not_found,
+            // …) must be tool errors with error_kind, not protocol
+            // internal_error (CLI --json parity).
+            Err(e) => {
+                if crate::exit::classify_typed_error(&e).is_some() {
+                    let (payload, _code) = crate::exit::structured_error_payload(&e);
+                    let text =
+                        serde_json::to_string_pretty(&payload).unwrap_or_else(|_| e.to_string());
+                    return Ok(CallToolResult::error(vec![ContentBlock::text(text)]));
+                }
+                return Err(McpError::internal_error(format!("{e}"), None));
+            }
+        };
     // CHANGES_DETECTED (2) is a valid success for doc diff (differences found).
     // After #1843, doc has always exits 0 for true/false, so do not promote
     // NO_MATCHES (real get/keys/len misses) to success.

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -618,6 +618,19 @@ pub(crate) fn run_parsed_plan(
     };
 
     if global.apply {
+        // Soft replace miss with no writes: report before commit + lifecycle.
+        // Avoids format/validate rewriting collateral files when nothing was
+        // staged (CLI was ordering lifecycle before the soft-miss return).
+        // Lifecycle-only plans (empty ops + validate) still reach commit.
+        if result.replace_no_matches {
+            if structured {
+                let output = build_full_tx_output("no_matches", &mut result, &cwd);
+                let ok = emit_output_json(&output, compact);
+                return Ok(exit_after_emit(ok, exit::NO_MATCHES));
+            }
+            print_human_replace_honesty(&result, &cwd, global.quiet);
+            return Ok(exit::NO_MATCHES);
+        }
         return commit_and_finalize(&ctx, &mut result, global, global.diff);
     }
 

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -752,6 +752,10 @@ fn serialize_multi_document_yaml(
 ///
 /// Recognition order: JSON-quoted string, JSON object/array, boolean, null,
 /// i64, f64, then fallback to bare string.
+///
+/// Bare floats (`2.0`, `1.5`) become JSON numbers by design (batch/CLI
+/// contract). For a string version field, quote the value:
+/// `doc set package.json version '"2.0"'` or plan/MCP typed string.
 pub fn parse_value(s: &str) -> serde_json::Value {
     // JSON-quoted string
     if s.starts_with('"')

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -164,12 +164,48 @@ fn parse_file_path(line: &str) -> String {
         .or_else(|| line.strip_prefix("--- "))
         .unwrap_or(line);
 
-    let path = raw
+    // Strip tab-separated timestamp from `diff -u` output first so C-quoted
+    // paths with spaces are not split mid-name.
+    let mut path = raw.split('\t').next().unwrap_or(raw);
+
+    // Git C-quotes special paths: `+++ "b/my file.rs"`. Unquote before a/b
+    // strip so agents replaying `git diff` resolve the real path.
+    let owned_unquoted;
+    if path.len() >= 2 && path.starts_with('"') && path.ends_with('"') {
+        owned_unquoted = unquote_git_c_string(&path[1..path.len() - 1]);
+        path = owned_unquoted.as_str();
+    }
+
+    let path = path
         .strip_prefix("b/")
-        .or_else(|| raw.strip_prefix("a/"))
-        .unwrap_or(raw);
-    // Strip tab-separated timestamp from `diff -u` output (e.g. "file.txt\t2024-01-01 ...")
-    path.split('\t').next().unwrap_or(path).to_string()
+        .or_else(|| path.strip_prefix("a/"))
+        .unwrap_or(path);
+    path.to_string()
+}
+
+/// Minimal Git C-string unescape for paths inside double quotes.
+fn unquote_git_c_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('n') => out.push('\n'),
+                Some('t') => out.push('\t'),
+                Some('r') => out.push('\r'),
+                Some('"') => out.push('"'),
+                Some('\\') => out.push('\\'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 fn parse_hunk_header(line: &str) -> Result<Hunk, String> {

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1205,4 +1205,23 @@ mod regression {
             files[0].hunks[0].lines
         );
     }
+
+    #[test]
+    fn parse_git_c_quoted_path_with_space() {
+        // `git diff` quotes paths with spaces as C strings.
+        let diff = "\
+--- \"a/my file.txt\"
++++ \"b/my file.txt\"
+@@ -1 +1 @@
+-old
++new
+";
+        let files = parse_patch(diff).expect("c-quoted path should parse");
+        assert_eq!(files.len(), 1);
+        assert_eq!(
+            files[0].path, "my file.txt",
+            "must strip quotes and a/b prefix, got {:?}",
+            files[0].path
+        );
+    }
 }

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -76,7 +76,12 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             force,
         } => {
             let file_path = tx.cwd.join(path);
-            if file_path.exists() && !file_path.is_file() {
+            // Dangling symlinks are present entries (Path::exists is false).
+            // Use classify/path_entry_exists so create matches delete/rename
+            // and preview/apply already_exists stay dual-path honest.
+            use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
+            let entry = classify_path_entry(&file_path);
+            if entry == PathEntryKind::RealDirectory {
                 return Err(crate::exit::InvalidInputError {
                     msg: format!("target is not a file: {path}"),
                 }
@@ -90,7 +95,8 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 // invalid UTF-8, or unreadable prior → empty original so hosts
                 // need no remove+recreate loop (#1962). PathGuard still applies
                 // at plan entry; hardlink-preserving write stays on commit path.
-                if tx.pending.contains_key(&file_path) || file_path.exists() {
+                // path_entry_exists covers dangling symlink entries.
+                if tx.pending.contains_key(&file_path) || path_entry_exists(&file_path) {
                     let _ = read_file_content_for_force_create(
                         tx.pending,
                         tx.existed_before,
@@ -101,7 +107,9 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
             } else {
                 let exists_in_tx =
                     tx.pending.contains_key(&file_path) && !tx.deletions.contains(&file_path);
-                if exists_in_tx || (!tx.deletions.contains(&file_path) && file_path.exists()) {
+                if exists_in_tx
+                    || (!tx.deletions.contains(&file_path) && path_entry_exists(&file_path))
+                {
                     return Err(crate::exit::AlreadyExistsError {
                         msg: format!("file already exists: {path} (use force to overwrite)"),
                     }

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -68,16 +68,32 @@ pub(crate) fn read_file_content_for_force_create<'a>(
     existed_before: &mut HashSet<PathBuf>,
     path: &Path,
 ) -> anyhow::Result<&'a str> {
+    use crate::ops::file::{PathEntryKind, classify_path_entry};
+
     match pending.entry(path.to_path_buf()) {
         Entry::Occupied(entry) => Ok(&entry.into_mut().1),
         Entry::Vacant(entry) => {
             let display = path.display().to_string();
-            let content = match crate::files::load_text_strict(path, &display) {
-                Ok(s) => s,
-                Err(e) if crate::exit::is_load_text_strict_fail(&e) => String::new(),
-                Err(e) => return Err(e),
+            let kind = classify_path_entry(path);
+            // Special (including dangling symlink): empty snapshot; do not
+            // follow/open. Regular text soft-loads; binary/encoding → empty.
+            let content = match kind {
+                PathEntryKind::Special => String::new(),
+                PathEntryKind::RegularFile => {
+                    match crate::files::load_text_strict(path, &display) {
+                        Ok(s) => s,
+                        Err(e) if crate::exit::is_load_text_strict_fail(&e) => String::new(),
+                        Err(e) => return Err(e),
+                    }
+                }
+                PathEntryKind::Missing | PathEntryKind::RealDirectory => {
+                    // Caller only invokes when path_entry_exists; treat as empty.
+                    String::new()
+                }
             };
-            if path.exists() {
+            // Mark present entries so commit uses atomic_write (replaces
+            // dangling links) instead of atomic_create_new.
+            if kind != PathEntryKind::Missing {
                 existed_before.insert(path.to_path_buf());
             }
             Ok(&entry.insert((content.clone(), content)).1)

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -721,8 +721,21 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             continue;
                         }
                         let to_text = if let Some(ib) = insert_before {
+                            // Parity with path arm: normalize line insert EOL.
+                            let ib = normalize_line_insert(
+                                &content,
+                                &anchor.matched_text,
+                                ib,
+                                InsertSide::Before,
+                            );
                             format!("{}{}", ib, anchor.matched_text)
                         } else if let Some(ia) = insert_after {
+                            let ia = normalize_line_insert(
+                                &content,
+                                &anchor.matched_text,
+                                ia,
+                                InsertSide::After,
+                            );
                             format!("{}{}", anchor.matched_text, ia)
                         } else {
                             new_text.as_deref().unwrap_or("").to_string()
@@ -754,11 +767,14 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         // Parity with single-path arm: keep diagnostics for
                         // require_change / replace_no_matches surfaces.
                         tx.replace_hint = Some(edit_error.message.clone());
+                        // Soft refuse this candidate after fuzzy/context miss.
+                        record_soft_no_match(tx, &file_path);
                     }
                 }
             } else if !regex_mode {
-                // Exact miss, no fuzzy/context: did-you-mean for this file
-                // (last non-empty similar list wins; used if no file matched).
+                // Exact miss, no fuzzy/context: soft refuse + did-you-mean so
+                // multi-file glob partial apply is visible in refused[].
+                record_soft_no_match(tx, &file_path);
                 let similar = crate::fallback::find_similar_targets(&content, old, 3);
                 if !similar.is_empty() {
                     let rel = crate::files::relative_display(&file_path, tx.cwd).to_string_lossy();

--- a/src/write.rs
+++ b/src/write.rs
@@ -1,4 +1,7 @@
 //! Atomic write, final newline, EOL normalization, trailing-whitespace trimming.
+//!
+//! size-waiver: atomic write + hardlink + symlink write-through domain (#1230 / #1733);
+//! dangling-link replace co-located with live-link resolve. Policy #1408.
 
 use std::path::Path;
 
@@ -681,15 +684,29 @@ pub(crate) fn atomic_create_new(
 pub(crate) fn atomic_write(path: &Path, content: &str, policy: &WritePolicy) -> anyhow::Result<()> {
     let final_content = apply_policy(content, policy);
 
-    // Resolve symlinks: write to the target file, not the symlink entry (#1230).
-    // Without this, persist() (rename) replaces the symlink directory entry
-    // with a regular file, destroying the symlink and leaving the target unchanged.
+    // Resolve live symlinks: write to the target file, not the symlink entry
+    // (#1230). Without this, persist() (rename) replaces the symlink directory
+    // entry with a regular file, destroying the symlink and leaving the target
+    // unchanged.
+    //
+    // Dangling symlinks cannot be resolved. Force-create / overwrite must still
+    // materialize a regular file at `path` (agent recreate after bad rename).
+    // Unlink the broken link entry, then write to `path` itself.
     let resolved;
     let write_path = if path.is_symlink() {
-        // dunce: strip Windows \\?\ so display and multi-link checks stay clean.
-        resolved = crate::containment::safe_canonicalize(path)
-            .with_context(|| format!("failed to resolve symlink {}", path.display()))?;
-        resolved.as_path()
+        match crate::containment::safe_canonicalize(path) {
+            Ok(p) => {
+                // dunce: strip Windows \\?\ so display and multi-link checks stay clean.
+                resolved = p;
+                resolved.as_path()
+            }
+            Err(_) => {
+                std::fs::remove_file(path).with_context(|| {
+                    format!("failed to replace dangling symlink {}", path.display())
+                })?;
+                path
+            }
+        }
     } else {
         path
     };

--- a/src/write_tests.rs
+++ b/src/write_tests.rs
@@ -846,19 +846,19 @@ mod symlink_handling {
     }
 
     #[test]
-    fn atomic_write_through_dangling_symlink_fails() {
-        // A dangling symlink (target does not exist) should produce
-        // a clear error, not silently create a file at the symlink path.
+    fn atomic_write_replaces_dangling_symlink_with_regular_file() {
+        // Dangling symlink cannot write-through. Force-create / overwrite must
+        // replace the broken link entry with a regular file (agent recreate
+        // after bad rename). Live symlinks still write through (#1230).
         let dir = tempfile::tempdir().unwrap();
         let link = dir.path().join("dangling.txt");
         std::os::unix::fs::symlink(dir.path().join("nonexistent.txt"), &link).unwrap();
 
         let policy = WritePolicy::default();
-        let err = atomic_write(&link, "content\n", &policy).unwrap_err();
-        assert!(
-            err.to_string().contains("resolve symlink") || err.to_string().contains("No such file"),
-            "expected symlink resolution error, got: {err}"
-        );
+        atomic_write(&link, "content\n", &policy).unwrap();
+        assert!(link.is_file());
+        assert!(!link.symlink_metadata().unwrap().file_type().is_symlink());
+        assert_eq!(fs::read_to_string(&link).unwrap(), "content\n");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixloop round (real-world filter only) for agent/CLI/library hosts on patchloom 0.24.0.

### Accepted and fixed

- **Create dangling symlink dual-path:** `Path::exists` treated broken links as free; preview looked free while apply/`--force` failed. Now uses `path_entry_exists` / classify; force replaces dangling with a regular file.
- **Library fuzzy no-op Apply:** fuzzy/context/command_position path always called `write_if_apply`; soft misses set `applied: true` and made backups. Gate on `content_result.changed`.
- **Library post-write format honesty:** format failure after Apply omitted `backup_session` / written paths. Attach them for undo.
- **MCP insert preflight:** `validate_edit_nth` with empty `new` simulated delete and warned on structured files while insert succeeded. Skip preflight for insert_before/after.
- **MCP doc_readonly typed errors:** multi-doc bare key `type_error` was protocol `internal_error`. Map typed errors to tool error envelopes.
- **CLI tx soft miss ordering:** pure soft replace miss still ran commit + lifecycle (format collateral). Return `no_matches` before commit when `replace_no_matches`.
- **Glob replace honesty:** soft exact miss records `refused[]`; fuzzy insert uses `normalize_line_insert` like the path arm.
- **Git C-quoted patch paths:** paths with spaces from `git diff` now unquote and strip `a/`/`b/`.

### Rejected (noise / intentional)

- Bare CLI float `2.0` → number: **intentional** (integration lock `test_batch_doc_set_version_bare_2_0_becomes_number`); quote for strings.
- MD first-match on duplicate headings, git rename patches, ast dir walk: larger product design; not fixed this round without issues if needed later.
- Session-id traversal, hardlink recovery swallow: low realistic agent hit rate.

## Test plan

- [x] `make check-fast` (fmt, clippy, lib, integration, pty, README, server.json)
- [x] Unit: create dangling preview/force, git C-quoted path, dangling atomic_write replace
- [ ] CI green on PR