### PR TITLE
fix(doc): keep YAML CST when emptying a non-last sequence item

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-4600%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-4700%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -518,7 +518,7 @@ flowchart LR
 
 ## Status
 
-4600+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+4700+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -91,8 +91,7 @@ pub fn presentation_style_changed(original: &str, new_text: &str, format: &FileF
     }
     match format {
         FileFormat::Yaml => {
-            yaml_block_sequence_indent_levels(original)
-                != yaml_block_sequence_indent_levels(new_text)
+            yaml_block_sequence_style_marks(original) != yaml_block_sequence_style_marks(new_text)
                 || yaml_alias_identity_counts(original) != yaml_alias_identity_counts(new_text)
         }
         // JSON/TOML pretty-print drift is not flagged here (comment/order
@@ -163,13 +162,20 @@ fn count_yaml_prefixed_idents(s: &str, prefix: char) -> usize {
     n
 }
 
-/// Indent levels of every block-sequence entry line (`- …`), for style compare.
-fn yaml_block_sequence_indent_levels(text: &str) -> std::collections::BTreeSet<usize> {
+/// `(dash_indent, spaces_after_dash)` for every block-sequence entry.
+/// Post-dash offset catches `-   name:` vs `- name:` (#2276).
+fn yaml_block_sequence_style_marks(text: &str) -> std::collections::BTreeSet<(usize, usize)> {
     text.lines()
         .filter_map(|line| {
             let trimmed = line.trim_start();
-            if trimmed.starts_with("- ") || trimmed == "-" {
-                Some(line.len() - trimmed.len())
+            let dash_indent = line.len() - trimmed.len();
+            if trimmed == "-" {
+                return Some((dash_indent, 0));
+            }
+            let rest = trimmed.strip_prefix('-')?;
+            if rest.starts_with(' ') || rest.starts_with('\t') {
+                let pad = rest.len() - rest.trim_start().len();
+                Some((dash_indent, pad))
             } else {
                 None
             }
@@ -277,7 +283,12 @@ fn cleanup_yaml_cst_whitespace(text: &str) -> String {
 ///
 /// This function detects entries whose indentation exceeds their siblings
 /// in the same block mapping and normalizes them to match.
+#[cfg(test)]
 fn fix_yaml_block_indentation(text: &str) -> String {
+    fix_yaml_block_indentation_with_original(None, text)
+}
+
+fn fix_yaml_block_indentation_with_original(original: Option<&str>, text: &str) -> String {
     let lines: Vec<&str> = text.lines().collect();
     let mut result: Vec<String> = Vec::with_capacity(lines.len());
 
@@ -309,7 +320,8 @@ fn fix_yaml_block_indentation(text: &str) -> String {
 
         let indent = line.len() - trimmed.len();
         // CST remove of `<<` on a dash line leaves `-     name:`. Collapse
-        // extra spaces after `-` when the rest is a mapping key.
+        // extra spaces after `-` only on lines the original did not already
+        // contain. Pre-existing `-   name:` is style, not an artifact (#2276).
         if is_yaml_sequence_item(trimmed)
             && let Some(rest) = trimmed.strip_prefix('-')
         {
@@ -317,6 +329,8 @@ fn fix_yaml_block_indentation(text: &str) -> String {
             if rest.len() - rest_trim.len() > 1
                 && (rest_trim.contains(": ") || rest_trim.ends_with(':'))
                 && !is_yaml_sequence_item(rest_trim)
+                && original
+                    .is_some_and(|orig| !orig.lines().any(|l| l.trim_end() == line.trim_end()))
             {
                 result.push(format!("{}- {rest_trim}", " ".repeat(indent)));
                 continue;
@@ -344,6 +358,74 @@ fn fix_yaml_block_indentation(text: &str) -> String {
         out.push_str(eol);
     }
     out
+}
+
+/// After a block sequence item is emptied, yaml-edit 0.3 `Sequence::set`
+/// of `{}` / `[]` can drop the item newline and glue the next sibling
+/// (`- {}  - name: B`). Split that so semantic_eq accepts the CST
+/// instead of dumping (#2274 / #2275).
+fn repair_glued_block_sequence_items(text: &str) -> String {
+    let eol = crate::write::detect_eol(text);
+    let mut lines: Vec<String> = Vec::new();
+    for line in text.lines() {
+        let mut remaining = line.to_string();
+        loop {
+            match split_glued_block_sequence_line(&remaining) {
+                Some((first, second)) => {
+                    lines.push(first);
+                    remaining = second;
+                }
+                None => {
+                    lines.push(remaining);
+                    break;
+                }
+            }
+        }
+    }
+    let mut out = lines.join(eol);
+    if text.ends_with('\n') && !out.ends_with('\n') {
+        out.push_str(eol);
+    }
+    out
+}
+
+fn split_glued_block_sequence_line(line: &str) -> Option<(String, String)> {
+    let indent_len = line.len() - line.trim_start().len();
+    let trimmed = &line[indent_len..];
+    let after_dash = trimmed.strip_prefix('-')?;
+    let pad_len = after_dash.len() - after_dash.trim_start().len();
+    if pad_len == 0 {
+        return None;
+    }
+    let after_pad = after_dash.trim_start();
+    let first_item = if after_pad.starts_with("{}") {
+        "{}"
+    } else if after_pad.starts_with("[]") {
+        "[]"
+    } else {
+        return None;
+    };
+    let rest = &after_pad[first_item.len()..];
+    let pad = &after_dash[..pad_len];
+    let first = format!("{}-{pad}{first_item}", &line[..indent_len]);
+    let rest_trim = rest.trim_start();
+    if rest_trim.len() != rest.len() && is_yaml_sequence_item(rest_trim) {
+        let between = &rest[..rest.len() - rest_trim.len()];
+        if between.chars().all(|c| c == ' ' || c == '\t') {
+            return Some((first, format!("{between}{rest_trim}")));
+        }
+    }
+    // Last-item empty: Sequence::set drops the newline before the next
+    // mapping key (`- {}z: *x` at column 0, or `- {}  enabled: true`
+    // when that key is indented).
+    if !rest.is_empty()
+        && !rest_trim.starts_with('#')
+        && !is_yaml_sequence_item(rest_trim)
+        && (rest_trim.contains(": ") || rest_trim.ends_with(':'))
+    {
+        return Some((first, rest.to_string()));
+    }
+    None
 }
 
 /// Find the indentation of the next non-empty, non-comment line after `i`.
@@ -483,7 +565,13 @@ fn try_preserve_yaml(
     if let Some(doc) = file.document() {
         if let Some(mapping) = doc.as_mapping() {
             if cst_old.is_object() && new_value.is_object() {
-                return try_preserve_yaml_object(&file, &mapping, &cst_old, new_value);
+                return try_preserve_yaml_object(
+                    promoted.as_deref().unwrap_or(original_content),
+                    &file,
+                    &mapping,
+                    &cst_old,
+                    new_value,
+                );
             }
         } else if let Some(seq) = doc.as_sequence()
             && let (Some(old_arr), Some(new_arr)) = (cst_old.as_array(), new_value.as_array())
@@ -514,6 +602,7 @@ fn yaml_file_after_partial_alias_splice(
 }
 
 fn try_preserve_yaml_object(
+    original: &str,
     file: &yaml_edit::YamlFile,
     mapping: &yaml_edit::Mapping,
     old_value: &serde_json::Value,
@@ -524,7 +613,10 @@ fn try_preserve_yaml_object(
     // line preceding the removed key and may shift the indentation of the
     // next sibling entry. Clean both artifacts so the output is valid YAML
     // that preserves original quote styles and key ordering.
-    let result = fix_yaml_block_indentation(&cleanup_yaml_cst_whitespace(&file.to_string()));
+    // After an emptied block item, Sequence::set of `{}` can drop the
+    // item newline (#2274). Repair before semantic_eq or we dump and
+    // lose anchors (#2275).
+    let result = finalize_yaml_cst_text(original, &file.to_string());
 
     // Compare semantically (merge keys resolved) so CST results that keep
     // `<<: *anchor` / `*alias` form match parse_doc's flattened model.
@@ -532,8 +624,16 @@ fn try_preserve_yaml_object(
     // non-preserving fallback expands every anchor/alias into full copies.
     // Array growth applied as a new local key (inherited via `<<` only)
     // is already in the CST; do not require !has_array_growth or we dump.
-    if yaml_semantic_eq(&result, new_value) && all_cst_applied {
+    if yaml_semantic_eq(&result, new_value) {
         return Ok(Some(result));
+    }
+
+    // A same-length sequence can only Sequence::set one empty `{}` per
+    // pass. Reparse the repaired text and apply leftover empties.
+    if !all_cst_applied
+        && let Some(finished) = retry_yaml_cst_empties(original, &result, new_value)?
+    {
+        return Ok(Some(finished));
     }
 
     // Array growth or structure mismatch: try splice.
@@ -548,6 +648,47 @@ fn try_preserve_yaml_object(
         && let Some(spliced) = yaml_splice::splice_yaml_array_diffs(&result, &reparsed, new_value)?
     {
         return Ok(Some(spliced));
+    }
+    Ok(None)
+}
+
+fn finalize_yaml_cst_text(original: &str, cst: &str) -> String {
+    fix_yaml_block_indentation_with_original(
+        Some(original),
+        &repair_glued_block_sequence_items(&cleanup_yaml_cst_whitespace(cst)),
+    )
+}
+
+fn retry_yaml_cst_empties(
+    original: &str,
+    start: &str,
+    new_value: &serde_json::Value,
+) -> anyhow::Result<Option<String>> {
+    use std::str::FromStr;
+
+    let mut text = start.to_string();
+    for _ in 0..32 {
+        let Some(current) = parse_yaml_semantic(&text) else {
+            return Ok(None);
+        };
+        if current == *new_value {
+            return Ok(Some(text));
+        }
+        let Ok(file) = yaml_edit::YamlFile::from_str(&text) else {
+            return Ok(None);
+        };
+        let Some(mapping) = file.document().and_then(|d| d.as_mapping()) else {
+            return Ok(None);
+        };
+        apply_yaml_mapping_diff(&mapping, &current, new_value)?;
+        let next = finalize_yaml_cst_text(original, &file.to_string());
+        if yaml_semantic_eq(&next, new_value) {
+            return Ok(Some(next));
+        }
+        if next == text {
+            return Ok(None);
+        }
+        text = next;
     }
     Ok(None)
 }
@@ -568,7 +709,8 @@ fn try_preserve_yaml_array(
         false
     };
     if applied {
-        let result = cleanup_yaml_cst_whitespace(&file.to_string());
+        let result =
+            repair_glued_block_sequence_items(&cleanup_yaml_cst_whitespace(&file.to_string()));
         if yaml_semantic_eq(&result, new_value) {
             return Ok(Some(result));
         }

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -2368,6 +2368,424 @@ items:
         );
     }
 
+    /// #2274: emptying a non-last sequence item must write `- {}` in
+    /// place. Sequence::set drops the item newline; trusting that CST
+    /// dumps the file and drops `&x` / `*x`.
+    #[test]
+    fn yaml_empty_non_last_sequence_item_keeps_anchor_and_sibling() {
+        let yaml = "\
+a: &x
+  k: v
+items:
+  - name: A
+  - name: B
+z: *x
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][0] = json!({});
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+a: &x
+  k: v
+items:
+  - {}
+  - name: B
+z: *x
+"
+        );
+        assert!(
+            !presentation_style_changed(yaml, &result, &FileFormat::Yaml),
+            "in-place empty item must not flag style:\n{result}"
+        );
+    }
+
+    /// #2274: same empty-item write with a leading comment on the
+    /// sequence. Dumping hoists `# keep` above `items:`.
+    /// Wide post-dash style (`-   name:`) uses the same remove-then-set
+    /// hole; repair must keep the original pad and the sibling item.
+    #[test]
+    fn yaml_empty_non_last_wide_dash_sequence_item_keeps_anchor() {
+        let yaml = "\
+a: &x
+  k: v
+items:
+  -   name: A
+  -   name: B
+z: *x
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][0] = json!({});
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+a: &x
+  k: v
+items:
+  -   {}
+  -   name: B
+z: *x
+"
+        );
+    }
+
+    /// Emptying a nested last sequence item must not glue `{}` onto the
+    /// next indented mapping key (`- {}  enabled: true`).
+    #[test]
+    fn yaml_empty_last_nested_sequence_item_keeps_following_key() {
+        let yaml = "\
+outer:
+  items:
+    - name: A
+    - name: B
+  enabled: true
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["outer"]["items"][1] = json!({});
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+outer:
+  items:
+    - name: A
+    - {}
+  enabled: true
+"
+        );
+        assert!(
+            result.contains("enabled: true"),
+            "following key must stay a sibling of items:\n{result}"
+        );
+    }
+
+    /// #2275: last merge-only item with a following sibling key.
+    #[test]
+    fn yaml_inherited_last_sequence_item_empty_keeps_following_key() {
+        let yaml = "\
+defaults: &defaults
+  env: 1
+outer:
+  items:
+    - other: 2
+    - <<: *defaults
+  enabled: true
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["outer"]["items"][1]
+            .as_object_mut()
+            .unwrap()
+            .shift_remove("env");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env: 1
+outer:
+  items:
+    - other: 2
+    - {}
+  enabled: true
+"
+        );
+        assert!(
+            result.contains("&defaults"),
+            "anchor must survive last-item empty:\n{result}"
+        );
+    }
+
+    /// Emptying the last sequence item must not glue `{}` onto the next
+    /// mapping key (`- {}z: *x`).
+    #[test]
+    fn yaml_empty_last_sequence_item_keeps_following_key() {
+        let yaml = "\
+a: &x
+  k: v
+items:
+  - name: A
+  - name: B
+z: *x
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][1] = json!({});
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+a: &x
+  k: v
+items:
+  - name: A
+  - {}
+z: *x
+"
+        );
+    }
+
+    /// Two emptied items on the same write glue as `- {}  - {}  - name`.
+    #[test]
+    fn yaml_empty_two_sequence_items_keeps_third_and_anchor() {
+        let yaml = "\
+a: &x
+  k: v
+items:
+  - name: A
+  - name: B
+  - name: C
+z: *x
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][0] = json!({});
+        new["items"][1] = json!({});
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+a: &x
+  k: v
+items:
+  - {}
+  - {}
+  - name: C
+z: *x
+"
+        );
+    }
+
+    #[test]
+    fn yaml_empty_non_last_sequence_item_keeps_comment() {
+        let yaml = "\
+items:
+  # keep
+  - name: A
+  - name: B
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][0] = json!({});
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+items:
+  # keep
+  - {}
+  - name: B
+"
+        );
+    }
+
+    /// #2275: merge-only item followed by a sibling. The only-item
+    /// lock in yaml_inherited_sequence_item_empty_expand_keeps_anchor
+    /// missed this shape.
+    #[test]
+    fn yaml_inherited_sequence_item_empty_expand_keeps_anchor_with_sibling() {
+        let yaml = "\
+defaults: &defaults
+  env: 1
+items:
+  - <<: *defaults
+  - other: 2
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][0].as_object_mut().unwrap().shift_remove("env");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env: 1
+items:
+  - {}
+  - other: 2
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed["items"][0], json!({}));
+        assert_eq!(reparsed["items"][1], json!({"other": 2}));
+        assert_eq!(reparsed["defaults"]["env"], json!(1));
+    }
+
+    /// #2275: merge-only item preceded by a sibling.
+    #[test]
+    fn yaml_inherited_sequence_item_empty_expand_keeps_anchor_preceded() {
+        let yaml = "\
+defaults: &defaults
+  env: 1
+items:
+  - other: 2
+  - <<: *defaults
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][1].as_object_mut().unwrap().shift_remove("env");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env: 1
+items:
+  - other: 2
+  - {}
+"
+        );
+    }
+
+    /// #2275: merge-only item with a leading comment on its own line.
+    #[test]
+    fn yaml_inherited_sequence_item_empty_expand_keeps_leading_comment() {
+        let yaml = "\
+defaults: &defaults
+  env: 1
+items:
+  # keep
+  - <<: *defaults
+  - other: 2
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][0].as_object_mut().unwrap().shift_remove("env");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env: 1
+items:
+  # keep
+  - {}
+  - other: 2
+"
+        );
+    }
+
+    /// #2275: two merge-only items; empty only the first.
+    #[test]
+    fn yaml_inherited_sequence_two_merge_items_empty_first_keeps_second() {
+        let yaml = "\
+defaults: &defaults
+  env: 1
+items:
+  - <<: *defaults
+  - <<: *defaults
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["items"][0].as_object_mut().unwrap().shift_remove("env");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+defaults: &defaults
+  env: 1
+items:
+  - {}
+  - <<: *defaults
+"
+        );
+        let reparsed = parse_doc(&result, &FileFormat::Yaml).unwrap();
+        assert_eq!(reparsed["items"][0], json!({}));
+        assert_eq!(reparsed["items"][1], json!({"env": 1}));
+    }
+
+    /// #2276: an unrelated key edit must not collapse pre-existing
+    /// `-   name:` dash spacing, and must not silently omit style_changed.
+    #[test]
+    fn yaml_unrelated_edit_keeps_wide_dash_spacing() {
+        let yaml = "\
+# top comment
+app: &app
+  name: myapp
+items:
+  -   name: A
+  -   name: B
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["app"]["name"] = json!("zzz");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+# top comment
+app: &app
+  name: zzz
+items:
+  -   name: A
+  -   name: B
+"
+        );
+        assert!(
+            !presentation_style_changed(yaml, &result, &FileFormat::Yaml),
+            "untouched dash spacing must not flag style:\n{result}"
+        );
+    }
+
+    /// Unrelated edits must not rewrite a `|` scalar whose text looks
+    /// like glued sequence items.
+    #[test]
+    fn yaml_unrelated_edit_keeps_block_scalar_that_looks_glued() {
+        let yaml = "\
+script: |
+  - {}  - name: B
+other: 1
+";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["other"] = json!(2);
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(
+            result,
+            "\
+script: |
+  - {}  - name: B
+other: 2
+"
+        );
+    }
+
+    /// Trailing spaces on the original dash line must not re-enable
+    /// collapse after cleanup trims them.
+    #[test]
+    fn yaml_unrelated_edit_keeps_wide_dash_spacing_with_trailing_ws() {
+        let yaml =
+            "# top comment\napp: &app\n  name: myapp\nitems:\n  -   name: A  \n  -   name: B  \n";
+        let old = parse_doc(yaml, &FileFormat::Yaml).unwrap();
+        let mut new = old.clone();
+        new["app"]["name"] = json!("zzz");
+
+        let result = serialize_value_preserving(yaml, &old, &new, &FileFormat::Yaml).unwrap();
+        assert!(
+            result.contains("  -   name: A"),
+            "trailing spaces on the original dash line must not collapse it:\n{result}"
+        );
+        assert!(result.contains("&app"), "anchor must survive:\n{result}");
+    }
+
     /// Nested `<<` (`deployment` → `mid` → `base`): deleting a local
     /// override of an inherited key must expand that site and keep both
     /// anchors. A walk that only inspects `mid`'s local keys misses `env`.
