### PR TITLE
test: lock comparison predicate fail-closed on MCP and batch

### DIFF
--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -366,6 +366,50 @@ fn test_batch_doc_update_port_gt_predicate_writes_matching_row() {
     assert_eq!(v["servers"][1]["port"], 443, "{v}");
 }
 
+/// #2230: batch `doc.update` non-numeric comparison is invalid_input (tx sibling).
+#[test]
+fn test_batch_doc_update_port_gt_non_numeric_operand_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("svc.json"), r#"{"servers":[{"port":80}]}"#).unwrap();
+    fs::write(dir.path().join("keep.txt"), "stay\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["batch", "--apply"])
+        .write_stdin(
+            "replace keep.txt stay kept\n\
+             doc.update svc.json servers[port>abc].port 443\n",
+        )
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON envelope");
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "non-numeric comparison operand must be invalid_input: {json}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("svc.json")).unwrap(),
+        r#"{"servers":[{"port":80}]}"#,
+        "failed batch must not write the bad update"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("keep.txt")).unwrap(),
+        "stay\n",
+        "failed batch must not leave sibling apply"
+    );
+}
+
 #[test]
 fn test_batch_json_empty_input_returns_structured_success() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -727,6 +727,43 @@ async fn test_mcp_doc_update_port_gt_predicate() {
     client.cancel().await.unwrap();
 }
 
+/// #2230: MCP `doc_update` comparison operand that is not numeric is invalid_input.
+#[tokio::test]
+async fn test_mcp_doc_update_port_gt_non_numeric_operand_invalid_input() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("svc.json"), r#"{"servers":[{"port":80}]}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_update",
+        serde_json::json!({
+            "path": "svc.json",
+            "selector": "servers[port>abc].port",
+            "value": 443
+        }),
+    )
+    .await;
+    assert!(
+        is_error,
+        "non-numeric comparison operand must fail closed via MCP: {val}"
+    );
+    assert_eq!(val["ok"], false, "{val}");
+    assert_eq!(
+        val["error_kind"], "invalid_input",
+        "MCP remapper must keep invalid_input: {val}"
+    );
+    let body = fs::read_to_string(dir.path().join("svc.json")).unwrap();
+    assert_eq!(
+        body, r#"{"servers":[{"port":80}]}"#,
+        "MCP fail-closed must not write: {body}"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// #1467: singular `path` is accepted as an alias for `paths: [path]`.
 #[tokio::test]
 async fn test_mcp_search_files_accepts_path_alias() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2498,13 +2498,23 @@ fn test_tx_doc_update_port_gt_predicate_writes_matching_row() {
     let plan_file = dir.path().join("plan.json");
     fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
 
-    Command::cargo_bin("patchloom")
+    let output = Command::cargo_bin("patchloom")
         .unwrap()
+        .arg("--json")
         .arg("tx")
         .arg(plan_file.to_str().unwrap())
         .arg("--apply")
-        .assert()
-        .code(0);
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["ok"], true, "{json}");
+    assert_eq!(json["files_changed"], 1, "{json}");
 
     let v: serde_json::Value = serde_json::from_str(&fs::read_to_string(&file).unwrap()).unwrap();
     assert_eq!(v["servers"][0]["port"], 80, "{v}");


### PR DESCRIPTION
## Summary

Lock fail-closed `invalid_input` for a non-numeric comparison operand on MCP `doc_update` and batch `doc.update`, matching the existing plan/`tx` lock.

## Problem

#2237 locked the write happy path on tx, MCP, and batch, and fail-closed `[port>abc]` only on `tx`. A remapper collapse on MCP or batch would still pass those tests.

## Change

- MCP `doc_update` `[port>abc]`: `is_error`, `ok: false`, `error_kind: invalid_input`, file unchanged.
- batch `doc.update` `[port>abc]`: exit 1, same `error_kind`, file unchanged, sibling `replace` not applied.
- tx happy path now uses `--json` and locks `files_changed: 1`.

## Validation

- `cargo test --test integration --all-features port_gt` (10 passed)
- Reviewer: 0 must-fix
- `make check` green locally (README 4400+, 4460 tests)

Ref #2230
