### PR TITLE
fix: never open FIFOs on rename, backup, or binary probe

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -142,13 +142,24 @@ impl BackupSession {
             if let Some(parent) = backup_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
-            std::fs::copy(file_path, &backup_path).with_context(|| {
-                format!(
-                    "failed to back up {} to {}",
-                    file_path.display(),
-                    backup_path.display()
-                )
-            })?;
+            // Same special-node rule as save_before_delete: never `fs::copy` a
+            // FIFO/socket/device (blocks forever) or symlink target (#2087).
+            if crate::ops::file::is_regular_file_for_backup(file_path) {
+                std::fs::copy(file_path, &backup_path).with_context(|| {
+                    format!(
+                        "failed to back up {} to {}",
+                        file_path.display(),
+                        backup_path.display()
+                    )
+                })?;
+            } else {
+                std::fs::write(&backup_path, b"").with_context(|| {
+                    format!(
+                        "writing empty backup marker for {} (special node)",
+                        file_path.display()
+                    )
+                })?;
+            }
             self.entries.push(ManifestEntry {
                 path: rel_str,
                 action: FileAction::Modified,
@@ -846,6 +857,41 @@ mod tests {
         let restored = restore_session(dir.path(), &ts).unwrap();
         assert_eq!(restored, 1);
         assert_eq!(std::fs::read_to_string(&file).unwrap(), "doomed content");
+    }
+
+    /// `save_before_write` must not `fs::copy` a FIFO (blocks forever).
+    #[cfg(unix)]
+    #[test]
+    fn save_before_write_fifo_empty_marker_no_hang() {
+        use std::process::Command as StdCommand;
+        use std::time::{Duration, Instant};
+
+        let dir = TempDir::new().unwrap();
+        let fifo = dir.path().join("pipe.fifo");
+        let status = StdCommand::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo available on unix CI");
+        assert!(status.success());
+
+        let mut session = BackupSession::new(dir.path()).unwrap();
+        let start = Instant::now();
+        session
+            .save_before_write(&fifo)
+            .expect("FIFO write backup must not hang");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "save_before_write on FIFO took {:?}",
+            start.elapsed()
+        );
+        let ts = session.finalize().unwrap().unwrap();
+        let marker = dir
+            .path()
+            .join(".patchloom/backups")
+            .join(&ts)
+            .join("pipe.fifo");
+        assert!(marker.exists());
+        assert_eq!(std::fs::read(&marker).unwrap(), b"");
     }
 
     #[test]

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -261,9 +261,13 @@ fn run_direct_rename(
 
     // Synthetic rename diff for JSON/--diff so agents see the path move even
     // when content is byte-identical (matches engine-backed text rename UX).
+    // Never open special nodes: `read_to_string` on a FIFO blocks forever
+    // (fixrealloop / MPI dogfood after #2091 path-only rename).
     let from_disp = args.from.clone();
     let to_disp = args.to.clone();
-    let content_for_diff = if matches!(kind, DirectRenameKind::Binary) {
+    let content_for_diff = if matches!(kind, DirectRenameKind::Binary)
+        || !crate::ops::file::is_regular_file_for_backup(src)
+    {
         None
     } else {
         fs::read_to_string(src).ok()
@@ -616,6 +620,49 @@ mod tests {
         assert_eq!(code, exit::SUCCESS);
         assert!(!src.exists());
         assert_eq!(fs::read(&dst).unwrap(), b"\x00\x01\x02\xff\xfe");
+    }
+
+    /// FIFO rename must not open the pipe for a text probe (hangs forever).
+    #[cfg(unix)]
+    #[test]
+    fn rename_fifo_apply_path_only_no_hang() {
+        use std::process::Command as StdCommand;
+        use std::time::{Duration, Instant};
+
+        let dir = TempDir::new().unwrap();
+        let src = dir.path().join("pipe.fifo");
+        let dst = dir.path().join("moved.fifo");
+        let status = StdCommand::new("mkfifo")
+            .arg(&src)
+            .status()
+            .expect("mkfifo available on unix CI");
+        assert!(status.success(), "mkfifo must create {src:?}");
+
+        let mut global = GlobalFlags::test_with_cwd(dir.path());
+        global.apply = true;
+        let args = RenameArgs {
+            from: "pipe.fifo".into(),
+            to: "moved.fifo".into(),
+            force: false,
+            write: Default::default(),
+        };
+
+        let start = Instant::now();
+        let code = run(args, &global).expect("FIFO rename must not hang or error");
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "FIFO rename took {:?}; likely opened the pipe",
+            start.elapsed()
+        );
+        assert_eq!(code, exit::SUCCESS);
+        assert!(!src.exists(), "source FIFO unlinked");
+        assert!(dst.exists(), "dest FIFO path exists");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::FileTypeExt;
+            let ft = fs::symlink_metadata(&dst).unwrap().file_type();
+            assert!(ft.is_fifo(), "dest must remain a FIFO, not a regular file");
+        }
     }
 
     #[test]

--- a/src/ops/file.rs
+++ b/src/ops/file.rs
@@ -138,6 +138,13 @@ pub fn rename_or_copy(src: &Path, dst: &Path) -> anyhow::Result<()> {
     match std::fs::rename(src, dst) {
         Ok(()) => Ok(()),
         Err(e) if is_cross_device_rename_error(&e) => {
+            // Cross-device copy opens the source; FIFO/socket would block forever.
+            if !is_regular_file_for_backup(src) {
+                anyhow::bail!(
+                    "cannot cross-device rename special node {}: copy would open a non-regular file",
+                    src.display()
+                );
+            }
             let dest_existed = path_entry_exists(dst);
             std::fs::copy(src, dst).with_context(|| {
                 format!("cross-device copy {} -> {}", src.display(), dst.display())
@@ -217,6 +224,11 @@ pub fn ensure_not_binary_file(path: &Path, display: &str) -> Result<(), crate::e
     use std::io::Read;
 
     if !path.exists() {
+        return Ok(());
+    }
+    // Never open FIFOs/sockets/devices for a binary probe (blocks forever).
+    // Callers that must reject special nodes do so before this helper.
+    if !is_regular_file_for_backup(path) {
         return Ok(());
     }
     let mut file = match std::fs::File::open(path) {
@@ -638,6 +650,31 @@ mod tests {
     fn ensure_not_binary_missing_path_ok() {
         let dir = TempDir::new().unwrap();
         ensure_not_binary_file(&dir.path().join("nope"), "nope").unwrap();
+    }
+
+    /// Must not open FIFOs for the binary probe (blocks forever).
+    #[cfg(unix)]
+    #[test]
+    fn ensure_not_binary_fifo_no_hang() {
+        use std::process::Command as StdCommand;
+        use std::time::{Duration, Instant};
+
+        let dir = TempDir::new().unwrap();
+        let fifo = dir.path().join("p.fifo");
+        assert!(
+            StdCommand::new("mkfifo")
+                .arg(&fifo)
+                .status()
+                .unwrap()
+                .success()
+        );
+        let start = Instant::now();
+        ensure_not_binary_file(&fifo, "p.fifo").unwrap();
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "ensure_not_binary_file on FIFO took {:?}",
+            start.elapsed()
+        );
     }
 
     #[test]

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1245,6 +1245,42 @@ rename to new.rs\n";
     client.cancel().await.unwrap();
 }
 
+/// Pure rename must refuse an existing destination (CLI/library parity, #2107).
+#[tokio::test]
+async fn test_mcp_apply_patch_pure_rename_refuses_existing_dest() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("old.rs"), "source\n").unwrap();
+    fs::write(dir.path().join("new.rs"), "dest-existing\n").unwrap();
+
+    let diff = "\
+diff --git a/old.rs b/new.rs\n\
+similarity index 100%\n\
+rename from old.rs\n\
+rename to new.rs\n";
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "apply_patch", serde_json::json!({"diff": diff})).await;
+    assert!(is_error, "overwrite dest via pure rename must fail: {val}");
+    let s = val.to_string();
+    assert!(
+        s.contains("already_exists") || s.contains("already exists"),
+        "expected already_exists honesty, got: {val}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("old.rs")).unwrap(),
+        "source\n"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("new.rs")).unwrap(),
+        "dest-existing\n"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// Pure rename source outside workspace must fail closed (#2109 PathGuard).
 #[tokio::test]
 async fn test_mcp_apply_patch_pure_rename_escape_source_rejected() {


### PR DESCRIPTION
## Summary

Real hang found during multi-perspective dogfood: `patchloom rename pipe.fifo dest --apply` never returned because the plain special-node rename path called `read_to_string` for a synthetic JSON path-move diff.

### Fixes

1. **CLI direct rename** - Do not read content for non-regular sources when building the synthetic rename diff.
2. **`save_before_write`** - Use empty backup markers for special nodes (same as `save_before_delete`); `fs::copy` on a FIFO blocks forever (force-overwrite dest cases).
3. **`ensure_not_binary_file`** - Skip open/read for non-regular files (md/tx/append binary probe path).
4. **`rename_or_copy` EXDEV** - Fail closed instead of `fs::copy` when the source is not a regular file.

### Tests

- Unit: FIFO rename apply, save_before_write FIFO, ensure_not_binary FIFO (no hang under 2s)
- Integration: MCP pure rename refuses existing dest (multi-surface lock for #2107)

## Verification

- `make check-fast` green
- Live: `rename f.fifo t2.fifo --apply` returns in <1s; dest remains FIFO