### PR TITLE
test: lock SEARCH/REPLACE detect and mcp-setup honesty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2676,9 +2676,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.12"
+version = "0.26.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
+checksum = "17ebdd3a5a7e28a1890b876fdbd0c3c0fe0a6336cffaa104f11b9f720c9daa29"
 dependencies = [
  "cc",
  "regex",

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -224,7 +224,7 @@ AST tools so `list_tools` stays honest about what is callable.
 | `prepend_file` | Prepend content to an existing file |
 | `delete_file` | Delete a file |
 | `move_file` | Move or rename a file (binary-safe) |
-| `apply_patch` | Apply a unified diff |
+| `apply_patch` | Apply a unified diff, Codex Begin Patch, or SEARCH/REPLACE / DiffFenced document (unique unless `replace_all`) |
 | `batch_replace` | Replace the same text across multiple files atomically |
 | `batch_tidy` | Fix whitespace in multiple files atomically |
 | `execute_plan` | Execute a full multi-op transaction plan atomically (recommended for complex/multi-file edits; equivalent to CLI `tx`). Supports inline plan or plan_path. |

--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -25,7 +25,7 @@ pub fn apply_patch(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<EditResult> {
     if crate::ops::begin_patch::looks_like_begin_patch(patch_text) {
-        if patch_text.lines().any(|l| l.trim() == "<<<<<<< SEARCH") {
+        if crate::ops::search_replace::has_search_replace_marker(patch_text) {
             return Err(anyhow::Error::new(crate::exit::ParseErrorError {
                 msg: "mixed Begin Patch and SEARCH/REPLACE grammar is not supported".into(),
             }));
@@ -221,7 +221,7 @@ pub fn apply_patch_file(
     guard: Option<&PathGuard>,
 ) -> anyhow::Result<Vec<EditResult>> {
     if crate::ops::begin_patch::looks_like_begin_patch(patch_text) {
-        if patch_text.lines().any(|l| l.trim() == "<<<<<<< SEARCH") {
+        if crate::ops::search_replace::has_search_replace_marker(patch_text) {
             return Err(anyhow::Error::new(crate::exit::ParseErrorError {
                 msg: "mixed Begin Patch and SEARCH/REPLACE grammar is not supported".into(),
             }));

--- a/src/api/search_replace.rs
+++ b/src/api/search_replace.rs
@@ -358,4 +358,47 @@ new
         );
         assert_eq!(results[0].match_count, 1);
     }
+
+    #[test]
+    fn apply_patch_detects_search_replace_document() {
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("code.rs");
+        std::fs::write(&dest, "fn old() {}\n").unwrap();
+        let input = "\
+<<<<<<< SEARCH
+code.rs
+-------
+fn old() {}
+=======
+fn new() {}
+>>>>>>> REPLACE
+";
+        let result = crate::api::apply_patch(&dest, input, ApplyMode::Apply, None)
+            .expect("apply_patch detects SEARCH/REPLACE");
+        assert!(result.applied);
+        assert_eq!(std::fs::read_to_string(&dest).unwrap(), "fn new() {}\n");
+    }
+
+    #[test]
+    fn apply_patch_file_detects_search_replace_document() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("code.rs"), "fn old() {}\n").unwrap();
+        let input = "\
+<<<<<<< SEARCH
+code.rs
+-------
+fn old() {}
+=======
+fn new() {}
+>>>>>>> REPLACE
+";
+        let results = crate::api::apply_patch_file(input, dir.path(), ApplyMode::Apply, None)
+            .expect("apply_patch_file detects SEARCH/REPLACE");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].applied);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("code.rs")).unwrap(),
+            "fn new() {}\n"
+        );
+    }
 }

--- a/src/cmd/mcp/handlers.rs
+++ b/src/cmd/mcp/handlers.rs
@@ -681,7 +681,7 @@ impl PatchloomService {
                         None,
                     ));
                 }
