### PR TITLE
refactor(replace): bundle replacement_text args into context struct

### DIFF
--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -235,16 +235,16 @@ fn replace_write(
         } else {
             None
         };
-        let replacement = ops::replace::replacement_text_ci(
-            &old,
-            &direct_to,
-            &insert_before,
-            &insert_after,
-            compiled_re.is_some(),
-            is_regex,
-            &original,
+        let replacement = ops::replace::replacement_text_ci(&ops::replace::ReplacementTextParams {
+            from: &old,
+            to: &direct_to,
+            insert_before: &insert_before,
+            insert_after: &insert_after,
+            use_match_anchor: compiled_re.is_some(),
+            regex_mode: is_regex,
+            file_content: &original,
             case_insensitive,
-        );
+        });
 
         let parsed_range = range.as_deref().map(|r| {
             let parts: Vec<&str> = r.splitn(2, ':').collect();
@@ -647,16 +647,16 @@ fn replace_in_content_inner(
     } else {
         None
     };
-    let replacement = ops::replace::replacement_text_ci(
+    let replacement = ops::replace::replacement_text_ci(&ops::replace::ReplacementTextParams {
         from,
-        &direct_to,
-        &opts.insert_before,
-        &opts.insert_after,
-        compiled_re.is_some(),
-        is_regex,
-        content,
-        opts.case_insensitive,
-    );
+        to: &direct_to,
+        insert_before: &opts.insert_before,
+        insert_after: &opts.insert_after,
+        use_match_anchor: compiled_re.is_some(),
+        regex_mode: is_regex,
+        file_content: content,
+        case_insensitive: opts.case_insensitive,
+    });
 
     let parsed_range = opts.range;
 

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -347,14 +347,16 @@ fn collect_replacements_with_list(
         crate::par_process_files(&file_paths, glob_matcher.as_ref(), &glob_roots, |path| {
             let content = crate::files::read_text_file_logged(path, "replace", quiet)?;
             let replacement = crate::ops::replace::replacement_text_ci(
-                from,
-                &new_opt,
-                &insert_before,
-                &insert_after,
-                use_match_anchor,
-                regex_mode,
-                &content,
-                case_insensitive,
+                &crate::ops::replace::ReplacementTextParams {
+                    from,
+                    to: &new_opt,
+                    insert_before: &insert_before,
+                    insert_after: &insert_after,
+                    use_match_anchor,
+                    regex_mode,
+                    file_content: &content,
+                    case_insensitive,
+                },
             );
             let (replaced, count) = if command_position {
                 let (out, n) =

--- a/src/cmd/tx_tests.rs
+++ b/src/cmd/tx_tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::ops::replace::replacement_text;
+use crate::ops::replace::{ReplacementTextParams, replacement_text};
 use crate::tx::{read_and_probe, read_file_content, update_file_content, validate_operation};
 use crate::write::WritePolicy;
 use std::collections::{HashMap, HashSet};
@@ -218,14 +218,34 @@ mod basic {
 
     #[test]
     fn regex_insert_before_uses_match_anchor_in_replacement_text() {
-        let text = replacement_text("b+", &None, &Some("X".to_string()), &None, true, true, "");
+        let insert_before = Some("X".to_string());
+        let text = replacement_text(&ReplacementTextParams {
+            from: "b+",
+            to: &None,
+            insert_before: &insert_before,
+            insert_after: &None,
+            use_match_anchor: true,
+            regex_mode: true,
+            file_content: "",
+            case_insensitive: false,
+        });
 
         assert_eq!(text, "X${0}");
     }
 
     #[test]
     fn regex_insert_after_uses_match_anchor_in_replacement_text() {
-        let text = replacement_text("b+", &None, &None, &Some("X".to_string()), true, true, "");
+        let insert_after = Some("X".to_string());
+        let text = replacement_text(&ReplacementTextParams {
+            from: "b+",
+            to: &None,
+            insert_before: &None,
+            insert_after: &insert_after,
+            use_match_anchor: true,
+            regex_mode: true,
+            file_content: "",
+            case_insensitive: false,
+        });
 
         assert_eq!(text, "${0}X");
     }

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -365,60 +365,51 @@ fn is_line_boundary_byte(b: u8) -> bool {
     b == b'\n' || b == b'\r'
 }
 
-/// Build the replacement string for replace / insert modes.
+/// Parameters for [`replacement_text`] / [`replacement_text_ci`].
 ///
-/// `file_content` is the file (or buffer) being edited; it is used to decide
-/// line-oriented insert normalization (#1885). Pass `""` only in pure unit
-/// tests that do not exercise whole-line-anchor detection.
-pub fn replacement_text(
-    from: &str,
-    to: &Option<String>,
-    insert_before: &Option<String>,
-    insert_after: &Option<String>,
-    use_match_anchor: bool,
-    regex_mode: bool,
-    file_content: &str,
-) -> String {
-    replacement_text_ci(
-        from,
-        to,
-        insert_before,
-        insert_after,
-        use_match_anchor,
-        regex_mode,
-        file_content,
-        false,
-    )
+/// Bundles the from/to/insert/anchor/regex/file/ci inputs so call sites do not
+/// hit `clippy::too_many_arguments` (#2163).
+#[derive(Clone, Copy)]
+pub struct ReplacementTextParams<'a> {
+    pub from: &'a str,
+    pub to: &'a Option<String>,
+    pub insert_before: &'a Option<String>,
+    pub insert_after: &'a Option<String>,
+    pub use_match_anchor: bool,
+    pub regex_mode: bool,
+    /// File (or buffer) being edited; used for line-oriented insert
+    /// normalization (#1885). Pass `""` only in pure unit tests that do not
+    /// exercise whole-line-anchor detection.
+    pub file_content: &'a str,
+    /// When true, whole-line insert detection is case-insensitive.
+    pub case_insensitive: bool,
 }
 
-/// Like [`replacement_text`] with case-insensitive whole-line insert detection.
-#[allow(clippy::too_many_arguments)]
-pub fn replacement_text_ci(
-    from: &str,
-    to: &Option<String>,
-    insert_before: &Option<String>,
-    insert_after: &Option<String>,
-    use_match_anchor: bool,
-    regex_mode: bool,
-    file_content: &str,
-    case_insensitive: bool,
-) -> String {
-    let anchor = if use_match_anchor { "${0}" } else { from };
+/// Build the replacement string for replace / insert modes.
+///
+/// Whole-line insert detection respects [`ReplacementTextParams::case_insensitive`].
+pub fn replacement_text(p: &ReplacementTextParams<'_>) -> String {
+    replacement_text_ci(p)
+}
+
+/// Alias of [`replacement_text`] (kept for call-site clarity at CI replace paths).
+pub fn replacement_text_ci(p: &ReplacementTextParams<'_>) -> String {
+    let anchor = if p.use_match_anchor { "${0}" } else { p.from };
 
     // When a regex is compiled internally (case_insensitive / word_boundary)
     // but the user did NOT request regex mode, dollar signs in user-provided
     // replacement text must be escaped so caps.expand() treats them literally.
-    let needs_escape = use_match_anchor && !regex_mode;
+    let needs_escape = p.use_match_anchor && !p.regex_mode;
 
-    if let Some(text) = insert_before {
+    if let Some(text) = p.insert_before {
         // Normalize against the literal `from` pattern (not ${0}) so whole-line
         // detection sees the real anchor text in the file.
         let normalized = normalize_line_insert_ci(
-            file_content,
-            from,
+            p.file_content,
+            p.from,
             text,
             InsertSide::Before,
-            case_insensitive,
+            p.case_insensitive,
         );
         let safe = if needs_escape {
             normalized.replace('$', "$$")
@@ -428,13 +419,13 @@ pub fn replacement_text_ci(
         return format!("{safe}{anchor}");
     }
 
-    if let Some(text) = insert_after {
+    if let Some(text) = p.insert_after {
         let normalized = normalize_line_insert_ci(
-            file_content,
-            from,
+            p.file_content,
+            p.from,
             text,
             InsertSide::After,
-            case_insensitive,
+            p.case_insensitive,
         );
         let safe = if needs_escape {
             normalized.replace('$', "$$")
@@ -444,7 +435,7 @@ pub fn replacement_text_ci(
         return format!("{anchor}{safe}");
     }
 
-    let raw = to.clone().unwrap_or_default();
+    let raw = p.to.clone().unwrap_or_default();
     if needs_escape {
         raw.replace('$', "$$")
     } else {

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -87,64 +87,81 @@ mod replace_tests {
 
         #[test]
         fn replacement_text_with_to() {
-            let result =
-                replacement_text("from", &Some("to".into()), &None, &None, false, false, "");
+            let to = Some("to".into());
+            let result = replacement_text(&ReplacementTextParams {
+                from: "from",
+                to: &to,
+                insert_before: &None,
+                insert_after: &None,
+                use_match_anchor: false,
+                regex_mode: false,
+                file_content: "",
+                case_insensitive: false,
+            });
             assert_eq!(result, "to");
         }
 
         #[test]
         fn replacement_text_insert_before_literal() {
-            let result = replacement_text(
-                "original",
-                &None,
-                &Some("PREFIX\n".into()),
-                &None,
-                false,
-                false,
-                "original",
-            );
+            let insert_before = Some("PREFIX\n".into());
+            let result = replacement_text(&ReplacementTextParams {
+                from: "original",
+                to: &None,
+                insert_before: &insert_before,
+                insert_after: &None,
+                use_match_anchor: false,
+                regex_mode: false,
+                file_content: "original",
+                case_insensitive: false,
+            });
             assert_eq!(result, "PREFIX\noriginal");
         }
 
         #[test]
         fn replacement_text_insert_after_literal() {
-            let result = replacement_text(
-                "original",
-                &None,
-                &None,
-                &Some("\nSUFFIX".into()),
-                false,
-                false,
-                "original",
-            );
+            let insert_after = Some("\nSUFFIX".into());
+            let result = replacement_text(&ReplacementTextParams {
+                from: "original",
+                to: &None,
+                insert_before: &None,
+                insert_after: &insert_after,
+                use_match_anchor: false,
+                regex_mode: false,
+                file_content: "original",
+                case_insensitive: false,
+            });
             assert_eq!(result, "original\nSUFFIX");
         }
 
         #[test]
         fn replacement_text_insert_before_regex_anchor() {
-            let result = replacement_text(
-                "ignored",
-                &None,
-                &Some("PREFIX\n".into()),
-                &None,
-                true,
-                true,
-                "ignored",
-            );
+            let insert_before = Some("PREFIX\n".into());
+            let result = replacement_text(&ReplacementTextParams {
+                from: "ignored",
+                to: &None,
+                insert_before: &insert_before,
+                insert_after: &None,
+                use_match_anchor: true,
+                regex_mode: true,
+                file_content: "ignored",
+                case_insensitive: false,
+            });
             assert_eq!(result, "PREFIX\n${0}");
         }
 
         #[test]
         fn replacement_text_insert_after_regex_anchor() {
-            let result = replacement_text(
-                "ignored",
-                &None,
-                &None,
-                &Some("\nSUFFIX".into()),
-                true,
-                true,
-                "ignored",
-            );
+            let insert_after = Some("\nSUFFIX".into());
+            let result = replacement_text(&ReplacementTextParams {
+                from: "ignored",
+                to: &None,
+                insert_before: &None,
+                insert_after: &insert_after,
+                use_match_anchor: true,
+                regex_mode: true,
+                file_content: "ignored",
+                case_insensitive: false,
+            });
             assert_eq!(result, "${0}\nSUFFIX");
         }
 
@@ -153,23 +170,34 @@ mod replace_tests {
         #[test]
         fn replacement_text_escapes_dollars_for_internal_regex() {
             // use_match_anchor=true (internal regex), regex_mode=false (not user-requested)
-            let result =
-                replacement_text("cost", &Some("$100".into()), &None, &None, true, false, "");
+            let to = Some("$100".into());
+            let result = replacement_text(&ReplacementTextParams {
+                from: "cost",
+                to: &to,
+                insert_before: &None,
+                insert_after: &None,
+                use_match_anchor: true,
+                regex_mode: false,
+                file_content: "",
+                case_insensitive: false,
+            });
             assert_eq!(result, "$$100");
         }
 
         #[test]
         fn replacement_text_preserves_dollars_for_user_regex() {
             // use_match_anchor=true, regex_mode=true (user explicitly requested regex)
-            let result = replacement_text(
-                "(c)ost",
-                &Some("$1ost".into()),
-                &None,
-                &None,
-                true,
-                true,
-                "",
-            );
+            let to = Some("$1ost".into());
+            let result = replacement_text(&ReplacementTextParams {
+                from: "(c)ost",
+                to: &to,
+                insert_before: &None,
+                insert_after: &None,
+                use_match_anchor: true,
+                regex_mode: true,
+                file_content: "",
+                case_insensitive: false,
+            });
             assert_eq!(result, "$1ost");
         }
 
@@ -232,16 +260,17 @@ mod replace_tests {
             assert!(!anchor_is_whole_line_ci("Debug\n", "debug", false));
             let out = normalize_line_insert_ci("Debug\n", "debug", "note", InsertSide::After, true);
             assert_eq!(out, "\nnote");
-            let full = replacement_text_ci(
-                "debug",
-                &None,
-                &None,
-                &Some("note".into()),
-                true,
-                false,
-                "Debug\n",
-                true,
-            );
+            let insert_after = Some("note".into());
+            let full = replacement_text_ci(&ReplacementTextParams {
+                from: "debug",
+                to: &None,
+                insert_before: &None,
+                insert_after: &insert_after,
+                use_match_anchor: true,
+                regex_mode: false,
+                file_content: "Debug\n",
+                case_insensitive: true,
+            });
             // ${0} + \nnote expands later; template must include line-oriented insert
             assert!(full.contains("note"), "got {full}");
             assert!(

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -6,8 +6,9 @@
 use super::execute::{TxState, read_and_probe, read_file_content};
 use crate::api::MatchMode;
 use crate::ops::replace::{
-    InsertSide, compile_replace_regex, context_filtered_span_with_re, expand_match_anchor_template,
-    normalize_line_insert, replace_content, replace_whole_lines, replacement_text_ci,
+    InsertSide, ReplacementTextParams, compile_replace_regex, context_filtered_span_with_re,
+    expand_match_anchor_template, normalize_line_insert, replace_content, replace_whole_lines,
+    replacement_text_ci,
 };
 use crate::plan::Operation;
 use crate::tx::output::merge_match_modes;
@@ -223,16 +224,16 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             Err(e) => return Err(e),
         };
         // Per-file content so whole-line anchor detection is accurate (#1885).
-        let replacement = replacement_text_ci(
-            old,
-            new_text,
+        let replacement = replacement_text_ci(&ReplacementTextParams {
+            from: old,
+            to: new_text,
             insert_before,
             insert_after,
-            use_regex,
+            use_match_anchor: use_regex,
             regex_mode,
-            content,
-            *case_insensitive,
-        );
+            file_content: content,
+            case_insensitive: *case_insensitive,
+        });
         let (replaced, match_count) = if *command_position {
             let to = new_text.as_deref().unwrap_or("");
             let (out, n) = crate::ops::shell_token::replace_command_position(content, old, to);
@@ -544,16 +545,16 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 .get(&file_path)
                 .map(|(_, c)| c.clone())
                 .expect("read_and_probe guarantees entry exists in pending");
-            let replacement = replacement_text_ci(
-                old,
-                new_text,
+            let replacement = replacement_text_ci(&ReplacementTextParams {
+                from: old,
+                to: new_text,
                 insert_before,
                 insert_after,
-                use_regex,
+                use_match_anchor: use_regex,
                 regex_mode,
-                &content,
-                *case_insensitive,
-            );
+                file_content: &content,
+                case_insensitive: *case_insensitive,
+            });
             let (replaced, match_count) = if *command_position {
                 let to = new_text.as_deref().unwrap_or("");
                 let (out, n) = crate::ops::shell_token::replace_command_position(&content, old, to);


### PR DESCRIPTION
## Summary

- Introduce `ReplacementTextParams` for the from/to/insert/anchor/regex/file/ci bundle used by `replacement_text` / `replacement_text_ci`
- Drop `#[allow(clippy::too_many_arguments)]` on `replacement_text_ci`
- Update production call sites (`api/replace`, `cmd/replace`, `tx/replace_op`) and unit tests

Behavior is unchanged; existing `replacement_text` unit tests remain the lock.

## Test plan

- [x] `cargo test --lib --all-features replacement_text` (9 tests)
- [x] `cargo test --lib --all-features ops::replace` (95 tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`

Closes #2163