### PR TITLE
docs: agent DX for doc set vs update; version channel discipline

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -7,7 +7,8 @@
 |--------|-----|--------------------------|----------|
 | multi-op atomic | `tx` | (plan root) | `execute_plan` |
 | identifier rename | `ast rename` | `ast.rename` | `ast_rename` or plan via `execute_plan` |
-| structured set | `doc set` / `doc update` | `doc.set` / `doc.update` | `doc_set` / plan |
+| structured single path | `doc set` | `doc.set` | `doc_set` |
+| structured multi-match (predicate/wildcard) | `doc update` | `doc.update` | `doc_update` |
 | search | `search` | n/a | `search_files` |
 | list files | n/a (MCP) | n/a | `list_files` |
 | read | `read` | n/a | `read_file` |
@@ -51,7 +52,8 @@ Prefer Patchloom over shell `sed`/`jq`/`yq` and over whole-file rewrites when th
 
 | If the task is… | Prefer | Avoid |
 |---|---|---|
-| JSON/YAML/TOML key mutate | `doc set` / plan `doc.*` / MCP `doc_set` | regex replace on structured files |
+| JSON/YAML/TOML single key/index path | `doc set` / plan `doc.set` / MCP `doc_set` (e.g. `server.port`, `items.0.v`) | regex replace on structured files |
+| JSON/YAML/TOML multi-match by predicate or wildcard | `doc update` / plan `doc.update` / MCP `doc_update` (e.g. `items[name=a].v`, `items[*].enabled`) | `doc set` with predicates (fails closed) |
 | Multi-document YAML | selector `0.key` or `[0].key` | bare key on stream root |
 | Markdown section/bullet/table | `md *` | whole-file rewrite |
 | Identifier rename in code | `ast rename` / `ast_rename_project` | fuzzy replace for symbols |
