### PR TITLE
fix(apply-fragment): copy line indent when the anchor includes spaces

### DIFF
--- a/src/cmd/apply_fragment.rs
+++ b/src/cmd/apply_fragment.rs
@@ -340,6 +340,56 @@ mod tests {
     }
 
     #[test]
+    fn apply_fragment_after_anchor_that_includes_indent_is_own_indented_line() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.rs");
+        std::fs::write(&path, "fn main() {\n    let x = 1;\n}\n").unwrap();
+        let code = run(
+            ApplyFragmentArgs {
+                file: path.to_string_lossy().into(),
+                fragment: Some("let y = 2;".into()),
+                stdin: false,
+                instruction: None,
+                after: Some("    let x = 1;".into()),
+                before: None,
+                old: None,
+                allow_non_unique: false,
+                write: Default::default(),
+            },
+            &g_apply(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::SUCCESS);
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body, "fn main() {\n    let x = 1;\n    let y = 2;\n}\n");
+    }
+
+    #[test]
+    fn apply_fragment_before_anchor_that_includes_indent_is_own_indented_line() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("t.rs");
+        std::fs::write(&path, "fn main() {\n    let x = 1;\n}\n").unwrap();
+        let code = run(
+            ApplyFragmentArgs {
+                file: path.to_string_lossy().into(),
+                fragment: Some("let y = 2;".into()),
+                stdin: false,
+                instruction: None,
+                after: None,
+                before: Some("    let x = 1;".into()),
+                old: None,
+                allow_non_unique: false,
+                write: Default::default(),
+            },
+            &g_apply(),
+        )
+        .unwrap();
+        assert_eq!(code, crate::exit::SUCCESS);
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert_eq!(body, "fn main() {\n    let y = 2;\n    let x = 1;\n}\n");
+    }
+
+    #[test]
     fn apply_fragment_anchor_miss_no_matches() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("t.rs");

--- a/src/ops/replace.rs
+++ b/src/ops/replace.rs
@@ -400,8 +400,11 @@ fn skip_horiz_fwd(bytes: &[u8], mut i: usize) -> usize {
     i
 }
 
-/// Horizontal indent immediately before the first `anchor` match, if that
-/// whitespace is the line indent (not mid-line spaces).
+/// Horizontal indent of the line that contains the first `anchor` match.
+///
+/// Uses the line indent even when `anchor` itself starts with those spaces
+/// (copy-paste of `    let x = 1;` as `--after` / `--before`). Mid-line
+/// matches still return empty.
 fn indent_before_first_anchor<'a>(file_content: &'a str, anchor: &str) -> &'a str {
     indent_before_first_anchor_ci(file_content, anchor, false)
 }
@@ -420,8 +423,15 @@ fn indent_before_first_anchor_ci<'a>(
     let Some(i) = i else {
         return "";
     };
-    let start = leading_line_indent_start(file_content, i);
-    &file_content[start..i]
+    line_indent_at(file_content, i)
+}
+
+/// Indent of the line containing `match_start`, or empty when the match is
+/// mid-line (not preceded only by spaces/tabs back to a line boundary).
+fn line_indent_at(file_content: &str, match_start: usize) -> &str {
+    let start = leading_line_indent_start(file_content, match_start);
+    let end = skip_horiz_fwd(file_content.as_bytes(), start);
+    &file_content[start..end]
 }
 
 /// Parameters for [`build_replacement_text`].
@@ -833,7 +843,7 @@ pub fn replace_insert_before<'a>(
         let line_oriented = insert_before_is_line_oriented(&out, from, insert, case_insensitive);
         let (span_start, replacement) = if line_oriented {
             let indent_start = leading_line_indent_start(&out, hit.start);
-            let indent = out[indent_start..hit.start].to_string();
+            let indent = line_indent_at(&out, hit.start).to_string();
             // Detect whole-line using `from` (the pattern), not `matched`.
             let normalized =
                 normalize_line_insert_ci(&out, from, insert, InsertSide::Before, case_insensitive);
@@ -842,7 +852,14 @@ pub fn replace_insert_before<'a>(
             } else {
                 format!("{indent}{normalized}")
             };
