### PR TITLE
docs(scripts): prefer Release-As over force_release_version branch edit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke windows-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test chocolatey-package-test pack-mcpb pack-mcpb-test server-json-test git-clean clean
+.PHONY: help fmt fmt-check build test test-no-default test-ast-only test-mcp-no-ast test-library-hygiene integration-test pty-test clippy check check-fast update-readme check-readme sync-patchloom-md check-patchloom-md agent-test embedder-smoke windows-smoke audit-test-hygiene audit deny bench-cli bench-mcp bench-agent bench-agent-dry-run bench-agent-report fuzz scoop-manifest-test chocolatey-package-test pack-mcpb pack-mcpb-test force-release-version-test server-json-test git-clean clean
 
 .DEFAULT_GOAL := help
 
@@ -75,6 +75,9 @@ pack-mcpb: ## Pack mcpb/ into target/mcpb/patchloom-<version>.mcpb (Smithery / d
 
 pack-mcpb-test: ## Unit tests for scripts/pack-mcpb.sh (VERSION override + pack stamp)
 	python3 scripts/test_pack_mcpb.py
+
+force-release-version-test: ## Unit tests for force_release_version.py (Release-As preferred path)
+	python3 scripts/test_force_release_version.py
 
 server-json-test: ## Lock server.json MCP Registry constraints (description ≤100 chars)
 	python3 scripts/test_server_json.py
@@ -195,23 +198,30 @@ fuzz: ## Run fuzz tests (requires nightly). Use FUZZ_TIME=N for seconds per targ
 	echo "All fuzz targets passed."
 
 # EMERGENCY only: edits the synthetic release-please branch (wiped on next main merge).
-# Preferred: land on main with commit body "Release-As: X.Y.Z" (or fix!:/BREAKING CHANGE).
-# See patchloom-contrib "Force next release version (Release-As)".
-force-release-version: ## EMERGENCY: edit release-please branch version (prefer Release-As on main). VERSION=X.Y.Z
+# PREFERRED (durable): land on main:
+#   git commit --allow-empty -s -m "chore: release X.Y.Z" -m "Release-As: X.Y.Z"
+# Or fix!:/BREAKING CHANGE on the product PR. See ci-build-release skill
+# "Force next release version (Release-As)" (patchloom-contrib cross-links).
+force-release-version: ## EMERGENCY: branch-only force (prefer Release-As on main). VERSION=X.Y.Z
 ifndef VERSION
 	$(error Set VERSION, e.g. make force-release-version VERSION=0.26.0)
 endif
-	@echo "EMERGENCY force of release-please branch to $(VERSION)..."
-	@echo "Prefer instead: empty commit on main with body Release-As: $(VERSION)"
+	@echo "=============================================================="
+	@echo "PREFERRED (durable) on main, not this target:"
+	@echo "  git commit --allow-empty -s -m 'chore: release $(VERSION)' -m 'Release-As: $(VERSION)'"
+	@echo "Docs: ci-build-release skill, Force next release version (Release-As)"
+	@echo "=============================================================="
+	@echo "EMERGENCY: forcing release-please branch files to $(VERSION)..."
 	@git fetch origin
 	@git checkout -B release-please--branches--main--components--patchloom origin/release-please--branches--main--components--patchloom
 	@# scripts/force_release_version.py updates manifest key ".", Cargo.toml/lock, CHANGELOG
 	@# (do not sed the first JSON string: that rewrote {".": "x"} into {"y": "x"} on #2114).
-	@python3 scripts/force_release_version.py "$(VERSION)"
+	@# Requires --i-know-this-is-wiped so the preferred path is always printed first.
+	@python3 scripts/force_release_version.py --i-know-this-is-wiped "$(VERSION)"
 	@make sync-patchloom-md || true
 	@git add .release-please-manifest.json Cargo.toml Cargo.lock CHANGELOG.md PATCHLOOM.md
 	@git commit -s -m "chore: force release version to $(VERSION) in release-please branch" || true
 	@git push origin HEAD:release-please--branches--main--components--patchloom
 	@echo "Now clean the PR: gh pr edit <PR> --title 'chore(main): release patchloom $(VERSION)'"
 	@echo "This will be wiped on the next main merge unless main has Release-As: $(VERSION)."
