### PR TITLE
fix: PatchApply entry PathGuard for pure renames

### DIFF
--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -142,6 +142,12 @@ batch gate (#2064). When each replace uses `for_agent()`, over-wide fuzzy fails
 inside that op (all-or-nothing batch). Plan/tx multi-path top-level honesty
 matches that worst-case rollup (#2007).
 
+**Multi-file `apply_patch_file`:** preflights every hunk, then one backup
+session for every path (including creates and rename destinations). Mid-batch
+write failure restores the whole session (no orphan creates or half-renames).
+Prefer this (or plan/`execute_plan` patch ops) over looping single-file
+`apply_patch` when a unified diff touches multiple files.
+
 ## Related
 
 - [Comparisons](comparisons.md) (Morph, filesystem MCP, yq, ast-grep)

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1217,6 +1217,52 @@ fn apply_patch_file_stale_second_file_leaves_first_unchanged() {
     assert_eq!(fs::read_to_string(&b).unwrap(), "bbb\n");
 }
 
+/// Pure rename then a later write failure must restore source and remove dest
+/// (rename pairs backed up as Deleted + Created; fixloop #2120 / MPI follow-up).
+#[test]
+fn apply_patch_file_mid_write_after_pure_rename_restores() {
+    let dir = TempDir::new().unwrap();
+    let a = dir.path().join("a.txt");
+    fs::write(&a, "src-content\n").unwrap();
+    // Parent that cannot host a child (blocks second create after rename).
+    let nested = dir.path().join("nested");
+    fs::write(&nested, "block\n").unwrap();
+
+    let patch = "\
+diff --git a/a.txt b/b.txt\n\
+similarity index 100%\n\
+rename from a.txt\n\
+rename to b.txt\n\
+--- /dev/null\n\
++++ b/nested/child.txt\n\
+@@ -0,0 +1 @@\n\
++orphan\n";
+
+    let err = apply_patch_file(patch, dir.path(), ApplyMode::Apply, None).unwrap_err();
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("nested")
+            || msg.contains("Not a directory")
+            || msg.contains("not a directory")
+            || msg.contains("failed")
+            || msg.contains("restore"),
+        "expected mid-write failure after rename, got: {msg}"
+    );
+    assert!(
+        a.exists(),
+        "source a.txt must be restored after rename + later failure"
+    );
+    assert_eq!(
+        fs::read_to_string(&a).unwrap(),
+        "src-content\n",
+        "restored source content"
+    );
+    assert!(
+        !dir.path().join("b.txt").exists(),
+        "rename dest b.txt must be removed on restore"
+    );
+}
+
 /// Multi-file patch: create then a write that fails mid-batch must remove the
 /// created path (Created backup). Without backing up missing paths, restore
 /// left orphan creates (fixloop 2026-08-02).

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -265,18 +265,10 @@ fn execute_plan_inner(
 
     // PathGuard enforcement (same pattern as lifecycle.rs execute_plan_direct).
     // Use GuardRejected (not InvalidInput) so edit_error_kind peels correctly (#1935).
-    // FileDelete / FileRename use entry (no-follow last component) so symlink
-    // targets outside the workspace do not block unlink/rename (#2115).
+    // FileDelete / FileRename / PatchApply pure renames use entry mode (#2115).
     if let Some(g) = options.guard {
         for op in &operations {
-            for p in op.declared_paths() {
-                let r = if op.uses_entry_containment() {
-                    g.check_path_entry(&p)
-                } else {
-                    g.check_path(&p)
-                };
-                r.map_err(crate::fallback::EditError::guard_rejected)?;
-            }
+            super::execute::enforce_guard_for_op(g, op)?;
         }
     }
 

--- a/src/tx/execute/mod.rs
+++ b/src/tx/execute/mod.rs
@@ -25,6 +25,47 @@ mod tests;
 pub(crate) use file_ops::execute_file_op;
 pub(crate) use policy::{build_write_policy, build_write_policy_with_plan};
 
+/// Upfront PathGuard for one plan op.
+///
+/// [`Operation::FileDelete`] / [`Operation::FileRename`] use entry mode
+/// (no-follow last component, #2115). [`Operation::PatchApply`] is
+/// per-file: pure/git renames use entry mode; content hunks use follow
+/// mode so symlink smuggling stays blocked (MPI 2026-08-02 / MCP
+/// `apply_patch` pure rename of workspace link → outside target).
+pub(crate) fn enforce_guard_for_op(
+    g: &crate::containment::PathGuard,
+    op: &Operation,
+) -> anyhow::Result<()> {
+    if let Operation::PatchApply { diff, .. } = op {
+        // Parse failure deferred to apply time (same as declared_paths).
+        if let Ok(files) = crate::ops::patch::parse_patch(diff) {
+            for pf in files {
+                if pf.rename_from.is_some() {
+                    g.check_path_entry(&pf.path)
+                        .map_err(crate::fallback::EditError::guard_rejected)?;
+                    if let Some(from) = &pf.rename_from {
+                        g.check_path_entry(from)
+                            .map_err(crate::fallback::EditError::guard_rejected)?;
+                    }
+                } else {
+                    g.check_path(&pf.path)
+                        .map_err(crate::fallback::EditError::guard_rejected)?;
+                }
+            }
+        }
+        return Ok(());
+    }
+    for p in op.declared_paths() {
+        let r = if op.uses_entry_containment() {
+            g.check_path_entry(&p)
+        } else {
+            g.check_path(&p)
+        };
+        r.map_err(crate::fallback::EditError::guard_rejected)?;
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Pending file changes
 // ---------------------------------------------------------------------------
@@ -717,21 +758,13 @@ pub(crate) fn execute_and_collect(
     let mut renames: Vec<(PathBuf, PathBuf)> = Vec::new();
     let mut policy_finalized: HashSet<PathBuf> = HashSet::new();
 
-    // Upfront PathGuard on declared paths (same contract as execute_plan_inner /
-    // execute_plan_direct). CLI `tx` and `batch` call this function directly and
-    // previously only had guard wiring on replace glob expansion, so
-    // `file.create ../escape` under `--contain` could still write outside the
-    // workspace (MPI cycle 13). Entry ops use no-follow last component (#2115).
+    // Upfront PathGuard (same contract as execute_plan_inner /
+    // execute_plan_direct). CLI `tx` and `batch` call this function directly.
+    // PatchApply renames use entry mode; content paths follow (see
+    // enforce_guard_for_op).
     if let Some(g) = guard {
         for op in &plan.operations {
-            for p in op.declared_paths() {
-                let r = if op.uses_entry_containment() {
-                    g.check_path_entry(&p)
-                } else {
-                    g.check_path(&p)
-                };
-                r.map_err(crate::fallback::EditError::guard_rejected)?;
-            }
+            enforce_guard_for_op(g, op)?;
         }
     }
 

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -113,18 +113,10 @@ pub fn execute_plan_direct(
                 )));
             }
         }
-        // Upfront check on declared paths using shared helper; dynamic (globs
-        // patterns, patch embedded paths) are best-effort or handled by loaders.
-        // Entry ops (delete/rename) use no-follow last component (#2115).
+        // Upfront check on declared paths; PatchApply renames use entry mode
+        // (no-follow last component) like FileRename (#2115 / MPI 2026-08-02).
         for op in &plan.operations {
-            for p in op.declared_paths() {
-                let r = if op.uses_entry_containment() {
-                    g.check_path_entry(&p)
-                } else {
-                    g.check_path(&p)
-                };
-                r.map_err(crate::fallback::EditError::guard_rejected)?;
-            }
+            super::super::execute::enforce_guard_for_op(g, op)?;
         }
     }
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1281,6 +1281,51 @@ rename to new.rs\n";
     client.cancel().await.unwrap();
 }
 
