### PR TITLE
fix: real-world half-apply restore, FIFO diag hang, MCP path honesty

### DIFF
--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -125,7 +125,13 @@ fn patch_write(
             if let Some(ref from) = pf.rename_from {
                 let old = cwd.join(from);
                 if crate::ops::file::path_entry_exists(&old) {
-                    let _ = std::fs::remove_file(&old);
+                    // Hard-fail remove (no silent dual-path leave-behind).
+                    std::fs::remove_file(&old).map_err(|e| {
+                        anyhow::anyhow!(
+                            "patch rename: failed to remove source {}: {e}",
+                            old.display()
+                        )
+                    })?;
                 }
             }
         }
@@ -285,23 +291,25 @@ pub fn apply_patch_file(
             }
         }
         let mut backup = crate::backup::BackupSession::new(cwd)?;
+        // Always record every path (including creates and rename dests as
+        // FileAction::Created when missing). Skipping non-existent paths left
+        // orphans after mid-batch restore (fixloop 2026-08-02; same class as
+        // write_if_apply_many).
         for op in &staged {
             match op {
                 StageOp::Write { write_path, .. } => {
-                    if crate::ops::file::path_entry_exists(write_path) {
-                        backup.save_before_write(write_path)?;
-                    }
+                    backup.save_before_write(write_path)?;
                 }
                 StageOp::Delete { path, .. } => {
                     if crate::ops::file::path_entry_exists(path) {
-                        backup.save_before_write(path)?;
+                        backup.save_before_delete(path)?;
                     }
                 }
                 StageOp::Rename { from, to, .. } => {
                     if crate::ops::file::path_entry_exists(from) {
-                        backup.save_before_write(from)?;
+                        backup.save_before_delete(from)?;
                     }
-                    if crate::ops::file::path_entry_exists(to) && to != from {
+                    if to != from {
                         backup.save_before_write(to)?;
                     }
                 }

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1217,6 +1217,53 @@ fn apply_patch_file_stale_second_file_leaves_first_unchanged() {
     assert_eq!(fs::read_to_string(&b).unwrap(), "bbb\n");
 }
 
+/// Multi-file patch: create then a write that fails mid-batch must remove the
+/// created path (Created backup). Without backing up missing paths, restore
+/// left orphan creates (fixloop 2026-08-02).
+#[test]
+fn apply_patch_file_mid_write_after_create_restores_orphan() {
+    let dir = TempDir::new().unwrap();
+    // Parent path that cannot host a child file (regular file, not directory).
+    let nested = dir.path().join("nested");
+    fs::write(&nested, "block\n").unwrap();
+
+    // First file: create ok. Second: create nested/child.txt fails because
+    // parent `nested` is a file (preflight is creation-only; no load of parent).
+    let patch = "\
+--- /dev/null\n\
++++ b/new.txt\n\
+@@ -0,0 +1 @@\n\
++created\n\
+--- /dev/null\n\
++++ b/nested/child.txt\n\
+@@ -0,0 +1 @@\n\
++orphan\n";
+
+    let err = apply_patch_file(patch, dir.path(), ApplyMode::Apply, None).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("nested")
+            || msg.contains("Not a directory")
+            || msg.contains("not a directory")
+            || msg.contains("failed")
+            || msg.contains("restore"),
+        "expected mid-write failure, got: {msg}"
+    );
+    assert!(
+        !dir.path().join("new.txt").exists(),
+        "created new.txt must be restored (removed) when later write fails; orphan left behind"
+    );
+    assert!(
+        !dir.path().join("nested").join("child.txt").exists(),
+        "failed second create must not leave nested/child.txt"
+    );
+    assert_eq!(
+        fs::read_to_string(&nested).unwrap(),
+        "block\n",
+        "blocking parent file must stay intact"
+    );
+}
+
 /// Mid-write failure after a successful first write must restore all files.
 #[test]
 fn write_if_apply_many_restores_on_second_write_failure() {

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -141,7 +141,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Query a JSON, YAML, or TOML file. Actions: \"has\" (check if selector exists, returns true/false), \"keys\" (list object keys at selector path), \"len\" (count items at selector path), \"select\" (filter array by predicate), \"flatten\" (list all leaf paths and values). Example: {\"action\": \"has\", \"path\": \"config.json\", \"selector\": \"database.host\"}"
+        description = "Query a JSON, YAML, or TOML file. Actions: \"has\" (check if selector exists, returns true/false), \"keys\" (list object keys at selector path), \"len\" (count items at selector path), \"select\" (filter array via selector predicates, e.g. users[role=admin] or items[0].name; there is no separate predicate field), \"flatten\" (list all leaf paths and values). Example: {\"action\": \"has\", \"path\": \"config.json\", \"selector\": \"database.host\"}"
     )]
     async fn doc_query(
         &self,
@@ -659,10 +659,16 @@ impl PatchloomService {
                 McpError::invalid_params(format!("failed to parse diff: {e}"), None)
             })?;
             for pf in &patch_files {
-                svc.check_path(&pf.path)?;
-                // Git rename source must be contained too (pure rename of ../x).
-                if let Some(from) = &pf.rename_from {
-                    svc.check_path(from)?;
+                // Pure/git renames are path-only (entry mode, #2115); content
+                // patches follow. Match execute_plan validation so symlink
+                // renames are not rejected when the target is outside.
+                if pf.rename_from.is_some() {
+                    svc.check_path_entry(&pf.path)?;
+                    if let Some(from) = &pf.rename_from {
+                        svc.check_path_entry(from)?;
+                    }
+                } else {
+                    svc.check_path(&pf.path)?;
                 }
             }
 
@@ -767,7 +773,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Execute an arbitrary multi-step transaction plan atomically (MCP equivalent of `patchloom tx`). Provide either an inline 'plan' object or a 'plan_path' to a plan file. Supports mixed operations (doc.*, md.*, replace, file create/delete/rename, tidy, patch, etc). Plan field for the op list is `operations` (alias `ops` accepted). Optional plan.cwd (relative path under the server workspace) re-roots relative op paths; absolute paths and ../ escapes are rejected. Do not set both plan.cwd and for_each. plan.format/validate lifecycle shell steps are ignored on MCP (use project config). Strongly recommended for multi-file or multi-op work. See agent-rules --mode mcp or PATCHLOOM.md for plan schema examples. Nested example: {\"plan\": {\"version\": 1, \"cwd\": \"fixtures/svc\", \"operations\": [{\"op\": \"doc.set\", \"path\": \"configs/app.yaml\", \"selector\": \"name\", \"value\": \"x\"}]}}"
+        description = "Execute an arbitrary multi-step transaction plan atomically (MCP equivalent of `patchloom tx`). Provide either an inline 'plan' object or a 'plan_path' to a plan file. Supports mixed operations (doc.*, md.*, replace, file create/delete/rename, tidy, patch, etc). Plan field for the op list is `operations` (alias `ops` accepted). Optional plan.cwd must be a relative path under the server workspace (re-roots relative op paths); absolute plan.cwd strings and ../ escapes are rejected. Op path fields may use absolute paths that resolve inside the workspace (AllowIfContained). Do not set both plan.cwd and for_each. plan.format/validate lifecycle shell steps are ignored on MCP (use project config). Strongly recommended for multi-file or multi-op work. See agent-rules --mode mcp or PATCHLOOM.md for plan schema examples. Nested example: {\"plan\": {\"version\": 1, \"cwd\": \"fixtures/svc\", \"operations\": [{\"op\": \"doc.set\", \"path\": \"configs/app.yaml\", \"selector\": \"name\", \"value\": \"x\"}]}}"
     )]
     async fn execute_plan(
         &self,
@@ -971,7 +977,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Return server identity and workspace root: cwd, surface (full|core), tool_count, package version, MCP protocol_version from handshake, and optional recommendation (coding agents may prefer core). Use this to discover the root path before file operations; path parameters on other tools are relative to cwd."
+        description = "Return server identity and workspace root: cwd, surface (full|core), tool_count, package version, MCP protocol_version from handshake, and optional recommendation (coding agents may prefer core). Prefer relative path parameters under cwd; absolute paths are allowed only when they resolve inside the workspace (AllowIfContained). Outside-workspace and ../ escapes are rejected."
     )]
     async fn server_info(
         &self,

--- a/src/files.rs
+++ b/src/files.rs
@@ -755,12 +755,18 @@ pub(crate) fn read_text_file_logged(path: &Path, cmd: &str, quiet: bool) -> Opti
         }
         Err(SoftTextSkip::Unreadable) => {
             if !quiet {
-                // Surface the real OS error when possible (permission, etc.).
-                let detail = std::fs::File::open(path)
-                    .err()
-                    .map(|e| e.to_string())
-                    .or_else(|| std::fs::metadata(path).err().map(|e| e.to_string()))
-                    .unwrap_or_else(|| "unreadable".into());
+                // Never re-open for diagnostics: FIFO/socket/device hang forever
+                // (#fixloop 2026-08-02). Soft load already refused specials via
+                // is_openable_regular_file; only open regular files for OS detail.
+                let detail = if !is_openable_regular_file(path) {
+                    "not a regular file".to_string()
+                } else {
+                    std::fs::File::open(path)
+                        .err()
+                        .map(|e| e.to_string())
+                        .or_else(|| std::fs::metadata(path).err().map(|e| e.to_string()))
+                        .unwrap_or_else(|| "unreadable".into())
+                };
                 eprintln!("{cmd}: skipping {}: {detail}", path.display());
             }
             None
@@ -1409,6 +1415,30 @@ mod tests {
         assert!(
             start.elapsed().as_secs() < 2,
             "try_read_text_file on FIFO took {:?}",
+            start.elapsed()
+        );
+    }
+
+    /// CLI soft-read diagnostic must not re-open FIFOs for OS error text
+    /// (hang residual after soft refuse; fixloop 2026-08-02).
+    #[cfg(all(unix, feature = "cli"))]
+    #[test]
+    fn read_text_file_logged_fifo_no_hang() {
+        use std::time::Instant;
+        let dir = tempfile::tempdir().unwrap();
+        let fifo = dir.path().join("p.fifo");
+        std::process::Command::new("mkfifo")
+            .arg(&fifo)
+            .status()
+            .expect("mkfifo");
+        let start = Instant::now();
+        assert!(
+            read_text_file_logged(&fifo, "replace", false).is_none(),
+            "FIFO must soft-skip"
+        );
+        assert!(
+            start.elapsed().as_secs() < 2,
+            "read_text_file_logged on FIFO took {:?}",
             start.elapsed()
         );
     }


### PR DESCRIPTION
## Summary

Fixloop audit (real-world triage only) found host/agent bugs and fixed them:

1. **Library multi-file `apply_patch_file` half-apply restore** — backup only ran when the path already existed, so creates and rename destinations never got `FileAction::Created`. Mid-batch write failure left orphan files while Apply returned `Err`. Always `save_before_write` / `save_before_delete` for every staged path (same class as `write_if_apply_many`).
2. **CLI soft-read FIFO hang residual** — `try_read_text_file` correctly refuses specials, but the non-quiet diagnostic re-opened the path with `File::open` and blocked forever on named pipes listed via `--files-from`. Diagnostic now uses metadata only for non-regular files.
3. **MCP path honesty** — `apply_patch` rename validation uses entry PathGuard (parity with `execute_plan`); `server_info` / `execute_plan` / `doc_query` descriptions match AllowIfContained and selector predicates (no invent-`predicate` field).

## Test plan

- [x] `cargo test --lib --all-features mid_write_after_create`
- [x] `cargo test --lib --all-features read_text_file_logged_fifo`
- [x] `cargo test --lib --all-features apply_patch_file`
- [x] MCP integration apply_patch filter
- [x] `make check-fast`