### PR TITLE
fix: md ambiguous headings, git rename patches, ast dir walk

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-4000%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-4100%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -508,7 +508,7 @@ flowchart LR
 
 ## Status
 
-4000+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+4100+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/examples/03-markdown-editing.json
+++ b/examples/03-markdown-editing.json
@@ -3,9 +3,9 @@
   "write_policy": { "ensure_final_newline": true },
   "operations": [
     { "op": "md.replace_section", "path": "CHANGELOG.md", "heading": "## Unreleased", "content": "- Added new feature\n- Fixed bug in parser" },
+    { "op": "md.dedupe_headings", "path": "AGENTS.md" },
     { "op": "md.upsert_bullet", "path": "AGENTS.md", "heading": "## Safety rules", "bullet": "- Always run `make check` before committing" },
     { "op": "md.table_append", "path": "README.md", "heading": "## Commands", "row": "| `new-cmd` | Description of the new command |" },
-    { "op": "md.dedupe_headings", "path": "AGENTS.md" },
     { "op": "md.move_section", "path": "AGENTS.md", "heading": "## FAQ", "before": "## License" }
   ]
 }

--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -84,26 +84,27 @@ fn md_write(
     let new_content = match _op {
         Operation::MdReplaceSection {
             heading, content, ..
-        } => ops::md::replace_section_in(&original, &heading, &content),
+        } => ops::md::replace_section_in(&original, &heading, &content)
+            .map_err(|e| e.into_anyhow(&heading))?,
         Operation::MdInsertAfterHeading {
             heading, content, ..
-        } => ops::md::insert_after_heading_in(&original, &heading, &content),
+        } => ops::md::insert_after_heading_in(&original, &heading, &content)
+            .map_err(|e| e.into_anyhow(&heading))?,
         Operation::MdInsertAfterSection {
             heading, content, ..
-        } => ops::md::insert_after_section_in(&original, &heading, &content),
+        } => ops::md::insert_after_section_in(&original, &heading, &content)
+            .map_err(|e| e.into_anyhow(&heading))?,
         Operation::MdInsertBeforeHeading {
             heading, content, ..
-        } => ops::md::insert_before_heading_in(&original, &heading, &content),
+        } => ops::md::insert_before_heading_in(&original, &heading, &content)
+            .map_err(|e| e.into_anyhow(&heading))?,
         Operation::MdUpsertBullet {
             heading, bullet, ..
-        } => ops::md::upsert_bullet_in(&original, &heading, &bullet),
+        } => ops::md::upsert_bullet_in(&original, &heading, &bullet)
+            .map_err(|e| e.into_anyhow(&heading))?,
         Operation::MdTableAppend { heading, row, .. } => {
             let (body_start, body_end) =
-                ops::md::find_section(&original, &heading).ok_or_else(|| {
-                    anyhow::Error::new(crate::exit::NoMatchError {
-                        msg: format!("heading not found in {path_str}"),
-                    })
-                })?;
+                ops::md::find_section(&original, &heading).map_err(|e| e.into_anyhow(&heading))?;
             return match ops::md::table_append_in(&original, body_start, body_end, &row) {
                 Ok(new_content) => {
                     let policy = WritePolicy::default();
@@ -125,13 +126,12 @@ fn md_write(
                 })),
             };
         }
-        _ => None,
-    }
-    .ok_or_else(|| {
-        anyhow::Error::new(crate::exit::NoMatchError {
-            msg: format!("heading not found in {path_str}"),
-        })
-    })?;
+        _ => {
+            return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                msg: format!("unsupported md operation in no-cli path for {path_str}"),
+            }));
+        }
+    };
 
     let policy = WritePolicy::default();
     let (applied, backup_session) =
@@ -256,10 +256,11 @@ pub fn md_move_section(
 
     let (new_source, new_dest) =
         ops::md::move_section_in(&original, heading, &dest_content, position, to.is_none())
-            .ok_or_else(|| {
-                anyhow::Error::new(crate::exit::NoMatchError {
+            .map_err(|e| match e {
+                ops::md::SectionError::NotFound => anyhow::Error::new(crate::exit::NoMatchError {
                     msg: format!("heading '{heading}' not found"),
-                })
+                }),
+                other => other.into_anyhow(heading),
             })?;
 
     let policy = crate::write::WritePolicy::default();

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -83,11 +83,17 @@ fn patch_write(
             }));
         }
 
-        // Apply to the first file in the patch.
+        // Apply to the first file in the patch (git rename: load old path).
         let pf = &patch_files[0];
-        let file_path = cwd.join(&pf.path);
+        let load_rel = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
+        let load_path = cwd.join(load_rel);
+        let write_path = cwd.join(&pf.path);
         // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
-        let original = crate::files::load_text_strict(&file_path, &pf.path)?;
+        let original = if pf.is_creation {
+            String::new()
+        } else {
+            crate::files::load_text_strict(&load_path, load_rel)?
+        };
 
         let new_content = ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
             if e.contains("stale context") {
@@ -103,7 +109,15 @@ fn patch_write(
 
         let policy = crate::write::WritePolicy::default();
         let (applied, backup_session) =
-            super::write_if_apply(&file_path, &new_content, mode, &policy, guard)?;
+            super::write_if_apply(&write_path, &new_content, mode, &policy, guard)?;
+        if applied {
+            if let Some(ref from) = pf.rename_from {
+                let old = cwd.join(from);
+                if crate::ops::file::path_entry_exists(&old) {
+                    let _ = std::fs::remove_file(&old);
+                }
+            }
+        }
         {
             let mut __e =
                 super::build_edit_result(&pf.path, original, new_content, applied, "patch", None);
@@ -137,11 +151,24 @@ pub fn apply_patch_file(
     })?;
 
     // Phase 1: preflight load + hunk apply for every file (no disk writes).
-    let mut staged: Vec<(std::path::PathBuf, String, String, String)> = Vec::new();
+    // Git rename: load from rename_from, write to path, delete old after apply (#2101).
+    let mut staged: Vec<(
+        std::path::PathBuf,
+        String,
+        String,
+        String,
+        Option<std::path::PathBuf>,
+    )> = Vec::new();
     for pf in &patch_files {
-        let file_path = cwd.join(&pf.path);
-        // Strict sole-path (#1894).
-        let original = crate::files::load_text_strict(&file_path, &pf.path)?;
+        let load_rel = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
+        let load_path = cwd.join(load_rel);
+        let write_path = cwd.join(&pf.path);
+        // Strict sole-path (#1894). Creation: empty original.
+        let original = if pf.is_creation {
+            String::new()
+        } else {
+            crate::files::load_text_strict(&load_path, load_rel)?
+        };
 
         let new_content = crate::ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
             if e.contains("stale context") {
@@ -154,20 +181,64 @@ pub fn apply_patch_file(
                 })
             }
         })?;
