### PR TITLE
fix: empty path reject; honest winget docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.5"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -394,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.8"
+version = "4.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f84a88507dbd05c695f2cb5e8558e747179134005e9893882dec964190ed89"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
 dependencies = [
  "clap",
 ]
@@ -511,9 +511,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -521,26 +521,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -623,7 +623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1897,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad26b216c966e987e80e86daf784a455c039c43d98575ceed57b8faa259e5695"
+checksum = "094c075f6698deef5a657cf4df6b684dff65157d255978b92b552ec22503f17a"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -1930,15 +1930,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41bc748630c2be2a71b614c2f40d27bc0df0060696d224e1692c72345b7e0b79"
+checksum = "737d947bcfd946fae6a179a4ef6487be6dcf25c930c2393856b820f1386e52a6"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1993,7 +1993,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2050,7 +2050,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2403,7 +2403,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3102,7 +3102,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ MCP mode wins overall (228.5s vs 233.8s native) because structured tool calls sk
 ## Install
 
 Prefer channels that track each GitHub Release (Homebrew, Scoop, crates,
-npm, Releases). winget and Chocolatey community catalogs are for discovery
-only; they often lag for days or weeks.
+npm, Releases). On Windows, Scoop is recommended. winget
+(`Patchloom.Patchloom`) is published per release and is usually current
+after Microsoft's publish pipeline (`winget source update` if search is
+stale). Chocolatey often lags while community moderation runs.
 
 ```bash
 # Homebrew (macOS/Linux)
@@ -189,8 +191,8 @@ scoop install patchloom/patchloom
 Pre-built binaries for Linux, macOS, and Windows are on the
 [Releases](https://github.com/patchloom/patchloom/releases/latest) page.
 See [Installation](./docs/getting-started/installation.md) for shell
-installer scripts, source builds, shell completions, and the winget /
-Chocolatey discovery listings.
+installer scripts, source builds, shell completions, and winget /
+Chocolatey notes.
 
 - MCP Registry name: `mcp-name: io.github.patchloom/patchloom`
 
@@ -509,7 +511,7 @@ flowchart LR
 
 | Component | Status |
 |---|---|
-| CLI | Install from [crates.io](https://crates.io/crates/patchloom), [Homebrew](https://github.com/patchloom/homebrew-tap), [Scoop](https://github.com/patchloom/scoop-bucket), [npm](https://www.npmjs.com/package/patchloom) (`npx patchloom`), or [GitHub Releases](https://github.com/patchloom/patchloom/releases/latest). Also listed on [winget](https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/Patchloom/Patchloom) and [Chocolatey](https://community.chocolatey.org/packages/patchloom) for search discovery only (community indexes often lag the latest release). |
+| CLI | Install from [crates.io](https://crates.io/crates/patchloom), [Homebrew](https://github.com/patchloom/homebrew-tap), [Scoop](https://github.com/patchloom/scoop-bucket), [npm](https://www.npmjs.com/package/patchloom) (`npx patchloom`), or [GitHub Releases](https://github.com/patchloom/patchloom/releases/latest). Also on [winget](https://github.com/microsoft/winget-pkgs/tree/master/manifests/p/Patchloom/Patchloom) (`Patchloom.Patchloom`; usually current after Microsoft publish) and [Chocolatey](https://community.chocolatey.org/packages/patchloom) (community moderation often lags GitHub). |
 | MCP server | Official [MCP Registry](https://registry.modelcontextprotocol.io/) name `io.github.patchloom/patchloom` (stdio; crates.io / npm packages; see `server.json`). Local MCPB for [Smithery](https://smithery.ai/) / desktop hosts: `make pack-mcpb` (`mcpb/`). [Glama](https://glama.ai/mcp/servers) directory prep: root `glama.json` + manual **Add MCP Server** (see [MCP setup](./docs/getting-started/mcp-setup.md#glama-directory)) |
 | Editor extension | Published on [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=patchloom.patchloom) and [Open VSX](https://open-vsx.org/extension/patchloom/patchloom) |
 

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -81,8 +81,10 @@ scoop install patchloom/patchloom
 ```
 
 Or download a prebuilt binary from [GitHub Releases](https://github.com/patchloom/patchloom/releases).
-winget and Chocolatey community listings exist for search discovery only;
-prefer Scoop or Releases when you need the current version.
+winget (`Patchloom.Patchloom`) is published per release (use
+`winget source update` if search is stale). Chocolatey often lags
+GitHub while versions wait for moderation. Prefer Scoop or Releases
+when you need a known-current build.
 
 Set up your project in one command:
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,9 +2,10 @@
 
 **Prefer channels we control.** They track each GitHub Release within minutes:
 Homebrew, Scoop, crates.io, npm, and GitHub Release binaries/installers.
-Community catalogs (winget, Chocolatey) are listed so Windows search can
-discover the project; they often ship **older** builds for days or weeks.
-Do not use them when you need the current release.
+On Windows, **Scoop** is still the recommended path. Community catalogs
+(winget, Chocolatey) remain useful for discovery and are fine when they
+match the version you need; see the winget/Chocolatey section for how
+each lags after a new GitHub Release.
 
 ## Recommended: Homebrew (macOS and Linux)
 
@@ -104,28 +105,31 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/patchloom/patchloo
 
 Pre-built binaries include all commands, including the MCP server.
 
-## Discoverability only: winget and Chocolatey (Windows)
+## winget and Chocolatey (Windows)
 
-These community catalogs help people who only know `winget search` or
-`choco search` find that patchloom exists. They are **not** recommended for
-day-to-day installs or upgrades. Moderated community feeds lag GitHub
-Releases (often by days or weeks). After you discover the project this way,
-switch to **Scoop** or a **GitHub Release** installer for current builds.
+Prefer **Scoop** or a GitHub Release installer when you want the channel we
+operate. Use winget or Chocolatey when that is what your environment already
+allows. Both are published from Release CI; currency differs after each tag.
 
 ```powershell
-# Discovery / advertisement paths only (may install an older version)
+# winget (package id is Patchloom.Patchloom)
+winget source update
 winget install Patchloom.Patchloom
+# or upgrade an existing install
+winget upgrade Patchloom.Patchloom
+
+# Chocolatey (community feed; may trail GitHub latest)
 choco install patchloom
 ```
 
-| Catalog | Id / package | Why it lags |
-|---------|--------------|-------------|
-| winget | `Patchloom.Patchloom` | PRs to `microsoft/winget-pkgs` plus Microsoft validation and human queues |
-| Chocolatey | `patchloom` on the community feed | Every version is moderated before it becomes the installable latest |
+| Catalog | Id / package | Currency after a GitHub Release |
+|---------|--------------|----------------------------------|
+| winget | `Patchloom.Patchloom` | Release CI opens a `microsoft/winget-pkgs` PR. After Microsoft merge and publish, refresh with `winget source update`. Can lag by days while the PR waits; once published it is usually current. |
+| Chocolatey | `patchloom` | Each nupkg is pushed automatically, then community moderation must approve it before it is installable as latest. Often trails GitHub longer than winget. |
 
-We still publish version PRs / nupkgs so the listings stay alive. If either
-channel only offers an old build, that is expected. Use Scoop or GitHub
-Releases for the version you just saw announced.
+If `winget show` / `choco list` only offers an older build, that is expected
+until the community queue clears. Use Scoop or GitHub Releases for the
+version you just saw announced.
 
 ## From source
 

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -82,8 +82,10 @@ requires a Glama session (unauthenticated calls redirect to sign-up).
 
 The MCP server is included by default in all pre-built binaries and in
 recommended installs (Homebrew, Scoop, npm `npx` / global, crates.io).
-Community winget/Chocolatey builds may lag; use Scoop or a GitHub Release
-binary when you need a current MCP server. Verify it works:
+winget usually tracks the latest GitHub Release after Microsoft publishes
+the version PR; Chocolatey often lags while versions wait for moderation.
+Prefer Scoop or a GitHub Release binary when you need a known-current MCP
+server. Verify it works:
 
 ```bash
 patchloom mcp-server --help

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -7670,7 +7670,10 @@ fn file_delete_binary_path_only_succeeds() {
     let r = file_delete(&bin, ApplyMode::Apply, None).expect("binary delete (#2031)");
     assert!(r.applied);
     assert!(!bin.exists());
-    assert!(r.backup_session.is_some());
+    assert!(
+        r.backup_session.as_ref().is_some_and(|s| !s.is_empty()),
+        "binary delete must record backup session: {r:?}"
+    );
 }
 
 /// FIFO delete under PathGuard (#2087).
@@ -8221,7 +8224,10 @@ fn apply_fragment_to_file_after_strips_markers() {
     let body = fs::read_to_string(&path).unwrap();
     assert!(body.contains("bar();"), "body: {body}");
     assert!(!body.contains("existing code"), "markers stripped: {body}");
-    assert!(r.backup_session.is_some());
+    assert!(
+        r.backup_session.as_ref().is_some_and(|s| !s.is_empty()),
+        "apply_fragment apply must record backup session: {r:?}"
+    );
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -908,10 +908,20 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     // --contain on read-only doc paths (writes use execute_via_engine guard).
     match &args.action {
         DocAction::Diff { file_a, file_b } => {
+            for p in [file_a.as_str(), file_b.as_str()] {
+                if p.trim().is_empty() {
+                    global.emit_error_json_kind(Some("invalid_input"), "path must not be empty")?;
+                    return Ok(exit::FAILURE);
+                }
+            }
             global.check_paths_contained(&cwd, [file_a.as_str(), file_b.as_str()])?;
         }
         _ => {
             if let Some(p) = args.action.file_path() {
+                if p.trim().is_empty() {
+                    global.emit_error_json_kind(Some("invalid_input"), "path must not be empty")?;
+                    return Ok(exit::FAILURE);
+                }
                 global.check_paths_contained(&cwd, [p])?;
             }
         }

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -249,11 +249,30 @@ fn execute_plan_inner(
         operations.len(),
         options.guard.is_some()
     );
-    // Full op validation (empty path, replace args, tidy.fix, …).
-    // Defense in depth when callers skip validate_plan_operations (CLI
-    // stage_for_write / single-op paths historically only re-checked TidyFix).
+    // Empty path/glob strings join to cwd and produce opaque errors
+    // (`: target is not a file: <cwd>`). Reject early on all stage paths
+    // (CLI stage_for_write skips validate_plan_operations).
     for op in &operations {
-        crate::tx::validate::validate_operation(op)?;
+        for p in op.declared_paths() {
+            if p.trim().is_empty() {
+                return Err(crate::exit::InvalidInputError {
+                    msg: "path must not be empty".into(),
+                }
+                .into());
+            }
+        }
+    }
+    // TidyFix-specific constraints when callers skip validate_plan_operations.
+    for op in &operations {
+        if let Operation::TidyFix { dedent, indent, .. } = op
+            && dedent.is_some()
+            && indent.is_some()
+        {
+            return Err(crate::exit::InvalidInputError {
+                msg: "tidy.fix: 'dedent' and 'indent' cannot both be set".into(),
+            }
+            .into());
+        }
     }
 
     // PathGuard enforcement (same pattern as lifecycle.rs execute_plan_direct).

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -249,18 +249,11 @@ fn execute_plan_inner(
         operations.len(),
         options.guard.is_some()
     );
-    // Validate TidyFix-specific constraints (dedent + indent mutual exclusion).
-    // Defense in depth when callers skip validate_plan_operations.
+    // Full op validation (empty path, replace args, tidy.fix, …).
+    // Defense in depth when callers skip validate_plan_operations (CLI
+    // stage_for_write / single-op paths historically only re-checked TidyFix).
     for op in &operations {
-        if let Operation::TidyFix { dedent, indent, .. } = op
-            && dedent.is_some()
-            && indent.is_some()
-        {
-            return Err(crate::exit::InvalidInputError {
-                msg: "tidy.fix: 'dedent' and 'indent' cannot both be set".into(),
-            }
-            .into());
-        }
+        crate::tx::validate::validate_operation(op)?;
     }
 
     // PathGuard enforcement (same pattern as lifecycle.rs execute_plan_direct).

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -8,6 +8,17 @@ pub(super) fn op_label(op: &Operation) -> &'static str {
 }
 
 pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
+    // Empty path/glob strings resolve as cwd and produce opaque errors
+    // (`: target is not a file: <cwd>`). Reject early like CLI read/create.
+    for p in op.declared_paths() {
+        if p.trim().is_empty() {
+            return Err(crate::exit::InvalidInputError {
+                msg: "path must not be empty".into(),
+            }
+            .into());
+        }
+    }
+
     match op {
         Operation::Replace {
             old,
@@ -254,6 +265,32 @@ mod tests {
         let err = validate_operation(&op).unwrap_err();
         assert!(
             err.to_string().contains("nth must be >= 1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn empty_path_doc_set_rejected() {
+        let op = Operation::DocSet {
+            path: String::new(),
+            selector: "a".into(),
+            value: serde_json::json!(1),
+        };
+        let err = validate_operation(&op).unwrap_err();
+        assert!(
+            err.to_string().contains("path must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn whitespace_only_path_rejected() {
+        let op = Operation::FileDelete {
+            path: "  \t".into(),
+        };
+        let err = validate_operation(&op).unwrap_err();
+        assert!(
+            err.to_string().contains("path must not be empty"),
             "unexpected error: {err}"
         );
     }


### PR DESCRIPTION
## Summary

MPI cycle after winget channel went live at 0.27.0 and Chocolatey still lagging.

- Reject empty/whitespace-only operation paths early with stable `path must not be empty` / `error_kind: invalid_input` (plan validate + engine stage + doc read CLI). Previously empty path joined to cwd and printed `: target is not a file: <cwd>`.
- Engine defense-in-depth checks empty `declared_paths` only (not full `validate_operation`), so API `replace_text` insert_before/after still works.
- Installation docs, README, mcp-setup, launch notes: winget is published per release and usually current after Microsoft publish; Chocolatey still often lags; Scoop remains the recommended Windows channel we operate.
- Patch bumps: clap 4.6.6, clap_complete 4.6.9, rmcp 3.1.1.
- Stronger backup_session assertions on binary delete and apply_fragment.

## Test plan

- [x] `cargo test --lib --all-features` (empty path + insert_before/after regressions)
- [x] CLI: `patchloom --json doc set '' …` → `path must not be empty`
- [x] `make check-fast`

## Notes

Ref #961 (Chocolatey currency docs). Issue #960 already closed separately when winget publish pipeline succeeded.