### PR TITLE
feat(ast): rewrite consumer imports after ast.move

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -568,8 +568,8 @@ dependencies[name=react].version # predicate filter
 - `ast.imports`: Manage import/use statements: add (idempotent), remove, deduplicate.
 - `ast.reorder`: Reorder symbols within a file or scope by name, kind, or custom order.
 - `ast.group`: Group symbols into a named module within a file.
-- `ast.move`: Move symbols between files with optional target creation.
-- `ast.extract_to_file`: Extract a symbol to a separate file with optional module unwrapping.
+- `ast.move`: Move symbols between files with optional target creation. Set update_imports with old_module_path and new_module_path to rewrite consumer use/import statements.
+- `ast.extract_to_file`: Extract a symbol to a separate file with optional module unwrapping. Set update_imports with old_module_path and new_module_path to rewrite consumer use/import statements.
 - `ast.split`: Split a file into multiple target files by distributing symbols.
 
 ## Troubleshooting

--- a/docs/getting-started/mcp-setup.md
+++ b/docs/getting-started/mcp-setup.md
@@ -244,8 +244,8 @@ AST tools so `list_tools` stays honest about what is callable.
 | `ast_imports` | List, add, remove, or deduplicate import statements in source files. |
 | `ast_reorder` | Reorder symbols by strategy: alphabetical, reverse, kind-first, or custom order. |
 | `ast_group` | Move symbols into a new or existing module block within the same file. |
-| `ast_move` | Move symbols between files with configurable insertion position. |
-| `ast_extract_to_file` | Extract a symbol to a new file, optionally unwrapping module blocks. |
+| `ast_move` | Move symbols between files with configurable insertion position. Optional `update_imports` plus `old_module_path` / `new_module_path` rewrites consumer imports. |
+| `ast_extract_to_file` | Extract a symbol to a new file, optionally unwrapping module blocks. Optional `update_imports` plus `old_module_path` / `new_module_path` rewrites consumer imports. |
 | `ast_split` | Split a file by distributing symbols across multiple target files. |
 
 ## How MCP mode differs from CLI mode

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1351,17 +1351,17 @@ The operations below are the building blocks inside `operations`.
 <!-- ref:tx-op:ast.move -->
 ### `ast.move`
 
-- **What it does:** Moves symbols from one file to another, removing them from the source and inserting at a specified position in the target. Supports creating the target file with an optional prepend. Preserves attached doc comments and attributes.
+- **What it does:** Moves symbols from one file to another, removing them from the source and inserting at a specified position in the target. Supports creating the target file with an optional prepend. Preserves attached doc comments and attributes. Set `update_imports` with `old_module_path` and `new_module_path` to rewrite consumer `use`/import statements of the moved symbols (default off; missing module paths fail with `invalid_input`).
 - **Use when:** You need to relocate functions, structs, or constants between files during a refactoring (e.g., moving helpers from `lib.rs` to `utils.rs`).
-- **Failure behavior:** Missing source or target anchor symbols exit **3** (`no_matches`) with `error_kind: "no_matches"`.
+- **Failure behavior:** Missing source or target anchor symbols exit **3** (`no_matches`) with `error_kind: "no_matches"`. `update_imports: true` without both module paths exits **1** with `error_kind: "invalid_input"`.
 - **Related:** `ast.extract_to_file`, `ast.group`, `ast.imports`
 
 <!-- ref:tx-op:ast.extract_to_file -->
 ### `ast.extract_to_file`
 
-- **What it does:** Extracts a single symbol from a source file into a new target file. For module blocks, it can unwrap the module wrapper and un-indent the body. Leaves an optional replacement text (e.g., `mod tests;`) in the source. Supports a prepend for the target (e.g., `use super::*;`).
+- **What it does:** Extracts a single symbol from a source file into a new target file. For module blocks, it can unwrap the module wrapper and un-indent the body. Leaves an optional replacement text (e.g., `mod tests;`) in the source. Supports a prepend for the target (e.g., `use super::*;`). Set `update_imports` with `old_module_path` and `new_module_path` to rewrite consumer `use`/import statements of the extracted symbol (default off; missing module paths fail with `invalid_input`).
 - **Use when:** You want to extract a test module, a large struct, or a helper block into its own file while leaving a `mod` declaration behind.
-- **Failure behavior:** Missing symbol exits **3** (`no_matches`) with `error_kind: "no_matches"`. Existing target without force exits **1** with `error_kind: "already_exists"`.
+- **Failure behavior:** Missing symbol exits **3** (`no_matches`) with `error_kind: "no_matches"`. Existing target without force exits **1** with `error_kind: "already_exists"`. `update_imports: true` without both module paths exits **1** with `error_kind: "invalid_input"`.
 - **Related:** `ast.split`, `ast.move`, `ast.imports`
 
 <!-- ref:tx-op:ast.split -->

--- a/src/ast/import_rewrite.rs
+++ b/src/ast/import_rewrite.rs
@@ -35,9 +35,10 @@ pub fn rewrite_imports_in_source(
     }
 
     let lines: Vec<&str> = source.lines().collect();
