### PR TITLE
test: lock if_exists default false and fail-closed batch miss

### DIFF
--- a/src/cmd/batch_tests.rs
+++ b/src/cmd/batch_tests.rs
@@ -127,8 +127,12 @@ mod basic {
         let op = parse_line("doc.set config.json version 42", 1).unwrap();
         assert!(matches!(
             op,
-            Operation::DocSet { path, selector, value, .. }
-            if path == "config.json" && selector == "version" && value == serde_json::json!(42)
+            Operation::DocSet {
+                path,
+                selector,
+                value,
+                if_exists: false,
+            } if path == "config.json" && selector == "version" && value == serde_json::json!(42)
         ));
     }
 

--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -277,6 +277,10 @@ fn test_batch_doc_set_and_delete_if_exists_missing_soft_skips() {
     );
     let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(
+        json["files_changed"], 2,
+        "pkg.json + keep.txt, not the missing paths: {json}"
+    );
     let pkg: serde_json::Value =
         serde_json::from_str(&fs::read_to_string(dir.path().join("pkg.json")).unwrap()).unwrap();
     assert_eq!(pkg["version"], 2);
@@ -291,6 +295,39 @@ fn test_batch_doc_set_and_delete_if_exists_missing_soft_skips() {
     assert!(
         !dir.path().join("gone.txt").exists(),
         "file.delete --if-exists must not create missing file"
+    );
+}
+
+/// Without --if-exists, a missing doc.set path still aborts the batch.
+#[test]
+fn test_batch_doc_set_missing_file_without_if_exists_fails() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("keep.txt"), "stay\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["batch", "--apply"])
+        .write_stdin(
+            "replace keep.txt stay kept\n\
+             doc.set absent.json version 9\n",
+        )
+        .output()
+        .unwrap();
+
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "missing doc.set without --if-exists must fail: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("keep.txt")).unwrap(),
+        "stay\n",
+        "failed batch must not leave sibling apply"
     );
 }
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -3477,6 +3477,10 @@ async fn test_mcp_doc_set_if_exists_missing_file_succeeds() {
         "doc_set if_exists missing file should succeed: {val}"
     );
     assert_eq!(val["ok"], true, "doc_set if_exists ok: {val}");
+    assert_eq!(
+        val["files_changed"], 0,
+        "missing-file if_exists must not count a write: {val}"
+    );
     assert!(
         !dir.path().join("absent.json").exists(),
         "if_exists must not create missing file"
@@ -3532,6 +3536,11 @@ async fn test_mcp_delete_file_if_exists_missing_succeeds() {
     assert!(
         !is_error,
         "delete_file if_exists missing file should succeed: {val}"
+    );
+    assert_eq!(val["ok"], true, "delete_file if_exists ok: {val}");
+    assert_eq!(
+        val["files_deleted"], 0,
+        "missing-file if_exists must not count a delete: {val}"
     );
     assert!(
         !dir.path().join("absent.txt").exists(),


### PR DESCRIPTION
Test Auditor pass after #2235.

`parse_line_doc_set` used `..` and would still pass if `if_exists` defaulted to true. MCP soft-skip tests did not lock `files_changed` / `files_deleted`. A missing `doc.set` without `--if-exists` must abort the batch and leave sibling files unchanged.

Ref #2231