### PR TITLE
test: lock insert-after trailing NL on MCP, tx, and library

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2699,10 +2699,30 @@ fn replace_text_insert_after() {
     let result = replace_text(&file, "hello", "", &opts, ApplyMode::Preview, None).unwrap();
 
     assert!(result.changed);
-    assert!(
-        result.new_content.contains("hello\n beautiful"),
-        "line-oriented insert_after: {}",
-        result.new_content
+    assert_eq!(
+        result.new_content, "hello\n beautiful world\n",
+        "line-oriented insert_after must be exact"
+    );
+}
+
+/// #2209 sibling: insert_after payload that already ends in a newline
+/// must not add a blank line (CLI cargo-bin already locks this).
+#[test]
+fn replace_text_insert_after_trailing_nl_does_not_add_blank_line() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "fn foo() {\n  a();\n}\n").unwrap();
+
+    let opts = ReplaceOptions {
+        insert_after: Some("  bar();\n".to_string()),
+        ..ReplaceOptions::default()
+    };
+    let result = replace_text(&file, "fn foo() {", "", &opts, ApplyMode::Apply, None).unwrap();
+    assert!(result.applied);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn foo() {\n  bar();\n  a();\n}\n",
+        "trailing NL on insert_after must not insert a blank line"
     );
 }
 
@@ -3460,15 +3480,15 @@ fn file_append_write_modes_matrix() {
         assert_eq!(res.applied, expect_applied, "{mode:?}");
         let on_disk = fs::read_to_string(&file).unwrap();
         if expect_applied {
-            assert!(
-                on_disk.contains("+more"),
-                "{mode:?} expected write, got {on_disk}"
+            assert_eq!(
+                on_disk, "base\n +more",
+                "{mode:?} append inserts one EOL when the file has none"
             );
         } else {
             assert_eq!(on_disk, "base", "{mode:?} must not write");
-            assert!(
-                res.new_content.contains("+more"),
-                "{mode:?} new_content should preview append"
+            assert_eq!(
+                res.new_content, "base\n +more",
+                "{mode:?} preview new_content must be exact"
             );
         }
     }

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -5402,14 +5402,39 @@ async fn test_mcp_replace_text_insert_after_line_oriented() {
     .await;
     assert!(!is_error, "replace_text insert_after should succeed: {val}");
     assert_eq!(val["ok"], true, "insert_after ok: {val}");
-    let content = fs::read_to_string(dir.path().join("code.rs")).unwrap();
-    assert!(
-        content.contains("fn process_data() {}\n    // after body"),
-        "line-oriented insert_after: {content}"
+    assert_eq!(
+        fs::read_to_string(dir.path().join("code.rs")).unwrap(),
+        "fn process_data() {}\n    // after body\n",
+        "line-oriented insert_after must be exact"
     );
-    assert!(
-        !content.contains("fn process_data() {}    // after body"),
-        "must not glue comment onto line: {content}"
+    client.cancel().await.unwrap();
+}
+
+/// CLI `replace --insert-after` trailing-NL lock (#2210) must hold on MCP.
+#[tokio::test]
+async fn test_mcp_replace_text_insert_after_trailing_nl_does_not_add_blank_line() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("code.rs"), "fn foo() {\n  a();\n}\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "code.rs",
+            "old": "fn foo() {",
+            "insert_after": "  bar();\n"
+        }),
+    )
+    .await;
+    assert!(!is_error, "insert_after trailing NL should succeed: {val}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("code.rs")).unwrap(),
+        "fn foo() {\n  bar();\n  a();\n}\n",
+        "MCP insert_after trailing NL must not add a blank line"
     );
     client.cancel().await.unwrap();
 }
@@ -5528,10 +5553,10 @@ async fn test_mcp_execute_plan_insert_after_line_oriented() {
     let (is_error, val) =
         call_tool_value(&client, "execute_plan", serde_json::json!({"plan": plan})).await;
     assert!(!is_error, "execute_plan insert_after should succeed: {val}");
-    let content = fs::read_to_string(dir.path().join("t.txt")).unwrap();
-    assert!(
-        content.contains("// next") && !content.contains("beta// next"),
-        "plan insert_after line-oriented: {content}"
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.txt")).unwrap(),
+        "alpha\nbeta\n// next\n",
+        "plan insert_after must be an exact sibling line"
     );
     client.cancel().await.unwrap();
 }

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -1871,6 +1871,39 @@ fn test_tx_replace_insert_after_with_regex_in_plan() {
     assert_eq!(fs::read_to_string(&file).unwrap(), "aaa\nbbbX\nccc\n");
 }
 
+/// CLI `replace --insert-after` trailing-NL lock must hold on plan/tx.
+#[test]
+fn test_tx_replace_insert_after_trailing_nl_does_not_add_blank_line() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "fn foo() {\n  a();\n}\n").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "replace",
+            "path": file.to_str().unwrap(),
+            "old": "fn foo() {",
+            "insert_after": "  bar();\n"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "fn foo() {\n  bar();\n  a();\n}\n"
+    );
+}
+
 #[test]
 fn test_tx_replace_rejects_both_insert_before_and_after() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Lock `replace` insert-after trailing-newline wrap on MCP, tx, and the library. Agents use those surfaces more than the CLI cargo-bin test that already existed.

## The problem

CLI `replace --insert-after '  bar();\n'` already asserted no extra blank line. MCP `replace_text`, `execute_plan`, library `replace_text`, and `tx` did not. A wrap regression could pass CLI and still break hosts.

`file_append` write-mode tests used `contains("+more")`, which hid the intended EOL join when the file has no final newline.

## The change

- Library: exact insert-after trailing-NL body; exact append `base\n +more`.
- MCP: exact line-oriented insert-after body; new trailing-NL test; exact `execute_plan` insert-after body.
- `tx`: cargo-bin plan with the same trailing-NL fixture as CLI.

## Validation

- `cargo test --lib --all-features -- replace_text_insert_after` (4 ok)
- `cargo test --lib --all-features -- file_append_write_modes_matrix`
- `cargo test --test integration --all-features --` insert-after MCP/tx filters
- `make check-fast` locally

Ref #2210
Ref #2211