+    let eol = crate::write::detect_eol(source);
     let mut replacements: Vec<(usize, usize, String)> = Vec::new();
     for import in &imports {
-        let Some(rewritten) = rewrite_rust_use_block(&import.text, moves) else {
+        let Some(rewritten) = rewrite_rust_use_block(&import.text, moves, eol) else {
             continue;
         };
         let start = import.line.saturating_sub(1);
@@ -88,7 +89,7 @@ fn apply_line_replacements(
 }
 
 /// Rewrite one Rust `use` block (single- or multi-line text from `list_imports`).
-fn rewrite_rust_use_block(text: &str, moves: &[SymbolMove]) -> Option<String> {
+fn rewrite_rust_use_block(text: &str, moves: &[SymbolMove], eol: &str) -> Option<String> {
     let compact = flatten_import_text(text);
     let (vis, body) = rust_use_prefix_and_body(&compact)?;
     if body.ends_with("::*") || body.contains("::*") && !body.contains('{') {
@@ -104,7 +105,7 @@ fn rewrite_rust_use_block(text: &str, moves: &[SymbolMove]) -> Option<String> {
         if inner.split(',').any(is_glob_item) {
             return None;
         }
-        return rewrite_grouped_use(vis, path, inner, moves);
+        return rewrite_grouped_use(vis, path, inner, moves, eol);
     }
     rewrite_simple_use(vis, body, moves)
 }
@@ -154,7 +155,13 @@ fn rewrite_simple_use(vis: &str, body: &str, moves: &[SymbolMove]) -> Option<Str
     None
 }
 
-fn rewrite_grouped_use(vis: &str, path: &str, inner: &str, moves: &[SymbolMove]) -> Option<String> {
+fn rewrite_grouped_use(
+    vis: &str,
+    path: &str,
+    inner: &str,
+    moves: &[SymbolMove],
+    eol: &str,
+) -> Option<String> {
     let path = normalize_module(path);
     let items: Vec<&str> = inner
         .split(',')
@@ -165,16 +172,12 @@ fn rewrite_grouped_use(vis: &str, path: &str, inner: &str, moves: &[SymbolMove])
         return None;
     }
 
-    let mut remaining: Vec<&str> = Vec::new();
-    let mut moved: Vec<(&str, &SymbolMove)> = Vec::new();
+    let mut remaining: Vec<String> = Vec::new();
+    let mut moved: Vec<(String, String)> = Vec::new();
     for item in &items {
-        let (name, _) = split_name_alias(item);
-        match moves
-            .iter()
-            .find(|mv| normalize_module(&mv.old_module) == path && mv.name == name)
-        {
-            Some(mv) => moved.push((item, mv)),
-            None => remaining.push(item),
+        match match_grouped_item(&path, item, moves) {
+            Some((dest, dest_item)) => moved.push((dest, dest_item)),
+            None => remaining.push((*item).to_string()),
         }
     }
     if moved.is_empty() {
@@ -183,27 +186,76 @@ fn rewrite_grouped_use(vis: &str, path: &str, inner: &str, moves: &[SymbolMove])
 
     let mut parts: Vec<String> = Vec::new();
     if !remaining.is_empty() {
-        parts.push(format_use_items(vis, &path, &remaining));
+        let refs: Vec<&str> = remaining.iter().map(String::as_str).collect();
+        parts.push(format_use_items(vis, &path, &refs));
     }
     // Group moved items by destination module, preserving encounter order.
-    let mut dest_items: Vec<(String, Vec<&str>)> = Vec::new();
-    for (item, mv) in moved {
-        let dest = normalize_module(&mv.new_module);
+    let mut dest_items: Vec<(String, Vec<String>)> = Vec::new();
+    for (dest, dest_item) in moved {
         if let Some((_, bucket)) = dest_items.iter_mut().find(|(d, _)| *d == dest) {
-            bucket.push(item);
+            bucket.push(dest_item);
         } else {
-            dest_items.push((dest, vec![item]));
+            dest_items.push((dest, vec![dest_item]));
         }
     }
     for (dest, names) in dest_items {
-        parts.push(format_use_items(vis, &dest, &names));
+        let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+        parts.push(format_use_items(vis, &dest, &refs));
     }
-    Some(parts.join("\n"))
+    Some(parts.join(eol))
+}
+
+/// Match a grouped item against moves.
+///
+/// rustfmt crate-root form `use crate::{old_mod::helper}` treats
+/// `{group}::{item_prefix}` as the module and the last path segment as
+/// the symbol.
+fn match_grouped_item(
+    group_path: &str,
+    item: &str,
+    moves: &[SymbolMove],
+) -> Option<(String, String)> {
+    let (name, alias) = split_name_alias(item);
+    if name.contains('{') {
+        return None;
+    }
+    let (item_mod, symbol) = match name.rfind("::") {
+        Some(i) => (&name[..i], &name[i + 2..]),
+        None => ("", name),
+    };
+    if symbol.is_empty() || symbol == "*" {
+        return None;
+    }
+    let full_mod = if item_mod.is_empty() {
+        group_path.to_string()
+    } else if group_path.is_empty() {
+        normalize_module(item_mod)
+    } else {
+        format!("{}::{}", group_path, normalize_module(item_mod))
+    };
+    for mv in moves {
+        if mv.name == symbol && normalize_module(&mv.old_module) == full_mod {
+            let dest_item = match alias {
+                Some(a) => format!("{symbol} as {a}"),
+                None => symbol.to_string(),
+            };
+            return Some((normalize_module(&mv.new_module), dest_item));
+        }
+    }
+    None
 }
 
 fn format_use_items(vis: &str, module: &str, items: &[&str]) -> String {
     if items.len() == 1 {
-        format!("{vis}{module}::{};", items[0])
+        let item = items[0];
+        let (name, alias) = split_name_alias(item);
+        if name == "self" {
+            return match alias {
+                Some(a) => format!("{vis}{module} as {a};"),
+                None => format!("{vis}{module};"),
+            };
+        }
+        format!("{vis}{module}::{item};")
     } else {
         format!("{vis}{module}::{{{}}};", items.join(", "))
     }
@@ -314,5 +366,44 @@ mod tests {
         let source = "use crate::old_mod::*;\n\nfn main() {}\n";
         let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("helper")]);
         assert_eq!(out, None);
+    }
+
+    #[test]
+    fn rewrite_grouped_self_leftover_is_bare_module_use() {
+        let source = "use crate::old_mod::{self, helper};\n\nfn main() {}\n";
+        let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("helper")])
+            .expect("should rewrite grouped self leftover");
+        assert_eq!(
+            out,
+            "use crate::old_mod;\nuse crate::new_mod::helper;\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn rewrite_grouped_split_preserves_crlf() {
+        let source = "use crate::old_mod::{alpha, beta, gamma};\r\n\r\nfn main() {}\r\n";
+        let moves = [rust_move("alpha"), rust_move("gamma")];
+        let out = rewrite_imports_in_source(source, Language::Rust, &moves)
+            .expect("should rewrite grouped use");
+        assert_eq!(
+            out,
+            "use crate::old_mod::beta;\r\nuse crate::new_mod::{alpha, gamma};\r\n\r\nfn main() {}\r\n"
+        );
+        assert!(!out.contains('\n') || out.contains("\r\n"));
+        assert!(
+            !out.replace("\r\n", "").contains('\n'),
+            "mixed endings: {out:?}"
+        );
+    }
+
+    #[test]
+    fn rewrite_rustfmt_crate_root_grouped_path_item() {
+        let source = "use crate::{old_mod::helper, other::Thing};\n\nfn main() {}\n";
+        let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("helper")])
+            .expect("should rewrite rustfmt crate-root item");
+        assert_eq!(
+            out,
+            "use crate::other::Thing;\nuse crate::new_mod::helper;\n\nfn main() {}\n"
+        );
     }
 }

--- a/src/ast/import_rewrite.rs
+++ b/src/ast/import_rewrite.rs
@@ -1,0 +1,318 @@
+//! Rewrite consumer import/use statements after `ast.move` / `ast.extract_to_file`.
+//!
+//! Detection uses [`super::imports::list_imports`]. This module only rewrites
+//! already-found import blocks (Rust `use` first).
+
+use super::Language;
+use super::imports::list_imports;
+
+/// One symbol that moved from `old_module` to `new_module`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SymbolMove {
+    /// Identifier as it appears in `use path::Name` (not the `as` alias).
+    pub name: String,
+    /// Module path consumers currently import from (e.g. `crate::old_mod`).
+    pub old_module: String,
+    /// Module path consumers should import from (e.g. `crate::new_mod`).
+    pub new_module: String,
+}
+
+/// Rewrite import blocks in `source` for the given symbol moves.
+///
+/// Returns `None` when no import text changes (no matching consumer, glob
+/// left as-is, or language not rewritten).
+pub fn rewrite_imports_in_source(
+    source: &str,
+    lang: Language,
+    moves: &[SymbolMove],
+) -> Option<String> {
+    if moves.is_empty() || !matches!(lang, Language::Rust) {
+        return None;
+    }
+    let imports = list_imports(source, lang);
+    if imports.is_empty() {
+        return None;
+    }
+
+    let lines: Vec<&str> = source.lines().collect();
+    let mut replacements: Vec<(usize, usize, String)> = Vec::new();
+    for import in &imports {
+        let Some(rewritten) = rewrite_rust_use_block(&import.text, moves) else {
+            continue;
+        };
+        let start = import.line.saturating_sub(1);
+        if start >= lines.len() {
+            continue;
+        }
+        let count = import.text.lines().count().max(1);
+        let end = (start + count).min(lines.len());
+        replacements.push((start, end, rewritten));
+    }
+    if replacements.is_empty() {
+        return None;
+    }
+    Some(apply_line_replacements(source, &lines, &replacements))
+}
+
+fn apply_line_replacements(
+    source: &str,
+    lines: &[&str],
+    replacements: &[(usize, usize, String)],
+) -> String {
+    let eol = crate::write::detect_eol(source);
+    let mut out = String::new();
+    let mut i = 0usize;
+    let mut r = 0usize;
+    while i < lines.len() {
+        if r < replacements.len() && i == replacements[r].0 {
+            let (_, end, ref text) = replacements[r];
+            out.push_str(text);
+            if !text.is_empty() && !text.ends_with('\n') {
+                // Keep a trailing newline after the replacement unless this
+                // block was the last line of a file that had no final newline.
+                if end < lines.len() || source.ends_with('\n') {
+                    out.push_str(eol);
+                }
+            }
+            i = end;
+            r += 1;
+        } else {
+            out.push_str(lines[i]);
+            if i + 1 < lines.len() || source.ends_with('\n') {
+                out.push_str(eol);
+            }
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Rewrite one Rust `use` block (single- or multi-line text from `list_imports`).
+fn rewrite_rust_use_block(text: &str, moves: &[SymbolMove]) -> Option<String> {
+    let compact = flatten_import_text(text);
+    let (vis, body) = rust_use_prefix_and_body(&compact)?;
+    if body.ends_with("::*") || body.contains("::*") && !body.contains('{') {
+        return None;
+    }
+    if let Some(brace) = body.find('{') {
+        let close = body.rfind('}')?;
+        if close < brace {
+            return None;
+        }
+        let path = body[..brace].trim().trim_end_matches(':').trim();
+        let inner = &body[brace + 1..close];
+        if inner.split(',').any(is_glob_item) {
+            return None;
+        }
+        return rewrite_grouped_use(vis, path, inner, moves);
+    }
+    rewrite_simple_use(vis, body, moves)
+}
+
+fn flatten_import_text(text: &str) -> String {
+    text.lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn rust_use_prefix_and_body(text: &str) -> Option<(&str, &str)> {
+    let trimmed = text.trim();
+    let vis = if trimmed.starts_with("pub(crate) use ") {
+        "pub(crate) use "
+    } else if trimmed.starts_with("pub(super) use ") {
+        "pub(super) use "
+    } else if trimmed.starts_with("pub use ") {
+        "pub use "
+    } else if trimmed.starts_with("use ") {
+        "use "
+    } else {
+        return None;
+    };
+    let rest = trimmed.get(vis.len()..)?.trim();
+    let rest = rest.strip_suffix(';').unwrap_or(rest).trim();
+    Some((vis, rest))
+}
+
+fn rewrite_simple_use(vis: &str, body: &str, moves: &[SymbolMove]) -> Option<String> {
+    for mv in moves {
+        let old = normalize_module(&mv.old_module);
+        let Some(tail) = module_tail(body, &old) else {
+            continue;
+        };
+        if tail.is_empty() || tail == "*" || tail.contains("::") {
+            continue;
+        }
+        let (name, _) = split_name_alias(tail);
+        if name != mv.name {
+            continue;
+        }
+        let new = normalize_module(&mv.new_module);
+        return Some(format!("{vis}{new}::{tail};"));
+    }
+    None
+}
+
+fn rewrite_grouped_use(vis: &str, path: &str, inner: &str, moves: &[SymbolMove]) -> Option<String> {
+    let path = normalize_module(path);
+    let items: Vec<&str> = inner
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if items.is_empty() {
+        return None;
+    }
+
+    let mut remaining: Vec<&str> = Vec::new();
+    let mut moved: Vec<(&str, &SymbolMove)> = Vec::new();
+    for item in &items {
+        let (name, _) = split_name_alias(item);
+        match moves
+            .iter()
+            .find(|mv| normalize_module(&mv.old_module) == path && mv.name == name)
+        {
+            Some(mv) => moved.push((item, mv)),
+            None => remaining.push(item),
+        }
+    }
+    if moved.is_empty() {
+        return None;
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+    if !remaining.is_empty() {
+        parts.push(format_use_items(vis, &path, &remaining));
+    }
+    // Group moved items by destination module, preserving encounter order.
+    let mut dest_items: Vec<(String, Vec<&str>)> = Vec::new();
+    for (item, mv) in moved {
+        let dest = normalize_module(&mv.new_module);
+        if let Some((_, bucket)) = dest_items.iter_mut().find(|(d, _)| *d == dest) {
+            bucket.push(item);
+        } else {
+            dest_items.push((dest, vec![item]));
+        }
+    }
+    for (dest, names) in dest_items {
+        parts.push(format_use_items(vis, &dest, &names));
+    }
+    Some(parts.join("\n"))
+}
+
+fn format_use_items(vis: &str, module: &str, items: &[&str]) -> String {
+    if items.len() == 1 {
+        format!("{vis}{module}::{};", items[0])
+    } else {
+        format!("{vis}{module}::{{{}}};", items.join(", "))
+    }
+}
+
+fn normalize_module(module: &str) -> String {
+    module.trim().trim_end_matches(':').trim().to_string()
+}
+
+fn module_tail<'a>(path: &'a str, module: &str) -> Option<&'a str> {
+    if path == module {
+        return Some("");
+    }
+    path.strip_prefix(module)
+        .and_then(|rest| rest.strip_prefix("::"))
+}
+
+fn split_name_alias(item: &str) -> (&str, Option<&str>) {
+    let item = strip_line_comment(item);
+    let mut parts = item.split_whitespace();
+    let name = parts.next().unwrap_or("");
+    let alias = match (parts.next(), parts.next()) {
+        (Some(kw), Some(alias)) if kw.eq_ignore_ascii_case("as") => Some(alias),
+        _ => None,
+    };
+    (name, alias)
+}
+
+fn strip_line_comment(s: &str) -> &str {
+    match s.find("//") {
+        Some(i) => s[..i].trim(),
+        None => s.trim(),
+    }
+}
+
+fn is_glob_item(part: &str) -> bool {
+    let name = split_name_alias(part).0;
+    name == "*"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rust_move(name: &str) -> SymbolMove {
+        SymbolMove {
+            name: name.into(),
+            old_module: "crate::old_mod".into(),
+            new_module: "crate::new_mod".into(),
+        }
+    }
+
+    #[test]
+    fn rewrite_simple_use_line() {
+        let source = "use crate::old_mod::helper;\n\nfn main() {}\n";
+        let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("helper")])
+            .expect("should rewrite simple use");
+        assert_eq!(out, "use crate::new_mod::helper;\n\nfn main() {}\n");
+    }
+
+    #[test]
+    fn rewrite_grouped_partial_move() {
+        let source = "use crate::old_mod::{alpha, beta, gamma};\n\nfn main() {}\n";
+        let moves = [rust_move("alpha"), rust_move("gamma")];
+        let out = rewrite_imports_in_source(source, Language::Rust, &moves)
+            .expect("should rewrite grouped use");
+        assert_eq!(
+            out,
+            "use crate::old_mod::beta;\nuse crate::new_mod::{alpha, gamma};\n\nfn main() {}\n"
+        );
+    }
+
+    #[test]
+    fn rewrite_preserves_visibility_prefix() {
+        let source = "pub use crate::old_mod::helper;\npub(crate) use crate::old_mod::helper;\n";
+        let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("helper")])
+            .expect("should rewrite vis use");
+        assert_eq!(
+            out,
+            "pub use crate::new_mod::helper;\npub(crate) use crate::new_mod::helper;\n"
+        );
+    }
+
+    #[test]
+    fn rewrite_leaves_indented_use_unchanged() {
+        let source = "fn main() {\n    use crate::old_mod::helper;\n}\n";
+        let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("helper")]);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn rewrite_no_matching_consumer_is_unchanged() {
+        let source = "use crate::other::foo;\n\nfn main() {}\n";
+        let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("helper")]);
+        assert_eq!(out, None);
+    }
+
+    #[test]
+    fn rewrite_keeps_name_as_alias() {
+        let source = "use crate::old_mod::Name as Alias;\n\nfn main() {}\n";
+        let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("Name")])
+            .expect("should rewrite aliased use");
+        assert_eq!(out, "use crate::new_mod::Name as Alias;\n\nfn main() {}\n");
+    }
+
+    #[test]
+    fn rewrite_leaves_glob_use_unchanged() {
+        let source = "use crate::old_mod::*;\n\nfn main() {}\n";
+        let out = rewrite_imports_in_source(source, Language::Rust, &[rust_move("helper")]);
+        assert_eq!(out, None);
+    }
+}

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -9,6 +9,7 @@ pub mod diff;
 pub mod extract_to_file;
 pub mod group;
 pub mod impact;
