### PR TITLE
fix(apply-fragment): place bare fragments on their own indented line

### DIFF
--- a/src/cmd/apply_fragment.rs
+++ b/src/cmd/apply_fragment.rs
@@ -23,12 +23,16 @@ EXAMPLES:
 NOTES:
   Exactly one of --after, --before, or --old is required (no anchor-less Morph merge).
   Lazy marker lines such as // ... existing code ... are stripped from --fragment.
+  A fragment without a trailing newline is still placed on its own line next to a
+  whole-line (or indented whole-line) anchor; the anchor's indent is copied.
   Dry-run by default (exit 2 when changes would apply). See docs/plans/morph-gap-matrix.md."
 )]
 pub struct ApplyFragmentArgs {
     /// Path of the file to edit.
     pub file: String,
     /// New text or Morph-style snippet (lazy marker lines stripped).
+    /// Without a trailing newline, still inserted as its own line next to a
+    /// whole-line / indented whole-line anchor.
     #[arg(long)]
     pub fragment: Option<String>,
     /// Read fragment from stdin.
@@ -281,6 +285,58 @@ mod tests {
         assert_eq!(code, crate::exit::SUCCESS);
         let body = std::fs::read_to_string(&path).unwrap();
         assert!(body.contains("  pre();\n  a();"), "{body}");
+    }
+
+    /// #2200: `--before` / `--after` with a fragment that has no trailing
+    /// newline still land on their own indented line.
+    #[test]
+    fn apply_fragment_before_bare_fragment_is_own_indented_line() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.rs");
+        std::fs::write(&path, "fn main() {\n    let x = 1;\n}\n").unwrap();
+        let code = run(
+            ApplyFragmentArgs {
+                file: path.to_string_lossy().into(),
+                fragment: Some("let y = 2;".into()),
+                stdin: false,
+                instruction: None,
+                after: None,
+                before: Some("let x = 1;".into()),
+                old: None,
+                allow_non_unique: false,
+                write: Default::default(),
+            },
+            &g_apply(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::SUCCESS);
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body, "fn main() {\n    let y = 2;\n    let x = 1;\n}\n");
+    }
+
+    #[test]
+    fn apply_fragment_after_bare_fragment_is_own_indented_line() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.rs");
+        std::fs::write(&path, "fn main() {\n    let x = 1;\n}\n").unwrap();
+        let code = run(
+            ApplyFragmentArgs {
+                file: path.to_string_lossy().into(),
+                fragment: Some("let y = 2;".into()),
+                stdin: false,
+                instruction: None,
+                after: Some("let x = 1;".into()),
+                before: None,
+                old: None,
+                allow_non_unique: false,
+                write: Default::default(),
+            },
+            &g_apply(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::SUCCESS);
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body, "fn main() {\n    let x = 1;\n    let y = 2;\n}\n");
     }
 
     #[test]

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -205,7 +205,12 @@ pub fn normalize_line_insert(
             if looks_like_new_line_payload(insert_content)
                 || anchor_is_whole_line(file_content, anchor)
             {
-                format!("{eol}{insert_content}")
+                let indent = if insert_content.starts_with([' ', '\t']) {
+                    ""
+                } else {
+                    indent_before_first_anchor(file_content, anchor)
+                };
+                format!("{eol}{indent}{insert_content}")
             } else {
                 insert_content.to_string()
             }
@@ -247,7 +252,12 @@ pub fn normalize_line_insert_ci(
             if looks_like_new_line_payload(insert_content)
                 || anchor_is_whole_line_ci(file_content, anchor, true)
             {
-                format!("{eol}{insert_content}")
+                let indent = if insert_content.starts_with([' ', '\t']) {
+                    ""
+                } else {
+                    indent_before_first_anchor_ci(file_content, anchor, true)
+                };
+                format!("{eol}{indent}{insert_content}")
             } else {
                 insert_content.to_string()
             }
@@ -318,10 +328,13 @@ pub fn anchor_is_whole_line_ci(file_content: &str, anchor: &str, case_insensitiv
         let mut any = false;
         for (i, _) in file_content.match_indices(anchor) {
             any = true;
-            let before_ok = i == 0 || is_line_boundary_byte(bytes[i - 1]);
-            let end = i + anchor.len();
-            let after_ok = end == file_content.len()
-                || bytes.get(end).copied().is_some_and(is_line_boundary_byte);
+            // Indent / trailing spaces on the same line still count as whole-line
+            // (#2200): `    let x = 1;` is the line for anchor `let x = 1;`.
+            let bol = skip_horiz_back(bytes, i);
+            let before_ok = bol == 0 || is_line_boundary_byte(bytes[bol - 1]);
+            let after = skip_horiz_fwd(bytes, i + anchor.len());
+            let after_ok = after == file_content.len()
+                || bytes.get(after).copied().is_some_and(is_line_boundary_byte);
             if !(before_ok && after_ok) {
                 return false;
             }
@@ -341,13 +354,13 @@ pub fn anchor_is_whole_line_ci(file_content: &str, anchor: &str, case_insensitiv
             .map(|i| start + i)
             .unwrap_or(file_content.len());
         let line = &file_content[start..line_end];
-        if line.to_ascii_lowercase() == needle {
+        let trimmed = line.trim_matches([' ', '\t']);
+        if trimmed.to_ascii_lowercase() == needle {
             any = true;
-            // whole line by construction (line == match span)
         } else if !line.is_empty() {
             // Mid-line occurrence of the pattern is not whole-line.
             let lower = line.to_ascii_lowercase();
-            if lower.contains(&needle) && lower != needle {
+            if lower.contains(&needle) && trimmed.to_ascii_lowercase() != needle {
                 return false;
             }
         }
@@ -369,6 +382,46 @@ pub fn anchor_is_whole_line_ci(file_content: &str, anchor: &str, case_insensitiv
 #[inline]
 fn is_line_boundary_byte(b: u8) -> bool {
     b == b'\n' || b == b'\r'
+}
+
+#[inline]
+fn skip_horiz_back(bytes: &[u8], mut i: usize) -> usize {
+    while i > 0 && (bytes[i - 1] == b' ' || bytes[i - 1] == b'\t') {
+        i -= 1;
+    }
+    i
+}
+
+#[inline]
+fn skip_horiz_fwd(bytes: &[u8], mut i: usize) -> usize {
+    while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+        i += 1;
+    }
+    i
+}
+
+/// Horizontal indent immediately before the first `anchor` match, if that
+/// whitespace is the line indent (not mid-line spaces).
+fn indent_before_first_anchor<'a>(file_content: &'a str, anchor: &str) -> &'a str {
+    indent_before_first_anchor_ci(file_content, anchor, false)
+}
+
+fn indent_before_first_anchor_ci<'a>(
+    file_content: &'a str,
+    anchor: &str,
+    case_insensitive: bool,
+) -> &'a str {
+    let i = if case_insensitive {
+        let needle = anchor.to_ascii_lowercase();
+        file_content.to_ascii_lowercase().find(&needle)
+    } else {
+        file_content.find(anchor)
+    };
+    let Some(i) = i else {
+        return "";
+    };
+    let start = leading_line_indent_start(file_content, i);
+    &file_content[start..i]
 }
 
 /// Parameters for [`build_replacement_text`].
@@ -784,7 +837,12 @@ pub fn replace_insert_before<'a>(
             // Detect whole-line using `from` (the pattern), not `matched`.
             let normalized =
                 normalize_line_insert_ci(&out, from, insert, InsertSide::Before, case_insensitive);
-            (indent_start, format!("{normalized}{indent}{matched}"))
+            let insert_out = if insert.starts_with([' ', '\t']) {
+                normalized
+            } else {
+                format!("{indent}{normalized}")
+            };
+            (indent_start, format!("{insert_out}{indent}{matched}"))
         } else {
             (hit.start, format!("{insert}{matched}"))
         };

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -242,6 +242,13 @@ mod replace_tests {
         }
 
         #[test]
+        fn normalize_line_insert_after_indented_anchor_copies_indent() {
+            let file = "fn main() {\n    let x = 1;\n}\n";
+            let out = normalize_line_insert(file, "let x = 1;", "let y = 2;", InsertSide::After);
+            assert_eq!(out, "\n    let y = 2;");
+        }
+
+        #[test]
         fn normalize_line_insert_after_whole_line_crlf_bare_payload() {
             // CRLF after anchor must still count as a line boundary, and the
             // separator must be CRLF so the file does not get mixed LF (fixrealloop).
@@ -331,6 +338,25 @@ mod replace_tests {
                 replace_insert_before(file, "let x = 1;", "    let y = 0;", None, None, false);
             assert_eq!(n, 1);
             assert_eq!(out, "fn main() {\n    let y = 0;\n    let x = 1;\n}\n");
+        }
+
+        /// #2200: fragment without indent or trailing NL is still its own indented line.
+        #[test]
+        fn replace_insert_before_bare_fragment_gets_indent_and_newline() {
+            let file = "fn main() {\n    let x = 1;\n}\n";
+            let (out, n) =
+                replace_insert_before(file, "let x = 1;", "let y = 2;", None, None, false);
+            assert_eq!(n, 1);
+            assert_eq!(out, "fn main() {\n    let y = 2;\n    let x = 1;\n}\n");
+        }
+
+        #[test]
+        fn replace_insert_before_bare_fragment_with_trailing_nl_keeps_indent() {
+            let file = "fn main() {\n    let x = 1;\n}\n";
+            let (out, n) =
+                replace_insert_before(file, "let x = 1;", "let y = 2;\n", None, None, false);
+            assert_eq!(n, 1);
+            assert_eq!(out, "fn main() {\n    let y = 2;\n    let x = 1;\n}\n");
         }
 
         #[test]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -3535,6 +3535,55 @@ fn test_apply_fragment_cli_before_preserves_anchor_indent() {
     );
 }
 
+/// #2200: fragment without indent or trailing NL is still its own indented line.
+#[test]
+fn test_apply_fragment_cli_before_bare_fragment_own_line() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.rs");
+    fs::write(&file, "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("apply-fragment")
+        .arg(file.to_str().unwrap())
+        .arg("--before")
+        .arg("let x = 1;")
+        .arg("--fragment")
+        .arg("let y = 2;")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn main() {\n    let y = 2;\n    let x = 1;\n}\n"
+    );
+}
+
+#[test]
+fn test_apply_fragment_cli_after_bare_fragment_own_line() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.rs");
+    fs::write(&file, "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("apply-fragment")
+        .arg(file.to_str().unwrap())
+        .arg("--after")
+        .arg("let x = 1;")
+        .arg("--fragment")
+        .arg("let y = 2;")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn main() {\n    let x = 1;\n    let y = 2;\n}\n"
+    );
+}
+
 /// #2018: CLI apply-fragment dry-run preview is exit 2 and leaves file unchanged.
 #[test]
 fn test_apply_fragment_cli_preview_exit_2() {


### PR DESCRIPTION
## Summary

`apply-fragment --before` / `--after` glued a fragment with no trailing newline onto the same line as an indented anchor (`    let y = 2;let x = 1;`).

An indented match now counts as a whole line. A fragment that does not already start with spaces gets the anchor indent and a line ending.

## Problem

```bash
printf '    let x = 1;\n' > m.rs
patchloom apply-fragment m.rs --before 'let x = 1;' --fragment 'let y = 2;' --apply
# was:    let y = 2;let x = 1;
# now:    let y = 2;
#         let x = 1;
```

`--after` had the same glue. #2188 kept indent when the fragment already started with spaces. Bare `let y = 2;` still took the mid-line path.

## Change

- `anchor_is_whole_line` allows leading/trailing spaces or tabs on the line
- `replace_insert_before` copies indent onto a fragment that has none
- `normalize_line_insert` After does the same for `--after`
- clap `--fragment` / NOTES mention the line placement
- Unit + in-process CLI + cargo-bin locks

## Validation

- `replace_insert_before_bare_fragment_gets_indent_and_newline`
- `normalize_line_insert_after_indented_anchor_copies_indent`
- `apply_fragment_before_bare_fragment_is_own_indented_line`
- `apply_fragment_after_bare_fragment_is_own_indented_line`
- `test_apply_fragment_cli_before_bare_fragment_own_line`
- `test_apply_fragment_cli_after_bare_fragment_own_line`
- Mid-line `xx foo` and #2188 indented-fragment tests still pass

Closes #2200
