### PR TITLE
test: strengthen apply-fragment and search -L honesty locks

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -8712,17 +8712,17 @@ fn apply_fragment_to_file_replace_old() {
     let r = apply_fragment_to_file(
         &path,
         "return 1;\n",
-        FragmentPlacement::Replace("return 0;".into()),
+        FragmentPlacement::Replace("return 0;\n".into()),
         true,
         ApplyMode::Apply,
         None,
     )
     .expect("replace old");
     assert!(r.applied);
-    let body = fs::read_to_string(&path).unwrap();
-    assert!(
-        body.starts_with("return 1;"),
-        "replace old result: {body:?}"
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        "return 1;\n",
+        "replace must swap the whole old line, not prepend"
     );
 }
 

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -908,13 +908,32 @@ fn test_search_files_without_match_all_hits_exits_3() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("hit.txt"), "needle\n").unwrap();
 
-    Command::cargo_bin("patchloom")
+    let output = Command::cargo_bin("patchloom")
         .unwrap()
-        .args(["--cwd"])
+        .args(["--json", "--cwd"])
         .arg(dir.path())
         .args(["search", "needle", ".", "--files-without-match"])
-        .assert()
-        .code(3);
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("hit.txt"),
+        "-L must not list a hit as a miss: {stdout}"
+    );
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(v["error_kind"], "no_matches", "{v}");
+    assert_eq!(v["file_count"], 0, "{v}");
+    if let Some(files) = v["files"].as_array() {
+        assert!(files.is_empty(), "files must be empty on all-hits -L: {v}");
+    }
 }
 
 #[test]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -9942,13 +9942,32 @@ fn test_tx_apply_fragment_unique_ambiguous_exit_5() {
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
 
-    Command::cargo_bin("patchloom")
+    let out = Command::cargo_bin("patchloom")
         .unwrap()
-        .arg("tx")
+        .args(["--json", "tx"])
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
-        .assert()
-        .code(5); // AMBIGUOUS
+        .output()
+        .unwrap();
+    assert_eq!(
+        out.status.code(),
+        Some(5),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap_or_else(|_| {
+        panic!(
+            "expected JSON stdout: {}",
+            String::from_utf8_lossy(&out.stdout)
+        )
+    });
+    assert_eq!(v["error_kind"], "ambiguous", "{v}");
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("allow-non-unique"),
+        "ambiguous hint must name --allow-non-unique (not only replace --nth): {v}"
+    );
     assert_eq!(fs::read_to_string(&file).unwrap(), "dup\ndup\n");
 }
 
@@ -9964,8 +9983,8 @@ fn test_tx_apply_fragment_replace_old() {
         "operations": [{
             "op": "apply.fragment",
             "path": portable_path_str(&file),
-            "old": "return 0;",
-            "fragment": "return 1;"
+            "old": "return 0;\n",
+            "fragment": "return 1;\n"
         }]
     });
     let plan_file = dir.path().join("plan.json");
@@ -9979,10 +9998,10 @@ fn test_tx_apply_fragment_replace_old() {
         .assert()
         .code(0);
 
-    let body = fs::read_to_string(&file).unwrap();
-    assert!(
-        body.starts_with("return 1;"),
-        "expected replace to return 1; got {body:?}"
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "return 1;\n",
+        "replace must swap the whole old line, not prepend"
     );
 }
 


### PR DESCRIPTION
## Summary

Strengthen three recent tests so they fail if the product regresses to the wrong shape, not only the wrong exit code.

## Problem

`starts_with("return 1;")` on apply-fragment replace-old passed when the old span omitted the line ending and the fragment included one (extra blank line). `search --files-without-match` on an all-hits tree only checked exit 3. Plan `apply.fragment` unique multi-match only checked exit 5.

## Change

- Library and tx replace-old: include the newline in `old` (same as the CLI unit fixture) and `assert_eq!` the exact file body.
- `search --files-without-match` with only hits: JSON `error_kind: no_matches`, `file_count: 0`, and `hit.txt` must not be listed.
- tx `apply.fragment` unique multi-match: `error_kind: ambiguous` and the `--allow-non-unique` hint (CLI parity).

## Validation

- `cargo test --lib --all-features apply_fragment_to_file_replace_old`
- `cargo test --test integration --all-features test_search_files_without_match_all_hits_exits_3`
- `cargo test --test integration --all-features test_tx_apply_fragment_unique_ambiguous_exit_5`
- `cargo test --test integration --all-features test_tx_apply_fragment_replace_old`
- `make check-fast` (2907 lib, 1377 integration, 10 PTY)

Ref #2204
Ref #2184
