### PR TITLE
test(doc): lock scalar sequence alias CST as not applied

### DIFF
--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -952,6 +952,22 @@ mod tests {
         assert_eq!(doc.to_string(), yaml);
     }
 
+    /// Scalar `- *alias` is the same Sequence::set no-op (non-object arm).
+    #[test]
+    fn sequence_diff_on_scalar_alias_item_is_not_applied() {
+        let yaml = "shared: &shared hello\nitems:\n  - *shared\n";
+        let doc = parse_yaml(yaml);
+        let mapping = doc.as_mapping().unwrap();
+        let seq = mapping.get_sequence("items").unwrap();
+        let old = vec![json!("hello")];
+        let new = vec![json!("world")];
+        assert!(
+            !apply_yaml_sequence_diff(&seq, &old, &new).unwrap(),
+            "scalar alias item set must not report applied"
+        );
+        assert_eq!(doc.to_string(), yaml);
+    }
+
     // ---- apply_yaml_sequence_resize ----
 
     #[test]


### PR DESCRIPTION
## Summary

Lock the non-object arm of `apply_yaml_sequence_diff` for `- *alias` scalars.

## Problem

#2255 covered object alias items. The `_` arm uses the same `try_sequence_set`. A scalar `- *shared` would have been an untested sibling.

## Change

- `sequence_diff_on_scalar_alias_item_is_not_applied`: `Ok(false)` and unchanged YAML.

## Validation

- `cargo test --lib sequence_diff_on_scalar_alias_item_is_not_applied`
- `make check-fast`

Ref #2255
