### PR TITLE
fix(batch): peel content=/old=/new= plan-shaped key prefixes

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -266,8 +266,8 @@ md.upsert_bullet CHANGELOG.md "## Changes" "- Bumped to 2.0.0"
 EOF
 ```
 
-One line per operation. Double-quote values with spaces. Unquoted JSON objects/arrays (`file.create f.json {"x":1}`) keep inner quotes. In `file.create`/`append`/`prepend` content, `\n` `\t` `\r` `\\` `\"` expand (multi-line content on one batch line).
-Batch `replace` accepts optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.
+One line per operation. Double-quote values with spaces. Unquoted JSON objects/arrays (`file.create f.json {"x":1}`) keep inner quotes. In `file.create`/`append`/`prepend` content, `\n` `\t` `\r` `\\` `\"` expand (multi-line content on one batch line). Prefer positional content (`file.create f.txt "hi"`); a leading `content=` / `body=` key is also accepted so plan-shaped lines do not write literal `content=…` bytes.
+Batch `replace` is `replace PATH OLD NEW` (not CLI `replace OLD --new NEW path`). Optional `old=`/`new=` (or `from=`/`to=`) prefixes on the pattern tokens are peeled. Optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.
 
 On Windows (where heredocs are not available), write operations to a file and pass it:
 

--- a/src/cmd/agent_rules/surfaces.rs
+++ b/src/cmd/agent_rules/surfaces.rs
@@ -78,10 +78,14 @@ pub(crate) fn append_surfaces(
                  ```\n\n\
                  One line per operation. Double-quote values with spaces. Unquoted JSON objects/arrays \
                  (`file.create f.json {\"x\":1}`) keep inner quotes. In `file.create`/`append`/`prepend` content, \
-                 `\\n` `\\t` `\\r` `\\\\` `\\\"` expand (multi-line content on one batch line).\n\
-                 Batch `replace` accepts optional flags after path/old/new: `--fuzzy`, `--min-fuzzy-score`, \
-                 `--word-boundary`/`-w`, `--command-position`, `--require-change`, `-i`/`--case-insensitive`, \
-                 `--if-exists`. Advanced options (regex, context, nth) need a `tx` plan.\n\n",
+                 `\\n` `\\t` `\\r` `\\\\` `\\\"` expand (multi-line content on one batch line). Prefer positional \
+                 content (`file.create f.txt \"hi\"`); a leading `content=` / `body=` key is also accepted so \
+                 plan-shaped lines do not write literal `content=…` bytes.\n\
+                 Batch `replace` is `replace PATH OLD NEW` (not CLI `replace OLD --new NEW path`). Optional \
+                 `old=`/`new=` (or `from=`/`to=`) prefixes on the pattern tokens are peeled. Optional flags after \
+                 path/old/new: `--fuzzy`, `--min-fuzzy-score`, `--word-boundary`/`-w`, `--command-position`, \
+                 `--require-change`, `-i`/`--case-insensitive`, `--if-exists`. Advanced options (regex, context, \
+                 nth) need a `tx` plan.\n\n",
             );
         }
 

--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -688,6 +688,16 @@ fn parse_replace_line(args: &[String], line_num: usize) -> anyhow::Result<Operat
         })
     })?;
 
+    // Plan/MCP-shaped `old=`/`new=` (and from=/to= aliases) glued by tokenize
+    // when agents write `replace f.txt old="x" new="y"`. Without peeling, old
+    // becomes the literal `old=x` and soft no_match (fixrealloop 0.28).
+    let old = peel_named_kv_prefix(&old, &["old", "from"])
+        .map(str::to_string)
+        .unwrap_or(old);
+    let new_text = peel_named_kv_prefix(&new_text, &["new", "to"])
+        .map(str::to_string)
+        .unwrap_or(new_text);
+
     // Agents often paste CLI order (`replace OLD --new NEW path` → batch line
     // `replace OLD NEW path`). Batch is PATH OLD NEW. When the first token is
     // not a file and the third token is, fail early with the correct order.
@@ -761,6 +771,47 @@ fn parse_json_value(s: &str) -> anyhow::Result<serde_json::Value> {
     Ok(crate::ops::doc::parse_value(s))
 }
 
+/// Peel plan/CLI-shaped `key=value` prefixes agents paste into batch lines.
+///
+/// Tokenizer turns `content="hi"` into one token `content=hi` (unquoted key, quoted
+/// value glued). Without peeling, `file.create f.txt content="hi"` writes the
+/// literal bytes `content=hi` (fixrealloop 0.28 honesty dogfood). Same class as
+/// replace `old=` / `new=` below. Empty value after `=` is allowed (`content=`).
+fn peel_named_kv_prefix<'a>(tok: &'a str, keys: &[&str]) -> Option<&'a str> {
+    for key in keys {
+        if let Some(rest) = tok.strip_prefix(key)
+            && let Some(rest) = rest.strip_prefix('=')
+        {
+            return Some(rest);
+        }
+    }
+    None
+}
+
+/// Join free-form content tokens, peeling a leading `content=` (or `body=`) key.
+fn join_content_tokens(parts: &[&str]) -> String {
+    if parts.is_empty() {
+        return String::new();
+    }
+    if parts.len() == 1 {
+        if let Some(rest) = peel_named_kv_prefix(parts[0], &["content", "body"]) {
+            return expand_content_escapes(rest);
+        }
+        return expand_content_escapes(parts[0]);
+    }
+    // Multi-token: peel only when the first token is a bare key= form so
+    // `content=hello world` (unquoted multi-word) still works.
+    if let Some(rest) = peel_named_kv_prefix(parts[0], &["content", "body"]) {
+        let mut joined = rest.to_string();
+        for p in &parts[1..] {
+            joined.push(' ');
+            joined.push_str(p);
+        }
+        return expand_content_escapes(&joined);
+    }
+    expand_content_escapes(&parts.join(" "))
+}
+
 /// Path + free-form content for file.create/append/prepend.
 ///
 /// Requires at least a path. Remaining tokens are joined with a single space so
