### PR TITLE
docs: add release notes for 0.26.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,11 +194,15 @@ fuzz: ## Run fuzz tests (requires nightly). Use FUZZ_TIME=N for seconds per targ
 	done; \
 	echo "All fuzz targets passed."
 
-force-release-version: ## Helper to reduce manual force-edits for release-please desync (tech-debt #738). Run: make force-release-version VERSION=0.5.0
+# EMERGENCY only: edits the synthetic release-please branch (wiped on next main merge).
+# Preferred: land on main with commit body "Release-As: X.Y.Z" (or fix!:/BREAKING CHANGE).
+# See patchloom-contrib "Force next release version (Release-As)".
+force-release-version: ## EMERGENCY: edit release-please branch version (prefer Release-As on main). VERSION=X.Y.Z
 ifndef VERSION
-	$(error Set VERSION, e.g. make force-release-version VERSION=0.5.0)
+	$(error Set VERSION, e.g. make force-release-version VERSION=0.26.0)
 endif
-	@echo "Forcing release-please branch to $(VERSION)..."
+	@echo "EMERGENCY force of release-please branch to $(VERSION)..."
+	@echo "Prefer instead: empty commit on main with body Release-As: $(VERSION)"
 	@git fetch origin
 	@git checkout -B release-please--branches--main--components--patchloom origin/release-please--branches--main--components--patchloom
 	@# scripts/force_release_version.py updates manifest key ".", Cargo.toml/lock, CHANGELOG
@@ -209,4 +213,5 @@ endif
 	@git commit -s -m "chore: force release version to $(VERSION) in release-please branch" || true
 	@git push origin HEAD:release-please--branches--main--components--patchloom
 	@echo "Now clean the PR: gh pr edit <PR> --title 'chore(main): release patchloom $(VERSION)'"