+pub mod import_rewrite;
 pub mod imports;
 pub mod insert;
 pub mod map;

--- a/src/cmd/explain/describe.rs
+++ b/src/cmd/explain/describe.rs
@@ -497,10 +497,16 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             path,
             target,
             symbols,
+            update_imports,
             ..
         } => {
+            let extra = if *update_imports {
+                ", update imports"
+            } else {
+                ""
+            };
             format!(
-                "AST move {} symbol(s) from {path} to {target}",
+                "AST move {} symbol(s) from {path} to {target}{extra}",
                 symbols.len()
             )
         }
@@ -509,9 +515,15 @@ pub(super) fn describe_operation(op: &Operation) -> String {
             source,
             symbol,
             target,
+            update_imports,
             ..
         } => {
-            format!("AST extract \"{symbol}\" from {source} to {target}")
+            let extra = if *update_imports {
+                ", update imports"
+            } else {
+                ""
+            };
+            format!("AST extract \"{symbol}\" from {source} to {target}{extra}")
         }
         #[cfg(feature = "ast")]
         Operation::AstSplit {

--- a/src/cmd/mcp/ast_tools.rs
+++ b/src/cmd/mcp/ast_tools.rs
@@ -959,6 +959,9 @@ pub(super) fn handle_ast_move(
         position: p.position,
         target_prepend: p.target_prepend,
         lang: p.lang,
+        update_imports: p.update_imports,
+        old_module_path: p.old_module_path,
+        new_module_path: p.new_module_path,
     };
     svc.run_one_op(op, None)
 }