-        staged.push((file_path, pf.path.clone(), original, new_content));
+        let delete_after = pf.rename_from.as_ref().map(|f| cwd.join(f));
+        staged.push((
+            write_path,
+            pf.path.clone(),
+            original,
+            new_content,
+            delete_after,
+        ));
     }
 
-    // Phase 2: one backup session + all-or-nothing write on Apply.
+    // Phase 2: one backup session covering write targets + rename sources,
+    // then all-or-nothing write; on success remove rename sources.
     let policy = crate::write::WritePolicy::default();
-    let write_pairs: Vec<(&std::path::Path, &str)> = staged
-        .iter()
-        .map(|(p, _, _, n)| (p.as_path(), n.as_str()))
-        .collect();
-    let (applied, backup_session) =
-        super::write_if_apply_many(&write_pairs, mode, &policy, guard, cwd)?;
+    let (applied, backup_session) = if mode == ApplyMode::Apply {
+        for (write_path, _, _, _, delete_after) in &staged {
+            super::ensure_contained(guard, write_path)?;
+            if let Some(old) = delete_after {
+                super::ensure_contained(guard, old)?;
+            }
+        }
+        let mut backup = crate::backup::BackupSession::new(cwd)?;
+        for (write_path, _, _, _, delete_after) in &staged {
+            if crate::ops::file::path_entry_exists(write_path) {
+                backup.save_before_write(write_path)?;
+            }
+            if let Some(old) = delete_after
+                && old != write_path
+                && crate::ops::file::path_entry_exists(old)
+            {
+                backup.save_before_write(old)?;
+            }
+        }
+        let session = backup.finalize()?;
+        let write_result = (|| -> anyhow::Result<()> {
+            for (write_path, _, _, new_content, _) in &staged {
+                crate::write::atomic_write(write_path, new_content, &policy)?;
+            }
+            for (_, _, _, _, delete_after) in &staged {
+                if let Some(old) = delete_after
+                    && crate::ops::file::path_entry_exists(old)
+                {
+                    std::fs::remove_file(old).map_err(|e| {
+                        anyhow::anyhow!("patch rename: failed to remove {}: {e}", old.display())
+                    })?;
+                }
+            }
+            Ok(())
+        })();
+        if let Err(e) = write_result {
+            return Err(super::mutation_err_after_backup(cwd, session.as_deref(), e));
+        }
+        (true, session)
+    } else {
+        (false, None)
+    };
 
     let mut results = Vec::with_capacity(staged.len());
