### PR TITLE
fix: fail-restore session peel parity and embed version 0.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Add patchloom as a dependency (omit CLI/MCP/AST with `default-features = false`)
 
 ```toml
 [dependencies]
-patchloom = { version = "0.25.0", default-features = false }
+patchloom = { version = "0.26.0", default-features = false }
 ```
 
 ```rust

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -129,14 +129,14 @@ Rust tools. Disable default features to omit CLI (clap), MCP server, and AST:
 
 ```toml
 [dependencies]
-patchloom = { version = "0.25.0", default-features = false }
+patchloom = { version = "0.26.0", default-features = false }
 ```
 
 To add AST support without CLI/MCP (LLM agent embedders typically use
 `ast` + `files` for plan execution and AST file mutators):
 
 ```toml
-patchloom = { version = "0.25.0", default-features = false, features = ["ast", "files"] }
+patchloom = { version = "0.26.0", default-features = false, features = ["ast", "files"] }
 ```
 
 See the [crate documentation](https://docs.rs/patchloom) for the full API

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -63,7 +63,7 @@ Patchloom is also a Rust library. Add it as a dependency to embed structured fil
 
 ```toml
 [dependencies]
-patchloom = { version = "0.25.0", default-features = false }
+patchloom = { version = "0.26.0", default-features = false }
 ```
 
 The `api` module exposes doc, replace, markdown, file, patch, multi-op content

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1377,6 +1377,7 @@ The operations below are the building blocks inside `operations`.
 | Match honesty (fuzzy confidence) | `EditResult` / `ContentEditsResult` `match_mode` / `match_score` (#1662); CLI/MCP JSON (#1669); plan/tx `TxChange` + aggregate mode/score/`match_count` from engine meta (#1674) |
 | Reject weak fuzzy matches | CLI `--min-fuzzy-score` / `ReplaceOptions.min_fuzzy_score` / plan `min_fuzzy_score` / MCP `min_fuzzy_score` (#1687); range `0.0..=1.0` |
 | Apply session id for surgical undo | `EditResult.backup_session` after Apply (#1686); pair with `restore_path_from_session` |
+| Session id on fail-restore / FormatFailed | `api::backup_session_from_error(&err)` (#2127); also `format_failed_backup_session` / `MutationAfterBackupError` |
 | Nested monorepo backup listing | `backup::list_sessions_under` + `ListSessionsOptions` (#1688) |
 | Ancestor backup root discovery | `backup::find_backup_roots(path)` walks parents for `.patchloom/backups` (#1934) |
 | File op structured kinds | `file_create` / `file_delete` / `file_rename` / `file_append`: dest-exists without force → `AlreadyExists` (#1947); missing path → `NotFound`; dir/empty path → `InvalidInput`; append/prepend on binary → `Binary` / invalid UTF-8 → `InvalidEncoding` (#1963); **path-only** `file_rename` / `file_delete` succeed on binary and invalid UTF-8 with byte backup (#2031); force create overwrites non-text prior (#1962); PathGuard → `GuardRejected` (#1935) |

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -259,16 +259,21 @@ pub fn backup_write_files(
     })();
 
     if let Err(e) = write_result {
-        // Auto-restore from backup on partial write failure so the caller
-        // does not end up with a half-written batch.
-        if let Some(ref ts) = backup_ts
-            && let Err(restore_err) = restore_session(cwd, ts)
-        {
-            return Err(e.context(format!(
-                "write failed AND auto-restore also failed: {restore_err}"
-            )));
-        }
-        return Err(e);
+        // Auto-restore on partial write failure; surface typed fail-restore
+        // so hosts peel session via `backup_session_from_error` (#2127 residual).
+        let Some(ts) = backup_ts else {
+            return Err(e);
+        };
+        let mutation_msg = e.to_string();
+        return match restore_session(cwd, &ts) {
+            Ok(_) => Err(crate::exit::MutationAfterBackupError::restored(ts, mutation_msg).into()),
+            Err(restore_err) => Err(crate::exit::MutationAfterBackupError::restore_failed(
+                ts,
+                restore_err.to_string(),
+                mutation_msg,
+            )
+            .into()),
+        };
     }
     Ok(())
 }
@@ -1259,8 +1264,13 @@ mod tests {
         let files: Vec<(&Path, &str, &crate::write::WritePolicy)> =
             vec![(&real, "updated", &policy), (&bad, "x", &policy)];
         let result = backup_write_files(dir.path(), &files);
-        assert!(result.is_err(), "write to missing dir should fail");
-
+        let err = result.expect_err("write to missing dir should fail");
+        let session = crate::exit::backup_session_from_error(&err)
+            .expect("fail-restore must peel session without Display scrape");
+        assert!(
+            !session.is_empty(),
+            "session id must be non-empty after finalize"
+        );
         // After the auto-restore, the first file should be back to its
         // original content (not left in the "updated" state).
         assert_eq!(
@@ -1283,11 +1293,13 @@ mod tests {
         let files: Vec<(&Path, &str, &crate::write::WritePolicy)> =
             vec![(&real, "updated", &policy), (&bad, "x", &policy)];
         let result = backup_write_files(dir.path(), &files);
-        assert!(result.is_err(), "write to missing dir should fail");
+        let err = result.expect_err("write to missing dir should fail");
 
         // The manifest must exist because finalize() runs before writes.
         let sessions = list_sessions(dir.path()).unwrap();
         assert_eq!(sessions.len(), 1, "backup session must be finalized");
+        let session = crate::exit::backup_session_from_error(&err).expect("peel session");
+        assert_eq!(session, sessions[0].timestamp);
 
         // Auto-restore should have reverted the first file back to original.
         assert_eq!(std::fs::read_to_string(&real).unwrap(), "original");

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -484,7 +484,7 @@ pub fn agent_error_message(err: &anyhow::Error) -> String {
 /// Build the shared JSON error envelope + exit code for agent `--json` paths.
 ///
 /// Includes `error_kind` when classifiable and `backup_session` when a
-/// post-write format failure carries one.
+/// FormatFailed or fail-restore error carries one (#2127).
 #[must_use]
 pub fn structured_error_payload(err: &anyhow::Error) -> (serde_json::Value, u8) {
     let (kind, code) = match classify_typed_error(err) {
@@ -498,13 +498,14 @@ pub fn structured_error_payload(err: &anyhow::Error) -> (serde_json::Value, u8) 
     if let Some(k) = kind {
         output["error_kind"] = serde_json::Value::String(k.to_string());
     }
-    if let Some(bs) = format_failed_backup_session(err) {
+    // FormatFailed and MutationAfterBackup (#2127 residual CLI JSON parity).
+    if let Some(bs) = backup_session_from_error(err) {
         output["backup_session"] = serde_json::Value::String(bs.to_string());
     }
     let written = format_failed_written_files(err);
     // Write landed if we have written paths, or a backup session (callback
     // renames / soft-empty path-only ops attach backup with empty written[]).
-    let write_landed = !written.is_empty() || format_failed_backup_session(err).is_some();
+    let write_landed = !written.is_empty() || backup_session_from_error(err).is_some();
     if write_landed {
         // Canonical with other mutators (#1831 / #1788): agents branch on
         // `applied`. Keep `write_applied` as a deprecated alias for one release.
@@ -718,6 +719,34 @@ mod tests {
         // Simulate outer wrap that still peels FormatFailed via chain.
         let wrapped = fmt.context("post-write hooks failed");
         assert_eq!(backup_session_from_error(&wrapped), Some("fmt_sess"));
+    }
+
+    #[test]
+    fn backup_session_from_error_peels_mutation_under_outer_context() {
+        // Root typed error + outer Display context (CLI remappers often wrap).
+        let root: anyhow::Error =
+            MutationAfterBackupError::restored("wrap_1", "write failed").into();
+        let wrapped = root.context("operation 0 failed");
+        assert_eq!(backup_session_from_error(&wrapped), Some("wrap_1"));
+    }
+
+    #[test]
+    fn structured_error_payload_includes_mutation_after_backup_session() {
+        let err: anyhow::Error = MutationAfterBackupError::restored("json_1", "disk full").into();
+        let (payload, code) = structured_error_payload(&err);
+        assert_eq!(code, FAILURE);
+        assert_eq!(payload["backup_session"], "json_1");
+        assert_eq!(
+            payload["applied"], true,
+            "fail-restore means write attempt landed (session finalized): {payload}"
+        );
+        assert!(
+            payload["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("restored session json_1"),
+            "error text should mention session: {payload}"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,13 @@
 //!
 //! ```toml
 //! [dependencies]