@@ -978,6 +981,9 @@ pub(super) fn handle_ast_extract_to_file(
         prepend: p.prepend,
         force: p.force,
         lang: p.lang,
+        update_imports: p.update_imports,
+        old_module_path: p.old_module_path,
+        new_module_path: p.new_module_path,
     };
     svc.run_one_op(op, None)
 }

--- a/src/cmd/mcp/params.rs
+++ b/src/cmd/mcp/params.rs
@@ -706,6 +706,15 @@ pub(crate) struct AstMoveParams {
     pub target_prepend: Option<String>,
     /// Language hint.
     pub lang: Option<String>,
+    /// Rewrite consumer `use`/import statements of moved symbols.
+    #[serde(default)]
+    pub update_imports: bool,
+    /// Module path consumers currently import from (required with `update_imports`).
+    #[serde(default)]
+    pub old_module_path: Option<String>,
+    /// Module path consumers should import from (required with `update_imports`).
+    #[serde(default)]
+    pub new_module_path: Option<String>,
 }
 
 #[cfg(feature = "ast")]
@@ -732,6 +741,15 @@ pub(crate) struct AstExtractToFileParams {
     pub force: bool,
     /// Language hint.
     pub lang: Option<String>,
+    /// Rewrite consumer `use`/import statements of the extracted symbol.
+    #[serde(default)]
+    pub update_imports: bool,
+    /// Module path consumers currently import from (required with `update_imports`).
+    #[serde(default)]
+    pub old_module_path: Option<String>,
+    /// Module path consumers should import from (required with `update_imports`).
+    #[serde(default)]
+    pub new_module_path: Option<String>,
 }
 
 #[cfg(feature = "ast")]