-	@echo "Full process in patchloom-contrib skill under 'Major version bumps'."
+	@echo "This will be wiped on the next main merge unless main has Release-As: $(VERSION)."
+	@echo "Primary process: patchloom-contrib 'Force next release version (Release-As)'."

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,86 @@
+# Patchloom 0.26.0
+
+Safer path containment, FIFO handling, and multi-file soft skips for agents
+and library hosts. Pure renames and deletes guard the path you named, not only
+the symlink target. Special files (FIFOs and similar) no longer hang text probes
+or get mislabeled as unreadable. Public soft-skip reporting gains
+`not_regular_file`. Minor release for a public SoftTextSkip break under 0.x
+(`bump-minor-pre-major`).
+
+## Highlights
+
+PathGuard can check the **entry** (the path you pass) for delete and path-only
+rename, including pure git rename patches under `--contain`. Soft text and
+binary probes refuse non-regular files before open, so FIFOs do not block the
+CLI. Multi-path replace, search, and tidy put special co-paths in `refused[]`
+with `reason: not_regular_file` so agents do not retry chmod. Multi-file patch
+apply always backs up creates and rename destinations so a mid-batch failure
+can restore. Windows install docs prefer Scoop and GitHub assets over winget
+and Chocolatey while those channels catch up.
+
+## Breaking changes
+
+- **`SoftTextSkip` is `#[non_exhaustive]` and gains `NotRegularFile`.**
+  Hosts that match on `SoftTextSkip` exhaustively must add a `_` arm.
+  Existing specials (FIFO, socket, device, and other non-regular entries)
+  use `NotRegularFile` (`as_reason` → `not_regular_file`) instead of
+  `Unreadable`. Missing paths stay `Unreadable`. ([#2122](https://github.com/patchloom/patchloom/pull/2122))
+
+## Bug fixes
+
+- **FIFOs hung rename, backup, and binary probes.**
+  Rename, backup, and related paths no longer open special nodes for
+  content probes. Path-only rename of a FIFO still works when the product
+  allows it; text ops refuse FIFO with a clear error. ([#2113](https://github.com/patchloom/patchloom/pull/2113))
+
+- **`is_binary_file` and soft text read still opened specials.**
+  Public probes refuse non-regular paths from metadata before open (same
+  hang class as rename). ([#2118](https://github.com/patchloom/patchloom/pull/2118))
+
+- **PathGuard followed symlink targets for delete and path-only rename.**
+  Entry mode checks the path you named so a workspace symlink to an
+  outside target is not treated as an allowed outside path. CLI, MCP, and
+  library delete/rename dual paths share the policy. Pure patch renames
+  use entry guard at execute; content hunks still follow. ([#2116](https://github.com/patchloom/patchloom/pull/2116), [#2117](https://github.com/patchloom/patchloom/pull/2117), [#2121](https://github.com/patchloom/patchloom/pull/2121))
+
+- **Multi-file patch apply could leave orphan creates after a mid-batch failure.**
+  Creates and rename destinations always get a backup marker so restore can
+  undo a partial apply. Soft-read diagnostics no longer re-open a FIFO on
+  error. ([#2120](https://github.com/patchloom/patchloom/pull/2120))
+
+- **Multi-path FIFO soft skip said `unreadable` while stderr said not a regular file.**
+  Soft skip reason is `not_regular_file`. Search and tidy multi-path lists
+  now refuse the same specials as replace (not silent skip of non-`is_file`
+  entries). ([#2122](https://github.com/patchloom/patchloom/pull/2122), [#2123](https://github.com/patchloom/patchloom/pull/2123))
+
+- **Git octal C-quotes, dangling paths, and sole special peels.**
+  Pure renames decode git octal escapes; dangling append/prepend/create
+  peels are consistent; sole-path text ops still follow real symlink
+  targets. ([#2110](https://github.com/patchloom/patchloom/pull/2110))
+
+## Docs
+
+- Install docs prefer Scoop and GitHub portable assets over winget and
+  Chocolatey while community packages lag. ([#2119](https://github.com/patchloom/patchloom/pull/2119))
+
+## Numbers
+
+| Metric | Notes |
+|--------|--------|
+| Version | 0.25.0 → 0.26.0 (0.x minor for public SoftTextSkip change) |
+| Focus | PathGuard entry, FIFO safety, multi-path soft refuse honesty |
+
+## Upgrading
+
+- **Library hosts matching `SoftTextSkip`:** handle `NotRegularFile` or use
+  a wildcard arm (`#[non_exhaustive]`).
+- **Agents:** multi-path specials report `refused[].reason: not_regular_file`.
+  Do not treat that as a permission problem.
+- **Containment:** delete and path-only rename (including pure patch renames)
+  use entry PathGuard when that mode is enabled.
+- Install from crates.io, npm, Homebrew, or Scoop after the tag ships. Winget
+  and Chocolatey may lag.
+
+## Full changelog
+
+https://github.com/patchloom/patchloom/compare/patchloom-v0.25.0...patchloom-v0.26.0

--- a/scripts/force_release_version.py
+++ b/scripts/force_release_version.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
-"""Force version fields on the release-please branch (make force-release-version).
+"""EMERGENCY: force version fields on the release-please branch.
+
+Prefer landing ``Release-As: X.Y.Z`` in a commit body on **main** (or a
+``fix!:`` / ``BREAKING CHANGE`` commit) so release-please recomputes the
+version on every run. Edits to the synthetic release-please branch are
+wiped when main advances.
 
 Updates .release-please-manifest.json package key ".", Cargo.toml version,
 Cargo.lock root package version, and the top versioned CHANGELOG section.
 
-Intentionally does NOT use naive sed on the manifest: replacing the first
-quoted string turns {".": "0.25.1"} into {"0.26.0": "0.25.1"} (bug hit when
-forcing PR #2114 from 0.25.1 to 0.26.0 for SoftTextSkip non_exhaustive).
+Does NOT use naive sed on the manifest: replacing the first quoted string
+turns {".": "0.25.1"} into {"0.26.0": "0.25.1"} (bug hit on #2114).
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Curated `RELEASE_NOTES.md` for **0.26.0** (PathGuard entry, FIFO safety,
multi-path `not_regular_file`, SoftTextSkip break). Documents that
`make force-release-version` is emergency-only.

**Release-As: 0.26.0** is in this PR so release-please keeps the open
release PR at 0.26.0 after merge (do not hand-edit the synthetic branch).

## Test plan

- [x] `make verify-release-notes`
- [x] no em dash
- [ ] CI green
- [ ] After merge, #2114 stays or returns to 0.26.0 without force-branch

Release-As: 0.26.0