### PR TITLE
test: MCP suggested_op multi-surface + brew check docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ cd patchloom
 make check
 ```
 
-`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast + library-hygiene), integration tests, PTY tests, release notes verification, test hygiene audit, generated-doc freshness checks (`check-patchloom-md`, `check-readme`), and `server-json-test` (MCP Registry `server.json` description ≤100 chars). While iterating locally, `make check-fast` is almost the same but skips only `check-patchloom-md` (still runs `check-readme` and `server-json-test`).
+`make check` runs formatting, clippy, unit tests (all-features + no-default-features + ast-only + mcp-without-ast + library-hygiene), integration tests, PTY tests, release notes verification, test hygiene audit, generated-doc freshness checks (`check-patchloom-md`, `check-readme`), `server-json-test` (MCP Registry `server.json` description ≤100 chars), and `verify-homebrew-version-test` (release tap version-assert script helpers). While iterating locally, `make check-fast` is almost the same but skips only `check-patchloom-md` (still runs `check-readme`, `server-json-test`, and `verify-homebrew-version-test`).
 
 ## Issues and triage
 
@@ -58,7 +58,8 @@ This is a quick-reference subset. For the complete list, see [AGENTS.md](./AGENT
 | `make pty-test` | Run PTY-based interactive terminal tests (serial) |
 | `make clippy` | Run clippy with `-D warnings` |
 | `make check` | Full CI gate (run before every commit) |
-| `make check-fast` | Fast check (skips PATCHLOOM.md sync only; still checks README test count) |
+| `make check-fast` | Fast check (skips PATCHLOOM.md sync only; still checks README count + homebrew version script tests) |
+| `make verify-homebrew-version-test` | Unit tests for `scripts/verify-homebrew-version.sh` (part of `check`) |
 | `make embedder-smoke` | Pre-release host contracts (fuzzy token span with `--allow-absent-old`, nested undo list, plan `key` alias, `--contain` → `guard_rejected`, create/rename dest-exists → `already_exists`, delete missing → `not_found`, sole binary → `binary`, invalid UTF-8 → `invalid_encoding`, library `fuzzy_span_suspicious` #1981, buffer multi-op `refuse_batch_if_suspicious_fuzzy` #2064, path-only non-text rename/delete + `apply_fragment_to_file` + honesty constructors #2031-#2033). Not part of `check`; run before tagging a release |
 | `make windows-smoke` | PowerShell dogfood (`scripts/windows-smoke.ps1`; peels, tx, CRLF, rename force/binary; backslash paths on Windows). Not part of `check`; CI `ci-windows`. Local `pwsh` on macOS/Linux supported. Requires `pwsh` |
 | `make audit` | Run `cargo audit` for known vulnerabilities (also in CI) |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -766,7 +766,8 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 - **What it does:** Sets or creates a value at a selector path.
 - **Use when:** One exact selector path should be updated deterministically.
-- **Prefer instead:** Use `doc merge` for multi field updates, or `doc ensure` when existing values should be preserved.
+- **Prefer instead:** Use `doc merge` for multi field updates, or `doc ensure` when existing values should be preserved. Use `doc update` for predicate or wildcard multi-match (`items[name=a].v`, `items[*].enabled`).
+- **Failure behavior:** Predicate or wildcard selectors fail closed (exit 1) with `error_kind: "invalid_input"` and machine-stable `suggested_op: "doc.update"` under `--json` / plan / MCP (#2133).
 - **Leading slash:** A single leading `/` is stripped (JSON Pointer habit). `/feature_flag` sets key `feature_flag`, not a key named `/feature_flag` (#1794). Prefer bare keys in agent prompts.
 
 <!-- ref:doc-action:delete -->
@@ -1378,6 +1379,7 @@ The operations below are the building blocks inside `operations`.
 | Reject weak fuzzy matches | CLI `--min-fuzzy-score` / `ReplaceOptions.min_fuzzy_score` / plan `min_fuzzy_score` / MCP `min_fuzzy_score` (#1687); range `0.0..=1.0` |
 | Apply session id for surgical undo | `EditResult.backup_session` after Apply (#1686); pair with `restore_path_from_session` |
 | Session id on fail-restore / FormatFailed | `api::backup_session_from_error(&err)` (#2127); also `format_failed_backup_session` / `MutationAfterBackupError` |
+| Alternate plan op after fail-closed write-nav | `api::suggested_op_from_error(&err)` → plan serde name (`doc.update`, `doc.delete_where`) when a predicate/wildcard hit `doc.set`/`ensure`/`delete` (#2133); CLI/tx/MCP JSON field `suggested_op` (same values); keep `error_kind: invalid_input` |
 | Nested monorepo backup listing | `backup::list_sessions_under` + `ListSessionsOptions` (#1688) |
 | Ancestor backup root discovery | `backup::find_backup_roots(path)` walks parents for `.patchloom/backups` (#1934) |
 | File op structured kinds | `file_create` / `file_delete` / `file_rename` / `file_append`: dest-exists without force → `AlreadyExists` (#1947); missing path → `NotFound`; dir/empty path → `InvalidInput`; append/prepend on binary → `Binary` / invalid UTF-8 → `InvalidEncoding` (#1963); **path-only** `file_rename` / `file_delete` succeed on binary and invalid UTF-8 with byte backup (#2031); force create overwrites non-text prior (#1962); PathGuard → `GuardRejected` (#1935) |

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -755,6 +755,21 @@ mod tests {
     }
 
     #[test]
+    fn move_predicate_has_no_suggested_op() {
+        let mut root = json!({"items":[{"id":"a","val":1}]});
+        // from path ends with predicate: no multi-match move sibling.
+        let err = move_at_path(&mut root, &segs("items[id=a]"), &segs("elsewhere")).unwrap_err();
+        assert!(
+            crate::exit::suggested_op_from_error(&err).is_none(),
+            "doc.move multi-match has no alternate op: {err}"
+        );
+        assert!(
+            err.to_string().contains("wildcard/predicate"),
+            "still fail-closed with predicate message: {err}"
+        );
+    }
+
+    #[test]
     fn set_at_path_array_root_key_hints_document_index() {
         // Multi-doc YAML / top-level array: key at root needs 0.key / [0].key.
         let mut root = json!([{"a": 1}, {"b": 2}]);

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -281,6 +281,52 @@ async fn test_mcp_doc_set_nonexistent_file_returns_error() {
     client.cancel().await.unwrap();
 }
 
+/// Multi-surface (#2133): MCP doc_set with predicate selector peels suggested_op.
+#[tokio::test]
+async fn test_mcp_doc_set_predicate_emits_suggested_op() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("data.json"),
+        r#"{"items":[{"id":"a","val":1}]}"#,
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_set",
+        serde_json::json!({
+            "path": "data.json",
+            "selector": "items[id=a].val",
+            "value": 9
+        }),
+    )
+    .await;
+    assert!(
+        is_error,
+        "predicate doc_set must fail closed via MCP: {val}"
+    );
+    assert_eq!(val["error_kind"], "invalid_input", "{val}");
+    assert_eq!(
+        val["suggested_op"], "doc.update",
+        "MCP must expose machine-stable suggested_op (#2133): {val}"
+    );
+    assert_eq!(val["ok"], false, "{val}");
+    assert_eq!(
+        val["applied"], false,
+        "fail-closed must not claim applied: {val}"
+    );
+    let content = fs::read_to_string(dir.path().join("data.json")).unwrap();
+    assert_eq!(
+        content, r#"{"items":[{"id":"a","val":1}]}"#,
+        "MCP fail-closed must not write: {content}"
+    );
+    client.cancel().await.unwrap();
+}
+
 #[tokio::test]
 async fn test_mcp_search_finds_pattern() {
     if !has_mcp_support() {


### PR DESCRIPTION
## Summary

MPI cycle after #2136/#2137: close multi-surface coverage gaps for `suggested_op` and fix contributor gate docs.

## Changes

- MCP integration: `doc_set` with predicate peels `suggested_op: doc.update` and does not write
- Unit: `doc.move` predicate has no `suggested_op`
- CONTRIBUTING.md documents `verify-homebrew-version-test` in the `make check` gate
- Reference: `doc set` failure + embedder table for `suggested_op_from_error`

## Pre-rotation gate

- Main CI green
- Open PRs: release-please #2130 only (not merged; needs explicit approval)
- Open issues: #1990 human outreach, #960/#961 community catalog lag (blocked upstream); #2138 filed for navigate_mut intermediate hint

## Test plan

- [x] `cargo test --lib move_predicate_has_no_suggested_op`
- [x] `cargo test --test integration test_mcp_doc_set_predicate_emits_suggested_op`
- [x] `make check-fast`

Ref #2133
Ref #2138