### PR TITLE
test: lock insert-before trailing NL on MCP and library

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -208,7 +208,7 @@ Use patchloom when:
 
 **CLI undo (dry-run by default):** `patchloom undo` only previews the most recent backup and exits 2 with `applied: false` and `status: changes_detected`. Restore with `patchloom undo --apply` (optional `--session <timestamp>`), which sets `applied: true` and `status: restored` (#1830). List sessions with `patchloom undo --list`. There is no `--latest` flag.
 **Replace mode flags (#1829):** CLI replacement text is `--new` (not positional NEW and not `--to`). Missing mode errors name `--new` / `--insert-before` / `--insert-after` first; plan/MCP still accept field aliases `new`/`to`.
-**Insert line placement (#1885):** `--insert-before` / `--insert-after` (and plan/MCP `insert_before` / `insert_after`) are line-oriented by default: payloads that look like a new line (indent, `//`/`#` comment, embedded newline) or a whole-line anchor get a separating newline so agents do not glue text onto the match. Pure mid-line inserts (e.g. `X` after `foo` inside a line) stay byte-exact.
+**Insert line placement (#1885):** `--insert-before` / `--insert-after` (and plan/MCP `insert_before` / `insert_after`) are line-oriented by default: payloads that look like a new line (indent, `//`/`#` comment, embedded newline) or a whole-line anchor get a separating newline so agents do not glue text onto the match. A payload that already ends in a newline stays one sibling line (no extra blank). Pure mid-line inserts (e.g. `X` after `foo` inside a line) stay byte-exact.
 Example (anchor is positional OLD; insert text is on the flag; path last; never `replace ANCHOR NEW path`):
 `patchloom replace 'use std::io;' --insert-after 'use std::fs;' src/main.rs --apply`
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -546,7 +546,7 @@ These are meaningful command-specific modes that change how a top-level command 
 <!-- ref:replace-mode:insert-before -->
 ### `replace --insert-before`
 
-- **What it does:** Inserts text before each match instead of replacing it. The matched text is preserved.
+- **What it does:** Inserts text before each match instead of replacing it. The matched text is preserved. A payload that already ends in a newline is still one sibling line (no extra blank line). Same wrap as `apply-fragment --before`.
 - **Use when:** You need to add a line or annotation above an existing anchor without repeating the anchor in the replacement text.
 - **Example:** `patchloom replace 'fn main() {' --insert-before '// entry' src/main.rs --apply`
 - **Prefer instead:** Use `--new` when the matched text should actually change, not just receive a prefix.

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -2795,6 +2795,34 @@ fn replace_text_insert_before_preserves_crlf() {
     );
 }
 
+/// CLI/tx already lock insert-before trailing NL. Library must match.
+#[test]
+fn replace_text_insert_before_trailing_nl_does_not_add_blank_line() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("code.rs");
+    fs::write(&file, "    /// Doc comment.\n    pub field: bool,\n").unwrap();
+
+    let opts = ReplaceOptions {
+        insert_before: Some("    // marker\n".to_string()),
+        ..ReplaceOptions::default()
+    };
+    let result = replace_text(
+        &file,
+        "    /// Doc comment.",
+        "",
+        &opts,
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(result.applied);
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "    // marker\n    /// Doc comment.\n    pub field: bool,\n",
+        "trailing NL on insert_before must not insert a blank line"
+    );
+}
+
 #[test]
 fn replace_text_insert_after_midline_bare() {
     let dir = TempDir::new().unwrap();
@@ -4113,7 +4141,10 @@ fn replace_in_content_insert_after() {
     };
     let result = replace::replace_in_content(content, "use std::io;", "", &opts).unwrap();
     assert!(result.changed);
-    assert!(result.new_content.contains("use std::io;\nuse std::fs;"));
+    assert_eq!(
+        result.new_content, "use std::io;\nuse std::fs;\n\nfn main() {}\n",
+        "insert_after must be exact (no extra blank)"
+    );
 }
 
 #[test]
@@ -4125,7 +4156,10 @@ fn replace_in_content_insert_before() {
     };
     let result = replace::replace_in_content(content, "use std::io;", "", &opts).unwrap();
     assert!(result.changed);
-    assert!(result.new_content.contains("use std::fs;\nuse std::io;"));
+    assert_eq!(
+        result.new_content, "use std::fs;\nuse std::io;\n\nfn main() {}\n",
+        "insert_before must be exact (no extra blank)"
+    );
 }
 
 #[test]

--- a/src/cmd/agent_rules/policy.rs
+++ b/src/cmd/agent_rules/policy.rs
@@ -287,7 +287,8 @@ success lines are the full path list.\n\n\
              **Insert line placement (#1885):** `--insert-before` / `--insert-after` (and plan/MCP \
              `insert_before` / `insert_after`) are line-oriented by default: payloads that look like a \
              new line (indent, `//`/`#` comment, embedded newline) or a whole-line anchor get a separating \
-             newline so agents do not glue text onto the match. Pure mid-line inserts (e.g. `X` after \
+             newline so agents do not glue text onto the match. A payload that already ends in a \
+             newline stays one sibling line (no extra blank). Pure mid-line inserts (e.g. `X` after \
              `foo` inside a line) stay byte-exact.\n\
              Example (anchor is positional OLD; insert text is on the flag; path last; never \
              `replace ANCHOR NEW path`):\n\

--- a/src/cmd/agent_rules/tests.rs
+++ b/src/cmd/agent_rules/tests.rs
@@ -662,8 +662,8 @@ fn agent_rules_documents_library_type_error_and_binary_preflight() {
     );
     // Line-oriented insert is CLI-facing as well (mode All includes CLI).
     assert!(
-        out.contains("Insert line placement"),
-        "agents need line-oriented insert default (#1885)"
+        out.contains("Insert line placement") && out.contains("no extra blank"),
+        "agents need line-oriented insert default and trailing-NL wrap (#1885)"
     );
     // Copy-paste shape: anchor + flag + path (not positional NEW / wrong order).
     assert!(

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -5439,6 +5439,39 @@ async fn test_mcp_replace_text_insert_after_trailing_nl_does_not_add_blank_line(
     client.cancel().await.unwrap();
 }
 
+/// CLI/tx insert-before trailing-NL lock must hold on MCP replace_text.
+#[tokio::test]
+async fn test_mcp_replace_text_insert_before_trailing_nl_does_not_add_blank_line() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("code.rs"),
+        "    /// Doc comment.\n    pub field: bool,\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "replace_text",
+        serde_json::json!({
+            "path": "code.rs",
+            "old": "    /// Doc comment.",
+            "insert_before": "    // marker\n"
+        }),
+    )
+    .await;
+    assert!(!is_error, "insert_before trailing NL should succeed: {val}");
+    assert_eq!(
+        fs::read_to_string(dir.path().join("code.rs")).unwrap(),
+        "    // marker\n    /// Doc comment.\n    pub field: bool,\n",
+        "MCP insert_before trailing NL must not add a blank line"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// MCP insert_after on CRLF files must keep CRLF separators (#1892).
 #[tokio::test]
 async fn test_mcp_replace_text_insert_after_preserves_crlf() {


### PR DESCRIPTION
## Summary

Lock `replace --insert-before` trailing-newline wrap on MCP and the library. CLI and tx already used exact bodies. Document the same wrap in reference and agent-rules.

## The problem

`replace_in_content` insert after/before only used `contains`, so an extra blank line would still pass. MCP `replace_text` had no insert-before trailing-NL lock after #2212 covered insert-after. Reference described the wrap for `--insert-after` only.

## The change

- Exact bodies for `replace_in_content` insert after/before.
- Library `replace_text` and MCP `replace_text` insert-before trailing-NL exact body (same fixture as CLI).
- Reference `--insert-before` wrap sentence. Agent-rules / PATCHLOOM.md: payload that already ends in a newline stays one sibling line.

## Validation

- `cargo test --lib --all-features -- replace_in_content_insert`
- `cargo test --lib --all-features -- replace_text_insert_before`
- `cargo test --test integration --all-features -- mcp_replace_text_insert_before_trailing_nl`
- `make check-fast` plus `make check-patchloom-md`

Ref #2212
