### PR TITLE
fix: pure git renames, move_section dest messages, ast .git skip

### DIFF
--- a/src/api/md.rs
+++ b/src/api/md.rs
@@ -256,12 +256,7 @@ pub fn md_move_section(
 
     let (new_source, new_dest) =
         ops::md::move_section_in(&original, heading, &dest_content, position, to.is_none())
-            .map_err(|e| match e {
-                ops::md::SectionError::NotFound => anyhow::Error::new(crate::exit::NoMatchError {
-                    msg: format!("heading '{heading}' not found"),
-                }),
-                other => other.into_anyhow(heading),
-            })?;
+            .map_err(|e| e.into_anyhow(heading, position.1))?;
 
     let policy = crate::write::WritePolicy::default();
     let dest = to.map(|p| p.to_string_lossy().to_string());

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -170,17 +170,22 @@ pub fn apply_patch_file(
             crate::files::load_text_strict(&load_path, load_rel)?
         };
 
-        let new_content = crate::ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
-            if e.contains("stale context") {
-                anyhow::Error::new(crate::exit::AmbiguousError {
-                    msg: format!("patch apply error for {}: {e}", pf.path),
-                })
-            } else {
-                anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("patch apply error for {}: {e}", pf.path),
-                })
-            }
-        })?;
+        // Pure rename (empty hunks): keep content as-is.
+        let new_content = if pf.rename_from.is_some() && pf.hunks.is_empty() {
+            original.clone()
+        } else {
+            crate::ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
+                if e.contains("stale context") {
+                    anyhow::Error::new(crate::exit::AmbiguousError {
+                        msg: format!("patch apply error for {}: {e}", pf.path),
+                    })
+                } else {
+                    anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("patch apply error for {}: {e}", pf.path),
+                    })
+                }
+            })?
+        };
         let delete_after = pf.rename_from.as_ref().map(|f| cwd.join(f));
         staged.push((
             write_path,

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -565,8 +565,11 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     continue;
                 }
             };
