### PR TITLE
test(doc): lock yaml-edit 0.3 set and get_mapping alias contracts

### DIFF
--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -1,3 +1,5 @@
+// size-waiver: accepted single-domain bulk (policy #1408). yaml-edit CST
+// mapping/sequence diffs plus alias-to-merge line splice (#2243 / #2252).
 pub(crate) fn apply_yaml_mapping_diff(
     mapping: &yaml_edit::Mapping,
     old: &serde_json::Value,
@@ -708,9 +710,9 @@ mod tests {
     }
 
     /// yaml-edit 0.3 still cannot turn `key: *alias` into `<<: *alias` via
-    /// `Mapping::set`. A CST set of the expanded object inlines the map and
-    /// can drop the sibling `&shared` definition. Keep
-    /// [`rewrite_yaml_alias_object_edits`] (#2250).
+    /// `Mapping::set`. A CST set of the expanded object inlines the map.
+    /// The sibling `&shared` definition stays. Keep
+    /// [`rewrite_yaml_alias_object_edits`].
     #[test]
     fn yaml_edit_set_on_pure_alias_does_not_become_merge() {
         let yaml = "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a: *shared\n";
@@ -727,11 +729,66 @@ mod tests {
             !result.contains("service_a: *shared"),
             "0.3 Mapping::set left the alias (would drop the override):\n{result}"
         );
+        assert!(
+            result.contains("&shared"),
+            "0.3 Mapping::set must keep the sibling anchor:\n{result}"
+        );
         // Concrete map is fine; identity is not. The line splice is still required.
         assert!(
             result.contains("timeout: 60"),
             "0.3 Mapping::set must still write the override:\n{result}"
         );
+    }
+
+    /// Merge writes already work on 0.3 if the replacement CST already has
+    /// `<<: *name`. That is the write-side contract (jelmer/yaml-edit#39).
+    #[test]
+    fn yaml_edit_set_of_merge_mapping_keeps_alias() {
+        let yaml = "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a: *shared\n";
+        let doc = parse_yaml(yaml);
+        let root = doc.as_mapping().unwrap();
+        let merge_src = parse_yaml("<<: *shared\ntimeout: 60\n");
+        let merge_map = merge_src.as_mapping().expect("merge snippet is a mapping");
+        root.set("service_a", &merge_map);
+        let result = doc.to_string();
+        assert!(
+            result.contains("&shared") && result.contains("<<: *shared"),
+            "set of a merge-shaped mapping must write << and keep the anchor:\n{result}"
+        );
+        assert!(
+            result.contains("timeout: 60"),
+            "local override missing after merge set:\n{result}"
+        );
+        assert!(
+            !result.contains("service_a: *shared"),
+            "pure alias must be replaced by the merge block:\n{result}"
+        );
+    }
+
+    /// `get_mapping` on `key: *alias` must not yield the `&anchor` node.
+    /// If it did, `apply_yaml_mapping_diff` would mutate the definition.
+    #[test]
+    fn yaml_edit_get_mapping_on_alias_is_not_the_anchor() {
+        let yaml = "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a: *shared\n";
+        let doc = parse_yaml(yaml);
+        let root = doc.as_mapping().unwrap();
+        let service_a = root.get("service_a").expect("service_a key");
+        assert!(
+            service_a.as_alias().is_some(),
+            "service_a must still be an alias node"
+        );
+        if let Some(child) = root.get_mapping("service_a") {
+            child.set("timeout", json_to_yaml_node(&json!(99)).unwrap());
+            let result = doc.to_string();
+            assert!(
+                result.contains("&shared") && result.contains("timeout: 30"),
+                "get_mapping on an alias must not rewrite the &shared definition:\n{result}"
+            );
+            assert!(
+                !result.contains("timeout: 99"),
+                "get_mapping on an alias must not write through to the anchor:\n{result}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Lock the yaml-edit 0.3 write-side contracts we measured after the 0.3 bump.

## Problem

`#2252` bumped yaml-edit to 0.3 and asserted that `Mapping::set` of a resolved object does not invent `<<: *alias`. That left two related 0.3 facts untested: the sibling `&anchor` stays, and `set` of a mapping that already contains `<<: *name` writes a merge. `get_mapping` on `key: *alias` must also not share the definition node (otherwise a CST recurse would rewrite the anchor).

## Change

- Strengthen `yaml_edit_set_on_pure_alias_does_not_become_merge` to require `&shared`.
- Add `yaml_edit_set_of_merge_mapping_keeps_alias`.
- Add `yaml_edit_get_mapping_on_alias_is_not_the_anchor`.
- Correct the probe comment: 0.3 does not drop the sibling definition.

## Validation

- `cargo test --lib yaml_edit_`
- `make check-fast`

No product behavior change. Line splice in `rewrite_yaml_alias_object_edits` stays the Patchloom path for `key: *alias`.
