### PR TITLE
fix: C-quoted pure renames and Preview changed for path renames

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -311,7 +311,7 @@ pub struct EditResult {
     pub diff: String,
     /// Whether the file was actually written to disk.
     pub applied: bool,
-    /// Whether the content changed.
+    /// Whether apply would mutate the tree (content and/or path rename).
     pub changed: bool,
     /// Action/kind of the edit (e.g. "append", "create", "replace", "rename", "doc.set").
     /// Helps agent hosts distinguish cross-file or op type without parsing path.

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -243,9 +243,27 @@ pub fn apply_patch_file(
     };
 
     let mut results = Vec::with_capacity(staged.len());
-    for (_abs, display, original, new_content, _) in staged {
+    for (_abs, display, original, new_content, delete_after) in staged {
         let mut edit =
             super::build_edit_result(&display, original, new_content, applied, "patch", None);
+        // Path rename (any rename_from with a distinct write target): content may
+        // equal original (pure rename), but the tree still changes. Hosts branch
+        // on `changed` for Preview; report path=old, dest_path=new like file_rename.
+        if delete_after
+            .as_ref()
+            .is_some_and(|old| old.as_path() != _abs.as_path())
+        {
+            edit.changed = true;
+            if let Some(old) = delete_after.as_ref() {
+                let old_display = old
+                    .strip_prefix(cwd)
+                    .unwrap_or(old.as_path())
+                    .to_string_lossy()
+                    .into_owned();
+                edit.dest_path = Some(display.clone());
+                edit.path = old_display;
+            }
+        }
         // Same session id on every file result so hosts can undo once.
         edit.backup_session = backup_session.clone();
         results.push(edit);

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1091,6 +1091,68 @@ fn apply_patch_file_applies_multi_file_patch() {
     assert_eq!(sessions[0], sessions[1], "both files share one session");
 }
 
+/// Pure rename Preview: content may be unchanged, but path moves so `changed`
+/// must be true and path/dest_path must report old → new for host branching.
+#[test]
+fn apply_patch_file_pure_rename_preview_sets_changed_and_paths() {
+    let dir = TempDir::new().unwrap();
+    let old = dir.path().join("old.rs");
+    fs::write(&old, "fn main() {}\n").unwrap();
+
+    let patch = "\
+diff --git a/old.rs b/new.rs\n\
+similarity index 100%\n\
+rename from old.rs\n\
+rename to new.rs\n";
+
+    let results = apply_patch_file(patch, dir.path(), ApplyMode::Preview, None).unwrap();
+    assert_eq!(results.len(), 1);
+    let r = &results[0];
+    assert!(
+        r.changed,
+        "pure rename Preview must set changed=true even when content equals original"
+    );
+    assert!(!r.applied);
+    assert_eq!(r.path, "old.rs");
+    assert_eq!(r.dest_path.as_deref(), Some("new.rs"));
+    assert_eq!(r.new_content, "fn main() {}\n");
+    // Preview must not mutate the tree.
+    assert!(old.exists(), "source still present in Preview");
+    assert!(!dir.path().join("new.rs").exists());
+}
+
+/// C-quoted pure rename through the library API (spaces in paths).
+#[test]
+fn apply_patch_file_pure_rename_c_quoted_preview() {
+    let dir = TempDir::new().unwrap();
+    let old = dir.path().join("old name.rs");
+    fs::write(&old, "body\n").unwrap();
+
+    let patch = "\
+diff --git \"a/old name.rs\" \"b/new name.rs\"\n\
+similarity index 100%\n\
+rename from \"old name.rs\"\n\
+rename to \"new name.rs\"\n";
+
+    let results = apply_patch_file(patch, dir.path(), ApplyMode::Preview, None).unwrap();
+    assert_eq!(results.len(), 1);
+    let r = &results[0];
+    assert!(r.changed);
+    assert_eq!(r.path, "old name.rs");
+    assert_eq!(r.dest_path.as_deref(), Some("new name.rs"));
+
+    let applied = apply_patch_file(patch, dir.path(), ApplyMode::Apply, None).unwrap();
+    assert_eq!(applied.len(), 1);
+    assert!(applied[0].changed && applied[0].applied);
+    assert_eq!(applied[0].path, "old name.rs");
+    assert_eq!(applied[0].dest_path.as_deref(), Some("new name.rs"));
+    assert!(!old.exists(), "source removed on Apply");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new name.rs")).unwrap(),
+        "body\n"
+    );
+}
+
 /// Multi-file Apply must not leave a half-applied tree when a later file fails
 /// hunk preflight (stale context). Previously wrote earlier files then Err.
 #[test]

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -78,17 +78,69 @@ fn is_file_header(lines: &[&str], idx: usize) -> bool {
     idx == 0
 }
 
+/// Strip optional Git C-quotes from a path token (`"my file.rs"` → `my file.rs`).
+fn unquote_git_path_meta(s: &str) -> String {
+    let s = s.trim();
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        unquote_git_c_string(&s[1..s.len() - 1])
+    } else {
+        s.to_string()
+    }
+}
+
 /// Parse `diff --git a/old b/new` into (old, new) relative paths.
+/// Handles C-quoted paths with spaces: `diff --git "a/my f.rs" "b/other f.rs"`.
 fn parse_diff_git_paths(line: &str) -> Option<(String, String)> {
     let rest = line.strip_prefix("diff --git ")?;
-    // Format: a/path b/path (paths may contain spaces only when C-quoted).
+    // Prefer quoted form first.
+    if rest.starts_with('"') {
+        // "a/..." "b/..."
+        let mut chars = rest.chars().peekable();
+        let mut parts = Vec::new();
+        while chars.peek().is_some() {
+            while matches!(chars.peek(), Some(c) if c.is_whitespace()) {
+                chars.next();
+            }
+            if chars.peek() != Some(&'"') {
+                break;
+            }
+            chars.next(); // opening "
+            // Keep escapes intact; unquote_git_c_string handles \n, \", \\, etc.
+            let mut raw = String::new();
+            while let Some(c) = chars.next() {
+                if c == '\\' {
+                    raw.push('\\');
+                    if let Some(n) = chars.next() {
+                        raw.push(n);
+                    }
+                } else if c == '"' {
+                    break;
+                } else {
+                    raw.push(c);
+                }
+            }
+            parts.push(unquote_git_c_string(&raw));
+            if parts.len() == 2 {
+                break;
+            }
+        }
+        if parts.len() == 2 {
+            let a = parts[0].strip_prefix("a/").unwrap_or(&parts[0]);
+            let b = parts[1].strip_prefix("b/").unwrap_or(&parts[1]);
+            if !a.is_empty() && !b.is_empty() {
+                return Some((a.to_string(), b.to_string()));
+            }
+        }
+        return None;
+    }
+    // Unquoted: a/path b/path (split on " b/").
     let mut parts = rest.splitn(2, " b/");
     let a = parts.next()?.strip_prefix("a/")?;
     let b = parts.next()?;
     if a.is_empty() || b.is_empty() {
         return None;
     }
-    Some((a.to_string(), b.to_string()))
+    Some((unquote_git_path_meta(a), unquote_git_path_meta(b)))
 }
 
 pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
@@ -111,9 +163,10 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
             let mut j = i + 1;
             while j < lines.len() && !lines[j].starts_with("diff ") && !is_file_header(&lines, j) {
                 if let Some(rest) = lines[j].strip_prefix("rename from ") {
-                    rename_from_meta = Some(rest.to_string());
+                    // C-quoted paths with spaces: rename from "my file.rs"
+                    rename_from_meta = Some(unquote_git_path_meta(rest));
                 } else if let Some(rest) = lines[j].strip_prefix("rename to ") {
-                    rename_to_meta = Some(rest.to_string());
+                    rename_to_meta = Some(unquote_git_path_meta(rest));
                 } else if lines[j].starts_with("@@ ") {
                     // Has hunks under this diff without ---/+++; fall through
                     // to normal scan (should not happen in git format).

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1349,4 +1349,63 @@ copy to bar.rs
             "copy must not become a rename file entry, got: {err}"
         );
     }
+
+    #[test]
+    fn parse_pure_git_rename_c_quoted_paths_with_spaces() {
+        // Git C-quotes paths with spaces on pure renames (no hunks).
+        let diff = "\
+diff --git \"a/old name.rs\" \"b/new name.rs\"
+similarity index 100%
+rename from \"old name.rs\"
+rename to \"new name.rs\"
+";
+        let files = parse_patch(diff).expect("C-quoted pure rename should parse");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "new name.rs");
+        assert_eq!(files[0].rename_from.as_deref(), Some("old name.rs"));
+        assert!(files[0].hunks.is_empty());
+    }
+
+    #[test]
+    fn parse_diff_git_c_quoted_paths_with_escape() {
+        // Nested quote in path: git uses \" inside C-quoted tokens.
+        let diff = "\
+diff --git \"a/say\\\"hi.rs\" \"b/say\\\"bye.rs\"
+similarity index 100%
+rename from \"say\\\"hi.rs\"
+rename to \"say\\\"bye.rs\"
+";
+        let files = parse_patch(diff).expect("escaped quotes in C-quoted rename");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "say\"bye.rs");
+        assert_eq!(files[0].rename_from.as_deref(), Some("say\"hi.rs"));
+    }
+
+    #[cfg(any(feature = "cli", feature = "files"))]
+    #[test]
+    fn apply_pure_rename_c_quoted_paths() {
+        use crate::ops::patch::{ApplyHunksOptions, apply_patch_with_loader};
+        let mut files = std::collections::HashMap::new();
+        files.insert("old name.rs".to_string(), "body\n".to_string());
+        let results = apply_patch_with_loader(
+            "\
+diff --git \"a/old name.rs\" \"b/new name.rs\"
+similarity index 100%
+rename from \"old name.rs\"
+rename to \"new name.rs\"
+",
+            |path| {
+                files
+                    .get(path)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("missing {path}"))
+            },
+            ApplyHunksOptions::default(),
+        )
+        .expect("apply C-quoted pure rename");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "new name.rs");
+        assert_eq!(results[0].rename_from.as_deref(), Some("old name.rs"));
+        assert_eq!(results[0].content, "body\n");
+    }
 }

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -338,6 +338,50 @@ fn test_patch_check_pure_rename_exits_2() {
 }
 
 #[test]
