### PR TITLE
test: lock comparison predicates on tx, MCP, and batch writes

### DIFF
--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -331,6 +331,41 @@ fn test_batch_doc_set_missing_file_without_if_exists_fails() {
     );
 }
 
+/// #2230: batch `doc.update` honors comparison predicates (CLI/tx/MCP sibling).
+#[test]
+fn test_batch_doc_update_port_gt_predicate_writes_matching_row() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("svc.json"),
+        r#"{"servers":[{"name":"web","port":80},{"name":"api","port":9000}]}"#,
+    )
+    .unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["batch", "--apply"])
+        .write_stdin("doc.update svc.json servers[port>8000].port 443\n")
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(json["files_changed"], 1, "{json}");
+    let v: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dir.path().join("svc.json")).unwrap()).unwrap();
+    assert_eq!(v["servers"][0]["port"], 80, "{v}");
+    assert_eq!(v["servers"][1]["port"], 443, "{v}");
+}
+
 #[test]
 fn test_batch_json_empty_input_returns_structured_success() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -689,6 +689,44 @@ async fn test_mcp_doc_get_port_gt_predicate() {
     client.cancel().await.unwrap();
 }
 
+/// #2230: MCP `doc_update` honors comparison predicates (CLI/tx sibling).
+#[tokio::test]
+async fn test_mcp_doc_update_port_gt_predicate() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("svc.json"),
+        r#"{"servers":[{"name":"web","port":80},{"name":"api","port":9000}]}"#,
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_update",
+        serde_json::json!({
+            "path": "svc.json",
+            "selector": "servers[port>8000].port",
+            "value": 443
+        }),
+    )
+    .await;
+    assert!(
+        !is_error,
+        "doc_update comparison selector should succeed: {val}"
+    );
+    assert_eq!(val["ok"], true, "doc_update ok: {val}");
+    assert_eq!(val["files_changed"], 1, "doc_update files_changed: {val}");
+
+    let body = fs::read_to_string(dir.path().join("svc.json")).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["servers"][0]["port"], 80, "{body}");
+    assert_eq!(v["servers"][1]["port"], 443, "{body}");
+    client.cancel().await.unwrap();
+}
+
 /// #1467: singular `path` is accepted as an alias for `paths: [path]`.
 #[tokio::test]
 async fn test_mcp_search_files_accepts_path_alias() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2475,6 +2475,85 @@ fn test_tx_doc_update_in_plan() {
     assert!(items.iter().all(|i| i["status"] == "archived"));
 }
 
+/// #2230: plan/tx `doc.update` must honor comparison predicates (CLI/MCP sibling).
+#[test]
+fn test_tx_doc_update_port_gt_predicate_writes_matching_row() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("svc.json");
+    fs::write(
+        &file,
+        r#"{"servers":[{"name":"web","port":80},{"name":"api","port":9000}]}"#,
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "doc.update",
+            "path": portable_path_str(&file),
+            "selector": "servers[port>8000].port",
+            "value": 443
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
+    assert_eq!(v["servers"][0]["port"], 80, "{v}");
+    assert_eq!(v["servers"][1]["port"], 443, "{v}");
+}
+
+/// #2230: plan/tx comparison operand that is not numeric is invalid_input.
+#[test]
+fn test_tx_doc_update_port_gt_non_numeric_operand_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("svc.json");
+    fs::write(&file, r#"{"servers":[{"port":80}]}"#).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "doc.update",
+            "path": portable_path_str(&file),
+            "selector": "servers[port>abc].port",
+            "value": 443
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON envelope");
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "non-numeric comparison operand must be invalid_input: {json}"
+    );
+    let body = fs::read_to_string(&file).unwrap();
+    assert_eq!(body, r#"{"servers":[{"port":80}]}"#);
+}
+
 #[test]
 fn test_tx_md_insert_before_heading_in_plan() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Lock `servers[port>8000]` writes on the surfaces agents actually call: plan/`tx`, MCP `doc_update`, and batch.

## Problem

#2230 shipped comparison predicates with CLI `doc get` / `doc update` and MCP `doc_get`. Agents more often write through `tx`, MCP `doc_update`, and batch. Those paths had no lock that the matching row is updated and the sibling row is left alone.

## Change

- `tx`: apply `doc.update` with `servers[port>8000].port` and assert ports `80` / `443`.
- `tx`: non-numeric operand `[port>abc]` is `invalid_input` (exit 1) and the file is unchanged.
- MCP `doc_update`: same apply lock plus `files_changed: 1`.
- batch: `doc.update svc.json servers[port>8000].port 443`.

## Validation

- `cargo test --test integration --all-features port_gt` (8 passed)
- Reviewer: 0 must-fix
- `make check` green locally (README 4400+, 4458 tests)

Ref #2230
