### PR TITLE
docs: sync install/embed Windows guidance for 0.27

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,17 @@ EOF
 Values are JSON-first: unquoted `2.0` becomes a number. Force a string with nested
 quotes as above (Unix shells).
 
+On Windows PowerShell (no bash heredoc), write ops to a file:
+
+```powershell
+@'
+doc.set config.json version "\"2.0.0\""
+md.upsert_bullet AGENTS.md "Rules" "- Always test"
+replace src/main.rs "v1" "v2"
+'@ | Set-Content ops.txt -Encoding utf8
+patchloom batch --apply ops.txt
+```
+
 Or use a JSON plan with format and validate lifecycle:
 
 ```json
@@ -296,7 +307,7 @@ Add patchloom as a dependency (omit CLI/MCP/AST with `default-features = false`)
 
 ```toml
 [dependencies]
-patchloom = { version = "0.26.0", default-features = false }
+patchloom = { version = "0.27.0", default-features = false }
 ```
 
 ```rust

--- a/chocolatey/patchloom.nuspec
+++ b/chocolatey/patchloom.nuspec
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Packaging template only. Release CI rewrites <version> and tools
+     checksums before push. Live installable version is on
+     community.chocolatey.org/packages/patchloom, not this file. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>patchloom</id>

--- a/docs/blog/launch-announcement.md
+++ b/docs/blog/launch-announcement.md
@@ -109,10 +109,12 @@ There is also a [VS Code extension](https://github.com/patchloom/patchloom-vscod
 
 ## By the numbers
 
-- **2,800+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
+Numbers below track the current mainline product (not a frozen launch snapshot):
+
+- **4100+ tests**, zero unsafe in library code (one `unsafe killpg` in exec.rs behind `#[expect]`)
 - **24 commands** including MCP server with 58 structured tool calls
 - **Agent-tested** with Grok 4.3, GPT-5.4, and Claude Opus 4.6
-- **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64)
+- **Cross-platform**: Linux (x64, ARM64), macOS (x64, ARM64), Windows (x64, ARM64)
 - **MIT OR Apache-2.0** licensed
 - **Rust 1.95+**, single static binary with no runtime dependencies
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -90,8 +90,8 @@ already have an older cellar linked; run `brew upgrade patchloom` there.
 Pre-built binaries for Linux (x64, ARM64, musl), macOS (x64, ARM64), and
 Windows (x64, ARM64) are available on the
 [Releases](https://github.com/patchloom/patchloom/releases/latest) page.
-Download the archive for your platform, extract, and place `patchloom` on
-your PATH.
+Download the archive for your platform, extract, and place `patchloom` (or
+`patchloom.exe` on Windows) on your PATH.
 
 Shell and PowerShell installer scripts are also available:
 
@@ -104,6 +104,30 @@ powershell -ExecutionPolicy ByPass -c "irm https://github.com/patchloom/patchloo
 ```
 
 Pre-built binaries include all commands, including the MCP server.
+
+### Portable zip (Windows)
+
+Each release ships flat zips (no nested folder). Common asset names:
+
+- `patchloom-x86_64-pc-windows-msvc.zip` (x64)
+- `patchloom-aarch64-pc-windows-msvc.zip` (ARM64)
+
+Tag form is `patchloom-vX.Y.Z` (for example `patchloom-v0.27.0`).
+
+```powershell
+$ver = "0.27.0"   # or the version you need
+$tag = "patchloom-v$ver"
+$url = "https://github.com/patchloom/patchloom/releases/download/$tag/patchloom-x86_64-pc-windows-msvc.zip"
+$dir = "$env:TEMP\patchloom-portable"
+New-Item -ItemType Directory -Force -Path $dir | Out-Null
+$zip = Join-Path $dir "pl.zip"
+Invoke-WebRequest -Uri $url -OutFile $zip
+Expand-Archive -Path $zip -DestinationPath $dir -Force
+# Layout: patchloom.exe, LICENSE, README.md, CHANGELOG.md at $dir root
+& "$dir\patchloom.exe" --version
+& "$dir\patchloom.exe" --help
+# Optional: copy patchloom.exe to a directory already on PATH
+```
 
 ## winget and Chocolatey (Windows)
 
@@ -130,6 +154,13 @@ choco install patchloom
 If `winget show` / `choco list` only offers an older build, that is expected
 until the community queue clears. Use Scoop or GitHub Releases for the
 version you just saw announced.
+
+The files under [`chocolatey/`](../../chocolatey/) in this repository are a
+**packaging template**. Release CI rewrites the nuspec version and checksums
+before push; do not treat the in-tree `version` field as the live community
+feed version. Check
+[community.chocolatey.org/packages/patchloom](https://community.chocolatey.org/packages/patchloom)
+for what `choco install` actually resolves.
 
 ## From source
 
@@ -165,14 +196,14 @@ Rust tools. Disable default features to omit CLI (clap), MCP server, and AST:
 
 ```toml
 [dependencies]
-patchloom = { version = "0.26.0", default-features = false }
+patchloom = { version = "0.27.0", default-features = false }
 ```
 
 To add AST support without CLI/MCP (LLM agent embedders typically use
 `ast` + `files` for plan execution and AST file mutators):
 
 ```toml
-patchloom = { version = "0.26.0", default-features = false, features = ["ast", "files"] }
+patchloom = { version = "0.27.0", default-features = false, features = ["ast", "files"] }
 ```
 
 See the [crate documentation](https://docs.rs/patchloom) for the full API

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -93,13 +93,28 @@ patchloom mcp-server --help
 
 ## Configure your agent
 
+Set `command` to an absolute path to the binary, or to `patchloom` if the
+CLI is already on `PATH` (Homebrew, Scoop, `cargo install`, installer).
+
+Examples:
+
+| Platform | Typical `command` value |
+|----------|-------------------------|
+| Unix (Homebrew / cargo) | `patchloom` or `/opt/homebrew/bin/patchloom` |
+| Windows (Scoop) | `patchloom` or `C:\\Users\\you\\scoop\\shims\\patchloom.exe` |
+| Windows (portable zip) | `C:\\path\\to\\patchloom.exe` |
+
+JSON configs need escaped backslashes on Windows paths
+(`C:\\\\Users\\\\...\\\\patchloom.exe`). Prefer the bare name `patchloom`
+when the shim is on `PATH`.
+
 ### Grok (config.toml)
 
 Add to `~/.grok/config.toml`:
 
 ```toml
 [mcp_servers.patchloom]
-command = "/path/to/patchloom"
+command = "patchloom"
 args = ["mcp-server"]
 ```
 
@@ -111,7 +126,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 {
   "mcpServers": {
     "patchloom": {
-      "command": "/path/to/patchloom",
+      "command": "patchloom",
       "args": ["mcp-server"]
     }
   }
@@ -126,7 +141,7 @@ Create `.vscode/mcp.json` in your workspace root:
 {
   "servers": {
     "patchloom": {
-      "command": "/path/to/patchloom",
+      "command": "patchloom",
       "args": ["mcp-server"]
     }
   }
@@ -141,7 +156,7 @@ Create `.cursor/mcp.json` in your workspace root:
 {
   "servers": {
     "patchloom": {
-      "command": "/path/to/patchloom",
+      "command": "patchloom",
       "args": ["mcp-server"]
     }
   }

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -104,6 +104,24 @@ md.insert_after_heading CHANGELOG.md "## Unreleased" "- Bumped to v3.0.0"
 EOF
 ```
 
+### On Windows / PowerShell
+
+Classic PowerShell does not support bash heredocs (`<<'EOF'`). Write the
+ops to a file, or use a here-string piped into a temp file:
+
+```powershell
+@'
+doc.set package.json version "3.0.0"
+replace README.md "v1.0.0" "v3.0.0"
+md.insert_after_heading CHANGELOG.md "## Unreleased" "- Bumped to v3.0.0"
+'@ | Set-Content ops.txt -Encoding utf8
+patchloom batch --apply ops.txt
+```
+
+Cross-platform alternative: put the same ops in a JSON plan and run
+`patchloom tx bump.json --apply` (Step 5). Prefer `tx` or MCP when shell
+quoting is painful.
+
 ## Step 5: Run an atomic transaction with a saved plan
 
 Use `tx` when the change should live in a reusable plan file, or when you need

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -63,7 +63,7 @@ Patchloom is also a Rust library. Add it as a dependency to embed structured fil
 
 ```toml
 [dependencies]
-patchloom = { version = "0.26.0", default-features = false }
+patchloom = { version = "0.27.0", default-features = false }
 ```
 
 The `api` module exposes doc, replace, markdown, file, patch, multi-op content

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,13 @@
 //!
 //! ```toml
 //! [dependencies]
-//! patchloom = { version = "0.26.0", default-features = false }
+//! patchloom = { version = "0.27.0", default-features = false }
 //! ```
 //!
 //! Or with AST support:
 //!
 //! ```toml
-//! patchloom = { version = "0.26.0", default-features = false, features = ["ast"] }
+//! patchloom = { version = "0.27.0", default-features = false, features = ["ast"] }
 //! ```
 //!
 //! (Keep the version in sync with Cargo.toml / release-please. See the release checklist.)

--- a/tests/integration/smoke_tests.rs
+++ b/tests/integration/smoke_tests.rs
@@ -776,6 +776,96 @@ fn test_smoke_rust_version_docs_and_ci_match_cargo_metadata() {
 }
 
 #[test]
+fn test_smoke_library_embed_version_matches_cargo() {
+    let cargo = fs::read_to_string(repo_root().join("Cargo.toml")).unwrap();
+    let version_line = cargo
+        .lines()
+        .find(|line| line.starts_with("version = "))
+        .expect("Cargo.toml should declare package version");
+    let version = version_line
+        .split('"')
+        .nth(1)
+        .expect("package version should be quoted");
+    let needle = format!("patchloom = {{ version = \"{version}\"");
+
+    let files = [
+        repo_root().join("src/lib.rs"),
+        readme_path(),
+        installation_path(),
+        repo_root().join("docs/introduction.md"),
+    ];
+    for path in files {
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+        assert!(
+            content.contains(&needle),
+            "{} must embed Cargo.toml version {version} (expected snippet: {needle})",
+            path.display()
+        );
+    }
+
+    // Portable zip PowerShell example should use the same release version.
+    let installation = fs::read_to_string(installation_path()).unwrap();
+    assert!(
+        installation.contains(&format!("$ver = \"{version}\"")),
+        "installation portable zip example should set $ver to Cargo.toml version {version}"
+    );
+}
+
+#[test]
+fn test_smoke_windows_install_and_batch_docs() {
+    let installation = fs::read_to_string(installation_path()).unwrap();
+    assert!(
+        installation.contains("Portable zip (Windows)"),
+        "installation guide should document portable Windows zip layout"
+    );
+    assert!(
+        installation.contains("patchloom-x86_64-pc-windows-msvc.zip"),
+        "installation guide should name the Windows x64 zip asset"
+    );
+    assert!(
+        installation.contains("patchloom.exe"),
+        "installation guide should mention patchloom.exe for Windows"
+    );
+    assert!(
+        installation.contains("packaging template"),
+        "installation guide should note chocolatey/ is a packaging template"
+    );
+
+    let quickstart = fs::read_to_string(quickstart_path()).unwrap();
+    assert!(
+        quickstart.contains("On Windows / PowerShell"),
+        "quickstart should have a Windows/PowerShell batch section"
+    );
+    assert!(
+        quickstart.contains("Set-Content ops.txt"),
+        "quickstart should show PowerShell Set-Content batch ops"
+    );
+
+    let readme = fs::read_to_string(readme_path()).unwrap();
+    assert!(
+        readme.contains("Set-Content ops.txt"),
+        "README should show PowerShell batch without bash heredoc"
+    );
+
+    let mcp = fs::read_to_string(
+        repo_root()
+            .join("docs")
+            .join("getting-started")
+            .join("mcp-setup.md"),
+    )
+    .unwrap();
+    assert!(
+        mcp.contains("Windows (Scoop)"),
+        "mcp-setup should document Windows command path examples"
+    );
+    assert!(
+        mcp.contains("\"command\": \"patchloom\""),
+        "mcp-setup examples should prefer PATH binary name patchloom"
+    );
+}
+
+#[test]
 fn test_smoke_readme_command_examples() {
     // README links to the reference doc; detailed examples live there.
     let readme = fs::read_to_string(readme_path()).unwrap();
@@ -811,7 +901,7 @@ fn test_smoke_readme_command_examples() {
     assert!(launch.contains("appends the rules to an existing agent instructions file"));
     assert!(launch.contains(".vscode/mcp.json"));
     assert!(launch.contains(".cursor/mcp.json"));
-    assert!(launch.contains("2,800+ tests"));
+    assert!(launch.contains("4100+ tests"));
     assert!(
         launch.contains("24 commands"),
         "launch announcement CLI command count drifted"


### PR DESCRIPTION
## Summary

- Bump library embed version snippets from 0.26.0 to **0.27.0** (`src/lib.rs`, README, installation, introduction).
- Add integration smoke lock: embed pins and portable-zip `$ver` must match `Cargo.toml`.
- Installation: portable Windows zip layout + verify snippet; Chocolatey tree is a packaging template.
- Quickstart + README: PowerShell batch without bash heredocs.
- MCP setup: PATH/`patchloom` command examples and Windows Scoop/portable paths.
- Launch announcement: 4100+ tests and Windows ARM64.

## Test plan

- [x] `cargo test --test integration --all-features smoke_library_embed`
- [x] `cargo test --test integration --all-features smoke_windows_install`
- [x] `cargo test --test integration --all-features smoke_readme_command`
- [x] `python3 scripts/test_update_chocolatey_package.py`
- [ ] CI green on PR