### PR TITLE
fix(doc): keep mixed-flow aliases and cap merge depth

### DIFF
--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -1054,12 +1054,21 @@ pub fn diff_values(
 /// `"<<"` key whose value is the referenced mapping.  This function walks
 /// the tree and flattens those entries into the parent object, matching
 /// YAML merge-key semantics (existing keys take precedence).
+///
+/// Recursion stops at `MAX_MERGE_DEPTH` (128, same cap as `deep_merge`).
 fn resolve_yaml_merge_keys(value: &mut serde_json::Value) {
+    resolve_yaml_merge_keys_inner(value, 0);
+}
+
+fn resolve_yaml_merge_keys_inner(value: &mut serde_json::Value, depth: usize) {
+    if depth >= navigate::MAX_MERGE_DEPTH {
+        return;
+    }
     match value {
         serde_json::Value::Object(map) => {
             // First, recurse into all child values (including the merge value itself).
             for v in map.values_mut() {
-                resolve_yaml_merge_keys(v);
+                resolve_yaml_merge_keys_inner(v, depth + 1);
             }
 
             // Then resolve `<<` if present.
@@ -1089,7 +1098,7 @@ fn resolve_yaml_merge_keys(value: &mut serde_json::Value) {
         }
         serde_json::Value::Array(arr) => {
             for v in arr {
-                resolve_yaml_merge_keys(v);
+                resolve_yaml_merge_keys_inner(v, depth + 1);
             }
         }
         _ => {}

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -429,6 +429,15 @@ fn try_preserve_yaml(
     {
         return Ok(Some(cleanup_yaml_cst_whitespace(spliced)));
     }
+    // Leftover array growth: splice the alias-rewritten text. A yaml-edit
+    // re-serialize of `- <<: *alias` plus overrides drops indent, then
+    // parse_yaml_semantic fails and we dump.
+    if let Some(spliced) = promoted.as_deref()
+        && let Some(reparsed) = parse_yaml_semantic(spliced)
+        && let Some(grown) = yaml_splice::splice_yaml_array_diffs(spliced, &reparsed, new_value)?
+    {
+        return Ok(Some(grown));
+    }
     let (file, cst_old) = if let Some(spliced) = promoted.as_deref() {
         match yaml_file_after_partial_alias_splice(spliced) {
             Some(pair) => pair,

--- a/src/ops/doc/navigate.rs
+++ b/src/ops/doc/navigate.rs
@@ -598,7 +598,7 @@ pub fn move_at_path(
     Ok(())
 }
 
-const MAX_MERGE_DEPTH: usize = 128;
+pub(crate) const MAX_MERGE_DEPTH: usize = 128;
 
 pub fn deep_merge(base: &mut serde_json::Value, other: &serde_json::Value) {
     deep_merge_inner(base, other, 0);

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1681,6 +1681,39 @@ block:
         assert_eq!(reparsed["shared"]["timeout"], json!(30));
     }
 
+    /// Mixed flow `[*shared]` plus later block `- *shared`. Editing the
+    /// block item must splice and leave the flow sibling (and `&shared`).
+    #[test]
+    fn yaml_mixed_flow_sequence_block_alias_block_edit_keeps_flow_sibling() {
+        let yaml = "\
+shared: &shared
+  timeout: 30
+flow: [*shared]
+block:
+  - *shared
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["block"][0]["timeout"] = json!(60);
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+shared: &shared
+  timeout: 30
+flow: [*shared]
+block:
+  - <<: *shared
+    timeout: 60
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed["block"][0]["timeout"], json!(60));
+        assert_eq!(reparsed["flow"][0]["timeout"], json!(30));
+        assert_eq!(reparsed["shared"]["timeout"], json!(30));
+    }
+
     /// Pure prepend must not zip `new[0]` onto `- *shared`. The inserted
     /// object is spliced in; the alias item and its trailing comment stay.
     #[test]

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1647,6 +1647,74 @@ service_a: *shared  # inherited
         assert_eq!(reparsed["service_a"]["retries"], json!(3));
     }
 
+    /// Mixed flow `{cfg: *shared}` plus later block `cfg: *shared`. Editing
+    /// the block site must splice and leave the flow sibling (and `&shared`).
+    #[test]
+    fn yaml_mixed_flow_block_alias_block_edit_keeps_flow_sibling() {
+        let yaml = "\
+shared: &shared
+  timeout: 30
+flow: {cfg: *shared}
+block:
+  cfg: *shared
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["block"]["cfg"]["timeout"] = json!(60);
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+shared: &shared
+  timeout: 30
+flow: {cfg: *shared}
+block:
+  cfg:
+    <<: *shared
+    timeout: 60
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed["block"]["cfg"]["timeout"], json!(60));
+        assert_eq!(reparsed["flow"]["cfg"]["timeout"], json!(30));
+        assert_eq!(reparsed["shared"]["timeout"], json!(30));
+    }
+
+    /// Pure prepend must not zip `new[0]` onto `- *shared`. The inserted
+    /// object is spliced in; the alias item and its trailing comment stay.
+    #[test]
+    fn yaml_sequence_alias_pure_prepend_keeps_alias() {
+        let yaml = "\
+shared: &shared
+  timeout: 30
+items:
+  - *shared  # inherited
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"]
+            .as_array_mut()
+            .unwrap()
+            .insert(0, json!({"name": "x"}));
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+shared: &shared
+  timeout: 30
+items:
+  - name: x
+  - *shared  # inherited
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed["items"][0], json!({"name": "x"}));
+        assert_eq!(reparsed["items"][1]["timeout"], json!(30));
+        assert_eq!(reparsed["shared"]["timeout"], json!(30));
+    }
+
     /// Multi-doc streams serialize per document. A pure alias in doc 1 must
     /// become a merge without dumping doc 0.
     #[test]

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -2137,6 +2137,45 @@ mod security {
         // Should not panic; at depth 128 it clones instead of recursing
         assert!(base.is_object());
     }
+
+    #[test]
+    fn resolve_yaml_merge_keys_depth_guard_caps_recursion() {
+        // 200-level nest (same pattern as cmd/doc_tests deep_merge_depth_guard)
+        // with a `<<` merge key at the innermost object. Without a depth cap
+        // the walker resolves that key; with MAX_MERGE_DEPTH (128) it stops
+        // and the merge key remains.
+        let mut inner = json!({"<<": {"from_merge": 1}});
+        for _ in 0..200 {
+            inner = json!({"nested": inner});
+        }
+        super::super::resolve_yaml_merge_keys(&mut inner);
+        assert!(inner.is_object());
+        assert!(
+            inner.get("nested").is_some(),
+            "top-level 'nested' key must exist"
+        );
+        let mut cursor = &inner;
+        for _ in 0..10 {
+            cursor = cursor
+                .get("nested")
+                .expect("nesting should be at least 10 levels deep");
+        }
+        assert!(cursor.is_object());
+        // Walk past the 128 cap; merge keys beyond it stay unresolved.
+        cursor = &inner;
+        for _ in 0..150 {
+            cursor = cursor
+                .get("nested")
+                .expect("nesting should continue past the merge-key depth cap");
+        }
+        while let Some(next) = cursor.get("nested") {
+            cursor = next;
+        }
+        assert!(
+            cursor.get("<<").is_some(),
+            "merge key beyond MAX_MERGE_DEPTH must remain unresolved"
+        );
+    }
 }
 
 mod regression {

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1715,6 +1715,137 @@ items:
         assert_eq!(reparsed["shared"]["timeout"], json!(30));
     }
 
+    /// Shrink-first + edit remaining must not rewrite `*gone` as if it
+    /// were `*keep`. Length shifts leave the remaining item to splice.
+    #[test]
+    fn yaml_sequence_alias_shrink_first_does_not_rewrite_gone() {
+        let yaml = "\
+gone: &gone
+  timeout: 10
+keep: &keep
+  timeout: 30
+items:
+  - *gone
+  - *keep
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"].as_array_mut().unwrap().remove(0);
+        new["items"][0]["timeout"] = json!(60);
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+gone: &gone
+  timeout: 10
+keep: &keep
+  timeout: 30
+items:
+  - timeout: 60
+"
+        );
+        assert!(
+            !result.contains("*gone") || result.contains("&gone"),
+            "must not rewrite the removed - *gone site:\n{result}"
+        );
+        assert!(
+            !result.contains("<<: *gone"),
+            "must not treat *gone as the remaining edit:\n{result}"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed["items"], json!([{"timeout": 60}]));
+        assert_eq!(reparsed["gone"]["timeout"], json!(10));
+        assert_eq!(reparsed["keep"]["timeout"], json!(30));
+    }
+
+    /// Prepend on sequence A must not steal file-wide nth from sequence B.
+    #[test]
+    fn yaml_sequence_alias_prepend_does_not_steal_sibling_nth() {
+        let yaml = "\
+shared: &shared
+  timeout: 30
+first:
+  - *shared
+second:
+  - *shared
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["first"]
+            .as_array_mut()
+            .unwrap()
+            .insert(0, json!({"name": "x"}));
+        new["second"][0]["timeout"] = json!(60);
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+shared: &shared
+  timeout: 30
+first:
+  - name: x
+  - *shared
+second:
+  - <<: *shared
+    timeout: 60
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed["first"][0], json!({"name": "x"}));
+        assert_eq!(reparsed["first"][1]["timeout"], json!(30));
+        assert_eq!(reparsed["second"][0]["timeout"], json!(60));
+        assert_eq!(reparsed["shared"]["timeout"], json!(30));
+    }
+
+    /// Insert-middle + edit later `- *shared` must keep alias identity
+    /// off the inserted object (length shift is unaligned).
+    #[test]
+    fn yaml_sequence_alias_insert_middle_does_not_rewrite_later_alias() {
+        let yaml = "\
+shared: &shared
+  timeout: 30
+items:
+  - name: a
+  - *shared
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"]
+            .as_array_mut()
+            .unwrap()
+            .insert(1, json!({"name": "mid"}));
+        new["items"][2]["timeout"] = json!(60);
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+shared: &shared
+  timeout: 30
+items:
+  - name: a
+  - name: mid
+  - timeout: 60
+"
+        );
+        assert!(
+            result.contains("&shared"),
+            "anchor definition must remain:\n{result}"
+        );
+        assert!(
+            !result.contains("- *shared") && !result.contains("<<: *shared"),
+            "unaligned insert must dump the later item, not zip - *shared:\n{result}"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            reparsed["items"],
+            json!([{"name": "a"}, {"name": "mid"}, {"timeout": 60}])
+        );
+        assert_eq!(reparsed["shared"]["timeout"], json!(30));
+    }
+
     /// Multi-doc streams serialize per document. A pure alias in doc 1 must
     /// become a merge without dumping doc 0.
     #[test]

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -351,6 +351,11 @@ fn collect_mapping_alias_rewrites(
         if let Some(node) = mapping.get(key.as_str())
             && let Some(alias) = node.as_alias()
         {
+            // Flow `{key: *alias}` is not a block `key: *alias` line. Counting
+            // it inflates nth so a later block site dumps or splices wrong.
+            if mapping.is_flow_style() {
+                continue;
+            }
             let name = alias.name();
             let occ = map_alias_seen
                 .entry((key.clone(), name.clone()))
@@ -382,11 +387,21 @@ fn collect_sequence_alias_rewrites(
     map_alias_seen: &mut std::collections::HashMap<(String, String), usize>,
     out: &mut Vec<AliasLineRewrite>,
 ) -> anyhow::Result<()> {
+    // Index zip is wrong on pure prepend/append (`new[0]` is the inserted
+    // object, `old[0]` is still `- *alias`). Leave those to splice.
+    if is_pure_array_extend(old_arr, new_arr) {
+        return Ok(());
+    }
+    let skip_flow_aliases = seq.is_flow_style();
     for (i, old_val) in old_arr.iter().enumerate() {
         let Some(node) = seq.get(i) else {
             continue;
         };
         if let Some(alias) = node.as_alias() {
+            // Flow `[*alias]` is not a block `- *alias` line.
+            if skip_flow_aliases {
+                continue;
+            }
             let name = alias.name();
             let occ = seq_alias_seen.entry(name.clone()).or_insert(0);
             let this = *occ;
@@ -417,6 +432,16 @@ fn collect_sequence_alias_rewrites(
         }
     }
     Ok(())
+}
+
+/// True when `new_arr` is `old_arr` with a prefix or suffix added.
+fn is_pure_array_extend(old_arr: &[serde_json::Value], new_arr: &[serde_json::Value]) -> bool {
+    let old_len = old_arr.len();
+    let new_len = new_arr.len();
+    if new_len <= old_len || old_len == 0 {
+        return false;
+    }
+    &new_arr[new_len - old_len..] == old_arr || &new_arr[..old_len] == old_arr
 }
 
 fn alias_object_rewrite(
@@ -1360,6 +1385,73 @@ block:
                 );
             }
         }
+    }
+
+    /// Mixed flow `{cfg: *shared}` plus later block `cfg: *shared`. Editing
+    /// the block site must splice only that line.
+    #[test]
+    fn rewrite_mixed_flow_mapping_block_edit_splices_block_only() {
+        use std::str::FromStr;
+        let yaml = "\
+shared: &shared
+  timeout: 30
+flow: {cfg: *shared}
+block:
+  cfg: *shared
+";
+        let old = json!({
+            "shared": {"timeout": 30},
+            "flow": {"cfg": {"timeout": 30}},
+            "block": {"cfg": {"timeout": 30}}
+        });
+        let new = json!({
+            "shared": {"timeout": 30},
+            "flow": {"cfg": {"timeout": 30}},
+            "block": {"cfg": {"timeout": 60}}
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new)
+            .unwrap()
+            .expect("block-site edit must splice, not dump");
+        assert_eq!(
+            result,
+            "\
+shared: &shared
+  timeout: 30
+flow: {cfg: *shared}
+block:
+  cfg:
+    <<: *shared
+    timeout: 60
+"
+        );
+    }
+
+    /// Pure prepend must not emit a sequence alias rewrite (zip would treat
+    /// the inserted object as an edit of `- *shared`).
+    #[test]
+    fn rewrite_sequence_alias_pure_prepend_returns_none() {
+        use std::str::FromStr;
+        let yaml = "\
+shared: &shared
+  timeout: 30
+items:
+  - *shared  # inherited
+";
+        let old = json!({
+            "shared": {"timeout": 30},
+            "items": [{"timeout": 30}]
+        });
+        let new = json!({
+            "shared": {"timeout": 30},
+            "items": [{"name": "x"}, {"timeout": 30}]
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new).unwrap();
+        assert!(
+            result.is_none(),
+            "pure prepend must not rewrite - *shared, got {result:?}"
+        );
     }
 
     #[test]

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -387,12 +387,11 @@ fn collect_sequence_alias_rewrites(
     map_alias_seen: &mut std::collections::HashMap<(String, String), usize>,
     out: &mut Vec<AliasLineRewrite>,
 ) -> anyhow::Result<()> {
-    // Index zip is wrong on pure prepend/append (`new[0]` is the inserted
-    // object, `old[0]` is still `- *alias`). Leave those to splice.
-    if is_pure_array_extend(old_arr, new_arr) {
-        return Ok(());
-    }
+    // Index zip is only sound when lengths match. Always walk old items so
+    // file-wide nth stays correct; leave length shifts to splice.
+    let aligned = old_arr.len() == new_arr.len();
     let skip_flow_aliases = seq.is_flow_style();
+    let empty_obj = serde_json::json!({});
     for (i, old_val) in old_arr.iter().enumerate() {
         let Some(node) = seq.get(i) else {
             continue;
@@ -406,6 +405,9 @@ fn collect_sequence_alias_rewrites(
             let occ = seq_alias_seen.entry(name.clone()).or_insert(0);
             let this = *occ;
             *occ += 1;
+            if !aligned {
+                continue;
+            }
             let Some(new_val) = new_arr.get(i) else {
                 continue;
             };
@@ -418,13 +420,20 @@ fn collect_sequence_alias_rewrites(
                 out.push(rewrite);
             }
         } else if let Some(child) = node.as_mapping()
-            && let (Some(new_val), serde_json::Value::Object(_)) = (new_arr.get(i), old_val)
-            && new_val.is_object()
+            && matches!(old_val, serde_json::Value::Object(_))
         {
+            let child_new = if aligned {
+                new_arr
+                    .get(i)
+                    .filter(|v| v.is_object())
+                    .unwrap_or(&empty_obj)
+            } else {
+                &empty_obj
+            };
             collect_mapping_alias_rewrites(
                 child,
                 old_val,
-                new_val,
+                child_new,
                 seq_alias_seen,
                 map_alias_seen,
                 out,
@@ -432,16 +441,6 @@ fn collect_sequence_alias_rewrites(
         }
     }
     Ok(())
-}
-
-/// True when `new_arr` is `old_arr` with a prefix or suffix added.
-fn is_pure_array_extend(old_arr: &[serde_json::Value], new_arr: &[serde_json::Value]) -> bool {
-    let old_len = old_arr.len();
-    let new_len = new_arr.len();
-    if new_len <= old_len || old_len == 0 {
-        return false;
-    }
-    &new_arr[new_len - old_len..] == old_arr || &new_arr[..old_len] == old_arr
 }
 
 fn alias_object_rewrite(
@@ -1452,6 +1451,121 @@ items:
             result.is_none(),
             "pure prepend must not rewrite - *shared, got {result:?}"
         );
+    }
+
+    /// Shrink-first + edit remaining must not zip `*gone` with the
+    /// surviving object (that would rewrite `*gone` as if it were `*keep`).
+    #[test]
+    fn rewrite_sequence_alias_shrink_first_does_not_rewrite_removed_item() {
+        use std::str::FromStr;
+        let yaml = "\
+gone: &gone
+  timeout: 10
+keep: &keep
+  timeout: 30
+items:
+  - *gone
+  - *keep
+";
+        let old = json!({
+            "gone": {"timeout": 10},
+            "keep": {"timeout": 30},
+            "items": [{"timeout": 10}, {"timeout": 30}]
+        });
+        let new = json!({
+            "gone": {"timeout": 10},
+            "keep": {"timeout": 30},
+            "items": [{"timeout": 60}]
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new).unwrap();
+        match result {
+            None => {}
+            Some(text) => {
+                assert!(
+                    text.contains("- *gone"),
+                    "removed first alias must keep - *gone identity:\n{text}"
+                );
+                assert!(
+                    !text.contains("<<: *gone"),
+                    "must not rewrite *gone as if it were the remaining edit:\n{text}"
+                );
+            }
+        }
+    }
+
+    /// Prepend on sequence A must still count its `- *shared` so editing
+    /// sequence B rewrites the second site, not the first.
+    #[test]
+    fn rewrite_sequence_alias_prepend_does_not_steal_sibling_nth() {
+        use std::str::FromStr;
+        let yaml = "\
+shared: &shared
+  timeout: 30
+first:
+  - *shared
+second:
+  - *shared
+";
+        let old = json!({
+            "shared": {"timeout": 30},
+            "first": [{"timeout": 30}],
+            "second": [{"timeout": 30}]
+        });
+        let new = json!({
+            "shared": {"timeout": 30},
+            "first": [{"name": "x"}, {"timeout": 30}],
+            "second": [{"timeout": 60}]
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new)
+            .unwrap()
+            .expect("aligned sibling edit must splice");
+        assert_eq!(
+            result,
+            "\
+shared: &shared
+  timeout: 30
+first:
+  - *shared
+second:
+  - <<: *shared
+    timeout: 60
+"
+        );
+    }
+
+    /// Insert-middle + edit later `- *shared` must not zip the later alias
+    /// onto the inserted object.
+    #[test]
+    fn rewrite_sequence_alias_insert_middle_does_not_rewrite_later_alias() {
+        use std::str::FromStr;
+        let yaml = "\
+shared: &shared
+  timeout: 30
+items:
+  - name: a
+  - *shared
+";
+        let old = json!({
+            "shared": {"timeout": 30},
+            "items": [{"name": "a"}, {"timeout": 30}]
+        });
+        let new = json!({
+            "shared": {"timeout": 30},
+            "items": [{"name": "a"}, {"name": "mid"}, {"timeout": 60}]
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new).unwrap();
+        match result {
+            None => {}
+            Some(text) => {
+                assert!(
+                    text.lines().any(|l| l.trim() == "- *shared"),
+                    "later - *shared must stay an alias:\n{text}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -1426,6 +1426,45 @@ block:
         );
     }
 
+    /// Mixed flow `[*shared]` plus later block `- *shared`. Editing the
+    /// block item must splice only that line.
+    #[test]
+    fn rewrite_mixed_flow_sequence_block_edit_splices_block_only() {
+        use std::str::FromStr;
+        let yaml = "\
+shared: &shared
+  timeout: 30
+flow: [*shared]
+block:
+  - *shared
+";
+        let old = json!({
+            "shared": {"timeout": 30},
+            "flow": [{"timeout": 30}],
+            "block": [{"timeout": 30}]
+        });
+        let new = json!({
+            "shared": {"timeout": 30},
+            "flow": [{"timeout": 30}],
+            "block": [{"timeout": 60}]
+        });
+        let file = yaml_edit::YamlFile::from_str(yaml).unwrap();
+        let result = rewrite_yaml_alias_object_edits(yaml, &file, &old, &new)
+            .unwrap()
+            .expect("block-site edit must splice, not dump");
+        assert_eq!(
+            result,
+            "\
+shared: &shared
+  timeout: 30
+flow: [*shared]
+block:
+  - <<: *shared
+    timeout: 60
+"
+        );
+    }
+
     /// Pure prepend must not emit a sequence alias rewrite (zip would treat
     /// the inserted object as an edit of `- *shared`).
     #[test]

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1453,6 +1453,34 @@ fn test_doc_set_yaml_mixed_flow_block_alias_keeps_flow() {
 }
 
 #[test]
+fn test_doc_set_yaml_mixed_flow_sequence_block_alias_keeps_flow() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.yaml");
+    fs::write(
+        &file,
+        "shared: &shared\n  timeout: 30\nflow: [*shared]\nblock:\n  - *shared\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("block[0].timeout")
+        .arg("60")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        content,
+        "shared: &shared\n  timeout: 30\nflow: [*shared]\nblock:\n  - <<: *shared\n    timeout: 60\n"
+    );
+}
+
+#[test]
 fn test_doc_set_yaml_apply() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("config.yaml");

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1422,6 +1422,36 @@ fn test_doc_set_yaml_sequence_alias_item_becomes_merge() {
         .stdout(predicate::str::starts_with("3"));
 }
 
+/// Mixed flow `{cfg: *shared}` plus later block `cfg: *shared`. `doc set` on
+/// the block site must splice and leave the flow sibling.
+#[test]
+fn test_doc_set_yaml_mixed_flow_block_alias_keeps_flow() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.yaml");
+    fs::write(
+        &file,
+        "shared: &shared\n  timeout: 30\nflow: {cfg: *shared}\nblock:\n  cfg: *shared\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("block.cfg.timeout")
+        .arg("60")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        content,
+        "shared: &shared\n  timeout: 30\nflow: {cfg: *shared}\nblock:\n  cfg:\n    <<: *shared\n    timeout: 60\n"
+    );
+}
+
 #[test]
 fn test_doc_set_yaml_apply() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
YAML `doc` edits now keep aliases that sit next to flow maps or sequences, and they stop walking merge keys after 128 levels.

## Problem

A YAML file can mix a flow map such as `{cfg: *alias}` with a later block mapping that also uses `*alias`. The CST rewrite counted the flow alias toward the block `nth` slot, so a later block edit inlined the wrong node.

Prepend and shrink of a sequence also dropped remaining `- *alias` items when the old and new list lengths differed, because the rewrite returned before walking the rest of the file.

A 200-level nested `<<:` chain flattened past the same 128-level cap that `deep_merge` already uses, so a hostile or generated document could walk without a bound.

## Change

- File-wide alias rewrite ignores flow `{key: *alias}` and `[*alias]` when assigning the block `nth`.
- Sequence aliases are counted even when the list grows or shrinks. The rewrite runs only when the old and new lengths match.
- Leftover array growth after a comment-preserving splice is applied in `try_preserve_yaml`.
- `resolve_yaml_merge_keys` shares `navigate::MAX_MERGE_DEPTH` (128) and leaves deeper `<<:` keys unresolved instead of flattening them.

## Validation

- `make check-fast` passed on this branch (fmt, clippy, lib tests, integration, PTY, README count, server.json, Homebrew version helpers).
- New unit tests: mixed flow plus block (mapping and sequence), prepend, shrink, sibling `nth`, 200-nest merge depth.
- New cargo-bin integration tests for mixed flow plus block (mapping and sequence).

No issue is closed. The human Show HN issue stays open.
