### PR TITLE
fix: refuse patch rename overwrite; multi-surface pure rename locks

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -926,7 +926,7 @@ Use these when the change already exists as a unified diff.
 <!-- ref:patch-action:check -->
 ### `patch check`
 
-- **What it does:** Dry-run a unified diff without writing. Per-file status is `would_change` (exit 2) when the patch applies and content would change, `unchanged` when the result equals the current file, or `stale`/`missing`/`error` (exit 5) when the patch cannot apply.
+- **What it does:** Dry-run a unified diff without writing. Per-file status is `would_change` (exit 2) when the patch applies and content would change (including pure git renames where content is identical but the path moves), `unchanged` when the result equals the current file, or fail-closed statuses for problems (`missing` → `not_found`, rename dest exists → `already_exists`, `stale` → `ambiguous` / exit 5).
 - **Use when:** CI or agents need the same “would change” signal as `patch apply` preview before committing to `--apply`.
 - **Prefer instead:** Use `patch apply` when the patch should be written, or `replace` and `doc` when you do not actually need to carry a diff file.
 - **JSON:** Includes `applied: false`. Do not treat historical status `clean` as “nothing to do”; that name meant “applies without fuzz” and confused agents.
@@ -934,8 +934,9 @@ Use these when the change already exists as a unified diff.
 <!-- ref:patch-action:apply -->
 ### `patch apply`
 
-- **What it does:** Applies a unified diff. Use `--on-stale merge` to retry with three-way merge when context is stale.
+- **What it does:** Applies a unified diff, including git renames with hunks and pure renames (`similarity index 100%` with `rename from` / `rename to`, optional C-quoted paths with spaces). Use `--on-stale merge` to retry with three-way merge when context is stale.
 - **Use when:** The desired change is already available as patch text and should be replayed directly.
