### PR TITLE
fix(cli,mcp): entry PathGuard on delete/rename dual paths

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -64,7 +64,18 @@
 //! );
 //! ```
 //!
-//! **Guard semantics:** The guard provides *write-time* enforcement and is only checked for `ApplyMode::Apply` writes (via `ensure_contained` + `write_if_apply`). Reads (e.g. for diff computation, `Preview`/`Check` modes, `doc_get`, search) and pre-write loads may still observe or describe paths outside the guard. This is intentional for trusted library embedding (the host/caller controls visibility). MCP uses a separate strict pre-check layer on all paths. `execute_plan` also accepts a guard and performs upfront validation on declared paths.
+//! **Guard semantics:** The guard provides *write-time* enforcement for most
+//! mutators (via `ensure_contained` / follow-mode `PathGuard::check_path` on
+//! Apply). **Entry ops** (`file_delete`, path-only `file_rename`) use
+//! `ensure_contained_entry` / `PathGuard::check_path_entry` (parent follows;
+//! final component does not) on Preview/Check/Apply so a workspace symlink
+//! whose target is outside the root can still be unlinked (#2115). Content
+//! writes (`replace`, `doc_*`, append) stay on follow mode so they cannot
+//! smuggle writes outside the root through a link. Reads (diff computation,
+//! `doc_get`, search) may still observe paths outside the guard; the host
+//! controls visibility. MCP and CLI `--contain` use the same entry vs follow
+//! split for delete/rename. `execute_plan` pre-checks declared paths with
+//! the matching mode per op.
 //!
 //! ## Guard & WritePolicy contract
 //!

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -466,26 +466,60 @@ impl GlobalFlags {
     ///   so backup and apply never see raw Windows `\\?\` paths (#1931).
     /// - **Relative:** optionally validate under `--contain`, but keep the
     ///   original string for agent JSON (`skipped` / `refused` / plan paths).
+    ///
+    /// Uses follow-mode containment (content ops). For delete/rename entry
+    /// ops under `--contain`, use [`rewrite_user_path_arg_entry`] (#2115).
     pub fn rewrite_user_path_arg(
         &self,
         cwd: &std::path::Path,
         path: &str,
     ) -> anyhow::Result<String> {
+        self.rewrite_user_path_arg_inner(cwd, path, false)
+    }
+
+    /// Like [`rewrite_user_path_arg`] but uses entry-mode PathGuard checks
+    /// (no-follow last component) for `delete` / `rename` under `--contain`.
+    pub fn rewrite_user_path_arg_entry(
+        &self,
+        cwd: &std::path::Path,
+        path: &str,
+    ) -> anyhow::Result<String> {
+        self.rewrite_user_path_arg_inner(cwd, path, true)
+    }
+
+    fn rewrite_user_path_arg_inner(
+        &self,
+        cwd: &std::path::Path,
+        path: &str,
+        entry: bool,
+    ) -> anyhow::Result<String> {
+        if path.trim().is_empty() {
+            return Err(crate::exit::InvalidInputError {
+                msg: "path must not be empty".into(),
+            }
+            .into());
+        }
+        if let Some(guard) = self.workspace_guard(cwd)? {
+            let resolved = if entry {
+                guard
+                    .check_path_entry(path)
+                    .map_err(crate::fallback::EditError::guard_rejected)?
+            } else {
+                guard
+                    .check_path(path)
+                    .map_err(crate::fallback::EditError::guard_rejected)?
+            };
+            if std::path::Path::new(path).is_absolute() {
+                return Ok(resolved.to_string_lossy().into_owned());
+            }
+            // Relative: validate under contain, keep original spelling for agents.
+            return Ok(path.to_string());
+        }
         if std::path::Path::new(path).is_absolute() {
-            Ok(self
-                .normalize_io_path(cwd, path)?
+            Ok(dunce::simplified(std::path::Path::new(path))
                 .to_string_lossy()
                 .into_owned())
         } else {
-            // Validate only when sandboxing; keep relative display form.
-            if self.contain {
-                self.normalize_io_path(cwd, path)?;
-            } else if path.trim().is_empty() {
-                return Err(crate::exit::InvalidInputError {
-                    msg: "path must not be empty".into(),
-                }
-                .into());
-            }
             Ok(path.to_string())
         }
     }

--- a/src/cmd/delete.rs
+++ b/src/cmd/delete.rs
@@ -29,7 +29,7 @@ struct DeleteOutput {
 pub fn run(mut args: DeleteArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     crate::verbose!("delete: file={}", args.file);
     let cwd = global.resolve_cwd()?;
-    args.file = global.rewrite_user_path_arg(&cwd, &args.file)?;
+    args.file = global.rewrite_user_path_arg_entry(&cwd, &args.file)?;
     let path = cwd.join(&args.file);
 
     // One classify: dangling ok; real directories refuse; no follow (#2087).

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -41,6 +41,7 @@ fn validate_op_paths_under_plan_cwd(
     let Some(prefix) = plan_cwd else {
         return svc.validate_op_paths(op);
     };
+    let entry = op.uses_entry_containment();
     let check = |path: &str| -> Result<(), McpError> {
         let candidate = if std::path::Path::new(path).is_absolute() {
             path.to_string()
@@ -51,7 +52,11 @@ fn validate_op_paths_under_plan_cwd(
                 path.trim_start_matches('/')
             )
         };
-        svc.check_path(&candidate)
+        if entry {
+            svc.check_path_entry(&candidate)
+        } else {
+            svc.check_path(&candidate)
+        }
     };
     for declared in op.declared_paths() {
         check(&declared)?;
@@ -64,7 +69,33 @@ fn validate_op_paths_under_plan_cwd(
             )
         })?;
         for pf in &patch_files {
-            check(&pf.path)?;
+            if pf.rename_from.is_some() {
+                // Path-only rename headers: entry containment (#2115).
+                let candidate = if std::path::Path::new(pf.path.as_str()).is_absolute() {
+                    pf.path.clone()
+                } else {
+                    format!(
+                        "{}/{}",
+                        prefix.trim_end_matches('/'),
+                        pf.path.trim_start_matches('/')
+                    )
+                };
+                svc.check_path_entry(&candidate)?;
+                if let Some(from) = &pf.rename_from {
+                    let from_c = if std::path::Path::new(from.as_str()).is_absolute() {
+                        from.clone()
+                    } else {
+                        format!(
+                            "{}/{}",
+                            prefix.trim_end_matches('/'),
+                            from.trim_start_matches('/')
+                        )
+                    };
+                    svc.check_path_entry(&from_c)?;
+                }
+            } else {
+                check(&pf.path)?;
+            }
         }
     }
     Ok(())

--- a/src/cmd/mcp/mod.rs
+++ b/src/cmd/mcp/mod.rs
@@ -237,6 +237,15 @@ impl PatchloomService {
         Ok(())
     }
 
+    /// Entry-mode path check (delete / path-only rename): do not follow the
+    /// final path component (#2115).
+    fn check_path_entry(&self, path: &str) -> Result<(), McpError> {
+        self.path_guard
+            .check_path_entry(path)
+            .map_err(|e| McpError::invalid_params(e.to_string(), None))?;
+        Ok(())
+    }
+
     /// The workspace root directory (non-canonicalized).
     fn cwd(&self) -> &std::path::Path {
         self.path_guard.root()
@@ -322,8 +331,13 @@ impl PatchloomService {
 
     /// Validate paths for a single operation (including embedded paths for PatchApply).
     fn validate_op_paths(&self, op: &Operation) -> Result<(), McpError> {
+        let entry = op.uses_entry_containment();
         for declared in op.declared_paths() {
-            self.check_path(&declared)?;
+            if entry {
+                self.check_path_entry(&declared)?;
+            } else {
+                self.check_path(&declared)?;
+            }
         }
         if let Operation::PatchApply { diff, .. } = op {
             let patch_files = crate::ops::patch::parse_patch(diff).map_err(|e| {
@@ -333,9 +347,14 @@ impl PatchloomService {
                 )
             })?;
             for pf in &patch_files {
-                self.check_path(&pf.path)?;
-                if let Some(from) = &pf.rename_from {
-                    self.check_path(from)?;
+                // Pure/git renames are path-only; content patches follow.
+                if pf.rename_from.is_some() {
+                    self.check_path_entry(&pf.path)?;
+                    if let Some(from) = &pf.rename_from {
+                        self.check_path_entry(from)?;
+                    }
+                } else {
+                    self.check_path(&pf.path)?;
                 }
             }
         }

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -15,8 +15,10 @@ use crate::plan::Operation;
 
 /// Validation rule for a single field in an auto-generated MCP tool.
 pub(super) enum FieldValidation {
-    /// Validate a string field with `check_path` (path containment).
+    /// Validate a string field with follow-mode `check_path` (content ops).
     Path(&'static str),
+    /// Validate with entry-mode `check_path_entry` (delete / path-only rename) (#2115).
+    PathEntry(&'static str),
     /// Validate a string field with `validate_param_size` (1 MiB limit).
     ParamSize(&'static str),
     /// Validate a string field with `validate_content_size` (10 MiB limit).
@@ -266,7 +268,10 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
             "Use force=true to overwrite an existing destination. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: false,
-        validations: &[FieldValidation::Path("from"), FieldValidation::Path("to")],
+        validations: &[
+            FieldValidation::PathEntry("from"),
+            FieldValidation::PathEntry("to"),
+        ],
     },
     McpToolMeta {
         tool_name: "append_file",
@@ -311,7 +316,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
             "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: false,
-        validations: &[FieldValidation::Path("path")],
+        validations: &[FieldValidation::PathEntry("path")],
     },
     // MCP-friendly alias of tidy.fix with agent-oriented defaults (trim + final
     // newline on when omitted). Defaults applied in handle_simple_op.
@@ -457,6 +462,11 @@ pub(super) fn handle_simple_op(
             FieldValidation::Path(field) => {
                 if let Some(val) = args_obj.get(*field).and_then(|v| v.as_str()) {
                     service.check_path(val)?;
+                }
+            }
+            FieldValidation::PathEntry(field) => {
+                if let Some(val) = args_obj.get(*field).and_then(|v| v.as_str()) {
+                    service.check_path_entry(val)?;
                 }
             }
             FieldValidation::ParamSize(field) => {

--- a/src/cmd/rename.rs
+++ b/src/cmd/rename.rs
@@ -48,8 +48,8 @@ pub fn run(mut args: RenameArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     let cwd = global.resolve_cwd()?;
     // Empty-path + --contain, and rewrite absolute paths so case-only / backup
     // I/O never sees Windows \\?\ UNC forms (#1931 / platform path suite).
-    args.from = global.rewrite_user_path_arg(&cwd, &args.from)?;
-    args.to = global.rewrite_user_path_arg(&cwd, &args.to)?;
+    args.from = global.rewrite_user_path_arg_entry(&cwd, &args.from)?;
+    args.to = global.rewrite_user_path_arg_entry(&cwd, &args.to)?;
     let src = cwd.join(&args.from);
     let dst = cwd.join(&args.to);
 

--- a/tests/integration/delete_tests.rs
+++ b/tests/integration/delete_tests.rs
@@ -397,6 +397,33 @@ fn test_delete_contain_allows_in_workspace() {
     assert!(!dir.path().join("inside.txt").exists());
 }
 
+/// Entry containment: workspace symlink to outside target under `--contain` (#2115).
+#[cfg(unix)]
+#[test]
+fn test_delete_contain_allows_symlink_to_outside_target() {
+    let dir = TempDir::new().unwrap();
+    let outside = TempDir::new().unwrap();
+    let secret = outside.path().join("secret.env");
+    fs::write(&secret, "SECRET=1\n").unwrap();
+    let link = dir.path().join("link-out");
+    std::os::unix::fs::symlink(&secret, &link).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["--contain", "delete", "link-out", "--apply"])
+        .assert()
+        .code(0);
+
+    assert!(
+        fs::symlink_metadata(&link).is_err(),
+        "link entry must be unlinked"
+    );
+    assert!(secret.exists(), "outside target must remain");
+    assert_eq!(fs::read_to_string(&secret).unwrap(), "SECRET=1\n");
+}
+
 #[test]
 fn test_delete_json_not_found_sets_error_kind() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Follow-up to #2116 / #2115. Reviewer found dual-path gaps: library and engine entry containment were correct, but **MCP** and **CLI `--contain`** still pre-checked with follow-mode `check_path`, so agents could not delete a workspace symlink whose target is outside the root.

### Changes

- `FieldValidation::PathEntry` on `delete_file` / `move_file`
- MCP `validate_op_paths` and plan-cwd validation use `uses_entry_containment()`
- Patch pure-rename headers use entry checks
- CLI `rewrite_user_path_arg_entry` for `delete` / `rename`
- Integration: `test_delete_contain_allows_symlink_to_outside_target`

Ref #2115 (closed by #2116; this completes multi-surface honesty)

## Verification

- `make check-fast` green