### PR TITLE
chore(deps): bump yaml-edit to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3407,9 +3407,9 @@ dependencies = [
 
 [[package]]
 name = "yaml-edit"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d25d3b32461fbd629221a7356eb48c86ad435356db0bfa93e26e8c1509c1836"
+checksum = "792f97ea57f2bab429eeceaf3bea8aad29ebf65a5ba652f0c11c958ebde7df27"
 dependencies = [
  "base64 0.22.1",
  "rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ clap = { version = "4", features = ["derive"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 serde_yaml_ng = "0.10"
-yaml-edit = "0.2"
+yaml-edit = "0.3"
 toml_edit = { version = "0.25", features = ["serde"] }
 ignore = { version = "0.4", optional = true }
 globset = { version = "0.4", optional = true }

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -707,6 +707,33 @@ mod tests {
         assert_eq!(result, yaml);
     }
 
+    /// yaml-edit 0.3 still cannot turn `key: *alias` into `<<: *alias` via
+    /// `Mapping::set`. A CST set of the expanded object inlines the map and
+    /// can drop the sibling `&shared` definition. Keep
+    /// [`rewrite_yaml_alias_object_edits`] (#2250).
+    #[test]
+    fn yaml_edit_set_on_pure_alias_does_not_become_merge() {
+        let yaml = "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a: *shared\n";
+        let doc = parse_yaml(yaml);
+        let root = doc.as_mapping().unwrap();
+        let replacement = json_to_yaml_mapping(&json!({"timeout": 60, "retries": 3})).unwrap();
+        root.set("service_a", &replacement);
+        let result = doc.to_string();
+        assert!(
+            !result.contains("<<: *shared"),
+            "0.3 Mapping::set unexpectedly produced a merge:\n{result}"
+        );
+        assert!(
+            !result.contains("service_a: *shared"),
+            "0.3 Mapping::set left the alias (would drop the override):\n{result}"
+        );
+        // Concrete map is fine; identity is not. The line splice is still required.
+        assert!(
+            result.contains("timeout: 60"),
+            "0.3 Mapping::set must still write the override:\n{result}"
+        );
+    }
+
     #[test]
     fn mapping_diff_pure_alias_override_to_merge() {
         use std::str::FromStr;


### PR DESCRIPTION
Bump `yaml-edit` from 0.2.3 to 0.3.0 and lock that CST `Mapping::set` still cannot turn `key: *alias` into `<<: *name`.

## Problem

`yaml-edit` 0.3.0 shipped 2026-08-25. Patchloom stayed on 0.2 because `rewrite_yaml_alias_object_edits` was written against 0.2 `Mapping::set` inlining a pure alias. 0.3 also makes `Document::from_str` stricter on stream-level content, so multi-doc `---` had to be re-checked.

## Change

- Pin `yaml-edit = "0.3"` and lock 0.3.0.
- Add `yaml_edit_set_on_pure_alias_does_not_become_merge`: CST set writes the override (`timeout: 60`) but does not emit `<<: *shared` and does not leave `service_a: *shared`.
- Keep `rewrite_yaml_alias_object_edits`. 0.3 merge APIs (`merged()` / `get_resolved()`) are read-side only.

Out of scope: `tree-sitter-proto` 0.5 (incompatible); Show HN (#1990).

## Validation

- `yaml_edit_set_on_pure_alias_does_not_become_merge` ok
- `cargo test --lib ops::doc::` 330 ok (includes alias-to-merge and multi-doc unit)
- `cargo test --test integration yaml` 34 ok (CLI, tx, MCP `doc_set` alias-to-merge)
- `cargo test --test integration multi_doc` 13 ok (`test_doc_set_multi_document_apply_preserves_separators`)
- `api::tests::yaml_doc_set_pure_alias_becomes_merge` ok
- `cargo clippy --all-targets --all-features -- -D warnings` ok
- `cargo fmt --all` clean

## Acceptance (#2250)

- [x] Land 0.3 with the alias and multi-doc matrix green
- [x] 0.3 cannot CST-rewrite `key: *alias` to `<<: *name`; splice kept
- [x] Multi-doc YAML `---` round-trip still locked

Closes #2250
