### PR TITLE
fix(doc): keep sibling anchors when deleting inherited merge keys

### DIFF
--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -91,7 +91,8 @@ pub fn presentation_style_changed(original: &str, new_text: &str, format: &FileF
     }
     match format {
         FileFormat::Yaml => {
-            yaml_block_sequence_indents(original) != yaml_block_sequence_indents(new_text)
+            yaml_block_sequence_indent_levels(original)
+                != yaml_block_sequence_indent_levels(new_text)
                 || yaml_alias_identity_counts(original) != yaml_alias_identity_counts(new_text)
         }
         // JSON/TOML pretty-print drift is not flagged here (comment/order
@@ -163,7 +164,7 @@ fn count_yaml_prefixed_idents(s: &str, prefix: char) -> usize {
 }
 
 /// Indent levels of every block-sequence entry line (`- …`), for style compare.
-fn yaml_block_sequence_indents(text: &str) -> Vec<usize> {
+fn yaml_block_sequence_indent_levels(text: &str) -> std::collections::BTreeSet<usize> {
     text.lines()
         .filter_map(|line| {
             let trimmed = line.trim_start();

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -2114,6 +2114,98 @@ deployment: {}
         );
     }
 
+    /// Deleting a local override of an inherited key must expand that site
+    /// (drop `<<`). CST remove of the override leaves `<<`, which re-injects
+    /// the inherited value.
+    #[test]
+    fn yaml_inherited_local_override_delete_keeps_anchor() {
+        let yaml = "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+  env:
+    - name: B
+      value: \"2\"
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["deployment"]
+            .as_object_mut()
+            .unwrap()
+            .shift_remove("env");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment: {}
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert!(
+            reparsed["deployment"].get("env").is_none(),
+            "overridden env must be gone from deployment:\n{result}"
+        );
+        assert_eq!(
+            reparsed["defaults"]["env"],
+            json!([{"name": "A", "value": "1"}])
+        );
+    }
+
+    /// Deleting a local-only key must keep `<<`. The key is not on the
+    /// merge source, so remove cannot re-inject it.
+    #[test]
+    fn yaml_inherited_local_only_delete_keeps_merge() {
+        let yaml = "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+  replicas: 3
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["deployment"]
+            .as_object_mut()
+            .unwrap()
+            .shift_remove("replicas");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert!(
+            reparsed["deployment"].get("replicas").is_none(),
+            "replicas must be gone:\n{result}"
+        );
+        assert_eq!(
+            reparsed["deployment"]["env"],
+            json!([{"name": "A", "value": "1"}])
+        );
+        assert_eq!(
+            reparsed["defaults"]["env"],
+            json!([{"name": "A", "value": "1"}])
+        );
+    }
+
     /// Replacing a merge map with a non-superset object must expand that
     /// site only. Keeping `<<` would leak inherited keys.
     #[test]

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -2021,6 +2021,10 @@ deployment:
             reparsed["defaults"]["env"],
             json!([{"name": "A", "value": "1"}])
         );
+        assert!(
+            !presentation_style_changed(yaml, &result, &FileFormat::Yaml),
+            "same indent level and &/* /<< counts must not flag style:\n{result}"
+        );
     }
 
     /// Shrinking the same inherited array still keeps `<<` and adds a local
@@ -2066,6 +2070,84 @@ deployment:
         assert_eq!(
             reparsed["defaults"]["env"],
             json!([{"name": "A", "value": "1"}, {"name": "B", "value": "2"}])
+        );
+    }
+
+    /// Deleting a key inherited only via `<<` must expand that site (drop
+    /// `<<`, write the remaining local map). Dumping loses `&defaults`.
+    #[test]
+    fn yaml_inherited_delete_expands_site_keeps_anchor() {
+        let yaml = "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["deployment"]
+            .as_object_mut()
+            .unwrap()
+            .shift_remove("env");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment: {}
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert!(
+            reparsed["deployment"].get("env").is_none(),
+            "inherited env must be gone from deployment:\n{result}"
+        );
+        assert_eq!(
+            reparsed["defaults"]["env"],
+            json!([{"name": "A", "value": "1"}])
+        );
+    }
+
+    /// Replacing a merge map with a non-superset object must expand that
+    /// site only. Keeping `<<` would leak inherited keys.
+    #[test]
+    fn yaml_inherited_non_superset_replace_expands_site() {
+        let yaml = "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  <<: *defaults
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["deployment"] = json!({"name": "api"});
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+deployment:
+  name: api
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed["deployment"], json!({"name": "api"}));
+        assert!(reparsed["deployment"].get("env").is_none());
+        assert_eq!(
+            reparsed["defaults"]["env"],
+            json!([{"name": "A", "value": "1"}])
         );
     }
 

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -38,7 +38,14 @@ pub(crate) fn apply_yaml_mapping_diff(
                 // preserved).
                 (serde_json::Value::Object(_), serde_json::Value::Object(_)) => {
                     if let Some(child) = mapping.get_mapping(key.as_str()) {
-                        if !apply_yaml_mapping_diff(&child, old_val, new_val)? {
+                        // Delete / non-superset of an inherited key cannot
+                        // drop `<<` via CST remove. Expand this site only.
+                        if merge_site_drops_inherited(&child, old_val, new_val) {
+                            if !try_mapping_set(mapping, key.as_str(), json_to_yaml_node(new_val)?)
+                            {
+                                all_applied = false;
+                            }
+                        } else if !apply_yaml_mapping_diff(&child, old_val, new_val)? {
                             all_applied = false;
                         }
                     } else if !try_mapping_set(
@@ -177,6 +184,36 @@ fn try_sequence_set(
         return Ok(true);
     }
     Ok(seq.set(index, json_to_yaml_node(new_val)?))
+}
+
+/// yaml-edit 0.3 tokenizes `<<` as `MERGE_KEY`, so `Mapping::get("<<")`
+/// never hits. Walk keys the same way yaml-edit's own merge tests do.
+fn mapping_has_merge_key(mapping: &yaml_edit::Mapping) -> bool {
+    mapping
+        .keys()
+        .any(|k| k.as_scalar().is_some_and(|s| s.as_string() == "<<"))
+}
+
+/// True when this CST mapping has `<<` and `new` omits a key that only
+/// existed via the merge. `Mapping::remove` cannot drop inherited keys,
+/// so the caller must expand this site (drop `<<`, write remaining local).
+fn merge_site_drops_inherited(
+    mapping: &yaml_edit::Mapping,
+    old: &serde_json::Value,
+    new: &serde_json::Value,
+) -> bool {
+    if !mapping_has_merge_key(mapping) {
+        return false;
+    }
+    let Some(old_map) = old.as_object() else {
+        return false;
+    };
+    let Some(new_map) = new.as_object() else {
+        return true;
+    };
+    old_map
+        .keys()
+        .any(|k| mapping.get(k.as_str()).is_none() && !new_map.contains_key(k))
 }
 
 /// yaml-edit 0.3 `Mapping::set` on an existing `key: *alias` inlines the

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -194,9 +194,10 @@ fn mapping_has_merge_key(mapping: &yaml_edit::Mapping) -> bool {
         .any(|k| k.as_scalar().is_some_and(|s| s.as_string() == "<<"))
 }
 
-/// True when this CST mapping has `<<` and `new` omits a key that only
-/// existed via the merge. `Mapping::remove` cannot drop inherited keys,
-/// so the caller must expand this site (drop `<<`, write remaining local).
+/// True when this CST mapping has `<<` and `new` omits a key that the
+/// merge would restore. `Mapping::remove` cannot drop inherited keys, and
+/// removing a local override of an inherited key leaves `<<` to re-inject
+/// it, so the caller must expand this site (drop `<<`, write remaining local).
 fn merge_site_drops_inherited(
     mapping: &yaml_edit::Mapping,
     old: &serde_json::Value,
@@ -211,9 +212,57 @@ fn merge_site_drops_inherited(
     let Some(new_map) = new.as_object() else {
         return true;
     };
-    old_map
-        .keys()
-        .any(|k| mapping.get(k.as_str()).is_none() && !new_map.contains_key(k))
+    old_map.keys().any(|k| {
+        if new_map.contains_key(k) {
+            return false;
+        }
+        // Inherited only: CST has no local key, so remove is a no-op.
+        if mapping.get(k.as_str()).is_none() {
+            return true;
+        }
+        // Local override: expand only if `<<` would put K back.
+        merge_source_has_key(mapping, k)
+    })
+}
+
+/// `Mapping::get("<<")` misses MERGE_KEY. Walk entries and resolve `*alias`
+/// against the document tree so a local override can be distinguished from
+/// a local-only key.
+fn merge_source_has_key(mapping: &yaml_edit::Mapping, key: &str) -> bool {
+    let registry = yaml_edit::AsYaml::as_node(mapping).map(|node| {
+        let root = node.ancestors().last().unwrap_or_else(|| node.clone());
+        yaml_edit::AnchorRegistry::from_tree(&root)
+    });
+    mapping.iter().any(|(k, v)| {
+        k.as_scalar().is_some_and(|s| s.as_string() == "<<")
+            && merge_value_has_key(&v, key, registry.as_ref())
+    })
+}
+
+fn merge_value_has_key(
+    node: &yaml_edit::YamlNode,
+    key: &str,
+    registry: Option<&yaml_edit::AnchorRegistry>,
+) -> bool {
+    if let Some(map) = node.as_mapping() {
+        return map.get(key).is_some();
+    }
+    if let Some(alias) = node.as_alias() {
+        let Some(registry) = registry else {
+            return false;
+        };
+        let Some(target) = registry.resolve(&alias.name()) else {
+            return false;
+        };
+        return yaml_edit::YamlNode::from_syntax(target.clone())
+            .is_some_and(|resolved| merge_value_has_key(&resolved, key, Some(registry)));
+    }
+    if let Some(seq) = node.as_sequence() {
+        return seq
+            .values()
+            .any(|item| merge_value_has_key(&item, key, registry));
+    }
+    false
 }
 
 /// yaml-edit 0.3 `Mapping::set` on an existing `key: *alias` inlines the


### PR DESCRIPTION
Deleting or replacing a key that exists only through `<<: *anchor`
used to dump the whole file. Values stayed correct. The source
`&anchor` was lost.

yaml-edit 0.3 tokenizes `<<` as `MERGE_KEY`, so `Mapping::get("<<")`
never hits and CST `remove` cannot drop inherited keys. This expands
that merge site only (drop `<<`, write the remaining local map).

The same expand runs when the deleted key was a local override of an
inherited key. CST `remove` would drop the override, leave `<<`, and
the inherited value would come back.

Also compares YAML sequence indent as a set of levels, so growing a
list at the same indent does not set `style_changed`.

## Tests

- Unit exact body: delete inherited `env` keeps `&defaults`
- Unit exact body: delete local override of inherited `env` keeps `&defaults`
- Unit exact body: delete local-only sibling keeps `<<`
- Unit exact body: non-superset replace of the merge map
- Growth fixture: `style_changed` false when indent level is unchanged

Ref #2270

Do not merge release #2266.
