### PR TITLE
feat(api): public backup_session_from_error for fail-restore

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -121,6 +121,7 @@ Example: `{"path":"install.sh","old":"pip","new":"uv","command_position":true,"r
 
 **Library embedder undo / post-write (Rust hosts, not CLI-only):**
 - After `ApplyMode::Apply`, `EditResult.backup_session` is the session id for that write (#1686).
+- On `Err` after write/backup (`format_failed` or fail-restore), `api::backup_session_from_error(&err)` peels the session id without scraping Display (#2127).
 - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path
 - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)
 - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)

--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -26,7 +26,10 @@ Bline is a real embedder that dogfooded these steps; the checklist is host-gener
    peels. Keep a `_` arm: `EditErrorKind` is `#[non_exhaustive]`.
 6. **Apply writers:** prefer `api` file_* / `replace_text` /
    `apply_content_edits_to_file` (hardlink preserve, `backup_session`). Persist
-   `EditResult.backup_session` if the host exposes undo.
+   `EditResult.backup_session` on success if the host exposes undo. On `Err`
+   after write/backup (FormatFailed or fail-restore), use
+   `api::backup_session_from_error(&err)` for the same session id without
+   scraping English Display (#2127).
 7. **Multi-op / multi-path honesty:**
    - Buffer multi-op: `apply_content_edits` + **`ContentEditsResult.op_honesty`**
      (per-replace `old` + `matched_text` + `match_score`; #2006).

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -133,6 +133,9 @@
 //!   [`is_type_error`], [`is_format_failed`], [`is_guard_rejected`],
 //!   [`is_invalid_input`], [`is_binary`], [`is_invalid_encoding`],
 //!   [`is_no_match`], [`is_ambiguous`]
+//! - [`backup_session_from_error`]: session id on FormatFailed / fail-restore
+//!   errors without Display scrape (#2127); prefer [`EditResult::backup_session`]
+//!   on success
 //! - [`file_create`] with `force: true` overwrites unreadable/binary priors
 //!   without a host remove+recreate loop (#1962); hardlinks stay on the normal
 //!   Apply write path
@@ -600,9 +603,14 @@ impl ReplaceOptions {
 
 pub use fuzzy_span::{FuzzySpanPolicy, fuzzy_span_suspicious, fuzzy_span_suspicious_with_policy};
 
-// Re-export structured edit errors for embedders (#1492, #1659, #1947, #1948, #1963, #1964).
+// Re-export structured edit errors for embedders (#1492, #1659, #1947, #1948, #1963, #1964, #2127).
 /// Re-export: binary | invalid_encoding | invalid_input from sole-path loads (#1963).
 pub use crate::exit::is_load_text_strict_fail;
+/// Re-export: session id + written paths from FormatFailed / fail-restore (#2127).
+pub use crate::exit::{
+    FormatFailedError, MutationAfterBackupError, backup_session_from_error,
+    format_failed_backup_session, format_failed_written_files, mutation_after_backup_session,
+};
 pub use crate::fallback::{
     EditError, EditErrorKind, PeeledError, classify_error, classify_error_ref, edit_error_kind,
     edit_error_ref, error_kind_str, find_similar_targets, is_already_exists, is_ambiguous,
@@ -753,21 +761,27 @@ pub(crate) fn apply_mutation(
 /// On mutation failure after finalize: restore the session, and always
 /// surface restore outcome + session id so hosts can undo or report
 /// half-applied state (do not swallow restore errors with `let _ =`).
-fn mutation_err_after_backup(
+///
+/// Returns typed [`crate::exit::MutationAfterBackupError`] as the root error
+/// (not `.context()`) so [`backup_session_from_error`] can downcast without
+/// Display scrape (#2127). Mutation detail is in the Display/`mutation_msg`.
+pub(crate) fn mutation_err_after_backup(
     backup_root: &Path,
     session: Option<&str>,
     mutation_err: anyhow::Error,
 ) -> anyhow::Error {
+    use crate::exit::MutationAfterBackupError;
     let Some(ts) = session else {
         return mutation_err;
     };
+    // Use Display (not {:#}) for the nested detail: the typed error is the
+    // root, so the full chain is only this one layer.
+    let mutation_msg = mutation_err.to_string();
     match crate::backup::restore_session(backup_root, ts) {
-        Ok(_) => mutation_err.context(format!(
-            "mutation failed after backup finalize; restored session {ts} (undo still available)"
-        )),
-        Err(re) => mutation_err.context(format!(
-            "mutation failed after backup finalize; restore of session {ts} also failed: {re}"
-        )),
+        Ok(_) => MutationAfterBackupError::restored(ts, mutation_msg).into(),
+        Err(re) => {
+            MutationAfterBackupError::restore_failed(ts, re.to_string(), mutation_msg).into()
+        }
     }
 }
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1358,12 +1358,50 @@ fn apply_mutation_restores_on_perform_failure() {
         msg.contains("restored session") || msg.contains("backup finalize"),
         "hosts must see restore outcome + session, got: {msg}"
     );
-    assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
+    // #2127: hosts peel session without Display scrape.
+    let session = super::backup_session_from_error(&err).expect("session after fail-restore");
+    assert!(
+        !session.is_empty(),
+        "backup_session_from_error must return finalized session id"
+    );
     let sessions = crate::backup::list_sessions(dir.path()).unwrap();
+    assert!(
+        sessions.iter().any(|s| s.timestamp == session),
+        "peeled session {session:?} must match list_sessions: {sessions:?}"
+    );
+    assert_eq!(fs::read_to_string(&file).unwrap(), "original\n");
     assert!(
         !sessions.is_empty(),
         "finalize-before-mutate must leave a discoverable session for undo"
     );
+}
+
+#[test]
+fn backup_session_from_error_format_failed_with_session() {
+    let err: anyhow::Error = super::FormatFailedError::new("format command failed")
+        .with_backup_session(Some("fmt_1".into()))
+        .into();
+    assert_eq!(super::backup_session_from_error(&err), Some("fmt_1"));
+    assert_eq!(super::format_failed_backup_session(&err), Some("fmt_1"));
+}
+
+#[test]
+fn backup_session_from_error_none_for_no_match() {
+    let err: anyhow::Error = crate::exit::NoMatchError {
+        msg: "no matches".into(),
+    }
+    .into();
+    assert_eq!(super::backup_session_from_error(&err), None);
+}
+
+#[test]
+fn backup_session_from_error_none_for_guard_rejected() {
+    let err: anyhow::Error = crate::fallback::EditError::new(
+        crate::fallback::EditErrorKind::GuardRejected,
+        "path outside workspace",
+    )
+    .into();
+    assert_eq!(super::backup_session_from_error(&err), None);
 }
 
 #[test]

--- a/src/cmd/agent_rules/policy.rs
+++ b/src/cmd/agent_rules/policy.rs
@@ -140,6 +140,7 @@ Per-path details stay on `changes[]`. File multi-op Apply with a final span gate
 refuses before write/backup (#2008). Prefer per-op honesty; rollup fields are worst-case only.\n\n\
              **Library embedder undo / post-write (Rust hosts, not CLI-only):**\n\
              - After `ApplyMode::Apply`, `EditResult.backup_session` is the session id for that write (#1686).\n\
+             - On `Err` after write/backup (`format_failed` or fail-restore), `api::backup_session_from_error(&err)` peels the session id without scraping Display (#2127).\n\
              - `backup::restore_path_from_latest_backup(project_root, path)` — latest session that contains the path\n\
              - `backup::restore_path_from_session(project_root, timestamp, path)` — one path from a chosen session (#1660)\n\
              - `backup::list_sessions_under(root, &ListSessionsOptions { descendants: true, .. })` — nested monorepo sessions (#1688)\n\

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -1,4 +1,9 @@
-//! Exit codes for patchloom.
+//! Exit codes and typed agent-facing errors for patchloom.
+//!
+//! size-waiver: accepted single-domain bulk (policy #1408). Exit constants,
+//! typed peel errors (NoMatch, FormatFailed, MutationAfterBackup, …), and
+//! JSON structured_error_payload stay one unit so remappers cannot drift
+//! (#2127 fail-restore session peels live with FormatFailed helpers).
 
 #![cfg_attr(not(feature = "cli"), allow(dead_code))]
 
@@ -343,6 +348,107 @@ pub fn format_failed_written_files(err: &anyhow::Error) -> Vec<String> {
         .unwrap_or_default()
 }
 
+/// Mutation failed after backup finalize (library Apply fail-restore path).
+///
+/// Constructed as the **root** of an `anyhow` error (via [`Into`]), not as
+/// `.context()`, so [`backup_session_from_error`] can downcast it. Hosts read
+/// [`Self::session`] without scraping Display (#2127).
+///
+/// The original mutation failure is kept in [`Self::mutation_msg`] for humans;
+/// prefer session peel over re-classifying the mutation kind.
+#[derive(Debug)]
+pub struct MutationAfterBackupError {
+    /// Finalized backup session id (same shape as [`FormatFailedError::backup_session`]).
+    pub session: String,
+    /// `true` when `restore_session` succeeded after the mutation failure.
+    pub restored: bool,
+    /// Present when restore failed; human-readable restore error.
+    pub restore_err: Option<String>,
+    /// Display of the original mutation error (kept for diagnostics).
+    pub mutation_msg: String,
+}
+
+impl MutationAfterBackupError {
+    /// Build a restored-session error (undo still available).
+    #[must_use]
+    pub fn restored(session: impl Into<String>, mutation_msg: impl Into<String>) -> Self {
+        Self {
+            session: session.into(),
+            restored: true,
+            restore_err: None,
+            mutation_msg: mutation_msg.into(),
+        }
+    }
+
+    /// Build a restore-failed error (disk may still be half-applied).
+    #[must_use]
+    pub fn restore_failed(
+        session: impl Into<String>,
+        restore_err: impl Into<String>,
+        mutation_msg: impl Into<String>,
+    ) -> Self {
+        Self {
+            session: session.into(),
+            restored: false,
+            restore_err: Some(restore_err.into()),
+            mutation_msg: mutation_msg.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for MutationAfterBackupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.restored, &self.restore_err) {
+            (true, _) => write!(
+                f,
+                "mutation failed after backup finalize; restored session {} (undo still available): {}",
+                self.session, self.mutation_msg
+            ),
+            (false, Some(re)) => write!(
+                f,
+                "mutation failed after backup finalize; restore of session {} also failed: {re}: {}",
+                self.session, self.mutation_msg
+            ),
+            (false, None) => write!(
+                f,
+                "mutation failed after backup finalize; restore of session {} also failed: {}",
+                self.session, self.mutation_msg
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MutationAfterBackupError {}
+
+/// First [`MutationAfterBackupError::session`] found in the error chain.
+#[must_use]
+pub fn mutation_after_backup_session(err: &anyhow::Error) -> Option<&str> {
+    err.chain().find_map(|cause| {
+        cause
+            .downcast_ref::<MutationAfterBackupError>()
+            .map(|e| e.session.as_str())
+    })
+}
+
+/// Backup session id from fail-restore or FormatFailed errors (#2127).
+///
+/// Prefer [`crate::api::EditResult::backup_session`] on success. Use this on
+/// `Err` paths so hosts can call undo without scraping English Display text.
+///
+/// Peels, in order:
+/// 1. [`FormatFailedError::backup_session`]
+/// 2. [`MutationAfterBackupError::session`]
+///
+/// Returns `None` when no session was finalized (e.g. NoMatch, GuardRejected).
+///
+/// Note: [`MutationAfterBackupError`] must be the root (or a downcastable
+/// cause via [`std::error::Error::source`]), not an `anyhow` Display-only
+/// `.context()` layer, or this helper cannot see it.
+#[must_use]
+pub fn backup_session_from_error(err: &anyhow::Error) -> Option<&str> {
+    format_failed_backup_session(err).or_else(|| mutation_after_backup_session(err))
+}
+
 /// True when any cause is an IO `IsADirectory` (path exists but is a directory).
 #[must_use]
 pub fn is_io_is_a_directory(err: &anyhow::Error) -> bool {
@@ -542,6 +648,76 @@ mod tests {
             classify_typed_error(&wrapped),
             Some(("format_failed", FAILURE))
         );
+    }
+
+    #[test]
+    fn backup_session_from_error_peels_format_failed() {
+        let err: anyhow::Error = FormatFailedError::new("format command failed (false)")
+            .with_backup_session(Some("99_0".into()))
+            .into();
+        assert_eq!(backup_session_from_error(&err), Some("99_0"));
+        assert_eq!(format_failed_backup_session(&err), Some("99_0"));
+    }
+
+    #[test]
+    fn backup_session_from_error_peels_mutation_after_backup() {
+        // Root via Into (not .context): anyhow context layers are not downcastable.
+        let err: anyhow::Error = MutationAfterBackupError::restored("42_1", "disk full").into();
+        assert_eq!(backup_session_from_error(&err), Some("42_1"));
+        assert_eq!(mutation_after_backup_session(&err), Some("42_1"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("restored session 42_1"),
+            "Display stays human-readable: {msg}"
+        );
+        assert!(
+            msg.contains("disk full"),
+            "mutation detail must remain visible: {msg}"
+        );
+    }
+
+    #[test]
+    fn backup_session_from_error_peels_restore_failed() {
+        let err: anyhow::Error =
+            MutationAfterBackupError::restore_failed("7_0", "permission denied", "write failed")
+                .into();
+        assert_eq!(backup_session_from_error(&err), Some("7_0"));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("restore of session 7_0"),
+            "Display keeps restore-failed wording: {msg}"
+        );
+        assert!(msg.contains("write failed"), "mutation detail: {msg}");
+    }
+
+    #[test]
+    fn backup_session_from_error_none_for_plain_no_match_and_guard() {
+        let no_match: anyhow::Error = NoMatchError {
+            msg: "no matches for old".into(),
+        }
+        .into();
+        assert_eq!(backup_session_from_error(&no_match), None);
+
+        let guard: anyhow::Error = crate::fallback::EditError::new(
+            crate::fallback::EditErrorKind::GuardRejected,
+            "path outside workspace",
+        )
+        .into();
+        assert_eq!(backup_session_from_error(&guard), None);
+
+        let plain = anyhow::anyhow!("something went wrong");
+        assert_eq!(backup_session_from_error(&plain), None);
+    }
+
+    #[test]
+    fn backup_session_from_error_prefers_format_failed_when_both_in_chain() {
+        // FormatFailed is the primary post-write path; prefer it if both appear.
+        let fmt: anyhow::Error = FormatFailedError::new("fmt")
+            .with_backup_session(Some("fmt_sess".into()))
+            .into();
+        // Simulate outer wrap that still peels FormatFailed via chain.
+        let wrapped = fmt.context("post-write hooks failed");
+        assert_eq!(backup_session_from_error(&wrapped), Some("fmt_sess"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,7 @@
 //! | Soft zero matches | [`EditErrorKind::NoMatch`] / [`api::is_no_match`] (JSON kind `no_matches`) |
 //! | Unique multi-match ambiguity | [`EditErrorKind::AmbiguousTarget`] / [`api::is_ambiguous`] (JSON `ambiguous`) |
 //! | Post-write format/lint failure | [`EditErrorKind::FormatFailed`] / [`api::is_format_failed`] |
+//! | Session id after FormatFailed or fail-restore (undo without Display scrape) | [`api::backup_session_from_error`] (#2127); success path: [`EditResult::backup_session`] |
 //! | Shared agent replace policy (primary + fallback) | [`ReplaceOptions::for_agent`] / [`AGENT_MIN_FUZZY_SCORE`] (#1965 / #2005) |
 //! | Over-wide fuzzy auto-refuse on `for_agent` | [`ReplaceOptions::refuse_suspicious_fuzzy`] / [`EditErrorKind::FuzzySpanSuspicious`] / [`api::is_fuzzy_span_suspicious`] (#2005) |
 //! | Custom over-wide fuzzy refuse | [`api::fuzzy_span_suspicious`] / [`FuzzySpanPolicy`] (#1981) |
@@ -332,6 +333,11 @@ pub use api::{
     load_text, load_text_strict, merge_match_modes, parse_unified_diff, peel_error,
     plan_apply_fragment_to_replace, prefer_widest_matched_text, refuse_batch_if_suspicious_fuzzy,
     run_post_write_validation, search_file, strip_lazy_markers, text_diff,
+};
+/// Fail-restore / FormatFailed session peel for library hosts (#2127).
+pub use api::{
+    FormatFailedError, MutationAfterBackupError, backup_session_from_error,
+    format_failed_backup_session, format_failed_written_files, mutation_after_backup_session,
 };
 #[cfg(any(feature = "cli", feature = "files"))]
 pub use api::{


### PR DESCRIPTION
## Summary

Library hosts can now peel a backup session id from fail-restore and FormatFailed errors without scraping English Display text.

## Problem

Success path already exposes `EditResult.backup_session`. After a failed mutation (post-finalize restore) or post-write format failure, bline and other embedders had to scrape phrases like `restored session`, `backup session`, etc. `format_failed_backup_session` existed but lived in crate-private `exit`.

## Change

- `MutationAfterBackupError` typed root error for library fail-restore (not `anyhow` Display-only `.context()`, which is not downcastable)
- `api::backup_session_from_error` peels FormatFailed then MutationAfterBackup
- Re-export `format_failed_backup_session`, `format_failed_written_files`, and related types on `api` and crate root
- Docs: lib.rs host table, embedder-host checklist, agent-rules / PATCHLOOM.md

## Validation

- Unit tests for issue ACs (fail-restore peel, FormatFailed peel, None for NoMatch/GuardRejected)
- `apply_mutation_restores_on_perform_failure` asserts peel matches `list_sessions`
- `make check-fast` green
- Reviewer: Approve (no blockers)

Closes #2127