### PR TITLE
fix(api): PathGuard entry mode for delete and path-only rename

### DIFF
--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -48,11 +48,16 @@ Bline is a real embedder that dogfooded these steps; the checklist is host-gener
    following the target; directories stay refused (#2087, #2091). Soft-loading a
    symlink as text then writing would rewrite the **target**; rename uses an
    empty path-only snapshot so write policies never mutate the link target.
-   Append/prepend refuse non-text and special entries (including dangling
-   symlinks) with `invalid_input` (not `not_found`). Sole explicit
-   replace/search/tidy paths use the same classification via
-   `sole_explicit_non_text` so agents do not mis-branch on `not_found` for a
-   present non-file entry.
+   **Entry containment (#2115):** delete and path-only rename use
+   `PathGuard::check_path_entry` (parent follows; final component does not).
+   A workspace link whose target is outside the root can be unlinked or
+   renamed under a workspace guard without parent-only host workarounds or
+   `guard: None`. Content writes (`replace`, `doc_*`, append) still use
+   follow-mode `check_path`. Append/prepend refuse non-text and special
+   entries (including dangling symlinks) with `invalid_input` (not
+   `not_found`). Sole explicit replace/search/tidy paths use the same
+   classification via `sole_explicit_non_text` so agents do not mis-branch
+   on `not_found` for a present non-file entry.
 9. **Doc presentation honesty:** library `EditResult.style_changed` (and
    `is_style_changed`) mirrors CLI/MCP when YAML block-sequence layout
    collapses; values can still be correct (#2088). Warn hosts/agents; do not

--- a/src/api/file.rs
+++ b/src/api/file.rs
@@ -132,12 +132,14 @@ fn file_write(
             } else {
                 String::new()
             };
+            // Entry containment: do not follow symlink targets (#2115).
             // Preview/Check: report would-delete without unlinking (#2087 DryRun).
             let (applied, backup_session) = if mode == ApplyMode::Apply {
+                super::ensure_contained_entry(guard, path)?;
                 super::apply_mutation(
                     path,
                     mode,
-                    guard,
+                    None, // already checked with entry semantics
                     |backup| backup.save_before_delete(path),
                     || {
                         std::fs::remove_file(path)
@@ -145,7 +147,7 @@ fn file_write(
                     },
                 )?
             } else {
-                super::ensure_contained(guard, path)?;
+                super::ensure_contained_entry(guard, path)?;
                 (false, None)
             };
             {
@@ -315,6 +317,12 @@ pub fn file_create(
 /// is backed up for undo; special nodes get an empty backup marker (restore
 /// recreates an empty regular file, not the original node type).
 ///
+/// **Guard:** uses entry containment ([`PathGuard::check_path_entry`]): the
+/// directory entry must sit under the workspace; the symlink **target** is not
+/// used for allow/deny (#2115). So `workspace/link → /etc/passwd` can be
+/// deleted with a workspace guard without treating the op as touching
+/// `/etc/passwd`.
+///
 /// DryRun / Preview / Check report would-delete without unlinking.
 pub fn file_delete(
     path: &Path,
@@ -339,6 +347,11 @@ pub fn file_delete(
 /// special nodes use an empty path-only snapshot so write policies never
 /// rewrite the link target. Regular-file content is soft-loaded for
 /// preview/diff; binary / invalid UTF-8 still path-rename (#2031).
+///
+/// **Guard:** both `src` and `dst` use entry containment
+/// ([`PathGuard::check_path_entry`]) so a link whose target is outside the
+/// workspace can still be renamed when the **entry paths** stay inside
+/// (#2115).
 pub fn file_rename(
     src: &Path,
     dst: &Path,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -777,11 +777,18 @@ fn apply_cross_file_mutation(
     perform_mutation: impl FnOnce() -> anyhow::Result<()>,
 ) -> anyhow::Result<(bool, Option<String>)> {
     if mode != ApplyMode::Apply {
+        // Still enforce entry containment on preview/check so hosts see
+        // guard_rejected without mutating (#2115).
+        ensure_contained_entry(guard, src)?;
+        if let Some(d) = dst {
+            ensure_contained_entry(guard, d)?;
+        }
         return Ok((false, None));
     }
-    ensure_contained(guard, src)?;
+    // Path-only rename: entry semantics (no-follow final component) on both ends.
+    ensure_contained_entry(guard, src)?;
     if let Some(d) = dst {
-        ensure_contained(guard, d)?;
+        ensure_contained_entry(guard, d)?;
     }
     let cwd = src.parent().unwrap_or_else(|| Path::new("."));
     let mut backup = BackupSession::new(cwd)?;
@@ -884,6 +891,16 @@ pub(crate) fn maybe_post_write(
 pub(crate) fn ensure_contained(guard: Option<&PathGuard>, path: &Path) -> anyhow::Result<()> {
     if let Some(g) = guard {
         g.check_path(&path.to_string_lossy())
+            .map_err(crate::fallback::EditError::guard_rejected)?;
+    }
+    Ok(())
+}
+
+/// Containment for directory-entry ops (delete / path-only rename): do not follow
+/// the final path component (#2115). See [`PathGuard::check_path_entry`].
+pub(crate) fn ensure_contained_entry(guard: Option<&PathGuard>, path: &Path) -> anyhow::Result<()> {
+    if let Some(g) = guard {
+        g.check_path_entry(&path.to_string_lossy())
             .map_err(crate::fallback::EditError::guard_rejected)?;
     }
     Ok(())

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -276,10 +276,11 @@ pub fn apply_patch_file(
         for op in &staged {
             match op {
                 StageOp::Write { write_path, .. } => super::ensure_contained(guard, write_path)?,
-                StageOp::Delete { path, .. } => super::ensure_contained(guard, path)?,
+                // Path-only delete/rename: entry containment (#2115).
+                StageOp::Delete { path, .. } => super::ensure_contained_entry(guard, path)?,
                 StageOp::Rename { from, to, .. } => {
-                    super::ensure_contained(guard, from)?;
-                    super::ensure_contained(guard, to)?;
+                    super::ensure_contained_entry(guard, from)?;
+                    super::ensure_contained_entry(guard, to)?;
                 }
             }
         }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7602,6 +7602,60 @@ fn file_delete_symlink_unlinks_link_not_target() {
     assert_eq!(fs::read_to_string(&target).unwrap(), "keep me\n");
 }
 
+/// Symlink to a path outside the workspace: entry guard allows unlink (#2115).
+///
+/// Follow-mode `check_path` would deny (resolved target escapes). Hosts must
+/// not need parent-only precheck + `guard: None`.
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_delete_symlink_to_outside_under_workspace_guard() {
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let secret = outside.path().join("secret.env");
+    fs::write(&secret, "SECRET=1\n").unwrap();
+    let link = dir.path().join("link-out");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+    let guard = crate::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .expect("guard");
+    // Sanity: follow-mode containment would reject the resolved target.
+    assert!(
+        guard.check_path(link.to_str().unwrap()).is_err(),
+        "check_path must follow outside target and deny"
+    );
+    assert!(
+        guard.would_allow_entry(link.to_str().unwrap()),
+        "check_path_entry must allow the workspace link entry"
+    );
+
+    let r = file_delete(&link, ApplyMode::Apply, Some(&guard))
+        .expect("entry guard must allow unlink of outside-target link");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+    assert!(secret.exists(), "outside target must never be deleted");
+    assert_eq!(fs::read_to_string(&secret).unwrap(), "SECRET=1\n");
+}
+
+/// Dangling symlink under workspace guard (#2115 entry mode).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_delete_dangling_symlink_under_guard() {
+    let dir = TempDir::new().unwrap();
+    let link = dir.path().join("dangling");
+    std::os::unix::fs::symlink(dir.path().join("missing-target"), &link).unwrap();
+    let guard = crate::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .expect("guard");
+    let r = file_delete(&link, ApplyMode::Apply, Some(&guard)).expect("dangling under guard");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+}
+
 /// Dangling symlink is still unlinkable (#2087 path_entry_exists).
 #[cfg(all(unix, any(feature = "cli", feature = "files")))]
 #[test]
@@ -7637,6 +7691,32 @@ fn file_delete_symlink_to_directory() {
         fs::read_to_string(real_dir.join("inside.txt")).unwrap(),
         "x\n"
     );
+}
+
+/// Rename of outside-target symlink under workspace guard (#2115).
+#[cfg(all(unix, any(feature = "cli", feature = "files")))]
+#[test]
+fn file_rename_symlink_to_outside_under_workspace_guard() {
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let secret = outside.path().join("secret.env");
+    fs::write(&secret, "SECRET=1\n").unwrap();
+    let link = dir.path().join("link-out");
+    let moved = dir.path().join("moved-out");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+    let guard = crate::containment::PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .expect("guard");
+    let r = file_rename(&link, &moved, false, ApplyMode::Apply, Some(&guard))
+        .expect("entry guard must allow rename of outside-target link");
+    assert!(r.applied);
+    assert!(!crate::ops::file::path_entry_exists(&link));
+    assert!(moved.is_symlink());
+    assert_eq!(fs::read_link(&moved).unwrap(), secret);
+    assert_eq!(fs::read_to_string(&secret).unwrap(), "SECRET=1\n");
 }
 
 /// Rename moves the symlink entry only; never rewrites the target (#2091).

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -8,6 +8,13 @@
 //! 1. **Syntactic check** (no I/O): rejects `../` traversal that goes beyond root depth
 //! 2. **Symlink-aware check**: canonicalizes and verifies the resolved path is contained
 //!
+//! ## Content vs entry containment (#2115)
+//!
+//! | Mode | API | Use for |
+//! |------|-----|---------|
+//! | **Follow** (default) | [`PathGuard::check_path`] | Content writes (`replace`, `doc_*`, append) so a symlink cannot smuggle writes outside the root |
+//! | **Entry** (no-follow last component) | [`PathGuard::check_path_entry`] | Directory-entry ops (`file_delete`, path-only `file_rename`) so `workspace/link → /etc/passwd` can be unlinked without treating the op as touching `/etc/passwd` |
+//!
 //! ## Policy choices for different use cases
 //!
 //! | Policy | Use when | Example |
@@ -214,30 +221,17 @@ impl PathGuard {
     /// Validate that `path` stays within the workspace root (or additional roots if configured).
     ///
     /// Returns the canonicalized path on success. Rejects paths that
-    /// escape the allowed roots via `../` traversal or symlinks.
+    /// escape the allowed roots via `../` traversal or **followed** symlinks.
+    ///
+    /// Use this for **content** ops. For unlink/rename of directory entries
+    /// (including symlinks whose target is outside the workspace), use
+    /// [`check_path_entry`] instead (#2115).
     pub fn check_path(&self, path: &str) -> Result<PathBuf, ContainmentError> {
         let p = Path::new(path);
 
         if p.is_absolute() {
-            match &self.absolute_policy {
-                AbsolutePathPolicy::Reject => {
-                    return Err(ContainmentError::AbsolutePath(path.to_string()));
-                }
-                AbsolutePathPolicy::AllowIfContained => {
-                    // Skip syntactic check, go straight to symlink-aware check.
-                    let roots = vec![self.canon_root.clone()];
-                    return self.check_resolved_absolute(path, p, &roots);
-                }
-                AbsolutePathPolicy::AllowAdditionalRoots(extra) => {
-                    let mut allowed = vec![self.canon_root.clone()];
-                    for r in extra {
-                        if let Ok(c) = safe_canonicalize(r) {
-                            allowed.push(c);
-                        }
-                    }
-                    return self.check_resolved_absolute(path, p, &allowed);
-                }
-            }
+            let roots = self.absolute_allowed_roots(path)?;
+            return self.check_resolved_absolute(path, p, &roots);
         }
 
         // Syntactic depth-tracking check (no I/O). Relative always against primary root.
@@ -245,6 +239,30 @@ impl PathGuard {
 
         // Symlink-aware containment check (primary root).
         self.check_resolved_relative(path)
+    }
+
+    /// Validate that a **directory entry** path stays under allowed roots without
+    /// following the final path component (#2115).
+    ///
+    /// Resolves the **parent** with normal symlink following, then appends the
+    /// final file name without following that name. Use for `file_delete` and
+    /// path-only `file_rename` so hosts can unlink `workspace/link → outside`
+    /// under a workspace PathGuard without the guard treating the op as
+    /// touching the outside target.
+    ///
+    /// Intermediate directory components still follow (a parent dir that is a
+    /// symlink out of the workspace is still rejected).
+    pub fn check_path_entry(&self, path: &str) -> Result<PathBuf, ContainmentError> {
+        let p = Path::new(path);
+
+        if p.is_absolute() {
+            let roots = self.absolute_allowed_roots(path)?;
+            return self.check_entry_under_roots(path, p, &roots);
+        }
+
+        validate_relative_depth(path, p, &self.root)?;
+        let joined = self.root.join(path);
+        self.check_entry_under_roots(path, &joined, std::slice::from_ref(&self.canon_root))
     }
 
     /// The original (non-canonicalized) workspace root.
@@ -258,9 +276,65 @@ impl PathGuard {
     }
 
     /// Returns true if the path would be allowed under the current policy
-    /// (dry-run, no error details).
+    /// (dry-run, no error details). Follow semantics ([`check_path`]).
     pub fn would_allow(&self, path: &str) -> bool {
         self.check_path(path).is_ok()
+    }
+
+    /// Dry-run entry-mode check ([`check_path_entry`]).
+    pub fn would_allow_entry(&self, path: &str) -> bool {
+        self.check_path_entry(path).is_ok()
+    }
+
+    /// Allowed canonical roots for absolute-path checks under the current policy.
+    ///
+    /// Returns `Err(AbsolutePath)` when absolute paths are rejected.
+    fn absolute_allowed_roots(&self, path: &str) -> Result<Vec<PathBuf>, ContainmentError> {
+        match &self.absolute_policy {
+            AbsolutePathPolicy::Reject => Err(ContainmentError::AbsolutePath(path.to_string())),
+            AbsolutePathPolicy::AllowIfContained => Ok(vec![self.canon_root.clone()]),
+            AbsolutePathPolicy::AllowAdditionalRoots(extra) => {
+                let mut allowed = vec![self.canon_root.clone()];
+                for r in extra {
+                    if let Ok(c) = safe_canonicalize(r) {
+                        allowed.push(c);
+                    }
+                }
+                Ok(allowed)
+            }
+        }
+    }
+
+    /// Parent-follow + final-component no-follow under `allowed_roots`.
+    fn check_entry_under_roots(
+        &self,
+        display: &str,
+        path: &Path,
+        allowed_roots: &[PathBuf],
+    ) -> Result<PathBuf, ContainmentError> {
+        let normalized = normalize_lexical(path);
+        let Some(file_name) = normalized.file_name() else {
+            // No final component (e.g. `/` or `..`): fall back to follow check.
+            return self.check_resolved_absolute(display, path, allowed_roots);
+        };
+        let parent = normalized.parent().unwrap_or_else(|| Path::new("."));
+        let parent_canon =
+            canonicalize_or_ancestor(parent).map_err(|e| ContainmentError::Canonicalize {
+                path: display.to_string(),
+                source: e,
+            })?;
+        let contained = allowed_roots.iter().any(|r| parent_canon.starts_with(r));
+        if !contained {
+            return Err(ContainmentError::Escaped {
+                path: dunce::simplified(Path::new(display))
+                    .to_string_lossy()
+                    .into_owned(),
+                root: self.root.display().to_string(),
+            });
+        }
+        let mut entry = parent_canon;
+        entry.push(file_name);
+        Ok(entry)
     }
 
     /// Check that an absolute path resolves within one of the allowed roots.

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -218,6 +218,44 @@ fn path_guard_canon_root_has_no_windows_unc_prefix() {
         guard_abs.canon_root()
     );
 }
+/// Entry mode: symlink to outside target is allowed when the link entry is inside (#2115).
+#[cfg(unix)]
+#[test]
+fn check_path_entry_allows_symlink_to_outside_target() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+    let secret = outside.path().join("secret");
+    fs::write(&secret, "x").unwrap();
+    let link = dir.path().join("link");
+    symlink(&secret, &link).unwrap();
+
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    assert!(
+        guard.check_path(link.to_str().unwrap()).is_err(),
+        "follow mode must deny outside target"
+    );
+    let entry = guard
+        .check_path_entry(link.to_str().unwrap())
+        .expect("entry mode must allow workspace link");
+    assert!(
+        entry.starts_with(guard.canon_root()),
+        "entry path under root: {entry:?}"
+    );
+    assert!(guard.would_allow_entry(link.to_str().unwrap()));
+}
+
+/// Entry mode still rejects paths that escape via relative traversal.
+#[test]
+fn check_path_entry_rejects_parent_escape() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
+    assert!(guard.check_path_entry("../../etc/passwd").is_err());
+}
 
 #[cfg(windows)]
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,7 @@
 //! | Force create over binary/unreadable prior | [`api::file_create`](..., `force: true`) (#1962) |
 //! | Path-only rename/delete non-text (byte backup, no OS dual-path) | [`api::file_rename`] / [`api::file_delete`] (#2031) |
 //! | Delete FIFO/socket/device/symlink under PathGuard | [`api::file_delete`] (dirs still refused; #2087) |
+//! | Unlink/rename symlink when target is outside workspace | Entry guard [`PathGuard::check_path_entry`] on delete/rename (#2115) |
 //! | Rename symlink/FIFO/dangling (path-only; never rewrites link target) | [`api::file_rename`] (#2091) |
 //! | YAML presentation drift on library writes | [`EditResult::style_changed`] / [`api::is_style_changed`] (#2088) |
 //! | Morph-class freeform on disk | [`api::apply_fragment_to_file`] + [`FragmentPlacement`] (#2032) |

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -682,6 +682,12 @@ impl Operation {
     pub fn declared_paths(&self) -> Vec<String> {
         crate::plan::declared_paths(self)
     }
+
+    /// True when declared paths should use entry containment (no-follow last
+    /// component) rather than follow-mode `PathGuard::check_path` (#2115).
+    pub fn uses_entry_containment(&self) -> bool {
+        matches!(self, Self::FileDelete { .. } | Self::FileRename { .. })
+    }
 }
 
 /// Serde default for [`Operation::ApplyFragment::unique`] (agents need fail-closed uniqueness).

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -265,11 +265,17 @@ fn execute_plan_inner(
 
     // PathGuard enforcement (same pattern as lifecycle.rs execute_plan_direct).
     // Use GuardRejected (not InvalidInput) so edit_error_kind peels correctly (#1935).
+    // FileDelete / FileRename use entry (no-follow last component) so symlink
+    // targets outside the workspace do not block unlink/rename (#2115).
     if let Some(g) = options.guard {
         for op in &operations {
             for p in op.declared_paths() {
-                g.check_path(&p)
-                    .map_err(crate::fallback::EditError::guard_rejected)?;
+                let r = if op.uses_entry_containment() {
+                    g.check_path_entry(&p)
+                } else {
+                    g.check_path(&p)
+                };
+                r.map_err(crate::fallback::EditError::guard_rejected)?;
             }
         }
     }

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -721,12 +721,16 @@ pub(crate) fn execute_and_collect(
     // execute_plan_direct). CLI `tx` and `batch` call this function directly and
     // previously only had guard wiring on replace glob expansion, so
     // `file.create ../escape` under `--contain` could still write outside the
-    // workspace (MPI cycle 13).
+    // workspace (MPI cycle 13). Entry ops use no-follow last component (#2115).
     if let Some(g) = guard {
         for op in &plan.operations {
             for p in op.declared_paths() {
-                g.check_path(&p)
-                    .map_err(crate::fallback::EditError::guard_rejected)?;
+                let r = if op.uses_entry_containment() {
+                    g.check_path_entry(&p)
+                } else {
+                    g.check_path(&p)
+                };
+                r.map_err(crate::fallback::EditError::guard_rejected)?;
             }
         }
     }

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -115,10 +115,15 @@ pub fn execute_plan_direct(
         }
         // Upfront check on declared paths using shared helper; dynamic (globs
         // patterns, patch embedded paths) are best-effort or handled by loaders.
+        // Entry ops (delete/rename) use no-follow last component (#2115).
         for op in &plan.operations {
             for p in op.declared_paths() {
-                g.check_path(&p)
-                    .map_err(crate::fallback::EditError::guard_rejected)?;
+                let r = if op.uses_entry_containment() {
+                    g.check_path_entry(&p)
+                } else {
+                    g.check_path(&p)
+                };
+                r.map_err(crate::fallback::EditError::guard_rejected)?;
             }
         }
     }


### PR DESCRIPTION
## Summary

Implements [patchloom#2115](https://github.com/patchloom/patchloom/issues/2115): entry containment so library hosts can delete/rename symlink directory entries under PathGuard when the **target** is outside the workspace.

### Behavior

| Mode | API | Used for |
|------|-----|----------|
| Follow | `PathGuard::check_path` | Content writes (unchanged) |
| Entry | `PathGuard::check_path_entry` | `file_delete`, path-only `file_rename` (and plan/tx/engine/patch declared paths for those ops) |

Entry mode resolves the **parent** with normal following, then appends the final component without following it.

### Tests

- Containment: outside-target symlink allowed in entry mode; relative escape still denied
- Library: delete/rename outside-target symlink under workspace guard; dangling under guard
- Existing FIFO/symlink suites remain green

### Docs

- `docs/getting-started/embedder-host.md` entry vs content
- API rustdoc + `lib.rs` embedder table

Closes #2115

## Verification

- `make check-fast` green