### PR TITLE
test: lock proto AST and YAML sequence-item alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,9 +349,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1502,11 +1502,11 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "3.0.6"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.0",
  "serde_core",
 ]
 
@@ -1773,9 +1773,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
 dependencies = [
  "pem",
  "ring",

--- a/src/ast/symbols/tests.rs
+++ b/src/ast/symbols/tests.rs
@@ -935,3 +935,23 @@ func (e *External) DoWork() {}
         "orphan method should stay top-level"
     );
 }
+
+#[test]
+fn extract_proto_symbols() {
+    let source = r#"
+syntax = "proto3";
+package demo;
+message Ping { string id = 1; }
+enum Status { UNKNOWN = 0; }
+service Greeter { rpc SayHello (Ping) returns (Ping); }
+"#;
+    let symbols = extract_symbols(source, Language::Protobuf);
+    let ping = find_symbol(&symbols, "Ping").expect("Ping");
+    assert_eq!(ping.kind, SymbolKind::Struct);
+    let status = find_symbol(&symbols, "Status").expect("Status");
+    assert_eq!(status.kind, SymbolKind::Enum);
+    let greeter = find_symbol(&symbols, "Greeter").expect("Greeter");
+    assert_eq!(greeter.kind, SymbolKind::Interface);
+    let say = find_symbol(&symbols, "SayHello").expect("SayHello");
+    assert_eq!(say.kind, SymbolKind::Method);
+}

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -378,12 +378,9 @@ fn try_preserve_yaml(
         return Ok(Some(cleanup_yaml_cst_whitespace(spliced)));
     }
     let (file, cst_old) = if let Some(spliced) = promoted.as_deref() {
-        match yaml_edit::YamlFile::from_str(spliced) {
-            Ok(reparsed) => {
-                let cst_old = parse_yaml_semantic(spliced).unwrap_or_else(|| old_value.clone());
-                (reparsed, cst_old)
-            }
-            Err(_) => (file, old_value.clone()),
+        match yaml_file_after_partial_alias_splice(spliced, old_value) {
+            Some(pair) => pair,
+            None => return Ok(None),
         }
     } else {
         (file, old_value.clone())
@@ -408,6 +405,19 @@ fn try_preserve_yaml(
         }
     }
     Ok(None)
+}
+
+/// After an alias splice that is not yet semantic-eq, reparse for leftover CST diffs.
+/// Parse failure must dump (None), not CST the pre-splice document.
+fn yaml_file_after_partial_alias_splice(
+    spliced: &str,
+    old_value: &serde_json::Value,
+) -> Option<(yaml_edit::YamlFile, serde_json::Value)> {
+    use std::str::FromStr;
+
+    let reparsed = yaml_edit::YamlFile::from_str(spliced).ok()?;
+    let cst_old = parse_yaml_semantic(spliced).unwrap_or_else(|| old_value.clone());
+    Some((reparsed, cst_old))
 }
 
 fn try_preserve_yaml_object(

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -748,6 +748,26 @@ mod tests {
         );
     }
 