--- a/src/plan/operation.rs
+++ b/src/plan/operation.rs
@@ -509,6 +509,15 @@ pub enum Operation {
         target_prepend: Option<String>,
         #[serde(default)]
         lang: Option<String>,
+        /// Rewrite consumer `use`/import statements of moved symbols.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        update_imports: bool,
+        /// Module path consumers currently import from (required with `update_imports`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        old_module_path: Option<String>,
+        /// Module path consumers should import from (required with `update_imports`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        new_module_path: Option<String>,
     },
     #[cfg(feature = "ast")]
     #[serde(rename = "ast.extract_to_file")]
@@ -533,6 +542,15 @@ pub enum Operation {
         force: bool,
         #[serde(default)]
         lang: Option<String>,
+        /// Rewrite consumer `use`/import statements of the extracted symbol.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        update_imports: bool,
+        /// Module path consumers currently import from (required with `update_imports`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        old_module_path: Option<String>,
+        /// Module path consumers should import from (required with `update_imports`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        new_module_path: Option<String>,
     },
     #[cfg(feature = "ast")]
     #[serde(rename = "ast.split")]

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -309,11 +309,24 @@ fn parse_all_operation_variants() {
             {"op": "ast.reorder", "path": "f.rs", "order": ["b", "a"], "inside": "mod tests"},
             {"op": "ast.group", "path": "f.rs", "module": "tests", "symbols": ["test_a"]},
             {"op": "ast.move", "path": "src.rs", "target": "dst.rs", "symbols": ["foo"]},
+            {"op": "ast.move", "path": "src.rs", "target": "dst.rs", "symbols": ["foo"], "update_imports": true, "old_module_path": "crate::old_mod", "new_module_path": "crate::new_mod"},
             {"op": "ast.extract_to_file", "source": "lib.rs", "symbol": "tests", "target": "lib_tests.rs"},
             {"op": "ast.split", "source": "big.rs", "targets": [{"path": "a.rs", "symbols": ["A"]}]}
         ]}"#;
     let plan = parse_plan(json).unwrap();
