### PR TITLE
fix: path honesty for git octal, dangling, sole special

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -151,7 +151,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 - Text I/O honesty (#1894):
 | Surface | Binary / invalid UTF-8 | Unreadable (IO) |
 |---------|------------------------|-----------------|
-| Sole explicit path (`load_text_strict` / `sole_explicit_non_text`) | `binary` / `invalid_encoding` / `invalid_input` | IO / `not_found` |
+| Sole explicit path (`load_text_strict` / `sole_explicit_non_text`) | `binary` / `invalid_encoding` / `invalid_input` (also dangling/FIFO `not a file`) | IO / `not_found` |
 | Explicit multi-file list | `refused[]` reason `binary` or `invalid_utf8` | `refused[]` reason `unreadable` |
 | Directory walk (`try_read_text_file`) | content SoftSkip (silent) | SoftSkip; empty scan must not report pattern `no_matches` if unreadable may have masked it (AST rename) |
 | Tx multi-path probe (`read_and_probe`) | SoftSkip `Ok(false)` | Hard `Err` (plan names paths) |

--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -48,7 +48,11 @@ Bline is a real embedder that dogfooded these steps; the checklist is host-gener
    following the target; directories stay refused (#2087, #2091). Soft-loading a
    symlink as text then writing would rewrite the **target**; rename uses an
    empty path-only snapshot so write policies never mutate the link target.
-   Append/prepend/replace still refuse non-text loads.
+   Append/prepend refuse non-text and special entries (including dangling
+   symlinks) with `invalid_input` (not `not_found`). Sole explicit
+   replace/search/tidy paths use the same classification via
+   `sole_explicit_non_text` so agents do not mis-branch on `not_found` for a
+   present non-file entry.
 9. **Doc presentation honesty:** library `EditResult.style_changed` (and
    `is_style_changed`) mirrors CLI/MCP when YAML block-sequence layout
    collapses; values can still be correct (#2088). Warn hosts/agents; do not

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -64,16 +64,21 @@ fn file_write(
     match op {
         Operation::FileCreate { content, force, .. } => {
             let path_str = path.to_string_lossy();
-            if path.exists() && !path.is_file() {
-                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("target is not a file: {}", path.display()),
-                }));
+            use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
+            // Match engine: entry presence (dangling is present) + real dirs refuse.
+            match classify_path_entry(path) {
+                PathEntryKind::RealDirectory => {
+                    return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                        msg: format!("target is not a file: {}", path.display()),
+                    }));
+                }
+                PathEntryKind::Missing | PathEntryKind::RegularFile | PathEntryKind::Special => {}
             }
             crate::ops::file::ensure_parent_components_are_directories(path)?;
             let force = force.unwrap_or(false);
             // Match engine path: refuse existing without force in all modes
             // (Preview/Check/Apply). Preview must not soft-succeed (#MPI dual-path).
-            if !force && path.exists() {
+            if !force && path_entry_exists(path) {
                 return Err(anyhow::Error::new(crate::exit::AlreadyExistsError {
                     msg: format!(
                         "file already exists: {} (use force to overwrite)",
@@ -82,14 +87,20 @@ fn file_write(
                 }));
             }
             // Force: soft-load prior (binary/encoding/unreadable → empty) (#1962).
-            let original = if path.exists() {
-                match crate::files::load_text_strict(path, &path_str) {
-                    Ok(s) => s,
-                    Err(e) if force && crate::exit::is_load_text_strict_fail(&e) => String::new(),
-                    Err(e) => return Err(e),
+            // Special nodes (dangling) → empty original; regular text strict load.
+            let original = match classify_path_entry(path) {
+                PathEntryKind::RegularFile => {
+                    match crate::files::load_text_strict(path, &path_str) {
+                        Ok(s) => s,
+                        Err(e) if force && crate::exit::is_load_text_strict_fail(&e) => {
+                            String::new()
+                        }
+                        Err(e) => return Err(e),
+                    }
                 }
-            } else {
-                String::new()
+                PathEntryKind::Missing | PathEntryKind::Special | PathEntryKind::RealDirectory => {
+                    String::new()
+                }
             };
             let policy = crate::write::WritePolicy::default();
             let (applied, backup_session) =

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -154,17 +154,20 @@ fn file_write(
             let is_append = matches!(op, Operation::FileAppend { .. });
             let content = content.clone();
             let path_str = path.to_string_lossy();
-            if path.exists() && !path.is_file() {
-                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-                    msg: format!("target is not a file: {}", path.display()),
-                }));
-            }
-            if !path.exists() {
+            // Match CLI/tx: entry presence (dangling symlink is present) and
+            // require a regular file for content inject (#2087 dual-path).
+            use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
+            if !path_entry_exists(path) {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     format!("file does not exist: {}", path.display()),
                 )
                 .into());
+            }
+            if classify_path_entry(path) != PathEntryKind::RegularFile {
+                return Err(anyhow::Error::new(crate::exit::InvalidInputError {
+                    msg: format!("target is not a file: {}", path.display()),
+                }));
             }
             let original = crate::files::load_text_strict(path, &path_str)?;
             let combined = if is_append {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7372,6 +7372,26 @@ fn file_append_missing_is_not_found() {
     );
 }
 
+/// Dangling symlink is present but not a regular file → invalid_input, not not_found.
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_append_dangling_symlink_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let link = dir.path().join("dangling.txt");
+    std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+    let err = file_append(&link, "x\n", ApplyMode::Apply, None).unwrap_err();
+    assert_eq!(
+        crate::fallback::edit_error_kind(&err),
+        Some(EditErrorKind::InvalidInput),
+        "dangling append must be invalid_input: {err}"
+    );
+    assert!(
+        crate::fallback::is_invalid_input(&err),
+        "is_invalid_input peel: {err}"
+    );
+    assert!(crate::ops::file::path_entry_exists(&link));
+}
+
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]
 fn execute_plan_patch_merge_conflict_is_conflicts() {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7302,6 +7302,29 @@ fn file_create_already_exists_is_already_exists() {
     );
 }
 
+/// Dangling symlink is a present entry → already_exists without force (#2087).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_create_dangling_symlink_is_already_exists() {
+    let dir = TempDir::new().unwrap();
+    let link = dir.path().join("dangling.txt");
+    std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+    let err = file_create(&link, "y\n", false, ApplyMode::Apply, None).unwrap_err();
+    assert!(
+        crate::fallback::is_already_exists(&err),
+        "dangling create without force: {err}"
+    );
+    assert_eq!(
+        crate::fallback::error_kind_str(&err),
+        Some("already_exists")
+    );
+    // force overwrites the dangling entry with a regular file
+    let r = file_create(&link, "y\n", true, ApplyMode::Apply, None).unwrap();
+    assert!(r.applied);
+    assert!(link.is_file());
+    assert_eq!(fs::read_to_string(&link).unwrap(), "y\n");
+}
+
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]
 fn file_rename_destination_exists_is_already_exists() {

--- a/src/cmd/agent_rules/policy.rs
+++ b/src/cmd/agent_rules/policy.rs
@@ -183,7 +183,7 @@ refuses before write/backup (#2008). Prefer per-op honesty; rollup fields are wo
              - Text I/O honesty (#1894):\n\
                | Surface | Binary / invalid UTF-8 | Unreadable (IO) |\n\
                |---------|------------------------|-----------------|\n\
-               | Sole explicit path (`load_text_strict` / `sole_explicit_non_text`) | `binary` / `invalid_encoding` / `invalid_input` | IO / `not_found` |\n\
+               | Sole explicit path (`load_text_strict` / `sole_explicit_non_text`) | `binary` / `invalid_encoding` / `invalid_input` (also dangling/FIFO `not a file`) | IO / `not_found` |\n\
                | Explicit multi-file list | `refused[]` reason `binary` or `invalid_utf8` | `refused[]` reason `unreadable` |\n\
                | Directory walk (`try_read_text_file`) | content SoftSkip (silent) | SoftSkip; empty scan must not report pattern `no_matches` if unreadable may have masked it (AST rename) |\n\
                | Tx multi-path probe (`read_and_probe`) | SoftSkip `Ok(false)` | Hard `Err` (plan names paths) |\n\

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -285,6 +285,28 @@ mod tests {
         assert_eq!(code, exit::FAILURE);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn append_rejects_dangling_symlink_as_invalid_input() {
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("dangling.txt");
+        std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+
+        let args = AppendArgs {
+            file: link.to_string_lossy().into_owned(),
+            content: Some("content\n".to_string()),
+            stdin: false,
+            write: Default::default(),
+        };
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.json = true;
+
+        let code = run(args, &global).unwrap();
+        assert_eq!(code, exit::FAILURE);
+        // Dangling is present: invalid_input, not not_found (matches create/delete).
+        assert!(crate::ops::file::path_entry_exists(&link));
+    }
+
     #[test]
     fn append_rejects_binary_file() {
         let dir = TempDir::new().unwrap();

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -88,15 +88,27 @@ pub(crate) fn run_content_inject(
     let file = global.rewrite_user_path_arg(&cwd, file)?;
     let file = file.as_str();
     let path = cwd.join(file);
-    if !path.exists() {
+    // Entry presence (not Path::exists follow): dangling symlink is present
+    // like create/delete/rename (#2087 dual-path), not not_found.
+    use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
+    if !path_entry_exists(&path) {
         let msg = format!("file does not exist: {file}");
         global.emit_error_json_kind(Some("not_found"), &msg)?;
         return Ok(crate::exit::FAILURE);
     }
-    if !path.is_file() {
-        let msg = format!("target is not a file: {file}");
-        global.emit_error_json_kind(Some("invalid_input"), &msg)?;
-        return Ok(crate::exit::FAILURE);
+    match classify_path_entry(&path) {
+        PathEntryKind::RegularFile => {}
+        PathEntryKind::Missing => {
+            let msg = format!("file does not exist: {file}");
+            global.emit_error_json_kind(Some("not_found"), &msg)?;
+            return Ok(crate::exit::FAILURE);
+        }
+        _ => {
+            // Dangling/symlink-to-dir/FIFO/dir: content ops need a regular file.
+            let msg = format!("target is not a file: {file}");
+            global.emit_error_json_kind(Some("invalid_input"), &msg)?;
+            return Ok(crate::exit::FAILURE);
+        }
     }
     // Fail before the engine so --json gets error_kind and binaries are not
     // rewritten as text (NUL is valid UTF-8).

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -265,23 +265,33 @@ pub fn sole_explicit_non_text(paths: &[String], cwd: &Path) -> Option<anyhow::Er
             cwd.join(p)
         }
     };
-    // Classify without following: dangling symlink / FIFO is present but not
-    // text. Path::is_file() follows and reports false → used to fall through
-    // as not_found after soft scan (#2087 dual-path vs append/create).
+    // Presence without following, then follow only for loadable targets.
+    // Symlink-to-file must still load (replace/search follow); symlink-to-dir
+    // returns None so directory walks proceed. Dangling (and other specials
+    // that are neither file nor dir after follow) used to fall through
+    // Path::is_file()==false into soft not_found (#2087 dual-path).
     match classify_path_entry(&path) {
         PathEntryKind::Missing | PathEntryKind::RealDirectory => {
             // Missing: later not_found. Directory: walk / multi-file scan.
             return None;
         }
-        PathEntryKind::Special => {
-            return Some(
-                crate::exit::InvalidInputError {
-                    msg: format!("target is not a file: {display}"),
-                }
-                .into(),
-            );
-        }
         PathEntryKind::RegularFile => {}
+        PathEntryKind::Special => {
+            if path.is_file() {
+                // Symlink to a regular file (or rare special that follows as file).
+            } else if path.is_dir() {
+                // Symlink to a directory: allow multi-file scan.
+                return None;
+            } else {
+                // Dangling symlink, socket, etc.: present but not text.
+                return Some(
+                    crate::exit::InvalidInputError {
+                        msg: format!("target is not a file: {display}"),
+                    }
+                    .into(),
+                );
+            }
+        }
     }
     // Strict sole-path: binary / invalid UTF-8 → typed kinds; unreadable IO
     // on an existing file must also hard-fail (not soft no_matches / clean).
@@ -667,6 +677,35 @@ mod tests {
         );
         assert!(err.to_string().contains("not a file"), "got: {err}");
         assert_eq!(crate::fallback::error_kind_str(&err), Some("invalid_input"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sole_explicit_non_text_allows_symlink_to_text_file() {
+        let dir = TempDir::new().unwrap();
+        let real = dir.path().join("real.txt");
+        fs::write(&real, "hi\n").unwrap();
+        let link = dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        assert!(
+            sole_explicit_non_text(&["link.txt".into()], dir.path()).is_none(),
+            "symlink-to-file must still load as sole text path"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sole_explicit_non_text_allows_symlink_to_directory() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("nested");
+        fs::create_dir(&nested).unwrap();
+        fs::write(nested.join("a.txt"), "x\n").unwrap();
+        let link = dir.path().join("link_dir");
+        std::os::unix::fs::symlink(&nested, &link).unwrap();
+        assert!(
+            sole_explicit_non_text(&["link_dir".into()], dir.path()).is_none(),
+            "symlink-to-dir must allow multi-file scan"
+        );
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -265,8 +265,23 @@ pub fn sole_explicit_non_text(paths: &[String], cwd: &Path) -> Option<anyhow::Er
             cwd.join(p)
         }
     };
-    if !path.is_file() {
-        return None;
+    // Classify without following: dangling symlink / FIFO is present but not
+    // text. Path::is_file() follows and reports false → used to fall through
+    // as not_found after soft scan (#2087 dual-path vs append/create).
+    match classify_path_entry(&path) {
+        PathEntryKind::Missing | PathEntryKind::RealDirectory => {
+            // Missing: later not_found. Directory: walk / multi-file scan.
+            return None;
+        }
+        PathEntryKind::Special => {
+            return Some(
+                crate::exit::InvalidInputError {
+                    msg: format!("target is not a file: {display}"),
+                }
+                .into(),
+            );
+        }
+        PathEntryKind::RegularFile => {}
     }
     // Strict sole-path: binary / invalid UTF-8 → typed kinds; unreadable IO
     // on an existing file must also hard-fail (not soft no_matches / clean).
@@ -637,6 +652,21 @@ mod tests {
         assert!(sole_explicit_non_text(&["t.txt".into()], dir.path()).is_none());
         assert!(sole_explicit_non_text(&["t.txt".into(), "b.bin".into()], dir.path()).is_none());
         assert!(sole_explicit_non_text(&[".".into()], dir.path()).is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sole_explicit_non_text_rejects_dangling_symlink() {
+        let dir = TempDir::new().unwrap();
+        let link = dir.path().join("dangling.txt");
+        std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+        let err = sole_explicit_non_text(&["dangling.txt".into()], dir.path()).unwrap();
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "dangling sole path must be invalid_input not not_found: {err}"
+        );
+        assert!(err.to_string().contains("not a file"), "got: {err}");
+        assert_eq!(crate::fallback::error_kind_str(&err), Some("invalid_input"));
     }
 
     #[test]

--- a/src/ops/patch.rs
+++ b/src/ops/patch.rs
@@ -355,29 +355,47 @@ fn parse_file_path(line: &str) -> String {
     path.to_string()
 }
 
-/// Minimal Git C-string unescape for paths inside double quotes.
+/// Git C-string unescape for paths inside double quotes.
+///
+/// Handles `\"`, `\\`, `\n`/`\t`/`\r`, and up to three-digit octal byte escapes
+/// (`\303\251` → UTF-8 `é`) used by `core.quotePath` for non-ASCII names.
 fn unquote_git_c_string(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
+    let mut bytes = Vec::with_capacity(s.len());
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\\' {
             match chars.next() {
-                Some('n') => out.push('\n'),
-                Some('t') => out.push('\t'),
-                Some('r') => out.push('\r'),
-                Some('"') => out.push('"'),
-                Some('\\') => out.push('\\'),
-                Some(other) => {
-                    out.push('\\');
-                    out.push(other);
+                Some('n') => bytes.push(b'\n'),
+                Some('t') => bytes.push(b'\t'),
+                Some('r') => bytes.push(b'\r'),
+                Some('"') => bytes.push(b'"'),
+                Some('\\') => bytes.push(b'\\'),
+                Some(d) if d.is_digit(8) => {
+                    // Up to three octal digits (git C-quoted path bytes).
+                    let mut val = d.to_digit(8).unwrap_or(0);
+                    for _ in 0..2 {
+                        match chars.peek().and_then(|n| n.to_digit(8)) {
+                            Some(nd) => {
+                                chars.next();
+                                val = val * 8 + nd;
+                            }
+                            None => break,
+                        }
+                    }
+                    bytes.push(val as u8);
                 }
-                None => out.push('\\'),
+                Some(other) => {
+                    let mut buf = [0u8; 4];
+                    bytes.extend(other.encode_utf8(&mut buf).as_bytes());
+                }
+                None => bytes.push(b'\\'),
             }
         } else {
-            out.push(c);
+            let mut buf = [0u8; 4];
+            bytes.extend(c.encode_utf8(&mut buf).as_bytes());
         }
     }
-    out
+    String::from_utf8_lossy(&bytes).into_owned()
 }
 
 fn parse_hunk_header(line: &str) -> Result<Hunk, String> {

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1389,6 +1389,7 @@ rename to \"caf\\303\\251-new.rs\"
         assert_eq!(files[0].rename_from.as_deref(), Some("café.rs"));
     }
 
+    #[cfg(any(feature = "cli", feature = "files"))]
     #[test]
     fn apply_pure_rename_octal_c_quoted_paths() {
         use crate::ops::patch::{ApplyHunksOptions, apply_patch_with_loader};

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1390,6 +1390,33 @@ rename to \"caf\\303\\251-new.rs\"
     }
 
     #[test]
+    fn apply_pure_rename_octal_c_quoted_paths() {
+        use crate::ops::patch::{ApplyHunksOptions, apply_patch_with_loader};
+        let mut files = std::collections::HashMap::new();
+        files.insert("café.rs".to_string(), "body\n".to_string());
+        let results = apply_patch_with_loader(
+            "\
+diff --git \"a/caf\\303\\251.rs\" \"b/caf\\303\\251-new.rs\"
+similarity index 100%
+rename from \"caf\\303\\251.rs\"
+rename to \"caf\\303\\251-new.rs\"
+",
+            |path| {
+                files
+                    .get(path)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("missing {path}"))
+            },
+            ApplyHunksOptions::default(),
+        )
+        .expect("apply octal C-quoted pure rename");
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].path, "café-new.rs");
+        assert_eq!(results[0].rename_from.as_deref(), Some("café.rs"));
+        assert_eq!(results[0].content, "body\n");
+    }
+
+    #[test]
     fn rename_would_clobber_dest_true_when_dest_exists() {
         assert!(rename_would_clobber_dest("old.rs", "new.rs", true));
         assert!(!rename_would_clobber_dest("old.rs", "new.rs", false));

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1375,6 +1375,21 @@ copy to dst.rs
     }
 
     #[test]
+    fn parse_git_c_quoted_octal_utf8_path() {
+        // core.quotePath: café.rs → "caf\303\251.rs"
+        let diff = "\
+diff --git \"a/caf\\303\\251.rs\" \"b/caf\\303\\251-new.rs\"
+similarity index 100%
+rename from \"caf\\303\\251.rs\"
+rename to \"caf\\303\\251-new.rs\"
+";
+        let files = parse_patch(diff).expect("octal C-quoted pure rename");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].path, "café-new.rs");
+        assert_eq!(files[0].rename_from.as_deref(), Some("café.rs"));
+    }
+
+    #[test]
     fn rename_would_clobber_dest_true_when_dest_exists() {
         assert!(rename_would_clobber_dest("old.rs", "new.rs", true));
         assert!(!rename_would_clobber_dest("old.rs", "new.rs", false));

--- a/src/tx/execute/file_ops.rs
+++ b/src/tx/execute/file_ops.rs
@@ -11,12 +11,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
     match op {
         Operation::FileAppend { path, content } => {
             let file_path = tx.cwd.join(path);
-            if file_path.exists() && !file_path.is_file() {
-                return Err(crate::exit::InvalidInputError {
-                    msg: format!("target is not a file: {path}"),
-                }
-                .into());
-            }
+            use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
             if tx.deletions.contains(&file_path) {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
@@ -24,15 +19,22 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 )
                 .into());
             }
-            if !file_path.exists() && !tx.pending.contains_key(&file_path) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("file does not exist: {path}"),
-                )
-                .into());
-            }
-            // On-disk binary only (in-tx text create then append is fine).
             if !tx.pending.contains_key(&file_path) {
+                if !path_entry_exists(&file_path) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("file does not exist: {path}"),
+                    )
+                    .into());
+                }
+                // Dangling symlink is present (not not_found) but not a regular file.
+                if classify_path_entry(&file_path) != PathEntryKind::RegularFile {
+                    return Err(crate::exit::InvalidInputError {
+                        msg: format!("target is not a file: {path}"),
+                    }
+                    .into());
+                }
+                // On-disk binary only (in-tx text create then append is fine).
                 crate::ops::file::ensure_not_binary_file(&file_path, path)?;
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;
@@ -42,12 +44,7 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
 
         Operation::FilePrepend { path, content } => {
             let file_path = tx.cwd.join(path);
-            if file_path.exists() && !file_path.is_file() {
-                return Err(crate::exit::InvalidInputError {
-                    msg: format!("target is not a file: {path}"),
-                }
-                .into());
-            }
+            use crate::ops::file::{PathEntryKind, classify_path_entry, path_entry_exists};
             if tx.deletions.contains(&file_path) {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::NotFound,
@@ -55,14 +52,20 @@ pub(crate) fn execute_file_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::R
                 )
                 .into());
             }