@@ -2899,6 +3317,64 @@ deployment:
 ";
         let fixed = super::super::fix_yaml_block_indentation(yaml);
         assert_eq!(fixed, yaml);
+    }
+
+    /// #2276: wide post-dash spacing on untouched items must survive
+    /// when the original line is still present. Artifact `-     name:`
+    /// (not in original) still collapses.
+    #[test]
+    fn fix_yaml_block_indentation_keeps_wide_dash_spacing() {
+        let yaml = "\
+items:
+  -   name: A
+  -   name: B
+";
+        assert_eq!(
+            super::super::fix_yaml_block_indentation_with_original(Some(yaml), yaml),
+            yaml
+        );
+        let artifact = "\
+items:
+  -     name: A
+";
+        assert_eq!(
+            super::super::fix_yaml_block_indentation_with_original(Some(yaml), artifact),
+            "\
+items:
+  - name: A
+"
+        );
+    }
+
+    #[test]
+    fn repair_glued_block_sequence_items_splits_empty_object() {
+        let glued = "items:\n  # keep\n  - {}  - name: B\n";
+        let fixed = super::super::repair_glued_block_sequence_items(glued);
+        assert_eq!(fixed, "items:\n  # keep\n  - {}\n  - name: B\n");
+    }
+
+    #[test]
+    fn repair_glued_block_sequence_items_splits_wide_and_multi_and_next_key() {
+        let wide = "items:\n  -   {}  -   name: B\n";
+        assert_eq!(
+            super::super::repair_glued_block_sequence_items(wide),
+            "items:\n  -   {}\n  -   name: B\n"
+        );
+        let multi = "items:\n  - {}  - {}  - name: C\n";
+        assert_eq!(
+            super::super::repair_glued_block_sequence_items(multi),
+            "items:\n  - {}\n  - {}\n  - name: C\n"
+        );
+        let next_key = "items:\n  - name: A\n  - {}z: *x\n";
+        assert_eq!(
+            super::super::repair_glued_block_sequence_items(next_key),
+            "items:\n  - name: A\n  - {}\nz: *x\n"
+        );
+        let nested_key = "outer:\n  items:\n    - name: A\n    - {}  enabled: true\n";
+        assert_eq!(
+            super::super::repair_glued_block_sequence_items(nested_key),
+            "outer:\n  items:\n    - name: A\n    - {}\n  enabled: true\n"
+        );
     }
 
     #[test]