-    assert_eq!(plan.operations.len(), 45);
+    assert_eq!(plan.operations.len(), 46);
+    let found = plan.operations.iter().any(|op| {
+        matches!(
+            op,
+            Operation::AstMove {
+                update_imports: true,
+                old_module_path: Some(old),
+                new_module_path: Some(new),
+                ..
+            } if old == "crate::old_mod" && new == "crate::new_mod"
+        )
+    });
+    assert!(found, "ast.move update_imports fields should parse");
 }
 
 /// Canonical plan field is `selector` (matches CLI help). Alias `key` must

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -542,21 +542,33 @@ const AST_OPERATION_REGISTRY: &[OpMeta] = &[
     },
     OpMeta {
         name: "ast.move",
-        description: "Move symbols between files with optional target creation.",
+        description: "Move symbols between files with optional target creation. Set update_imports with old_module_path and new_module_path to rewrite consumer use/import statements.",
         tier: Tier::Medium,
-        examples: &[(
-            "Move helpers to a utility file",
-            r###"{"op":"ast.move","path":"src/lib.rs","target":"src/helpers.rs","symbols":["helper_fn"]}"###,
-        )],
+        examples: &[
+            (
+                "Move helpers to a utility file",
+                r###"{"op":"ast.move","path":"src/lib.rs","target":"src/helpers.rs","symbols":["helper_fn"]}"###,
+            ),
+            (
+                "Move a helper and rewrite consumer imports",
+                r###"{"op":"ast.move","path":"src/old_mod.rs","target":"src/new_mod.rs","symbols":["helper"],"update_imports":true,"old_module_path":"crate::old_mod","new_module_path":"crate::new_mod"}"###,
+            ),
+        ],
     },
     OpMeta {
         name: "ast.extract_to_file",
-        description: "Extract a symbol to a separate file with optional module unwrapping.",
+        description: "Extract a symbol to a separate file with optional module unwrapping. Set update_imports with old_module_path and new_module_path to rewrite consumer use/import statements.",
         tier: Tier::Medium,
-        examples: &[(
-            "Extract test module to companion file",
-            r###"{"op":"ast.extract_to_file","source":"src/lib.rs","symbol":"tests","target":"src/lib_tests.rs","replacement":"mod tests;","prepend":"use super::*;"}"###,
-        )],
+        examples: &[
+            (
+                "Extract test module to companion file",
+                r###"{"op":"ast.extract_to_file","source":"src/lib.rs","symbol":"tests","target":"src/lib_tests.rs","replacement":"mod tests;","prepend":"use super::*;"}"###,
+            ),
+            (
+                "Extract Config and rewrite consumer imports",
+                r###"{"op":"ast.extract_to_file","source":"src/lib.rs","symbol":"Config","target":"src/config.rs","update_imports":true,"old_module_path":"crate::old_mod","new_module_path":"crate::config"}"###,
+            ),
+        ],
     },
     OpMeta {
         name: "ast.split",

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -1,4 +1,4 @@
-use super::execute::{TxState, read_file_content};
+use super::execute::{TxState, read_and_probe, read_file_content};
 use crate::plan::Operation;
 
 use std::path::{Path, PathBuf};
@@ -413,7 +413,12 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             position,
             target_prepend,
             lang,
+            update_imports,
+            old_module_path,
+            new_module_path,
         } => {
+            let rewrite_mods =
+                import_rewrite_modules(*update_imports, old_module_path, new_module_path)?;
             let abs_source = tx.cwd.join(path);
             let abs_target = tx.cwd.join(target);
             let source_content =
@@ -440,6 +445,15 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             )?;
             tx.write_file(&abs_source, result.source_content);
             tx.write_file(&abs_target, result.target_content);
+            if let Some((old, new)) = rewrite_mods {
+                apply_consumer_import_rewrites(
+                    tx,
+                    &abs_source,
+                    &abs_target,
+                    lang_val,
+                    &symbol_moves(sym_names, &old, &new),
+                )?;
+            }
             Ok(result.symbols_moved)
         }
 
@@ -452,7 +466,12 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             prepend,
             force,
             lang,
+            update_imports,
+            old_module_path,
+            new_module_path,
         } => {
+            let rewrite_mods =
+                import_rewrite_modules(*update_imports, old_module_path, new_module_path)?;
             let abs_source = tx.cwd.join(source);
             let abs_target = tx.cwd.join(target);
             if !force && (abs_target.exists() || tx.pending.contains_key(&abs_target)) {
@@ -479,6 +498,15 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
             )?;
             tx.write_file(&abs_source, result.source_content);
             tx.write_file(&abs_target, result.target_content);
+            if let Some((old, new)) = rewrite_mods {
+                apply_consumer_import_rewrites(
+                    tx,
+                    &abs_source,
+                    &abs_target,
+                    lang_val,
+                    &symbol_moves(std::slice::from_ref(symbol), &old, &new),
+                )?;
+            }
             Ok(1)
         }
 
@@ -525,6 +553,109 @@ pub(crate) fn execute_ast_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::Re
 
         _ => unreachable!("execute_ast_op called with non-AST operation"),
     }
+}
+
+fn import_rewrite_modules(
+    update_imports: bool,
+    old_module_path: &Option<String>,
+    new_module_path: &Option<String>,
+) -> anyhow::Result<Option<(String, String)>> {
+    if !update_imports {
+        return Ok(None);
+    }
+    let old = old_module_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    let new = new_module_path
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+    match (old, new) {
+        (Some(old), Some(new)) => Ok(Some((old.to_string(), new.to_string()))),
+        _ => Err(crate::exit::InvalidInputError {
+            msg: "update_imports requires old_module_path and new_module_path".into(),
+        }
+        .into()),
+    }
+}
+
+fn symbol_moves(
+    symbols: &[String],
+    old: &str,
+    new: &str,
+) -> Vec<crate::ast::import_rewrite::SymbolMove> {
+    symbols
+        .iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|name| crate::ast::import_rewrite::SymbolMove {
+            name: name.to_string(),
+            old_module: old.to_string(),
+            new_module: new.to_string(),
+        })
+        .collect()
+}
+
+/// After a successful move/extract, optionally rewrite consumer imports.
+fn apply_consumer_import_rewrites(
+    tx: &mut TxState<'_>,
+    source: &Path,
+    target: &Path,
+    lang: crate::ast::Language,
+    moves: &[crate::ast::import_rewrite::SymbolMove],
+) -> anyhow::Result<()> {
+    if moves.is_empty() {
+        return Ok(());
+    }
+
+    let files = collect_ast_source_files(tx.cwd)?;
+    for file in files {
+        if paths_equal(&file, source) || paths_equal(&file, target) {
+            continue;
+        }
+        if crate::ast::Language::from_path(&file) != lang {
+            continue;
+        }
+        if is_skipped_consumer_path(&file, tx.cwd) {
+            continue;
+        }
+        if let Some(g) = tx.guard {
+            let rel = file.strip_prefix(tx.cwd).unwrap_or(file.as_path());
+            g.check_path(&rel.to_string_lossy())
+                .map_err(crate::fallback::EditError::guard_rejected)?;
+        }
+        if !read_and_probe(tx.pending, tx.existed_before, &file)? {
+            continue;
+        }
+        let content = read_file_content(tx.pending, tx.existed_before, &file)?.to_string();
+        if let Some(rewritten) =
+            crate::ast::import_rewrite::rewrite_imports_in_source(&content, lang, moves)
+        {
+            tx.write_file(&file, rewritten);
+        }
+    }
+    Ok(())
+}
+
+fn paths_equal(a: &Path, b: &Path) -> bool {
+    if a == b {
+        return true;
+    }
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(x), Ok(y)) => x == y,
+        _ => false,
+    }
+}
+
+fn is_skipped_consumer_path(path: &Path, cwd: &Path) -> bool {
+    let rel = path.strip_prefix(cwd).unwrap_or(path);
+    rel.components().any(|c| {
+        matches!(
+            c.as_os_str().to_str(),
+            Some("target" | "node_modules" | ".git" | ".patchloom")
+        )
+    })
 }
 
 #[cfg(all(test, any(feature = "cli", feature = "files")))]

