### PR TITLE
test: strengthen apply-fragment, search, and patch assertions

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -211,7 +211,7 @@ These are the main entry points. If you are deciding between commands, start her
 - **What it does:** Searches text files with literal or regex matching, optional context, counts, and file only results. Binary and invalid UTF-8 files are skipped.
 - **Use when:** You need to locate candidate edits, audit repo state, or narrow inputs before changing files. For AI agents, native search/grep tools are typically faster for simple pattern matching.
 - **Prefer instead:** Use `replace` for actual text mutation, or `doc`, `md`, or `patch` when you already know the structured change you want.
-- **Failure behavior:** Pattern miss on existing roots exits `3` with `error_kind: "no_matches"`. When every explicit path root (or non-stdin `--files-from` entry) is missing, exit `1` with `error_kind: "not_found"`. Empty pattern, incompatible flags, and invalid regex patterns use `invalid_input`.
+- **Failure behavior:** Pattern miss on existing roots exits `3` with `error_kind: "no_matches"`. When every explicit path root (or non-stdin `--files-from` entry) is missing, exit `1` with `error_kind: "not_found"`. Empty pattern, incompatible flags (`-l` with `-L`, `--unique`, invalid regex) use `invalid_input`. Search `--unique` is rejected with a pointer at `replace --unique` (search is read-only).
 - **Related:** `--glob`, `--files-from`, `replace`
 
 <!-- ref:command:replace -->