-            (indent_start, format!("{insert_out}{indent}{matched}"))
+            // When the match already includes the line indent, do not
+            // prefix it again (copy-paste `--before '    let x = 1;'`).
+            let keep_indent = if hit.start == indent_start {
+                ""
+            } else {
+                indent.as_str()
+            };
+            (indent_start, format!("{insert_out}{keep_indent}{matched}"))
         } else {
             (hit.start, format!("{insert}{matched}"))
         };

--- a/src/ops/replace_tests.rs
+++ b/src/ops/replace_tests.rs
@@ -248,6 +248,15 @@ mod replace_tests {
             assert_eq!(out, "\n    let y = 2;");
         }
 
+        /// Copy-paste of the indented line as `--after` must still indent the insert.
+        #[test]
+        fn normalize_line_insert_after_anchor_that_includes_indent_copies_line_indent() {
+            let file = "fn main() {\n    let x = 1;\n}\n";
+            let out =
+                normalize_line_insert(file, "    let x = 1;", "let y = 2;", InsertSide::After);
+            assert_eq!(out, "\n    let y = 2;");
+        }
+
         #[test]
         fn normalize_line_insert_after_whole_line_crlf_bare_payload() {
             // CRLF after anchor must still count as a line boundary, and the
@@ -346,6 +355,15 @@ mod replace_tests {
             let file = "fn main() {\n    let x = 1;\n}\n";
             let (out, n) =
                 replace_insert_before(file, "let x = 1;", "let y = 2;", None, None, false);
+            assert_eq!(n, 1);
+            assert_eq!(out, "fn main() {\n    let y = 2;\n    let x = 1;\n}\n");
+        }
+
+        #[test]
+        fn replace_insert_before_anchor_that_includes_indent_does_not_double_indent() {
+            let file = "fn main() {\n    let x = 1;\n}\n";
+            let (out, n) =
+                replace_insert_before(file, "    let x = 1;", "let y = 2;", None, None, false);
             assert_eq!(n, 1);
             assert_eq!(out, "fn main() {\n    let y = 2;\n    let x = 1;\n}\n");
         }

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -3584,6 +3584,30 @@ fn test_apply_fragment_cli_after_bare_fragment_own_line() {
     );
 }
 
+#[test]
+fn test_apply_fragment_cli_after_anchor_includes_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.rs");
+    fs::write(&file, "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("apply-fragment")
+        .arg(file.to_str().unwrap())
+        .arg("--after")
+        .arg("    let x = 1;")
+        .arg("--fragment")
+        .arg("let y = 2;")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn main() {\n    let x = 1;\n    let y = 2;\n}\n"
+    );
+}
+
 /// #2018: CLI apply-fragment dry-run preview is exit 2 and leaves file unchanged.
 #[test]
 fn test_apply_fragment_cli_preview_exit_2() {


### PR DESCRIPTION
## Summary

`apply-fragment --after` / `--before` now keep the line indent when the
anchor string already includes those leading spaces.

## Problem

#2202 copies indent from the bytes *before* the match. That works for
`--after 'let x = 1;'` on an indented line. Agents and humans often
copy the whole line (`    let x = 1;`). The match then starts at the
indent, so the insert landed at column 0:

```
    let x = 1;
let y = 2;
```

`--before` with the same copied line left the new statement unindented
as well.

## Change

- `indent_before_first_anchor` returns the line indent (spaces/tabs from
  the start of the line), not only the slice before the match.
- `replace_insert_before` uses that indent for the new line and does
  not prefix it again when the match already includes it.

Mid-line inserts stay byte-exact.

## Validation

- Unit: `normalize_line_insert_after_anchor_that_includes_indent_copies_line_indent`
- Unit: `replace_insert_before_anchor_that_includes_indent_does_not_double_indent`
- In-process apply-fragment after/before with indented anchors
- cargo-bin `test_apply_fragment_cli_after_anchor_includes_indent`
- Existing #2202 unindented-anchor tests still pass

Found in fixrealloop R90.