-                if p.diff.lines().any(|l| l.trim() == "<<<<<<< SEARCH") {
+                if crate::ops::search_replace::has_search_replace_marker(&p.diff) {
                     return Err(McpError::invalid_params(
                         "mixed Begin Patch and SEARCH/REPLACE grammar is not supported",
                         None,

--- a/src/cmd/patch.rs
+++ b/src/cmd/patch.rs
@@ -614,7 +614,7 @@ pub fn run(args: PatchArgs, global: &GlobalFlags) -> anyhow::Result<u8> {
         return Ok(exit::FAILURE);
     }
     if crate::ops::begin_patch::looks_like_begin_patch(&diff_text) {
-        if diff_text.lines().any(|l| l.trim() == "<<<<<<< SEARCH") {
+        if crate::ops::search_replace::has_search_replace_marker(&diff_text) {
             emit_error(
                 global,
                 "patch: mixed Begin Patch and SEARCH/REPLACE grammar is not supported",

--- a/src/ops/search_replace.rs
+++ b/src/ops/search_replace.rs
@@ -4,6 +4,12 @@
 //! `replacen(..., 1)` or raw `fs::write` for this format. CLI / MCP / tx
 //! detect this grammar via [`looks_like_search_replace`] (#2221).
 
+/// True when any line trims to `<<<<<<< SEARCH`.
+#[must_use]
+pub fn has_search_replace_marker(input: &str) -> bool {
+    input.lines().any(|l| l.trim() == "<<<<<<< SEARCH")
+}
+
 /// True when the payload is a SEARCH/REPLACE or DiffFenced document.
 ///
 /// First non-empty line must be `<<<<<<< SEARCH` or a fence (` ``` `) so a
@@ -11,7 +17,7 @@
 /// still parsed as a unified diff.
 #[must_use]
 pub fn looks_like_search_replace(input: &str) -> bool {
-    if !input.lines().any(|l| l.trim() == "<<<<<<< SEARCH") {
+    if !has_search_replace_marker(input) {
         return false;
     }
     match input.lines().map(str::trim).find(|l| !l.is_empty()) {
@@ -382,6 +388,8 @@ new
             ),
             "unified diff that mentions SEARCH later is not SEARCH/REPLACE"
         );
+        assert!(has_search_replace_marker("--- a/x\n<<<<<<< SEARCH\nkeep\n"));
+        assert!(!has_search_replace_marker("--- a/x\n+++ b/x\n"));
     }
 
     #[test]

--- a/src/tx/patch_op.rs
+++ b/src/tx/patch_op.rs
@@ -18,7 +18,7 @@ pub(crate) fn execute_patch_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::
                 .into());
             }
             if crate::ops::begin_patch::looks_like_begin_patch(diff) {
-                if diff.lines().any(|l| l.trim() == "<<<<<<< SEARCH") {
+                if crate::ops::search_replace::has_search_replace_marker(diff) {
                     return Err(crate::exit::ParseErrorError {
                         msg: "mixed Begin Patch and SEARCH/REPLACE grammar is not supported".into(),
                     }

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -5859,3 +5859,66 @@ async fn test_mcp_apply_patch_replace_all_on_unified_is_invalid() {
     );
     client.cancel().await.unwrap();
 }
+
+#[tokio::test]
+async fn test_mcp_apply_patch_replace_all_on_begin_patch_is_invalid() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("code.rs"), "fn old() {}\n").unwrap();
+    let diff = "*** Begin Patch\n*** Update File: code.rs\n@@\n-fn old() {}\n+fn new() {}\n*** End Patch\n";
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "apply_patch",
+        serde_json::json!({"diff": diff, "replace_all": true}),
+    )
+    .await;
+    assert!(is_error, "replace_all on Begin Patch should fail: {val}");
+    let blob = val.to_string();
+    assert!(
+        blob.contains("replace_all") || blob.contains("SEARCH/REPLACE"),
+        "expected replace_all refuse, got {val}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("code.rs")).unwrap(),
+        "fn old() {}\n"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// SEARCH/REPLACE is a content write: follow PathGuard so a workspace
+/// symlink whose target is outside must not be rewritten.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_mcp_apply_patch_search_replace_symlink_outside_target() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    let outside = dir
+        .path()
+        .parent()
+        .unwrap()
+        .join("pl-mcp-sr-symlink-target.txt");
+    fs::write(&outside, "outside-old\n").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink(&outside, &link).unwrap();
+    let diff =
+        "<<<<<<< SEARCH\nlink.txt\n-------\noutside-old\n=======\nmutated\n>>>>>>> REPLACE\n";
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) =
+        call_tool_value(&client, "apply_patch", serde_json::json!({"diff": diff})).await;
+    assert!(
+        is_error,
+        "SEARCH/REPLACE through outside symlink must fail closed: {val}"
+    );
+    assert_eq!(
+        fs::read_to_string(&outside).unwrap(),
+        "outside-old\n",
+        "outside target must not be rewritten"
+    );
+    client.cancel().await.unwrap();
+    let _ = fs::remove_file(&outside);
+}


### PR DESCRIPTION
Post-#2221 MPI on the new SEARCH/REPLACE surfaces.

- Library `apply_patch` / `apply_patch_file` detect the grammar
- MCP refuses `replace_all` on Begin Patch
- MCP follow-mode dest-deny for a workspace symlink whose target is outside
- Shared `has_search_replace_marker` for mixed-grammar refuse
- mcp-setup `apply_patch` row names Begin Patch and SEARCH/REPLACE
- tree-sitter 0.26.12 to 0.26.13

Ref #2221