+/// Pure rename of a workspace symlink whose *target* is outside must succeed
+/// with entry-mode PathGuard (follow mode rejected the link; #2120 apply_patch
+/// parity with execute_plan).
+#[cfg(unix)]
+#[tokio::test]
+async fn test_mcp_apply_patch_pure_rename_symlink_outside_target() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let outside = dir
+        .path()
+        .parent()
+        .unwrap()
+        .join("pl-mcp-symlink-target.txt");
+    fs::write(&outside, "outside-payload\n").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink(&outside, &link).unwrap();
+
+    let diff = "\
+diff --git a/link.txt b/link2.txt\n\
+similarity index 100%\n\
+rename from link.txt\n\
+rename to link2.txt\n";
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "apply_patch", serde_json::json!({"diff": diff})).await;
+    assert!(
+        !is_error,
+        "path-only rename of in-workspace symlink must not follow target: {val}"
+    );
+    assert_eq!(val["ok"], true, "ok: {val}");
+    assert!(!link.exists(), "old link removed");
+    let dest = dir.path().join("link2.txt");
+    assert!(dest.symlink_metadata().unwrap().file_type().is_symlink());
+    assert_eq!(
+        fs::read_to_string(&outside).unwrap(),
+        "outside-payload\n",
+        "outside target content must not be rewritten"
+    );
+    client.cancel().await.unwrap();
+    let _ = fs::remove_file(&outside);
+}
+
 /// Pure rename source outside workspace must fail closed (#2109 PathGuard).
 #[tokio::test]
 async fn test_mcp_apply_patch_pure_rename_escape_source_rejected() {


### PR DESCRIPTION
## Summary

MPI rotation after #2120 found a real dual-path bug:

- MCP `apply_patch` precheck used entry PathGuard for pure renames, but
  `execute_plan` / engine still applied **follow** mode to all
  `PatchApply` declared paths. Pure rename of a workspace symlink whose
  target is outside the root failed at execute with `guard_rejected`.
- Shared `enforce_guard_for_op`: PatchApply renames use entry mode;
  content hunks still follow (symlink write smuggle stays blocked).

Also locks mid-write pure-rename restore for multi-file `apply_patch_file`
and documents multi-file patch atomic backup for embedders.

## Test plan

- [x] `cargo test --test integration test_mcp_apply_patch_pure_rename_symlink_outside_target`
- [x] pure rename escape source still rejected
- [x] `mid_write_after_pure_rename` / create restore unit tests
- [x] `make check-fast`