-//! patchloom = { version = "0.25.0", default-features = false }
+//! patchloom = { version = "0.26.0", default-features = false }
 //! ```
 //!
 //! Or with AST support:
 //!
 //! ```toml
-//! patchloom = { version = "0.25.0", default-features = false, features = ["ast"] }
+//! patchloom = { version = "0.26.0", default-features = false, features = ["ast"] }
 //! ```
 //!
 //! (Keep the version in sync with Cargo.toml / release-please. See the release checklist.)


### PR DESCRIPTION
## Summary

MPI cycle after #2129: close residual fail-restore honesty gaps and refresh embedder version examples for 0.26.0.

## Changes

1. **`backup_write_files`** returns `MutationAfterBackupError` on partial write failure (peelable via `backup_session_from_error`), matching library `mutation_err_after_backup`.
2. **`structured_error_payload`** peels session via `backup_session_from_error` (FormatFailed + fail-restore), so CLI `--json` gets `backup_session` / `applied: true` when a session was finalized.
3. **Docs:** reference embedder table row; library embedding snippets 0.25.0 → 0.26.0 (README, lib.rs, intro, install).
4. **Tests:** peel on `backup_write_files` failure; MutationAfterBackup under outer context; structured_error_payload mutation session.

## Validation

- `make check-fast` green
- Unit filters for backup_write_files / backup_session_from_error / structured_error_payload

## Gate

Only open ready issues remain external B-path: #1990 (human post), #960 winget, #961 Chocolatey.