### PR TITLE
docs: mention append/prepend line separator in help

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -528,8 +528,8 @@ dependencies[name=react].version # predicate filter
 
 - `replace`: Replace text in a file using literal string matching. Optional require_change (fail closed on zero matches), command_position (shell invocable tokens only; peels sudo/timeout/busybox/flock/runuser/run0/gosu/unshare/nsenter/taskset/systemd-run/firejail/chpst/softlimit/envdir/setlock wrappers, not uv pip), and fuzzy (similarity fallback when exact match fails). When exact old is absent, fuzzy refuses by default even above min_fuzzy_score; set allow_absent_old for deliberate approximate recovery (#1758). Prefer ast.rename for identifiers.
 - `apply.fragment`: Constrained freeform fragment apply (#2018). Strips Morph-style // ... existing code ... marker lines from fragment, then inserts or replaces at a required unique anchor (exactly one of after, before, old). Fail-closed: no anchor-less Morph model merge. Prefer for lazy-snippet agent output when anchors are known; use replace/ast for precise edits.
-- `file.append`: Append content to an existing file.
-- `file.prepend`: Prepend content to an existing file.
+- `file.append`: Append content to an existing file. Inserts the file's line ending first when the file does not already end with one.
+- `file.prepend`: Prepend content to an existing file. Inserts the file's line ending after the new text when that text does not already end with one.
 - `file.create`: Create a new file with specified content.
 - `file.delete`: Delete a file.
 - `file.rename`: Rename (move) a file.

--- a/src/cmd/agent_rules/tests.rs
+++ b/src/cmd/agent_rules/tests.rs
@@ -44,6 +44,13 @@ fn default_includes_all_sections() {
         out.contains("doc set FILE . VALUE") && out.contains("replaces the whole document"),
         "selector table must say `.` is root for doc set: {out}"
     );
+    assert!(
+        out.contains("file.append")
+            && out.contains("line ending first")
+            && out.contains("file.prepend")
+            && out.contains("line ending after"),
+        "catalogue must name append/prepend separator newlines (#2199): {out}"
+    );
 }
 
 #[test]

--- a/src/cmd/append.rs
+++ b/src/cmd/append.rs
@@ -8,11 +8,17 @@ use serde::Serialize;
 #[command(after_help = "\
 EXAMPLES:
   patchloom append tests/integration.rs --content 'fn new_test() {}' --apply
-  echo 'new content' | patchloom append tests/integration.rs --stdin --apply")]
+  echo 'new content' | patchloom append tests/integration.rs --stdin --apply
+
+NOTES:
+  If the file does not already end with a newline, append inserts the file's
+  line ending before --content so the new text starts on its own line.")]
 pub struct AppendArgs {
     /// Path of the file to append to.
     pub file: String,
     /// Content to append (alternative to --stdin).
+    /// If the file does not already end with a newline, the file's line ending
+    /// is inserted first.
     #[arg(long)]
     pub content: Option<String>,
     /// Read content from stdin.
@@ -173,6 +179,20 @@ mod tests {
 
         let content = fs::read_to_string(&file).unwrap();
         assert_eq!(content, "line one\nline two\n");
+    }
+
+    #[test]
+    fn append_help_mentions_separator_newline() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::Cli::command();
+        let append = cmd.find_subcommand("append").expect("append");
+        let mut buf = Vec::new();
+        append.clone().write_long_help(&mut buf).unwrap();
+        let help = String::from_utf8(buf).unwrap();
+        assert!(
+            help.contains("line ending") && help.contains("newline"),
+            "append --help must mention the separator newline (#2199):\n{help}"
+        );
     }
 
     #[test]

--- a/src/cmd/prepend.rs
+++ b/src/cmd/prepend.rs
@@ -6,11 +6,17 @@ use clap::Args;
 #[command(after_help = "\
 EXAMPLES:
   patchloom prepend src/main.rs --content '// Copyright 2026' --apply
-  echo '# Header' | patchloom prepend README.md --stdin --apply")]
+  echo '# Header' | patchloom prepend README.md --stdin --apply
+
+NOTES:
+  If --content does not already end with a newline, prepend inserts the file's
+  line ending after it so existing text starts on the next line.")]
 pub struct PrependArgs {
     /// Path of the file to prepend to.
     pub file: String,
     /// Content to prepend (alternative to --stdin).
+    /// If this text does not already end with a newline, the file's line ending
+    /// is inserted after it.
     #[arg(long)]
     pub content: Option<String>,
     /// Read content from stdin.
@@ -129,6 +135,10 @@ mod tests {
         assert!(
             help.contains("--content '// Copyright 2026'"),
             "help should still show the copyright prepend example:\n{help}"
+        );
+        assert!(
+            help.contains("line ending") && help.contains("newline"),
+            "help must mention the separator newline (#2199):\n{help}"
         );
     }
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -217,7 +217,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "file.append",
-        description: "Append content to an existing file.",
+        description: "Append content to an existing file. Inserts the file's line ending first when the file does not already end with one.",
         tier: Tier::Weak,
         examples: &[(
             "Append a test function to a test file",
@@ -226,7 +226,7 @@ const OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "file.prepend",
-        description: "Prepend content to an existing file.",
+        description: "Prepend content to an existing file. Inserts the file's line ending after the new text when that text does not already end with one.",
         tier: Tier::Weak,
         examples: &[(
             "Prepend a license header",


### PR DESCRIPTION
## Summary

`append` and `prepend` insert the file's line ending between existing text and `--content` when a join would glue two fragments on one line. Help and the operations catalogue now say that.

## Problem

```bash
printf 'base' > t.txt
patchloom append t.txt --content tail --apply
# disk is 'base\ntail', not 'basetail'
```

`--help` only said "Content to append/prepend". Agents guessed byte concat. The engine already unit-tests the separator (`append_content` / `prepend_content`).

## Change

- clap `--content` docs and EXAMPLES NOTES on `append` and `prepend`
- schema catalogue lines for `file.append` / `file.prepend` (feeds agent-rules / PATCHLOOM.md)
- clap `write_long_help` tests + agent-rules inventory assert

## Validation

- `append_help_mentions_separator_newline`
- `prepend_help_example_does_not_advertise_backslash_n_escape` (still no `\n` escape; now also requires "line ending")
- `default_includes_all_sections`

Closes #2199
