### PR TITLE
fix(batch): suggest file.create for bare creat typo

### DIFF
--- a/src/cmd/batch.rs
+++ b/src/cmd/batch.rs
@@ -470,10 +470,17 @@ fn suggest_batch_op(op: &str) -> Option<String> {
         return Some(suffix.join(", "));
     }
 
+    // Score full names (`file.creat` → `file.create`) and leaves
+    // (`creat` → `create` → `file.create`). Bare JW vs `file.create`
+    // stays below 0.86 (#2189).
     let mut scored: Vec<(&str, f64)> = KNOWN_BATCH_OPS
         .iter()
         .copied()
-        .map(|k| (k, strsim::jaro_winkler(op, k)))
+        .map(|k| {
+            let leaf = k.rsplit_once('.').map(|(_, l)| l).unwrap_or(k);
+            let score = strsim::jaro_winkler(op, k).max(strsim::jaro_winkler(op, leaf));
+            (k, score)
+        })
         .filter(|(_, score)| *score >= 0.86)
         .collect();
     scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));

--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -949,6 +949,16 @@ mod error_handling {
         );
     }
 
+    #[test]
+    fn parse_line_suggests_file_create_for_bare_creat_typo() {
+        let err = parse_line(r#"creat path.txt "hi""#, 1).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did you mean") && msg.contains("file.create"),
+            "expected leaf-typo suggestion, got: {msg}"
+        );
+    }
+
     /// Agents invent `file.replace` from `file.create` / `file.delete`.
     /// Suggest bare `replace`, not JW neighbors like `file.rename`.
     #[test]

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -445,6 +445,21 @@ fn test_batch_bare_create_suggests_file_create() {
         .stderr(predicates::str::contains("did you mean: file.create?"));
 }
 
+/// Bare 1-char typo of a leaf (`creat`) should still suggest `file.create` (#2189).
+#[test]
+fn test_batch_bare_creat_typo_suggests_file_create() {
+    let dir = TempDir::new().unwrap();
+    patchloom_in(dir.path())
+        .arg("batch")
+        .arg("--apply")
+        .write_stdin("creat new.txt \"hi\"\n")
+        .assert()
+        .code(4) // PARSE_ERROR
+        .stderr(
+            predicates::str::contains("did you mean").and(predicates::str::contains("file.create")),
+        );
+}
+
 /// Typo of a known op should offer fuzzy neighbors.
 #[test]
 fn test_batch_typo_file_create_suggests_neighbors() {


### PR DESCRIPTION
Bare batch typo `creat` had no did-you-mean, while `create` and `file.creat` already suggested `file.create`.

## Problem

`suggest_batch_op` exact-matches a bare name to a known leaf, then fuzzy-compares only against full namespaced ops. `creat` vs `file.create` stays below the 0.86 floor.

Found in fixrealloop R42.

## Change

Fuzzy scoring also compares the typed token to each op's leaf (`create` in `file.create`). `creat` now suggests `file.create`. Existing `create` and `file.creat` paths are unchanged.

## Validation

- Unit: `parse_line_suggests_file_create_for_bare_creat_typo` plus existing create / file.creat / append / file.replace tests
- Integration: `test_batch_bare_creat_typo_suggests_file_create`
- `make check` green locally

Closes #2189