-    for (_abs, display, original, new_content) in staged {
+    for (_abs, display, original, new_content, _) in staged {
         let mut edit =
             super::build_edit_result(&display, original, new_content, applied, "patch", None);
         // Same session id on every file result so hosts can undo once.

--- a/src/cmd/md.rs
+++ b/src/cmd/md.rs
@@ -252,6 +252,10 @@ fn execute_md_op(
             if exit::is_no_match(&e) {
                 global.emit_error_json_kind(Some("no_matches"), &e.to_string())?;
                 Ok(exit::NO_MATCHES)
+            } else if exit::is_ambiguous(&e) {
+                // Duplicate headings: fail closed exit 5 even without --json (#2100).
+                global.emit_error_json_kind(Some("ambiguous"), &e.to_string())?;
+                Ok(exit::AMBIGUOUS)
             } else {
                 Err(e)
             }
@@ -633,12 +637,18 @@ pub fn run(args: MdArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 Err(e) => return Err(e).with_context(|| format!("reading {file}")),
             };
             match find_section(&content, &heading) {
-                None => {
+                Err(crate::ops::md::SectionError::NotFound) => {
                     let msg = format!("heading {:?} not found in {file}", heading);
                     global.emit_error_json_kind(Some("no_matches"), &msg)?;
                     Ok(exit::NO_MATCHES)
                 }
-                Some((body_start, body_end)) => {
+                Err(e @ crate::ops::md::SectionError::Ambiguous { .. }) => {
+                    let err = e.into_anyhow(&heading);
+                    let msg = err.to_string();
+                    global.emit_error_json_kind(Some("ambiguous"), &msg)?;
+                    Ok(exit::AMBIGUOUS)
+                }
+                Ok((body_start, body_end)) => {
                     // Verify the table exists and the row is valid.
                     if let Err(e) =
                         crate::ops::md::table_append_in(&content, body_start, body_end, &row)

--- a/src/cmd/md_tests.rs
+++ b/src/cmd/md_tests.rs
@@ -596,7 +596,7 @@ mod error_handling {
 
     #[test]
     fn find_section_none_for_missing() {
-        assert!(find_section("# X\n", "Y").is_none());
+        assert!(find_section("# X\n", "Y").is_err());
     }
 
     #[test]

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -521,9 +521,11 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let mut any_problem = false;
         let mut results = Vec::new();
         for pf in &patch_files {
-            let file_path = cwd.join(&pf.path);
+            // Git rename: check loads old path content (#2101).
+            let load_rel = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
+            let file_path = cwd.join(load_rel);
             // Strict target load (#1896); creation allows missing → empty.
-            let original = match load_patch_target(&file_path, &pf.path, pf.is_creation) {
+            let original = match load_patch_target(&file_path, load_rel, pf.is_creation) {
                 Ok(s) => s,
                 Err(PatchTargetError::NotFound) => {
                     let msg = format!("file not found: {}", file_path.display());
@@ -620,9 +622,11 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         let mut all_ok = true;
         let mut any_would_change = false;
         for pf in &patch_files {
-            let file_path = cwd.join(&pf.path);
+            // Git rename: load old path (parity with non-merge check) (#2101).
+            let load_rel = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
+            let file_path = cwd.join(load_rel);
             // Merge check: missing target → empty; binary/utf8 → typed kinds.
-            let original = match load_patch_target(&file_path, &pf.path, true) {
+            let original = match load_patch_target(&file_path, load_rel, true) {
                 Ok(s) => s,
                 Err(PatchTargetError::Binary(msg)) => {
                     global.emit_error_json_kind(Some("binary"), &msg)?;

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -269,13 +269,57 @@ fn heading_matches(h: &HeadingInfo, level: Option<usize>, query: &str) -> bool {
     h.text.trim() == query && level.is_none_or(|lvl| h.level == lvl)
 }
 
-pub fn find_section(content: &str, heading: &str) -> Option<(usize, usize)> {
+/// Section lookup failure for mutators and unique heading resolution (#2100).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SectionError {
+    /// No heading matched the query.
+    NotFound,
+    /// More than one heading matched (fail-closed for mutators).
+    Ambiguous { count: usize },
+}
+
+impl SectionError {
+    /// Map to typed exit errors for CLI/tx/MCP agent branching.
+    pub fn into_anyhow(self, heading: &str) -> anyhow::Error {
+        match self {
+            SectionError::NotFound => crate::exit::NoMatchError {
+                msg: format!("heading not found: {heading}"),
+            }
+            .into(),
+            SectionError::Ambiguous { count } => crate::exit::AmbiguousError {
+                msg: format!(
+                    "ambiguous heading: {heading:?} matches {count} times; make the heading unique or use a level-qualified query (e.g. \"## Rules\")"
+                ),
+            }
+            .into(),
+        }
+    }
+}
+
+fn matching_heading_indices<'a>(
+    headings: &'a [HeadingInfo],
+    level: Option<usize>,
+    query: &str,
+) -> Vec<&'a HeadingInfo> {
+    headings
+        .iter()
+        .filter(|h| heading_matches(h, level, query))
+        .collect()
+}
+
+/// Body byte range `(start, end)` for a heading, fail-closed on duplicates (#2100).
+///
+/// Zero matches → [`SectionError::NotFound`]. Two or more →
+/// [`SectionError::Ambiguous`]. Parity with replace/apply-fragment unique anchors.
+pub fn find_section(content: &str, heading: &str) -> Result<(usize, usize), SectionError> {
     let headings = parse_headings(content);
     let offsets = line_byte_starts(content);
     let (level, query) = normalize_heading_query(heading);
-
-    for h in &headings {
-        if heading_matches(h, level, query) {
+    let matches = matching_heading_indices(&headings, level, query);
+    match matches.len() {
+        0 => Err(SectionError::NotFound),
+        1 => {
+            let h = matches[0];
             let body_start = if h.body_line < offsets.len() {
                 offsets[h.body_line]
             } else {
@@ -286,34 +330,36 @@ pub fn find_section(content: &str, heading: &str) -> Option<(usize, usize)> {
             } else {
                 content.len()
             };
-            return Some((body_start, body_end));
+            Ok((body_start, body_end))
         }
+        count => Err(SectionError::Ambiguous { count }),
     }
-    None
 }
 
-/// Return the full byte range of a section INCLUDING its heading line.
+/// Full byte range of a section INCLUDING its heading line (unique only, #2100).
 ///
 /// Unlike `find_section` which returns only the body range (after the
 /// heading), this returns `(section_start, section_end)` where
 /// `section_start` is the first byte of the heading line itself.
-pub fn section_range(content: &str, heading: &str) -> Option<(usize, usize)> {
+pub fn section_range(content: &str, heading: &str) -> Result<(usize, usize), SectionError> {
     let headings = parse_headings(content);
     let offsets = line_byte_starts(content);
     let (level, query) = normalize_heading_query(heading);
-
-    for h in &headings {
-        if heading_matches(h, level, query) {
+    let matches = matching_heading_indices(&headings, level, query);
+    match matches.len() {
+        0 => Err(SectionError::NotFound),
+        1 => {
+            let h = matches[0];
             let section_start = offsets[h.line_start];
             let section_end = if h.line_end < offsets.len() {
                 offsets[h.line_end]
             } else {
                 content.len()
             };
-            return Some((section_start, section_end));
+            Ok((section_start, section_end))
         }
+        count => Err(SectionError::Ambiguous { count }),
     }
-    None
 }
 
 /// Move a heading section to a new location, either within the same file
@@ -329,7 +375,7 @@ pub fn move_section_in(
     dest_content: &str,
     position: (&str, &str),
     same_file: bool,
-) -> Option<(String, String)> {
+) -> Result<(String, String), SectionError> {
     let (section_start, section_end) = section_range(source_content, heading)?;
     let section_text = &source_content[section_start..section_end];
 
@@ -347,26 +393,22 @@ pub fn move_section_in(
             "after" => {
                 // Insert after the *full* destination section body (so that the
                 // destination's table/list/etc stays under its heading).
-                if let Some((_, dest_body_end)) = find_section(&without_section, position.1) {
-                    let mut out =
-                        String::with_capacity(without_section.len() + section_text.len() + 2);
-                    out.push_str(&without_section[..dest_body_end]);
-                    if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") && !out.is_empty() {
-                        out.push_str(eol);
-                    }
-                    out.push_str(section_text);
-                    if !section_text.ends_with('\n') {
-                        out.push_str(eol);
-                    }
-                    out.push_str(&without_section[dest_body_end..]);
-                    out
-                } else {
-                    return None;
+                let (_, dest_body_end) = find_section(&without_section, position.1)?;
+                let mut out = String::with_capacity(without_section.len() + section_text.len() + 2);
+                out.push_str(&without_section[..dest_body_end]);
+                if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") && !out.is_empty() {
+                    out.push_str(eol);
                 }
+                out.push_str(section_text);
+                if !section_text.ends_with('\n') {
+                    out.push_str(eol);
+                }
+                out.push_str(&without_section[dest_body_end..]);
+                out
             }
-            _ => return None,
+            _ => return Err(SectionError::NotFound),
         };
-        Some((result.clone(), result))
+        Ok((result.clone(), result))
     } else {
         // Cross-file move: remove from source, insert into dest.
         let eol = crate::write::detect_eol(dest_content);
@@ -378,30 +420,30 @@ pub fn move_section_in(
         let new_dest = match position.0 {
             "before" => insert_before_heading_in(dest_content, position.1, section_text)?,
             "after" => {
-                if let Some((_, dest_body_end)) = find_section(dest_content, position.1) {
-                    let mut out =
-                        String::with_capacity(dest_content.len() + section_text.len() + 2);
-                    out.push_str(&dest_content[..dest_body_end]);
-                    if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") && !out.is_empty() {
-                        out.push_str(eol);
-                    }
-                    out.push_str(section_text);
-                    if !section_text.ends_with('\n') {
-                        out.push_str(eol);
-                    }
-                    out.push_str(&dest_content[dest_body_end..]);
-                    out
-                } else {
-                    return None;
+                let (_, dest_body_end) = find_section(dest_content, position.1)?;
+                let mut out = String::with_capacity(dest_content.len() + section_text.len() + 2);
+                out.push_str(&dest_content[..dest_body_end]);
+                if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") && !out.is_empty() {
+                    out.push_str(eol);
                 }
+                out.push_str(section_text);
+                if !section_text.ends_with('\n') {
+                    out.push_str(eol);
+                }
+                out.push_str(&dest_content[dest_body_end..]);
+                out
             }
-            _ => return None,
+            _ => return Err(SectionError::NotFound),
         };
-        Some((new_source, new_dest))
+        Ok((new_source, new_dest))
     }
 }
 
-pub fn replace_section_in(content: &str, heading: &str, replacement: &str) -> Option<String> {
+pub fn replace_section_in(
+    content: &str,
+    heading: &str,
+    replacement: &str,
+) -> Result<String, SectionError> {
     let eol = crate::write::detect_eol(content);
     let (body_start, body_end) = find_section(content, heading)?;
 
@@ -434,7 +476,7 @@ pub fn replace_section_in(content: &str, heading: &str, replacement: &str) -> Op
         }
     }
     out.push_str(&content[body_end..]);
-    Some(out)
+    Ok(out)
 }
 
 /// Strip a leading heading line from `text` if it matches `heading`.
@@ -454,7 +496,11 @@ fn strip_leading_heading<'a>(text: &'a str, heading: &str) -> &'a str {
     }
 }
 
-pub fn insert_after_heading_in(content: &str, heading: &str, insertion: &str) -> Option<String> {
+pub fn insert_after_heading_in(
+    content: &str,
+    heading: &str,
+    insertion: &str,
+) -> Result<String, SectionError> {
     let eol = crate::write::detect_eol(content);
     let (body_start, _) = find_section(content, heading)?;
     let mut out = String::with_capacity(content.len() + insertion.len());
@@ -464,14 +510,18 @@ pub fn insert_after_heading_in(content: &str, heading: &str, insertion: &str) ->
         out.push_str(eol);
     }
     out.push_str(&content[body_start..]);
-    Some(out)
+    Ok(out)
 }
 
 /// Insert content after the **full section body** (after the last line of the
 /// section, before the next same-or-higher heading). Use this to add a sibling
 /// section; prefer [`insert_after_heading_in`] to insert under the heading line
 /// (e.g. intro text before an existing table). See #1726.
-pub fn insert_after_section_in(content: &str, heading: &str, insertion: &str) -> Option<String> {
+pub fn insert_after_section_in(
+    content: &str,
+    heading: &str,
+    insertion: &str,
+) -> Result<String, SectionError> {
     let eol = crate::write::detect_eol(content);
     let (_, body_end) = find_section(content, heading)?;
     let mut out = String::with_capacity(content.len() + insertion.len() + 4);
@@ -491,34 +541,30 @@ pub fn insert_after_section_in(content: &str, heading: &str, insertion: &str) ->
         }
     }
     out.push_str(&content[body_end..]);
-    Some(out)
+    Ok(out)
 }
 
-pub fn insert_before_heading_in(content: &str, heading: &str, insertion: &str) -> Option<String> {
+pub fn insert_before_heading_in(
+    content: &str,
+    heading: &str,
+    insertion: &str,
+) -> Result<String, SectionError> {
     let eol = crate::write::detect_eol(content);
-    let headings = parse_headings(content);
-    let offsets = line_byte_starts(content);
-    let (level, query) = normalize_heading_query(heading);
-
-    for h in &headings {
-        if heading_matches(h, level, query) {
-            let heading_start = offsets[h.line_start];
-            let mut out = String::with_capacity(content.len() + insertion.len());
-            out.push_str(&content[..heading_start]);
-            if !insertion.is_empty() {
-                out.push_str(insertion);
-                if !insertion.ends_with('\n') {
-                    out.push_str(eol);
-                }
-                if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") {
-                    out.push_str(eol);
-                }
-            }
-            out.push_str(&content[heading_start..]);
-            return Some(out);
+    // Reuse unique resolution via section_range (heading start = section start).
+    let (heading_start, _) = section_range(content, heading)?;
+    let mut out = String::with_capacity(content.len() + insertion.len());
+    out.push_str(&content[..heading_start]);
+    if !insertion.is_empty() {
+        out.push_str(insertion);
+        if !insertion.ends_with('\n') {
+            out.push_str(eol);
+        }
+        if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") {
+            out.push_str(eol);
         }
     }
-    None
+    out.push_str(&content[heading_start..]);
+    Ok(out)
 }
 
 /// Strip a bullet prefix (`- `, `* `, `+ `) from a trimmed line,
@@ -531,7 +577,11 @@ fn strip_bullet_prefix(s: &str) -> &str {
     }
 }
 
-pub fn upsert_bullet_in(content: &str, heading: &str, bullet: &str) -> Option<String> {
+pub fn upsert_bullet_in(
+    content: &str,
+    heading: &str,
+    bullet: &str,
+) -> Result<String, SectionError> {
     let eol = crate::write::detect_eol(content);
     let (body_start, body_end) = find_section(content, heading)?;
     let body = &content[body_start..body_end];
@@ -558,7 +608,7 @@ pub fn upsert_bullet_in(content: &str, heading: &str, bullet: &str) -> Option<St
         {
             let existing_text = strip_bullet_prefix(trimmed);
             if existing_text == new_text {
-                return Some(content.to_string());
+                return Ok(content.to_string());
             }
         }
     }
@@ -599,7 +649,7 @@ pub fn upsert_bullet_in(content: &str, heading: &str, bullet: &str) -> Option<St
         out.push_str(eol);
     }
     out.push_str(remainder);
-    Some(out)
+    Ok(out)
 }
 
 pub fn dedupe_headings_in(content: &str) -> (String, Vec<String>) {
@@ -786,15 +836,17 @@ pub fn table_append_in(
     Ok(out)
 }
 
+/// Append a table row under a unique heading. Section miss/ambiguous map to
+/// [`TableAppendError::NoTable`] for this helper; CLI/tx call `find_section`
+/// first so agents get typed `no_matches` / `ambiguous`.
 pub fn table_append_for_tx(
     content: &str,
     heading: &str,
     row: &str,
-) -> Result<Option<String>, TableAppendError> {
-    let Some((body_start, body_end)) = find_section(content, heading) else {
-        return Ok(None);
-    };
-    table_append_in(content, body_start, body_end, row).map(Some)
+) -> Result<String, TableAppendError> {
+    let (body_start, body_end) =
+        find_section(content, heading).map_err(|_| TableAppendError::NoTable)?;
+    table_append_in(content, body_start, body_end, row)
 }
 
 /// Strip inline code spans (between backticks) from a line so that

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -264,9 +264,7 @@ mod basic {
     #[test]
     fn table_append_for_tx_basic() {
         let content = "# API\n| Name | Value |\n|---|---|\n| a | 1 |\n";
-        let result = table_append_for_tx(content, "API", "| b | 2 |")
-            .unwrap()
-            .expect("heading exists");
+        let result = table_append_for_tx(content, "API", "| b | 2 |").unwrap();
         assert!(result.contains("| a | 1 |\n| b | 2 |\n"));
     }
 
@@ -776,7 +774,7 @@ mod edge_cases {
 
     #[test]
     fn insert_after_section_missing_heading_returns_none() {
-        assert!(insert_after_section_in("# Title\n\nBody\n", "## Missing", "x\n").is_none());
+        assert!(insert_after_section_in("# Title\n\nBody\n", "## Missing", "x\n").is_err());
     }
 
     #[test]
@@ -805,7 +803,7 @@ mod edge_cases {
         let content = "# A\na body\n# B\nb body\n";
         let result = move_section_in(content, "A", content, ("before", "A"), true);
         assert!(
-            result.is_none(),
+            result.is_err(),
             "self-move (before self) should return None: {:?}",
             result
         );
@@ -817,7 +815,7 @@ mod edge_cases {
         let content = "# A\na body\n# B\nb body\n";
         let result = move_section_in(content, "A", content, ("after", "A"), true);
         assert!(
-            result.is_none(),
+            result.is_err(),
             "self-move (after self) should return None: {:?}",
             result
         );
@@ -997,11 +995,13 @@ mod edge_cases {
     }
 
     #[test]
-    fn find_section_duplicate_headings_returns_first() {
+    fn find_section_duplicate_headings_is_ambiguous() {
+        // Fail closed when the same heading text appears twice (#2100).
         let content = "# A\nfirst body\n# B\nmiddle\n# A\nsecond body\n";
-        let (start, end) = find_section(content, "A").unwrap();
-        let body = &content[start..end];
-        assert_eq!(body, "first body\n");
+        assert!(matches!(
+            find_section(content, "A"),
+            Err(SectionError::Ambiguous { count: 2 })
+        ));
     }
 
     #[test]
@@ -1088,13 +1088,13 @@ mod error_handling {
     #[test]
     fn find_section_missing() {
         let content = "# Title\nBody\n";
-        assert!(find_section(content, "Nonexistent").is_none());
+        assert!(find_section(content, "Nonexistent").is_err());
     }
 
     #[test]
     fn replace_section_missing_heading() {
         let content = "# Title\nBody\n";
-        assert!(replace_section_in(content, "Missing", "x").is_none());
+        assert!(replace_section_in(content, "Missing", "x").is_err());
     }
 
     #[test]
@@ -1138,19 +1138,19 @@ mod error_handling {
     #[test]
     fn section_range_missing() {
         let content = "# A\nbody\n";
-        assert!(section_range(content, "Missing").is_none());
+        assert!(section_range(content, "Missing").is_err());
     }
 
     #[test]
     fn move_section_missing_source_heading() {
         let content = "# A\nbody\n";
-        assert!(move_section_in(content, "Missing", content, ("before", "A"), true).is_none());
+        assert!(move_section_in(content, "Missing", content, ("before", "A"), true).is_err());
     }
 
     #[test]
     fn move_section_missing_target_heading() {
         let content = "# A\nbody\n# B\nbody\n";
-        assert!(move_section_in(content, "A", content, ("before", "Missing"), true).is_none());
+        assert!(move_section_in(content, "A", content, ("before", "Missing"), true).is_err());
     }
 }
 
@@ -1557,14 +1557,18 @@ body text
         assert_eq!(body, "Detailed reference\n");
     }
 
-    /// A plain text query (no `#` prefix) should match any heading level.
+    /// A plain text query (no `#` prefix) matches any level; duplicates fail closed.
     #[test]
     fn find_section_plain_text_matches_any_level() {
-        let content = "## Intro\nSome text\n# Intro\nOther text\n";
-        // Plain "Intro" matches the first occurrence regardless of level.
-        let (start, end) = find_section(content, "Intro").unwrap();
-        let body = &content[start..end];
-        assert_eq!(body, "Some text\n");
+        let unique = "## Intro\nSome text\n# Other\nOther text\n";
+        let (start, end) = find_section(unique, "Intro").unwrap();
+        assert_eq!(&unique[start..end], "Some text\n");
+        // Same text at two levels is ambiguous (#2100).
+        let dup = "## Intro\nSome text\n# Intro\nOther text\n";
+        assert!(matches!(
+            find_section(dup, "Intro"),
+            Err(SectionError::Ambiguous { count: 2 })
+        ));
     }
 
     #[test]
@@ -1630,8 +1634,34 @@ body text
     fn upsert_bullet_still_dedups_against_actual_bullet() {
         let content = "# Rules\n- Run make check\n";
         let out = upsert_bullet_in(content, "Rules", "- Run make check")
-            .expect("upsert_bullet_in should return Some for dedup case");
+            .expect("upsert_bullet_in should return Ok for dedup case");
         // Should return unchanged content (dedup).
         assert_eq!(out, content);
+    }
+
+    #[test]
+    fn find_section_duplicate_heading_is_ambiguous() {
+        let content = "# Rules\none\n# Rules\ntwo\n";
+        match find_section(content, "Rules") {
+            Err(SectionError::Ambiguous { count }) => assert_eq!(count, 2),
+            other => panic!("expected Ambiguous, got {other:?}"),
+        }
+        assert!(matches!(
+            upsert_bullet_in(content, "Rules", "- x"),
+            Err(SectionError::Ambiguous { count: 2 })
+        ));
+    }
+
+    #[test]
+    fn find_section_level_disambiguates_duplicate_text() {
+        let content = "# Rules\ntop\n## Rules\nnested\n";
+        // bare "Rules" matches both levels
+        assert!(matches!(
+            find_section(content, "Rules"),
+            Err(SectionError::Ambiguous { count: 2 })
+        ));
+        // level-qualified is unique
+        let (start, end) = find_section(content, "## Rules").unwrap();
+        assert_eq!(&content[start..end], "nested\n");
     }
 }

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -28,6 +28,9 @@ pub struct PatchFile {
     pub is_creation: bool,
     /// `true` when the `+++` line is `/dev/null` (file deletion).
     pub is_deletion: bool,
+    /// When `--- a/old` and `+++ b/new` differ (git rename), the pre-rename path.
+    /// Content is loaded from this path; result is written to [`path`] (#2101).
+    pub rename_from: Option<String>,
 }
 
 /// Check whether line `idx` is a real file header ("--- " followed by "+++"),
@@ -82,10 +85,16 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
         }
 
         // For deletions the `+++` line is `/dev/null`; take path from `---`.
+        // Git renames use different minus/plus paths (neither `/dev/null`).
         let minus_path = parse_file_path(lines[i]);
         let plus_path = parse_file_path(lines[i + 1]);
         let is_creation = minus_path == "/dev/null";
         let is_deletion = plus_path == "/dev/null";
+        let rename_from = if !is_creation && !is_deletion && minus_path != plus_path {
+            Some(minus_path.clone())
+        } else {
+            None
+        };
         let path = if is_deletion { minus_path } else { plus_path };
         i += 2;
 
@@ -148,6 +157,7 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
             hunks,
             is_creation,
             is_deletion,
+            rename_from,
         });
     }
 
@@ -334,6 +344,8 @@ pub struct PatchApplyFileResult {
     pub is_creation: bool,
     /// `true` when the patch deletes a file (`+++ /dev/null`).
     pub is_deletion: bool,
+    /// Pre-rename path when applying a git rename patch (#2101).
+    pub rename_from: Option<String>,
 }
 
 pub fn apply_hunks(original: &str, hunks: &[Hunk]) -> Result<String, String> {
@@ -800,10 +812,12 @@ where
     let mut results = Vec::new();
     for pf in &patch_files {
         // New file creation: original is empty, don't try to load from disk.
+        // Git rename: load from rename_from (old path), write to path (new).
+        let load_path = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
         let original = if pf.is_creation {
             String::new()
         } else {
-            load_original(&pf.path)?
+            load_original(load_path)?
         };
         // File deletion: still run hunk application so stale context fails
         // closed (check and apply must agree). Skipping hunks always deleted
@@ -818,6 +832,7 @@ where
                     conflicts: Vec::new(),
                     is_creation: false,
                     is_deletion: true,
+                    rename_from: None,
                 });
                 continue;
             }
@@ -852,6 +867,7 @@ where
                 conflicts: applied.conflicts,
                 is_creation: false,
                 is_deletion: is_clean_delete,
+                rename_from: None,
             });
             continue;
         }
@@ -884,6 +900,7 @@ where
             conflicts: applied.conflicts,
             is_creation: pf.is_creation,
             is_deletion: false,
+            rename_from: pf.rename_from.clone(),
         });
     }
     Ok(results)

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1224,4 +1224,50 @@ mod regression {
             files[0].path
         );
     }
+
+    #[test]
+    fn parse_git_rename_paths() {
+        let diff = "\
+--- a/old_name.rs
++++ b/new_name.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let files = parse_patch(diff).expect("rename patch parses");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "new_name.rs");
+        assert_eq!(files[0].rename_from.as_deref(), Some("old_name.rs"));
+        assert!(!files[0].is_creation);
+        assert!(!files[0].is_deletion);
+    }
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn apply_git_rename_loads_old_writes_new() {
+        use crate::ops::patch::{ApplyHunksOptions, apply_patch_with_loader};
+        let mut files = std::collections::HashMap::new();
+        files.insert("old_name.rs".to_string(), "old\n".to_string());
+        let results = apply_patch_with_loader(
+            "\
+--- a/old_name.rs
++++ b/new_name.rs
+@@ -1 +1 @@
+-old
++new
+",
+            |path| {
+                files
+                    .get(path)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("missing {path}"))
+            },
+            ApplyHunksOptions::default(),
+        )
+        .expect("apply rename");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "new_name.rs");
+        assert_eq!(results[0].rename_from.as_deref(), Some("old_name.rs"));
+        assert_eq!(results[0].content, "new\n");
+    }
 }

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -5,20 +5,54 @@ use std::path::{Path, PathBuf};
 
 /// Walk a directory and collect files that have a tree-sitter grammar.
 /// Used by ast.rename/ast.replace in execute_plan when the path is a directory.
+///
+/// Honors `.gitignore` / standard ignore filters and does **not** follow
+/// symlinks (avoids vendor trees and symlink cycles; #2102). Parity with CLI
+/// `ast rename` / MCP collection via WalkBuilder.
 fn collect_ast_source_files(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
-    let mut files = Vec::new();
-    collect_ast_source_files_recursive(dir, &mut files)?;
-    files.sort();
-    Ok(files)
+    #[cfg(any(feature = "cli", feature = "files"))]
+    {
+        use ignore::WalkBuilder;
+        let mut files = Vec::new();
+        let walker = WalkBuilder::new(dir)
+            .follow_links(false)
+            .standard_filters(true)
+            .hidden(false)
+            .build();
+        for entry in walker {
+            let entry = entry.map_err(|e| {
+                anyhow::anyhow!("ast directory walk failed under {}: {e}", dir.display())
+            })?;
+            let path = entry.path();
+            if path.is_file() && crate::ast::Language::from_path(path).has_grammar() {
+                files.push(path.to_path_buf());
+            }
+        }
+        files.sort();
+        Ok(files)
+    }
+    #[cfg(not(any(feature = "cli", feature = "files")))]
+    {
+        // ast-only builds: no ignore crate. Still refuse symlink dirs.
+        let mut files = Vec::new();
+        collect_ast_source_files_simple(dir, &mut files)?;
+        files.sort();
+        Ok(files)
+    }
 }
 
-fn collect_ast_source_files_recursive(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow::Result<()> {
+#[cfg(not(any(feature = "cli", feature = "files")))]
+fn collect_ast_source_files_simple(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow::Result<()> {
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
-        if path.is_dir() {
-            collect_ast_source_files_recursive(&path, out)?;
-        } else if path.is_file() && crate::ast::Language::from_path(&path).has_grammar() {
+        let ft = entry.file_type()?;
+        if ft.is_symlink() {
+            continue;
+        }
+        if ft.is_dir() {
+            collect_ast_source_files_simple(&path, out)?;
+        } else if ft.is_file() && crate::ast::Language::from_path(&path).has_grammar() {
             out.push(path);
         }
     }
@@ -483,5 +517,59 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
         }
 
         _ => unreachable!("execute_ast_op called with non-AST operation"),
+    }
+}
+
+#[cfg(all(test, any(feature = "cli", feature = "files")))]
+mod tests {
+    use super::collect_ast_source_files;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use tempfile::TempDir;
+
+    #[test]
+    fn collect_respects_gitignore() {
+        let dir = TempDir::new().unwrap();
+        // ignore::WalkBuilder applies .gitignore when a git work tree exists.
+        std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir.path())
+            .status()
+            .expect("git init");
+        fs::write(dir.path().join(".gitignore"), "ignored.rs\n").unwrap();
+        fs::write(dir.path().join("kept.rs"), "fn kept() {}\n").unwrap();
+        fs::write(dir.path().join("ignored.rs"), "fn ignored() {}\n").unwrap();
+        let files = collect_ast_source_files(dir.path()).unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert!(names.contains(&"kept.rs".to_string()), "got {names:?}");
+        assert!(
+            !names.contains(&"ignored.rs".to_string()),
+            "gitignore must exclude ignored.rs: {names:?}"
+        );
+    }
+
+    #[test]
+    fn collect_does_not_follow_symlink_dirs() {
+        let dir = TempDir::new().unwrap();
+        // Target lives *outside* the walk root so only a symlink would expose it.
+        let outside = TempDir::new().unwrap();
+        fs::write(outside.path().join("inside.rs"), "fn inside() {}\n").unwrap();
+        let link = dir.path().join("linkdir");
+        symlink(outside.path(), &link).unwrap();
+        fs::write(dir.path().join("root.rs"), "fn root() {}\n").unwrap();
+        let files = collect_ast_source_files(dir.path()).unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert!(names.contains(&"root.rs".to_string()), "got {names:?}");
+        // WalkBuilder follow_links(false): symlink dir not entered
+        assert!(
+            !names.contains(&"inside.rs".to_string()),
+            "must not follow symlink dir: {names:?}"
+        );
     }
 }

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -524,7 +524,6 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
 mod tests {
     use super::collect_ast_source_files;
     use std::fs;
-    use std::os::unix::fs::symlink;
     use tempfile::TempDir;
 
     #[test]
@@ -551,8 +550,10 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
     #[test]
     fn collect_does_not_follow_symlink_dirs() {
+        use std::os::unix::fs::symlink;
         let dir = TempDir::new().unwrap();
         // Target lives *outside* the walk root so only a symlink would expose it.
         let outside = TempDir::new().unwrap();

--- a/src/tx/md_op.rs
+++ b/src/tx/md_op.rs
@@ -9,24 +9,21 @@ use crate::plan::Operation;
 /// Apply a markdown heading operation (read file, transform, write back).
 ///
 /// Five of the six md operations follow an identical pattern: resolve path,
-/// read content, call a `(&str, &str, &str) -> Option<String>` transform,
-/// error on `None`, and update pending state. This helper captures that pattern.
+/// read content, call a `(&str, &str, &str) -> Result<String, SectionError>`
+/// transform, map section errors to typed exit kinds, and update pending.
 fn apply_md_heading_op(
     tx: &mut TxState<'_>,
     path: &str,
     heading: &str,
     extra: &str,
-    op: impl FnOnce(&str, &str, &str) -> Option<String>,
-    err_label: &str,
+    op: impl FnOnce(&str, &str, &str) -> Result<String, crate::ops::md::SectionError>,
+    _err_label: &str,
 ) -> anyhow::Result<()> {
     let file_path = tx.cwd.join(path);
     // Sole binary must not surface as heading no_matches (NUL is valid UTF-8).
     crate::ops::file::ensure_not_binary_file(&file_path, path)?;
     let file_content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
-    let new_content =
-        op(file_content, heading, extra).ok_or_else(|| crate::exit::NoMatchError {
-            msg: format!("{err_label} not found: {heading}"),
-        })?;
+    let new_content = op(file_content, heading, extra).map_err(|e| e.into_anyhow(heading))?;
     tx.write_file(&file_path, new_content);
     Ok(())
 }
@@ -100,9 +97,7 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
             crate::ops::file::ensure_not_binary_file(&file_path, path)?;
             let file_content = read_file_content(tx.pending, tx.existed_before, &file_path)?;
             let (body_start, body_end) = crate::ops::md::find_section(file_content, heading)
-                .ok_or_else(|| crate::exit::NoMatchError {
-                    msg: format!("heading not found: {heading}"),
-                })?;
+                .map_err(|e| e.into_anyhow(heading))?;
             let new_content =
                 crate::ops::md::table_append_in(file_content, body_start, body_end, row).map_err(
                     |e| {
@@ -156,8 +151,12 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
             };
             let (new_source, new_dest) =
                 move_section_in(&source_content, heading, &dest_content, position, same_file)
-                    .ok_or_else(|| crate::exit::NoMatchError {
-                        msg: "md.move_section: heading or target not found".to_string(),
+                    .map_err(|e| match e {
+                        crate::ops::md::SectionError::NotFound => crate::exit::NoMatchError {
+                            msg: "md.move_section: heading or target not found".to_string(),
+                        }
+                        .into(),
+                        other => other.into_anyhow(heading),
                     })?;
             tx.write_file(&source_path, new_source);
             if !same_file {

--- a/src/tx/patch_op.rs
+++ b/src/tx/patch_op.rs
@@ -26,12 +26,41 @@ pub(crate) fn execute_patch_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::
                 options,
             )?;
             for result in patched_files {
-                let file_path = tx.cwd.join(&result.path);
                 if result.is_deletion {
+                    let file_path = tx.cwd.join(&result.path);
                     // File deletion via patch: mark for deletion.
                     tx.deletions.insert(file_path.clone());
                     tx.write_targets.insert(file_path);
+                } else if let Some(ref from) = result.rename_from {
+                    // Git rename: load was from `from`; stage rename + new content (#2101).
+                    let from_path = tx.cwd.join(from);
+                    let to_path = tx.cwd.join(&result.path);
+                    // Ensure source is in pending (loader already did); record rename
+                    // so commit uses fs::rename then write dest content.
+                    if !tx.existed_before.contains(&from_path)
+                        && crate::ops::file::path_entry_exists(&from_path)
+                    {
+                        tx.existed_before.insert(from_path.clone());
+                    }
+                    if crate::ops::file::path_entry_exists(&to_path)
+                        && !tx.existed_before.contains(&to_path)
+                    {
+                        // Dest exists: soft-load so commit overwrites rather than create_new.
+                        let _ = read_file_content(tx.pending, tx.existed_before, &to_path)?;
+                    }
+                    tx.renames.push((from_path.clone(), to_path.clone()));
+                    tx.write_file(&to_path, result.content);
+                    // Stage source delete (same as file.rename).
+                    if let Some((original, _)) = tx.pending.get(&from_path) {
+                        let orig = original.clone();
+                        tx.pending.insert(from_path.clone(), (orig, String::new()));
+                    } else {
+                        tx.pending
+                            .insert(from_path.clone(), (String::new(), String::new()));
+                    }
+                    tx.deletions.insert(from_path);
                 } else {
+                    let file_path = tx.cwd.join(&result.path);
                     tx.write_file(&file_path, result.content);
                 }
             }


### PR DESCRIPTION
## Summary

Implements the three multi-day findings filed after fixloop:

- **#2100** — `find_section` / md mutators fail closed when a heading matches more than once (`error_kind: ambiguous`, exit 5). Level-qualified queries (e.g. `## Rules`) still disambiguate. CLI non-JSON paths remap via `is_ambiguous`.
- **#2101** — Git rename patches (`--- a/old` / `+++ b/new`): parse `rename_from`, load old content, write new path, stage rename (tx + library `apply_patch_file` + CLI check/merge check).
- **#2102** — Plan/tx `ast.rename` directory walk uses `ignore::WalkBuilder` with gitignore and `follow_links(false)`.

Also reorders `examples/03-markdown-editing.json` to `dedupe_headings` before `upsert_bullet` so the smoke fixture stays valid under fail-closed uniqueness.

## Test plan

- [x] Unit: duplicate heading ambiguous, level disambiguation, git rename parse/apply, gitignore + symlink-dir collect
- [x] `make check-fast` (fmt, clippy, lib, no-default, integration, pty, README)
- [x] Reviewer pass (fixed exit 5 remap, library rename half-apply, merge-check load path)
- [ ] CI green

Closes #2100
Closes #2101
Closes #2102