### PR TITLE
fix: FIFO-safe text probes and entry PathGuard parent escape test

### DIFF
--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -257,6 +257,42 @@ fn check_path_entry_rejects_parent_escape() {
     assert!(guard.check_path_entry("../../etc/passwd").is_err());
 }
 
+/// Entry mode follows intermediate directory components: a parent that is a
+/// symlink out of the workspace is still rejected (#2115).
+#[cfg(unix)]
+#[test]
+fn check_path_entry_rejects_intermediate_parent_symlink_escape() {
+    use std::os::unix::fs::symlink;
+    let dir = tempfile::TempDir::new().unwrap();
+    let outside = tempfile::TempDir::new().unwrap();
+    fs::write(outside.path().join("secret"), "x").unwrap();
+    // workspace/outlink → outside dir; path outlink/secret would reach outside.
+    let outlink = dir.path().join("outlink");
+    symlink(outside.path(), &outlink).unwrap();
+
+    let guard = PathGuard::new(
+        dir.path().to_path_buf(),
+        AbsolutePathPolicy::AllowIfContained,
+    )
+    .unwrap();
+    let via = outlink.join("secret");
+    let via_str = via.to_str().expect("utf-8 temp path");
+    assert!(
+        guard.check_path(via_str).is_err(),
+        "follow mode must deny intermediate outlink"
+    );
+    assert!(
+        guard.check_path_entry(via_str).is_err(),
+        "entry mode must still deny intermediate parent symlink escape"
+    );
+    // The outlink entry itself remains an in-workspace name (delete/rename ok).
+    let outlink_str = outlink.to_str().expect("utf-8 temp path");
+    assert!(
+        guard.check_path_entry(outlink_str).is_ok(),
+        "entry mode must allow the symlink directory entry itself"
+    );
+}
+
 #[cfg(windows)]
 #[test]
 fn windows_safe_canonicalize_preserves_drive_letter() {

--- a/src/files.rs
+++ b/src/files.rs
@@ -151,13 +151,23 @@ pub fn load_text_strict(path: &Path, display: &str) -> anyhow::Result<String> {
     }
 }
 
+/// True when `path` is a regular file (or symlink to one) safe to open for
+/// text/binary probes. FIFOs, sockets, devices, and directories return false so
+/// callers never block forever on open (#2113 family).
+fn is_openable_regular_file(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(m) => m.is_file(),
+        Err(_) => false,
+    }
+}
+
 /// Returns whether the file at `path` appears to be binary by reading only its
 /// first 8 KiB (streaming, no full allocation for large files).
 ///
 /// Heuristic: true when a NUL byte appears in the probe window (same rule as
 /// [`is_binary`]). Returns **false** if the path cannot be opened or read
-/// (missing, permission, …); callers that need a typed open error should open
-/// the path themselves.
+/// (missing, permission, FIFO/socket/device, …); callers that need a typed open
+/// error should open the path themselves.
 ///
 /// Public for embedder preflight (#1884) so hosts do not reimplement the
 /// window size or probe semantics. Writers still enforce binary themselves
@@ -165,6 +175,10 @@ pub fn load_text_strict(path: &Path, display: &str) -> anyhow::Result<String> {
 /// Available with default features and under `features = ["files"]` (always
 /// compiled; no `cli` gate).
 pub fn is_binary_file(path: &Path) -> bool {
+    // Never open special nodes: FIFO/socket open blocks forever.
+    if !is_openable_regular_file(path) {
+        return false;
+    }
     let mut file = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(_) => return false,
@@ -654,8 +668,16 @@ impl SoftTextSkip {
 ///
 /// For files larger than 8 KiB, only the first 8 KiB are read initially
 /// for the binary check. If the file is binary, no further I/O occurs.
+///
+/// Never opens FIFOs, sockets, or devices (would block forever); those
+/// return [`SoftTextSkip::Unreadable`].
 pub fn try_read_text_file(path: &Path) -> Result<String, SoftTextSkip> {
     use std::io::Read;
+
+    // Metadata-first: `File::open` on a FIFO blocks until a writer connects.
+    if !is_openable_regular_file(path) {
+        return Err(SoftTextSkip::Unreadable);
+    }
 
     let mut file = match std::fs::File::open(path) {
         Ok(f) => f,
@@ -1014,6 +1036,26 @@ mod tests {
         assert!(!is_binary_file(&dir.path().join("nope.bin"))); // open fails -> false
     }
 
+    /// Public binary probe must not open FIFOs (blocks forever).
+    #[cfg(unix)]
+    #[test]
+    fn is_binary_file_fifo_no_hang() {
+        use std::time::Instant;
+        let dir = tempfile::TempDir::new().unwrap();
+        let fifo = dir.path().join("p.fifo");
+        std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo");
+        let start = Instant::now();
+        assert!(!is_binary_file(&fifo));
+        assert!(
+            start.elapsed().as_secs() < 2,
+            "is_binary_file on FIFO took {:?}",
+            start.elapsed()
+        );
+    }
+
     // ── Text I/O honesty (#1894) ──────────────────────────────────────
 
     #[test]
@@ -1346,6 +1388,29 @@ mod tests {
         assert!(SoftTextSkip::Binary.is_content_skip());
         assert!(!SoftTextSkip::Unreadable.is_content_skip());
         assert_eq!(SoftTextSkip::InvalidUtf8.as_reason(), "invalid_utf8");
+    }
+
+    /// Soft text load must not open FIFOs (blocks forever).
+    #[cfg(unix)]
+    #[test]
+    fn try_read_text_file_fifo_no_hang() {
+        use std::time::Instant;
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("p.fifo");
+        std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo");
+        let start = Instant::now();
+        assert_eq!(
+            try_read_text_file(&fifo).unwrap_err(),
+            SoftTextSkip::Unreadable
+        );
+        assert!(
+            start.elapsed().as_secs() < 2,
+            "try_read_text_file on FIFO took {:?}",
+            start.elapsed()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

MPI cycle after PathGuard entry-mode (#2116/#2117) and FIFO hang fixes (#2113).

1. **Library text/binary probes no longer open FIFOs.** `is_binary_file` and `try_read_text_file` used `File::open` without a regular-file precheck. Explicit FIFO paths could hang forever (rename/backup/ensure_not_binary were already fixed). Both helpers now require `metadata().is_file()` before open, with no-hang unit tests.

2. **Entry PathGuard intermediate parent escape.** Residual test: a workspace dir symlink to an outside directory rejects `outlink/secret` in both follow and entry mode, while the `outlink` entry itself remains allowlisted for unlink/rename.

## Gate notes (not closed by this PR)

- Release PR #2114 (0.25.1) is green/MERGEABLE; **not merged** (needs explicit human approval).
- #960 winget: author response + `Commands: [patchloom]` on microsoft/winget-pkgs#410918; older version PRs closed as superseded. Still blocked on upstream validation.
- #961 chocolatey: product automation complete; OData latest approved is 0.22.0, 0.25.0 in moderation lag.
- #1990 community launch pack: draft on main; human post only.

## Test plan

- [x] `cargo test --lib --all-features fifo_no_hang`
- [x] `cargo test --lib --all-features intermediate_parent`
- [x] `make check-fast`

Ref #2113
Ref #2115
