### PR TITLE
fix(cli): list empty-create dests and peel for_each invalid_input

### DIFF
--- a/src/cmd/tx.rs
+++ b/src/cmd/tx.rs
@@ -394,9 +394,14 @@ pub(crate) fn run_parsed_plan(
         && let Err(e) = crate::plan::expand_for_each(&mut plan, &base_cwd)
     {
         let msg = e.to_string();
-        // Zero matches is no_matches (exit 3); other expand failures stay parse_error.
+        // Zero-match is no_matches (exit 3). cwd+for_each / bad glob / bad
+        // templates are InvalidInputError (library peels invalid_input; do not
+        // collapse those to parse_error). Remaining untyped expand errors stay
+        // parse_error (fixrealloop R9).
         let (kind, code) = if crate::exit::is_no_match(&e) {
             ("no_matches", exit::NO_MATCHES)
+        } else if let Some((k, c)) = exit::classify_typed_error(&e) {
+            (k, c)
         } else {
             ("parse_error", exit::PARSE_ERROR)
         };

--- a/src/tx/engine.rs
+++ b/src/tx/engine.rs
@@ -110,18 +110,35 @@ impl ExecutionResult {
             }
             let rel = crate::files::relative_display(path, &self.cwd);
             let path_str = rel.to_string_lossy();
-            let diff = crate::diff::unified_diff(&path_str, original, new_content);
+            let mut diff = crate::diff::unified_diff(&path_str, original, new_content);
+            // Empty-create: original == new == "" so unified_diff has no hunks,
+            // but the dest is a new file. Engine already counts this as a
+            // change; CLI `files[]` must list it (fixrealloop R9).
+            if !diff.has_changes
+                && !self.exec_result.existed_before.contains(path)
+                && original.is_empty()
+                && new_content.is_empty()
+            {
+                diff.has_changes = true;
+            }
             if diff.has_changes {
                 diffs.push(diff);
             }
         }
-        // Include diffs for deletions (content -> empty).
+        // Include diffs for deletions (content -> empty). Empty-file delete
+        // has no hunks; still list the dest (sibling of empty-create).
         for path in &self.exec_result.deletions {
-            if let Some((original, _)) = self.exec_result.pending.get(path)
-                && !original.is_empty()
-            {
+            if let Some((original, _)) = self.exec_result.pending.get(path) {
                 let rel = crate::files::relative_display(path, &self.cwd);
                 let path_str = rel.to_string_lossy();
+                if original.is_empty() {
+                    diffs.push(crate::diff::FileDiff {
+                        path: path_str.into_owned(),
+                        hunks: String::new(),
+                        has_changes: true,
+                    });
+                    continue;
+                }
                 let diff = crate::diff::unified_diff(&path_str, original, "");
                 if diff.has_changes {
                     diffs.push(diff);
@@ -756,6 +773,36 @@ mod tests {
         let diffs = result.build_diffs();
         assert!(!diffs.is_empty());
         assert!(diffs[0].has_changes);
+    }
+
+    #[test]
+    fn execute_single_empty_create_build_diffs_lists_dest() {
+        // Empty-to-empty unified_diff has no hunks, but creating a 0-byte
+        // dest is still a change (fixrealloop R9: patch apply files[]).
+        let dir = TempDir::new().unwrap();
+        let global = GlobalFlags::test_default();
+        let op = Operation::FileCreate {
+            path: "empty.txt".to_string(),
+            content: String::new(),
+            force: None,
+        };
+        let result = execute_single(op, test_options(dir.path(), &global)).unwrap();
+        assert!(
+            result.has_changes,
+            "empty create must be an effective change"
+        );
+        let diffs = result.build_diffs();
+        assert_eq!(
+            diffs.len(),
+            1,
+            "empty create must appear in diffs: {diffs:?}"
+        );
+        assert!(diffs[0].has_changes, "{diffs:?}");
+        assert!(
+            diffs[0].path.ends_with("empty.txt"),
+            "dest path: {}",
+            diffs[0].path
+        );
     }
 
     #[test]

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -557,6 +557,50 @@ fn test_patch_check_copy_and_empty_create_dest_honesty() {
 }
 
 #[test]
+fn test_patch_apply_empty_create_lists_dest_in_json() {
+    // fixrealloop R9: apply wrote a 0-byte dest with applied:true but files[].
+    let dir = TempDir::new().unwrap();
+    let patch_file = dir.path().join("create-new.patch");
+    fs::write(
+        &patch_file,
+        "diff --git a/.brand-new b/.brand-new\n\
+         new file mode 100644\n\
+         index 0000000..e69de29\n",
+    )
+    .unwrap();
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("--json")
+        .arg("patch")
+        .arg("apply")
+        .arg(&patch_file)
+        .arg("--apply")
+        .output()
+        .unwrap();
+    let code = output.status.code().unwrap_or(-1);
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+        panic!(
+            "stdout not JSON (exit {code}): {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(code, 0, "{json}");
+    assert_eq!(json["applied"], true, "{json}");
+    assert_eq!(
+        json["files"][0]["path"], ".brand-new",
+        "empty-create apply must list dest: {json}"
+    );
+    assert_eq!(json["files"][0]["status"], "applied", "{json}");
+    assert_eq!(
+        fs::read(dir.path().join(".brand-new")).unwrap(),
+        b"",
+        "dest must be empty"
+    );
+}
+
+#[test]
 fn test_patch_check_pure_rename_c_quoted_paths() {
     // Git C-quotes paths with spaces; check/apply must unquote and move.
     let dir = TempDir::new().unwrap();

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8132,21 +8132,31 @@ fn test_tx_for_each_rejects_plan_cwd() {
         .arg("--apply")
         .output()
         .unwrap();
-    assert_ne!(
+    assert_eq!(
         output.status.code(),
-        Some(0),
-        "cwd+for_each must fail; stdout={}",
+        Some(1),
+        "cwd+for_each must be invalid_input exit 1; stdout={}",
         String::from_utf8_lossy(&output.stdout)
     );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|_| {
+        panic!(
+            "stdout not JSON: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "CLI must not remap cwd+for_each to parse_error: {json}"
+    );
+    assert_eq!(json["applied"], false, "{json}");
     let combined = format!(
         "{}{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        combined.contains("plan.cwd cannot be combined with for_each")
-            || combined.contains("invalid_input"),
-        "expected invalid_input / cwd+for_each message, got: {combined}"
+        combined.contains("plan.cwd cannot be combined with for_each"),
+        "expected cwd+for_each message, got: {combined}"
     );
     // File must remain unchanged (no partial apply).
     assert_eq!(
@@ -9577,12 +9587,12 @@ fn test_tx_for_each_item_alias_and_unknown_placeholder() {
         .unwrap();
     assert_eq!(
         out.status.code(),
-        Some(4),
+        Some(1),
         "stderr={}",
         String::from_utf8_lossy(&out.stderr)
     );
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
-    assert_eq!(v["error_kind"], "parse_error", "{v}");
+    assert_eq!(v["error_kind"], "invalid_input", "{v}");
     assert!(v["error"].as_str().unwrap_or("").contains("{file}"), "{v}");
 }
 


### PR DESCRIPTION
## Summary

CLI `patch apply --json` now lists an empty-create dest in `files[]`, and `tx` `for_each` expand failures keep their typed `error_kind` instead of being remapped to `parse_error`.

## Problem

Fixrealloop R9 dest-host dogfood of the 0.28.1 release binary found two agent-facing gaps:

1. `patch apply` of a git empty-create (`new file mode` + empty index) wrote a 0-byte dest, set `applied: true`, and still emitted `"files": []`. Agents that iterate `files[]` would miss the write. Library `apply_patch_file` and plan/tx `changes[]` already reported the dest.
2. Combining `plan.cwd` with `for_each` is `InvalidInputError` on the library path (and documented as `invalid_input`). CLI `tx` remapped every expand failure except zero-match to `parse_error` / exit 4. Agents that branch on `invalid_input` would miss the combo refuse. Unknown `{placeholder}` templates had the same remapper collapse.

## Change

- `ExecutionResult::build_diffs`: treat empty-to-empty new files (and empty-file deletes) as `has_changes` so CLI `files[]` includes the dest.
- `run_parsed_plan` `for_each` expand: use `classify_typed_error` so `invalid_input` / other typed kinds survive. Zero-match stays `no_matches` / exit 3.

## Validation

- Unit: `execute_single_empty_create_build_diffs_lists_dest`
- Integration: `test_patch_apply_empty_create_lists_dest_in_json`
- Integration: `test_tx_for_each_rejects_plan_cwd` now asserts `error_kind: invalid_input` and exit 1
- Integration: unknown `{file}` placeholder now expects `invalid_input` / exit 1
- `make check-fast` green
- Release-binary re-run of R9 S4 and S11 after the rebuild

Found by running the release binary against dest-host / `for_each` / `--contain` scenarios (not by reading code first).
