### PR TITLE
fix: real-world rename/tx/patch honesty and containment

### DIFF
--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -162,14 +162,31 @@ pub fn apply_patch_file(
     })?;
 
     // Phase 1: preflight load + hunk apply for every file (no disk writes).
-    // Git rename: load from rename_from, write to path, delete old after apply (#2101).
-    let mut staged: Vec<(
-        std::path::PathBuf,
-        String,
-        String,
-        String,
-        Option<std::path::PathBuf>,
-    )> = Vec::new();
+    // Kinds: content write, deletion (unlink), path rename (fs::rename then optional rewrite).
+    #[derive(Clone)]
+    enum StageOp {
+        Write {
+            write_path: std::path::PathBuf,
+            display: String,
+            original: String,
+            new_content: String,
+        },
+        Delete {
+            path: std::path::PathBuf,
+            display: String,
+            original: String,
+        },
+        Rename {
+            from: std::path::PathBuf,
+            to: std::path::PathBuf,
+            from_display: String,
+            to_display: String,
+            original: String,
+            new_content: String,
+        },
+    }
+
+    let mut staged: Vec<StageOp> = Vec::new();
     for pf in &patch_files {
         let load_rel = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
         let load_path = cwd.join(load_rel);
@@ -185,15 +202,39 @@ pub fn apply_patch_file(
                 msg: crate::ops::patch::rename_dest_exists_msg(&pf.path),
             }));
         }
-        // Strict sole-path (#1894). Creation: empty original.
+
+        if pf.is_deletion {
+            // Real unlink, not empty rewrite (tx/CLI parity).
+            let original = if crate::ops::file::path_entry_exists(&load_path) {
+                crate::files::load_text_strict(&load_path, load_rel).unwrap_or_default()
+            } else {
+                String::new()
+            };
+            staged.push(StageOp::Delete {
+                path: load_path,
+                display: pf.path.clone(),
+                original,
+            });
+            continue;
+        }
+
+        // Pure path rename of non-text: soft empty snapshot (file_rename #2031).
+        let pure_rename = pf.rename_from.is_some() && pf.hunks.is_empty();
         let original = if pf.is_creation {
             String::new()
+        } else if pure_rename {
+            match crate::files::load_text_strict(&load_path, load_rel) {
+                Ok(s) => s,
+                Err(e) if crate::exit::is_binary(&e) || crate::exit::is_invalid_encoding(&e) => {
+                    String::new()
+                }
+                Err(e) => return Err(e),
+            }
         } else {
             crate::files::load_text_strict(&load_path, load_rel)?
         };
 
-        // Pure rename (empty hunks): keep content as-is.
-        let new_content = if pf.rename_from.is_some() && pf.hunks.is_empty() {
+        let new_content = if pure_rename {
             original.clone()
         } else {
             crate::ops::patch::apply_hunks(&original, &pf.hunks).map_err(|e| {
@@ -208,50 +249,110 @@ pub fn apply_patch_file(
                 }
             })?
         };
-        let delete_after = pf.rename_from.as_ref().map(|f| cwd.join(f));
-        staged.push((
-            write_path,
-            pf.path.clone(),
-            original,
-            new_content,
-            delete_after,
-        ));
+
+        if let Some(from) = pf.rename_from.as_ref() {
+            let from_path = cwd.join(from);
+            staged.push(StageOp::Rename {
+                from: from_path,
+                to: write_path,
+                from_display: from.clone(),
+                to_display: pf.path.clone(),
+                original,
+                new_content,
+            });
+        } else {
+            staged.push(StageOp::Write {
+                write_path,
+                display: pf.path.clone(),
+                original,
+                new_content,
+            });
+        }
     }
 