+- **Failure behavior:** Missing rename/source target → `not_found`. Git rename destination already present → `already_exists` (same policy as `rename` without `--force`; remove the dest or use `file.rename --force`).
 - **Prefer instead:** Use `replace`, `md`, or `doc` when you would rather describe the desired mutation at a higher level.
 
 <!-- ref:patch-action:merge -->

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -88,6 +88,17 @@ fn patch_write(
         let load_rel = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
         let load_path = cwd.join(load_rel);
         let write_path = cwd.join(&pf.path);
+        if let Some(from) = pf.rename_from.as_deref()
+            && crate::ops::patch::rename_would_clobber_dest(
+                from,
+                &pf.path,
+                crate::ops::file::path_entry_exists(&write_path),
+            )
+        {
+            return Err(anyhow::Error::new(crate::exit::AlreadyExistsError {
+                msg: crate::ops::patch::rename_dest_exists_msg(&pf.path),
+            }));
+        }
         // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
         let original = if pf.is_creation {
             String::new()
@@ -163,6 +174,17 @@ pub fn apply_patch_file(
         let load_rel = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
         let load_path = cwd.join(load_rel);
         let write_path = cwd.join(&pf.path);
+        if let Some(from) = pf.rename_from.as_deref()
+            && crate::ops::patch::rename_would_clobber_dest(
+                from,
+                &pf.path,
+                crate::ops::file::path_entry_exists(&write_path),
+            )
+        {
+            return Err(anyhow::Error::new(crate::exit::AlreadyExistsError {
+                msg: crate::ops::patch::rename_dest_exists_msg(&pf.path),
+            }));
+        }
         // Strict sole-path (#1894). Creation: empty original.
         let original = if pf.is_creation {
             String::new()

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1091,6 +1091,34 @@ fn apply_patch_file_applies_multi_file_patch() {
     assert_eq!(sessions[0], sessions[1], "both files share one session");
 }
 
+/// Patch rename must not overwrite an existing destination (file.rename parity).
+#[test]
+fn apply_patch_file_rename_refuses_existing_dest() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.rs"), "source\n").unwrap();
+    fs::write(dir.path().join("new.rs"), "dest-existing\n").unwrap();
+
+    let patch = "\
+diff --git a/old.rs b/new.rs\n\
+similarity index 100%\n\
+rename from old.rs\n\
+rename to new.rs\n";
+
+    let err = apply_patch_file(patch, dir.path(), ApplyMode::Apply, None).unwrap_err();
+    assert!(
+        crate::exit::is_already_exists(&err),
+        "expected already_exists, got: {err}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("old.rs")).unwrap(),
+        "source\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new.rs")).unwrap(),
+        "dest-existing\n"
+    );
+}
+
 /// Pure rename Preview: content may be unchanged, but path moves so `changed`
 /// must be true and path/dest_path must report old → new for host branching.
 #[test]

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -314,11 +314,23 @@ fn patch_problem_kind(results: &[PatchFileResult]) -> (&'static str, String, u8)
     let has_missing = results.iter().any(|r| r.status == "missing");
     let has_error = results.iter().any(|r| r.status == "error");
     let has_conflict = results.iter().any(|r| r.status == "conflict");
+    let has_already_exists = results.iter().any(|r| {
+        r.status == "already_exists"
+            || r.error
+                .as_deref()
+                .is_some_and(|e| e.contains("destination already exists"))
+    });
     if has_conflict {
         (
             "conflicts",
             "one or more patch targets have merge conflicts".into(),
             exit::CONFLICTS,
+        )
+    } else if has_already_exists {
+        (
+            "already_exists",
+            "one or more patch rename destinations already exist".into(),
+            exit::FAILURE,
         )
     } else if has_stale {
         (
@@ -568,6 +580,24 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
             // Pure rename: content may match original, but apply still moves
             // the path — report would_change so agents do not skip apply.
             let is_path_rename = pf.rename_from.as_ref().is_some_and(|from| from != &pf.path);
+            if let Some(from) = pf.rename_from.as_deref() {
+                let dest_path = cwd.join(&pf.path);
+                if crate::ops::patch::rename_would_clobber_dest(
+                    from,
+                    &pf.path,
+                    crate::ops::file::path_entry_exists(&dest_path),
+                ) {
+                    let msg = crate::ops::patch::rename_dest_exists_msg(&pf.path);
+                    results.push(PatchFileResult {
+                        path: pf.path.clone(),
+                        status: "already_exists",
+                        error: Some(msg),
+                        conflicts: None,
+                    });
+                    any_problem = true;
+                    continue;
+                }
+            }
             match apply_hunks(&original, &pf.hunks) {
                 Ok(new_content) if new_content == original && !is_path_rename => {
                     results.push(PatchFileResult {

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -38,6 +38,29 @@ pub struct PatchFile {
     pub rename_from: Option<String>,
 }
 
+/// True when a git rename would overwrite an existing destination that is not
+/// a case-only rename of the source (parity with `file.rename` without force).
+///
+/// Callers supply `dest_exists` from disk or tx pending state.
+pub fn rename_would_clobber_dest(from: &str, to: &str, dest_exists: bool) -> bool {
+    if !dest_exists || from == to {
+        return false;
+    }
+    let from_path = std::path::Path::new(from);
+    let to_path = std::path::Path::new(to);
+    let case_only = from_path.parent() == to_path.parent()
+        && from_path.file_name().map(|n| n.to_ascii_lowercase())
+            == to_path.file_name().map(|n| n.to_ascii_lowercase());
+    !case_only
+}
+
+/// Error message when [`rename_would_clobber_dest`] is true.
+pub fn rename_dest_exists_msg(to: &str) -> String {
+    format!(
+        "destination already exists: {to} (patch rename refuses overwrite; remove dest or use file.rename --force)"
+    )
+}
+
 /// Check whether line `idx` is a real file header ("--- " followed by "+++"),
 /// not a removed line whose content happens to start with "-- " (e.g. SQL
 /// comments produce `--- comment text` in the diff).

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1351,6 +1351,18 @@ copy to bar.rs
     }
 
     #[test]
+    fn rename_would_clobber_dest_true_when_dest_exists() {
+        assert!(rename_would_clobber_dest("old.rs", "new.rs", true));
+        assert!(!rename_would_clobber_dest("old.rs", "new.rs", false));
+        assert!(!rename_would_clobber_dest("same.rs", "same.rs", true));
+        // Case-only rename must not clobber (case-insensitive FS dest "exists").
+        assert!(!rename_would_clobber_dest("old.rs", "OLD.rs", true));
+        assert!(!rename_would_clobber_dest("dir/a.rs", "dir/A.rs", true));
+        // Different basenames still clobber.
+        assert!(rename_would_clobber_dest("dir/a.rs", "dir/b.rs", true));
+    }
+
+    #[test]
     fn parse_pure_git_rename_c_quoted_paths_with_spaces() {
         // Git C-quotes paths with spaces on pure renames (no hunks).
         let diff = "\

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -352,6 +352,10 @@ pub(crate) fn build_tx_output_with_meta(
         renamed_count += 1;
     }
 
+    // O(1) membership for deletion/refuse loops (AI finding + large-tx scale).
+    let change_paths: HashSet<&std::path::Path> =
+        changes.iter().map(|(c, _, _)| c.as_path()).collect();
+
     for (path, original, new_content) in changes {
         // Covered by a renamed entry (source deleted / dest created).
         if rename_from.contains(path) || rename_to.contains(path) {
@@ -420,7 +424,7 @@ pub(crate) fn build_tx_output_with_meta(
         if rename_from.contains(path) {
             continue;
         }
-        if !changes.iter().any(|(c, _, _)| c == path) {
+        if !change_paths.contains(path.as_path()) {
             let (match_mode, match_score, match_count, matched_text) =
                 match_meta_for_path(path, replace_match_meta);
             if let Some(m) = replace_match_meta.get(path) {
@@ -476,7 +480,7 @@ pub(crate) fn build_tx_output_with_meta(
     // do not treat overall ok as "every replace applied".
     let mut refused = Vec::new();
     for (path, m) in replace_match_meta {
-        if changes.iter().any(|(c, _, _)| c == path) || deletions.contains(path) {
+        if change_paths.contains(path.as_path()) || deletions.contains(path) {
             continue;
         }
         // Only surface zero-match soft skips (writes already listed in changes).

--- a/src/tx/patch_op.rs
+++ b/src/tx/patch_op.rs
@@ -35,6 +35,19 @@ pub(crate) fn execute_patch_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::
                     // Git rename: load was from `from`; stage rename + new content (#2101).
                     let from_path = tx.cwd.join(from);
                     let to_path = tx.cwd.join(&result.path);
+                    // Refuse overwrite of an existing dest (parity with file.rename
+                    // without force). Case-only renames still allowed.
+                    let dest_exists = (tx.pending.contains_key(&to_path)
+                        && !tx.deletions.contains(&to_path))
+                        || (!tx.deletions.contains(&to_path)
+                            && crate::ops::file::path_entry_exists(&to_path));
+                    if crate::ops::patch::rename_would_clobber_dest(from, &result.path, dest_exists)
+                    {
+                        return Err(crate::exit::AlreadyExistsError {
+                            msg: crate::ops::patch::rename_dest_exists_msg(&result.path),
+                        }
+                        .into());
+                    }
                     // Ensure source is in pending (loader already did); record rename
                     // so commit uses fs::rename then write dest content.
                     if !tx.existed_before.contains(&from_path)
@@ -45,7 +58,7 @@ pub(crate) fn execute_patch_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::
                     if crate::ops::file::path_entry_exists(&to_path)
                         && !tx.existed_before.contains(&to_path)
                     {
-                        // Dest exists: soft-load so commit overwrites rather than create_new.
+                        // Dest exists only for case-only renames after the check above.
                         let _ = read_file_content(tx.pending, tx.existed_before, &to_path)?;
                     }
                     tx.renames.push((from_path.clone(), to_path.clone()));

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1213,6 +1213,38 @@ async fn test_mcp_patch_round_trip() {
     client.cancel().await.unwrap();
 }
 
+/// Pure git rename (100% similarity, no hunks) via MCP apply_patch.
+/// Multi-surface lock: unit/CLI already cover; agents use MCP (#2104 follow-up).
+#[tokio::test]
+async fn test_mcp_apply_patch_pure_rename() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.rs"), "fn main() {}\n").unwrap();
+
+    let diff = "\
+diff --git a/old.rs b/new.rs\n\
+similarity index 100%\n\
+rename from old.rs\n\
+rename to new.rs\n";
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "apply_patch", serde_json::json!({"diff": diff})).await;
+    assert!(!is_error, "pure rename via MCP should succeed: {val}");
+    assert_eq!(val["ok"], true, "pure rename ok: {val}");
+    assert!(
+        !dir.path().join("old.rs").exists(),
+        "source removed after pure rename"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new.rs")).unwrap(),
+        "fn main() {}\n"
+    );
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_apply_patch_on_stale_merge() {
     if !has_mcp_support() {

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -338,6 +338,59 @@ fn test_patch_check_pure_rename_exits_2() {
 }
 
 #[test]
+fn test_patch_rename_refuses_existing_dest() {
+    // file.rename refuses without --force; patch rename must match (not clobber).
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.rs"), "source\n").unwrap();
+    fs::write(dir.path().join("new.rs"), "dest-existing\n").unwrap();
+
+    let patch_file = dir.path().join("rename.patch");
+    fs::write(
+        &patch_file,
+        "diff --git a/old.rs b/new.rs\n\
+         similarity index 100%\n\
+         rename from old.rs\n\
+         rename to new.rs\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--json")
+        .arg("patch")
+        .arg("check")
+        .arg(&patch_file)
+        .assert()
+        .code(1)
+        .stdout(predicates::str::contains("already_exists"));
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--json")
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--apply")
+        .assert()
+        .code(1)
+        .stdout(predicates::str::contains("already_exists"));
+
+    // Tree unchanged.
+    assert_eq!(
+        fs::read_to_string(dir.path().join("old.rs")).unwrap(),
+        "source\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new.rs")).unwrap(),
+        "dest-existing\n"
+    );
+}
+
+#[test]
 fn test_patch_check_pure_rename_c_quoted_paths() {
     // Git C-quotes paths with spaces; check/apply must unquote and move.
     let dir = TempDir::new().unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -3499,6 +3499,83 @@ fn test_tx_patch_apply_in_plan() {
     );
 }
 
+/// Pure git rename must refuse when dest already exists (parity with file.rename).
+#[test]
+fn test_tx_patch_apply_pure_rename_refuses_existing_dest() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.rs"), "source\n").unwrap();
+    fs::write(dir.path().join("new.rs"), "dest-existing\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "patch.apply",
+            "diff": "diff --git a/old.rs b/new.rs\nsimilarity index 100%\nrename from old.rs\nrename to new.rs\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("already_exists") || stdout.contains("destination already exists"),
+        "expected already_exists honesty, got: {stdout}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("old.rs")).unwrap(),
+        "source\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new.rs")).unwrap(),
+        "dest-existing\n"
+    );
+}
+
+/// Pure git rename (no hunks) through plan `patch.apply` (#2104 multi-surface).
+#[test]
+fn test_tx_patch_apply_pure_rename() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.rs"), "fn main() {}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "cwd": dir.path().to_str().unwrap(),
+        "operations": [{
+            "op": "patch.apply",
+            "diff": "diff --git a/old.rs b/new.rs\nsimilarity index 100%\nrename from old.rs\nrename to new.rs\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert!(
+        !dir.path().join("old.rs").exists(),
+        "source removed after pure rename via tx"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new.rs")).unwrap(),
+        "fn main() {}\n"
+    );
+}
+
 #[test]
 fn test_tx_patch_apply_uses_pending_file_state() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

MPI cycle after pure-rename polish (#2104/#2105):

1. **Bug:** pure/git path renames via `patch apply` silently overwrote an existing destination (unlike `rename` without `--force`). Now fail closed with `error_kind: already_exists` on library `apply_patch_file`, tx `patch.apply`, and CLI check/apply. Case-only renames remain allowed.
2. **Multi-surface tests:** MCP `apply_patch` pure rename + plan/tx pure rename (and dest-exists refusal).
3. **Perf:** O(1) `change_paths` HashSet when building tx JSON output (AI finding / large-tx scale).
4. **Docs:** pure renames, would_change for path moves, already_exists failure behavior.

## Follow-up

- Closes nothing product-tracked; residual tech-debt **#2106** (CLI JSON dual-file pure rename without from/to).

## Verification

- `make check-fast` green locally

## Do not merge

Release PR **#2085** remains user-gated (0.25.0).