### PR TITLE
fix(ast): match literal tokens in --pattern search

### DIFF
--- a/src/ast/search.rs
+++ b/src/ast/search.rs
@@ -120,6 +120,7 @@ pub fn search_file(
 /// Pattern mode: the pattern is parsed as source code for the target language,
 /// and its AST node kinds are converted into an S-expression query.
 /// `$NAME` meta-variables become `@name` captures on identifier nodes.
+/// Literal tokens (identifiers, numbers, strings) match that text via `#eq?`.
 ///
 /// Before parsing, meta-variables (`$NAME`) are replaced with valid placeholder
 /// identifiers (`_pl_NAME_`) so tree-sitter can parse the pattern without errors.
@@ -208,8 +209,19 @@ fn build_query_from_node(
     }
 
     if node.child_count() == 0 {
-        // Leaf node: match exact text
-        query.push_str(&format!("({kind}) @cap{capture_idx}"));
+        // Named leaf: constrain token text. Without #eq?, `(identifier) @cap`
+        // matches any identifier, so `fn compute() {}` also hits `fn other() {}`.
+        // Skip empty text: `class $NAME:` parses an empty `block` leaf that
+        // must still match classes with a body.
+        let cap = format!("cap{capture_idx}");
+        if text.is_empty() {
+            query.push_str(&format!("({kind}) @{cap}"));
+        } else {
+            query.push_str(&format!(
+                "(({kind}) @{cap} (#eq? @{cap} \"{}\"))",
+                escape_ts_string(text)
+            ));
+        }
         *capture_idx += 1;
         return;
     }
@@ -224,6 +236,21 @@ fn build_query_from_node(
         build_query_from_node(child, source, query, capture_idx, placeholders);
     }
     query.push(')');
+}
+
+fn escape_ts_string(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -311,6 +338,44 @@ fn main() {
         let results = search_query(source, &query, Language::Rust, None).unwrap();
         // Should match main and helper (no params), may or may not match process
         assert!(!results.is_empty(), "expected matches for fn pattern");
+    }
+
+    #[test]
+    fn compile_pattern_literal_identifier_is_not_wildcard() {
+        let query = compile_pattern_query("fn compute() {}", Language::Rust).unwrap();
+        let source = "fn compute() {}\nfn other() {}\n";
+        let results = search_query(source, &query, Language::Rust, None).unwrap();
+        let names: Vec<&str> = results
+            .iter()
+            .flat_map(|r| r.captures.iter())
+            .filter(|c| c.text == "compute" || c.text == "other")
+            .map(|c| c.text.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            ["compute"],
+            "literal `compute` must not match `other`; query={query}"
+        );
+        assert_eq!(results.len(), 1, "expected one match, query={query}");
+    }
+
+    #[test]
+    fn compile_pattern_dollar_name_still_matches_any_zero_arg_fn() {
+        let query = compile_pattern_query("fn $NAME() {}", Language::Rust).unwrap();
+        let source = "fn compute() {}\nfn other() {}\n";
+        let results = search_query(source, &query, Language::Rust, None).unwrap();
+        let names: Vec<&str> = results
+            .iter()
+            .flat_map(|r| r.captures.iter())
+            .filter(|c| c.name == "NAME")
+            .map(|c| c.text.as_str())
+            .collect();
+        assert_eq!(names, ["compute", "other"], "query={query}");
+    }
+
+    #[test]
+    fn escape_ts_string_quotes_and_backslash() {
+        assert_eq!(escape_ts_string(r#"a"b\c"#), r#"a\"b\\c"#);
     }
 
     #[test]

--- a/src/cmd/ast/query.rs
+++ b/src/cmd/ast/query.rs
@@ -369,7 +369,10 @@ pub struct SearchArgs {
     /// File or directory to search.
     pub path: String,
 
-    /// Treat the query as a code pattern with meta-variables ($VAR, $$$MULTI).
+    /// Treat the query as a code pattern with `$VAR` meta-variables.
+    /// The pattern must be valid source after substituting `$VAR` (use
+    /// `fn $NAME() {}`, not `fn $NAME()`). Literal tokens match exactly.
+    /// `$$$MULTI` is not implemented (use an S-expression query instead).
     #[arg(long)]
     pub pattern: bool,
 

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -1068,7 +1068,7 @@ impl PatchloomService {
     }
 
     #[tool(
-        description = "Structural search using AST queries. Use S-expression syntax or set pattern=true for code patterns with meta-variables ($VAR, $$$MULTI). Example: {\"query\": \"(function_item name: (identifier) @name)\", \"path\": \"src/\"}"
+        description = "Structural search using AST queries. Use S-expression syntax or set pattern=true for code patterns with $VAR meta-variables (pattern must be valid source after substitution, e.g. fn $NAME() {}). Literal tokens match exactly. $$$MULTI is not implemented. Example: {\"query\": \"(function_item name: (identifier) @name)\", \"path\": \"src/\"}"
     )]
     async fn ast_search(
         &self,

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -435,7 +435,9 @@ pub(crate) struct AstSearchParams {
     pub query: String,
     /// File or directory to search (relative to working directory).
     pub path: String,
-    /// Treat the query as a code pattern with meta-variables ($VAR, $$$MULTI).
+    /// Treat the query as a code pattern with `$VAR` meta-variables.
+    /// The pattern must be valid source after substituting `$VAR`.
+    /// Literal tokens match exactly. `$$$MULTI` is not implemented.
     #[serde(default)]
     pub pattern: bool,
     /// Language hint (required for pattern mode).

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -592,6 +592,41 @@ fn test_ast_search_invalid_query_exits_4() {
     assert_eq!(json["error_kind"], "parse_error", "{json}");
 }
 
+/// Pattern-mode literals must not act as wildcards (`fn compute() {}` ≠ `fn other()`).
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_search_pattern_literal_name_is_not_wildcard() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("lib.rs");
+    fs::write(&f, "fn compute() {}\nfn other() {}\n").unwrap();
+    let out = patchloom_in(dir.path())
+        .args([
+            "--json",
+            "ast",
+            "search",
+            "--pattern",
+            "fn compute() {}",
+            "--lang",
+            "rust",
+            "lib.rs",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let arr = json.as_array().expect("search --json is an array");
+    assert_eq!(arr.len(), 1, "{json}");
+    let blob = json.to_string();
+    assert!(blob.contains("compute"), "{json}");
+    assert!(!blob.contains("other"), "{json}");
+}
+
 /// Pattern mode must fail closed on compile errors (not soft no_matches).
 #[test]
 #[cfg(feature = "ast")]


### PR DESCRIPTION
`ast search --pattern 'fn compute() {}'` also matched `fn other() {}`.

## Problem

Pattern mode compiles source to a tree-sitter query. Named leaves were emitted as `(identifier) @cap` with no text constraint. The comment said "match exact text" but the query only matched node kinds. A literal function name was a wildcard.

Found in fixrealloop R34.

## Change

- Leaf tokens with non-empty text now use `#eq?` so `fn compute() {}` matches only `compute`.
- Empty leaves stay unconstrained (`class $NAME:` still matches classes that have a body).
- `$NAME` still matches any identifier.
- CLI/MCP help no longer claims `$$$MULTI` works. That gap is [#2185](https://github.com/patchloom/patchloom/issues/2185).

## Validation

- Unit: `compile_pattern_literal_identifier_is_not_wildcard`, `$NAME` still matches both names, Python `class $NAME:` still matches, string escape.
- Integration: `test_ast_search_pattern_literal_name_is_not_wildcard`.
- Dogfood: `fn compute() {}` hits one function; `fn $NAME() {}` hits both.
- `make check` green locally.

Ref #2185
