### PR TITLE
fix!: mark ContainmentError as non_exhaustive

### DIFF
--- a/src/containment.rs
+++ b/src/containment.rs
@@ -155,7 +155,12 @@ impl AbsolutePathPolicy {
 }
 
 /// Errors from workspace path validation.
+///
+/// Marked `#[non_exhaustive]` so new variants (e.g. [`Self::EmptyPath`]) can be
+/// added without a forced major bump for every future case. Downstream `match`
+/// arms should include a wildcard.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum ContainmentError {
     /// The path is absolute and the policy rejects absolute paths.
     AbsolutePath(String),


### PR DESCRIPTION
## Summary

Mark public `ContainmentError` as `#[non_exhaustive]` so additive variants (including `EmptyPath` from #2152) do not require a major bump every time.

## Release

Release-As: 0.28.0

This footer must stay in the squash commit body (release-please). After merge, release-please should replace the open 0.27.1 PR (#2151) with a 0.28.0 release PR so `cargo-semver-checks` accepts the API shape change vs published 0.27.0.

## Test plan

- [x] `cargo test --lib --all-features containment::`
- [ ] CI green

## Notes

Do not merge release PR #2151 (0.27.1); it is the wrong version for this break.