### PR TITLE
fix(doc): keep merge key when growing an inherited YAML array

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -8559,13 +8559,13 @@ fn file_rename_symlink_to_directory() {
     );
 }
 
-/// Library doc_set surfaces style_changed when YAML sequence indent collapses (#2088).
+/// Library doc_set keeps block-sequence item indent (`- name` / `value`).
+/// Collapse would be `style_changed` (#2088); CST now leaves it false.
 #[cfg(any(feature = "cli", feature = "files"))]
 #[test]
-fn doc_set_style_changed_on_yaml_sequence_indent() {
+fn doc_set_keeps_yaml_sequence_item_indent() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("cfg.yaml");
-    // Indented block sequence; emitter often collapses indent on rewrite.
     fs::write(&file, "env:\n  - name: FEATURE_FLAG\n    value: off\n").unwrap();
     let r = doc_set(
         &file,
@@ -8577,15 +8577,17 @@ fn doc_set_style_changed_on_yaml_sequence_indent() {
     .expect("doc_set");
     assert!(r.applied);
     assert!(r.changed);
+    assert_eq!(
+        r.new_content,
+        "env:\n  - name: FEATURE_FLAG\n    value: on\n"
+    );
     assert!(
-        r.style_changed,
-        "expected style_changed when YAML sequence presentation drifts; new=\n{}",
+        !r.style_changed,
+        "kept sequence indent must not flag style; new=\n{}",
         r.new_content
     );
-    assert!(crate::api::is_style_changed(&r));
+    assert!(!crate::api::is_style_changed(&r));
 
-    // Same presentation after second apply of same structure → typically false
-    // when re-serializing already-collapsed form.
     let r2 = doc_set(
         &file,
         "env.0.value",
@@ -8595,7 +8597,6 @@ fn doc_set_style_changed_on_yaml_sequence_indent() {
     )
     .expect("second doc_set");
     assert!(r2.applied);
-    // Non-doc op leaves style_changed false.
     let txt = dir.path().join("n.txt");
     fs::write(&txt, "a\n").unwrap();
     let cr = file_create(&txt, "b\n", true, ApplyMode::Apply, None).expect("create");

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -307,7 +307,10 @@ fn fix_yaml_block_indentation(text: &str) -> String {
         }
 
         let indent = line.len() - trimmed.len();
-        let is_mapping_entry = indent > 0 && (trimmed.contains(": ") || trimmed.ends_with(':'));
+        // `- name: A` is a sequence item, not a mapping sibling of `value:`.
+        let is_mapping_entry = indent > 0
+            && !is_yaml_sequence_item(trimmed)
+            && (trimmed.contains(": ") || trimmed.ends_with(':'));
 
         if is_mapping_entry
             && let Some(expected) = expected_sibling_indent(&lines, i, indent)
@@ -353,7 +356,7 @@ fn expected_sibling_indent(lines: &[&str], i: usize, current_indent: usize) -> O
     if let Some(next_line) = lines[i + 1..].iter().find(|l| is_significant(l)) {
         let nt = next_line.trim_start();
         let ni = next_line.len() - nt.len();
-        let next_is_entry = nt.contains(": ") || nt.ends_with(':');
+        let next_is_entry = !is_yaml_sequence_item(nt) && (nt.contains(": ") || nt.ends_with(':'));
 
         if ni < current_indent && ni > 0 && next_is_entry {
             // Verify: prev line must be a parent (indent < ni, ends ':')
@@ -363,7 +366,11 @@ fn expected_sibling_indent(lines: &[&str], i: usize, current_indent: usize) -> O
                 .rev()
                 .find(|l| is_significant(l))
                 .is_some_and(|l| {
-                    let pi = l.len() - l.trim_start().len();
+                    let t = l.trim_start();
+                    if is_yaml_sequence_item(t) {
+                        return false;
+                    }
+                    let pi = l.len() - t.len();
                     (pi < ni && l.trim_end().ends_with(':')) || pi == ni
                 });
             if prev_ok {
@@ -380,13 +387,24 @@ fn expected_sibling_indent(lines: &[&str], i: usize, current_indent: usize) -> O
 
         // Prev must be a complete mapping entry (has a value after the colon,
         // so it is a sibling rather than a parent). A parent key ends with ':'
-        // alone; a complete entry has ': <value>'.
-        if pi < current_indent && pi > 0 && pt.contains(": ") && !is_yaml_parent_line(pt) {
+        // alone; a complete entry has ': <value>'. A sequence item
+        // (`- name: A`) is not a mapping sibling of the next key.
+        if pi < current_indent
+            && pi > 0
+            && pt.contains(": ")
+            && !is_yaml_parent_line(pt)
+            && !is_yaml_sequence_item(pt)
+        {
             return Some(pi);
         }
     }
 
     None
+}
+
+/// Block sequence item (`- ` or a lone `-`), not a mapping sibling.
+fn is_yaml_sequence_item(trimmed: &str) -> bool {
+    trimmed == "-" || trimmed.starts_with("- ")
 }
 
 /// Check if a trimmed YAML line is a parent key (value is on the next line).
@@ -486,7 +504,6 @@ fn try_preserve_yaml_object(
     old_value: &serde_json::Value,
     new_value: &serde_json::Value,
 ) -> anyhow::Result<Option<String>> {
-    let has_array_growth = yaml_splice::has_array_growth_diffs(old_value, new_value);
     let all_cst_applied = apply_yaml_mapping_diff(mapping, old_value, new_value)?;
     // yaml_edit's Mapping::remove() can leave trailing whitespace on the
     // line preceding the removed key and may shift the indentation of the
@@ -498,7 +515,9 @@ fn try_preserve_yaml_object(
     // `<<: *anchor` / `*alias` form match parse_doc's flattened model.
     // Without this, verification always fails on merge-key documents and the
     // non-preserving fallback expands every anchor/alias into full copies.
-    if yaml_semantic_eq(&result, new_value) && !has_array_growth && all_cst_applied {
+    // Array growth applied as a new local key (inherited via `<<` only)
+    // is already in the CST; do not require !has_array_growth or we dump.
+    if yaml_semantic_eq(&result, new_value) && all_cst_applied {
         return Ok(Some(result));
     }
 

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -1974,6 +1974,101 @@ staging:
         assert_eq!(reparsed["staging"]["timeout"], json!(30));
     }
 
+    /// Growing an array inherited only via `<<: *anchor` must add a local
+    /// `env:` override beside the merge key. Dumping loses `&defaults`.
+    #[test]
+    fn yaml_inherited_array_growth_keeps_merge_key() {
+        let yaml = "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["deployment"]["env"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({"name": "B", "value": "2"}));
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        // Inserted override uses serde_yaml_ng quote style ('1' / '2').
+        // Anchor/merge and the original defaults.env quotes stay.
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+  env:
+    - name: A
+      value: '1'
+    - name: B
+      value: '2'
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            reparsed["deployment"]["env"],
+            json!([{"name": "A", "value": "1"}, {"name": "B", "value": "2"}])
+        );
+        assert_eq!(
+            reparsed["defaults"]["env"],
+            json!([{"name": "A", "value": "1"}])
+        );
+    }
+
+    /// Shrinking the same inherited array still keeps `<<` and adds a local
+    /// override (does not trip array-growth; indent fixer must not flatten).
+    #[test]
+    fn yaml_inherited_array_shrink_keeps_merge_key() {
+        let yaml = "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+    - name: B
+      value: \"2\"
+deployment:
+  <<: *defaults
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["deployment"]["env"].as_array_mut().unwrap().pop();
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+    - name: B
+      value: \"2\"
+deployment:
+  <<: *defaults
+  env:
+    - name: A
+      value: '1'
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            reparsed["deployment"]["env"],
+            json!([{"name": "A", "value": "1"}])
+        );
+        assert_eq!(
+            reparsed["defaults"]["env"],
+            json!([{"name": "A", "value": "1"}, {"name": "B", "value": "2"}])
+        );
+    }
+
     /// Multi-document stream: unrelated edit in one doc keeps that doc's merges.
     #[test]
     fn yaml_multi_doc_unrelated_edit_preserves_merges() {
@@ -2350,10 +2445,8 @@ mod regression {
 
     #[test]
     fn yaml_nested_array_growth_detected() {
-        // Regression: has_array_growth_diffs must recurse into same-length
-        // array elements to detect nested growth (e.g., adding a port to
-        // the first server's ports array while the outer array stays the
-        // same length).
+        // Regression: nested array growth (add a port on the first server
+        // while the outer array stays the same length) must not be dropped.
         let yaml = "# config comment\nservers:\n  - name: web\n    ports:\n      - 80\n";
         let old = parse_doc(yaml, &crate::ops::doc::FileFormat::Yaml).unwrap();
         let mut new = old.clone();
@@ -2445,6 +2538,25 @@ mod regression {
 
 mod yaml_cst_cleanup {
     use super::*;
+
+    #[test]
+    fn fix_yaml_block_indentation_keeps_sequence_item_fields() {
+        let yaml = "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+  env:
+    - name: A
+      value: '1'
+    - name: B
+      value: '2'
+";
+        let fixed = super::super::fix_yaml_block_indentation(yaml);
+        assert_eq!(fixed, yaml);
+    }
 
     #[test]
     fn delete_last_key_no_trailing_whitespace() {

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -2288,7 +2288,7 @@ mod security {
         assert!(leaf.get("a").is_none());
     }
 
-    fn nest_get<'a>(v: &'a serde_json::Value, depth: usize) -> Option<&'a serde_json::Value> {
+    fn nest_get(v: &serde_json::Value, depth: usize) -> Option<&serde_json::Value> {
         let mut cursor = v;
         for _ in 0..depth {
             cursor = cursor.get("n")?;
@@ -2296,10 +2296,7 @@ mod security {
         Some(cursor)
     }
 
-    fn nest_get_mut<'a>(
-        v: &'a mut serde_json::Value,
-        depth: usize,
-    ) -> Option<&'a mut serde_json::Value> {
+    fn nest_get_mut(v: &mut serde_json::Value, depth: usize) -> Option<&mut serde_json::Value> {
         let mut cursor = v;
         for _ in 0..depth {
             cursor = cursor.get_mut("n")?;

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -60,8 +60,12 @@ pub(crate) fn apply_yaml_mapping_diff(
                         } else if !apply_yaml_sequence_resize(&seq, old_arr, new_arr) {
                             all_applied = false;
                         }
-                    } else if !try_mapping_set(mapping, key.as_str(), json_to_yaml_node(new_val)?) {
-                        all_applied = false;
+                    } else {
+                        // Inherited via `<<` only: insert a local override
+                        // beside the merge. Rewriting the map inlines `<<`.
+                        if !try_mapping_set(mapping, key.as_str(), json_to_yaml_node(new_val)?) {
+                            all_applied = false;
+                        }
                     }
                 }
                 // Type changed or scalar change.

--- a/src/ops/doc/yaml_splice.rs
+++ b/src/ops/doc/yaml_splice.rs
@@ -1,34 +1,4 @@
 // size-waiver: accepted single-domain bulk (policy #1408). YAML comment-preserving splice is one unit; split risks dual writers.
-/// Check if there are any arrays that grew between `old` and `new`.
-pub(super) fn has_array_growth_diffs(old: &serde_json::Value, new: &serde_json::Value) -> bool {
-    if old == new {
-        return false;
-    }
-    match (old, new) {
-        (serde_json::Value::Object(old_map), serde_json::Value::Object(new_map)) => {
-            for (key, new_val) in new_map {
-                if let Some(old_val) = old_map.get(key)
-                    && has_array_growth_diffs(old_val, new_val)
-                {
-                    return true;
-                }
-            }
-            false
-        }
-        (serde_json::Value::Array(old_arr), serde_json::Value::Array(new_arr)) => {
-            if new_arr.len() > old_arr.len() {
-                return true;
-            }
-            // Recurse into same-length elements to detect nested growth.
-            old_arr
-                .iter()
-                .zip(new_arr.iter())
-                .any(|(o, n)| has_array_growth_diffs(o, n))
-        }
-        _ => false,
-    }
-}
-
 /// Text-level fallback for array diffs that the CST path could not
 /// handle (general restructuring where the array is neither a pure
 /// prepend nor a pure append of the original).
@@ -638,37 +608,6 @@ mod tests {
         // First line should be "  - ..." and continuation "    ..."
         let first_line = result.lines().next().unwrap();
         assert!(first_line.starts_with("  - "));
-    }
-
-    // -----------------------------------------------------------------------
-    // has_array_growth_diffs
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn has_array_growth_no_change() {
-        let v = serde_json::json!({"a": [1, 2]});
-        assert!(!has_array_growth_diffs(&v, &v));
-    }
-
-    #[test]
-    fn has_array_growth_detects_growth() {
-        let old = serde_json::json!({"a": [1]});
-        let new = serde_json::json!({"a": [1, 2]});
-        assert!(has_array_growth_diffs(&old, &new));
-    }
-
-    #[test]
-    fn has_array_growth_detects_nested_growth() {
-        let old = serde_json::json!({"a": {"b": [1]}});
-        let new = serde_json::json!({"a": {"b": [1, 2]}});
-        assert!(has_array_growth_diffs(&old, &new));
-    }
-
-    #[test]
-    fn has_array_growth_shrink_is_not_growth() {
-        let old = serde_json::json!({"a": [1, 2, 3]});
-        let new = serde_json::json!({"a": [1]});
-        assert!(!has_array_growth_diffs(&old, &new));
     }
 
     // -----------------------------------------------------------------------

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1422,6 +1422,55 @@ fn test_doc_set_yaml_sequence_alias_item_becomes_merge() {
         .stdout(predicate::str::starts_with("3"));
 }
 
+/// `doc set --apply` that appends to an array inherited only via `<<`
+/// must keep the merge key and add a local `env:` override.
+#[test]
+fn test_doc_set_yaml_inherited_array_growth_keeps_merge_key() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("config.yaml");
+    fs::write(
+        &file,
+        "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("deployment.env")
+        .arg(r#"[{"name":"A","value":"1"},{"name":"B","value":"2"}]"#)
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        content,
+        "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+  env:
+    - name: A
+      value: '1'
+    - name: B
+      value: '2'
+"
+    );
+}
+
 /// Mixed flow `{cfg: *shared}` plus later block `cfg: *shared`. `doc set` on
 /// the block site must splice and leave the flow sibling.
 #[test]

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -3806,7 +3806,7 @@ fn test_doc_merge_multi_doc_selector() {
 }
 
 #[test]
-fn style_changed_true_on_yaml_sequence_collapse() {
+fn style_changed_false_when_yaml_sequence_item_indent_stays() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("app.yaml");
     std::fs::write(
@@ -3834,16 +3834,20 @@ fn style_changed_true_on_yaml_sequence_collapse() {
     let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
     assert_eq!(v["ok"], true);
     assert_eq!(v["changed"], true);
-    assert_eq!(
+    assert_ne!(
         v["style_changed"], true,
-        "CLI doc --json must report style_changed when sequence indent collapses: {v}"
+        "CLI doc --json must not flag style when sequence indent stays: {v}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "env:\n  - name: FEATURE_FLAG\n    value: on\nlimits:\n  rate: 1\n"
     );
 }
 
-/// #2070 multi-surface: plan/tx `changes[]` must also report style_changed
-/// when YAML block-sequence indent collapses (CLI alone is not enough for agents).
+/// #2070 multi-surface: plan/tx `changes[]` must not flag style_changed
+/// when YAML block-sequence item indent stays (CLI already locks this).
 #[test]
-fn style_changed_true_on_tx_plan_yaml_sequence_collapse() {
+fn style_changed_false_on_tx_plan_yaml_sequence_item_indent() {
     let dir = tempfile::TempDir::new().unwrap();
     let path = dir.path().join("app.yaml");
     std::fs::write(
@@ -3879,8 +3883,8 @@ fn style_changed_true_on_tx_plan_yaml_sequence_collapse() {
     assert!(!changes.is_empty(), "expected at least one change: {v}");
     let style = changes.iter().any(|c| c["style_changed"] == true);
     assert!(
-        style,
-        "tx plan changes[] must report style_changed when sequence indent collapses: {v}"
+        !style,
+        "tx plan changes[] must not flag style when sequence indent stays: {v}"
     );
 }
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2471,10 +2471,10 @@ async fn test_mcp_doc_update_round_trip() {
     client.cancel().await.unwrap();
 }
 
-/// #2070 multi-surface: MCP doc_update must surface style_changed on YAML
-/// block-sequence indent collapse (same honesty as CLI/tx).
+/// #2070 multi-surface: MCP doc_update must not flag style_changed when
+/// YAML block-sequence item indent stays (same honesty as CLI/tx).
 #[tokio::test]
-async fn test_mcp_doc_update_yaml_style_changed() {
+async fn test_mcp_doc_update_yaml_style_unchanged_when_indent_stays() {
     if !has_mcp_support() {
         return;
     }
@@ -2503,8 +2503,8 @@ async fn test_mcp_doc_update_yaml_style_changed() {
         .unwrap_or_else(|| panic!("changes array: {val}"));
     let style = changes.iter().any(|c| c["style_changed"] == true);
     assert!(
-        style,
-        "MCP doc_update changes[] must report style_changed on sequence indent collapse: {val}"
+        !style,
+        "MCP doc_update changes[] must not flag style when sequence indent stays: {val}"
     );
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
Growing an array that exists only through `<<: *anchor` used to dump
the file. Values stayed correct. The merge key and the source
`&anchor` were lost.

`get_sequence` is `None` on a merge-only map, so leftover splice
never saw an array. The CST keep path also refused any array
growth. Shrink of the same inherited array already kept `<<`.

This inserts a local `env:` override beside `<<` (yaml-edit `set`
of the new sequence). The indent fixer no longer treats
`- name: A` as a mapping sibling, so the CST stays semantic-eq.

Also elides needless lifetimes on `nest_get` / `nest_get_mut`
(main CI clippy red after #2269).

A side effect: `doc set` on `env.0.value` no longer collapses
`- name` / `value` indent, so `style_changed` stays false on
that path. Collapse fingerprints still flag a real dump.

## Tests

- Unit exact body: append keeps `&defaults` and `<<: *defaults`
- Unit exact body: shrink of the same inherited array
- Indent fixer leaves sequence-item fields alone
- CLI `doc set --apply` cargo-bin lock

Closes #2268
Ref #2269

Do not merge release #2266.