-	@echo "Primary process: patchloom-contrib 'Force next release version (Release-As)'."
+	@echo "Land Release-As on main ASAP so the next release-please rebuild keeps $(VERSION)."

--- a/scripts/force_release_version.py
+++ b/scripts/force_release_version.py
@@ -1,10 +1,23 @@
 #!/usr/bin/env python3
 """EMERGENCY: force version fields on the release-please branch.
 
-Prefer landing ``Release-As: X.Y.Z`` in a commit body on **main** (or a
-``fix!:`` / ``BREAKING CHANGE`` commit) so release-please recomputes the
-version on every run. Edits to the synthetic release-please branch are
-wiped when main advances.
+**Preferred (durable) path: do this on main instead:**
+
+    git commit --allow-empty -s \\
+      -m "chore: release X.Y.Z" \\
+      -m "Release-As: X.Y.Z"
+
+Or put ``Release-As: X.Y.Z`` in the body of a normal main PR (e.g. curated
+``RELEASE_NOTES.md``). On squash-merge, keep the footer in the squash body.
+For public API breaks, prefer ``fix!:`` / ``feat!:`` or ``BREAKING CHANGE``.
+
+See ``~/.grok/skills/ci-build-release/SKILL.md`` section
+"Force next release version (Release-As)". Project notes:
+``~/.grok/skills/patchloom-contrib/SKILL.md`` (same section name).
+
+Edits to the synthetic release-please branch are **wiped** when main
+advances. This script only rewrites branch files for a short-lived CI
+unblock; land ``Release-As`` on main immediately after.
 
 Updates .release-please-manifest.json package key ".", Cargo.toml version,
 Cargo.lock root package version, and the top versioned CHANGELOG section.
@@ -19,12 +32,68 @@ import pathlib
 import re
 import sys
 
+ACK_FLAG = "--i-know-this-is-wiped"
+VERSION_RE = re.compile(r"\d+\.\d+\.\d+")
 
-def main() -> int:
-    if len(sys.argv) != 2 or not re.fullmatch(r"\d+\.\d+\.\d+", sys.argv[1]):
-        print("usage: force_release_version.py X.Y.Z", file=sys.stderr)
+
+def preferred_path_message(version: str = "X.Y.Z") -> str:
+    return f"""\
+PREFERRED (durable): land on **main**, do not rely on this script:
+
+  git commit --allow-empty -s \\
+    -m "chore: release {version}" \\
+    -m "Release-As: {version}"
+
+Or: Release-As footer on a normal main PR (keep footer on squash-merge).
+API break: use fix!: / feat!: / BREAKING CHANGE (bump-minor-pre-major -> 0.x minor).
+
+Docs: ci-build-release skill -> "Force next release version (Release-As)"
+
+This tool only rewrites the release-please **branch** and is wiped on the
+next main merge. After any emergency force, land Release-As on main ASAP.
+"""
+
+
+def usage() -> None:
+    print(preferred_path_message(), file=sys.stderr)
+    print(
+        f"EMERGENCY usage (branch only):\n"
+        f"  force_release_version.py {ACK_FLAG} X.Y.Z\n"
+        f"  make force-release-version VERSION=X.Y.Z\n",
+        file=sys.stderr,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+
+    if not args or args in (["-h"], ["--help"], ["help"]):
+        usage()
         return 2
-    v = sys.argv[1]
+
+    if ACK_FLAG not in args:
+        print(
+            f"error: refusing to run without {ACK_FLAG}\n"
+            f"(this is the emergency branch path; prefer Release-As on main)\n",
+            file=sys.stderr,
+        )
+        usage()
+        return 2
+
+    args = [a for a in args if a != ACK_FLAG]
+    if len(args) != 1 or not VERSION_RE.fullmatch(args[0]):
+        usage()
+        return 2
+
+    v = args[0]
+    # Always restate the durable path so agents/logs see it.
+    print(preferred_path_message(v), file=sys.stderr)
+    print(
+        f"EMERGENCY: rewriting release-please branch files to {v} "
+        f"(will not survive the next main merge)\n",
+        file=sys.stderr,
+    )
+
     root = pathlib.Path.cwd()
 
     manifest = root / ".release-please-manifest.json"
@@ -94,6 +163,11 @@ def main() -> int:
     else:
         print("CHANGELOG ok or missing versioned section")
 
+    print(
+        f"\nDone. Next: land Release-As: {v} on main so the next release-please "
+        f"rebuild keeps this version.",
+        file=sys.stderr,
+    )
     return 0
 
 

--- a/scripts/test_force_release_version.py
+++ b/scripts/test_force_release_version.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tests for scripts/force_release_version.py preferred-path messaging."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "force_release_version.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("force_release_version", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class ForceReleaseVersionTests(unittest.TestCase):
+    def test_refuses_without_ack_flag(self) -> None:
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT), "0.26.0"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("Release-As", r.stderr)
+        self.assertIn("--i-know-this-is-wiped", r.stderr)
+        self.assertIn("PREFERRED", r.stderr)
+
+    def test_help_mentions_preferred_path(self) -> None:
+        r = subprocess.run(
+            [sys.executable, str(SCRIPT), "--help"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(r.returncode, 2)
+        self.assertIn("Release-As", r.stderr)
+        self.assertIn("ci-build-release", r.stderr)
+
+    def test_ack_rewrites_manifest_key_dot(self) -> None:
+        mod = _load_module()
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".release-please-manifest.json").write_text(
+                json.dumps({".": "0.25.1"}, indent=2) + "\n"
+            )
+            (root / "Cargo.toml").write_text(
+                '[package]\nname = "patchloom"\nversion = "0.25.1"\n'
+            )
+            (root / "Cargo.lock").write_text(
+                'version = 4\n\n[[package]]\nname = "patchloom"\nversion = "0.25.1"\n'
+            )
+            (root / "CHANGELOG.md").write_text(
+                "# Changelog\n\n## [0.25.1](https://github.com/patchloom/patchloom/"
+                "compare/patchloom-v0.25.0...patchloom-v0.25.1)\n"
+            )
+            # Run in temp dir via chdir
+            import os
+
+            old = os.getcwd()
+            try:
+                os.chdir(root)
+                code = mod.main(["--i-know-this-is-wiped", "0.26.0"])
+            finally:
+                os.chdir(old)
+            self.assertEqual(code, 0)
+            data = json.loads((root / ".release-please-manifest.json").read_text())
+            self.assertEqual(data, {".": "0.26.0"})
+            self.assertNotIn("0.26.0", list(data.keys()))
+            cargo = (root / "Cargo.toml").read_text()
+            self.assertIn('version = "0.26.0"', cargo)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The emergency `force_release_version.py` / `make force-release-version` path still exists for short-lived CI unblocks, but every invocation now points agents at the durable process: land `Release-As: X.Y.Z` (or `fix!:`) on **main**.

## Changes

- Require `--i-know-this-is-wiped` (Makefile always passes it)
- Print preferred `git commit ... Release-As` command + skill pointer on help, refuse, and success paths
- Makefile target banners the preferred path first
- `make force-release-version-test` locks messaging and safe manifest rewrite

## Test plan

- [x] `make force-release-version-test`
- [x] `python3 scripts/force_release_version.py 0.26.0` exits 2 and mentions Release-As
- [ ] CI green