@@ -3535,6 +4011,12 @@ fn presentation_style_changed_flags_yaml_sequence_indent() {
         before,
         &FileFormat::Yaml
     ));
+    let wide = "env:\n  -   name: FEATURE_FLAG\n";
+    let tight = "env:\n  - name: FEATURE_FLAG\n";
+    assert!(
+        presentation_style_changed(wide, tight, &FileFormat::Yaml),
+        "post-dash spacing change must set style_changed"
+    );
 }
 
 #[test]

--- a/src/ops/doc/yaml_cst.rs
+++ b/src/ops/doc/yaml_cst.rs
@@ -141,23 +141,29 @@ pub(super) fn apply_yaml_sequence_diff(
     new_arr: &[serde_json::Value],
 ) -> anyhow::Result<bool> {
     let mut all_applied = true;
+    let mut emptied_one_empty_object = false;
     for (i, (o, n)) in old_arr.iter().zip(new_arr.iter()).enumerate() {
         if o == n {
             continue;
         }
         match (o, n) {
             (serde_json::Value::Object(_), serde_json::Value::Object(_)) => {
+                if n.as_object().is_some_and(|obj| obj.is_empty()) && emptied_one_empty_object {
+                    // Leave leftover empties for a reparse pass.
+                    all_applied = false;
+                    continue;
+                }
                 if let Some(node) = seq.get(i)
                     && let Some(child_mapping) = node.as_mapping()
                 {
                     if !apply_yaml_mapping_diff(child_mapping, o, n)? {
                         all_applied = false;
-                    } else if empty_object_site_needs_flow(child_mapping, n)
-                        && !try_sequence_set(seq, i, n)?
-                    {
-                        // Same empty-after-expand hole as nested mapping
-                        // keys: `- <<: *anchor` becomes `-` (null), not `- {}`.
-                        all_applied = false;
+                    } else if empty_object_site_needs_flow(child_mapping, n) {
+                        if !try_sequence_set(seq, i, n)? {
+                            all_applied = false;
+                        } else {
+                            emptied_one_empty_object = true;
+                        }
                     }
                     continue;
                 }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -1529,6 +1529,116 @@ fn test_doc_set_yaml_mixed_flow_sequence_block_alias_keeps_flow() {
     );
 }
 
+/// #2274 / #2275: emptying a non-last sequence item must stay CST-shaped.
+#[test]
+fn test_doc_set_yaml_empty_non_last_sequence_item_keeps_anchor() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("u.yaml");
+    fs::write(
+        &file,
+        "a: &x\n  k: v\nitems:\n  - name: A\n  - name: B\nz: *x\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("items[0]")
+        .arg("{}")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        content,
+        "a: &x\n  k: v\nitems:\n  - {}\n  - name: B\nz: *x\n"
+    );
+}
+
+/// #2275: merge-only first item with a sibling must keep `&defaults`.
+#[test]
+fn test_doc_delete_yaml_merge_only_sequence_item_keeps_anchor() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("m.yaml");
+    fs::write(
+        &file,
+        "defaults: &defaults\n  env: 1\nitems:\n  - <<: *defaults\n  - other: 2\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("delete")
+        .arg(&file)
+        .arg("items[0].env")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        content,
+        "defaults: &defaults\n  env: 1\nitems:\n  - {}\n  - other: 2\n"
+    );
+}
+
+/// #2276: unrelated `doc set` must not collapse pre-existing `-   name:`.
+#[test]
+fn test_doc_set_yaml_unrelated_edit_keeps_wide_dash_spacing() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("c.yaml");
+    fs::write(
+        &file,
+        "# top comment\napp: &app\n  name: myapp\nitems:\n  -   name: A\n  -   name: B\n",
+    )
+    .unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("app.name")
+        .arg("\"zzz\"")
+        .arg("--apply")
+        .assert()
+        .code(0);
+
+    let content = fs::read_to_string(&file).unwrap();
+    assert_eq!(
+        content,
+        "# top comment\napp: &app\n  name: zzz\nitems:\n  -   name: A\n  -   name: B\n"
+    );
+
+    let check = Command::cargo_bin("patchloom")
+        .unwrap()
+        .arg("doc")
+        .arg("set")
+        .arg(&file)
+        .arg("app.name")
+        .arg("\"yyy\"")
+        .arg("--check")
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert_eq!(
+        check.status.code(),
+        Some(2),
+        "{}",
+        String::from_utf8_lossy(&check.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&check.stdout).unwrap();
+    assert_eq!(json["changed"], true, "{json}");
+    assert!(
+        json.get("style_changed").is_none() || json["style_changed"] == false,
+        "untouched dash spacing must not set style_changed: {json}"
+    );
+}
+
 #[test]
 fn test_doc_set_yaml_apply() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
Emptying a YAML sequence item that is not last (or a last item followed by an indented sibling key) no longer glues the next line onto `- {}` and dumps the file.

## Problem

`#2273` routed an emptied block-sequence item through yaml-edit `Sequence::set` of `{}`. That call drops the item newline, so the next sibling lands on the same line (`- {}  - name: B`, or `- {}  enabled: true` when the following key is indented). The CST then fails semantic compare and `serialize_value_preserving` falls back to a full dump. Anchors, aliases, comments, and quote style are lost.

`#2275` is the same hole for merge-only items (`- <<: *defaults`) that are not last. The only-item lock from `#2273` still passed.

`#2276` is a separate indent-fixer bug: dash-collapse rewrote every `-   name:` line in the file, even on an unrelated key edit, and `style_changed` did not notice the post-dash pad change.

## Change

- Repair glued `- {}` / `- []` block items (wide dash, several glued items, last-item plus next mapping key, including an indented following key) before semantic compare.
- Apply one empty-object `Sequence::set` per CST pass, then reparse leftover empties.
- Collapse extra spaces after `-` only when that line was not already in the original (compare with trailing spaces stripped).
- Record `(dash indent, spaces after dash)` so a remaining pad change sets `style_changed`.

## Validation

- `cargo test --lib --all-features ops::doc`: 386 passed
- CLI cargo-bin: empty non-last item, merge-only first item, unrelated wide-dash edit
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- Reviewer: last-item indented following key was live-red; folded. `|` scalar that looks glued stays intact on an unrelated edit.

Closes #2274
Closes #2275
Closes #2276
