### PR TITLE
test: lock exact replace bodies and bump rmcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,9 +1899,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f17072af977b0f86f714dbd64b3d37d0715bb63064f9d13483f0a1775813374"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
  "async-trait",
  "base64 0.23.0",
@@ -1933,9 +1933,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.3"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54817231d63a35330d5c3a5782a4a166fbe3b914a9faab440d3dd8bd37971890"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/src/api/content_edits.rs
+++ b/src/api/content_edits.rs
@@ -860,13 +860,9 @@ mod tests {
             Some("TODO: fix"),
             "batch should report widest anchored/fuzzy matched_text (#1736 / #1981)"
         );
-        assert!(r.modified.starts_with("ALPHA\n"));
-        assert!(r.modified.contains("gamma\nTODO: done"));
-        // Context-anchored replace must not touch the first TODO: fix
-        assert!(
-            r.modified.contains("ALPHA\nTODO: fix\nbeta"),
-            "first TODO must remain: {}",
-            r.modified
+        assert_eq!(
+            r.modified, "ALPHA\nTODO: fix\nbeta\ngamma\nTODO: done\n",
+            "anchored replace must keep the first TODO and not add blanks"
         );
     }
 

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -3490,16 +3490,15 @@ fn file_prepend_write_modes_matrix() {
         assert_eq!(res.applied, expect_applied, "{mode:?}");
         let on_disk = fs::read_to_string(&file).unwrap();
         if expect_applied {
-            assert!(
-                on_disk.starts_with("HEAD\n"),
-                "{mode:?} expected prepend, got {on_disk}"
+            assert_eq!(
+                on_disk, "HEAD\nbase",
+                "{mode:?} prepend must be exact (no extra blank)"
             );
-            assert!(on_disk.contains("base"), "{mode:?} base content retained");
         } else {
             assert_eq!(on_disk, "base", "{mode:?} must not write");
-            assert!(
-                res.new_content.starts_with("HEAD\n"),
-                "{mode:?} new_content should preview prepend"
+            assert_eq!(
+                res.new_content, "HEAD\nbase",
+                "{mode:?} preview new_content must be exact"
             );
         }
     }
@@ -7358,15 +7357,10 @@ fn fuzzy_identifier_typo_keeps_line_syntax() {
     .expect("fuzzy typo should apply");
     assert!(r.changed);
     assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
-    assert!(
-        r.new_content
-            .starts_with("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
-        "must keep const/type/value: {}",
-        r.new_content
-    );
-    assert!(
-        !r.new_content.starts_with("CONFIGURATION_VALUE_SECONDARY\n"),
-        "must not replace whole first line with bare new text"
+    assert_eq!(
+        r.new_content,
+        "const CONFIGURATION_VALUE_SECONDARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+        "fuzzy typo must keep the rest of the line and the second site"
     );
 }
 
@@ -7392,23 +7386,10 @@ fn fuzzy_embedder_options_identifier_typo_safe() {
     assert!(r.changed);
     assert_eq!(r.match_mode, Some(MatchMode::Fuzzy));
     assert!(r.match_score.is_some_and(|s| s >= 0.80));
-    assert!(
-        r.new_content
-            .contains("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
-        "{}",
-        r.new_content
-    );
-    // Second occurrence still original (single fuzzy site).
-    assert!(
-        r.new_content.contains("CONFIGURATION_VALUE_PRIMARY"),
-        "second site left for single fuzzy replace: {}",
-        r.new_content
-    );
-    assert!(
-        !r.new_content
-            .lines()
-            .any(|l| l == "CONFIGURATION_VALUE_SECONDARY"),
-        "must not replace a whole line with bare new identifier"
+    assert_eq!(
+        r.new_content,
+        "const CONFIGURATION_VALUE_SECONDARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+        "embedder unique fuzzy must keep syntax and the second site"
     );
 }
 
@@ -7523,11 +7504,11 @@ fn fuzzy_identifier_typo_disk_apply_preserves_syntax() {
         r.backup_session
     );
     let on_disk = fs::read_to_string(&file).unwrap();
-    assert!(
-        on_disk.starts_with("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
-        "disk: {on_disk}"
+    assert_eq!(
+        on_disk,
+        "const CONFIGURATION_VALUE_SECONDARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+        "disk fuzzy apply must keep syntax and the second site: {on_disk}"
     );
-    assert!(on_disk.contains("CONFIGURATION_VALUE_PRIMARY"));
 }
 
 /// #1687: out-of-range min_fuzzy_score is InvalidInput.

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -4877,13 +4877,11 @@ fn replace_text_before_context_disambiguates() {
     };
     let result = replace_text(&file, "TODO: fix", "DONE", &opts, ApplyMode::Apply, None).unwrap();
     assert!(result.changed);
-    let content = fs::read_to_string(&file).unwrap();
-    // First occurrence should be untouched, second replaced.
-    assert!(
-        content.contains("TODO: fix"),
-        "first occurrence should remain"
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "alpha\nTODO: fix\nbeta\ngamma\nDONE\ndelta\n",
+        "before_context must replace only the TODO after gamma"
     );
-    assert!(content.contains("DONE"), "second should be replaced");
 }
 
 #[cfg(any(feature = "cli", feature = "files"))]
@@ -4900,13 +4898,11 @@ fn replace_text_after_context_disambiguates() {
     };
     let result = replace_text(&file, "TODO: fix", "DONE", &opts, ApplyMode::Apply, None).unwrap();
     assert!(result.changed);
-    let content = fs::read_to_string(&file).unwrap();
-    // First occurrence replaced, second should remain.
-    assert!(
-        content.contains("TODO: fix"),
-        "second occurrence should remain"
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "alpha\nDONE\nbeta\ngamma\nTODO: fix\ndelta\n",
+        "after_context must replace only the TODO before beta"
     );
-    assert!(content.contains("DONE"), "first should be replaced");
 }
 
 // ── #1314: Unicode/multibyte text tests for replace_in_content ──
@@ -5175,13 +5171,10 @@ fn replace_text_before_context_disambiguates_any_path() {
     )
     .unwrap();
     assert!(result.changed);
-    assert!(
-        result.new_content.contains("host = db.primary"),
-        "database host should be replaced"
-    );
-    assert!(
-        result.new_content.matches("host = localhost").count() == 1,
-        "cache host should remain unchanged"
+    assert_eq!(
+        result.new_content,
+        "[database]\nhost = db.primary\nport = 5432\n\n[cache]\nhost = localhost\nport = 6379\n",
+        "before_context must change only the database host"
     );
 }
 
@@ -5209,8 +5202,11 @@ fn replace_text_after_context_disambiguates_any_path() {
     )
     .unwrap();
     assert!(result.changed);
-    assert!(result.new_content.contains("[database]\nhost = db.primary"));
-    assert!(result.new_content.contains("[cache]\nhost = localhost"));
+    assert_eq!(
+        result.new_content,
+        "[database]\nhost = db.primary\nport = 5432\n\n[cache]\nhost = localhost\nport = 6379\n",
+        "after_context must change only the database host"
+    );
 }
 
 #[test]
@@ -6691,8 +6687,10 @@ fn match_mode_exact_fuzzy_and_anchored() {
         Some("TODO: fix"),
         "anchored multi-match path must report matched_text (#1736 parity)"
     );
-    assert!(r.new_content.contains("beta\nTODO: done"));
-    assert!(r.new_content.contains("alpha\nTODO: fix"));
+    assert_eq!(
+        r.new_content, "alpha\nTODO: fix\nbeta\nTODO: done\n",
+        "anchored replace must keep the first TODO and not add blanks"
+    );
 }
 
 /// Disk `replace_text` must honor pure `fuzzy: true` (no context).

--- a/src/tx/replace_op.rs
+++ b/src/tx/replace_op.rs
@@ -1811,17 +1811,10 @@ mod tests {
         drop(tx);
         assert_eq!(count, 1);
         let out = &f.pending[&file].1;
-        assert!(
-            out.starts_with("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
-            "tx fuzzy must keep syntax: {out}"
-        );
-        assert!(
-            out.contains("CONFIGURATION_VALUE_PRIMARY"),
-            "second occurrence left: {out}"
-        );
-        assert!(
-            !out.lines().any(|l| l == "CONFIGURATION_VALUE_SECONDARY"),
-            "must not bare-line replace: {out}"
+        assert_eq!(
+            out,
+            "const CONFIGURATION_VALUE_SECONDARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+            "tx fuzzy must keep syntax and the second site: {out}"
         );
         let meta = f.replace_match_meta.get(&file).expect("fuzzy meta");
         assert_eq!(meta.mode, crate::api::MatchMode::Fuzzy);

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -1211,9 +1211,9 @@ async fn test_mcp_search_files_without_match_all_hits_is_no_matches() {
     assert_eq!(val["error_kind"], "no_matches", "{val}");
     assert_eq!(val["file_count"], 0, "{val}");
     let err = val["error"].as_str().unwrap_or("");
-    assert!(
-        err.contains("no files without matches") && err.contains("needle"),
-        "all-hits -L must not look like a content miss: {val}"
+    assert_eq!(
+        err, "no files without matches for 'needle' in .",
+        "all-hits -L must use the files-without-match wording: {val}"
     );
     assert!(
         !err.contains("try -i"),

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -2317,19 +2317,10 @@ fn test_replace_fuzzy_identifier_typo_preserves_syntax() {
         .code(0);
 
     let on_disk = fs::read_to_string(&file).unwrap();
-    assert!(
-        on_disk.starts_with("const CONFIGURATION_VALUE_SECONDARY: i32 = 1;"),
-        "CLI fuzzy must keep const/type: {on_disk}"
-    );
-    assert!(
-        on_disk.contains("CONFIGURATION_VALUE_PRIMARY"),
-        "second site left: {on_disk}"
-    );
-    assert!(
-        !on_disk
-            .lines()
-            .any(|l| l.trim() == "CONFIGURATION_VALUE_SECONDARY"),
-        "must not bare-line replace: {on_disk}"
+    assert_eq!(
+        on_disk,
+        "const CONFIGURATION_VALUE_SECONDARY: i32 = 1;\nfn use_it() -> i32 { CONFIGURATION_VALUE_PRIMARY }\n",
+        "CLI fuzzy must keep const/type and the second site: {on_disk}"
     );
 }
 

--- a/tests/integration/search_tests.rs
+++ b/tests/integration/search_tests.rs
@@ -932,9 +932,9 @@ fn test_search_files_without_match_all_hits_exits_3() {
     assert_eq!(v["error_kind"], "no_matches", "{v}");
     assert_eq!(v["file_count"], 0, "{v}");
     let err = v["error"].as_str().unwrap_or("");
-    assert!(
-        err.contains("no files without matches") && err.contains("needle"),
-        "all-hits -L must not look like a content miss: {v}"
+    assert_eq!(
+        err, "no files without matches for 'needle' in .",
+        "all-hits -L must use the files-without-match wording: {v}"
     );
     assert!(
         !err.contains("try -i"),


### PR DESCRIPTION
## Summary

Lock exact file bodies and the exact `-L` all-hits error text so extra blank lines cannot hide behind `starts_with` / `contains`. Bump rmcp 3.1.3 to 3.1.4.

## The problem

After #2209, several honesty tests still used `starts_with` or a short `contains`. Those pass if the product inserts an extra blank line or extra suffix. CLI/MCP `-L` all-hits only checked that the error mentioned "no files without matches" and the pattern, not the full wording.

## The change

- Exact bodies for prepend write-mode preview/apply, fuzzy identifier replace (API, tx, CLI), content-edits anchored rollup, and before/after context replace.
- Exact error `no files without matches for 'needle' in .` on cargo-bin and MCP all-hits.
- `Cargo.lock`: rmcp / rmcp-macros 3.1.4.

## Validation

- Targeted lib + integration tests for the strengthened asserts
- `cargo test --lib --all-features -- mcp` (99 ok) after the rmcp bump
- `make check-fast` green locally (2912 lib, 1382 integration, 10 PTY; README 4300+)

Ref #2210