+    /// yaml-edit 0.3 `Sequence::set` copies an ALIAS child as-is and still
+    /// returns true. Product owner is [`try_sequence_set`], which refuses.
+    #[test]
+    fn yaml_edit_set_on_sequence_alias_item_is_noop() {
+        let yaml = "shared: &shared\n  timeout: 30\nitems:\n  - *shared\n";
+        let doc = parse_yaml(yaml);
+        let root = doc.as_mapping().unwrap();
+        let seq = root.get_sequence("items").expect("items sequence");
+        let ok = seq.set(0, json_to_yaml_node(&json!({"timeout": 60})).unwrap());
+        assert!(
+            ok,
+            "yaml-edit 0.3 Sequence::set reports success on alias item"
+        );
+        let result = doc.to_string();
+        assert!(
+            result.contains("- *shared"),
+            "0.3 Sequence::set must leave the alias item:\n{result}"
+        );
+    }
+
     /// Merge writes already work on 0.3 if the replacement CST already has
     /// `<<: *name`. That is the write-side contract (jelmer/yaml-edit#39).
     #[test]

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -53,14 +53,7 @@ pub(crate) fn apply_yaml_mapping_diff(
                             if !apply_yaml_sequence_diff(&seq, old_arr, new_arr)? {
                                 all_applied = false;
                             }
-                        } else if !apply_yaml_sequence_resize(
-                            &seq,
-                            old_arr,
-                            new_arr,
-                            mapping,
-                            key.as_str(),
-                            new_val,
-                        ) {
+                        } else if !apply_yaml_sequence_resize(&seq, old_arr, new_arr) {
                             all_applied = false;
                         }
                     } else {
@@ -191,9 +184,6 @@ fn apply_yaml_sequence_resize(
     seq: &yaml_edit::Sequence,
     old_arr: &[serde_json::Value],
     new_arr: &[serde_json::Value],
-    _mapping: &yaml_edit::Mapping,
-    _key: &str,
-    _new_val: &serde_json::Value,
 ) -> bool {
     if new_arr.len() < old_arr.len() && try_remove_subsequence(seq, old_arr, new_arr) {
         return true;
@@ -1048,10 +1038,7 @@ mod tests {
 
         let old = vec![json!("a"), json!("b"), json!("c")];
         let new = vec![json!("a"), json!("c")];
-        let new_val = json!(["a", "c"]);
-        assert!(apply_yaml_sequence_resize(
-            &seq, &old, &new, &mapping, "items", &new_val
-        ));
+        assert!(apply_yaml_sequence_resize(&seq, &old, &new));
         // yaml-edit leaves the next item over-indented; caller
         // `fix_yaml_block_indentation` repairs that. Lock items a, c only.
         assert_eq!(doc.to_string(), "items:\n  - a\n    - c\n");
@@ -1066,11 +1053,17 @@ mod tests {
 
         let old = vec![json!("a")];
         let new = vec![json!("a"), json!("b")];
-        let new_val = json!(["a", "b"]);
         // Growth is not handled by CST path, returns false.
-        assert!(!apply_yaml_sequence_resize(
-            &seq, &old, &new, &mapping, "items", &new_val
-        ));
+        assert!(!apply_yaml_sequence_resize(&seq, &old, &new));
+    }
+
+    #[test]
+    fn yaml_file_after_partial_alias_splice_invalid_yaml_returns_none() {
+        let old = json!({"k": 1});
+        assert!(
+            super::super::yaml_file_after_partial_alias_splice("{\n", &old).is_none(),
+            "unclosed '{{' fragment must dump, not CST the pre-splice file"
+        );
     }
 
     #[test]

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -43,6 +43,25 @@ fn test_ast_list_basic() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_list_proto() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("svc.proto");
+    fs::write(
+        &f,
+        "syntax = \"proto3\";\npackage demo;\nmessage Ping { string id = 1; }\nenum Status { UNKNOWN = 0; }\nservice Greeter { rpc SayHello (Ping) returns (Ping); }\n",
+    )
+    .unwrap();
+    patchloom_in(dir.path())
+        .args(["ast", "list", "svc.proto", "--json"])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("Ping"))
+        .stdout(predicates::str::contains("Greeter"))
+        .stdout(predicates::str::contains("SayHello"));
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_list_quiet_suppresses_text() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("lib.rs");
@@ -886,6 +905,40 @@ fn test_ast_rename_apply_exits_0() {
     assert!(
         !content.contains("old_name"),
         "old symbol name should be replaced: {content}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
+fn test_ast_rename_proto() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("svc.proto");
+    fs::write(
+        &f,
+        "syntax = \"proto3\";\npackage demo;\nmessage Ping { string id = 1; }\nenum Status { UNKNOWN = 0; }\nservice Greeter { rpc SayHello (Ping) returns (Ping); }\n",
+    )
+    .unwrap();
+    patchloom_in(dir.path())
+        .args([
+            "ast",
+            "rename",
+            "svc.proto",
+            "--old",
+            "Ping",
+            "--new",
+            "Pong",
+            "--apply",
+        ])
+        .assert()
+        .code(0);
+    let content = fs::read_to_string(&f).unwrap();
+    assert!(
+        content.contains("Pong"),
+        "ast rename --apply should rename proto message: {content}"
+    );
+    assert!(
+        !content.contains("message Ping"),
+        "old proto message name should be replaced: {content}"
     );
 }
 

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1376,6 +1376,52 @@ fn test_doc_set_yaml_pure_alias_becomes_merge() {
         .stdout(predicate::str::starts_with("3"));
 }
 
+/// Interior edit of a sequence item alias becomes `<<: *anchor` plus the local key.
+#[test]
+fn test_doc_set_yaml_sequence_alias_item_becomes_merge() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.yaml");
+    fs::write(
+        &file,
+        "shared: &shared\n  timeout: 30\n  retries: 3\nitems:\n  - *shared\n  - *shared\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("items[0].timeout")
+        .arg("60")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("&shared") && content.contains("- <<: *shared"),
+        "sequence alias override must become merge:\n{content}"
+    );
+    assert!(
+        content.contains("timeout: 60"),
+        "local override missing:\n{content}"
+    );
+    assert!(
+        content.contains("  - *shared"),
+        "untouched second item must stay a pure alias:\n{content}"
+    );
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("get")
+        .arg(&file)
+        .arg("items[0].retries")
+        .assert()
+        .success()
+        .stdout(predicate::str::starts_with("3"));
+}
+
 #[test]
 fn test_doc_set_yaml_apply() {
     let dir = TempDir::new().unwrap();

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -71,6 +71,48 @@ async fn test_mcp_doc_set_yaml_pure_alias_becomes_merge() {
     client.cancel().await.unwrap();
 }
 
+#[tokio::test]
+async fn test_mcp_doc_set_yaml_sequence_alias_item_becomes_merge() {
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("config.yaml"),
+        "shared: &shared\n  timeout: 30\n  retries: 3\nitems:\n  - *shared\n  - *shared\n",
+    )
+    .unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    let (is_error, val) = call_tool_value(
+        &client,
+        "doc_set",
+        serde_json::json!({
+            "path": "config.yaml",
+            "selector": "items[0].timeout",
+            "value": 60
+        }),
+    )
+    .await;
+    assert!(!is_error, "doc_set should succeed: {val}");
+    assert_eq!(val["ok"], true, "doc_set ok field: {val}");
+
+    let content = fs::read_to_string(dir.path().join("config.yaml")).unwrap();
+    assert!(
+        content.contains("&shared") && content.contains("- <<: *shared"),
+        "MCP doc_set must convert sequence alias to merge:\n{content}"
+    );
+    assert!(
+        content.contains("timeout: 60"),
+        "local override missing:\n{content}"
+    );
+    assert!(
+        content.contains("  - *shared"),
+        "untouched second item must stay a pure alias:\n{content}"
+    );
+    client.cancel().await.unwrap();
+}
+
 /// #2197: MCP `doc_set` selector `.` replaces the document root.
 #[tokio::test]
 async fn test_mcp_doc_set_dot_replaces_root() {

--- a/tests/integration/tx_tests.rs
+++ b/tests/integration/tx_tests.rs
@@ -2320,6 +2320,52 @@ fn test_tx_doc_set_yaml_pure_alias_becomes_merge() {
     );
 }
 
+/// Plan/tx interior edit of a sequence-item YAML alias becomes a merge override.
+#[test]
+fn test_tx_doc_set_yaml_sequence_alias_item_becomes_merge() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.yaml");
+    fs::write(
+        &file,
+        "shared: &shared\n  timeout: 30\n  retries: 3\nitems:\n  - *shared\n  - *shared\n",
+    )
+    .unwrap();
+
+    let plan = serde_json::json!({
+        "version": 1,
+        "operations": [{
+            "op": "doc.set",
+            "path": portable_path_str(&file),
+            "selector": "items[0].timeout",
+            "value": 60
+        }]
+    });
+    let plan_file = dir.path().join("plan.json");
+    fs::write(&plan_file, serde_json::to_string(&plan).unwrap()).unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("tx")
+        .arg(plan_file.to_str().unwrap())
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert!(
+        content.contains("&shared") && content.contains("- <<: *shared"),
+        "tx doc.set must convert sequence alias to merge:\n{content}"
+    );
+    assert!(
+        content.contains("timeout: 60"),
+        "local override missing:\n{content}"
+    );
+    assert!(
+        content.contains("  - *shared"),
+        "untouched second item must stay a pure alias:\n{content}"
+    );
+}
+
 #[test]
 fn test_tx_doc_set_selector_in_plan() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
Lock two agent-facing holes that unit tests on main would not catch after recent landings.

## Problem

1. `tree-sitter-proto` 0.5.0 landed in #2262 as a lock-only bump. `extract_proto` had no `extract_symbols` test and no cargo-bin `ast list` / `ast rename` coverage. A grammar node-kind change would return an empty symbol list and `make check` would still pass.

2. Mapping `key: *alias` is locked on CLI, tx, MCP, and library. Sequence item `- *shared` was unit-only (`serialize_value_preserving`). Agents call those other surfaces.

3. yaml-edit 0.3 `Sequence::set` on an alias item returns true and leaves `*alias`. Product comments claimed a crate lock; tests only went through `try_sequence_set`.

4. `apply_yaml_sequence_resize` took three unused arguments. After a partial alias splice, a `YamlFile` reparse failure continued CST on the pre-splice document, which can `Mapping::set` and inline `*alias`.

## Change

- `extract_proto_symbols` plus cargo-bin `ast list` / `ast rename` on `svc.proto`.
- CLI / tx / MCP `doc set items[0].timeout` locks: first item becomes `- <<: *shared` plus `timeout: 60`; sibling stays `- *shared`.
- Direct `Sequence::set(0, …)` lock: 0.3 still reports success and keeps `- *shared`.
- Resize signature is `(seq, old_arr, new_arr)` only.
- Splice reparse failure dumps (`Ok(None)`) instead of CSTing the original file.
- Lockfile: rcgen 0.14.10; unyanked chacha20 0.10.2 (cargo deny warned 0.10.1 via rmcp/rand).

## Validation

- `make check-fast` green (fmt, clippy `-D warnings`, lib 3140, integration 1498, pty 10, hygiene, README 4600+).
- Targeted: `extract_proto_symbols`, `yaml_edit_set_on_sequence_alias_item_is_noop`, `yaml_file_after_partial_alias_splice`, cargo-bin proto list/rename, sequence-alias CLI/tx/MCP.

Ref #2262
