### PR TITLE
fix: YAML alias splice dump and proto kind aliases

### DIFF
--- a/PATCHLOOM.md
+++ b/PATCHLOOM.md
@@ -25,7 +25,7 @@ When patchloom MCP is connected:
 
 ## Structured doc style honesty
 
-`doc.*` (CLI, plan, MCP) may re-emit **canonical YAML presentation** while keeping values correct (for example collapsing indented block sequences under a key). When **block-sequence indent presentation** shifts, write JSON reports `style_changed: true` on CLI `doc --json` and on plan/MCP `changes[]` entries for modified files. Detection is a block-sequence indent fingerprint (not every possible formatting change). Do not claim a pure surgical text edit when `style_changed` is true.
+`doc.*` (CLI, plan, MCP) may re-emit **canonical YAML presentation** while keeping values correct (for example collapsing indented block sequences under a key, or expanding aliases). When **block-sequence indent** or YAML alias/anchor/merge identity (`&name`, `*name`, `<<:`) changes, write JSON reports `style_changed: true` on CLI `doc --json` and on plan/MCP `changes[]` entries for modified files. Detection covers those two fingerprints, not every possible formatting change. Do not claim a pure surgical text edit when `style_changed` is true.
 
 ## Recommended MCP surface for coding agents
 

--- a/docs/getting-started/embedder-host.md
+++ b/docs/getting-started/embedder-host.md
@@ -76,10 +76,10 @@ Do not expose only `doc_set` if agents need list updates by name. See
    `not_found`). Sole explicit replace/search/tidy paths use the same
    classification via `sole_explicit_non_text` so agents do not mis-branch
    on `not_found` for a present non-file entry.
