### PR TITLE
fix(doc): treat . as document root on set

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -481,13 +481,15 @@ All `doc` operations use selector paths to address values inside JSON, YAML, and
 | Syntax | Meaning | Example |
 |--------|---------|---------|
 | `name` | Object key | `database.host` |
+| `.` | Document root | `doc keys FILE .`; `doc set FILE . VALUE` replaces the whole document |
 | `[N]` | Array index (zero-based) | `servers[0].port` |
 | `[*]` | Wildcard (all array elements) | `jobs[*].timeout` |
 | `[key=val]` | Predicate (filter by field value) | `deps[name=express].version` |
 
-Segments are separated by `.` or adjacent brackets. A single leading `/` is treated as "from root" and stripped (JSON Pointer habit), so `/feature_flag` sets key `feature_flag`, not a key literally named `/feature_flag` (#1794). Only one leading slash is special; `//a` keeps a key named `/a`. Prefer bare keys in prompts (`feature_flag`, `server.port`). Examples:
+Segments are separated by `.` or adjacent brackets. A single leading `/` is treated as "from root" and stripped (JSON Pointer habit), so `/feature_flag` sets key `feature_flag`, not a key literally named `/feature_flag` (#1794). Only one leading slash is special; `//a` keeps a key named `/a`. Prefer bare keys in prompts (`feature_flag`, `server.port`). A lone `.` (or empty / `/`) is the document root: `doc keys FILE .` lists top-level keys, and `doc set FILE . VALUE` replaces the whole document. Examples:
 
 ```text
+.                               # document root (keys / whole-document set)
 scripts.test                    # simple selector path
 /feature_flag                   # same as feature_flag (leading slash stripped)
 jobs[0].steps[*].name           # index + wildcard

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -777,6 +777,7 @@ Use these when the top level `doc` command is right, but you need a specific str
 - **Prefer instead:** Use `doc merge` for multi field updates, or `doc ensure` when existing values should be preserved. Use `doc update` for predicate or wildcard multi-match (`items[name=a].v`, `items[*].enabled`).
 - **Failure behavior:** Predicate or wildcard selectors fail closed (exit 1) with `error_kind: "invalid_input"` and machine-stable `suggested_op: "doc.update"` under `--json` / plan / MCP (#2133). The same mapping applies when the predicate is an **intermediate** parent segment (e.g. `items[id=a].val`), not only a leaf (#2138).
 - **Leading slash:** A single leading `/` is stripped (JSON Pointer habit). `/feature_flag` sets key `feature_flag`, not a key named `/feature_flag` (#1794). Prefer bare keys in agent prompts.
+- **Root selector:** `.` (also empty or `/`) is the document root. `doc keys FILE .` lists top-level keys. `doc set FILE . VALUE` replaces the whole document.
 
 <!-- ref:doc-action:delete -->
 ### `doc delete`

--- a/src/cmd/agent_rules/reference.rs
+++ b/src/cmd/agent_rules/reference.rs
@@ -11,12 +11,14 @@ pub(crate) fn append_reference(out: &mut String, show_cli: bool) {
          | Syntax | Meaning | Example |\n\
          |--------|---------|---------|\n\
          | `name` | Object key | `database.host` |\n\
+         | `.` | Document root | `doc keys FILE .`; `doc set FILE . VALUE` replaces the whole document |\n\
          | `[N]` | Array index (zero-based) | `servers[0].port` |\n\
          | `[*]` | Wildcard (all array elements) | `jobs[*].timeout` |\n\
          | `[key=val]` | Predicate (filter by field value) | `deps[name=express].version` |\n\n\
          Segments are separated by `.` or adjacent brackets. A single leading `/` is treated as \
-\"from root\" and stripped (JSON Pointer habit), so `/feature_flag` sets key `feature_flag`, not a key literally named `/feature_flag` (#1794). Only one leading slash is special; `//a` keeps a key named `/a`. Prefer bare keys in prompts (`feature_flag`, `server.port`). Examples:\n\n\
+\"from root\" and stripped (JSON Pointer habit), so `/feature_flag` sets key `feature_flag`, not a key literally named `/feature_flag` (#1794). Only one leading slash is special; `//a` keeps a key named `/a`. Prefer bare keys in prompts (`feature_flag`, `server.port`). A lone `.` (or empty / `/`) is the document root: `doc keys FILE .` lists top-level keys, and `doc set FILE . VALUE` replaces the whole document. Examples:\n\n\
          ```text\n\
+         .                               # document root (keys / whole-document set)\n\
          scripts.test                    # simple selector path\n\
          /feature_flag                   # same as feature_flag (leading slash stripped)\n\
          jobs[0].steps[*].name           # index + wildcard\n\

--- a/src/cmd/agent_rules/tests.rs
+++ b/src/cmd/agent_rules/tests.rs
@@ -40,6 +40,10 @@ fn default_includes_all_sections() {
             || out.contains("still a number"),
         "batch value note must warn that double-quoted 2.0 stays a JSON number: {out}"
     );
+    assert!(
+        out.contains("doc set FILE . VALUE") && out.contains("replaces the whole document"),
+        "selector table must say `.` is root for doc set: {out}"
+    );
 }
 
 #[test]

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -54,6 +54,7 @@ pub enum DocAction {
         /// File path (JSON, YAML, or TOML).
         file: String,
         /// Selector path (e.g. `server.port`, `items[0].name`).
+        /// Use `.` to replace the whole document (same root as `doc keys FILE .`).
         /// Single concrete path only (keys and indexes). Not for
         /// predicates or wildcards (`items[name=foo].v`, `items[*].v`);
         /// use `doc update` for multi-match writes.

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -123,10 +123,10 @@ pub fn set_at_path(
     segments: &[selector::Segment],
     value: serde_json::Value,
 ) -> anyhow::Result<()> {
+    // `.`, ``, and `/` parse to no segments. Same root as `doc keys FILE .`.
     if segments.is_empty() {
-        return Err(anyhow::Error::new(crate::exit::InvalidInputError {
-            msg: "empty selector".into(),
-        }));
+        *root = value;
+        return Ok(());
     }
     let (parent_path, last) = split_last(segments);
     let parent = navigate_mut(root, parent_path, true, "doc.set")?;
@@ -904,13 +904,13 @@ mod tests {
     }
 
     #[test]
-    fn set_at_path_empty_selector_errors() {
-        let mut root = json!({});
-        let err = set_at_path(&mut root, &[], json!(1)).expect_err("expected error");
-        assert!(
-            crate::exit::is_invalid_input(&err),
-            "empty selector should be invalid_input: {err}"
-        );
+    fn set_at_path_empty_selector_replaces_root() {
+        // `.` / `` / `/` parse to no segments. Same meaning as `doc keys FILE .`.
+        let mut root = json!({"a": 1});
+        set_at_path(&mut root, &[], json!({"b": 2})).unwrap();
+        assert_eq!(root, json!({"b": 2}));
+        set_at_path(&mut root, &segs("."), json!({"c": 3})).unwrap();
+        assert_eq!(root, json!({"c": 3}));
     }
 
     #[test]

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -111,6 +111,7 @@ pub enum Operation {
         /// Path to the JSON, YAML, or TOML file.
         path: String,
         /// Dot-notation selector path (e.g. "server.port", "env.0.value").
+        /// `.` (or empty / `/`) is the document root and replaces the whole value.
         /// Alias `key` accepted because agents often emit that name (LLM prior).
         #[serde(alias = "key")]
         selector: String,

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -3407,6 +3407,51 @@ fn test_doc_set_leading_slash_selector_strips_root() {
     assert_eq!(v2, serde_json::json!({"server": {"port": 8080}}));
 }
 
+/// #2197: `doc set FILE . VALUE` replaces the document root (same as `doc keys FILE .`).
+#[test]
+fn test_doc_set_dot_replaces_root() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("d.json");
+    fs::write(&file, "{\"a\":1}\n").unwrap();
+
+    let out = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["doc", "set", "d.json", ".", "{\"b\":2}", "--apply"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["applied"], true, "{v}");
+    assert_ne!(
+        v["error_kind"], "invalid_input",
+        "must not call `.` an empty selector: {v}"
+    );
+    let on_disk: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert_eq!(on_disk, serde_json::json!({"b": 2}));
+
+    // `doc keys FILE .` still lists root keys.
+    let keys = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["doc", "keys", "d.json", "."])
+        .output()
+        .unwrap();
+    assert_eq!(keys.status.code(), Some(0));
+    let kv: serde_json::Value = serde_json::from_slice(&keys.stdout).unwrap();
+    assert_eq!(kv["value"], serde_json::json!(["b"]), "{kv}");
+}
+
 /// #1810: doc set preview sets applied:false (changed means would-change).
 #[test]
 fn test_doc_set_preview_applied_false() {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -33,6 +33,30 @@ async fn test_mcp_doc_set_round_trip() {
     client.cancel().await.unwrap();
 }
 
+/// #2197: MCP `doc_set` selector `.` replaces the document root.
+#[tokio::test]
+async fn test_mcp_doc_set_dot_replaces_root() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("d.json"), r#"{"a":1}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_set",
+        serde_json::json!({"path": "d.json", "selector": ".", "value": {"b": 2}}),
+    )
+    .await;
+    assert!(!is_error, "doc_set `.` should succeed: {val}");
+    assert_eq!(val["ok"], true, "{val}");
+    let content = fs::read_to_string(dir.path().join("d.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+    assert_eq!(v, serde_json::json!({"b": 2}), "{content}");
+    client.cancel().await.unwrap();
+}
+
 /// #1696: registry MCP accepts LLM-prior `key` as alias for `selector`.
 #[tokio::test]
 async fn test_mcp_doc_delete_accepts_key_alias() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -706,6 +706,36 @@ fn test_tx_success_applies_all() {
     assert_eq!(v["version"], serde_json::json!(2));
 }
 
+/// #2197: plan `doc.set` with selector `.` replaces the document root.
+#[test]
+fn test_tx_doc_set_dot_replaces_root() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("d.json");
+    fs::write(&file, r#"{"a":1}"#).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {"op": "doc.set", "path": "d.json", "selector": ".", "value": {"b": 2}}
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--cwd")
+        .arg(dir.path())
+        .arg("tx")
+        .arg(&plan_file)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert_eq!(v, serde_json::json!({"b": 2}));
+}
+
 #[test]
 fn test_tx_check_mode_reports_changes_without_writing() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

`doc keys FILE .` lists root keys, but `doc set FILE . VALUE` used to fail with `empty selector` / `invalid_input`. Agents that learn `.` from `keys` reuse it on `set` and get a dead-end error.

`.` (and the same empty-segment parse of `` / `/`) now replaces the document root, matching `doc keys`.

## Problem

```bash
printf '{"a":1}\n' > d.json
patchloom doc keys d.json . --json   # ok, value ["a"]
patchloom doc set d.json . '{"b":2}' --json
# was: invalid_input: empty selector
```

The user passed `.`. Calling that empty was wrong.

## Change

- `set_at_path` with no segments assigns the new value to the document root
- CLI clap, plan `doc.set`, agent-rules selector table, and reference docs name `.` as root
- Multi-surface tests: unit, cargo-bin CLI, `tx`, MCP `doc_set`

## Validation

- Red: `set_at_path_empty_selector_replaces_root` failed with `empty selector`
- Green: that unit test plus
  - `test_doc_set_dot_replaces_root`
  - `test_tx_doc_set_dot_replaces_root`
  - `test_mcp_doc_set_dot_replaces_root`
  - `default_includes_all_sections`

`doc keys FILE .` still lists root keys (asserted in the CLI test).

Closes #2197
