### PR TITLE
feat(selector): comparison and negation predicates

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -489,9 +489,12 @@ All `doc` operations use selector paths to address values inside JSON, YAML, and
 | `.` | Document root | `doc keys FILE .`; `doc set FILE . VALUE` replaces the whole document |
 | `[N]` | Array index (zero-based) | `servers[0].port` |
 | `[*]` | Wildcard (all array elements) | `jobs[*].timeout` |
-| `[key=val]` | Predicate (filter by field value) | `deps[name=express].version` |
+| `[key=val]` | Equality predicate (filter by field value) | `deps[name=express].version` |
+| `[key!=val]` | Not-equal; missing fields do not match | `items[status!=disabled]` |
+| `[key>N]` `[key>=N]` `[key<N]` `[key<=N]` | Numeric compare (`f64`; JSON number or numeric string) | `servers[port>8000]` |
+| `[!key]` | Key absent, JSON `false`, or `null` | `flags[!deprecated]` |
 
-Segments are separated by `.` or adjacent brackets. A single leading `/` is treated as "from root" and stripped (JSON Pointer habit), so `/feature_flag` sets key `feature_flag`, not a key literally named `/feature_flag` (#1794). Only one leading slash is special; `//a` keeps a key named `/a`. Prefer bare keys in prompts (`feature_flag`, `server.port`). A lone `.` (or empty / `/`) is the document root: `doc keys FILE .` lists top-level keys, and `doc set FILE . VALUE` replaces the whole document. Examples:
+Equality is unchanged: `items[url=a=b]` and `items[url=a>b]` stay `key=value`. Comparison operands must be numeric (`[port>abc]` is `invalid_input`). A present non-numeric field vs `>` / `>=` / `<` / `<=` is also `invalid_input` (not a string compare). Regex predicates are not supported. Segments are separated by `.` or adjacent brackets. A single leading `/` is treated as "from root" and stripped (JSON Pointer habit), so `/feature_flag` sets key `feature_flag`, not a key literally named `/feature_flag` (#1794). Only one leading slash is special; `//a` keeps a key named `/a`. Prefer bare keys in prompts (`feature_flag`, `server.port`). A lone `.` (or empty / `/`) is the document root: `doc keys FILE .` lists top-level keys, and `doc set FILE . VALUE` replaces the whole document. Examples:
 
 ```text
 .                               # document root (keys / whole-document set)
@@ -499,6 +502,8 @@ scripts.test                    # simple selector path
 /feature_flag                   # same as feature_flag (leading slash stripped)
 jobs[0].steps[*].name           # index + wildcard
 dependencies[name=react].version # predicate filter
+data[type=server][port>8000]    # chained equality + numeric compare
+flags[!deprecated]              # absent, false, or null
 ```
 
 **Write ops and predicates:** `doc set` / `doc ensure` / `doc delete` / `doc move` are **single-path only** (keys and indexes such as `items.0.val`). Wildcards and predicates (`items[id=b].val`, `items[*].enabled`) belong on `doc update` (multi-match write) or `doc delete-where` (array filter). If you pass a predicate to `doc set`, the error points you at `doc update` or an index path. With `--json` / plan / MCP, that fail-closed path also sets machine-stable `suggested_op` (`"doc.update"` for set/ensure multi-match; `"doc.delete_where"` for predicate delete). Intermediate parent predicates (`items[id=a].val` on delete) use the same mapping as leaf predicates (#2138). Hosts can branch without scraping English (`api::suggested_op_from_error` on the library path).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-4300%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-4400%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -518,7 +518,7 @@ flowchart LR
 
 ## Status
 
-4300+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+4400+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -744,6 +744,16 @@ Use these when the top level `doc` command is right, but you need a specific str
 
 **Multi-document YAML:** Streams with more than one `---` document are modeled as a JSON array (one element per document). Use a document index in the selector (`0.metadata.name`, `[1].spec.ports[0].port`). A bare top-level key on a multi-doc file fails with an actionable type error that points at the index form. `doc merge` of any overlay (object or array) into the multi-doc root is also `type_error` (would replace the whole stream). Successful writes re-serialize with `---` separators (not as a single YAML sequence), so `kubectl apply -f` style multi-doc files stay valid.
 
+**Selector predicates:** Filter array items (or values of an object map) inside a selector path.
+
+- `=` equality. Unchanged from historical `key=value`. The value may contain `=` or `>` (`items[url=a=b]`, `items[url=a>b]`).
+- `!=` not-equal (`items[status!=disabled]`). A missing field does not match.
+- `>`, `>=`, `<`, `<=` numeric compare on JSON numbers or numeric strings (`servers[port>8000]`). The operand after the operator must parse as a number (`[port>abc]` is `invalid_input`). A present non-numeric field vs one of these operators is `invalid_input`, not a lexicographic compare. A missing field does not match.
+- `[!key]` matches when `key` is absent, JSON `false`, or `null` (`flags[!deprecated]`).
+- Regex predicates are not supported.
+
+Predicates can be chained: `data[type=server][port>8000]`.
+
 **JSON write summary:** Every doc write success payload under `--json` / `--jsonl` includes `changed` (bool). `doc delete` and `doc delete-where` also include `removed` (usize). Agents should not treat exit 0 alone as "something was deleted"; check `removed` / `changed` for idempotent no-ops. The same fields appear on MCP `doc_delete` / `doc_delete_where` and on `execute_plan` / `tx` reports (plus a `mutations` array with per-op `path`, `op`, `changed`, `removed` for multi-step plans).
 
 <!-- ref:doc-action:get -->

--- a/src/cmd/agent_rules/reference.rs
+++ b/src/cmd/agent_rules/reference.rs
@@ -14,7 +14,14 @@ pub(crate) fn append_reference(out: &mut String, show_cli: bool) {
          | `.` | Document root | `doc keys FILE .`; `doc set FILE . VALUE` replaces the whole document |\n\
          | `[N]` | Array index (zero-based) | `servers[0].port` |\n\
          | `[*]` | Wildcard (all array elements) | `jobs[*].timeout` |\n\
-         | `[key=val]` | Predicate (filter by field value) | `deps[name=express].version` |\n\n\
+         | `[key=val]` | Equality predicate (filter by field value) | `deps[name=express].version` |\n\
+         | `[key!=val]` | Not-equal; missing fields do not match | `items[status!=disabled]` |\n\
+         | `[key>N]` `[key>=N]` `[key<N]` `[key<=N]` | Numeric compare (`f64`; JSON number or numeric string) | `servers[port>8000]` |\n\
+         | `[!key]` | Key absent, JSON `false`, or `null` | `flags[!deprecated]` |\n\n\
+         Equality is unchanged: `items[url=a=b]` and `items[url=a>b]` stay `key=value`. \
+         Comparison operands must be numeric (`[port>abc]` is `invalid_input`). A present \
+         non-numeric field vs `>` / `>=` / `<` / `<=` is also `invalid_input` (not a string \
+         compare). Regex predicates are not supported. \
          Segments are separated by `.` or adjacent brackets. A single leading `/` is treated as \
 \"from root\" and stripped (JSON Pointer habit), so `/feature_flag` sets key `feature_flag`, not a key literally named `/feature_flag` (#1794). Only one leading slash is special; `//a` keeps a key named `/a`. Prefer bare keys in prompts (`feature_flag`, `server.port`). A lone `.` (or empty / `/`) is the document root: `doc keys FILE .` lists top-level keys, and `doc set FILE . VALUE` replaces the whole document. Examples:\n\n\
          ```text\n\
@@ -23,6 +30,8 @@ pub(crate) fn append_reference(out: &mut String, show_cli: bool) {
          /feature_flag                   # same as feature_flag (leading slash stripped)\n\
          jobs[0].steps[*].name           # index + wildcard\n\
          dependencies[name=react].version # predicate filter\n\
+         data[type=server][port>8000]    # chained equality + numeric compare\n\
+         flags[!deprecated]              # absent, false, or null\n\
          ```\n\n\
          **Write ops and predicates:** `doc set` / `doc ensure` / `doc delete` / `doc move` are \
          **single-path only** (keys and indexes such as `items.0.val`). Wildcards and predicates \

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -1159,7 +1159,7 @@ pub fn apply_doc_mutation(
         }
         DocMutation::Update { selector, value } => {
             let sel = selector::parse_anyhow(&selector)?;
-            if update_matching(root, &sel, &value) == 0 {
+            if update_matching(root, &sel, &value)? == 0 {
                 // Bare key on multi-doc / array root: soft no_matches hides shape errors.
                 if let Some(hint) = query::array_root_bare_key_hint(root, &sel) {
                     Ok(MutationResult::TypeError(hint))

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -1178,7 +1178,7 @@ pub fn apply_doc_mutation(
         }
         DocMutation::Ensure { selector, value } => {
             let sel = selector::parse_anyhow(&selector)?;
-            if !selector::eval(root, &sel).is_empty() {
+            if !selector::eval_result(root, &sel)?.is_empty() {
                 Ok(MutationResult::AlreadyExists)
             } else {
                 set_at_path(root, &sel, value)?;

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -625,10 +625,10 @@ pub fn update_matching(
     value: &mut serde_json::Value,
     segments: &[selector::Segment],
     new_val: &serde_json::Value,
-) -> usize {
+) -> anyhow::Result<usize> {
     if segments.is_empty() {
         *value = new_val.clone();
-        return 1;
+        return Ok(1);
     }
     let first = &segments[0];
     let rest = &segments[1..];
@@ -643,57 +643,105 @@ pub fn update_matching(
                 {
                     return update_matching(child, rest, new_val);
                 }
-                0
+                Ok(0)
             } else {
-                0
+                Ok(0)
             }
         }
         selector::Segment::Index(i) => {
             if let Some(child) = value.get_mut(*i) {
                 update_matching(child, rest, new_val)
             } else {
-                0
+                Ok(0)
             }
         }
         selector::Segment::Wildcard => {
             let mut count = 0;
             if let Some(arr) = value.as_array_mut() {
                 for item in arr.iter_mut() {
-                    count += update_matching(item, rest, new_val);
+                    count += update_matching(item, rest, new_val)?;
                 }
             } else if let Some(obj) = value.as_object_mut() {
                 for item in obj.values_mut() {
-                    count += update_matching(item, rest, new_val);
+                    count += update_matching(item, rest, new_val)?;
                 }
             }
-            count
+            Ok(count)
         }
         selector::Segment::Predicate {
             key,
             op,
             value: pred_val,
-        } => {
-            let mut count = 0;
-            if let Some(arr) = value.as_array_mut() {
-                for item in arr.iter_mut() {
-                    let matches =
-                        selector::item_matches_predicate(item, key, *op, pred_val).unwrap_or(false);
-                    if matches {
-                        count += update_matching(item, rest, new_val);
-                    }
+        } => update_matching_predicate(value, key, *op, pred_val, rest, new_val),
+    }
+}
+
+fn update_matching_predicate(
+    value: &mut serde_json::Value,
+    key: &str,
+    op: selector::PredicateOp,
+    pred_val: &str,
+    rest: &[selector::Segment],
+    new_val: &serde_json::Value,
+) -> anyhow::Result<usize> {
+    if value.is_array() {
+        let idxs: Result<Vec<usize>, _> = value
+            .as_array()
+            .into_iter()
+            .flatten()
+            .enumerate()
+            .filter_map(|(i, item)| {
+                match selector::item_matches_predicate(item, key, op, pred_val) {
+                    Ok(true) => Some(Ok(i)),
+                    Ok(false) => None,
+                    Err(e) => Some(Err(e)),
                 }
-            } else if let Some(obj) = value.as_object_mut() {
-                for item in obj.values_mut() {
-                    let matches =
-                        selector::item_matches_predicate(item, key, *op, pred_val).unwrap_or(false);
-                    if matches {
-                        count += update_matching(item, rest, new_val);
-                    }
-                }
+            })
+            .collect();
+        let idxs = idxs?;
+        let mut count = 0;
+        if let Some(arr) = value.as_array_mut() {
+            for i in idxs {
+                count += update_matching(&mut arr[i], rest, new_val)?;
             }
-            count
+        }
+        return Ok(count);
+    }
+
+    if !value.is_object() {
+        return Ok(0);
+    }
+
+    let test_self = selector::eval::predicate_tests_object_self(value, key);
+    let iterate = selector::eval::object_has_container_children(value);
+    let mut count = 0;
+    if test_self && selector::item_matches_predicate(value, key, op, pred_val)? {
+        count += update_matching(value, rest, new_val)?;
+        if rest.is_empty() {
+            return Ok(count);
         }
     }
+    if iterate {
+        let child_keys: Result<Vec<String>, _> = value
+            .as_object()
+            .into_iter()
+            .flatten()
+            .filter(|(_, v)| v.is_object() || v.is_array())
+            .filter_map(
+                |(k, v)| match selector::item_matches_predicate(v, key, op, pred_val) {
+                    Ok(true) => Some(Ok(k.clone())),
+                    Ok(false) => None,
+                    Err(e) => Some(Err(e)),
+                },
+            )
+            .collect();
+        for k in child_keys? {
+            if let Some(child) = value.get_mut(&k) {
+                count += update_matching(child, rest, new_val)?;
+            }
+        }
+    }
+    Ok(count)
 }
 
 #[cfg(test)]
@@ -1019,7 +1067,7 @@ mod tests {
                     value,
                     expect_n,
                 } => {
-                    let n = update_matching(&mut root, &segs(selector), &value);
+                    let n = update_matching(&mut root, &segs(selector), &value).unwrap();
                     assert_eq!(n, expect_n, "{label}");
                 }
             }
@@ -1169,7 +1217,7 @@ mod tests {
     #[test]
     fn update_matching_wildcard() {
         let mut root = json!({"items": [{"v": 1}, {"v": 2}]});
-        let count = update_matching(&mut root, &segs("items[*].v"), &json!(0));
+        let count = update_matching(&mut root, &segs("items[*].v"), &json!(0)).unwrap();
         assert_eq!(count, 2);
         assert_eq!(root, json!({"items": [{"v": 0}, {"v": 0}]}));
     }
@@ -1247,7 +1295,7 @@ mod tests {
     #[test]
     fn update_matching_numeric_dot_notation() {
         let mut root = json!({"env": [{"name": "A"}, {"name": "B"}]});
-        let count = update_matching(&mut root, &segs("env.0.name"), &json!("X"));
+        let count = update_matching(&mut root, &segs("env.0.name"), &json!("X")).unwrap();
         assert_eq!(count, 1);
         assert_eq!(root["env"][0]["name"], json!("X"));
     }

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -670,21 +670,22 @@ pub fn update_matching(
         }
         selector::Segment::Predicate {
             key,
+            op,
             value: pred_val,
         } => {
             let mut count = 0;
             if let Some(arr) = value.as_array_mut() {
                 for item in arr.iter_mut() {
-                    let matches = selector::get_nested(item, key)
-                        .is_some_and(|field| selector::value_matches_str(field, pred_val));
+                    let matches =
+                        selector::item_matches_predicate(item, key, *op, pred_val).unwrap_or(false);
                     if matches {
                         count += update_matching(item, rest, new_val);
                     }
                 }
             } else if let Some(obj) = value.as_object_mut() {
                 for item in obj.values_mut() {
-                    let matches = selector::get_nested(item, key)
-                        .is_some_and(|field| selector::value_matches_str(field, pred_val));
+                    let matches =
+                        selector::item_matches_predicate(item, key, *op, pred_val).unwrap_or(false);
                     if matches {
                         count += update_matching(item, rest, new_val);
                     }

--- a/src/ops/doc/query.rs
+++ b/src/ops/doc/query.rs
@@ -28,7 +28,7 @@ pub enum QueryResult {
 /// multi-doc bare keys (docs/reference multi-document YAML; fixrealloop).
 pub fn query_get(root: &serde_json::Value, selector: &str) -> anyhow::Result<QueryResult> {
     let segments = selector::parse_anyhow(selector)?;
-    let results = selector::eval(root, &segments);
+    let results = selector::eval_result(root, &segments)?;
     if results.is_empty() {
         if let Some(hint) = array_root_bare_key_hint(root, &segments) {
             return Err(crate::exit::TypeErrorError { msg: hint }.into());
@@ -68,7 +68,7 @@ pub(crate) fn array_root_bare_key_hint(
 /// [`query_get`] so agents do not treat a shape mistake as "key absent".
 pub fn query_has(root: &serde_json::Value, selector: &str) -> anyhow::Result<bool> {
     let segments = selector::parse_anyhow(selector)?;
-    let found = !selector::eval(root, &segments).is_empty();
+    let found = !selector::eval_result(root, &segments)?.is_empty();
     if !found && let Some(hint) = array_root_bare_key_hint(root, &segments) {
         return Err(crate::exit::TypeErrorError { msg: hint }.into());
     }
@@ -91,7 +91,7 @@ pub enum QueryKeysResult {
 /// [`crate::exit::TypeErrorError`] like [`query_get`] / [`query_has`].
 pub fn query_keys(root: &serde_json::Value, selector: &str) -> anyhow::Result<QueryKeysResult> {
     let segments = selector::parse_anyhow(selector)?;
-    let results = selector::eval(root, &segments);
+    let results = selector::eval_result(root, &segments)?;
     if results.is_empty() {
         if let Some(hint) = array_root_bare_key_hint(root, &segments) {
             return Err(crate::exit::TypeErrorError { msg: hint }.into());
@@ -119,7 +119,7 @@ pub enum QueryLenResult {
 /// Bare object keys at an array root return type_error like [`query_get`].
 pub fn query_len(root: &serde_json::Value, selector: &str) -> anyhow::Result<QueryLenResult> {
     let segments = selector::parse_anyhow(selector)?;
-    let results = selector::eval(root, &segments);
+    let results = selector::eval_result(root, &segments)?;
     if results.is_empty() {
         if let Some(hint) = array_root_bare_key_hint(root, &segments) {
             return Err(crate::exit::TypeErrorError { msg: hint }.into());
@@ -375,5 +375,37 @@ mod tests {
             query_len(&doc, "nonexistent").unwrap(),
             QueryLenResult::NoMatch
         ));
+    }
+
+    #[test]
+    fn get_port_gt_returns_matching_items() {
+        let doc = serde_json::json!({
+            "servers": [
+                {"name": "web", "port": 80},
+                {"name": "api", "port": 9000}
+            ]
+        });
+        match query_get(&doc, "servers[port>8000]").unwrap() {
+            QueryResult::Values(v) => {
+                assert_eq!(v.len(), 1);
+                assert_eq!(v[0]["name"], "api");
+            }
+            QueryResult::NoMatch => panic!("expected match"),
+        }
+    }
+
+    #[test]
+    fn get_non_numeric_comparison_operand_is_invalid_input() {
+        let doc = serde_json::json!({"servers": [{"port": 80}]});
+        let err = query_get(&doc, "servers[port>abc]").expect_err("bad operand");
+        assert!(
+            crate::exit::is_invalid_input(&err),
+            "expected invalid_input, got: {err}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("numeric") || msg.contains("comparison"),
+            "expected numeric/comparison message, got: {msg}"
+        );
     }
 }

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -172,7 +172,7 @@ mod basic {
     fn update_matching_by_key() {
         let mut val = json!({"a": {"b": "old"}});
         let seg = crate::selector::parse("a.b").unwrap();
-        let count = update_matching(&mut val, &seg, &json!("new"));
+        let count = update_matching(&mut val, &seg, &json!("new")).unwrap();
         assert_eq!(count, 1);
         assert_eq!(val, json!({"a": {"b": "new"}}));
     }
@@ -186,7 +186,7 @@ mod basic {
             {"name": "b", "v": 2}
         ]});
         let seg = crate::selector::parse("items[name=b].v").unwrap();
-        let count = update_matching(&mut val, &seg, &json!(42));
+        let count = update_matching(&mut val, &seg, &json!(42)).unwrap();
         assert_eq!(count, 1);
         assert_eq!(val["items"][1]["v"], json!(42));
         // First item unchanged
@@ -623,10 +623,45 @@ mod edge_cases {
     }
 
     #[test]
+    fn update_matching_chained_predicate_updates_row() {
+        let mut val = json!({
+            "data": [
+                {"type": "server", "port": 9000},
+                {"type": "web", "port": 80}
+            ]
+        });
+        let seg = crate::selector::parse("data[type=server][port>8000].port").unwrap();
+        let count = update_matching(&mut val, &seg, &json!(443)).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(val["data"][0]["port"], json!(443));
+        assert_eq!(val["data"][1]["port"], json!(80));
+    }
+
+    #[test]
+    fn update_matching_not_on_object_replaces_record() {
+        let mut val = json!({"item": {"name": "a"}});
+        let seg = crate::selector::parse("item[!deprecated]").unwrap();
+        let count = update_matching(&mut val, &seg, &json!({"name": "b"})).unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(val, json!({"item": {"name": "b"}}));
+    }
+
+    #[test]
+    fn update_matching_non_numeric_field_is_invalid_input() {
+        let mut val = json!({"servers": [{"port": "abc"}]});
+        let seg = crate::selector::parse("servers[port>8000]").unwrap();
+        let err = update_matching(&mut val, &seg, &json!(1)).unwrap_err();
+        assert!(
+            crate::api::is_invalid_input(&err),
+            "expected invalid_input, got {err}"
+        );
+    }
+
+    #[test]
     fn update_matching_missing_key_returns_zero() {
         let mut val = json!({"a": 1});
         let seg = crate::selector::parse("b.c").unwrap();
-        let count = update_matching(&mut val, &seg, &json!("x"));
+        let count = update_matching(&mut val, &seg, &json!("x")).unwrap();
         assert_eq!(count, 0);
     }
 

--- a/src/selector/eval.rs
+++ b/src/selector/eval.rs
@@ -1,10 +1,25 @@
 use super::parser::{Segment, Selector};
+use crate::exit::InvalidInputError;
+use crate::selector::{get_nested, item_matches_predicate};
 
 /// Evaluate a selector against a JSON value tree.
 ///
-/// Returns all matching leaf values.  For wildcards and predicates the
+/// Returns all matching leaf values. For wildcards and predicates the
 /// result may contain more than one entry.
+///
+/// Comparison type mismatches (a present non-numeric field vs `>` / `>=` /
+/// `<` / `<=`) are treated as no match. Use [`eval_result`] when the
+/// caller must surface those as `invalid_input`.
 pub fn eval<'a>(value: &'a serde_json::Value, selector: &Selector) -> Vec<&'a serde_json::Value> {
+    eval_result(value, selector).unwrap_or_default()
+}
+
+/// Like [`eval`], but a present non-numeric field vs a numeric compare
+/// returns [`InvalidInputError`].
+pub fn eval_result<'a>(
+    value: &'a serde_json::Value,
+    selector: &Selector,
+) -> Result<Vec<&'a serde_json::Value>, InvalidInputError> {
     crate::verbose!("selector: evaluating {:?}", selector);
     let mut current = vec![value];
 
@@ -37,23 +52,12 @@ pub fn eval<'a>(value: &'a serde_json::Value, selector: &Selector) -> Vec<&'a se
                 }
                 Segment::Predicate {
                     key,
+                    op,
                     value: pred_val,
                 } => {
-                    if let Some(arr) = val.as_array() {
-                        for item in arr {
-                            if let Some(field) = crate::selector::get_nested(item, key)
-                                && crate::selector::value_matches_str(field, pred_val)
-                            {
-                                next.push(item);
-                            }
-                        }
-                    } else if let Some(obj) = val.as_object() {
-                        for item in obj.values() {
-                            if let Some(field) = crate::selector::get_nested(item, key)
-                                && crate::selector::value_matches_str(field, pred_val)
-                            {
-                                next.push(item);
-                            }
+                    for item in predicate_candidates(val, key) {
+                        if item_matches_predicate(item, key, *op, pred_val)? {
+                            next.push(item);
                         }
                     }
                 }
@@ -62,7 +66,29 @@ pub fn eval<'a>(value: &'a serde_json::Value, selector: &Selector) -> Vec<&'a se
         current = next;
     }
 
-    current
+    Ok(current)
+}
+
+/// Items a predicate should test.
+///
+/// Arrays: each element. Objects: the object itself when it already has
+/// `key` (or has no object-valued children); otherwise each value, so
+/// `services[name=api]` still filters a map of objects. This also lets
+/// chained `data[type=server][port>8000]` test each selected item.
+fn predicate_candidates<'a>(val: &'a serde_json::Value, key: &str) -> Vec<&'a serde_json::Value> {
+    if let Some(arr) = val.as_array() {
+        return arr.iter().collect();
+    }
+    let Some(obj) = val.as_object() else {
+        return Vec::new();
+    };
+    if get_nested(val, key).is_some() {
+        return vec![val];
+    }
+    if obj.values().any(|v| v.is_object() || v.is_array()) {
+        return obj.values().collect();
+    }
+    vec![val]
 }
 
 #[cfg(test)]
@@ -257,5 +283,114 @@ mod tests {
         let results = eval(&data, &sel);
         let expected = json!("zero-key");
         assert_eq!(results, vec![&expected]);
+    }
+
+    // ── #2230 comparison and negation ──────────────────────────────
+
+    fn servers_doc() -> serde_json::Value {
+        json!({
+            "servers": [
+                {"name": "web", "port": 80},
+                {"name": "api", "port": 8080},
+                {"name": "edge", "port": 8000}
+            ]
+        })
+    }
+
+    #[test]
+    fn eval_numeric_gt() {
+        let data = servers_doc();
+        let sel = parse("servers[port>8000]").unwrap();
+        let results = eval(&data, &sel);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["name"], json!("api"));
+    }
+
+    #[test]
+    fn eval_numeric_ge_lt_le() {
+        let data = servers_doc();
+        assert_eq!(eval(&data, &parse("servers[port>=8000]").unwrap()).len(), 2);
+        assert_eq!(eval(&data, &parse("servers[port<8000]").unwrap()).len(), 1);
+        assert_eq!(eval(&data, &parse("servers[port<=8000]").unwrap()).len(), 2);
+    }
+
+    #[test]
+    fn eval_numeric_string_field_still_compares() {
+        let data = json!({"items": [{"n": "10"}, {"n": "3"}]});
+        let sel = parse("items[n>5]").unwrap();
+        let results = eval(&data, &sel);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["n"], json!("10"));
+    }
+
+    #[test]
+    fn eval_ne_matches_other_strings_not_missing() {
+        let data = json!({
+            "items": [
+                {"status": "done"},
+                {"status": "open"},
+                {"name": "no-status"}
+            ]
+        });
+        let sel = parse("items[status!=done]").unwrap();
+        let results = eval(&data, &sel);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["status"], json!("open"));
+    }
+
+    #[test]
+    fn eval_not_matches_absent_false_null_not_true() {
+        let data = json!({
+            "flags": [
+                {"name": "a"},
+                {"name": "b", "deprecated": false},
+                {"name": "c", "deprecated": null},
+                {"name": "d", "deprecated": true}
+            ]
+        });
+        let sel = parse("flags[!deprecated]").unwrap();
+        let results = eval(&data, &sel);
+        let names: Vec<&str> = results
+            .iter()
+            .filter_map(|v| v.get("name").and_then(|n| n.as_str()))
+            .collect();
+        assert_eq!(names, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn eval_existing_name_eq_still_works() {
+        let data = json!({"items": [{"name": "a"}, {"name": "b"}]});
+        let sel = parse("items[name=b]").unwrap();
+        let results = eval(&data, &sel);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["name"], json!("b"));
+    }
+
+    #[test]
+    fn eval_result_non_numeric_field_is_invalid_input() {
+        let data = json!({"items": [{"port": "abc"}]});
+        let sel = parse("items[port>8000]").unwrap();
+        let err = eval_result(&data, &sel).expect_err("non-numeric field vs >");
+        assert!(
+            err.msg.contains("numeric"),
+            "expected numeric type error, got: {}",
+            err.msg
+        );
+    }
+
+    #[test]
+    fn eval_chained_eq_and_gt() {
+        let data = json!({
+            "data": [
+                {"type": "server", "port": 9000},
+                {"type": "server", "port": 80},
+                {"type": "client", "port": 9000}
+            ]
+        });
+        let sel = parse("data[type=server][port>8000]").unwrap();
+        let results = eval(&data, &sel);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0]["port"], json!(9000));
+        assert_eq!(results[0]["type"], json!("server"));
     }
 }

--- a/src/selector/eval.rs
+++ b/src/selector/eval.rs
@@ -69,12 +69,27 @@ pub fn eval_result<'a>(
     Ok(current)
 }
 
+/// True when an object has object or array children (a map-of-records).
+pub(crate) fn object_has_container_children(val: &serde_json::Value) -> bool {
+    val.as_object()
+        .is_some_and(|obj| obj.values().any(|v| v.is_object() || v.is_array()))
+}
+
+/// Whether a predicate on an object should test the object itself.
+///
+/// Test self when `key` is present (chained `data[type=server][port>8000]`,
+/// or `[!key]` on a record). If the object is not a map-of-records, also
+/// test self so `[!deprecated]` on `{"name":"a"}` matches the record.
+pub(crate) fn predicate_tests_object_self(val: &serde_json::Value, key: &str) -> bool {
+    get_nested(val, key).is_some() || !object_has_container_children(val)
+}
+
 /// Items a predicate should test.
 ///
 /// Arrays: each element. Objects: the object itself when it already has
-/// `key` (or has no object-valued children); otherwise each value, so
-/// `services[name=api]` still filters a map of objects. This also lets
-/// chained `data[type=server][port>8000]` test each selected item.
+/// `key` (or is not a map-of-records), plus each object/array child so
+/// `services[name=api]` still filters a map of objects even if the map
+/// also has a `name` field.
 fn predicate_candidates<'a>(val: &'a serde_json::Value, key: &str) -> Vec<&'a serde_json::Value> {
     if let Some(arr) = val.as_array() {
         return arr.iter().collect();
@@ -82,13 +97,14 @@ fn predicate_candidates<'a>(val: &'a serde_json::Value, key: &str) -> Vec<&'a se
     let Some(obj) = val.as_object() else {
         return Vec::new();
     };
-    if get_nested(val, key).is_some() {
-        return vec![val];
+    let mut out = Vec::new();
+    if predicate_tests_object_self(val, key) {
+        out.push(val);
     }
-    if obj.values().any(|v| v.is_object() || v.is_array()) {
-        return obj.values().collect();
+    if object_has_container_children(val) {
+        out.extend(obj.values());
     }
-    vec![val]
+    out
 }
 
 #[cfg(test)]
@@ -214,6 +230,20 @@ mod tests {
         let results = eval(&data, &sel);
         let expected = json!(8080);
         assert_eq!(results, vec![&expected]);
+    }
+
+    #[test]
+    fn eval_predicate_object_map_with_same_key_still_filters_children() {
+        let data = json!({
+            "services": {
+                "name": "prod",
+                "web": {"name": "web"},
+                "api": {"name": "api"}
+            }
+        });
+        let sel = parse("services[name=api]").unwrap();
+        let results = eval(&data, &sel);
+        assert_eq!(results, vec![&data["services"]["api"]]);
     }
 
     #[test]

--- a/src/selector/mod.rs
+++ b/src/selector/mod.rs
@@ -1,8 +1,8 @@
 pub mod eval;
 pub mod parser;
 
-pub use eval::eval;
-pub use parser::{Segment, Selector, parse};
+pub use eval::{eval, eval_result};
+pub use parser::{PredicateOp, Segment, Selector, parse};
 
 /// Parse a selector string, mapping parse errors to `anyhow::Error` with
 /// a "selector error:" prefix for consistent error formatting.
@@ -40,13 +40,102 @@ pub fn get_nested<'a>(value: &'a serde_json::Value, key: &str) -> Option<&'a ser
 
 /// Check whether a JSON value matches a predicate string using string comparison.
 /// Numbers and booleans are compared via their string representation.
+///
+/// Equality wrapper around [`value_matches`].
 pub fn value_matches_str(field: &serde_json::Value, pred_val: &str) -> bool {
+    value_matches(field, PredicateOp::Eq, pred_val).unwrap_or(false)
+}
+
+/// Compare `field` against `pred_val` using `op`.
+///
+/// Numeric compares (`>`, `>=`, `<`, `<=`) accept a JSON number or a string
+/// that parses as `f64`. A present non-numeric field is
+/// [`InvalidInputError`](crate::exit::InvalidInputError), not a lexicographic
+/// compare. [`PredicateOp::Not`] is handled at the item level by
+/// [`item_matches_predicate`]; if called directly it matches JSON `false` or
+/// `null` only.
+pub fn value_matches(
+    field: &serde_json::Value,
+    op: PredicateOp,
+    pred_val: &str,
+) -> Result<bool, crate::exit::InvalidInputError> {
+    match op {
+        PredicateOp::Eq => Ok(eq_field(field, pred_val)),
+        PredicateOp::Ne => Ok(!eq_field(field, pred_val)),
+        PredicateOp::Not => Ok(field.is_null() || field == &serde_json::Value::Bool(false)),
+        PredicateOp::Gt | PredicateOp::Ge | PredicateOp::Lt | PredicateOp::Le => {
+            let Some(lhs) = as_f64(field) else {
+                return Err(crate::exit::InvalidInputError {
+                    msg: format!(
+                        "selector comparison requires a numeric field, found {}",
+                        value_type_name(field)
+                    ),
+                });
+            };
+            let rhs = pred_val
+                .parse::<f64>()
+                .map_err(|_| crate::exit::InvalidInputError {
+                    msg: format!("comparison operand must be numeric (got '{pred_val}')"),
+                })?;
+            Ok(match op {
+                PredicateOp::Gt => lhs > rhs,
+                PredicateOp::Ge => lhs >= rhs,
+                PredicateOp::Lt => lhs < rhs,
+                PredicateOp::Le => lhs <= rhs,
+                PredicateOp::Eq | PredicateOp::Ne | PredicateOp::Not => unreachable!(),
+            })
+        }
+    }
+}
+
+fn eq_field(field: &serde_json::Value, pred_val: &str) -> bool {
     match field {
         serde_json::Value::String(s) => s == pred_val,
         serde_json::Value::Number(n) => n.to_string() == pred_val,
         serde_json::Value::Bool(b) => b.to_string() == pred_val,
         serde_json::Value::Null => pred_val == "null",
         _ => false,
+    }
+}
+
+fn as_f64(field: &serde_json::Value) -> Option<f64> {
+    match field {
+        serde_json::Value::Number(n) => n.as_f64(),
+        serde_json::Value::String(s) => s.parse().ok(),
+        _ => None,
+    }
+}
+
+fn value_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Whether `item` satisfies `[key op value]` / `[!key]`.
+///
+/// Missing fields: no match for `=`, `!=`, and numeric compares (same as
+/// historical equality). [`PredicateOp::Not`] matches absent, JSON `false`,
+/// or `null`.
+pub fn item_matches_predicate(
+    item: &serde_json::Value,
+    key: &str,
+    op: PredicateOp,
+    pred_val: &str,
+) -> Result<bool, crate::exit::InvalidInputError> {
+    match get_nested(item, key) {
+        None => Ok(op == PredicateOp::Not),
+        Some(field) => {
+            if op == PredicateOp::Not {
+                return Ok(field.is_null() || field == &serde_json::Value::Bool(false));
+            }
+            value_matches(field, op, pred_val)
+        }
     }
 }
 
@@ -115,5 +204,22 @@ mod tests {
     #[test]
     fn value_matches_str_object_returns_false() {
         assert!(!value_matches_str(&json!({"a": 1}), ""));
+    }
+
+    #[test]
+    fn value_matches_numeric_gt() {
+        assert!(value_matches(&json!(10), PredicateOp::Gt, "5").unwrap());
+        assert!(!value_matches(&json!(5), PredicateOp::Gt, "5").unwrap());
+        assert!(value_matches(&json!("10"), PredicateOp::Gt, "5").unwrap());
+    }
+
+    #[test]
+    fn value_matches_non_numeric_is_invalid_input() {
+        let err = value_matches(&json!("abc"), PredicateOp::Gt, "5").unwrap_err();
+        assert!(
+            err.msg.contains("numeric"),
+            "expected numeric error, got: {}",
+            err.msg
+        );
     }
 }

--- a/src/selector/parser.rs
+++ b/src/selector/parser.rs
@@ -1,6 +1,37 @@
 /// A selector is a sequence of segments that navigate through a JSON value tree.
 pub type Selector = Vec<Segment>;
 
+/// Comparison operator inside a [`Segment::Predicate`].
+///
+/// Equality (`Eq`) is the default and matches historical `key=value`.
+/// Numeric compares require an `f64` operand at parse time. Regex is not
+/// supported. `[!key]` is [`PredicateOp::Not`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PredicateOp {
+    /// `key=value` (default).
+    #[default]
+    Eq,
+    /// `key!=value`. Missing fields do not match.
+    Ne,
+    /// `key>N` (numeric).
+    Gt,
+    /// `key>=N` (numeric).
+    Ge,
+    /// `key<N` (numeric).
+    Lt,
+    /// `key<=N` (numeric).
+    Le,
+    /// `[!key]`: field is absent, JSON `false`, or `null`.
+    Not,
+}
+
+impl PredicateOp {
+    /// True for `>`, `>=`, `<`, and `<=`.
+    pub fn is_numeric_compare(self) -> bool {
+        matches!(self, Self::Gt | Self::Ge | Self::Lt | Self::Le)
+    }
+}
+
 /// A single segment in a selector path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Segment {
@@ -10,8 +41,119 @@ pub enum Segment {
     Index(usize),
     /// Wildcard – matches all array elements: `[*]`.
     Wildcard,
-    /// Predicate filter on array elements, e.g. `[name=api]`.
-    Predicate { key: String, value: String },
+    /// Predicate filter on array or object-map elements, e.g. `[name=api]`.
+    Predicate {
+        key: String,
+        op: PredicateOp,
+        value: String,
+    },
+}
+
+/// Parse one `[...]` body into a segment.
+///
+/// Operator scan is left-to-right. At each index, two-character operators
+/// (`!=`, `>=`, `<=`) are tried before `=`, then `>` and `<`. Searching `>`
+/// before `=` would treat `items[url=a>b]` as a greater-than compare.
+fn parse_bracket_content(content: &str) -> Result<Segment, String> {
+    if content == "*" {
+        return Ok(Segment::Wildcard);
+    }
+
+    if let Some((key, op, value)) = split_predicate(content)? {
+        return Ok(Segment::Predicate { key, op, value });
+    }
+
+    if let Some(key) = content.strip_prefix('!') {
+        if key.is_empty() {
+            return Err("empty predicate key".to_string());
+        }
+        reject_question_prefix(key, "")?;
+        return Ok(Segment::Predicate {
+            key: key.to_string(),
+            op: PredicateOp::Not,
+            value: String::new(),
+        });
+    }
+
+    if let Ok(idx) = content.parse::<usize>() {
+        return Ok(Segment::Index(idx));
+    }
+    Err(format!("invalid bracket content: {content}"))
+}
+
+/// Split `key<op>value` if a comparison or equality operator is present.
+fn split_predicate(content: &str) -> Result<Option<(String, PredicateOp, String)>, String> {
+    let Some((key_end, op, value_start)) = find_predicate_op(content) else {
+        return Ok(None);
+    };
+    let key = &content[..key_end];
+    let mut value = content[value_start..].to_string();
+    if key.is_empty() {
+        return Err("empty predicate key".to_string());
+    }
+    reject_question_prefix(key, &value)?;
+    if op.is_numeric_compare() {
+        let trimmed = value.trim();
+        if trimmed.parse::<f64>().is_err() {
+            return Err(format!(
+                "comparison operand must be numeric (got '{value}' after {op})"
+            ));
+        }
+        value = trimmed.to_string();
+    }
+    Ok(Some((key.to_string(), op, value)))
+}
+
+/// First operator in `content`. Two-character forms win at the same index.
+fn find_predicate_op(content: &str) -> Option<(usize, PredicateOp, usize)> {
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if content[i..].starts_with("!=") {
+            return Some((i, PredicateOp::Ne, i + 2));
+        }
+        if content[i..].starts_with(">=") {
+            return Some((i, PredicateOp::Ge, i + 2));
+        }
+        if content[i..].starts_with("<=") {
+            return Some((i, PredicateOp::Le, i + 2));
+        }
+        match bytes[i] {
+            b'=' => return Some((i, PredicateOp::Eq, i + 1)),
+            b'>' => return Some((i, PredicateOp::Gt, i + 1)),
+            b'<' => return Some((i, PredicateOp::Lt, i + 1)),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+fn reject_question_prefix(key: &str, value: &str) -> Result<(), String> {
+    if let Some(stripped) = key.strip_prefix('?') {
+        let suggestion = if value.is_empty() {
+            format!("[{stripped}]")
+        } else {
+            format!("[{stripped}={value}]")
+        };
+        return Err(format!(
+            "predicate key starts with '?'; use {suggestion} instead of [{key}={value}]"
+        ));
+    }
+    Ok(())
+}
+
+impl std::fmt::Display for PredicateOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Eq => "=",
+            Self::Ne => "!=",
+            Self::Gt => ">",
+            Self::Ge => ">=",
+            Self::Lt => "<",
+            Self::Le => "<=",
+            Self::Not => "!",
+        })
+    }
 }
 
 /// Parse a selector string into a [`Selector`].
@@ -60,25 +202,7 @@ pub fn parse(input: &str) -> Result<Selector, String> {
             let content = &input[start..i];
             i += 1; // skip ']'
 
-            if content == "*" {
-                segments.push(Segment::Wildcard);
-            } else if let Some(eq_pos) = content.find('=') {
-                let key = content[..eq_pos].to_string();
-                let value = content[eq_pos + 1..].to_string();
-                if key.is_empty() {
-                    return Err("empty predicate key".to_string());
-                }
-                if let Some(stripped) = key.strip_prefix('?') {
-                    return Err(format!(
-                        "predicate key starts with '?'; use [{stripped}={value}] instead of [{key}={value}]"
-                    ));
-                }
-                segments.push(Segment::Predicate { key, value });
-            } else if let Ok(idx) = content.parse::<usize>() {
-                segments.push(Segment::Index(idx));
-            } else {
-                return Err(format!("invalid bracket content: {content}"));
-            }
+            segments.push(parse_bracket_content(content)?);
         } else {
             // Key segment: read until '.', '[', or end.
             let start = i;
@@ -130,6 +254,7 @@ mod tests {
                 Segment::Key("jobs".into()),
                 Segment::Predicate {
                     key: "id".into(),
+                    op: PredicateOp::Eq,
                     value: "test".into(),
                 },
                 Segment::Key("timeout".into()),
@@ -244,6 +369,7 @@ mod tests {
                 Segment::Key("items".into()),
                 Segment::Predicate {
                     key: "url".into(),
+                    op: PredicateOp::Eq,
                     value: "a=b".into(),
                 },
             ]
@@ -261,6 +387,7 @@ mod tests {
                 Segment::Key("items".into()),
                 Segment::Predicate {
                     key: "pattern".into(),
+                    op: PredicateOp::Eq,
                     value: "[0-9]".into(),
                 },
             ]
@@ -277,8 +404,139 @@ mod tests {
                 Segment::Key("data".into()),
                 Segment::Predicate {
                     key: "regex".into(),
+                    op: PredicateOp::Eq,
                     value: "[a[b]c]".into(),
                 },
+            ]
+        );
+    }
+
+    // ── #2230 comparison and negation predicates ───────────────────
+
+    fn pred(key: &str, op: PredicateOp, value: &str) -> Segment {
+        Segment::Predicate {
+            key: key.into(),
+            op,
+            value: value.into(),
+        }
+    }
+
+    #[test]
+    fn parse_gt_predicate() {
+        let sel = parse("servers[port>8000]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("servers".into()),
+                pred("port", PredicateOp::Gt, "8000")
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_ne_predicate() {
+        let sel = parse("items[status!=done]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("items".into()),
+                pred("status", PredicateOp::Ne, "done")
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_ge_lt_le_predicates() {
+        assert_eq!(
+            parse("servers[port>=8000]").unwrap(),
+            vec![
+                Segment::Key("servers".into()),
+                pred("port", PredicateOp::Ge, "8000")
+            ]
+        );
+        assert_eq!(
+            parse("servers[port<8000]").unwrap(),
+            vec![
+                Segment::Key("servers".into()),
+                pred("port", PredicateOp::Lt, "8000")
+            ]
+        );
+        assert_eq!(
+            parse("servers[port<=8000]").unwrap(),
+            vec![
+                Segment::Key("servers".into()),
+                pred("port", PredicateOp::Le, "8000")
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_equality_value_may_contain_equals() {
+        let sel = parse("items[url=a=b]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("items".into()),
+                pred("url", PredicateOp::Eq, "a=b")
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_equality_value_may_contain_gt() {
+        // Regression vs scanning `>` before `=`.
+        let sel = parse("items[url=a>b]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("items".into()),
+                pred("url", PredicateOp::Eq, "a>b")
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_negation_predicate() {
+        let sel = parse("flags[!deprecated]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("flags".into()),
+                pred("deprecated", PredicateOp::Not, ""),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_non_numeric_comparison_operand_errors() {
+        let err = parse("items[port>abc]").unwrap_err();
+        assert!(
+            err.contains("numeric") || err.contains("comparison"),
+            "expected numeric/comparison parse error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_jobs_id_test_still_eq() {
+        let sel = parse("jobs[id=test]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("jobs".into()),
+                pred("id", PredicateOp::Eq, "test")
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_chained_eq_and_gt() {
+        let sel = parse("data[type=server][port>8000]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("data".into()),
+                pred("type", PredicateOp::Eq, "server"),
+                pred("port", PredicateOp::Gt, "8000"),
             ]
         );
     }

--- a/src/selector/parser.rs
+++ b/src/selector/parser.rs
@@ -105,17 +105,21 @@ fn split_predicate(content: &str) -> Result<Option<(String, PredicateOp, String)
 }
 
 /// First operator in `content`. Two-character forms win at the same index.
+///
+/// Walk bytes and never slice `content[i..]` (a mid-character index is not
+/// a UTF-8 boundary). Operators are ASCII, so the returned indices are
+/// valid split points.
 fn find_predicate_op(content: &str) -> Option<(usize, PredicateOp, usize)> {
     let bytes = content.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        if content[i..].starts_with("!=") {
+        if bytes[i] == b'!' && bytes.get(i + 1) == Some(&b'=') {
             return Some((i, PredicateOp::Ne, i + 2));
         }
-        if content[i..].starts_with(">=") {
+        if bytes[i] == b'>' && bytes.get(i + 1) == Some(&b'=') {
             return Some((i, PredicateOp::Ge, i + 2));
         }
-        if content[i..].starts_with("<=") {
+        if bytes[i] == b'<' && bytes.get(i + 1) == Some(&b'=') {
             return Some((i, PredicateOp::Le, i + 2));
         }
         match bytes[i] {
@@ -524,6 +528,30 @@ mod tests {
             vec![
                 Segment::Key("jobs".into()),
                 pred("id", PredicateOp::Eq, "test")
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_non_ascii_key_equality_does_not_panic() {
+        let sel = parse("items[名前=x]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("items".into()),
+                pred("名前", PredicateOp::Eq, "x")
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_non_ascii_key_gt_does_not_panic() {
+        let sel = parse("items[café>1]").unwrap();
+        assert_eq!(
+            sel,
+            vec![
+                Segment::Key("items".into()),
+                pred("café", PredicateOp::Gt, "1")
             ]
         );
     }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -3706,6 +3706,75 @@ fn test_doc_get_port_gt_non_numeric_operand_invalid_input() {
     );
 }
 
+/// #2230: present non-numeric field vs `>` is invalid_input (eval-time).
+#[test]
+fn test_doc_get_port_gt_non_numeric_field_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("servers.json");
+    fs::write(&file, r#"{"servers":[{"port":"abc"}]}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("servers[port>8000]")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{:?}", output);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON error envelope");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(
+        v["error_kind"], "invalid_input",
+        "non-numeric field vs > must be invalid_input: {v}"
+    );
+}
+
+/// #2230: UTF-8 predicate key still parses.
+#[test]
+fn test_doc_get_unicode_predicate_key() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("items.json");
+    fs::write(&file, r#"{"items":[{"名前":"x","v":1}]}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("items[名前=x].v")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0), "{:?}", output);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["value"], 1, "{v}");
+}
+
+/// #2230: chained predicates write the matching row.
+#[test]
+fn test_doc_update_chained_predicate_apply() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("data.json");
+    fs::write(
+        &file,
+        r#"{"data":[{"type":"server","port":9000},{"type":"web","port":80}]}"#,
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["doc", "update"])
+        .arg(&file)
+        .arg("data[type=server][port>8000].port")
+        .arg("443")
+        .arg("--apply")
+        .assert()
+        .success();
+    let body = fs::read_to_string(&file).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["data"][0]["port"], 443, "{body}");
+    assert_eq!(v["data"][1]["port"], 80, "{body}");
+}
+
 /// #2230: existing key=value still works on doc get --json.
 #[test]
 fn test_doc_get_equality_predicate_still_works() {

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -3652,3 +3652,81 @@ fn style_changed_true_on_tx_plan_yaml_sequence_collapse() {
         "tx plan changes[] must report style_changed when sequence indent collapses: {v}"
     );
 }
+
+/// #2230: numeric comparison predicate on doc get --json.
+#[test]
+fn test_doc_get_port_gt_json() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("servers.json");
+    fs::write(
+        &file,
+        r#"{"servers":[{"name":"web","port":80},{"name":"api","port":9000}]}"#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("servers[port>8000]")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0), "{:?}", output);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["value"]["name"], "api", "{v}");
+    assert_eq!(v["value"]["port"], 9000, "{v}");
+}
+
+/// #2230: non-numeric comparison operand is invalid_input (parse-time).
+#[test]
+fn test_doc_get_port_gt_non_numeric_operand_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("servers.json");
+    fs::write(&file, r#"{"servers":[{"port":80}]}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("servers[port>abc]")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{:?}", output);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON error envelope");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(
+        v["error_kind"], "invalid_input",
+        "non-numeric comparison operand must be invalid_input: {v}"
+    );
+    let err = v["error"].as_str().unwrap_or("");
+    assert!(
+        err.contains("numeric") || err.contains("comparison"),
+        "error should name numeric/comparison, got: {v}"
+    );
+}
+
+/// #2230: existing key=value still works on doc get --json.
+#[test]
+fn test_doc_get_equality_predicate_still_works() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("items.json");
+    fs::write(
+        &file,
+        r#"{"items":[{"name":"a","v":1},{"name":"b","v":2}]}"#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "get"])
+        .arg(&file)
+        .arg("items[name=b]")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0), "{:?}", output);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(v["ok"], true, "{v}");
+    assert_eq!(v["value"]["name"], "b", "{v}");
+    assert_eq!(v["value"]["v"], 2, "{v}");
+}


### PR DESCRIPTION
Selectors already support exact `key=value`. Agents also need numeric comparisons and simple negation on doc paths.

This adds `>`, `<`, `>=`, `<=`, `!=`, and `[!key]` on selector predicates. `=` is tried before `>`/`<` so equality values may contain those characters (`url=a>b` stays Eq). Two-character ops (`!=`, `>=`, `<=`) are scanned first. Non-numeric `>`/`<`/`>=`/`<=` is `invalid_input` (not a lexical compare). Regex predicates (`=~`) are out of scope.

Write-path `update_matching` uses the same candidate walk as `doc get` (self plus map-of-records children) so chained predicates and `[!key]` do not diverge. Parse scans ASCII operator bytes so UTF-8 keys do not panic.

## Tests
- Parser + eval units: `>`, `<`, `>=`, `<=`, `!=`, `[!key]`, chained predicates, unicode keys, `url=a>b`
- `eval_result` / `update_matching` fail-closed on non-numeric compare
- CLI: `doc get` port `>`, non-numeric operand, non-numeric field, unicode key
- CLI apply: chained `data[type=server][port>8000].port`

Closes #2230