### PR TITLE
test: lock eval-time non-numeric compare on agent writes

### DIFF
--- a/tests/integration/batch_tests.rs
+++ b/tests/integration/batch_tests.rs
@@ -410,6 +410,53 @@ fn test_batch_doc_update_port_gt_non_numeric_operand_invalid_input() {
     );
 }
 
+/// #2230: batch `doc.update` present non-numeric field vs `>` is invalid_input.
+#[test]
+fn test_batch_doc_update_port_gt_non_numeric_field_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("svc.json"),
+        r#"{"servers":[{"port":"abc"}]}"#,
+    )
+    .unwrap();
+    fs::write(dir.path().join("keep.txt"), "stay\n").unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("--cwd")
+        .arg(dir.path())
+        .args(["batch", "--apply"])
+        .write_stdin(
+            "replace keep.txt stay kept\n\
+             doc.update svc.json servers[port>8000].port 443\n",
+        )
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON envelope");
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "non-numeric field vs > must be invalid_input: {json}"
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("svc.json")).unwrap(),
+        r#"{"servers":[{"port":"abc"}]}"#
+    );
+    assert_eq!(
+        fs::read_to_string(dir.path().join("keep.txt")).unwrap(),
+        "stay\n",
+        "failed batch must not leave sibling apply"
+    );
+}
+
 #[test]
 fn test_batch_json_empty_input_returns_structured_success() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -3729,6 +3729,62 @@ fn test_doc_get_port_gt_non_numeric_field_invalid_input() {
     );
 }
 
+/// #2230: CLI `doc update` parse-time non-numeric operand is invalid_input.
+#[test]
+fn test_doc_update_port_gt_non_numeric_operand_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("servers.json");
+    fs::write(&file, r#"{"servers":[{"port":80}]}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "update"])
+        .arg(&file)
+        .arg("servers[port>abc].port")
+        .arg("443")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{:?}", output);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON error envelope");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(
+        v["error_kind"], "invalid_input",
+        "non-numeric comparison operand must be invalid_input: {v}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        r#"{"servers":[{"port":80}]}"#
+    );
+}
+
+/// #2230: CLI `doc update` present non-numeric field vs `>` is invalid_input.
+#[test]
+fn test_doc_update_port_gt_non_numeric_field_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("servers.json");
+    fs::write(&file, r#"{"servers":[{"port":"abc"}]}"#).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "doc", "update"])
+        .arg(&file)
+        .arg("servers[port>8000].port")
+        .arg("443")
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(1), "{:?}", output);
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON error envelope");
+    assert_eq!(v["ok"], false, "{v}");
+    assert_eq!(
+        v["error_kind"], "invalid_input",
+        "non-numeric field vs > must be invalid_input: {v}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        r#"{"servers":[{"port":"abc"}]}"#
+    );
+}
+
 /// #2230: UTF-8 predicate key still parses.
 #[test]
 fn test_doc_get_unicode_predicate_key() {

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -764,6 +764,78 @@ async fn test_mcp_doc_update_port_gt_non_numeric_operand_invalid_input() {
     client.cancel().await.unwrap();
 }
 
+/// #2230: MCP `doc_update` present non-numeric field vs `>` is invalid_input.
+#[tokio::test]
+async fn test_mcp_doc_update_port_gt_non_numeric_field_invalid_input() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("svc.json"),
+        r#"{"servers":[{"port":"abc"}]}"#,
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_update",
+        serde_json::json!({
+            "path": "svc.json",
+            "selector": "servers[port>8000].port",
+            "value": 443
+        }),
+    )
+    .await;
+    assert!(
+        is_error,
+        "non-numeric field vs > must fail closed via MCP: {val}"
+    );
+    assert_eq!(val["ok"], false, "{val}");
+    assert_eq!(
+        val["error_kind"], "invalid_input",
+        "MCP remapper must keep invalid_input: {val}"
+    );
+    let body = fs::read_to_string(dir.path().join("svc.json")).unwrap();
+    assert_eq!(
+        body, r#"{"servers":[{"port":"abc"}]}"#,
+        "MCP fail-closed must not write: {body}"
+    );
+    client.cancel().await.unwrap();
+}
+
+/// #2230: MCP `doc_get` non-numeric comparison operand is invalid_input.
+#[tokio::test]
+async fn test_mcp_doc_get_port_gt_non_numeric_operand_invalid_input() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("svc.json"), r#"{"servers":[{"port":80}]}"#).unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_get",
+        serde_json::json!({
+            "path": "svc.json",
+            "selector": "servers[port>abc].port"
+        }),
+    )
+    .await;
+    assert!(
+        is_error,
+        "non-numeric comparison operand must fail closed via MCP get: {val}"
+    );
+    assert_eq!(val["ok"], false, "{val}");
+    assert_eq!(
+        val["error_kind"], "invalid_input",
+        "MCP get remapper must keep invalid_input: {val}"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// #1467: singular `path` is accepted as an alias for `paths: [path]`.
 #[tokio::test]
 async fn test_mcp_search_files_accepts_path_alias() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2564,6 +2564,51 @@ fn test_tx_doc_update_port_gt_non_numeric_operand_invalid_input() {
     assert_eq!(body, r#"{"servers":[{"port":80}]}"#);
 }
 
+/// #2230: plan/tx present non-numeric field vs `>` is invalid_input (eval-time).
+#[test]
+fn test_tx_doc_update_port_gt_non_numeric_field_invalid_input() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("svc.json");
+    fs::write(&file, r#"{"servers":[{"port":"abc"}]}"#).unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "doc.update",
+            "path": portable_path_str(&file),
+            "selector": "servers[port>8000].port",
+            "value": 443
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    let output = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("--json")
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).expect("JSON envelope");
+    assert_eq!(json["ok"], false, "{json}");
+    assert_eq!(
+        json["error_kind"], "invalid_input",
+        "non-numeric field vs > must be invalid_input: {json}"
+    );
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        r#"{"servers":[{"port":"abc"}]}"#
+    );
+}
+
 #[test]
 fn test_tx_md_insert_before_heading_in_plan() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Lock eval-time fail-closed `invalid_input` when a present field is not numeric (`port: "abc"` vs `[port>8000]`) on the agent write surfaces.

## Problem

#2230 already refused that case on CLI `doc get` and in unit eval. Agents write through `doc update`, plan/`tx`, MCP `doc_update`, and batch. Those paths had no lock, so a remapper collapse would stay green. Parse-time `[port>abc]` was also missing on CLI `doc update` and MCP `doc_get`.

## Change

- CLI `doc update`: `[port>abc]` and string `port` vs `[port>8000]`.
- `tx` / MCP `doc_update` / batch: string `port` vs `[port>8000]`, file unchanged. Batch also leaves a sibling replace unapplied.
- MCP `doc_get`: `[port>abc]` is `invalid_input`.

## Validation

- `cargo test --test integration --all-features port_gt` (16 passed)
- Reviewer: 0 must-fix
- `make check` green locally (README 4400+, 4466 tests)

Ref #2230
