### PR TITLE
fix(search): say replace --unique instead of tipping --quiet

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3042,6 +3042,7 @@ fn search_parity_custom_ignore_across_api_cli_and_plan() {
             case_insensitive: false,
             assert_count: None,
             max_results: opts.max_results,
+            unique: false,
         };
         let cli_results = crate::cmd::search::collect_matches(&cli_args, &g).unwrap();
         cli_results.file_match_counts.values().sum()

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -294,6 +294,7 @@ impl PatchloomService {
                 case_insensitive: p.case_insensitive,
                 assert_count: p.assert_count,
                 max_results: p.max_results,
+                unique: false,
             };
             let mut global = GlobalFlags::with_cwd_and_json(svc.cwd());
             global.glob = p.globs;

--- a/src/cmd/search.rs
+++ b/src/cmd/search.rs
@@ -83,6 +83,10 @@ pub struct SearchArgs {
     /// `truncated: true` when a list was cut.
     #[arg(long, default_value_t = 0)]
     pub max_results: usize,
+    /// Hidden reject so clap does not tip `--quiet` for `--unique` (#2196).
+    /// `--unique` is a replace flag (fail when the old string matches more than once).
+    #[arg(long, hide = true)]
+    pub unique: bool,
 }
 
 impl SearchArgs {
@@ -516,6 +520,11 @@ pub(crate) fn format_results(
 }
 
 pub fn run(args: SearchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
+    if args.unique {
+        let msg = "search does not take --unique; use replace --unique to fail when the old string matches more than once";
+        global.emit_error_json_kind(Some("invalid_input"), msg)?;
+        return Ok(exit::FAILURE);
+    }
     if args.pattern.is_empty() {
         let msg = "search pattern must not be empty";
         global.emit_error_json_kind(Some("invalid_input"), msg)?;
@@ -764,6 +773,7 @@ mod tests {
             case_insensitive: false,
             assert_count: None,
             max_results: 0,
+            unique: false,
         }
     }
 
@@ -771,6 +781,15 @@ mod tests {
     fn empty_pattern_rejected() {
         let dir = make_test_dir();
         let args = make_args("", vec![dir.path().to_string_lossy().into_owned()]);
+        let code = run(args, &GlobalFlags::test_default()).unwrap();
+        assert_eq!(code, exit::FAILURE);
+    }
+
+    #[test]
+    fn unique_flag_is_invalid_input() {
+        let dir = make_test_dir();
+        let mut args = make_args("Hello", vec![dir.path().to_string_lossy().into_owned()]);
+        args.unique = true;
         let code = run(args, &GlobalFlags::test_default()).unwrap();
         assert_eq!(code, exit::FAILURE);
     }

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -801,6 +801,33 @@ fn test_search_files_with_and_without_match_are_rejected_together() {
 }
 
 #[test]
+fn test_search_unique_is_invalid_input_mentions_replace() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("t.txt"), "needle\n").unwrap();
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["search", "needle", ".", "--unique"])
+        .output()
+        .unwrap();
+    assert_ne!(out.status.code(), Some(0));
+    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .unwrap_or_else(|_| serde_json::from_slice(&out.stderr).unwrap_or(serde_json::json!({})));
+    let blob = format!("{parsed}{}", String::from_utf8_lossy(&out.stderr));
+    assert!(
+        parsed.get("error_kind").and_then(|v| v.as_str()) == Some("invalid_input")
+            || blob.contains("invalid_input"),
+        "expected invalid_input: {blob}"
+    );
+    assert!(
+        blob.contains("replace") && blob.contains("--unique"),
+        "should point at replace --unique: {blob}"
+    );
+    assert!(!blob.contains("--quiet"), "must not tip --quiet: {blob}");
+}
+
+#[test]
 fn test_search_help_documents_files_without_match() {
     Command::cargo_bin("patchloom")
         .unwrap()


### PR DESCRIPTION
`search --unique` is not a search flag. Clap rejected it and suggested `--quiet`.

Search now accepts hidden `--unique` and returns `invalid_input` that names `replace --unique` (fail when the old string matches more than once).

## Tests
- Unit: `unique_flag_is_invalid_input`
- cargo-bin: JSON mentions replace `--unique`, not `--quiet`

Closes #2196