+            // Pure rename: content may match original, but apply still moves
+            // the path — report would_change so agents do not skip apply.
+            let is_path_rename = pf.rename_from.as_ref().is_some_and(|from| from != &pf.path);
             match apply_hunks(&original, &pf.hunks) {
-                Ok(new_content) if new_content == original => {
+                Ok(new_content) if new_content == original && !is_path_rename => {
                     results.push(PatchFileResult {
                         path: pf.path.clone(),
                         status: "unchanged",
@@ -658,8 +661,10 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                         all_ok = false;
                     }
                     // Clean means apply without fuzz, not "no content change".
-                    // Compare content for identity (new-file create is Clean).
-                    if applied.content != original {
+                    // Pure rename: content may equal original but path still moves.
+                    let is_path_rename =
+                        pf.rename_from.as_ref().is_some_and(|from| from != &pf.path);
+                    if applied.content != original || is_path_rename {
                         any_would_change = true;
                     }
                     results.push(patch_file_result(&pf.path, &applied));

--- a/src/files.rs
+++ b/src/files.rs
@@ -795,9 +795,10 @@ fn apply_exclude_globs(
 /// Directory basenames we never descend into when walking the tree.
 ///
 /// Applied even with `include_hidden=true` (tidy needs dotfiles but not VCS
-/// object stores or Patchloom backup sessions).
+/// object stores or Patchloom backup sessions). Shared by CLI/library collectors
+/// and plan/tx `ast.rename` directory walks.
 #[cfg(any(feature = "cli", feature = "files"))]
-fn should_skip_walk_dirname(name: &std::ffi::OsStr) -> bool {
+pub(crate) fn should_skip_walk_dirname(name: &std::ffi::OsStr) -> bool {
     name == ".git" || name == ".patchloom"
 }
 

--- a/src/ops/md.rs
+++ b/src/ops/md.rs
@@ -1,3 +1,8 @@
+//! Markdown section parse, mutators, and unique-heading resolution.
+//!
+//! size-waiver: single-domain md heading/section ops + unique-heading fail-closed (#2100).
+//! Co-located tests push line count. Policy #1408 — do not split for LOC alone.
+
 use std::borrow::Cow;
 use std::collections::HashSet;
 
@@ -296,6 +301,41 @@ impl SectionError {
     }
 }
 
+/// Failure from [`move_section_in`], naming whether source or dest heading failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MoveSectionError {
+    /// The section being moved (`heading`) was not found or ambiguous.
+    Source(SectionError),
+    /// The before/after target heading was not found or ambiguous.
+    Dest(SectionError),
+    /// Position was neither `before` nor `after`.
+    InvalidPosition,
+}
+
+impl MoveSectionError {
+    pub fn into_anyhow(self, source_heading: &str, dest_heading: &str) -> anyhow::Error {
+        match self {
+            MoveSectionError::Source(e) => e.into_anyhow(source_heading),
+            MoveSectionError::Dest(e) => match e {
+                SectionError::NotFound => crate::exit::NoMatchError {
+                    msg: format!("md.move_section: target heading not found: {dest_heading}"),
+                }
+                .into(),
+                SectionError::Ambiguous { count } => crate::exit::AmbiguousError {
+                    msg: format!(
+                        "ambiguous target heading: {dest_heading:?} matches {count} times; make the before/after heading unique or use a level-qualified query"
+                    ),
+                }
+                .into(),
+            },
+            MoveSectionError::InvalidPosition => crate::exit::InvalidInputError {
+                msg: "md.move_section requires exactly one of 'before' or 'after'".into(),
+            }
+            .into(),
+        }
+    }
+}
+
 fn matching_heading_indices<'a>(
     headings: &'a [HeadingInfo],
     level: Option<usize>,
@@ -369,14 +409,17 @@ pub fn section_range(content: &str, heading: &str) -> Result<(usize, usize), Sec
 /// should use only `new_source` (both values are identical).
 ///
 /// `position` is `("before", heading)` or `("after", heading)`.
+/// Source vs dest failures are distinguished in [`MoveSectionError`] so agents
+/// see the correct heading in ambiguous/not-found messages.
 pub fn move_section_in(
     source_content: &str,
     heading: &str,
     dest_content: &str,
     position: (&str, &str),
     same_file: bool,
-) -> Result<(String, String), SectionError> {
-    let (section_start, section_end) = section_range(source_content, heading)?;
+) -> Result<(String, String), MoveSectionError> {
+    let (section_start, section_end) =
+        section_range(source_content, heading).map_err(MoveSectionError::Source)?;
     let section_text = &source_content[section_start..section_end];
 
     if same_file {
@@ -389,11 +432,13 @@ pub fn move_section_in(
             &source_content[section_end..]
         );
         let result = match position.0 {
-            "before" => insert_before_heading_in(&without_section, position.1, section_text)?,
+            "before" => insert_before_heading_in(&without_section, position.1, section_text)
+                .map_err(MoveSectionError::Dest)?,
             "after" => {
                 // Insert after the *full* destination section body (so that the
                 // destination's table/list/etc stays under its heading).
-                let (_, dest_body_end) = find_section(&without_section, position.1)?;
+                let (_, dest_body_end) =
+                    find_section(&without_section, position.1).map_err(MoveSectionError::Dest)?;
                 let mut out = String::with_capacity(without_section.len() + section_text.len() + 2);
                 out.push_str(&without_section[..dest_body_end]);
                 if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") && !out.is_empty() {
@@ -406,7 +451,7 @@ pub fn move_section_in(
                 out.push_str(&without_section[dest_body_end..]);
                 out
             }
-            _ => return Err(SectionError::NotFound),
+            _ => return Err(MoveSectionError::InvalidPosition),
         };
         Ok((result.clone(), result))
     } else {
@@ -418,9 +463,11 @@ pub fn move_section_in(
             &source_content[section_end..]
         );
         let new_dest = match position.0 {
-            "before" => insert_before_heading_in(dest_content, position.1, section_text)?,
+            "before" => insert_before_heading_in(dest_content, position.1, section_text)
+                .map_err(MoveSectionError::Dest)?,
             "after" => {
-                let (_, dest_body_end) = find_section(dest_content, position.1)?;
+                let (_, dest_body_end) =
+                    find_section(dest_content, position.1).map_err(MoveSectionError::Dest)?;
                 let mut out = String::with_capacity(dest_content.len() + section_text.len() + 2);
                 out.push_str(&dest_content[..dest_body_end]);
                 if !out.ends_with("\n\n") && !out.ends_with("\r\n\r\n") && !out.is_empty() {
@@ -433,7 +480,7 @@ pub fn move_section_in(
                 out.push_str(&dest_content[dest_body_end..]);
                 out
             }
-            _ => return Err(SectionError::NotFound),
+            _ => return Err(MoveSectionError::InvalidPosition),
         };
         Ok((new_source, new_dest))
     }

--- a/src/ops/md_tests.rs
+++ b/src/ops/md_tests.rs
@@ -1144,13 +1144,19 @@ mod error_handling {
     #[test]
     fn move_section_missing_source_heading() {
         let content = "# A\nbody\n";
-        assert!(move_section_in(content, "Missing", content, ("before", "A"), true).is_err());
+        assert!(matches!(
+            move_section_in(content, "Missing", content, ("before", "A"), true),
+            Err(MoveSectionError::Source(SectionError::NotFound))
+        ));
     }
 
     #[test]
     fn move_section_missing_target_heading() {
         let content = "# A\nbody\n# B\nbody\n";
-        assert!(move_section_in(content, "A", content, ("before", "Missing"), true).is_err());
+        assert!(matches!(
+            move_section_in(content, "A", content, ("before", "Missing"), true),
+            Err(MoveSectionError::Dest(SectionError::NotFound))
+        ));
     }
 }
 
@@ -1663,5 +1669,51 @@ body text
         // level-qualified is unique
         let (start, end) = find_section(content, "## Rules").unwrap();
         assert_eq!(&content[start..end], "nested\n");
+    }
+
+    #[test]
+    fn move_section_dest_ambiguous_names_target() {
+        let content = "# Move
+body
+# Dest
+one
+# Dest
+two
+";
+        let err = move_section_in(content, "Move", content, ("before", "Dest"), true).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                MoveSectionError::Dest(SectionError::Ambiguous { count: 2 })
+            ),
+            "got {err:?}"
+        );
+        let msg = err.into_anyhow("Move", "Dest").to_string();
+        assert!(
+            msg.contains("target") || msg.contains("Dest"),
+            "message should name dest heading, got: {msg}"
+        );
+        assert!(
+            !msg.contains("ambiguous heading: \"Move\""),
+            "must not blame source: {msg}"
+        );
+    }
+
+    #[test]
+    fn move_section_source_ambiguous_names_source() {
+        let content = "# Move
+one
+# Move
+two
+# Dest
+body
+";
+        let err = move_section_in(content, "Move", content, ("before", "Dest"), true).unwrap_err();
+        assert!(matches!(
+            err,
+            MoveSectionError::Source(SectionError::Ambiguous { count: 2 })
+        ));
+        let msg = err.into_anyhow("Move", "Dest").to_string();
+        assert!(msg.contains("Move"), "got {msg}");
     }
 }

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -1,3 +1,8 @@
+//! Unified-diff parse and apply (git renames, pure renames, hunk fuzz).
+//!
+//! size-waiver: single-domain patch parse + apply + pure renames (#2101).
+//! Co-located tests push line count. Policy #1408 — do not split for LOC alone.
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -73,12 +78,76 @@ fn is_file_header(lines: &[&str], idx: usize) -> bool {
     idx == 0
 }
 
+/// Parse `diff --git a/old b/new` into (old, new) relative paths.
+fn parse_diff_git_paths(line: &str) -> Option<(String, String)> {
+    let rest = line.strip_prefix("diff --git ")?;
+    // Format: a/path b/path (paths may contain spaces only when C-quoted).
+    let mut parts = rest.splitn(2, " b/");
+    let a = parts.next()?.strip_prefix("a/")?;
+    let b = parts.next()?;
+    if a.is_empty() || b.is_empty() {
+        return None;
+    }
+    Some((a.to_string(), b.to_string()))
+}
+
 pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
     let lines: Vec<&str> = input.lines().collect();
     let mut files: Vec<PatchFile> = Vec::new();
     let mut i = 0;
 
     while i < lines.len() {
+        // Pure git rename (100% similarity) often has no ---/+++ headers:
+        //   diff --git a/old b/new
+        //   similarity index 100%
+        //   rename from old
+        //   rename to new
+        if lines[i].starts_with("diff --git ")
+            && (i + 1 >= lines.len() || !is_file_header(&lines, i + 1))
+        {
+            // Look ahead for rename from/to before next file/diff.
+            let mut rename_from_meta: Option<String> = None;
+            let mut rename_to_meta: Option<String> = None;
+            let mut j = i + 1;
+            while j < lines.len() && !lines[j].starts_with("diff ") && !is_file_header(&lines, j) {
+                if let Some(rest) = lines[j].strip_prefix("rename from ") {
+                    rename_from_meta = Some(rest.to_string());
+                } else if let Some(rest) = lines[j].strip_prefix("rename to ") {
+                    rename_to_meta = Some(rest.to_string());
+                } else if lines[j].starts_with("@@ ") {
+                    // Has hunks under this diff without ---/+++; fall through
+                    // to normal scan (should not happen in git format).
+                    break;
+                }
+                j += 1;
+            }
+            // If the next real header is ---/+++ for this same rename, let the
+            // normal path consume it (may include content hunks).
+            if j < lines.len() && is_file_header(&lines, j) {
+                i = j;
+                // fall through to ---/+++ handler below (no continue)
+            } else if let (Some(from), Some(to)) = (rename_from_meta, rename_to_meta) {
+                // Pure rename: require explicit rename from/to (never infer from
+                // path inequality alone — that mis-classifies copy as rename
+                // and would delete the source on apply).
+                files.push(PatchFile {
+                    path: to,
+                    hunks: Vec::new(),
+                    is_creation: false,
+                    is_deletion: false,
+                    rename_from: Some(from),
+                });
+                i = j;
+                continue;
+            } else {
+                // copy from/to or incomplete meta: skip this diff line; do not
+                // treat as rename (avoids deleting the source of a copy).
+                let _ = parse_diff_git_paths(lines[i]);
+                i += 1;
+                continue;
+            }
+        }
+
         if !is_file_header(&lines, i) {
             i += 1;
             continue;
@@ -143,14 +212,22 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
                     old_no_final_newline,
                     new_no_final_newline,
                 });
+            } else if lines[i].starts_with("diff ") {
+                break;
             } else {
                 i += 1;
             }
         }
 
-        if hunks.is_empty() {
+        // Empty hunks are valid for pure renames (100% similarity, no content
+        // change). Other empty-hunk files remain a parse error.
+        if hunks.is_empty() && rename_from.is_none() && !is_creation && !is_deletion {
             return Err(format!("no hunks found for file {path}"));
         }
+        if hunks.is_empty() && is_creation {
+            return Err(format!("no hunks found for file {path}"));
+        }
+        // Deletion without hunks is already allowed by apply path.
 
         files.push(PatchFile {
             path,
@@ -819,6 +896,19 @@ where
         } else {
             load_original(load_path)?
         };
+        // Pure rename (empty hunks): keep content, stage rename only.
+        if pf.rename_from.is_some() && pf.hunks.is_empty() && !pf.is_deletion && !pf.is_creation {
+            results.push(PatchApplyFileResult {
+                path: pf.path.clone(),
+                content: original,
+                status: ApplyHunksStatus::Clean,
+                conflicts: Vec::new(),
+                is_creation: false,
+                is_deletion: false,
+                rename_from: pf.rename_from.clone(),
+            });
+            continue;
+        }
         // File deletion: still run hunk application so stale context fails
         // closed (check and apply must agree). Skipping hunks always deleted
         // even when the file was edited after the patch was made.

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1270,4 +1270,83 @@ mod regression {
         assert_eq!(results[0].rename_from.as_deref(), Some("old_name.rs"));
         assert_eq!(results[0].content, "new\n");
     }
+
+    #[test]
+    fn parse_pure_git_rename_without_hunks() {
+        // 100% similarity rename: no ---/+++ and no @@ hunks.
+        let diff = "\
+diff --git a/old_name.rs b/new_name.rs
+similarity index 100%
+rename from old_name.rs
+rename to new_name.rs
+";
+        let files = parse_patch(diff).expect("pure rename should parse");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "new_name.rs");
+        assert_eq!(files[0].rename_from.as_deref(), Some("old_name.rs"));
+        assert!(files[0].hunks.is_empty());
+        assert!(!files[0].is_creation);
+        assert!(!files[0].is_deletion);
+    }
+
+    #[test]
+    fn parse_rename_with_headers_but_no_hunks() {
+        let diff = "\
+diff --git a/old.rs b/new.rs
+similarity index 100%
+rename from old.rs
+rename to new.rs
+--- a/old.rs
++++ b/new.rs
+";
+        let files = parse_patch(diff).expect("rename headers without hunks");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "new.rs");
+        assert_eq!(files[0].rename_from.as_deref(), Some("old.rs"));
+        assert!(files[0].hunks.is_empty());
+    }
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn apply_pure_rename_keeps_content() {
+        use crate::ops::patch::{ApplyHunksOptions, apply_patch_with_loader};
+        let mut files = std::collections::HashMap::new();
+        files.insert("old.rs".to_string(), "unchanged body\n".to_string());
+        let results = apply_patch_with_loader(
+            "\
+diff --git a/old.rs b/new.rs
+similarity index 100%
+rename from old.rs
+rename to new.rs
+",
+            |path| {
+                files
+                    .get(path)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("missing {path}"))
+            },
+            ApplyHunksOptions::default(),
+        )
+        .expect("apply pure rename");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "new.rs");
+        assert_eq!(results[0].rename_from.as_deref(), Some("old.rs"));
+        assert_eq!(results[0].content, "unchanged body\n");
+    }
+
+    #[test]
+    fn copy_from_to_is_not_parsed_as_rename() {
+        // Must not treat copy as rename (would delete source on apply).
+        let diff = "\
+diff --git a/foo.rs b/bar.rs
+similarity index 100%
+copy from foo.rs
+copy to bar.rs
+";
+        let err = parse_patch(diff).unwrap_err();
+        assert!(
+            err.contains("no files") || err.contains("no hunks"),
+            "copy must not become a rename file entry, got: {err}"
+        );
+    }
 }

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -14,10 +14,13 @@ fn collect_ast_source_files(dir: &Path) -> anyhow::Result<Vec<PathBuf>> {
     {
         use ignore::WalkBuilder;
         let mut files = Vec::new();
+        // Match CLI/library walks: never enter .git / .patchloom (even with
+        // hidden=false so other dotfiles can still be considered).
         let walker = WalkBuilder::new(dir)
             .follow_links(false)
             .standard_filters(true)
             .hidden(false)
+            .filter_entry(|e| !crate::files::should_skip_walk_dirname(e.file_name()))
             .build();
         for entry in walker {
             let entry = entry.map_err(|e| {
@@ -46,6 +49,10 @@ fn collect_ast_source_files_simple(dir: &Path, out: &mut Vec<PathBuf>) -> anyhow
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
+        let name = entry.file_name();
+        if name == ".git" || name == ".patchloom" {
+            continue;
+        }
         let ft = entry.file_type()?;
         if ft.is_symlink() {
             continue;
@@ -572,5 +579,25 @@ mod tests {
             !names.contains(&"inside.rs".to_string()),
             "must not follow symlink dir: {names:?}"
         );
+    }
+
+    #[test]
+    fn collect_skips_git_and_patchloom_dirs() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir_all(dir.path().join(".git/objects")).unwrap();
+        fs::write(dir.path().join(".git/objects/fake.rs"), "fn fake() {}\n").unwrap();
+        fs::create_dir_all(dir.path().join(".patchloom/backups")).unwrap();
+        fs::write(
+            dir.path().join(".patchloom/backups/also.rs"),
+            "fn also() {}\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("root.rs"), "fn root() {}\n").unwrap();
+        let files = collect_ast_source_files(dir.path()).unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+            .collect();
+        assert_eq!(names, vec!["root.rs".to_string()], "got {names:?}");
     }
 }

--- a/src/tx/md_op.rs
+++ b/src/tx/md_op.rs
@@ -151,13 +151,7 @@ pub(crate) fn execute_md_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Res
             };
             let (new_source, new_dest) =
                 move_section_in(&source_content, heading, &dest_content, position, same_file)
-                    .map_err(|e| match e {
-                        crate::ops::md::SectionError::NotFound => crate::exit::NoMatchError {
-                            msg: "md.move_section: heading or target not found".to_string(),
-                        }
-                        .into(),
-                        other => other.into_anyhow(heading),
-                    })?;
+                    .map_err(|e| e.into_anyhow(heading, position.1))?;
             tx.write_file(&source_path, new_source);
             if !same_file {
                 tx.write_file(&dest_path, new_dest);

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -293,6 +293,51 @@ fn test_patch_check_exits_2_when_would_change() {
 }
 
 #[test]
+fn test_patch_check_pure_rename_exits_2() {
+    // 100% similarity rename: content unchanged but path moves.
+    // Check must report would_change (exit 2), not success 0.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.rs"), "fn main() {}\n").unwrap();
+
+    let patch_file = dir.path().join("rename.patch");
+    fs::write(
+        &patch_file,
+        "diff --git a/old.rs b/new.rs\n\
+         similarity index 100%\n\
+         rename from old.rs\n\
+         rename to new.rs\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("check")
+        .arg(&patch_file)
+        .assert()
+        .code(2);
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert!(!dir.path().join("old.rs").exists(), "source removed");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new.rs")).unwrap(),
+        "fn main() {}\n"
+    );
+}
+
+#[test]
 fn test_patch_apply_check_counts_only_changed_files() {
     let dir = TempDir::new().unwrap();
     // File with a real change.


### PR DESCRIPTION
## Summary

Follow-up polish from the #2103 review:

1. **Pure git renames without hunks** — parse `diff --git` + `rename from`/`rename to` (no `@@` required); apply keeps content and stages path rename. `patch check` reports exit 2 / would_change for path renames. Explicit rename meta required so **copy** is never treated as rename.
2. **move_section dest messages** — `MoveSectionError::{Source,Dest}` so ambiguous/missing target headings name the before/after heading, not the source.
3. **ast.rename walk** — reuse `should_skip_walk_dirname` so `.git` / `.patchloom` are never entered (CLI collector parity).

## Test plan

- [x] Unit: pure rename parse/apply, copy not rename, dest/source ambiguous messages, skip .git/.patchloom
- [x] Integration: pure rename check exit 2 + apply renames file
- [x] `make check-fast`
- [x] Reviewer pass (fixed check honesty + copy false-rename)
- [ ] CI green