--- a/src/tx/ast_op.rs
+++ b/src/tx/ast_op.rs
@@ -609,9 +609,19 @@ fn apply_consumer_import_rewrites(
         return Ok(());
     }
 
-    let files = collect_ast_source_files(tx.cwd)?;
+    let mut files = collect_ast_source_files(tx.cwd)?;
+    // Same-plan creates exist only in pending until commit.
+    for pending in tx.pending.keys() {
+        if crate::ast::Language::from_path(pending) == lang && !files.iter().any(|f| f == pending) {
+            files.push(pending.clone());
+        }
+    }
+    files.sort();
     for file in files {
         if paths_equal(&file, source) || paths_equal(&file, target) {
+            continue;
+        }
+        if tx.deletions.contains(&file) {
             continue;
         }
         if crate::ast::Language::from_path(&file) != lang {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -4657,6 +4657,54 @@ async fn test_mcp_ast_move_between_files() {
     client.cancel().await.unwrap();
 }
 
+#[cfg(feature = "ast")]
+#[tokio::test]
+async fn test_mcp_ast_move_update_imports() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("old_mod.rs"),
+        "fn helper() {}\nfn keep() {}\n",
+    )
+    .unwrap();
+    fs::write(dir.path().join("new_mod.rs"), "").unwrap();
+    fs::write(
+        dir.path().join("consumer.rs"),
+        "use crate::old_mod::helper;\n\nfn main() { helper(); }\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "ast_move",
+        serde_json::json!({
+            "path": "old_mod.rs",
+            "target": "new_mod.rs",
+            "symbols": ["helper"],
+            "update_imports": true,
+            "old_module_path": "crate::old_mod",
+            "new_module_path": "crate::new_mod"
+        }),
+    )
+    .await;
+    assert!(!is_error, "ast_move update_imports should succeed: {val}");
+    assert_eq!(val["ok"], true, "ast_move ok: {val}");
+
+    let consumer = fs::read_to_string(dir.path().join("consumer.rs")).unwrap();
+    assert_eq!(
+        consumer,
+        "use crate::new_mod::helper;\n\nfn main() { helper(); }\n"
+    );
+    let src = fs::read_to_string(dir.path().join("old_mod.rs")).unwrap();
+    let dst = fs::read_to_string(dir.path().join("new_mod.rs")).unwrap();
+    assert!(!src.contains("fn helper"), "removed from source: {src}");
+    assert!(dst.contains("fn helper"), "added to target: {dst}");
+    client.cancel().await.unwrap();
+}
+
 // ── MCP ast_extract_to_file round-trip ─────────────────────────
 
 #[cfg(feature = "ast")]

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -8057,6 +8057,299 @@ fn test_tx_ast_move_creates_target() {
     assert!(tgt.contains("fn go"), "symbol should be present: {tgt}");
 }
 
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_update_imports() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("old_mod.rs");
+    let target = dir.path().join("new_mod.rs");
+    let consumer = dir.path().join("consumer.rs");
+    fs::write(&source, "fn keep() {}\nfn helper() { let x = 1; }\n").unwrap();
+    fs::write(&target, "").unwrap();
+    fs::write(
+        &consumer,
+        "use crate::old_mod::helper;\n\nfn main() { helper(); }\n",
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.move",
+            "path": portable_path_str(&source),
+            "target": portable_path_str(&target),
+            "symbols": ["helper"],
+            "update_imports": true,
+            "old_module_path": "crate::old_mod",
+            "new_module_path": "crate::new_mod"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let src_content = fs::read_to_string(&source).unwrap();
+    let tgt_content = fs::read_to_string(&target).unwrap();
+    let consumer_content = fs::read_to_string(&consumer).unwrap();
+    assert!(
+        !src_content.contains("fn helper"),
+        "source should lose helper: {src_content}"
+    );
+    assert!(
+        tgt_content.contains("fn helper"),
+        "target should gain helper: {tgt_content}"
+    );
+    assert_eq!(
+        consumer_content, "use crate::new_mod::helper;\n\nfn main() { helper(); }\n",
+        "consumer use should rewrite to new_mod"
+    );
+    assert!(
+        !consumer_content.contains("crate::old_mod"),
+        "old_mod import should be gone: {consumer_content}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_update_imports_grouped_use() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("old_mod.rs");
+    let target = dir.path().join("new_mod.rs");
+    let consumer = dir.path().join("consumer.rs");
+    fs::write(&source, "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n").unwrap();
+    fs::write(&target, "").unwrap();
+    fs::write(
+        &consumer,
+        "use crate::old_mod::{alpha, beta, gamma};\n\nfn main() { alpha(); beta(); gamma(); }\n",
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.move",
+            "path": portable_path_str(&source),
+            "target": portable_path_str(&target),
+            "symbols": ["alpha", "gamma"],
+            "update_imports": true,
+            "old_module_path": "crate::old_mod",
+            "new_module_path": "crate::new_mod"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let consumer_content = fs::read_to_string(&consumer).unwrap();
+    assert_eq!(
+        consumer_content,
+        "use crate::old_mod::beta;\nuse crate::new_mod::{alpha, gamma};\n\nfn main() { alpha(); beta(); gamma(); }\n"
+    );
+    let src = fs::read_to_string(&source).unwrap();
+    let tgt = fs::read_to_string(&target).unwrap();
+    assert!(src.contains("fn beta"), "beta stays in old_mod: {src}");
+    assert!(!src.contains("fn alpha"), "alpha left source: {src}");
+    assert!(
+        tgt.contains("fn alpha") && tgt.contains("fn gamma"),
+        "moved to target: {tgt}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_extract_to_file_update_imports() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("old_mod.rs");
+    let target = dir.path().join("config.rs");
+    let consumer = dir.path().join("consumer.rs");
+    fs::write(&source, "pub struct Config {}\nfn keep() {}\n").unwrap();
+    fs::write(
+        &consumer,
+        "use crate::old_mod::Config;\n\nfn main() { let _ = Config; }\n",
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.extract_to_file",
+            "source": portable_path_str(&source),
+            "symbol": "Config",
+            "target": portable_path_str(&target),
+            "update_imports": true,
+            "old_module_path": "crate::old_mod",
+            "new_module_path": "crate::config"
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let src = fs::read_to_string(&source).unwrap();
+    let tgt = fs::read_to_string(&target).unwrap();
+    let consumer_content = fs::read_to_string(&consumer).unwrap();
+    assert!(
+        !src.contains("struct Config"),
+        "Config should leave source: {src}"
+    );
+    assert!(
+        tgt.contains("struct Config"),
+        "Config should land in target: {tgt}"
+    );
+    assert_eq!(
+        consumer_content,
+        "use crate::config::Config;\n\nfn main() { let _ = Config; }\n"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_update_imports_missing_paths_errors() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("old_mod.rs");
+    let target = dir.path().join("new_mod.rs");
+    fs::write(&source, "fn helper() {}\n").unwrap();
+    fs::write(&target, "").unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.move",
+            "path": portable_path_str(&source),
+            "target": portable_path_str(&target),
+            "symbols": ["helper"],
+            "update_imports": true
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let assert = patchloom_in(dir.path())
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(1);
+    let stdout = String::from_utf8_lossy(&assert.get_output().stdout);
+    let v: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        v["error_kind"], "invalid_input",
+        "missing module paths should be invalid_input: {stdout}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_without_update_imports_does_not_rewrite() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("old_mod.rs");
+    let target = dir.path().join("new_mod.rs");
+    let consumer = dir.path().join("consumer.rs");
+    let consumer_src = "use crate::old_mod::helper;\n\nfn main() { helper(); }\n";
+    fs::write(&source, "fn helper() {}\n").unwrap();
+    fs::write(&target, "").unwrap();
+    fs::write(&consumer, consumer_src).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "ast.move",
+            "path": portable_path_str(&source),
+            "target": portable_path_str(&target),
+            "symbols": ["helper"]
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let consumer_content = fs::read_to_string(&consumer).unwrap();
+    assert_eq!(
+        consumer_content, consumer_src,
+        "default off must not rewrite consumer imports"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_tx_ast_move_update_imports_rollback_restores_consumer() {
+    let dir = TempDir::new().unwrap();
+    let source = dir.path().join("old_mod.rs");
+    let target = dir.path().join("new_mod.rs");
+    let consumer = dir.path().join("consumer.rs");
+    let consumer_src = "use crate::old_mod::helper;\n\nfn main() { helper(); }\n";
+    let source_src = "fn helper() {}\n";
+    fs::write(&source, source_src).unwrap();
+    fs::write(&target, "").unwrap();
+    fs::write(&consumer, consumer_src).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [
+            {
+                "op": "ast.move",
+                "path": portable_path_str(&source),
+                "target": portable_path_str(&target),
+                "symbols": ["helper"],
+                "update_imports": true,
+                "old_module_path": "crate::old_mod",
+                "new_module_path": "crate::new_mod"
+            },
+            {
+                "op": "replace",
+                "path": "missing.rs",
+                "old": "x",
+                "new": "y"
+            }
+        ]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    patchloom_in(dir.path())
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .failure();
+
+    assert_eq!(
+        fs::read_to_string(&consumer).unwrap(),
+        consumer_src,
+        "rollback must restore original consumer import"
+    );
+    assert_eq!(
+        fs::read_to_string(&source).unwrap(),
+        source_src,
+        "rollback must restore source"
+    );
+}
+
 // ── ast.extract_to_file (tx plan) ──────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

`ast.move` and `ast.extract_to_file` can optionally rewrite consumer `use` statements after a symbol moves, so the rest of the crate still compiles.

## Problem

Those ops copied the symbol text only. A consumer that still had `use crate::old_mod::helper;` pointed at a path that no longer exported the symbol.

This comes from Starfleet HARD `t-pieaGwFD0fZ2OXn60zr6U`. The model added a 1100-line five-language line parser. This PR keeps the opt-in plan fields and the Rust rewrite algorithm, but reuses `list_imports` instead of a second import engine.

## Change

- Opt-in plan/MCP fields on `ast.move` and `ast.extract_to_file` only: `update_imports`, `old_module_path`, `new_module_path` (default off).
- Missing module paths when opted in are `invalid_input`.
- Consumer rewrites go through `tx.write_file` so a later plan failure restores both the symbol files and the imports.
- PathGuard is checked at rewrite time. Deleted pending paths are skipped. Same-plan creates in `pending` are scanned.
- Rust only for this slice: simple `use`, grouped `{a, b}`, `self` leftover (`use crate::old_mod;`), `as` aliases, rustfmt `use crate::{old_mod::Name}`, CRLF-preserving splits. Globs and indented uses are left alone.

## Validation

- Red-green: unit tests failed before the rewriter existed, then passed.
- `cargo test --lib import_rewrite`: 10 passed
- `cargo test --test integration update_imports --all-features`: 7 passed (tx rubric case, grouped, extract, missing paths, default off, rollback, MCP)
- Reviewer: 2 bugs folded (`use module::self` leftover, mixed CRLF on grouped split) plus rustfmt crate-root match and pending/delete walk.
- `make check-fast` green on `c551cac7`

Closes #2229
