### PR TITLE
fix: MPI blank paths, release-please embed pins, dep bumps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ See also the branch hygiene rules in `~/.grok/skills/patchloom-contrib/SKILL.md`
 
 - The open release-please PR (#724 etc.) title must be correct. Use `gh pr edit --title` when it shows the wrong version.
 - The PR *body* can be very long and may temporarily show the wrong next version header (release-please behavior). This is tracked as tech-debt #740.
-- When updating library embedding examples (in lib.rs, README, docs/), keep the version string in sync with the current Cargo.toml / .release-please-manifest.json (avoids the 0.4 vs 0.5 drift reported in #816 follow-up).
+- When updating library embedding examples (in lib.rs, README, docs/), keep the version string in sync with the current Cargo.toml / .release-please-manifest.json (avoids the 0.4 vs 0.5 drift reported in #816 follow-up). Embed and portable-zip version lines carry `x-release-please-version` markers; `release-please-config.json` lists those files under `extra-files` so release PRs bump them with Cargo.toml. Integration smoke `test_smoke_library_embed_version_matches_cargo` fails if they drift. If you add a new hard-coded version pin, mark the line and add the file to `extra-files`.
 - **Library follow-up PRs and high-level API changes must use explicit Closes links in the PR body** (see #819 and the new rule in Git hygiene above). The #811-#815 library embedder work + #817/#818 follow-ups exposed the gap where minimal PR bodies left issues open after squash-merge. Always include them for traceability.
 - Primary curation is done via `RELEASE_NOTES.md` (applied to the final GitHub Release by the host job, not the PR body).
 - See `patchloom-contrib` skill ("Curated release notes" and "Major version bumps" sections) for the full process.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094c075f6698deef5a657cf4df6b684dff65157d255978b92b552ec22503f17a"
+checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -1930,9 +1930,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "737d947bcfd946fae6a179a4ef6487be6dcf25c930c2393856b820f1386e52a6"
+checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2673,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.11"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Add patchloom as a dependency (omit CLI/MCP/AST with `default-features = false`)
 
 ```toml
 [dependencies]
-patchloom = { version = "0.27.0", default-features = false }
+patchloom = { version = "0.27.0", default-features = false } <!-- x-release-please-version -->
 ```
 
 ```rust

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -112,10 +112,10 @@ Each release ships flat zips (no nested folder). Common asset names:
 - `patchloom-x86_64-pc-windows-msvc.zip` (x64)
 - `patchloom-aarch64-pc-windows-msvc.zip` (ARM64)
 
-Tag form is `patchloom-vX.Y.Z` (for example `patchloom-v0.27.0`).
+Tag form is `patchloom-vX.Y.Z` (for example `patchloom-v0.27.0`). <!-- x-release-please-version -->
 
 ```powershell
-$ver = "0.27.0"   # or the version you need
+$ver = "0.27.0"   # x-release-please-version (or pin an older release)
 $tag = "patchloom-v$ver"
 $url = "https://github.com/patchloom/patchloom/releases/download/$tag/patchloom-x86_64-pc-windows-msvc.zip"
 $dir = "$env:TEMP\patchloom-portable"
@@ -196,14 +196,14 @@ Rust tools. Disable default features to omit CLI (clap), MCP server, and AST:
 
 ```toml
 [dependencies]
-patchloom = { version = "0.27.0", default-features = false }
+patchloom = { version = "0.27.0", default-features = false } <!-- x-release-please-version -->
 ```
 
 To add AST support without CLI/MCP (LLM agent embedders typically use
 `ast` + `files` for plan execution and AST file mutators):
 
 ```toml
-patchloom = { version = "0.27.0", default-features = false, features = ["ast", "files"] }
+patchloom = { version = "0.27.0", default-features = false, features = ["ast", "files"] } <!-- x-release-please-version -->
 ```
 
 See the [crate documentation](https://docs.rs/patchloom) for the full API

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -63,7 +63,7 @@ Patchloom is also a Rust library. Add it as a dependency to embed structured fil
 
 ```toml
 [dependencies]
-patchloom = { version = "0.27.0", default-features = false }
+patchloom = { version = "0.27.0", default-features = false } <!-- x-release-please-version -->
 ```
 
 The `api` module exposes doc, replace, markdown, file, patch, multi-op content

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,13 @@
     ".": {
       "release-type": "rust",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "extra-files": [
+        { "type": "generic", "path": "src/lib.rs" },
+        { "type": "generic", "path": "README.md" },
+        { "type": "generic", "path": "docs/introduction.md" },
+        { "type": "generic", "path": "docs/getting-started/installation.md" }
+      ]
     }
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,13 @@
 //!
 //! ```toml
 //! [dependencies]
-//! patchloom = { version = "0.27.0", default-features = false }
+//! patchloom = { version = "0.27.0", default-features = false } // x-release-please-version
 //! ```
 //!
 //! Or with AST support:
 //!
 //! ```toml
-//! patchloom = { version = "0.27.0", default-features = false, features = ["ast"] }
+//! patchloom = { version = "0.27.0", default-features = false, features = ["ast"] } // x-release-please-version
 //! ```
 //!
 //! (Keep the version in sync with Cargo.toml / release-please. See the release checklist.)

--- a/tests/integration/file_ops_tests.rs
+++ b/tests/integration/file_ops_tests.rs
@@ -1054,3 +1054,64 @@ fn test_md_sole_binary_is_binary_error_kind_not_no_matches() {
         "{json}"
     );
 }
+
+/// #2152 family: blank/whitespace paths on file lifecycle CLI commands must
+/// fail closed as invalid_input (parity with read/doc/md empty-path tests).
+#[test]
+fn test_file_ops_blank_path_json_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let cases: &[(&[&str], &str)] = &[
+        (&["create", "", "--content", "x", "--apply"], "create empty"),
+        (
+            &["create", "   ", "--content", "x", "--apply"],
+            "create whitespace",
+        ),
+        (&["delete", "", "--apply"], "delete empty"),
+        (&["delete", "\t", "--apply"], "delete tab"),
+        (&["append", "", "--content", "x", "--apply"], "append empty"),
+        (
+            &["prepend", "", "--content", "x", "--apply"],
+            "prepend empty",
+        ),
+        (
+            &["rename", "", "dest.txt", "--apply"],
+            "rename empty source",
+        ),
+        (&["rename", "src.txt", "", "--apply"], "rename empty dest"),
+    ];
+
+    // rename dest empty needs a source file when validation order requires it
+    fs::write(dir.path().join("src.txt"), "hi\n").unwrap();
+
+    for (args, label) in cases {
+        let mut cmd = Command::cargo_bin("patchloom").unwrap();
+        cmd.arg("--json").arg("--cwd").arg(dir.path());
+        for a in *args {
+            cmd.arg(a);
+        }
+        let output = cmd.output().unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "{label}: expected exit 1, stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let parsed: serde_json::Value =
+            serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+                panic!(
+                    "{label}: invalid JSON: {e}; stdout={}",
+                    String::from_utf8_lossy(&output.stdout)
+                )
+            });
+        assert_eq!(parsed["ok"], false, "{label}: {parsed}");
+        assert_eq!(
+            parsed["error_kind"], "invalid_input",
+            "{label}: expected invalid_input: {parsed}"
+        );
+        let err = parsed["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("path must not be empty") || err.contains("empty"),
+            "{label}: error should mention empty path: {parsed}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Multi-perspective improve batch (session 2026-08-10):

- **QA:** Integration test that create/delete/append/prepend/rename reject blank and whitespace-only paths with `error_kind: invalid_input` (parity with read/doc/md).
- **Maintainer / End User:** `x-release-please-version` markers on library embed snippets and portable zip `$ver`; `release-please-config.json` `extra-files` so release PRs bump pins with Cargo.toml (prevents red CI after the embed version smoke lock from #2154).
- **Deps:** `rmcp` 3.1.1 → 3.1.2, `tree-sitter` 0.26.11 → 0.26.12.
- **Docs:** AGENTS.md notes markers + smoke test.

## Related

- Ref #2154 (embed lock that exposed release PR drift)
- Release PR #2151 already has manual 0.28.0 pin fix on the branch; future releases should auto-bump

## Test plan

- [x] `cargo test --test integration --all-features test_file_ops_blank_path`
- [x] `cargo test --test integration --all-features smoke_library_embed`
- [x] `cargo test --lib --all-features`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `make check-fast`
- [ ] CI green