@@ -768,6 +819,8 @@ fn parse_json_value(s: &str) -> anyhow::Result<serde_json::Value> {
 /// JSON-aware tokens (see [`tokenize`]) so unquoted `{"x":1}` is not mangled.
 /// Content expands `\n` `\t` `\r` `\\` `\"` so agents can write multi-line files
 /// on one batch line (fixrealloop: TOML/Rust scaffolds).
+/// Optional `content=` / `body=` prefix on the content is peeled (plan-shaped
+/// key=value agents paste into batch).
 fn path_and_joined_content(
     op: &str,
     args: &[String],
@@ -779,12 +832,8 @@ fn path_and_joined_content(
         }));
     }
     let path = args[0].clone();
-    let raw = if args.len() == 1 {
-        String::new()
-    } else {
-        args[1..].join(" ")
-    };
-    Ok((path, expand_content_escapes(&raw)))
+    let parts: Vec<&str> = args[1..].iter().map(String::as_str).collect();
+    Ok((path, join_content_tokens(&parts)))
 }
 
 /// Like [`path_and_joined_content`], but peels optional `--force` so CLI-shaped
@@ -816,8 +865,7 @@ fn path_and_joined_content_create(
         }
         content_parts.push(tok.as_str());
     }
-    let raw = content_parts.join(" ");
-    Ok((path, expand_content_escapes(&raw), force))
+    Ok((path, join_content_tokens(&content_parts), force))
 }
 
 /// Expand common escapes in batch file content (`\n` `\t` `\r` `\\` `\"`).

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -276,6 +276,38 @@ mod basic {
         );
     }
 
+    /// Plan-shaped `old=`/`new=` (no leading dashes) must peel, not search for
+    /// literal `old=x` and soft-miss (fixrealloop 0.28).
+    #[test]
+    fn parse_line_replace_peels_old_new_kv_prefixes() {
+        let op = parse_line(r#"replace hello.txt old="hi" new="hello""#, 1).unwrap();
+        assert!(
+            matches!(
+                op,
+                Operation::Replace {
+                    path: Some(ref p),
+                    ref old,
+                    new_text: Some(ref t),
+                    ..
+                } if p == "hello.txt" && old == "hi" && t == "hello"
+            ),
+            "got {op:?}"
+        );
+        let op = parse_line(r#"replace hello.txt from=hi to=hello"#, 1).unwrap();
+        assert!(
+            matches!(
+                op,
+                Operation::Replace {
+                    path: Some(ref p),
+                    ref old,
+                    new_text: Some(ref t),
+                    ..
+                } if p == "hello.txt" && old == "hi" && t == "hello"
+            ),
+            "got {op:?}"
+        );
+    }
+
     #[test]
     fn parse_line_replace_dash_prefixed_values_are_positionals() {
         // Bullet renames and flag-like strings must not be misread as flags.
@@ -323,6 +355,41 @@ mod basic {
             op,
             Operation::FileCreate { path, content, .. }
             if path == "hello.txt" && content == "Hello, World!"
+        ));
+    }
+
+    /// Plan-shaped `content="…"` must not write literal `content=…` bytes
+    /// (fixrealloop 0.28: agents paste plan keys into batch lines).
+    #[test]
+    fn parse_line_file_create_peels_content_kv_prefix() {
+        let op = parse_line(r#"file.create hello.txt content="hi""#, 1).unwrap();
+        assert!(
+            matches!(
+                &op,
+                Operation::FileCreate { path, content, .. }
+                if path == "hello.txt" && content == "hi"
+            ),
+            "got {op:?}"
+        );
+        let op = parse_line(r#"file.create hello.txt content=hi"#, 1).unwrap();
+        assert!(matches!(
+            &op,
+            Operation::FileCreate { path, content, .. }
+            if path == "hello.txt" && content == "hi"
+        ));
+        // Unquoted multi-word after content=
+        let op = parse_line("file.create note.txt content=hello world", 1).unwrap();
+        assert!(matches!(
+            &op,
+            Operation::FileCreate { path, content, .. }
+            if path == "note.txt" && content == "hello world"
+        ));
+        // body= alias
+        let op = parse_line(r#"file.append log.txt body="line\n""#, 1).unwrap();
+        assert!(matches!(
+            &op,
+            Operation::FileAppend { path, content }
+            if path == "log.txt" && content == "line\n"
         ));
     }
 


### PR DESCRIPTION
## Summary

- Batch line format is positional (`file.create PATH CONTENT`, `replace PATH OLD NEW`), but agents often paste plan/MCP-shaped `content=…`, `old=…`, `new=…` (and `from=`/`to=`/`body=` aliases).
- Tokenizer turns `content="hi"` into one token `content=hi`. Without peeling, create wrote those literal bytes; replace soft-missed on `old=x`.
- Peel the known key prefixes for create/append/prepend and replace. Keep primary docs as positional; document the peel in agent-rules / PATCHLOOM.md.

## Found by

`/fixrealloop` Round 2 multi-surface honesty dogfood against release 0.28.0 (`target/release/patchloom`).

## Test plan

- [x] Unit: `parse_line_file_create_peels_content_kv_prefix`, `parse_line_replace_peels_old_new_kv_prefixes`
- [x] `cargo test --lib batch::`
- [x] Runtime: batch with `content="hi"` + `old=`/`new=` applies correctly
- [x] `make embedder-smoke`
- [x] `make check-fast`
- [ ] CI green on this PR