### PR TITLE
fix: PathGuard and MCP reject blank paths

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -410,7 +410,7 @@ impl GlobalFlags {
     ) -> anyhow::Result<std::path::PathBuf> {
         let path = path.as_ref();
         let path_str = path.to_string_lossy();
-        if path_str.trim().is_empty() {
+        if crate::containment::is_blank_path(&path_str) {
             return Err(crate::exit::InvalidInputError {
                 msg: "path must not be empty".into(),
             }
@@ -441,7 +441,7 @@ impl GlobalFlags {
         cwd: &std::path::Path,
         path: &str,
     ) -> anyhow::Result<std::path::PathBuf> {
-        if path.trim().is_empty() {
+        if crate::containment::is_blank_path(path) {
             return Err(crate::exit::InvalidInputError {
                 msg: "path must not be empty".into(),
             }
@@ -493,7 +493,7 @@ impl GlobalFlags {
         path: &str,
         entry: bool,
     ) -> anyhow::Result<String> {
-        if path.trim().is_empty() {
+        if crate::containment::is_blank_path(path) {
             return Err(crate::exit::InvalidInputError {
                 msg: "path must not be empty".into(),
             }
@@ -567,7 +567,7 @@ impl GlobalFlags {
         let paths: Vec<_> = paths.into_iter().collect();
         for p in &paths {
             let p = p.as_ref();
-            if p.trim().is_empty() {
+            if crate::containment::is_blank_path(p) {
                 return Err(crate::exit::InvalidInputError {
                     msg: "path must not be empty".into(),
                 }

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -909,7 +909,7 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
     match &args.action {
         DocAction::Diff { file_a, file_b } => {
             for p in [file_a.as_str(), file_b.as_str()] {
-                if p.trim().is_empty() {
+                if crate::containment::is_blank_path(p) {
                     global.emit_error_json_kind(Some("invalid_input"), "path must not be empty")?;
                     return Ok(exit::FAILURE);
                 }
@@ -918,7 +918,7 @@ pub fn run(mut args: DocArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
         _ => {
             if let Some(p) = args.action.file_path() {
-                if p.trim().is_empty() {
+                if crate::containment::is_blank_path(p) {
                     global.emit_error_json_kind(Some("invalid_input"), "path must not be empty")?;
                     return Ok(exit::FAILURE);
                 }

--- a/src/cmd/mcp/registry.rs
+++ b/src/cmd/mcp/registry.rs
@@ -461,11 +461,17 @@ pub(super) fn handle_simple_op(
         match v {
             FieldValidation::Path(field) => {
                 if let Some(val) = args_obj.get(*field).and_then(|v| v.as_str()) {
+                    if crate::containment::is_blank_path(val) {
+                        return Err(McpError::invalid_params("path must not be empty", None));
+                    }
                     service.check_path(val)?;
                 }
             }
             FieldValidation::PathEntry(field) => {
                 if let Some(val) = args_obj.get(*field).and_then(|v| v.as_str()) {
+                    if crate::containment::is_blank_path(val) {
+                        return Err(McpError::invalid_params("path must not be empty", None));
+                    }
                     service.check_path_entry(val)?;
                 }
             }

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -60,6 +60,16 @@
 
 use std::path::{Component, Path, PathBuf};
 
+/// True when a path string is empty, whitespace-only, or only Unicode
+/// format characters that do not form a real path component (ZWSP/ZWNJ/ZWJ/BOM).
+///
+/// Empty paths would otherwise resolve as the workspace/cwd root (not a file).
+pub fn is_blank_path(path: &str) -> bool {
+    path.chars().all(|c| {
+        c.is_whitespace() || matches!(c, '\u{200b}' | '\u{200c}' | '\u{200d}' | '\u{feff}')
+    })
+}
+
 /// Canonicalize a path without the Windows `\\?\` UNC prefix when safe.
 ///
 /// On Windows, [`std::fs::canonicalize`] returns paths like
@@ -150,6 +160,9 @@ pub enum ContainmentError {
     /// The path is absolute and the policy rejects absolute paths.
     AbsolutePath(String),
 
+    /// Empty or whitespace-only path (would resolve as the workspace root).
+    EmptyPath,
+
     /// The path escapes the workspace directory (via `../` or symlinks).
     Escaped {
         /// The offending path.
@@ -171,6 +184,7 @@ impl std::fmt::Display for ContainmentError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ContainmentError::AbsolutePath(p) => write!(f, "absolute paths are not allowed: {p}"),
+            ContainmentError::EmptyPath => write!(f, "path must not be empty"),
             ContainmentError::Escaped { path, root } => {
                 write!(
                     f,
@@ -227,6 +241,9 @@ impl PathGuard {
     /// (including symlinks whose target is outside the workspace), use
     /// [`check_path_entry`] instead (#2115).
     pub fn check_path(&self, path: &str) -> Result<PathBuf, ContainmentError> {
+        if is_blank_path(path) {
+            return Err(ContainmentError::EmptyPath);
+        }
         let p = Path::new(path);
 
         if p.is_absolute() {
@@ -253,6 +270,9 @@ impl PathGuard {
     /// Intermediate directory components still follow (a parent dir that is a
     /// symlink out of the workspace is still rejected).
     pub fn check_path_entry(&self, path: &str) -> Result<PathBuf, ContainmentError> {
+        if is_blank_path(path) {
+            return Err(ContainmentError::EmptyPath);
+        }
         let p = Path::new(path);
 
         if p.is_absolute() {

--- a/src/containment_tests.rs
+++ b/src/containment_tests.rs
@@ -99,8 +99,26 @@ fn nonexistent_file_in_existing_directory() {
 fn empty_path() {
     let dir = tempfile::TempDir::new().unwrap();
     let guard = PathGuard::new(dir.path().to_path_buf(), AbsolutePathPolicy::Reject).unwrap();
-    // Empty string resolves to cwd itself, which is contained.
-    guard.check_path("").unwrap();
+    // Empty / whitespace would resolve as the workspace root (not a file target).
+    let err = guard.check_path("").expect_err("empty path rejected");
+    assert!(
+        matches!(err, ContainmentError::EmptyPath),
+        "expected EmptyPath, got {err:?}"
+    );
+    assert!(err.to_string().contains("path must not be empty"), "{err}");
+    let err = guard
+        .check_path("  \t")
+        .expect_err("whitespace path rejected");
+    assert!(matches!(err, ContainmentError::EmptyPath), "{err:?}");
+    let err = guard
+        .check_path_entry("")
+        .expect_err("empty entry path rejected");
+    assert!(matches!(err, ContainmentError::EmptyPath), "{err:?}");
+    let zwsp = "\u{200b}";
+    let err = guard.check_path(zwsp).expect_err("ZWSP-only path rejected");
+    assert!(matches!(err, ContainmentError::EmptyPath), "{err:?}");
+    assert!(crate::containment::is_blank_path("\u{200b}\u{feff}"));
+    assert!(!crate::containment::is_blank_path("a"));
 }
 
 #[test]
@@ -416,6 +434,13 @@ fn error_source_non_canonicalize_returns_none() {
         root: "/r".to_string(),
     };
     assert!(err2.source().is_none());
+    let err3 = ContainmentError::EmptyPath;
+    assert!(err3.source().is_none());
+    assert!(
+        err3.to_string().contains("path must not be empty"),
+        "{}",
+        err3
+    );
 }
 
 #[test]

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -254,7 +254,7 @@ fn execute_plan_inner(
     // (CLI stage_for_write skips validate_plan_operations).
     for op in &operations {
         for p in op.declared_paths() {
-            if p.trim().is_empty() {
+            if crate::containment::is_blank_path(&p) {
                 return Err(crate::exit::InvalidInputError {
                     msg: "path must not be empty".into(),
                 }

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -1721,7 +1721,15 @@ mod tests {
         );
         let meta = f.replace_match_meta.get(&file).expect("fuzzy meta");
         assert_eq!(meta.mode, crate::api::MatchMode::Fuzzy);
-        assert!(meta.score.is_some(), "similarity fallback should set score");
+        let score = meta.score.expect("similarity fallback should set score");
+        assert!(
+            (0.0..=1.0).contains(&score),
+            "fuzzy score should be in [0,1], got {score}"
+        );
+        assert!(
+            score > 0.0,
+            "matched fuzzy rewrite should have positive score"
+        );
         assert_eq!(meta.match_count, 1);
     }
 

--- a/src/tx/validate.rs
+++ b/src/tx/validate.rs
@@ -11,7 +11,7 @@ pub(crate) fn validate_operation(op: &Operation) -> anyhow::Result<()> {
     // Empty path/glob strings resolve as cwd and produce opaque errors
     // (`: target is not a file: <cwd>`). Reject early like CLI read/create.
     for p in op.declared_paths() {
-        if p.trim().is_empty() {
+        if crate::containment::is_blank_path(&p) {
             return Err(crate::exit::InvalidInputError {
                 msg: "path must not be empty".into(),
             }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -2837,6 +2837,30 @@ fn test_doc_set_on_directory_json_error_kind() {
     );
 }
 
+/// Empty path must not join to cwd as a directory target (#2150 follow-up).
+#[test]
+fn test_doc_set_empty_path_json_invalid_input() {
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "set", "", "a", "1", "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "empty path must be invalid_input: {json}"
+    );
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("path must not be empty"),
+        "error should name empty path, not cwd directory: {json}"
+    );
+}
+
 /// Predicate selectors on doc set point agents at doc update (#1725 / #2133).
 #[test]
 fn test_doc_set_predicate_errors_with_update_hint() {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -281,6 +281,29 @@ async fn test_mcp_doc_set_nonexistent_file_returns_error() {
     client.cancel().await.unwrap();
 }
 
+/// Empty path must fail closed at MCP validation (not resolve as workspace root).
+#[tokio::test]
+async fn test_mcp_doc_set_empty_path_rejected() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_set",
+        serde_json::json!({"path": "", "selector": "x", "value": 1}),
+    )
+    .await;
+    assert!(is_error, "empty path doc_set must error: {val}");
+    let msg = val.to_string();
+    assert!(
+        msg.contains("path must not be empty") || msg.contains("empty"),
+        "MCP empty path message: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// Multi-surface (#2133): MCP doc_set with predicate selector peels suggested_op.
 #[tokio::test]
 async fn test_mcp_doc_set_predicate_emits_suggested_op() {


### PR DESCRIPTION
## Summary

MPI cycle 2 (Test Auditor / Security / Adversarial).

- **PathGuard:** empty, whitespace-only, and format-char-only paths (ZWSP/BOM) no longer resolve as the workspace root. New `ContainmentError::EmptyPath` and shared `is_blank_path`.
- **MCP:** `FieldValidation::Path` / `PathEntry` reject blank paths with `path must not be empty` before containment checks.
- **CLI/tx:** use the same blank-path helper (validate, engine stage, global path rewrite, doc read).
- Multi-surface locks: cargo-bin `doc set` empty path + MCP `doc_set` empty path.
- Stronger fuzzy replace score assertion (`[0,1]` and `> 0`).

## Test plan

- [x] `cargo test --lib --all-features` containment empty_path
- [x] `cargo test --test integration --all-features test_doc_set_empty_path`
- [x] `cargo test --test integration --all-features test_mcp_doc_set_empty_path`
- [x] `make check-fast` (pre-amend; re-run matrix in CI)

## Notes

Release PR #2151 (0.27.1) remains user-gated. Does not close #961 / #1990.