### PR TITLE
test: lock apply-fragment --before indent on MCP, tx, and library

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -8660,6 +8660,50 @@ fn apply_fragment_to_file_after_strips_markers() {
 
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]
+fn apply_fragment_to_file_after_anchor_includes_indent() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("m.rs");
+    fs::write(&path, "fn main() {\n    let x = 1;\n}\n").unwrap();
+    let r = apply_fragment_to_file(
+        &path,
+        "let y = 2;",
+        FragmentPlacement::After("    let x = 1;".into()),
+        true,
+        ApplyMode::Apply,
+        None,
+    )
+    .expect("after indented anchor");
+    assert!(r.applied);
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        "fn main() {\n    let x = 1;\n    let y = 2;\n}\n"
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_fragment_to_file_before_anchor_includes_indent() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("m.rs");
+    fs::write(&path, "fn main() {\n    let x = 1;\n}\n").unwrap();
+    let r = apply_fragment_to_file(
+        &path,
+        "let y = 2;",
+        FragmentPlacement::Before("    let x = 1;".into()),
+        true,
+        ApplyMode::Apply,
+        None,
+    )
+    .expect("before indented anchor");
+    assert!(r.applied);
+    assert_eq!(
+        fs::read_to_string(&path).unwrap(),
+        "fn main() {\n    let y = 2;\n    let x = 1;\n}\n"
+    );
+}
+
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
 fn apply_fragment_to_file_requires_unique_anchor() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join("t.rs");

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -219,6 +219,34 @@ async fn test_mcp_apply_fragment_after_anchor_includes_indent() {
     client.cancel().await.unwrap();
 }
 
+/// #2204: copy-pasted indented `before` still indents a bare fragment (MCP).
+#[tokio::test]
+async fn test_mcp_apply_fragment_before_anchor_includes_indent() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("m.rs"), "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "apply_fragment",
+        serde_json::json!({
+            "path": "m.rs",
+            "before": "    let x = 1;",
+            "fragment": "let y = 2;"
+        }),
+    )
+    .await;
+    assert!(!is_error, "apply_fragment should succeed: {val}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("m.rs")).unwrap(),
+        "fn main() {\n    let y = 2;\n    let x = 1;\n}\n"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// #2018: MCP apply_fragment without anchors fails closed.
 #[tokio::test]
 async fn test_mcp_apply_fragment_requires_anchor() {

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -3608,6 +3608,30 @@ fn test_apply_fragment_cli_after_anchor_includes_indent() {
     );
 }
 
+#[test]
+fn test_apply_fragment_cli_before_anchor_includes_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.rs");
+    fs::write(&file, "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("apply-fragment")
+        .arg(file.to_str().unwrap())
+        .arg("--before")
+        .arg("    let x = 1;")
+        .arg("--fragment")
+        .arg("let y = 2;")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn main() {\n    let y = 2;\n    let x = 1;\n}\n"
+    );
+}
+
 /// #2018: CLI apply-fragment dry-run preview is exit 2 and leaves file unchanged.
 #[test]
 fn test_apply_fragment_cli_preview_exit_2() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -9876,6 +9876,39 @@ fn test_tx_apply_fragment_after_anchor_includes_indent() {
     );
 }
 
+/// #2204: copy-pasted indented `before` still indents a bare fragment (tx).
+#[test]
+fn test_tx_apply_fragment_before_anchor_includes_indent() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.rs");
+    fs::write(&file, "fn main() {\n    let x = 1;\n}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "apply.fragment",
+            "path": portable_path_str(&file),
+            "before": "    let x = 1;",
+            "fragment": "let y = 2;"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn main() {\n    let y = 2;\n    let x = 1;\n}\n"
+    );
+}
+
 /// #2018: apply.fragment without placement anchors is invalid_input (exit 1).
 #[test]
 fn test_tx_apply_fragment_requires_anchor() {


### PR DESCRIPTION
## Summary

Lock copy-pasted indented `--before` on the agent surfaces that already had `--after` coverage.

## Problem

CLI unit and cargo-bin tests already covered `--after` with leading spaces in the anchor, and a CLI unit test covered `--before`. MCP `apply_fragment`, plan/`tx` `apply.fragment`, and library `apply_fragment_to_file` only locked `--after`. A `--before` indent regression on those paths would not fail CI.

## Change

- MCP `apply_fragment` with indented `before` and a bare fragment
- Plan/`tx` `apply.fragment` same case
- Library `apply_fragment_to_file` After and Before indent, exact file body
- cargo-bin `--before` sibling of the existing `--after` integration test

## Validation

- `cargo test --lib --all-features apply_fragment_to_file_`
- `cargo test --test integration --all-features before_anchor_includes_indent`

Ref #2204
