### PR TITLE
fix: patch blank path invalid_input parity

### DIFF
--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -21,6 +21,10 @@ Do not expose only `doc_set` if agents need list updates by name. See
 
 1. **PathGuard** from the workspace root (and `allow_temp_directory` if the
    agent writes under `/tmp`). Pass `Some(&guard)` into Apply writers.
+   Blank or whitespace-only paths fail closed as `ContainmentError::EmptyPath`
+   (`path must not be empty`); they do not resolve as the workspace root.
+   Match `ContainmentError` with a `_` arm: the enum is `#[non_exhaustive]`
+   (0.28.0).
 2. **Sole-path text load:** `api::load_text` / `load_text_strict` (or
    `is_binary_file` preflight). Peel `Binary` / `InvalidEncoding` /
    `is_load_text_strict_fail` instead of scraping English.

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -84,6 +84,9 @@ enum DiffReadError {
     Binary(String),
     /// Diff bytes are not valid UTF-8 (#1896 / #1963).
     InvalidEncoding(String),
+    /// Blank / invalid patch *path* (not malformed diff text). Agents branch on
+    /// `invalid_input` like other commands (#2152 family).
+    InvalidInput(String),
 }
 
 fn classify_diff_bytes(bytes: Vec<u8>, display: &str) -> Result<String, DiffReadError> {
@@ -117,6 +120,12 @@ fn read_diff_input(
     if let Some(path) = file {
         if path == "-" {
             read_diff_stdin()
+        } else if crate::containment::is_blank_path(path) {
+            // Fail closed before resolve/load so blank paths do not become
+            // `parse_error` via IoError mapping (parity with create/doc/read).
+            Err(DiffReadError::InvalidInput(
+                "path must not be empty".to_string(),
+            ))
         } else {
             // Relative patch paths resolve under --cwd (parity with `tx` / `batch`).
             let full = global
@@ -130,9 +139,14 @@ fn read_diff_input(
                 } else if crate::exit::is_invalid_encoding(&e) {
                     DiffReadError::InvalidEncoding(e.to_string())
                 } else if crate::exit::is_invalid_input(&e) {
-                    // Directory / non-file / unreadable treated as IO for patch
-                    // input (agents still get a fail-closed read error).
-                    DiffReadError::IoError(display.clone(), std::io::Error::other(e.to_string()))
+                    let msg = e.to_string();
+                    if msg.contains("path must not be empty") {
+                        DiffReadError::InvalidInput(msg)
+                    } else {
+                        // Directory / non-file / unreadable treated as IO for patch
+                        // input (agents still get a fail-closed read error).
+                        DiffReadError::IoError(display.clone(), std::io::Error::other(msg))
+                    }
                 } else if crate::exit::is_io_not_found(&e) {
                     DiffReadError::IoError(
                         display.clone(),
@@ -539,6 +553,16 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         }
         Err(DiffReadError::InvalidEncoding(msg)) => {
             emit_error(global, &format!("patch: {msg}"), "invalid_encoding")?;
+            return Ok(exit::FAILURE);
+        }
+        Err(DiffReadError::InvalidInput(msg)) => {
+            // Blank path (and similar): stable agent peel, not parse_error.
+            let detail = if msg.contains("path must not be empty") {
+                "path must not be empty".to_string()
+            } else {
+                format!("patch: {msg}")
+            };
+            emit_error(global, &detail, "invalid_input")?;
             return Ok(exit::FAILURE);
         }
     };

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -1133,3 +1133,40 @@ fn test_batch_unreadable_input_does_not_double_wrap() {
         "must not double-wrap load_text_strict: {v}"
     );
 }
+
+/// Blank path on batch file ops is invalid_input (parity with CLI create).
+#[test]
+fn test_batch_blank_path_json_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    for line in [
+        r#"file.create "" "x""#,
+        r#"file.create "   " "x""#,
+        r#"file.delete """#,
+    ] {
+        let output = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "--cwd"])
+            .arg(dir.path())
+            .args(["batch", "--apply"])
+            .write_stdin(format!("{line}\n"))
+            .output()
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "line={line:?} stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(v["ok"], false, "line={line:?} {v}");
+        assert_eq!(
+            v["error_kind"], "invalid_input",
+            "line={line:?} {v}"
+        );
+        let err = v["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("path must not be empty") || err.contains("empty"),
+            "line={line:?} {v}"
+        );
+    }
+}

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -1159,10 +1159,7 @@ fn test_batch_blank_path_json_invalid_input() {
         );
         let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
         assert_eq!(v["ok"], false, "line={line:?} {v}");
-        assert_eq!(
-            v["error_kind"], "invalid_input",
-            "line={line:?} {v}"
-        );
+        assert_eq!(v["error_kind"], "invalid_input", "line={line:?} {v}");
         let err = v["error"].as_str().unwrap_or("");
         assert!(
             err.contains("path must not be empty") || err.contains("empty"),

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -210,6 +210,42 @@ fn test_patch_apply_missing_file_json_not_found() {
     );
 }
 
+/// Blank patch path is invalid_input (exit 1), not parse_error (exit 4).
+/// Parity with create/doc/read empty-path peels (#2152 family).
+#[test]
+fn test_patch_apply_blank_path_json_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    for path in ["", "   ", "\t"] {
+        let output = Command::cargo_bin("patchloom")
+            .unwrap()
+            .arg("--json")
+            .arg("--cwd")
+            .arg(dir.path())
+            .arg("patch")
+            .arg("apply")
+            .arg(path)
+            .output()
+            .unwrap();
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "blank path {path:?} exit: stderr={}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(v["ok"], false, "path={path:?} {v}");
+        assert_eq!(
+            v["error_kind"], "invalid_input",
+            "path={path:?} must not be parse_error: {v}"
+        );
+        let err = v["error"].as_str().unwrap_or("");
+        assert!(
+            err.contains("path must not be empty"),
+            "path={path:?} message: {v}"
+        );
+    }
+}
+
 #[test]
 fn test_patch_apply_json_stale_error_returns_error_object() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

MPI cycle after **0.28.0**:

- **Bug fix:** `patch apply` / `check` on empty or whitespace-only patch paths
  used to return `error_kind: parse_error` (exit 4). Now `invalid_input`
  (exit 1) with `path must not be empty`, matching create/doc/read and the
  0.28 blank-path work.
- **Tests:** cargo-bin locks for blank patch paths; batch `file.create` /
  `file.delete` blank path `invalid_input`.
- **Docs:** embedder-host PathGuard notes for `EmptyPath` and
  `ContainmentError` `#[non_exhaustive]`.

## Test plan

- [x] `cargo test --test integration --all-features test_patch_apply_blank_path`
- [x] `cargo test --test integration --all-features test_batch_blank_path`
- [x] `make check-fast`
- [ ] CI green