-            if !file_path.exists() && !tx.pending.contains_key(&file_path) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    format!("file does not exist: {path}"),
-                )
-                .into());
-            }
             if !tx.pending.contains_key(&file_path) {
+                if !path_entry_exists(&file_path) {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("file does not exist: {path}"),
+                    )
+                    .into());
+                }
+                if classify_path_entry(&file_path) != PathEntryKind::RegularFile {
+                    return Err(crate::exit::InvalidInputError {
+                        msg: format!("target is not a file: {path}"),
+                    }
+                    .into());
+                }
                 crate::ops::file::ensure_not_binary_file(&file_path, path)?;
             }
             let existing = read_file_content(tx.pending, tx.existed_before, &file_path)?;

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -797,3 +797,22 @@ fn rename_then_delete_dest_removes_both() {
         "dest delete must stick (stale rename must not re-create b)"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn append_dangling_symlink_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let link = dir.path().join("dangling.txt");
+    std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+    let op = Operation::FileAppend {
+        path: "dangling.txt".into(),
+        content: "x\n".into(),
+    };
+    let err = execute_file_op(&op, &mut tx).unwrap_err();
+    assert!(
+        crate::exit::is_invalid_input(&err),
+        "dangling symlink append must be invalid_input not not_found, got: {err}"
+    );
+}