@@ -526,7 +528,7 @@ dependencies[name=react].version # predicate filter
 - `file.delete`: Delete a file.
 - `file.rename`: Rename (move) a file.
 - `tidy.fix`: Normalize whitespace in a file. When op fields are omitted, defaults match CLI tidy fix (trim trailing whitespace + ensure final newline; normalize_eol stays keep). Precedence: defaults → plan write_policy → op fields. Plan write_policy is not re-applied at commit for paths last written by tidy.fix so op fields stick (#1840, #1847).
-- `doc.set`: Set a value at a selector path in a JSON, YAML, or TOML file. Parser-backed; output is always valid.
+- `doc.set`: Set a value at a single concrete selector path in a JSON, YAML, or TOML file (keys and indexes such as server.port or items.0.v). Parser-backed; output is always valid. Not for predicates or wildcards (items[name=foo].v, items[*].v); use doc.update for multi-match writes.
 - `doc.delete`: Delete a value at a selector path in a JSON, YAML, or TOML file. CLI --json and MCP/tx success include changed and removed (0 on missing key; exit 0 / ok is idempotent).
 - `doc.merge`: Deep-merge a JSON object into a document root, or into a selector path (e.g. multi-doc YAML `0` / `[0]`).
 - `doc.append`: Append a value to an array at a selector path.

--- a/REPO-SETUP.md
+++ b/REPO-SETUP.md
@@ -22,11 +22,12 @@ This file captures the recommended day 1 policy setup for `patchloom/patchloom`,
 
 Keep directory copy aligned with the tagged version. Automated where possible:
 
-1. **MCP Registry** — runs from Release after crates/npm; on failure: Actions → **Publish MCP Registry** → version input. `server.json` description should stay differentiation-focused (structured agent edits, not generic filesystem) and **at most 100 characters** (registry schema hard limit; longer values fail validate with 422). Version field is stamped by the publish job.
-2. **Smithery** — `publish-smithery.yml` after Release when `SMITHERY_API_KEY` is set; manual: `make pack-mcpb && bash scripts/publish-smithery.sh`.
-3. **Glama** — no API publish; after listing exists, sync from GitHub + `glama.json`. If description drifts, update via Glama UI (human session). Suggested blurb: same as `server.json` description.
-4. **Secondary marketplaces** (mcp.so, mcpservers.org, PulseMCP, awesome lists) — re-check only when deliberately listing; not release-blocking.
-5. **GitHub repo description / topics / homepage** — optional re-check after major messaging changes (`gh api repos/patchloom/patchloom`).
+1. **Version channels** — confirm crates.io max version, Homebrew formula on `patchloom/homebrew-tap`, and Scoop `bucket/patchloom.json` match the release tag. Operators still need `brew upgrade` / `scoop update` on machines that already had an older cellar; document that in install notes. Optional bottle `--version` CI is tracked separately (#2134).
+2. **MCP Registry** — runs from Release after crates/npm; on failure: Actions → **Publish MCP Registry** → version input. `server.json` description should stay differentiation-focused (structured agent edits, not generic filesystem) and **at most 100 characters** (registry schema hard limit; longer values fail validate with 422). Version field is stamped by the publish job.
+3. **Smithery** — `publish-smithery.yml` after Release when `SMITHERY_API_KEY` is set; manual: `make pack-mcpb && bash scripts/publish-smithery.sh`.
+4. **Glama** — no API publish; after listing exists, sync from GitHub + `glama.json`. If description drifts, update via Glama UI (human session). Suggested blurb: same as `server.json` description.
+5. **Secondary marketplaces** (mcp.so, mcpservers.org, PulseMCP, awesome lists) — re-check only when deliberately listing; not release-blocking.
+6. **GitHub repo description / topics / homepage** — optional re-check after major messaging changes (`gh api repos/patchloom/patchloom`).
 | Security reporting | commit `SECURITY.md` now, then enable GitHub private vulnerability reporting after the repo becomes public | private Free org repos do not expose GitHub private vulnerability reporting yet |
 | Branch protection | Protect `main` once the repo is public or on a plan that supports private branch protection | required before accepting outside patches |
 | Public repo metadata | commit `LICENSE`, `README.md`, `CONTRIBUTING.md`, and issue templates in the bootstrap | keep the repo legible from day one |

--- a/docs/getting-started/comparisons.md
+++ b/docs/getting-started/comparisons.md
@@ -42,7 +42,17 @@ Install notes: [MCP setup](mcp-setup.md) (Cursor / Claude / Codex paste configs 
 | `yq -i '.version = "2.0.0"' package.json` | `patchloom doc set package.json version '"2.0.0"' --apply` (or MCP `doc_set`) |
 | `yq 'select(document_index == 0) \| .a' multi.yaml` | `patchloom doc get multi.yaml 0.a` |
 | `yq -i '.[0].image = "x"' multi.yaml` | `patchloom doc set multi.yaml 0.image x --apply` |
+| `yq '(.items[] \| select(.name == "a")).v = 99' -i f.yaml` | `patchloom doc update f.yaml 'items[name=a].v' 99 --apply` (or MCP `doc_update`); **not** `doc set` |
 | `yq '.items[] \| select(.name == "a")' f.yaml` | `patchloom doc select f.yaml items --predicate name=a` (or MCP `doc_query` / plan) |
+
+### `doc set` vs `doc update` (agent DX)
+
+| Selector shape | Use |
+|----------------|-----|
+| Concrete path (`server.port`, `items.0.v`, `items[0].v`) | `doc set` / plan `doc.set` / MCP `doc_set` (also `doc ensure` for idempotent set) |
+| Predicate or wildcard multi-match (`items[name=a].v`, `items[*].enabled`) | `doc update` / plan `doc.update` / MCP `doc_update` |
+
+`doc set` is **single-path only**. Predicate selectors fail closed with `invalid_input` and a message that points at `doc update`. Prefer the right op on the first try so agents do not burn a turn.
 
 Prefer parser-backed `doc` over inventing `yq` in agent shells so peels, dry-run exit 2, and multi-doc honesty stay consistent.
 

--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -6,6 +6,17 @@ shell out to the CLI). Public API: [docs.rs/patchloom](https://docs.rs/patchloom
 This is the **one-screen** ordered checklist for a first host integration.
 Bline is a real embedder that dogfooded these steps; the checklist is host-generic.
 
+**Version dual-path:** a Cargo pin of patchloom (library) can be ahead of the
+operator shell binary (`brew` / `scoop` / old `cargo install`). When dogfooding
+CLI and library side by side, run `patchloom --version` and compare to
+`Cargo.lock` before treating CLI exit codes as a library regression. See
+[Installation: verify which binary](installation.md#verify-which-binary-and-crate-you-have).
+
+**`doc set` vs `doc update`:** single concrete paths use `doc.set` / MCP
+`doc_set`; predicate or wildcard multi-match uses `doc.update` / `doc_update`.
+Do not expose only `doc_set` if agents need list updates by name. See
+[Comparisons](comparisons.md#doc-set-vs-doc-update-agent-dx).
+
 ## Minimal checklist
 
 1. **PathGuard** from the workspace root (and `allow_temp_directory` if the

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -14,6 +14,15 @@ brew install patchloom/tap/patchloom
 
 This installs patchloom with all commands, including the MCP server.
 
+After a new GitHub Release, formula metadata can show the new version while
+your linked cellar is still the previous one until you upgrade:
+
+```bash
+brew update
+brew upgrade patchloom
+patchloom --version
+```
+
 ## Recommended: Scoop (Windows)
 
 ```powershell
@@ -51,6 +60,25 @@ new version via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishe
 ```bash
 cargo install patchloom
 ```
+
+## Verify which binary and crate you have
+
+Channels can disagree until you upgrade each one. Embedder hosts that pin
+patchloom in `Cargo.toml` / `Cargo.lock` often ship a **library** version
+ahead of the operator's shell `PATH` binary (Homebrew, Scoop, older
+`cargo install`).
+
+| Surface | How to check |
+|---------|----------------|
+| CLI on PATH | `patchloom --version` |
+| Homebrew formula / cellar | `brew info patchloom/tap/patchloom` then `brew upgrade patchloom` if linked is behind |
+| Scoop | `scoop update patchloom` then re-check `--version` |
+| crates.io install | `cargo install patchloom` (or `cargo install-update -a` if you use cargo-update) |
+| Embedder library pin | `Cargo.lock` entry for `name = "patchloom"` |
+
+Before filing "CLI behavior differs from 0.x" bugs, compare `patchloom --version`
+to the version your host embeds. Dual-path dogfood (library + brew CLI) is
+expected to split until the shell binary is upgraded.
 
 ## Recommended: GitHub Releases
 

--- a/src/cmd/agent_packaging.rs
+++ b/src/cmd/agent_packaging.rs
@@ -54,7 +54,8 @@ fn canonical_name_map_markdown_for_surface(full_ast_tools: bool) -> &'static str
 |--------|-----|--------------------------|----------|\n\
 | multi-op atomic | `tx` | (plan root) | `execute_plan` |\n\
 | identifier rename | `ast rename` | `ast.rename` | `ast_rename` or plan via `execute_plan` |\n\
-| structured set | `doc set` / `doc update` | `doc.set` / `doc.update` | `doc_set` / plan |\n\
+| structured single path | `doc set` | `doc.set` | `doc_set` |\n\
+| structured multi-match (predicate/wildcard) | `doc update` | `doc.update` | `doc_update` |\n\
 | search | `search` | n/a | `search_files` |\n\
 | list files | n/a (MCP) | n/a | `list_files` |\n\
 | read | `read` | n/a | `read_file` |\n\
@@ -70,7 +71,8 @@ patchloom usage.\n\n"
 |--------|-----|--------------------------|----------------------|\n\
 | multi-op atomic | `tx` | (plan root) | `execute_plan` |\n\
 | identifier rename | `ast rename` | `ast.rename` | plan via `execute_plan` only (no standalone `ast_*` on core) |\n\
-| structured set | `doc set` / `doc update` | `doc.set` / `doc.update` | `doc_set` / plan |\n\
+| structured single path | `doc set` | `doc.set` | `doc_set` |\n\
+| structured multi-match (predicate/wildcard) | `doc update` | `doc.update` | plan via `execute_plan` only (no standalone `doc_update` on core) |\n\
 | search | `search` | n/a | `search_files` |\n\
 | list files | n/a (MCP) | n/a | `list_files` |\n\
 | read | `read` | n/a | `read_file` |\n\
@@ -179,6 +181,7 @@ mod tests {
             "search_files",
             "read_file",
             "doc_set",
+            "doc_update",
             "ast_rename",
         ] {
             assert!(t.contains(id), "missing {id}");
@@ -186,6 +189,16 @@ mod tests {
         assert!(
             t.contains("invent") || t.contains("not** patchloom") || t.contains("Host meta-tools"),
             "name map must discourage invented ids"
+        );
+        assert!(
+            t.contains("structured multi-match") && t.contains("doc update"),
+            "full name map must separate set vs update (#2132): {t}"
+        );
+        let core = canonical_name_map_markdown_core();
+        assert!(
+            core.contains("no standalone `doc_update` on core")
+                || core.contains("execute_plan") && core.contains("doc.update"),
+            "core name map must not invent standalone doc_update tool: {core}"
         );
     }
 

--- a/src/cmd/agent_rules/policy.rs
+++ b/src/cmd/agent_rules/policy.rs
@@ -23,7 +23,8 @@ the edit is structured or multi-file. Prefer **ast-grep** (or similar) for \
 DSL; use Patchloom for host-safe apply, configs, markdown, batch/tx/undo, and peels.\n\n\
          | If the task is… | Prefer | Avoid |\n\
          |---|---|---|\n\
-         | JSON/YAML/TOML key mutate | `doc set` / plan `doc.*` / MCP `doc_set` | regex replace on structured files |\n\
+         | JSON/YAML/TOML single key/index path | `doc set` / plan `doc.set` / MCP `doc_set` (e.g. `server.port`, `items.0.v`) | regex replace on structured files |\n\
+         | JSON/YAML/TOML multi-match by predicate or wildcard | `doc update` / plan `doc.update` / MCP `doc_update` (e.g. `items[name=a].v`, `items[*].enabled`) | `doc set` with predicates (fails closed) |\n\
          | Multi-document YAML | selector `0.key` or `[0].key` | bare key on stream root |\n\
          | Markdown section/bullet/table | `md *` | whole-file rewrite |\n\
          | Identifier rename in code | `ast rename` / `ast_rename_project` | fuzzy replace for symbols |\n\

--- a/src/cmd/agent_rules/tests.rs
+++ b/src/cmd/agent_rules/tests.rs
@@ -518,8 +518,11 @@ fn agent_rules_documents_library_type_error_and_binary_preflight() {
         out.contains("Which surface to use")
             && out.contains("ast-grep")
             && out.contains("Context budget")
-            && out.contains("Multi-document YAML"),
-        "agent-rules need decision tree + ast-grep complement + context tips (#1992/#1993/#1996)"
+            && out.contains("Multi-document YAML")
+            && out.contains("doc update")
+            && out.contains("items[name=a].v")
+            && out.contains("structured multi-match"),
+        "agent-rules need decision tree + set-vs-update + ast-grep + context tips (#1992/#1993/#1996/#2132)"
     );
     assert!(
         out.contains("Morph Fast Apply")

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -54,6 +54,9 @@ pub enum DocAction {
         /// File path (JSON, YAML, or TOML).
         file: String,
         /// Selector path (e.g. `server.port`, `items[0].name`).
+        /// Single concrete path only (keys and indexes). Not for
+        /// predicates or wildcards (`items[name=foo].v`, `items[*].v`);
+        /// use `doc update` for multi-match writes.
         selector: String,
         /// Value (JSON literal or bare string).
         value: String,
@@ -145,6 +148,8 @@ pub enum DocAction {
         /// File path (JSON, YAML, or TOML).
         file: String,
         /// Selector path (e.g. `server.port`, `items[0].name`).
+        /// Single concrete path only (same rule as `doc set`). For
+        /// predicates or wildcards use `doc update`.
         selector: String,
         /// Value to set if missing (JSON literal or bare string).
         value: String,

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -62,7 +62,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         tool_name: "doc_set",
         op_name: "doc.set",
         extra: Some(
-            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+            "Single concrete path only (keys/indexes). For selector predicates or wildcards (items[name=foo].v, items[*].v) use doc_update / plan doc.update. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: true,
         validations: &[
@@ -151,7 +151,7 @@ pub(super) const MCP_TOOL_REGISTRY: &[McpToolMeta] = &[
         tool_name: "doc_update",
         op_name: "doc.update",
         extra: Some(
-            "IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
+            "Multi-match writes: use selector predicates or wildcards (items[name=foo].v, items[*].enabled). Prefer this over doc_set when filtering by field. IMPORTANT: do NOT issue concurrent calls targeting the same file; use execute_plan for multi-op atomicity.",
         ),
         has_strict: false,
         validations: &[

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -278,7 +278,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     // --- Medium tier ---
     OpMeta {
         name: "doc.set",
-        description: "Set a value at a selector path in a JSON, YAML, or TOML file. Parser-backed; output is always valid.",
+        description: "Set a value at a single concrete selector path in a JSON, YAML, or TOML file (keys and indexes such as server.port or items.0.v). Parser-backed; output is always valid. Not for predicates or wildcards (items[name=foo].v, items[*].v); use doc.update for multi-match writes.",
         tier: Tier::Medium,
         examples: &[(
             "Update a version in package.json",

--- a/src/schema_tests.rs
+++ b/src/schema_tests.rs
@@ -142,6 +142,28 @@ mod basic {
         );
     }
 
+    /// Agent DX: doc.set must steer multi-match predicates to doc.update (#2132).
+    #[test]
+    fn doc_set_description_points_predicates_to_doc_update() {
+        let base = operation_description("doc.set").expect("doc.set in registry");
+        assert!(
+            base.contains("single concrete") && base.contains("doc.update"),
+            "doc.set description must say single concrete path and point to doc.update: {base}"
+        );
+        assert!(
+            !base.contains("items[name=") || base.contains("doc.update"),
+            "if predicate examples appear they must still route to doc.update: {base}"
+        );
+        let desc = mcp_tool_description(
+            "doc.set",
+            Some("Single concrete path only. For selector predicates use doc_update."),
+        );
+        assert!(
+            desc.contains("doc.update") || desc.contains("doc_update"),
+            "MCP doc_set description must mention doc.update or doc_update: {desc}"
+        );
+    }
+
     #[test]
     fn mcp_tool_description_strips_op_from_all_registry_examples() {
         for meta in OPERATION_REGISTRY.iter() {


### PR DESCRIPTION
## Summary

Ship the accepted scope for #2132 (bline dogfood): make the `doc set` vs `doc update` split obvious on agent-facing surfaces, and document brew/PATH vs crates dual-path version checks. Write semantics stay fail-closed (no silent multi-match on `doc set`).

## Changes

- CLI: `doc set` / `doc ensure` selector help notes predicates → `doc update`
- Schema `doc.set` description + MCP `doc_set` / `doc_update` extras
- Agent-rules decision table + canonical name map (core pack honest: multi-match via `execute_plan` / `doc.update`, not a fake standalone `doc_update`)
- Comparisons cheat sheet; embedder host dual-path note
- Install docs: brew upgrade + verify table; REPO-SETUP post-release version channel step

## Deferred (separate issues)

- #2133 machine-stable `suggested_op` (or similar) on predicate-on-set fail-closed
- #2134 optional homebrew-tap bottle `--version` CI

## Test plan

- [x] `cargo test --lib` filters for schema + agent-rules + packaging
- [x] `make sync-patchloom-md`
- [x] `make check-fast`
- [x] `patchloom doc set --help` shows single-path / doc update note

Closes #2132
Ref #2133
Ref #2134