-9. **Doc presentation honesty:** library `EditResult.style_changed` (and
+9. **Doc presentation:** library `EditResult.style_changed` (and
    `is_style_changed`) mirrors CLI/MCP when YAML block-sequence layout
-   collapses; values can still be correct (#2088). Warn hosts/agents; do not
-   treat as failure.
+   collapses or when `&` / `*` / `<<:` identity is dropped; values can
+   still be correct (#2088). Warn hosts/agents; do not treat as failure.
 10. **Morph-class freeform on disk:** `apply_fragment_to_file(path, fragment,
    FragmentPlacement::After|Before|Replace(...), unique, mode, guard)` strips
    lazy markers and applies via the replace path (#2032).

--- a/src/ast/symbols/mod.rs
+++ b/src/ast/symbols/mod.rs
@@ -47,15 +47,15 @@ impl SymbolKind {
     pub fn from_str_loose(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "fn" | "func" | "function" => Some(Self::Function),
-            "struct" => Some(Self::Struct),
+            "struct" | "message" => Some(Self::Struct),
             "enum" => Some(Self::Enum),
             "trait" => Some(Self::Trait),
             "impl" => Some(Self::Impl),
             "class" => Some(Self::Class),
-            "method" => Some(Self::Method),
+            "method" | "rpc" => Some(Self::Method),
             "const" | "constant" => Some(Self::Const),
             "type" => Some(Self::Type),
-            "interface" => Some(Self::Interface),
+            "interface" | "service" => Some(Self::Interface),
             "mod" | "module" => Some(Self::Module),
             _ => None,
         }

--- a/src/ast/symbols/tests.rs
+++ b/src/ast/symbols/tests.rs
@@ -291,6 +291,15 @@ fn symbol_kind_from_str() {
         SymbolKind::from_str_loose("struct"),
         Some(SymbolKind::Struct)
     );
+    assert_eq!(
+        SymbolKind::from_str_loose("message"),
+        Some(SymbolKind::Struct)
+    );
+    assert_eq!(
+        SymbolKind::from_str_loose("service"),
+        Some(SymbolKind::Interface)
+    );
+    assert_eq!(SymbolKind::from_str_loose("rpc"), Some(SymbolKind::Method));
     assert_eq!(SymbolKind::from_str_loose("CONST"), Some(SymbolKind::Const));
     assert_eq!(SymbolKind::from_str_loose("unknown"), None);
     // Dead aliases must not appear in parse_kind_filter help.

--- a/src/cmd/agent_packaging.rs
+++ b/src/cmd/agent_packaging.rs
@@ -107,10 +107,11 @@ pub(crate) fn yaml_style_honesty_markdown() -> &'static str {
 \n\
 `doc.*` (CLI, plan, MCP) may re-emit **canonical YAML presentation** while \
 keeping values correct (for example collapsing indented block sequences under \
-a key). When **block-sequence indent presentation** shifts, write JSON reports \
-`style_changed: true` on CLI `doc --json` and on plan/MCP `changes[]` entries \
-for modified files. Detection is a block-sequence indent fingerprint (not every \
-possible formatting change). Do not claim a pure surgical text edit when \
+a key, or expanding aliases). When **block-sequence indent** or YAML \
+alias/anchor/merge identity (`&name`, `*name`, `<<:`) changes, write JSON \
+reports `style_changed: true` on CLI `doc --json` and on plan/MCP `changes[]` \
+entries for modified files. Detection covers those two fingerprints, not every \
+possible formatting change. Do not claim a pure surgical text edit when \
 `style_changed` is true.\n\n"
 }
 
@@ -272,5 +273,9 @@ mod tests {
         assert!(t.contains("changes[]") || t.contains("changes"));
         assert!(t.contains("CLI") || t.contains("doc --json"));
         assert!(t.contains("MCP") || t.contains("plan"));
+        assert!(
+            t.contains("*name") && t.contains("<<:"),
+            "style_changed contract must name alias/merge identity"
+        );
     }
 }

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -92,6 +92,7 @@ pub fn presentation_style_changed(original: &str, new_text: &str, format: &FileF
     match format {
         FileFormat::Yaml => {
             yaml_block_sequence_indents(original) != yaml_block_sequence_indents(new_text)
+                || yaml_alias_identity_counts(original) != yaml_alias_identity_counts(new_text)
         }
         // JSON/TOML pretty-print drift is not flagged here (comment/order
         // preservation paths already minimize noise).
@@ -108,6 +109,57 @@ pub fn style_changed_for_path(path: &str, original: &str, new_text: &str) -> boo
         return false;
     };
     presentation_style_changed(original, new_text, &fmt)
+}
+
+/// Counts of `&name`, `*name`, and `<<:` tokens, ignoring full-line and
+/// trailing comments so comment-only edits do not flag style.
+fn yaml_alias_identity_counts(text: &str) -> (usize, usize, usize) {
+    let mut anchors = 0usize;
+    let mut aliases = 0usize;
+    let mut merges = 0usize;
+    for line in text.lines() {
+        let code = yaml_line_without_comment(line);
+        anchors += count_yaml_prefixed_idents(code, '&');
+        aliases += count_yaml_prefixed_idents(code, '*');
+        merges += code.matches("<<:").count();
+    }
+    (anchors, aliases, merges)
+}
+
+fn yaml_line_without_comment(line: &str) -> &str {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with('#') {
+        return "";
+    }
+    match line.find(" #") {
+        Some(i) => &line[..i],
+        None => line,
+    }
+}
+
+fn count_yaml_prefixed_idents(s: &str, prefix: char) -> usize {
+    let chars: Vec<char> = s.chars().collect();
+    let mut n = 0usize;
+    let mut i = 0usize;
+    while i < chars.len() {
+        if chars[i] == prefix {
+            let next_ok = chars
+                .get(i + 1)
+                .is_some_and(|c| c.is_ascii_alphanumeric() || *c == '_');
+            if next_ok {
+                n += 1;
+                i += 2;
+                while i < chars.len()
+                    && (chars[i].is_ascii_alphanumeric() || chars[i] == '_' || chars[i] == '-')
+                {
+                    i += 1;
+                }
+                continue;
+            }
+        }
+        i += 1;
+    }
+    n
 }
 
 /// Indent levels of every block-sequence entry line (`- …`), for style compare.

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -378,7 +378,7 @@ fn try_preserve_yaml(
         return Ok(Some(cleanup_yaml_cst_whitespace(spliced)));
     }
     let (file, cst_old) = if let Some(spliced) = promoted.as_deref() {
-        match yaml_file_after_partial_alias_splice(spliced, old_value) {
+        match yaml_file_after_partial_alias_splice(spliced) {
             Some(pair) => pair,
             None => return Ok(None),
         }
@@ -411,12 +411,11 @@ fn try_preserve_yaml(
 /// Parse failure must dump (None), not CST the pre-splice document.
 fn yaml_file_after_partial_alias_splice(
     spliced: &str,
-    old_value: &serde_json::Value,
 ) -> Option<(yaml_edit::YamlFile, serde_json::Value)> {
     use std::str::FromStr;
 
     let reparsed = yaml_edit::YamlFile::from_str(spliced).ok()?;
-    let cst_old = parse_yaml_semantic(spliced).unwrap_or_else(|| old_value.clone());
+    let cst_old = parse_yaml_semantic(spliced)?;
     Some((reparsed, cst_old))
 }
 

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -2766,3 +2766,42 @@ fn presentation_style_changed_flags_yaml_sequence_indent() {
         &FileFormat::Yaml
     ));
 }
+
+#[test]
+fn presentation_style_changed_flags_yaml_alias_identity() {
+    let before = "shared: &shared\n  timeout: 30\nservice_a: *shared\n";
+    let after = "shared:\n  timeout: 30\nservice_a:\n  timeout: 30\n";
+    assert!(
+        presentation_style_changed(before, after, &FileFormat::Yaml),
+        "dump that drops &/* identity must set style_changed"
+    );
+    let after_indent = "env:\n  - name: FEATURE_FLAG\n    value: on\n";
+    let before_indent = "env:\n  - name: FEATURE_FLAG\n    value: off\n";
+    assert!(
+        !presentation_style_changed(before_indent, after_indent, &FileFormat::Yaml),
+        "indent-only same block sequence must stay false"
+    );
+}
+
+#[test]
+fn presentation_style_changed_flags_yaml_alias_dump() {
+    let yaml = "\
+shared: &shared
+  timeout: 30
+flow: {cfg: *shared}
+block:
+  cfg: *shared
+";
+    let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+    let mut new = old.clone();
+    new["flow"]["cfg"]["timeout"] = json!(60);
+    let dumped = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+    assert!(
+        !dumped.contains("&shared") && !dumped.contains("*shared"),
+        "fixture must dump without alias identity:\n{dumped}"
+    );
+    assert!(
+        presentation_style_changed(yaml, &dumped, &FileFormat::Yaml),
+        "alias-inlining dump must set style_changed:\n{dumped}"
+    );
+}

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -280,6 +280,9 @@ pub(crate) fn rewrite_yaml_alias_object_edits(
     if rewrites.is_empty() {
         return Ok(None);
     }
+    if !alias_cst_counts_match_block_lines(text, &rewrites, &seq_alias_seen, &map_alias_seen) {
+        return Ok(None);
+    }
     apply_alias_line_rewrites(text, &rewrites)
 }
 
@@ -511,6 +514,61 @@ fn format_alias_block_body(
     Ok(body)
 }
 
+/// Block-line regex indexes are only sound when every CST `*alias` is a
+/// block `key: *alias` / `- *alias` line. Flow `[*alias]` / `{k: *alias}`
+/// inflate CST counts; splicing would rewrite a later block site.
+fn alias_cst_counts_match_block_lines(
+    text: &str,
+    rewrites: &[AliasLineRewrite],
+    seq_alias_seen: &std::collections::HashMap<String, usize>,
+    map_alias_seen: &std::collections::HashMap<(String, String), usize>,
+) -> bool {
+    for rewrite in rewrites {
+        if let Some(key) = rewrite.key.as_deref() {
+            let cst = map_alias_seen
+                .get(&(key.to_string(), rewrite.alias.clone()))
+                .copied()
+                .unwrap_or(0);
+            let Some(hits) =
+                mapping_alias_line_re(key, &rewrite.alias).map(|re| re.find_iter(text).count())
+            else {
+                return false;
+            };
+            if cst != hits {
+                return false;
+            }
+        } else {
+            let cst = seq_alias_seen.get(&rewrite.alias).copied().unwrap_or(0);
+            let Some(hits) =
+                sequence_alias_line_re(&rewrite.alias).map(|re| re.find_iter(text).count())
+            else {
+                return false;
+            };
+            if cst != hits {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn mapping_alias_line_re(key: &str, alias: &str) -> Option<regex::Regex> {
+    let key_re = regex::escape(key);
+    let alias_re = regex::escape(alias);
+    regex::Regex::new(&format!(
+        r"(?m)^([ \t]*){key_re}:[ \t]*\*{alias_re}([ \t]*(?:#.*)?)?[ \t]*\r?$"
+    ))
+    .ok()
+}
+
+fn sequence_alias_line_re(alias: &str) -> Option<regex::Regex> {
+    let alias_re = regex::escape(alias);
+    regex::Regex::new(&format!(
+        r"(?m)^([ \t]*)-[ \t]*\*{alias_re}([ \t]*(?:#.*)?)?[ \t]*\r?$"
+    ))
+    .ok()
+}
+
 fn apply_alias_line_rewrites(
     text: &str,
     rewrites: &[AliasLineRewrite],
@@ -541,13 +599,8 @@ fn apply_alias_line_rewrites(
 }
 
 fn replace_unique_alias_line(text: &str, rewrite: &AliasLineRewrite) -> Option<String> {
-    let alias_re = regex::escape(&rewrite.alias);
     if let Some(key) = rewrite.key.as_deref() {
-        let key_re = regex::escape(key);
-        let mapping_re = regex::Regex::new(&format!(
-            r"(?m)^([ \t]*){key_re}:[ \t]*\*{alias_re}([ \t]*(?:#.*)?)?[ \t]*\r?$"
-        ))
-        .ok()?;
+        let mapping_re = mapping_alias_line_re(key, &rewrite.alias)?;
         let hits: Vec<regex::Match<'_>> = mapping_re.find_iter(text).collect();
         let idx = match rewrite.seq_occurrence {
             Some(i) => i,
@@ -565,10 +618,7 @@ fn replace_unique_alias_line(text: &str, rewrite: &AliasLineRewrite) -> Option<S
         return Some(splice_match(text, *hit, &replacement));
     }
 
-    let seq_re = regex::Regex::new(&format!(
-        r"(?m)^([ \t]*)-[ \t]*\*{alias_re}([ \t]*(?:#.*)?)?[ \t]*\r?$"
-    ))
-    .ok()?;
+    let seq_re = sequence_alias_line_re(&rewrite.alias)?;
     let hits: Vec<regex::Match<'_>> = seq_re.find_iter(text).collect();
     let idx = rewrite.seq_occurrence?;
     let hit = hits.get(idx)?;
@@ -1232,6 +1282,84 @@ right:
             result.contains("timeout: 60"),
             "remaining site must carry the edited value:\n{result}"
         );
+    }
+
+    /// Mixed flow `[*shared]` and later block `- *shared`. Editing the
+    /// flow site is CST occ=0; the line splice only matches block lines,
+    /// so it must dump instead of rewriting the unedited block item.
+    #[test]
+    fn rewrite_mixed_flow_and_block_alias_does_not_rewrite_unedited_block() {
+        use std::str::FromStr;
+        let yaml = "\
+shared: &shared
+  timeout: 30
+flow: [*shared]
+block:
+  - *shared
+";
+        let old = json!({
+            "shared": {"timeout": 30},
+            "flow": [{"timeout": 30}],
+            "block": [{"timeout": 30}]
+        });
+        let new = json!({
+            "shared": {"timeout": 30},
+            "flow": [{"timeout": 60}],
+            "block": [{"timeout": 30}]
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new).unwrap();
+        match result {
+            None => {}
+            Some(text) => {
+                assert!(
+                    text.lines().any(|l| l.trim() == "- *shared"),
+                    "unedited block site must stay - *shared:\n{text}"
+                );
+                assert!(
+                    !text.contains("- <<: *shared"),
+                    "must not rewrite the unedited block site into a merge:\n{text}"
+                );
+            }
+        }
+    }
+
+    /// Probe: flow `{cfg: *shared}` plus later block `cfg: *shared`.
+    #[test]
+    fn rewrite_mixed_flow_mapping_and_block_alias_does_not_rewrite_unedited_block() {
+        use std::str::FromStr;
+        let yaml = "\
+shared: &shared
+  timeout: 30
+flow: {cfg: *shared}
+block:
+  cfg: *shared
+";
+        let old = json!({
+            "shared": {"timeout": 30},
+            "flow": {"cfg": {"timeout": 30}},
+            "block": {"cfg": {"timeout": 30}}
+        });
+        let new = json!({
+            "shared": {"timeout": 30},
+            "flow": {"cfg": {"timeout": 60}},
+            "block": {"cfg": {"timeout": 30}}
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new).unwrap();
+        match result {
+            None => {}
+            Some(text) => {
+                assert!(
+                    text.contains("cfg: *shared"),
+                    "unedited block mapping site must stay cfg: *shared:\n{text}"
+                );
+                assert!(
+                    !text.contains("<<: *shared"),
+                    "must not rewrite the unedited block mapping site into a merge:\n{text}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -41,8 +41,12 @@ pub(crate) fn apply_yaml_mapping_diff(
                         if !apply_yaml_mapping_diff(&child, old_val, new_val)? {
                             all_applied = false;
                         }
-                    } else {
-                        mapping.set(key.as_str(), json_to_yaml_mapping(new_val)?);
+                    } else if !try_mapping_set(
+                        mapping,
+                        key.as_str(),
+                        json_to_yaml_mapping(new_val)?,
+                    ) {
+                        all_applied = false;
                     }
                 }
                 // Both arrays: update via the existing sequence node to
@@ -56,8 +60,8 @@ pub(crate) fn apply_yaml_mapping_diff(
                         } else if !apply_yaml_sequence_resize(&seq, old_arr, new_arr) {
                             all_applied = false;
                         }
-                    } else {
-                        mapping.set(key.as_str(), json_to_yaml_node(new_val)?);
+                    } else if !try_mapping_set(mapping, key.as_str(), json_to_yaml_node(new_val)?) {
+                        all_applied = false;
                     }
                 }
                 // Type changed or scalar change.
@@ -69,8 +73,8 @@ pub(crate) fn apply_yaml_mapping_diff(
                         && scalar.is_quoted()
                     {
                         set_quoted_scalar(scalar, new_str);
-                    } else {
-                        mapping.set(key.as_str(), json_to_yaml_node(new_val)?);
+                    } else if !try_mapping_set(mapping, key.as_str(), json_to_yaml_node(new_val)?) {
+                        all_applied = false;
                     }
                 }
             }
@@ -169,6 +173,17 @@ fn try_sequence_set(
         return Ok(true);
     }
     Ok(seq.set(index, json_to_yaml_node(new_val)?))
+}
+
+/// yaml-edit 0.3 `Mapping::set` on an existing `key: *alias` inlines the
+/// replacement. Refuse that so [`rewrite_yaml_alias_object_edits`] stays
+/// the only alias writer.
+fn try_mapping_set(mapping: &yaml_edit::Mapping, key: &str, value: impl yaml_edit::AsYaml) -> bool {
+    if mapping.get(key).is_some_and(|n| n.as_alias().is_some()) {
+        return false;
+    }
+    mapping.set(key, value);
+    true
 }
 
 /// Handle different-length array diffs while preserving comments.
@@ -279,16 +294,30 @@ fn collect_mapping_alias_rewrites(
     let (Some(old_map), Some(new_map)) = (old.as_object(), new.as_object()) else {
         return Ok(());
     };
-    for (key, new_val) in new_map {
+    // File order from the CST, then any semantic keys yaml-edit did not
+    // surface. Deleted keys must still consume a file-wide `*alias` index.
+    let mut keys: Vec<String> = mapping
+        .keys()
+        .filter_map(|k| k.as_scalar().map(|s| s.as_string()))
+        .collect();
+    for k in old_map.keys() {
+        if !keys.iter().any(|existing| existing == k) {
+            keys.push(k.clone());
+        }
+    }
+    for key in &keys {
         let Some(old_val) = old_map.get(key) else {
             continue;
         };
-        // Walk every child sequence so occurrence indexes match file-wide
-        // `- *alias` hits, including lists under unchanged sibling keys.
-        if let (serde_json::Value::Array(old_arr), serde_json::Value::Array(new_arr)) =
-            (old_val, new_val)
+        let new_val = new_map.get(key);
+        if let serde_json::Value::Array(old_arr) = old_val
             && let Some(seq) = mapping.get_sequence(key.as_str())
         {
+            let empty: &[serde_json::Value] = &[];
+            let new_arr = new_val
+                .and_then(serde_json::Value::as_array)
+                .map(Vec::as_slice)
+                .unwrap_or(empty);
             collect_sequence_alias_rewrites(
                 &seq,
                 old_arr,
@@ -298,13 +327,18 @@ fn collect_mapping_alias_rewrites(
                 out,
             )?;
         }
-        if let (serde_json::Value::Object(_), serde_json::Value::Object(_)) = (old_val, new_val)
+        if old_val.is_object()
             && let Some(child) = mapping.get_mapping(key.as_str())
         {
+            let empty_obj = serde_json::json!({});
+            let child_new = match new_val {
+                Some(v) if v.is_object() => v,
+                _ => &empty_obj,
+            };
             collect_mapping_alias_rewrites(
                 &child,
                 old_val,
-                new_val,
+                child_new,
                 seq_alias_seen,
                 map_alias_seen,
                 out,
@@ -314,17 +348,21 @@ fn collect_mapping_alias_rewrites(
         if let Some(node) = mapping.get(key.as_str())
             && let Some(alias) = node.as_alias()
         {
-            // Count every `key: *alias` so nth indexes match file-wide hits,
-            // including unchanged siblings (`cfg: *shared` under two list items).
             let name = alias.name();
             let occ = map_alias_seen
                 .entry((key.clone(), name.clone()))
                 .or_insert(0);
             let this = *occ;
             *occ += 1;
-            if old_val != new_val
-                && let Some(rewrite) =
-                    alias_object_rewrite(Some(node), Some(key), old_val, new_val, Some(this))?
+            if let Some(new_val) = new_val
+                && old_val != new_val
+                && let Some(rewrite) = alias_object_rewrite(
+                    Some(node),
+                    Some(key.as_str()),
+                    old_val,
+                    new_val,
+                    Some(this),
+                )?
             {
                 out.push(rewrite);
             }
@@ -794,17 +832,21 @@ mod tests {
     }
 
     /// CST fallback when rewrite is skipped: `get_mapping` is None, so
-    /// `apply_yaml_mapping_diff` `set`s the whole object. Must inline and
-    /// keep `&shared` (not mutate the definition).
+    /// `try_mapping_set` refuses. Must keep `*shared` and `&shared`.
     #[test]
-    fn mapping_diff_on_alias_key_inlines_and_keeps_anchor() {
+    fn mapping_diff_on_alias_key_refuses_and_keeps_anchor() {
         let yaml = "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a: *shared\n";
         let old = json!({"shared": {"timeout": 30, "retries": 3}, "service_a": {"timeout": 30, "retries": 3}});
         let new = json!({"shared": {"timeout": 30, "retries": 3}, "service_a": {"timeout": 60, "retries": 3}});
-        let result = apply_and_serialize(yaml, &old, &new);
+        let doc = parse_yaml(yaml);
+        let mapping = doc.as_mapping().unwrap();
+        assert!(
+            !apply_yaml_mapping_diff(&mapping, &old, &new).unwrap(),
+            "alias key must be refused"
+        );
         assert_eq!(
-            result,
-            "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a:\n  timeout: 60\n  retries: 3\n"
+            doc.to_string(),
+            "shared: &shared\n  timeout: 30\n  retries: 3\nservice_a: *shared\n"
         );
     }
 
@@ -1059,10 +1101,136 @@ mod tests {
 
     #[test]
     fn yaml_file_after_partial_alias_splice_invalid_yaml_returns_none() {
-        let old = json!({"k": 1});
         assert!(
-            super::super::yaml_file_after_partial_alias_splice("{\n", &old).is_none(),
+            super::super::yaml_file_after_partial_alias_splice("{\n").is_none(),
             "unclosed '{{' fragment must dump, not CST the pre-splice file"
+        );
+    }
+
+    #[test]
+    fn yaml_file_after_partial_alias_splice_valid_leftover_returns_some() {
+        let spliced = "\
+shared: &shared
+  timeout: 30
+  retries: 3
+service_a:
+  <<: *shared
+  timeout: 60
+items:
+  - *shared
+";
+        let dummy = json!({"k": "must-not-be-used"});
+        let some = super::super::yaml_file_after_partial_alias_splice(spliced);
+        assert!(
+            some.is_some(),
+            "valid leftover alias YAML after a successful sibling splice must reparse"
+        );
+        let (_, cst_old) = some.unwrap();
+        assert_ne!(
+            cst_old, dummy,
+            "cst_old must be the semantic reparse, not the pre-splice tree"
+        );
+        assert_eq!(cst_old["service_a"]["timeout"], json!(60));
+        assert_eq!(cst_old["items"][0]["timeout"], json!(30));
+    }
+
+    #[test]
+    fn yaml_file_after_partial_alias_splice_truncated_merge_returns_none() {
+        assert!(
+            super::super::yaml_file_after_partial_alias_splice("{\n  <<: *shared\n").is_none(),
+            "truncated merge block must dump"
+        );
+    }
+
+    /// yaml-edit accepts a dangling `*missing` alias; serde_yaml_ng does not.
+    /// The helper must dump instead of CST-ing `old_value`.
+    #[test]
+    fn yaml_file_after_partial_alias_splice_yaml_edit_ok_serde_fail_returns_none() {
+        use std::str::FromStr;
+        let spliced = "key: *missing\n";
+        assert!(
+            yaml_edit::YamlFile::from_str(spliced).is_ok(),
+            "fixture must be accepted by yaml-edit"
+        );
+        assert!(
+            serde_yaml_ng::from_str::<serde_json::Value>(spliced).is_err(),
+            "fixture must be rejected by serde_yaml_ng"
+        );
+        assert!(
+            super::super::yaml_file_after_partial_alias_splice(spliced).is_none(),
+            "yaml-edit-ok / serde-fail leftover must dump, not Some(old_value)"
+        );
+    }
+
+    /// Leftover `key: *alias` that the line splice skips (unsafe key) must
+    /// not be inlined by Mapping::set.
+    #[test]
+    fn try_mapping_set_refuses_existing_alias_key() {
+        let yaml = "shared: &shared\n  timeout: 30\n  retries: 3\n\"foo:bar\": *shared\n";
+        let old = json!({
+            "shared": {"timeout": 30, "retries": 3},
+            "foo:bar": {"timeout": 30, "retries": 3}
+        });
+        let new = json!({
+            "shared": {"timeout": 30, "retries": 3},
+            "foo:bar": {"timeout": 60, "retries": 3}
+        });
+        let doc = parse_yaml(yaml);
+        let mapping = doc.as_mapping().unwrap();
+        let applied = apply_yaml_mapping_diff(&mapping, &old, &new).unwrap();
+        assert!(
+            !applied,
+            "Mapping::set on an existing alias key must be refused"
+        );
+        let result = doc.to_string();
+        assert!(
+            result.contains("*shared"),
+            "leftover alias must stay *shared, not inline:\n{result}"
+        );
+        assert!(
+            !result.contains("timeout: 60"),
+            "refused alias set must not inline the expanded mapping:\n{result}"
+        );
+    }
+
+    /// Two same-key `*shared` mapping sites. Deleting the first must still
+    /// consume its file-wide nth so the remaining site is rewritten.
+    #[test]
+    fn collect_mapping_alias_rewrites_counts_deleted_keys() {
+        use std::str::FromStr;
+        let yaml = "\
+shared: &shared
+  timeout: 30
+  retries: 3
+left:
+  cfg: *shared
+right:
+  cfg: *shared
+";
+        let old = json!({
+            "shared": {"timeout": 30, "retries": 3},
+            "left": {"cfg": {"timeout": 30, "retries": 3}},
+            "right": {"cfg": {"timeout": 30, "retries": 3}}
+        });
+        let new = json!({
+            "shared": {"timeout": 30, "retries": 3},
+            "right": {"cfg": {"timeout": 60, "retries": 3}}
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new)
+            .unwrap()
+            .expect("remaining mapping alias site must be rewritten");
+        assert!(
+            result.contains("left:\n  cfg: *shared"),
+            "deleted first site must keep *alias identity, not be rewritten:\n{result}"
+        );
+        assert!(
+            !result.contains("right:\n  cfg: *shared"),
+            "remaining site must be rewritten, not left as the first hit:\n{result}"
+        );
+        assert!(
+            result.contains("timeout: 60"),
+            "remaining site must carry the edited value:\n{result}"
         );
     }
 

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -95,6 +95,51 @@ fn test_ast_list_proto() {
 
 #[test]
 #[cfg(feature = "ast")]
+fn test_ast_list_proto_kind_message() {
+    let dir = TempDir::new().unwrap();
+    let f = dir.path().join("svc.proto");
+    fs::write(
+        &f,
+        "syntax = \"proto3\";\npackage demo;\nmessage Ping { string id = 1; }\nenum Status { UNKNOWN = 0; }\nservice Greeter { rpc SayHello (Ping) returns (Ping); }\n",
+    )
+    .unwrap();
+    let out = patchloom_in(dir.path())
+        .args(["ast", "list", "svc.proto", "--json", "--kind", "message"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    assert!(
+        !text.contains("unknown symbol kind"),
+        "message must be accepted as a proto kind alias: {text}"
+    );
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("ast list --json must be single JSON document: {e}\n{text}"));
+    let arr = val
+        .as_array()
+        .unwrap_or_else(|| panic!("ast list --json must be a JSON array, got: {val}"));
+    let names: Vec<&str> = arr
+        .iter()
+        .filter_map(|v| v.get("name").and_then(|n| n.as_str()))
+        .collect();
+    assert!(
+        names.contains(&"Ping"),
+        "ast list --kind message must list Ping, got {names:?}"
+    );
+    let kinds: Vec<&str> = arr
+        .iter()
+        .filter_map(|v| v.get("kind").and_then(|k| k.as_str()))
+        .collect();
+    assert!(
+        kinds.iter().all(|k| *k == "struct"),
+        "serialized kind must stay struct, got {kinds:?}"
+    );
+}
+
+#[test]
+#[cfg(feature = "ast")]
 fn test_ast_list_quiet_suppresses_text() {
     let dir = TempDir::new().unwrap();
     let f = dir.path().join("lib.rs");

--- a/tests/integration/ast_tests.rs
+++ b/tests/integration/ast_tests.rs
@@ -51,13 +51,46 @@ fn test_ast_list_proto() {
         "syntax = \"proto3\";\npackage demo;\nmessage Ping { string id = 1; }\nenum Status { UNKNOWN = 0; }\nservice Greeter { rpc SayHello (Ping) returns (Ping); }\n",
     )
     .unwrap();
-    patchloom_in(dir.path())
+    let out = patchloom_in(dir.path())
         .args(["ast", "list", "svc.proto", "--json"])
         .assert()
         .success()
-        .stdout(predicates::str::contains("Ping"))
-        .stdout(predicates::str::contains("Greeter"))
-        .stdout(predicates::str::contains("SayHello"));
+        .get_output()
+        .stdout
+        .clone();
+    let text = String::from_utf8(out).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text)
+        .unwrap_or_else(|e| panic!("ast list --json must be single JSON document: {e}\n{text}"));
+    let arr = val
+        .as_array()
+        .unwrap_or_else(|| panic!("ast list --json must be a JSON array, got: {val}"));
+    fn collect_name_kinds(items: &[serde_json::Value], out: &mut Vec<(String, String)>) {
+        for v in items {
+            let name = v.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            let kind = v.get("kind").and_then(|k| k.as_str()).unwrap_or("");
+            out.push((name.to_string(), kind.to_string()));
+            if let Some(children) = v.get("children").and_then(|c| c.as_array()) {
+                collect_name_kinds(children, out);
+            }
+        }
+    }
+    let mut pairs = Vec::new();
+    collect_name_kinds(arr, &mut pairs);
+    for expected in [
+        ("Ping", "struct"),
+        ("Status", "enum"),
+        ("Greeter", "interface"),
+        ("SayHello", "method"),
+    ] {
+        assert!(
+            pairs
+                .iter()
+                .any(|(n, k)| n == expected.0 && k == expected.1),
+            "missing ({}, {}) in {pairs:?}",
+            expected.0,
+            expected.1
+        );
+    }
 }
 
 #[test]
@@ -932,13 +965,9 @@ fn test_ast_rename_proto() {
         .assert()
         .code(0);
     let content = fs::read_to_string(&f).unwrap();
-    assert!(
-        content.contains("Pong"),
-        "ast rename --apply should rename proto message: {content}"
-    );
-    assert!(
-        !content.contains("message Ping"),
-        "old proto message name should be replaced: {content}"
+    assert_eq!(
+        content,
+        "syntax = \"proto3\";\npackage demo;\nmessage Pong { string id = 1; }\nenum Status { UNKNOWN = 0; }\nservice Greeter { rpc SayHello (Pong) returns (Pong); }\n"
     );
 }
 


### PR DESCRIPTION
This batch hardens YAML alias preservation after #2264 and tightens proto AST tests.

## Problem

- A partial alias splice that yaml-edit accepts but serde rejects still CST-ed the pre-splice tree, which can inline `*alias`.
- `Mapping::set` inlined leftover alias keys. Sequence leftovers already refused.
- Mapping alias nth skipped deleted keys, so a leftover sibling could be rewritten as the first hit.
- Mixed flow (`[*shared]`) and block (`- *shared`) used CST-wide indexes against a block-line regex, so an edit of the flow site could rewrite the unedited block line.
- `ast list --kind message` (and `service` / `rpc`) failed as unknown kinds even though proto extract maps those to struct/interface/method.
- `style_changed` stayed false when a dump dropped `&` / `*` / `<<:` identity but indent did not move. Agent-rules still said indent-only.

## Change

- Dump when semantic reparse fails after a partial splice. Refuse `Mapping::set` on an existing `*alias` key. Count deleted mapping keys in file-wide nth.
- Fail closed (dump, do not splice) when CST `*alias` counts do not match block-line regex hits.
- Accept `message` / `service` / `rpc` as input aliases for `--kind`. Serialized kinds stay `struct` / `interface` / `method`.
- `presentation_style_changed` also compares `&name` / `*name` / `<<:` counts. Agent-rules and embedder host notes match.
- Proto list JSON asserts `(name, kind)` including `Status`/`enum`. Proto rename `assert_eq`s the full file so RPC types cannot stay `Ping`.

## Validation

- Red-green unit tests for dump, mapping refuse, mapping nth, mixed flow+block, and alias `style_changed`.
- `make check-fast` green (lib, integration 1499, pty 10, README 4600+).
- Reviewer: 0 must-fix.

Ref #2264

Residual #1990 Show HN stays open (human).
