### PR TITLE
fix(replace): keep line indent on insert-before

### DIFF
--- a/src/api/replace.rs
+++ b/src/api/replace.rs
@@ -256,7 +256,16 @@ fn replace_write(
             (start, end)
         });
 
-        let (new_content, count) = if whole_line {
+        let (new_content, count) = if let Some(ib) = insert_before.as_deref() {
+            ops::replace::replace_insert_before(
+                &original,
+                &old,
+                ib,
+                compiled_re.as_ref(),
+                nth,
+                case_insensitive,
+            )
+        } else if whole_line {
             ops::replace::replace_whole_lines(
                 &original,
                 &old,
@@ -661,7 +670,16 @@ fn replace_in_content_inner(
 
     let parsed_range = opts.range;
 
-    let (new_content, count) = if opts.whole_line {
+    let (new_content, count) = if let Some(ib) = opts.insert_before.as_deref() {
+        ops::replace::replace_insert_before(
+            content,
+            from,
+            ib,
+            compiled_re.as_ref(),
+            opts.nth,
+            opts.case_insensitive,
+        )
+    } else if opts.whole_line {
         ops::replace::replace_whole_lines(
             content,
             from,

--- a/src/cmd/replace.rs
+++ b/src/cmd/replace.rs
@@ -362,6 +362,15 @@ fn collect_replacements_with_list(
                 let (out, n) =
                     crate::ops::shell_token::replace_command_position(&content, from, to);
                 (std::borrow::Cow::Owned(out), n)
+            } else if let Some(ib) = insert_before.as_deref() {
+                crate::ops::replace::replace_insert_before(
+                    &content,
+                    from,
+                    ib,
+                    compiled_re.as_ref(),
+                    nth,
+                    case_insensitive,
+                )
             } else if whole_line {
                 replace_whole_lines(
                     &content,

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -685,6 +685,114 @@ pub fn replace_content<'a>(
     }
 }
 
+/// Start of horizontal whitespace before `start` when that whitespace is the
+/// whole indent of the line. Mid-line spaces (e.g. `xx foo`) are not indent.
+pub fn leading_line_indent_start(content: &str, start: usize) -> usize {
+    let bytes = content.as_bytes();
+    let mut i = start;
+    while i > 0 && (bytes[i - 1] == b' ' || bytes[i - 1] == b'\t') {
+        i -= 1;
+    }
+    if i == 0 || matches!(bytes[i - 1], b'\n' | b'\r') {
+        i
+    } else {
+        start
+    }
+}
+
+fn insert_before_is_line_oriented(
+    file_content: &str,
+    anchor: &str,
+    insert: &str,
+    case_insensitive: bool,
+) -> bool {
+    if ends_with_line_ending(insert) || starts_with_line_ending(anchor) {
+        return looks_like_new_line_payload(insert)
+            || anchor_is_whole_line_ci(file_content, anchor, case_insensitive);
+    }
+    looks_like_new_line_payload(insert)
+        || anchor_is_whole_line_ci(file_content, anchor, case_insensitive)
+}
+
+/// Insert `insert` before each match of `from`, keeping line indent on the
+/// original anchor when the insert is line-oriented (#2187).
+///
+/// `fn compute() {}` style `--before 'let x = 1;'` on an indented line must
+/// not steal the indent onto the new line and leave `let x` at column 0.
+pub fn replace_insert_before<'a>(
+    content: &'a str,
+    from: &str,
+    insert: &str,
+    compiled_re: Option<&Regex>,
+    nth: Option<usize>,
+    case_insensitive: bool,
+) -> (std::borrow::Cow<'a, str>, usize) {
+    use std::borrow::Cow;
+
+    struct Hit {
+        start: usize,
+        end: usize,
+    }
+
+    let mut hits: Vec<Hit> = Vec::new();
+    if let Some(re) = compiled_re {
+        let content_len = content.len();
+        for caps in re.captures_iter(content) {
+            let Some(m) = caps.get(0) else {
+                continue;
+            };
+            if m.start() == content_len && m.end() == content_len {
+                continue;
+            }
+            hits.push(Hit {
+                start: m.start(),
+                end: m.end(),
+            });
+        }
+    } else if !from.is_empty() {
+        for (start, _) in content.match_indices(from) {
+            hits.push(Hit {
+                start,
+                end: start + from.len(),
+            });
+        }
+    }
+
+    let selected: Vec<Hit> = if let Some(n) = nth {
+        hits.into_iter()
+            .nth(n.saturating_sub(1))
+            .into_iter()
+            .collect()
+    } else {
+        hits
+    };
+    if selected.is_empty() {
+        return (Cow::Borrowed(content), 0);
+    }
+
+    let count = selected.len();
+    let mut out = content.to_string();
+    for hit in selected.into_iter().rev() {
+        let matched = out[hit.start..hit.end].to_string();
+        // Whole-line detection uses the search pattern (`from`), not the
+        // matched text. A regex `b+` that matches a whole line `bbb` must
+        // stay byte-exact (legacy `Xbbb`), same as build_replacement_text.
+        let line_oriented = insert_before_is_line_oriented(&out, from, insert, case_insensitive);
+        let (span_start, replacement) = if line_oriented {
+            let indent_start = leading_line_indent_start(&out, hit.start);
+            let indent = out[indent_start..hit.start].to_string();
+            // Detect whole-line using `from` (the pattern), not `matched`.
+            let normalized =
+                normalize_line_insert_ci(&out, from, insert, InsertSide::Before, case_insensitive);
+            (indent_start, format!("{normalized}{indent}{matched}"))
+        } else {
+            (hit.start, format!("{insert}{matched}"))
+        };
+        out.replace_range(span_start..hit.end, &replacement);
+    }
+    (Cow::Owned(out), count)
+}
+
 /// Score how well a content fragment matches a context fragment.
 ///
 /// Uses Jaro-Winkler (full-string similarity) and substring containment.

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -318,6 +318,30 @@ mod replace_tests {
         }
 
         #[test]
+        fn leading_line_indent_start_line_start_vs_mid_line() {
+            assert_eq!(leading_line_indent_start("    let x = 1;\n", 4), 0);
+            assert_eq!(leading_line_indent_start("xx foo yy", 3), 3);
+            assert_eq!(leading_line_indent_start("a\n    b", 6), 2);
+        }
+
+        #[test]
+        fn replace_insert_before_keeps_indent_on_anchor() {
+            let file = "fn main() {\n    let x = 1;\n}\n";
+            let (out, n) =
+                replace_insert_before(file, "let x = 1;", "    let y = 0;", None, None, false);
+            assert_eq!(n, 1);
+            assert_eq!(out, "fn main() {\n    let y = 0;\n    let x = 1;\n}\n");
+        }
+
+        #[test]
+        fn replace_insert_before_midline_stays_byte_exact() {
+            let file = "xx foo yy\n";
+            let (out, n) = replace_insert_before(file, "foo", "X", None, None, false);
+            assert_eq!(n, 1);
+            assert_eq!(out, "xx Xfoo yy\n");
+        }
+
+        #[test]
         fn normalize_line_insert_already_has_newline_unchanged() {
             let file = "fn f() {\n}\n";
             let after = normalize_line_insert(file, "fn f() {", "\n// c\n", InsertSide::After);

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -8,7 +8,7 @@ use crate::api::MatchMode;
 use crate::ops::replace::{
     InsertSide, ReplacementTextParams, build_replacement_text, compile_replace_regex,
     context_filtered_span_with_re, expand_match_anchor_template, normalize_line_insert,
-    replace_content, replace_whole_lines,
+    replace_content, replace_insert_before, replace_whole_lines,
 };
 use crate::plan::Operation;
 use crate::tx::output::merge_match_modes;
@@ -238,6 +238,15 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
             let to = new_text.as_deref().unwrap_or("");
             let (out, n) = crate::ops::shell_token::replace_command_position(content, old, to);
             (std::borrow::Cow::Owned(out), n)
+        } else if let Some(ib) = insert_before.as_deref() {
+            crate::ops::replace::replace_insert_before(
+                content,
+                old,
+                ib,
+                compiled_re.as_ref(),
+                *nth,
+                *case_insensitive,
+            )
         } else if *whole_line {
             replace_whole_lines(
                 content,
@@ -389,14 +398,23 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             Some("exact_old_absent"),
                         );
                     } else {
+                        let match_end = anchor.start_offset + anchor.matched_text.len();
+                        let mut span_start = anchor.start_offset;
                         let to_text = if let Some(ib) = insert_before {
-                            let ib = normalize_line_insert(
-                                content,
-                                &anchor.matched_text,
-                                ib,
-                                InsertSide::Before,
-                            );
-                            format!("{}{}", ib, anchor.matched_text)
+                            let matched = &anchor.matched_text;
+                            let normalized =
+                                normalize_line_insert(content, matched, ib, InsertSide::Before);
+                            let indent_start =
+                                crate::ops::replace::leading_line_indent_start(content, span_start);
+                            if indent_start < span_start
+                                && (normalized.ends_with('\n') || normalized.ends_with('\r'))
+                            {
+                                let indent = &content[indent_start..span_start];
+                                span_start = indent_start;
+                                format!("{normalized}{indent}{matched}")
+                            } else {
+                                format!("{normalized}{matched}")
+                            }
                         } else if let Some(ia) = insert_after {
                             let ia = normalize_line_insert(
                                 content,
@@ -410,9 +428,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         };
                         let new_content = format!(
                             "{}{}{}",
-                            &content[..anchor.start_offset],
+                            &content[..span_start],
                             to_text,
-                            &content[anchor.start_offset + anchor.matched_text.len()..]
+                            &content[match_end..]
                         );
                         tx.write_file(&file_path, new_content);
                         record_replace_match(
@@ -559,6 +577,15 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                 let to = new_text.as_deref().unwrap_or("");
                 let (out, n) = crate::ops::shell_token::replace_command_position(&content, old, to);
                 (std::borrow::Cow::Owned(out), n)
+            } else if let Some(ib) = insert_before.as_deref() {
+                replace_insert_before(
+                    &content,
+                    old,
+                    ib,
+                    compiled_re.as_ref(),
+                    *nth,
+                    *case_insensitive,
+                )
             } else if *whole_line {
                 replace_whole_lines(
                     &content,
@@ -721,15 +748,24 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                             );
                             continue;
                         }
+                        let match_end = anchor.start_offset + anchor.matched_text.len();
+                        let mut span_start = anchor.start_offset;
                         let to_text = if let Some(ib) = insert_before {
-                            // Parity with path arm: normalize line insert EOL.
-                            let ib = normalize_line_insert(
-                                &content,
-                                &anchor.matched_text,
-                                ib,
-                                InsertSide::Before,
+                            let matched = &anchor.matched_text;
+                            let normalized =
+                                normalize_line_insert(&content, matched, ib, InsertSide::Before);
+                            let indent_start = crate::ops::replace::leading_line_indent_start(
+                                &content, span_start,
                             );
-                            format!("{}{}", ib, anchor.matched_text)
+                            if indent_start < span_start
+                                && (normalized.ends_with('\n') || normalized.ends_with('\r'))
+                            {
+                                let indent = &content[indent_start..span_start];
+                                span_start = indent_start;
+                                format!("{normalized}{indent}{matched}")
+                            } else {
+                                format!("{normalized}{matched}")
+                            }
                         } else if let Some(ia) = insert_after {
                             let ia = normalize_line_insert(
                                 &content,
@@ -743,9 +779,9 @@ pub(crate) fn execute_replace_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow
                         };
                         let new_content = format!(
                             "{}{}{}",
-                            &content[..anchor.start_offset],
+                            &content[..span_start],
                             to_text,
-                            &content[anchor.start_offset + anchor.matched_text.len()..]
+                            &content[match_end..]
                         );
                         tx.write_file(&file_path, new_content);
                         record_replace_match(

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -3510,6 +3510,31 @@ fn test_apply_fragment_cli_after_strips_markers() {
     );
 }
 
+/// #2187: --before must keep indent on the original anchor line.
+#[test]
+fn test_apply_fragment_cli_before_preserves_anchor_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.rs");
+    fs::write(&file, "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("apply-fragment")
+        .arg(file.to_str().unwrap())
+        .arg("--before")
+        .arg("let x = 1;")
+        .arg("--fragment")
+        .arg("    let y = 0;")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn main() {\n    let y = 0;\n    let x = 1;\n}\n"
+    );
+}
+
 /// #2018: CLI apply-fragment dry-run preview is exit 2 and leaves file unchanged.
 #[test]
 fn test_apply_fragment_cli_preview_exit_2() {


### PR DESCRIPTION
`apply-fragment --before` (and `replace --insert-before`) dropped the indent on the anchor line when the fragment looked like a new line.

## Problem

`--before 'let x = 1;'` matches the substring, not the full line. Leading spaces stayed in front of the replacement. A line-like fragment then became `{indent}{fragment}\n{anchor}`, so `let x` moved to column 0.

`--after` already kept the indent. Found in fixrealloop R38.

## Change

`replace_insert_before` extends a line-oriented match over the line indent and re-attaches that indent to the original anchor. Mid-line inserts stay byte-exact. Whole-line detection still uses the search pattern (regex `b+` matching `bbb` stays `Xbbb`).

## Validation

- Unit: indent kept on `let x = 1;`; mid-line `xx Xfoo yy`; indent-start helper
- Integration: `test_apply_fragment_cli_before_preserves_anchor_indent`
- Existing `--insert-before` / regex / nth / plan tests
- Dogfood: `fn main() {\n    let y = 0;\n    let x = 1;\n}\n`
- `make check` green locally

Closes #2187