-    // Phase 2: one backup session covering write targets + rename sources,
-    // then all-or-nothing write; on success remove rename sources.
+    // Phase 2: one backup session, then all-or-nothing mutate.
     let policy = crate::write::WritePolicy::default();
     let (applied, backup_session) = if mode == ApplyMode::Apply {
-        for (write_path, _, _, _, delete_after) in &staged {
-            super::ensure_contained(guard, write_path)?;
-            if let Some(old) = delete_after {
-                super::ensure_contained(guard, old)?;
+        for op in &staged {
+            match op {
+                StageOp::Write { write_path, .. } => super::ensure_contained(guard, write_path)?,
+                StageOp::Delete { path, .. } => super::ensure_contained(guard, path)?,
+                StageOp::Rename { from, to, .. } => {
+                    super::ensure_contained(guard, from)?;
+                    super::ensure_contained(guard, to)?;
+                }
             }
         }
         let mut backup = crate::backup::BackupSession::new(cwd)?;
-        for (write_path, _, _, _, delete_after) in &staged {
-            if crate::ops::file::path_entry_exists(write_path) {
-                backup.save_before_write(write_path)?;
-            }
-            if let Some(old) = delete_after
-                && old != write_path
-                && crate::ops::file::path_entry_exists(old)
-            {
-                backup.save_before_write(old)?;
+        for op in &staged {
+            match op {
+                StageOp::Write { write_path, .. } => {
+                    if crate::ops::file::path_entry_exists(write_path) {
+                        backup.save_before_write(write_path)?;
+                    }
+                }
+                StageOp::Delete { path, .. } => {
+                    if crate::ops::file::path_entry_exists(path) {
+                        backup.save_before_write(path)?;
+                    }
+                }
+                StageOp::Rename { from, to, .. } => {
+                    if crate::ops::file::path_entry_exists(from) {
+                        backup.save_before_write(from)?;
+                    }
+                    if crate::ops::file::path_entry_exists(to) && to != from {
+                        backup.save_before_write(to)?;
+                    }
+                }
             }
         }
         let session = backup.finalize()?;
         let write_result = (|| -> anyhow::Result<()> {
-            for (write_path, _, _, new_content, _) in &staged {
-                crate::write::atomic_write(write_path, new_content, &policy)?;
-            }
-            for (_, _, _, _, delete_after) in &staged {
-                if let Some(old) = delete_after
-                    && crate::ops::file::path_entry_exists(old)
-                {
-                    std::fs::remove_file(old).map_err(|e| {
-                        anyhow::anyhow!("patch rename: failed to remove {}: {e}", old.display())
-                    })?;
+            for op in &staged {
+                match op {
+                    StageOp::Write {
+                        write_path,
+                        new_content,
+                        ..
+                    } => {
+                        if let Some(parent) = write_path.parent()
+                            && !parent.as_os_str().is_empty()
+                            && !parent.exists()
+                        {
+                            std::fs::create_dir_all(parent)?;
+                        }
+                        crate::write::atomic_write(write_path, new_content, &policy)?;
+                    }
+                    StageOp::Delete { path, .. } => {
+                        if crate::ops::file::path_entry_exists(path) {
+                            std::fs::remove_file(path).map_err(|e| {
+                                anyhow::anyhow!(
+                                    "patch delete: failed to remove {}: {e}",
+                                    path.display()
+                                )
+                            })?;
+                        }
+                    }
+                    StageOp::Rename {
+                        from,
+                        to,
+                        original,
+                        new_content,
+                        ..
+                    } => {
+                        // fs::rename preserves case-only renames and binary bytes
+                        // (write-dest+delete-src would delete the only inode).
+                        if let Some(parent) = to.parent()
+                            && !parent.as_os_str().is_empty()
+                            && !parent.exists()
+                        {
+                            std::fs::create_dir_all(parent)?;
+                        }
+                        crate::ops::file::rename_or_copy(from, to)?;
+                        if new_content != original {
+                            crate::write::atomic_write(to, new_content, &policy)?;
+                        }
+                    }
                 }
             }
             Ok(())
@@ -265,28 +366,49 @@ pub fn apply_patch_file(
     };
 
     let mut results = Vec::with_capacity(staged.len());
-    for (_abs, display, original, new_content, delete_after) in staged {
-        let mut edit =
-            super::build_edit_result(&display, original, new_content, applied, "patch", None);
-        // Path rename (any rename_from with a distinct write target): content may
-        // equal original (pure rename), but the tree still changes. Hosts branch
-        // on `changed` for Preview; report path=old, dest_path=new like file_rename.
-        if delete_after
-            .as_ref()
-            .is_some_and(|old| old.as_path() != _abs.as_path())
-        {
-            edit.changed = true;
-            if let Some(old) = delete_after.as_ref() {
-                let old_display = old
-                    .strip_prefix(cwd)
-                    .unwrap_or(old.as_path())
-                    .to_string_lossy()
-                    .into_owned();
-                edit.dest_path = Some(display.clone());
-                edit.path = old_display;
+    for op in staged {
+        let mut edit = match op {
+            StageOp::Write {
+                display,
+                original,
+                new_content,
+                ..
+            } => super::build_edit_result(&display, original, new_content, applied, "patch", None),
+            StageOp::Delete {
+                display, original, ..
+            } => {
+                let mut e = super::build_edit_result(
+                    &display,
+                    original,
+                    String::new(),
+                    applied,
+                    "patch",
+                    None,
+                );
+                e.changed = true;
+                e
             }
-        }
-        // Same session id on every file result so hosts can undo once.
+            StageOp::Rename {
+                from_display,
+                to_display,
+                original,
+                new_content,
+                ..
+            } => {
+                let mut e = super::build_edit_result(
+                    &to_display,
+                    original,
+                    new_content,
+                    applied,
+                    "patch",
+                    Some(to_display.clone()),
+                );
+                e.changed = true;
+                e.path = from_display;
+                e.dest_path = Some(to_display);
+                e
+            }
+        };
         edit.backup_session = backup_session.clone();
         results.push(edit);
     }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -8140,3 +8140,57 @@ fn doc_set_relative_nested_path_does_not_double_join() {
         serde_json::from_str(&content).unwrap_or_else(|e| panic!("valid JSON: {e}; got {content}"));
     assert_eq!(val["v"], serde_json::json!(2), "got {content}");
 }
+
+#[test]
+fn apply_patch_file_deletion_unlinks() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("gone.txt");
+    fs::write(&f, "bye\n").unwrap();
+    let patch = "--- a/gone.txt\n+++ /dev/null\n@@ -1 +0,0 @@\n-bye\n";
+    let results = apply_patch_file(patch, dir.path(), ApplyMode::Apply, None).unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(results[0].changed);
+    assert!(
+        !f.exists(),
+        "deletion patch must unlink, not leave empty file"
+    );
+}
+
+#[test]
+fn apply_patch_file_case_only_rename_preserves_inode_content() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("readme.md");
+    fs::write(&src, "hello content\n").unwrap();
+    let patch = "\
+diff --git a/readme.md b/README.md\n\
+similarity index 100%\n\
+rename from readme.md\n\
+rename to README.md\n";
+    let results = apply_patch_file(patch, dir.path(), ApplyMode::Apply, None).unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(results[0].changed);
+    // Content must survive on case-insensitive FS (write+delete would wipe it).
+    let content = fs::read_to_string(dir.path().join("README.md"))
+        .or_else(|_| fs::read_to_string(dir.path().join("readme.md")))
+        .expect("content must exist after case-only rename");
+    assert_eq!(content, "hello content\n");
+}
+
+#[test]
+fn apply_patch_file_pure_rename_binary() {
+    let dir = TempDir::new().unwrap();
+    let src = dir.path().join("logo.png");
+    fs::write(&src, b"\x89PNG\r\n\x1a\n\x00\x00").unwrap();
+    let patch = "\
+diff --git a/logo.png b/assets/logo.png\n\
+similarity index 100%\n\
+rename from logo.png\n\
+rename to assets/logo.png\n";
+    let results = apply_patch_file(patch, dir.path(), ApplyMode::Apply, None).unwrap();
+    assert_eq!(results.len(), 1);
+    assert!(results[0].changed);
+    assert!(!src.exists());
+    let dest = dir.path().join("assets/logo.png");
+    assert!(dest.exists(), "binary pure rename must move bytes");
+    assert_eq!(fs::read(&dest).unwrap(), b"\x89PNG\r\n\x1a\n\x00\x00");
+}

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -629,6 +629,10 @@ impl PatchloomService {
             })?;
             for pf in &patch_files {
                 svc.check_path(&pf.path)?;
+                // Git rename source must be contained too (pure rename of ../x).
+                if let Some(from) = &pf.rename_from {
+                    svc.check_path(from)?;
+                }
             }
 
             let op = Operation::PatchApply {

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -334,6 +334,9 @@ impl PatchloomService {
             })?;
             for pf in &patch_files {
                 self.check_path(&pf.path)?;
+                if let Some(from) = &pf.rename_from {
+                    self.check_path(from)?;
+                }
             }
         }
         Ok(())

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -747,9 +747,33 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                     return Ok(exit::FAILURE);
                 }
             };
+            // Parity with normal patch check: refuse rename dest clobber early.
+            if let Some(from) = pf.rename_from.as_deref() {
+                let dest_path = cwd.join(&pf.path);
+                if crate::ops::patch::rename_would_clobber_dest(
+                    from,
+                    &pf.path,
+                    crate::ops::file::path_entry_exists(&dest_path),
+                ) {
+                    all_ok = false;
+                    results.push(PatchFileResult {
+                        path: pf.path.clone(),
+                        status: "already_exists",
+                        error: Some(crate::ops::patch::rename_dest_exists_msg(&pf.path)),
+                        conflicts: None,
+                        from: Some(from.to_string()),
+                        to: Some(pf.path.clone()),
+                        action: Some("renamed"),
+                    });
+                    continue;
+                }
+            }
             match apply_patch_file(&original, &pf.hunks, check_options) {
                 Ok(applied) => {
-                    if applied.status == ApplyHunksStatus::Conflict {
+                    // Conflicts are soft when --allow-conflicts (would write markers).
+                    if applied.status == ApplyHunksStatus::Conflict
+                        && !apply_options.allow_conflicts
+                    {
                         all_ok = false;
                     }
                     // Clean means apply without fuzz, not "no content change".
@@ -775,6 +799,8 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
                 }
             }
         }
+        // With --allow-conflicts, conflict rows are intentional would-change, not
+        // top-level ok:false / error_kind:conflicts (agents branch on ok first).
         emit_patch_files_output(global, all_ok, &results, Some(false), None)?;
         let has_errors = results.iter().any(|r| r.status == "error");
         let has_conflicts = results.iter().any(|r| r.status == "conflict");

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -170,6 +170,9 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
     let lines: Vec<&str> = input.lines().collect();
     let mut files: Vec<PatchFile> = Vec::new();
     let mut i = 0;
+    // When `diff --git` has copy from/to then ---/+++, do not treat path
+    // inequality as rename (would delete the copy source on apply).
+    let mut suppress_path_rename = false;
 
     while i < lines.len() {
         // Pure git rename (100% similarity) often has no ---/+++ headers:
@@ -183,6 +186,7 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
             // Look ahead for rename from/to before next file/diff.
             let mut rename_from_meta: Option<String> = None;
             let mut rename_to_meta: Option<String> = None;
+            let mut saw_copy = false;
             let mut j = i + 1;
             while j < lines.len() && !lines[j].starts_with("diff ") && !is_file_header(&lines, j) {
                 if let Some(rest) = lines[j].strip_prefix("rename from ") {
@@ -190,6 +194,8 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
                     rename_from_meta = Some(unquote_git_path_meta(rest));
                 } else if let Some(rest) = lines[j].strip_prefix("rename to ") {
                     rename_to_meta = Some(unquote_git_path_meta(rest));
+                } else if lines[j].starts_with("copy from ") || lines[j].starts_with("copy to ") {
+                    saw_copy = true;
                 } else if lines[j].starts_with("@@ ") {
                     // Has hunks under this diff without ---/+++; fall through
                     // to normal scan (should not happen in git format).
@@ -200,6 +206,7 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
             // If the next real header is ---/+++ for this same rename, let the
             // normal path consume it (may include content hunks).
             if j < lines.len() && is_file_header(&lines, j) {
+                suppress_path_rename = saw_copy;
                 i = j;
                 // fall through to ---/+++ handler below (no continue)
             } else if let (Some(from), Some(to)) = (rename_from_meta, rename_to_meta) {
@@ -235,11 +242,13 @@ pub fn parse_patch(input: &str) -> Result<Vec<PatchFile>, String> {
         let plus_path = parse_file_path(lines[i + 1]);
         let is_creation = minus_path == "/dev/null";
         let is_deletion = plus_path == "/dev/null";
-        let rename_from = if !is_creation && !is_deletion && minus_path != plus_path {
-            Some(minus_path.clone())
-        } else {
-            None
-        };
+        let rename_from =
+            if !is_creation && !is_deletion && minus_path != plus_path && !suppress_path_rename {
+                Some(minus_path.clone())
+            } else {
+                None
+            };
+        suppress_path_rename = false;
         let path = if is_deletion { minus_path } else { plus_path };
         i += 2;
 
@@ -967,13 +976,26 @@ where
         // New file creation: original is empty, don't try to load from disk.
         // Git rename: load from rename_from (old path), write to path (new).
         let load_path = pf.rename_from.as_deref().unwrap_or(pf.path.as_str());
+        let pure_rename =
+            pf.rename_from.is_some() && pf.hunks.is_empty() && !pf.is_deletion && !pf.is_creation;
         let original = if pf.is_creation {
             String::new()
         } else {
-            load_original(load_path)?
+            match load_original(load_path) {
+                Ok(s) => s,
+                // Pure path rename of binary / invalid UTF-8: soft empty snapshot
+                // (commit uses fs::rename so bytes stay intact; #2031 parity).
+                Err(e)
+                    if pure_rename
+                        && (crate::exit::is_binary(&e) || crate::exit::is_invalid_encoding(&e)) =>
+                {
+                    String::new()
+                }
+                Err(e) => return Err(e),
+            }
         };
         // Pure rename (empty hunks): keep content, stage rename only.
-        if pf.rename_from.is_some() && pf.hunks.is_empty() && !pf.is_deletion && !pf.is_creation {
+        if pure_rename {
             results.push(PatchApplyFileResult {
                 path: pf.path.clone(),
                 content: original,

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1351,6 +1351,30 @@ copy to bar.rs
     }
 
     #[test]
+    fn copy_with_headers_is_not_rename() {
+        // copy from/to + ---/+++ + hunks must not set rename_from (would delete source).
+        let diff = "\
+diff --git a/src.rs b/dst.rs
+similarity index 80%
+copy from src.rs
+copy to dst.rs
+--- a/src.rs
++++ b/dst.rs
+@@ -1 +1,2 @@
+ line
++added
+";
+        let files = parse_patch(diff).expect("copy with headers parses");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "dst.rs");
+        assert!(
+            files[0].rename_from.is_none(),
+            "copy must not become rename, got {:?}",
+            files[0].rename_from
+        );
+    }
+
+    #[test]
     fn rename_would_clobber_dest_true_when_dest_exists() {
         assert!(rename_would_clobber_dest("old.rs", "new.rs", true));
         assert!(!rename_would_clobber_dest("old.rs", "new.rs", false));

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -294,10 +294,20 @@ pub(crate) fn declared_paths(op: &Operation) -> Vec<String> {
             p
         }
         Operation::PatchApply { diff, .. } => {
-            // Parse the diff to extract file paths from ---/+++ headers.
+            // Parse the diff to extract write targets and git rename sources.
+            // rename_from must be guarded too (pure rename of ../outside must fail closed).
             // If parsing fails, return empty (the error will surface at apply time).
             match crate::ops::patch::parse_patch(diff) {
-                Ok(files) => files.into_iter().map(|pf| pf.path).collect(),
+                Ok(files) => files
+                    .into_iter()
+                    .flat_map(|pf| {
+                        let mut paths = vec![pf.path];
+                        if let Some(from) = pf.rename_from {
+                            paths.push(from);
+                        }
+                        paths
+                    })
+                    .collect(),
                 Err(_) => vec![],
             }
         }

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -13,6 +13,8 @@ pub enum Operation {
         /// Glob pattern to match files (e.g. "src/**/*.rs"). Mutually exclusive with path.
         glob: Option<String>,
         /// File path to replace in. Mutually exclusive with glob.
+        /// Alias `file` matches MCP replace_text / LLM prior (#fixloop).
+        #[serde(alias = "file")]
         path: Option<String>,
         /// Treat `old` as a regex pattern.
         #[serde(default)]

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -898,3 +898,23 @@ fn needs_doc_flush_includes_file_create_delete_rename() {
         "FileRename must trigger doc flush"
     );
 }
+
+#[test]
+fn replace_accepts_file_alias() {
+    let json =
+        r#"{"version":1,"operations":[{"op":"replace","file":"README.md","old":"a","new":"b"}]}"#;
+    let plan: Plan = serde_json::from_str(json).expect("deserialize");
+    match &plan.operations[0] {
+        Operation::Replace {
+            path,
+            old,
+            new_text,
+            ..
+        } => {
+            assert_eq!(path.as_deref(), Some("README.md"));
+            assert_eq!(old, "a");
+            assert_eq!(new_text.as_deref(), Some("b"));
+        }
+        other => panic!("expected Replace, got {other:?}"),
+    }
+}

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -161,8 +161,11 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 tx.deletions.remove(&file_path);
             } else {
                 tx.write_file(&file_path, String::new());
-                tx.deletions.insert(file_path);
+                tx.deletions.insert(file_path.clone());
             }
+            // Deleting a rename dest must drop the pair so commit does not
+            // fs::rename the source back into existence.
+            tx.renames.retain(|(_, to)| to != &file_path);
         }
 
         Operation::FileRename { from, to, force } => {

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -234,6 +234,10 @@ impl TxState<'_> {
     /// so commit-time write_policy can re-apply after non-tidy writers (#1847).
     pub(crate) fn write_file(&mut self, path: &Path, new_content: String) {
         self.policy_finalized.remove(path);
+        // Only when clearing a prior deletion (resurrect) drop rename pairs
+        // that still name this path as source. Staging a rename source as
+        // empty+delete must not wipe the pair we just recorded.
+        let resurrecting = self.deletions.contains(path);
         update_file_content(
             self.pending,
             self.deletions,
@@ -241,6 +245,9 @@ impl TxState<'_> {
             path,
             new_content,
         );
+        if resurrecting {
+            self.renames.retain(|(from, _)| from != path);
+        }
     }
 }
 

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -615,7 +615,6 @@ fn case_only_rename_plan_apply_preserves_content() {
         report.ok,
         "case-only rename plan should succeed: {report:?}"
     );
-
     // Content must still exist under either spelling (case-insensitive FS).
     let content = std::fs::read_to_string(dir.path().join("README.md"))
         .or_else(|_| std::fs::read_to_string(&src))
@@ -715,4 +714,86 @@ fn execute_and_collect_preserves_no_match_error_kind() {
             );
         }
     }
+}
+
+/// rename a→b then create a: both paths must exist with correct content.
+/// Stale tx.renames used to fs::rename a→b and skip writing resurrected a.
+#[test]
+fn rename_then_create_preserves_both_paths() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("lib.rs");
+    std::fs::write(&a, "old body\n").unwrap();
+
+    let plan = crate::plan::Plan {
+        version: crate::plan::SCHEMA_VERSION,
+        cwd: None,
+        operations: vec![
+            Operation::FileRename {
+                from: "lib.rs".into(),
+                to: "lib_old.rs".into(),
+                force: false,
+            },
+            Operation::FileCreate {
+                path: "lib.rs".into(),
+                content: "new body\n".into(),
+                force: Some(false),
+            },
+        ],
+        write_policy: None,
+        strict: None,
+        format: None,
+        validate: None,
+        verify: None,
+        for_each: None,
+    };
+    let report = crate::tx::execute_plan_direct(plan, dir.path(), None).expect("plan ok");
+    assert!(report.ok, "rename-then-create should succeed: {report:?}");
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("lib.rs")).unwrap(),
+        "new body\n",
+        "resurrected source must keep create content"
+    );
+    assert_eq!(
+        std::fs::read_to_string(dir.path().join("lib_old.rs")).unwrap(),
+        "old body\n",
+        "rename dest must keep original content"
+    );
+}
+
+/// rename a→b then delete b: neither path should remain.
+#[test]
+fn rename_then_delete_dest_removes_both() {
+    let dir = TempDir::new().unwrap();
+    std::fs::write(dir.path().join("a.txt"), "content\n").unwrap();
+
+    let plan = crate::plan::Plan {
+        version: crate::plan::SCHEMA_VERSION,
+        cwd: None,
+        operations: vec![
+            Operation::FileRename {
+                from: "a.txt".into(),
+                to: "b.txt".into(),
+                force: false,
+            },
+            Operation::FileDelete {
+                path: "b.txt".into(),
+            },
+        ],
+        write_policy: None,
+        strict: None,
+        format: None,
+        validate: None,
+        verify: None,
+        for_each: None,
+    };
+    let report = crate::tx::execute_plan_direct(plan, dir.path(), None).expect("plan ok");
+    assert!(
+        report.ok,
+        "rename-then-delete-dest should succeed: {report:?}"
+    );
+    assert!(!dir.path().join("a.txt").exists(), "source must be gone");
+    assert!(
+        !dir.path().join("b.txt").exists(),
+        "dest delete must stick (stale rename must not re-create b)"
+    );
 }

--- a/src/tx/lifecycle/commit.rs
+++ b/src/tx/lifecycle/commit.rs
@@ -165,9 +165,28 @@ pub(crate) fn commit_changes(
 
     // Prefer explicit file.rename records (covers rename-then-edit). Fall back
     // to content-based pure-rename detection for any remaining pairs.
-    let mut rename_pairs: Vec<(PathBuf, PathBuf)> = renames.to_vec();
-    let mut covered_from: HashSet<PathBuf> = renames.iter().map(|(f, _)| f.clone()).collect();
-    let mut covered_to: HashSet<PathBuf> = renames.iter().map(|(_, t)| t.clone()).collect();
+    // Drop stale rename records when a later op resurrected the source (e.g.
+    // rename a→b then create a) or removed the dest (rename a→b then delete b).
+    // Otherwise commit still fs::renames and skips writing resurrected content.
+    // Drop renames whose source was resurrected (e.g. rename a→b then create a).
+    // Keep intermediate chain sources that may not be in `deletions` because
+    // they were create-in-tx rename dests (empty original) before a further rename.
+    let mut rename_pairs: Vec<(PathBuf, PathBuf)> = renames
+        .iter()
+        .filter(|(from, _to)| {
+            if deletions.contains(from) {
+                return true;
+            }
+            // Resurrected: source is a non-empty write and not deleted.
+            let resurrected = changes
+                .iter()
+                .any(|(p, _, new_c)| p == from && !new_c.is_empty());
+            !resurrected
+        })
+        .cloned()
+        .collect();
+    let mut covered_from: HashSet<PathBuf> = rename_pairs.iter().map(|(f, _)| f.clone()).collect();
+    let mut covered_to: HashSet<PathBuf> = rename_pairs.iter().map(|(_, t)| t.clone()).collect();
     for (from, to) in detect_pure_renames(changes, deletions, existed_before) {
         if covered_from.contains(&from) || covered_to.contains(&to) {
             continue;


### PR DESCRIPTION
## Summary

Fixloop round with **strict real-world triage** (no theoretical defense-in-depth).

### Fixed

| Issue | Realistic scenario |
|-------|-------------------|
| Stale `tx.renames` | Plan `file.rename` a→b then `file.create` a lost new content; rename then delete dest left b |
| PathGuard / MCP | Pure rename `rename from ../outside` only checked dest path |
| Git copy as rename | `copy from/to` + `---/+++` deleted the copy source |
| `apply_patch_file` | Deletion left empty file; case-only rename wiped the only inode; binary pure rename failed closed; missing dest parents |
| Plan `replace` | `file` alias dropped (MCP `replace_text` accepts it) |
| Patch merge check | Rename dest clobber missed; `--allow-conflicts` top-level `ok: false` |

### Rejected (noise)

| Item | Why |
|------|-----|
| Counter saturating / u64 overflow | Internal counters never overflow in practice |
| Speculative pre-validation | Next layer already fail-closed |
| Git octal C-quote (`\303\251`) | Non-ASCII `core.quotePath`; spaces/`\"` already handled; rare agent path |
| Append on dangling symlink dual-path | Rare; create/delete entry ops intentionally differ from content append |

### Verification

`make check-fast` green locally (unit + integration + pty).