### PR TITLE
fix: preserve suggested_op on tx JSON path; harden brew re-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -675,8 +675,9 @@ jobs:
             echo "PLAN had no releases[0].app_version" >&2
             exit 1
           fi
-          # Formula was just pushed; tap may need a fresh fetch.
-          brew tap patchloom/tap || brew untap patchloom/tap; brew tap patchloom/tap
+          # Formula was just pushed; force a clean tap fetch (untap may no-op).
+          brew untap patchloom/tap 2>/dev/null || true
+          brew tap patchloom/tap
           EXPECTED_VERSION="$version" INSTALL=1 \
             bash scripts/verify-homebrew-version.sh
 

--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -4,7 +4,7 @@ use crate::exit;
 use crate::plan::{self, Plan};
 use crate::tx::{
     CommitError, TxArgs, TxExecResult, TxOutput, build_applied_with_error_output,
-    build_error_output, build_full_tx_output, exit_code_from_tx_output,
+    build_error_output_with_suggested_op, build_full_tx_output, exit_code_from_tx_output,
     format_error_with_backup_hint, run_lifecycle,
 };
 use crate::write::run_format_command;
@@ -28,8 +28,18 @@ fn emit_error_json(
     backup_session: Option<&str>,
     compact: bool,
 ) -> bool {
+    emit_error_json_with_suggested_op(error_kind, error, backup_session, None, compact)
+}
+
+fn emit_error_json_with_suggested_op(
+    error_kind: &str,
+    error: &str,
+    backup_session: Option<&str>,
+    suggested_op: Option<&str>,
+    compact: bool,
+) -> bool {
     emit_output_json(
-        &build_error_output(error_kind, error, backup_session),
+        &build_error_output_with_suggested_op(error_kind, error, backup_session, suggested_op),
         compact,
     )
 }
