### PR TITLE
fix: uniquify backup sessions across processes

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -80,8 +80,21 @@ fn sanitize_rel_path(file_path: &Path, project_root: &Path) -> PathBuf {
 }
 
 /// Monotonic counter to disambiguate backup sessions created in the same
-/// nanosecond (e.g., from concurrent threads).
+/// nanosecond in one process (concurrent threads).
 static SESSION_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Session directory name: `{nanos}_{pid}_{seq}`.
+///
+/// `seq` is per-process. Parallel CLI subprocesses (integration tests
+/// using `cargo_bin` against the same project root) each start `seq` at 0,
+/// so nanos+seq alone can collide and overwrite another apply's backup.
+fn new_session_id() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let seq = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    format!("{}_{}_{}", now.as_nanos(), std::process::id(), seq)
+}
 
 /// An active backup session that collects originals before writes.
 pub struct BackupSession {
@@ -95,13 +108,7 @@ impl BackupSession {
     /// Start a new backup session. Creates the session directory and prunes
     /// stale backups older than 7 days.
     pub fn new(project_root: &Path) -> anyhow::Result<Self> {
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default();
-        // Include a monotonic counter to prevent collisions when multiple
-        // threads create backup sessions in the same nanosecond.
-        let seq = SESSION_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let timestamp = format!("{}_{}", now.as_nanos(), seq);
+        let timestamp = new_session_id();
         let session_dir = project_root.join(BACKUP_DIR).join(&timestamp);
         std::fs::create_dir_all(&session_dir)
             .with_context(|| format!("failed to create backup dir {}", session_dir.display()))?;
@@ -779,8 +786,8 @@ pub fn prune_old_backups(project_root: &Path) -> anyhow::Result<usize> {
     for entry in std::fs::read_dir(&backup_dir)?.filter_map(|e| e.ok()) {
         let name = entry.file_name();
         let dir_name = name.to_string_lossy();
-        // Session directories are named "{nanos}_{seq}". Parse the
-        // nanos prefix to determine session age.
+        // Session directories are named "{nanos}_{pid}_{seq}" (older
+        // sessions were "{nanos}_{seq}"). Parse the nanos prefix.
         if let Some(nanos_str) = dir_name.split('_').next()
             && let Ok(nanos) = nanos_str.parse::<u128>()
         {
@@ -802,6 +809,21 @@ pub fn prune_old_backups(project_root: &Path) -> anyhow::Result<usize> {
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    #[test]
+    fn session_id_includes_pid_and_is_unique() {
+        let dir = TempDir::new().unwrap();
+        let a = BackupSession::new(dir.path()).unwrap();
+        let b = BackupSession::new(dir.path()).unwrap();
+        assert_ne!(a.timestamp, b.timestamp);
+        let pid = std::process::id().to_string();
+        let a_parts: Vec<&str> = a.timestamp.split('_').collect();
+        let b_parts: Vec<&str> = b.timestamp.split('_').collect();
+        assert_eq!(a_parts.len(), 3, "expected nanos_pid_seq: {}", a.timestamp);
+        assert_eq!(a_parts[1], pid);
+        assert_eq!(b_parts[1], pid);
+        assert_ne!(a_parts[2], b_parts[2]);
+    }
 
     #[test]
     fn backup_and_restore_modified_file() {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -5594,6 +5594,74 @@ async fn test_mcp_execute_plan_insert_after_line_oriented() {
     client.cancel().await.unwrap();
 }
 
+/// execute_plan insert_before is line-oriented over MCP (#2212 sibling).
+#[tokio::test]
+async fn test_mcp_execute_plan_insert_before_line_oriented() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("t.txt"), "alpha\nbeta\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": "t.txt",
+            "old": "beta",
+            "insert_before": "// prev"
+        }]
+    });
+    let (is_error, val) =
+        call_tool_value(&client, "execute_plan", serde_json::json!({"plan": plan})).await;
+    assert!(
+        !is_error,
+        "execute_plan insert_before should succeed: {val}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("t.txt")).unwrap(),
+        "alpha\n// prev\nbeta\n",
+        "plan insert_before must be an exact sibling line"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// execute_plan insert_before trailing-NL wrap (#2213 sibling on plan/MCP).
+#[tokio::test]
+async fn test_mcp_execute_plan_insert_before_trailing_nl_does_not_add_blank_line() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("code.rs"),
+        "    /// Doc comment.\n    pub field: bool,\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let plan = serde_json::json!({
+        "operations": [{
+            "op": "replace",
+            "path": "code.rs",
+            "old": "    /// Doc comment.",
+            "insert_before": "    // marker\n"
+        }]
+    });
+    let (is_error, val) =
+        call_tool_value(&client, "execute_plan", serde_json::json!({"plan": plan})).await;
+    assert!(
+        !is_error,
+        "execute_plan insert_before trailing NL should succeed: {val}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("code.rs")).unwrap(),
+        "    // marker\n    /// Doc comment.\n    pub field: bool,\n",
+        "plan insert_before trailing NL must not add a blank line"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// Sole binary path via MCP replace_text peels binary, not silent.
 #[tokio::test]
 async fn test_mcp_replace_text_sole_binary_refused() {

--- a/tests/integration/replace_tests.rs
+++ b/tests/integration/replace_tests.rs
@@ -1372,7 +1372,7 @@ fn test_replace_apply_prunes_old_backup_sessions() {
     fs::write(&file, "aaa\n").unwrap();
 
     // Create a fake old backup session with a timestamp 8 days in the past.
-    // Pruning now uses the directory name (nanos_seq) to determine age.
+    // Pruning uses the nanos prefix of the session dir (nanos_pid_seq).
     let eight_days_ago = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()


### PR DESCRIPTION
## Summary

Stop parallel applies from overwriting each other's backup sessions. Also lock MCP `execute_plan` insert-before the same way insert-after already is.

## The problem

`test_tx_default_strict_reverts_on_format_failure` failed once under the full integration matrix (exit 7, file still `changed`). Session ids were `{nanos}_{seq}`. `seq` is per process. Two `cargo_bin` applies in the same nanosecond against the same project root both use `seq=0` and can share one backup directory. Restore then reads the wrong original.

#2213 locked MCP `replace_text` insert-before trailing NL. Agents also call `execute_plan`. Insert-after already had that plan lock.

## The change

- Backup sessions are `{nanos}_{pid}_{seq}`. Prune still uses the nanos prefix. Older `{nanos}_{seq}` directories still prune.
- MCP `execute_plan` insert-before: exact sibling line and trailing-NL body (same fixture as #2213).

## Validation

- `cargo test --lib --all-features -- session_id_includes_pid`
- `cargo test --test integration --all-features -- mcp_execute_plan_insert_before`
- `make check-fast` (2915 lib, 1387 integration, README 4300+/4312)

Ref #2213