+fn test_patch_check_pure_rename_c_quoted_paths() {
+    // Git C-quotes paths with spaces; check/apply must unquote and move.
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old name.rs"), "fn main() {}\n").unwrap();
+
+    let patch_file = dir.path().join("rename.patch");
+    fs::write(
+        &patch_file,
+        "diff --git \"a/old name.rs\" \"b/new name.rs\"\n\
+         similarity index 100%\n\
+         rename from \"old name.rs\"\n\
+         rename to \"new name.rs\"\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("check")
+        .arg(&patch_file)
+        .assert()
+        .code(2);
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert!(!dir.path().join("old name.rs").exists(), "source removed");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new name.rs")).unwrap(),
+        "fn main() {}\n"
+    );
+}
+
+#[test]
 fn test_patch_apply_check_counts_only_changed_files() {
     let dir = TempDir::new().unwrap();
     // File with a real change.


### PR DESCRIPTION
## Summary

Follow-up polish after #2104 for pure git renames:

1. **C-quoted paths with spaces** — Git C-quotes rename paths (`diff --git "a/old name.rs" "b/new name.rs"`, `rename from "old name.rs"`). Parser now unquotes those tokens (including escapes) so pure renames with spaces resolve correctly.
2. **Preview `changed` for path renames** — `apply_patch_file` forces `EditResult.changed = true` when the path moves even if content is identical, and reports `path` = old / `dest_path` = new so hosts can branch on Preview the same way as `file_rename`.

## Tests

- Unit: parse C-quoted pure rename + escaped quotes; apply via loader
- Library API: pure rename Preview `changed`/`path`/`dest_path`; C-quoted Preview + Apply
- Integration: CLI `patch check` exit 2 and `patch apply` for C-quoted pure rename

## Reviewer

APPROVE_WITH_NITS (nits addressed: comment wording, Apply path asserts, `EditResult.changed` doc).

## Verification

- `make check-fast` green locally
- Targeted pure-rename unit + integration tests green