### PR TITLE
test: lock apply-fragment indent and search -L on MCP/tx

### DIFF
--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -202,7 +202,7 @@ AST tools so `list_tools` stays honest about what is callable.
 | `doc_get` | Read a value by selector path (read-only) |
 | `doc_query` | Query a structured file: has, keys, len, select, or flatten (read-only) |
 | `doc_diff` | Compare two structured files (read-only) |
-| `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes. Binary and invalid UTF-8 files are skipped (read-only) |
+| `search_files` | Search text files for a pattern, including literal, case-insensitive, count, file-only (`files_with_matches` / `files_without_match`), multiline, invert-match, and assert-count modes. Binary and invalid UTF-8 files are skipped (read-only) |
 | `list_files` | Bounded directory inventory with the same ignore/exclude/glob rules as search (read-only). Prefer this over a second generic filesystem MCP for list/tree. Optional `max_depth` prunes the walk per root (does not enter deeper dirs). `max_results` (default 500) still counts all in-depth matches then truncates and sets `truncated` / `total_matched` |
 | `git_status` | Show uncommitted file changes vs git HEAD (read-only) |
 | `server_info` | Return server identity and workspace root: `cwd`, `surface` (`full`\|`core`), `tool_count`, package `version`, and MCP `protocol_version` (read-only). Use `cwd` before relative path ops |

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1258,7 +1258,7 @@ The operations below are the building blocks inside `operations`.
 
 - **What it does:** Searches a file for a pattern inside a transaction and includes match results in the JSON output without writing anything.
 - **Use when:** An agent needs to locate patterns before replacing them in the same plan, enabling locate-then-edit in a single call.
-- **Optional fields:** `literal`, `regex`, `case_insensitive`, `multiline`, `invert_match`, `context`/`before_context`/`after_context`, `globs`, `exclude_patterns`, `custom_ignore_filenames` (for agent/tool ignore layering), `max_results`, `assert_count`. These provide full parity with the top-level `search` command and library `SearchOptions`.
+- **Optional fields:** `literal`, `regex`, `case_insensitive`, `multiline`, `invert_match`, `context`/`before_context`/`after_context`, `globs`, `exclude_patterns`, `custom_ignore_filenames` (for agent/tool ignore layering), `max_results`, `assert_count`. Match and ignore options match the top-level `search` command. File-list modes (`--files-with-matches` / `--files-without-match` / `--count`) are CLI and MCP `search_files` only.
 - **Related:** top level `search`
 
 <!-- ref:tx-op:read -->

--- a/tests/integration/mcp_tests.rs
+++ b/tests/integration/mcp_tests.rs
@@ -3,7 +3,7 @@ use super::*;
 #[test]
 fn test_mcp_setup_documents_search_files_modes() {
     let doc = fs::read_to_string(repo_root().join("docs/getting-started/mcp-setup.md")).unwrap();
-    assert!(doc.contains("literal, case-insensitive, count, file-only, multiline, invert-match, and assert-count modes"));
+    assert!(doc.contains("literal, case-insensitive, count, file-only (`files_with_matches` / `files_without_match`), multiline, invert-match, and assert-count modes"));
 }
 
 #[test]

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -191,6 +191,34 @@ async fn test_mcp_apply_fragment_after_round_trip() {
     client.cancel().await.unwrap();
 }
 
+/// #2204: copy-pasted indented `after` still indents a bare fragment (MCP).
+#[tokio::test]
+async fn test_mcp_apply_fragment_after_anchor_includes_indent() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("m.rs"), "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "apply_fragment",
+        serde_json::json!({
+            "path": "m.rs",
+            "after": "    let x = 1;",
+            "fragment": "let y = 2;"
+        }),
+    )
+    .await;
+    assert!(!is_error, "apply_fragment should succeed: {val}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("m.rs")).unwrap(),
+        "fn main() {\n    let x = 1;\n    let y = 2;\n}\n"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// #2018: MCP apply_fragment without anchors fails closed.
 #[tokio::test]
 async fn test_mcp_apply_fragment_requires_anchor() {
@@ -1083,6 +1111,41 @@ async fn test_mcp_search_rejects_conflicting_modes() {
         result.is_err(),
         "search with both files_with_matches and files_without_match should be rejected"
     );
+    client.cancel().await.unwrap();
+}
+
+/// #2184: MCP `files_without_match` lists only miss paths (CLI -L sibling).
+#[tokio::test]
+async fn test_mcp_search_files_without_match_lists_miss() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("hit.txt"), "needle\n").unwrap();
+    fs::write(dir.path().join("miss.txt"), "nothing here\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "search_files",
+        serde_json::json!({
+            "pattern": "needle",
+            "literal": true,
+            "files_without_match": true
+        }),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "files_without_match search should succeed: {val}"
+    );
+    assert_eq!(val["ok"], true, "{val}");
+    assert_eq!(val["file_count"], 1, "{val}");
+    let files = val["files"].as_array().expect("files array");
+    assert_eq!(files.len(), 1, "{val}");
+    let path = files[0]["path"].as_str().unwrap_or("");
+    assert!(path.contains("miss.txt"), "should list miss.txt: {val}");
+    assert!(!path.contains("hit.txt"), "must not list hit.txt: {val}");
     client.cancel().await.unwrap();
 }
 

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -9843,6 +9843,39 @@ fn test_tx_apply_fragment_after_strips_markers() {
     );
 }
 
+/// #2204: copy-pasted indented `after` still indents a bare fragment (tx).
+#[test]
+fn test_tx_apply_fragment_after_anchor_includes_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.rs");
+    fs::write(&file, "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "apply.fragment",
+            "path": portable_path_str(&file),
+            "after": "    let x = 1;",
+            "fragment": "let y = 2;"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn main() {\n    let x = 1;\n    let y = 2;\n}\n"
+    );
+}
+
 /// #2018: apply.fragment without placement anchors is invalid_input (exit 1).
 #[test]
 fn test_tx_apply_fragment_requires_anchor() {


### PR DESCRIPTION
## Summary

Lock the agent surfaces for two recent CLI features, and correct one dishonest plan-search claim.

## Problem

CLI already tested apply-fragment indent copy (#2204) and `search --files-without-match` (#2184). Agents more often call plan/`tx` and MCP. Those surfaces had no indent lock and no `files_without_match` happy path. The reference `tx-op:search` line also said "full parity" with top-level search even though plan search has no file-list modes.

## Change

- Plan/`tx` `apply.fragment`: copy-pasted indented `after` still indents a bare fragment.
- MCP `apply_fragment`: same indent lock.
- MCP `search_files` with `files_without_match`: lists only miss paths.
- mcp-setup `search_files` table names `files_without_match`.
- Reference: plan search match/ignore options only; file-list modes stay CLI and MCP.

## Validation

- `cargo test --test integration --all-features after_anchor_includes_indent`
- `cargo test --test integration --all-features test_mcp_search_files_without_match_lists_miss`
- `cargo test --test integration --all-features test_mcp_setup_documents_search_files_modes`
- `make check-fast` (2907 lib, 1377 integration, 10 PTY, README 4200+ / 4294)

Ref #2204
Ref #2184
