### PR TITLE
ci: raise Setup WSL step timeout to 15m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,9 @@ jobs:
 
       - name: Setup WSL (Ubuntu)
         uses: Vampire/setup-wsl@d1da7f2c0322a5ee4f24975344f67fc0f5baf364 # v7.0.0
-        timeout-minutes: 12
+        # Healthy on windows-2022 is ~3-12m (download + packages). Cap below job
+        # timeout so hangs fail closed instead of burning the full matrix.
+        timeout-minutes: 15
         with:
           distribution: Ubuntu-24.04
           # Full distro upgrade not needed; package install refreshes apt.


### PR DESCRIPTION
## Summary

Follow-up to #2140 WSL stabilization. First green run on `windows-2022` spent ~11 minutes in Setup WSL, against a 12m step timeout. Raise to 15m so healthy installs are not one slow apt mirror away from a false red.

Main stability fix already on main via #2140:
- pin `windows-2022`
- `update: false` (no full apt upgrade)
- step timeouts fail closed on hangs

## Test plan

- [x] Prior #2140 run: Setup WSL success in ~11m, full CI green including `ci-wsl`
- [ ] This PR: CI green (workflow-only path still triggers ci.yml filter)