### PR TITLE
fix(ast): give validate a message for zero-width parse errors

### DIFF
--- a/src/ast/validate.rs
+++ b/src/ast/validate.rs
@@ -13,7 +13,8 @@ pub struct SyntaxError {
     pub line: usize,
     /// 0-based column.
     pub column: usize,
-    /// The problematic source text (truncated).
+    /// Problematic source slice, or `missing <kind>` / `invalid <kind>`
+    /// when the tree-sitter node has a zero-width span.
     pub text: String,
 }
 
@@ -62,18 +63,31 @@ pub fn validate_file(path: &Path, lang_hint: Option<Language>) -> anyhow::Result
     })
 }
 
+fn error_node_text(node: tree_sitter_lib::Node, source: &str) -> String {
+    let start = node.start_byte();
+    let mut end = node.end_byte().min(start + 50);
+    while end > start && !source.is_char_boundary(end) {
+        end -= 1;
+    }
+    let span = source.get(start..end).unwrap_or("").trim();
+    if !span.is_empty() {
+        return span.to_string();
+    }
+    // MISSING / zero-width ERROR nodes have start==end. Use the grammar
+    // kind so --json agents get a non-empty text field (fixrealloop R31).
+    if node.is_missing() {
+        format!("missing {}", node.kind())
+    } else {
+        format!("invalid {}", node.kind())
+    }
+}
+
 fn collect_errors(node: tree_sitter_lib::Node, source: &str, errors: &mut Vec<SyntaxError>) {
     if node.is_error() || node.is_missing() {
-        let start = node.start_byte();
-        let mut end = node.end_byte().min(start + 50);
-        while end > start && !source.is_char_boundary(end) {
-            end -= 1;
-        }
-        let text = source[start..end].to_string();
         errors.push(SyntaxError {
             line: node.start_position().row + 1,
             column: node.start_position().column,
-            text,
+            text: error_node_text(node, source),
         });
         return; // Don't recurse into error nodes
     }
@@ -133,5 +147,27 @@ mod tests {
         assert!(!result.errors.is_empty());
         // Error should be on line 1 or 2
         assert!(result.errors[0].line <= 2);
+    }
+
+    #[test]
+    fn empty_span_error_has_nonempty_text() {
+        // MISSING / zero-width ERROR nodes have start==end, so a raw
+        // source slice is empty. Agents need a non-empty text field.
+        let source = "fn bad( {}\n";
+        let result = validate_source(source, Language::Rust).unwrap();
+        assert!(!result.valid);
+        assert!(
+            result.errors.iter().all(|e| !e.text.trim().is_empty()),
+            "empty error text: {:?}",
+            result.errors
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.text.starts_with("missing ") || e.text.starts_with("invalid ")),
+            "expected kind fallback text: {:?}",
+            result.errors
+        );
     }
 }

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -361,6 +361,11 @@ fn test_ast_validate_json_exit_code_on_invalid_file() {
     let arr = v.as_array().expect("validate --json must be array");
     assert_eq!(arr.len(), 1);
     assert_eq!(arr[0]["valid"], serde_json::json!(false));
+    let text_field = arr[0]["errors"][0]["text"].as_str().unwrap_or_default();
+    assert!(
+        !text_field.trim().is_empty(),
+        "validate JSON error text must be non-empty: {arr:?}"
+    );
 }
 
 /// Multi-file validate --json must be one array, not multi-document JSON.

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -3936,6 +3936,15 @@ async fn test_mcp_ast_validate_syntax_error() {
         results.iter().any(|r| r["valid"] == false),
         "broken code should fail validation: {val}"
     );
+    let texts: Vec<&str> = results
+        .iter()
+        .flat_map(|r| r["errors"].as_array().into_iter().flatten())
+        .filter_map(|e| e["text"].as_str())
+        .collect();
+    assert!(
+        texts.iter().any(|t| !t.trim().is_empty()),
+        "ast_validate error text must be non-empty: {val}"
+    );
     client.cancel().await.unwrap();
 }
 


### PR DESCRIPTION
`ast validate --json` reported `valid: false` with `errors[].text` set to an empty string when tree-sitter used a zero-width MISSING or ERROR node.

## Problem

A real dogfood run (`fn bad( {}`) returned:

```json
{"line": 1, "column": 7, "text": ""}
```

Agents that branch on the text field see a syntax failure with no reason. The source slice is empty because those nodes have `start == end`.

## Change

When the source slice is empty, use the grammar kind:

- `missing )` for MISSING nodes
- `invalid ERROR` for zero-width ERROR nodes

CLI `--json` and MCP `ast_validate` share `SyntaxError`.

## Validation

- Unit: `empty_span_error_has_nonempty_text`
- Integration: `test_ast_validate_json_exit_code_on_invalid_file`, `test_mcp_ast_validate_syntax_error`
- Re-ran the R31 fixture: `text` is now `missing )`
- `make check` passed locally

Found by fixrealloop R31.