@@ -229,7 +229,7 @@ These are the main entry points. If you are deciding between commands, start her
 
 - **What it does:** Applies a freeform text fragment with a **required** placement anchor. Strips Morph-style lazy marker lines such as `// ... existing code ...` from `--fragment`, then inserts after/before an anchor or replaces a unique `old` span. Dry-run by default. **Morph** here means [MorphLLM Fast Apply](https://www.morphllm.com/) (a cloud apply product); Patchloom only reuses the common marker style and does not call Morph's API.
 - **Use when:** An agent emitted a Morph-class lazy snippet but you know a unique placement (after/before/old). Prefer this over guessing without anchors.
-- **Flags:** Exactly one of `--after`, `--before`, or `--old`. Provide text via `--fragment` or `--stdin`. Default uniqueness: fail when the anchor matches more than once. Pass `--allow-non-unique` only when multi-match is intentional (plan/MCP field is `unique`, default `true`).
+- **Flags:** Exactly one of `--after`, `--before`, or `--old`. Provide text via `--fragment` or `--stdin`. Default uniqueness: fail when the anchor matches more than once. Pass `--allow-non-unique` only when multi-match is intentional (plan/MCP field is `unique`, default `true`). A fragment without a trailing newline is still placed on its own line next to a whole-line or indented whole-line anchor; the anchor's indent is copied (including when the `--after`/`--before` text itself includes those leading spaces).
 - **Prefer instead:** `replace` for exact known spans; `ast replace` / `ast rename` for code structure; never a cloud Morph merge for offline deterministic hosts.
 - **Failure behavior:** Missing placement or empty fragment after strip → `invalid_input` (exit 1). Anchor miss → `no_matches` (exit 3). Multi-match with default unique → `ambiguous` (exit 5). Preview without `--apply` → exit 2 when changes would apply.
 - **Related:** `replace`, `tx` plan op `apply.fragment`, MCP `apply_fragment`, `docs/plans/morph-gap-matrix.md`

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -1831,7 +1831,25 @@ fn apply_patch_path_matching_uses_path_components() {
 +changed\n";
 
     let result = apply_patch(&file, patch, ApplyMode::Preview, None);
-    assert!(result.is_err() || !result.unwrap().changed);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "original\n",
+        "must not rewrite notb/foo.rs when the patch dest is b/foo.rs"
+    );
+    match result {
+        Ok(r) => assert!(!r.changed, "b/foo.rs must not match notb/foo.rs: {r:?}"),
+        Err(e) => {
+            let msg = format!("{e:#}");
+            assert!(
+                msg.contains("b/foo.rs"),
+                "mismatch must name the patch dest b/foo.rs, got: {msg}"
+            );
+            assert!(
+                !msg.contains("notb/foo.rs"),
+                "must not treat notb/foo.rs as the dest: {msg}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/src/cmd/apply_fragment.rs
+++ b/src/cmd/apply_fragment.rs
@@ -247,7 +247,7 @@ mod tests {
                 instruction: None,
                 after: None,
                 before: None,
-                old: Some("return 0;".into()),
+                old: Some("return 0;\n".into()),
                 allow_non_unique: false,
                 write: Default::default(),
             },
@@ -256,10 +256,7 @@ mod tests {
         .unwrap();
         assert_eq!(code, crate::exit::SUCCESS);
         let body = std::fs::read_to_string(&path).unwrap();
-        assert!(
-            body.starts_with("return 1;"),
-            "expected replace to return 1; got {body:?}"
-        );
+        assert_eq!(body, "return 1;\n");
     }
 
     #[test]

--- a/src/ops/patch_tests.rs
+++ b/src/ops/patch_tests.rs
@@ -1540,7 +1540,11 @@ zcmV-30c%W6N;csHwEFcP0000N
         let files = parse_patch(diff).expect("binary-only must list dest");
         assert_eq!(files.len(), 1);
         assert_eq!(files[0].path, "secret.bin");
-        assert!(files[0].unsupported.is_some());
+        assert_eq!(
+            files[0].unsupported.as_deref(),
+            Some("GIT binary patch"),
+            "binary-only dest must name the git-meta reason (not only Some)"
+        );
     }
 
     #[test]

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -3653,8 +3653,8 @@ fn test_apply_fragment_cli_ambiguous_json_hint() {
     assert_eq!(v["error_kind"], "ambiguous", "{v}");
     let err = v["error"].as_str().unwrap_or("");
     assert!(
-        err.contains("allow-non-unique") || err.contains("apply-fragment"),
-        "ambiguous hint must guide apply-fragment users: {v}"
+        err.contains("allow-non-unique"),
+        "ambiguous hint must name --allow-non-unique (not only replace --nth): {v}"
     );
 }
 

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -811,20 +811,30 @@ fn test_search_unique_is_invalid_input_mentions_replace() {
         .args(["search", "needle", ".", "--unique"])
         .output()
         .unwrap();
-    assert_ne!(out.status.code(), Some(0));
-    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout)
-        .unwrap_or_else(|_| serde_json::from_slice(&out.stderr).unwrap_or(serde_json::json!({})));
-    let blob = format!("{parsed}{}", String::from_utf8_lossy(&out.stderr));
-    assert!(
-        parsed.get("error_kind").and_then(|v| v.as_str()) == Some("invalid_input")
-            || blob.contains("invalid_input"),
-        "expected invalid_input: {blob}"
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "search --unique must be invalid_input exit 1; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
     );
-    assert!(
-        blob.contains("replace") && blob.contains("--unique"),
-        "should point at replace --unique: {blob}"
+    let parsed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|_| {
+        panic!(
+            "expected JSON on stdout: {}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    });
+    assert_eq!(parsed["ok"], false, "{parsed}");
+    assert_eq!(
+        parsed["error_kind"], "invalid_input",
+        "search --unique must set error_kind: {parsed}"
     );
-    assert!(!blob.contains("--quiet"), "must not tip --quiet: {blob}");
+    let err = parsed["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("replace") && err.contains("--unique"),
+        "should point at replace --unique: {parsed}"
+    );
+    assert!(!err.contains("--quiet"), "must not tip --quiet: {parsed}");
 }
 
 #[test]


### PR DESCRIPTION
Strengthen a handful of tests that passed for the wrong reason, and catch reference docs up to current search and apply-fragment behavior.

## Problem

Weak assertions on recent honesty surfaces would stay green if the real contract drifted:

- apply-fragment ambiguous JSON accepted any mention of the command name, not `--allow-non-unique`
- search `--unique` only required a non-zero exit, and could scrape `invalid_input` from stderr
- binary-only patch parse only required `unsupported` to be `Some`
- apply-fragment replace-old used `starts_with`, which hid an extra trailing newline
- dest-path mismatch accepted any error, including a missing joined dest

Reference docs also omitted the search `--unique` reject and apply-fragment indent-copy behavior.

## Change

- Require `--allow-non-unique` in the apply-fragment ambiguous CLI JSON test
- Lock search `--unique` to exit 1, stdout `error_kind: invalid_input`, and a replace hint
- Assert binary-only git-meta reason is `GIT binary patch`
- Replace-old fixture includes the line ending and asserts the full file
- Dest-path mismatch must leave `notb/foo.rs` unchanged and name `b/foo.rs`
- Reference: search `--unique` is `invalid_input`; apply-fragment copies anchor indent

## Validation

- `cargo test --lib --all-features` (2907 passed)
- Targeted integration: `test_apply_fragment_cli_ambiguous_json_hint`, `test_search_unique_is_invalid_input_mentions_replace`
- `make check-fast` (fmt, clippy, lib, feature-subset, integration 1374, PTY 10, README count, server.json, homebrew script)

Ref #2204
Ref #2198
