### PR TITLE
fix(doc): write empty {} after expanding a merge-only site

### DIFF
--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -2323,6 +2323,51 @@ items:
         );
     }
 
+    /// Deleting the last inherited key on a merge-only sequence item must
+    /// write `{}` so the item is an empty object, not null. Dumping loses
+    /// `&defaults`.
+    #[test]
+    fn yaml_inherited_sequence_item_empty_expand_keeps_anchor() {
+        let yaml = "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+items:
+  - <<: *defaults
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][0].as_object_mut().unwrap().shift_remove("env");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env:
+    - name: A
+      value: \"1\"
+items:
+  - {}
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            reparsed["items"][0],
+            json!({}),
+            "empty merge-only item must reparse as {{}}, not null:\n{result}"
+        );
+        assert!(
+            reparsed["items"][0].get("env").is_none(),
+            "inherited env must be gone from the sequence item:\n{result}"
+        );
+        assert_eq!(
+            reparsed["defaults"]["env"],
+            json!([{"name": "A", "value": "1"}])
+        );
+    }
+
     /// Nested `<<` (`deployment` → `mid` → `base`): deleting a local
     /// override of an inherited key must expand that site and keep both
     /// anchors. A walk that only inspects `mid`'s local keys misses `env`.

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -58,8 +58,7 @@ pub(crate) fn apply_yaml_mapping_diff(
                     if let Some(child) = mapping.get_mapping(key.as_str()) {
                         if !apply_yaml_mapping_diff(&child, old_val, new_val)? {
                             all_applied = false;
-                        } else if new_val.as_object().is_some_and(|o| o.is_empty())
-                            && child.entries().next().is_none()
+                        } else if empty_object_site_needs_flow(&child, new_val)
                             && !try_mapping_set(mapping, key.as_str(), json_to_yaml_node(new_val)?)
                         {
                             // In-place drop of the last `<<` leaves an empty
@@ -152,6 +151,12 @@ pub(super) fn apply_yaml_sequence_diff(
                     && let Some(child_mapping) = node.as_mapping()
                 {
                     if !apply_yaml_mapping_diff(child_mapping, o, n)? {
+                        all_applied = false;
+                    } else if empty_object_site_needs_flow(child_mapping, n)
+                        && !try_sequence_set(seq, i, n)?
+                    {
+                        // Same empty-after-expand hole as nested mapping
+                        // keys: `- <<: *anchor` becomes `-` (null), not `- {}`.
                         all_applied = false;
                     }
                     continue;
@@ -338,6 +343,12 @@ fn merge_value_has_key(
             .any(|item| merge_value_has_key(&item, key, registry, depth + 1, visited));
     }
     false
+}
+
+/// Empty CST mapping after drop_merge serializes as null (`key:\n  ` or
+/// `-`). Callers parent-set `json_to_yaml_node({})` so the site is `{}`.
+fn empty_object_site_needs_flow(mapping: &yaml_edit::Mapping, new: &serde_json::Value) -> bool {
+    new.as_object().is_some_and(|o| o.is_empty()) && mapping.entries().next().is_none()
 }
 
 /// yaml-edit 0.3 `Mapping::set` on an existing `key: *alias` inlines the


### PR DESCRIPTION
A sequence item that is only `<<: *anchor` became empty after expand
and serialized as null (`-`), not `- {}`. Semantic compare then dumped
the file and dropped `&anchor`.

Nested mapping keys already parent-set `{}` in that case. Sequence
items now share the same helper.

Root merge-only delete already kept leftover sibling keys (`defaults`)
on #2272, so it was not live-red.

## Tests

- Unit exact body: `- <<: *defaults` then delete inherited `env` stays
  `- {}` and keeps `&defaults`

Ref #2272

Do not merge release #2266.