@@ -522,7 +532,8 @@ pub(crate) fn run_parsed_plan(
                 None => ("operation_failed", exit::OPERATION_FAILED),
             };
             if structured {
-                let ok = emit_error_json(kind, &msg, None, compact);
+                let suggested = exit::suggested_op_from_error(&e);
+                let ok = emit_error_json_with_suggested_op(kind, &msg, None, suggested, compact);
                 return Ok(exit_after_emit(ok, code));
             }
             eprintln!("tx: {msg}");

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -171,7 +171,7 @@ mod basic {
 
     #[test]
     fn build_error_output_produces_expected_shape() {
-        let output = build_error_output("rollback", "disk full", None);
+        let output = crate::tx::build_error_output("rollback", "disk full", None);
         assert!(!output.ok);
         assert_eq!(output.status, "error".to_string());
         assert_eq!(output.error_kind, Some("rollback".to_string()));

--- a/src/json_emit.rs
+++ b/src/json_emit.rs
@@ -235,6 +235,7 @@ mod tests {
             removed: None,
             error_kind: None,
             error: None,
+            suggested_op: None,
             backup_session: None,
             match_mode: None,
             match_score: None,

--- a/src/tx/lifecycle/plan_exec.rs
+++ b/src/tx/lifecycle/plan_exec.rs
@@ -8,12 +8,11 @@ use super::steps::{
 use crate::cli::global::GlobalFlags;
 use crate::plan::{self, Plan};
 use crate::tx::execute::execute_and_collect;
-use crate::tx::output::{
-    TxOutput, build_applied_with_error_output, build_error_output, build_full_tx_output,
-};
+use crate::tx::output::{TxOutput, build_applied_with_error_output, build_full_tx_output};
 use crate::tx::validate::validate_plan_operations;
 #[cfg(feature = "ast")]
 use crate::tx::verify;
+use crate::tx::{build_error_output, build_error_output_with_suggested_op};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -145,9 +144,15 @@ pub fn execute_plan_direct(
         Ok(r) => r,
         Err(e) => {
             // Shared typed-kind table (no_matches, ambiguous, …); unknown →
-            // operation_failed (tx default, exit 9).
+            // operation_failed (tx default, exit 9). Preserve suggested_op (#2133).
+            let suggested = crate::exit::suggested_op_from_error(&e);
             if let Some((kind, _)) = crate::exit::classify_typed_error(&e) {
-                return Ok(build_error_output(kind, &e.to_string(), None));
+                return Ok(build_error_output_with_suggested_op(
+                    kind,
+                    &e.to_string(),
+                    None,
+                    suggested,
+                ));
             }
             return Ok(build_error_output("operation_failed", &e.to_string(), None));
         }

--- a/src/tx/mod.rs
+++ b/src/tx/mod.rs
@@ -34,7 +34,8 @@ mod tidy_op;
 // output.rs
 pub(crate) use output::{
     ReplaceMatchMeta, TxExecResult, build_applied_with_error_output, build_error_output,
-    build_full_tx_output, format_error_with_backup_hint, match_mode_label,
+    build_error_output_with_suggested_op, build_full_tx_output, format_error_with_backup_hint,
+    match_mode_label,
 };
 pub use output::{
     TxChange, TxDocMutation, TxLintResult, TxOutput, TxReadResult, TxRefused, TxSearchMatch,

--- a/src/tx/output.rs
+++ b/src/tx/output.rs
@@ -58,6 +58,10 @@ pub struct TxOutput {
     pub error_kind: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub error: Option<String>,
+    /// Machine-stable alternate plan op (e.g. `"doc.update"`) on fail-closed
+    /// write-nav predicate errors (#2133). Omitted when none applies.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub suggested_op: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub backup_session: Option<String>,
     /// Aggregate replace match honesty when every replace-backed change agrees
@@ -541,6 +545,7 @@ pub(crate) fn build_tx_output_with_meta(
         removed: None,
         error_kind: None,
         error: None,
+        suggested_op: None,
         backup_session: None,
         match_mode: top_mode,
         match_score: top_score,
@@ -657,6 +662,16 @@ pub(crate) fn build_error_output(
     error: &str,
     backup_session: Option<&str>,
 ) -> TxOutput {
+    build_error_output_with_suggested_op(error_kind, error, backup_session, None)
+}
+
+/// Like [`build_error_output`], with optional machine-stable `suggested_op` (#2133).
+pub(crate) fn build_error_output_with_suggested_op(
+    error_kind: &str,
+    error: &str,
+    backup_session: Option<&str>,
+    suggested_op: Option<&str>,
+) -> TxOutput {
     let body = format_error_with_backup_hint(error, backup_session);
     TxOutput {
         ok: false,
@@ -675,6 +690,7 @@ pub(crate) fn build_error_output(
         removed: None,
         error_kind: Some(error_kind.to_string()),
         error: Some(format_error_with_kind(error_kind, &body)),
+        suggested_op: suggested_op.map(str::to_string),
         backup_session: backup_session.map(str::to_string),
         match_mode: None,
         match_score: None,
@@ -857,6 +873,7 @@ mod tests {
             removed: None,
             error_kind: None,
             error: None,
+            suggested_op: None,
             backup_session: None,
             match_mode: None,
             match_score: None,
@@ -884,6 +901,7 @@ mod tests {
             removed: None,
             error_kind: Some(kind.to_string()),
             error: Some("test error".to_string()),
+            suggested_op: None,
             backup_session: None,
             match_mode: None,
             match_score: None,

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2157,6 +2157,57 @@ fn test_tx_doc_set_selector_in_plan() {
     assert_eq!(v["nested"]["name"], "new");
 }
 
+/// Tx re-wrap must preserve suggested_op for predicate-on-doc.set (#2133).
+#[test]
+fn test_tx_doc_set_predicate_emits_suggested_op() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(&file, r#"{"items":[{"id":"a","val":1}]}"#).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "doc.set",
+            "path": portable_path_str(&file),
+            "selector": "items[id=a].val",
+            "value": 9
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "tx"])
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "predicate doc.set must fail closed"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "tx --json error envelope: {e}; stdout={stdout:?} stderr={:?}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    });
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
+    assert_eq!(
+        v["suggested_op"], "doc.update",
+        "tx re-wrap must keep suggested_op (#2133): {v}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        r#"{"items":[{"id":"a","val":1}]}"#,
+        "fail-closed must not write"
+    );
+}
+
 #[test]
 fn test_tx_doc_ensure_selector_in_plan() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Follow-up after #2136 (reviewer findings + integration gap).

### Why

#2136 shipped `suggested_op` on the CLI `doc set --json` path via `structured_error_payload`. Plan/`tx` and library `execute_plan` use `TxOutput` / `build_error_output`, which dropped the hint. Reviewer also flagged a `set -e` re-tap footgun in the Homebrew verify job.

### Changes

- `TxOutput.suggested_op` + `build_error_output_with_suggested_op`
- Thread peel through CLI `tx` and `execute_plan_direct`
- Integration: `test_tx_doc_set_predicate_emits_suggested_op`
- Release: safe `brew untap || true` then `brew tap`

### Test plan

- [x] `cargo test --test integration test_tx_doc_set_predicate_emits_suggested_op`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [ ] PR CI green

Ref #2133
Ref #2134