--- a/src/tx/execute/tests.rs
+++ b/src/tx/execute/tests.rs
@@ -816,3 +816,22 @@ fn append_dangling_symlink_is_invalid_input() {
         "dangling symlink append must be invalid_input not not_found, got: {err}"
     );
 }
+
+#[cfg(unix)]
+#[test]
+fn prepend_dangling_symlink_is_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let link = dir.path().join("dangling.txt");
+    std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+    let mut f = TxStateFixture::new();
+    let mut tx = f.state(dir.path());
+    let op = Operation::FilePrepend {
+        path: "dangling.txt".into(),
+        content: "x\n".into(),
+    };
+    let err = execute_file_op(&op, &mut tx).unwrap_err();
+    assert!(
+        crate::exit::is_invalid_input(&err),
+        "dangling symlink prepend must be invalid_input not not_found, got: {err}"
+    );
+}

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1245,6 +1245,41 @@ rename to new.rs\n";
     client.cancel().await.unwrap();
 }
 
+/// Pure rename source outside workspace must fail closed (#2109 PathGuard).
+#[tokio::test]
+async fn test_mcp_apply_patch_pure_rename_escape_source_rejected() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    // Outside file next to workspace
+    let outside = dir.path().parent().unwrap().join("pl-outside-secret.env");
+    fs::write(&outside, "SECRET=1\n").unwrap();
+    let outside_name = outside.file_name().unwrap().to_str().unwrap();
+
+    let diff = format!(
+        "diff --git a/../{out} b/stolen.env\nsimilarity index 100%\nrename from ../{out}\nrename to stolen.env\n",
+        out = outside_name
+    );
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "apply_patch", serde_json::json!({"diff": diff})).await;
+    assert!(is_error, "escape rename_from must fail: {val}");
+    let s = val.to_string();
+    assert!(
+        s.contains("guard") || s.contains("escape") || s.contains("reject") || s.contains("path"),
+        "expected containment failure, got: {val}"
+    );
+    assert!(
+        outside.exists() && fs::read_to_string(&outside).unwrap().contains("SECRET"),
+        "outside file must not be moved"
+    );
+    assert!(!dir.path().join("stolen.env").exists());
+    let _ = fs::remove_file(&outside);
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_apply_patch_on_stale_merge() {
     if !has_mcp_support() {


### PR DESCRIPTION
## Summary

MPI session batch after #2109: real-world path honesty for git C-quoted octal paths, dangling/special directory entries, and dual-path library/tx/CLI parity.

### Changes

- **Git C-string octal unescape** in pure renames (`core.quotePath` UTF-8 like `caf\303\251.rs` → `café.rs`), with parse + apply tests
- **Append/prepend** (CLI, tx, no-default API): dangling symlink is `invalid_input` (present entry), not `not_found`
- **Create** no-default API: dangling is `already_exists` without force (matches engine)
- **`sole_explicit_non_text`**: dangling peels as `invalid_input`; valid symlink-to-file and symlink-to-dir still follow for replace/search/tidy
- **MCP**: pure-rename source outside workspace fail-closed regression
- Docs: embedder host + agent-rules sole-path table

### Test plan

- [x] `make check-fast` green locally
- [x] Unit: octal parse/apply, append/prepend dangling, sole_explicit matrix (dangling / symlink-to-file / symlink-to-dir)
- [x] Integration: MCP escape pure rename; replace/search follows symlink
- [ ] Full CI matrix on PR

Ref: multi-perspective-improve after #2109