### PR TITLE
fix(doc): treat empty YAML as object for keys and len

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Release](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/release.json&logo=github)](https://github.com/patchloom/patchloom/releases/latest)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](./LICENSE)
 
-[![Tests](https://img.shields.io/badge/tests-4700%2B%20passing-brightgreen)](#)
+[![Tests](https://img.shields.io/badge/tests-4800%2B%20passing-brightgreen)](#)
 [![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/SebTardif/6a26adf6bfae45f530465f626c9154f4/raw/coverage.json)](https://github.com/patchloom/patchloom/actions/workflows/ci.yml)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13097/badge)](https://www.bestpractices.dev/projects/13097)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/patchloom/patchloom/badge)](https://securityscorecards.dev/viewer/?uri=github.com/patchloom/patchloom)
@@ -518,7 +518,7 @@ flowchart LR
 
 ## Status
 
-4700+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
+4800+ tests across 24 commands. Tested with Grok 4.3, GPT-5.4, and Claude Opus 4.6.
 
 | Component | Status |
 |---|---|

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -29,7 +29,7 @@ fn load_doc_value(path: &Path) -> anyhow::Result<serde_json::Value> {
     let path_str = path.to_string_lossy();
     let original = crate::files::load_text_strict(path, &path_str)?;
     let format = ops::doc::detect_format(&path_str)?;
-    ops::doc::parse_doc(&original, &format)
+    ops::doc::parse_doc_for_query(&original, &format)
 }
 
 /// Unified write path: delegates to the tx engine when available (cli/files),

--- a/src/api/doc.rs
+++ b/src/api/doc.rs
@@ -26,10 +26,7 @@ fn cwd_from_path(path: &Path) -> &Path {
 /// Load first (same order as CLI `load_file`) so a missing path peels as
 /// `not_found` even when the extension is absent or unsupported.
 fn load_doc_value(path: &Path) -> anyhow::Result<serde_json::Value> {
-    let path_str = path.to_string_lossy();
-    let original = crate::files::load_text_strict(path, &path_str)?;
-    let format = ops::doc::detect_format(&path_str)?;
-    ops::doc::parse_doc_for_query(&original, &format)
+    ops::doc::load_for_query(path)
 }
 
 /// Unified write path: delegates to the tx engine when available (cli/files),

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -413,6 +413,85 @@ fn doc_len_wildcard_one_or_zero_match_is_ambiguous() {
 }
 
 #[test]
+fn doc_keys_and_len_empty_yaml_match_empty_json() {
+    // Empty / whitespace YAML is Null in parse_doc; keys/len at `.` must
+    // still succeed like empty JSON (`[]` / `0`). #2283
+    let dir = TempDir::new().unwrap();
+    for (name, body) in [
+        ("empty.yaml", ""),
+        ("ws.yaml", "   \n  \n"),
+        ("empty.json", ""),
+    ] {
+        let file = dir.path().join(name);
+        fs::write(&file, body).unwrap();
+        let keys = doc_keys(&file, ".").unwrap_or_else(|e| panic!("{name} keys at .: {e}"));
+        assert_eq!(keys, Vec::<String>::new(), "{name} keys at . must be []");
+        assert_eq!(
+            doc_len(&file, ".").unwrap_or_else(|e| panic!("{name} len at .: {e}")),
+            0,
+            "{name} len at . must be 0"
+        );
+        // get/has share load_doc_value; empty YAML root is the same object.
+        assert_eq!(
+            doc_get(&file, ".").unwrap_or_else(|e| panic!("{name} get at .: {e}")),
+            serde_json::json!({}),
+            "{name} get at . must be {{}}"
+        );
+        assert!(
+            doc_has(&file, ".").unwrap_or_else(|e| panic!("{name} has at .: {e}")),
+            "{name} has at . must be true"
+        );
+    }
+}
+
+#[test]
+fn doc_keys_explicit_yaml_null_is_type_error() {
+    // Only empty / whitespace YAML is normalized. An explicit null scalar
+    // stays a scalar.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("null.yaml");
+    fs::write(&file, "null\n").unwrap();
+    let err = doc_keys(&file, ".").unwrap_err();
+    assert!(
+        crate::exit::is_type_error(&err),
+        "explicit YAML null must stay type_error, got: {err}"
+    );
+}
+
+#[test]
+fn doc_set_empty_yaml_write_bootstrap_unchanged() {
+    // parse_doc must keep empty YAML as Null so write bootstrap (null-to-object
+    // in set_at_path) is not rewritten to the JSON empty-object path. #2283
+    assert_eq!(
+        crate::ops::doc::parse_doc("", &crate::ops::doc::FileFormat::Yaml).unwrap(),
+        serde_json::Value::Null,
+        "parse_doc empty YAML must stay Null (write bootstrap)"
+    );
+    assert_eq!(
+        crate::ops::doc::parse_doc("   \n  \n", &crate::ops::doc::FileFormat::Yaml).unwrap(),
+        serde_json::Value::Null,
+        "parse_doc whitespace YAML must stay Null (write bootstrap)"
+    );
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.yaml");
+    fs::write(&file, "").unwrap();
+    let result = doc_set(
+        &file,
+        "name",
+        serde_json::json!("app"),
+        ApplyMode::Apply,
+        None,
+    )
+    .unwrap();
+    assert!(result.applied, "doc_set on empty YAML must apply");
+    assert_eq!(
+        fs::read_to_string(&file).unwrap(),
+        "name: app\n",
+        "empty YAML set must keep today's mapping write, not JSON-style {{}}"
+    );
+}
+
+#[test]
 fn doc_delete_removes_key() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("config.json");

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -457,6 +457,42 @@ fn doc_keys_explicit_yaml_null_is_type_error() {
 }
 
 #[test]
+fn doc_keys_and_len_bom_zwsp_yaml_match_empty() {
+    // trim() does not strip BOM/ZWSP, so a format-char-only YAML file must
+    // still query like empty (`[]` / `0`), not peel type_error.
+    let dir = TempDir::new().unwrap();
+    for (name, body) in [
+        ("bom.yaml", "\u{feff}"),
+        ("zwsp.yaml", "\u{200b}"),
+        ("bom_ws.yaml", "\u{feff}  \n  "),
+    ] {
+        let file = dir.path().join(name);
+        fs::write(&file, body).unwrap();
+        let keys = doc_keys(&file, ".").unwrap_or_else(|e| panic!("{name} keys at .: {e}"));
+        assert_eq!(keys, Vec::<String>::new(), "{name} keys at . must be []");
+        assert_eq!(
+            doc_len(&file, ".").unwrap_or_else(|e| panic!("{name} len at .: {e}")),
+            0,
+            "{name} len at . must be 0"
+        );
+    }
+}
+
+#[test]
+fn doc_keys_comment_only_yaml_is_type_error() {
+    // Comment-only YAML is a scalar/null document, not a blank file.
+    // Do not expand empty remapping to "# hi".
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("comment.yaml");
+    fs::write(&file, "# hi\n").unwrap();
+    let err = doc_keys(&file, ".").unwrap_err();
+    assert!(
+        crate::exit::is_type_error(&err),
+        "comment-only YAML must stay type_error, got: {err}"
+    );
+}
+
+#[test]
 fn doc_set_empty_yaml_write_bootstrap_unchanged() {
     // parse_doc must keep empty YAML as Null so write bootstrap (null-to-object
     // in set_at_path) is not rewritten to the JSON empty-object path. #2283

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -337,10 +337,8 @@ fn doc_keys_wildcard_multi_match_is_ambiguous() {
     );
     let msg = err.to_string();
     assert!(
-        (msg.contains("items[0]") || msg.contains("[0]"))
-            && msg.contains("one object")
-            && !msg.contains("or array"),
-        "ambiguous keys must name a concrete index and one object: {msg}"
+        msg.contains("items[0]") && msg.contains("one object") && !msg.contains("or array"),
+        "ambiguous keys must name items[0] and one object: {msg}"
     );
 }
 
@@ -361,8 +359,8 @@ fn doc_len_wildcard_multi_match_is_ambiguous() {
     );
     let msg = err.to_string();
     assert!(
-        (msg.contains("items[0]") || msg.contains("[0]")) && msg.contains("one object or array"),
-        "ambiguous len must name a concrete index: {msg}"
+        msg.contains("items[0]") && msg.contains("one object or array"),
+        "ambiguous len must name items[0]: {msg}"
     );
 }
 
@@ -383,8 +381,8 @@ fn doc_keys_wildcard_one_or_zero_match_is_ambiguous() {
         );
         let msg = err.to_string();
         assert!(
-            msg.contains("items[0]") || msg.contains("[0]"),
-            "ambiguous keys must name a concrete index: {msg}"
+            msg.contains("items[0]") && msg.contains("one object") && !msg.contains("or array"),
+            "ambiguous keys must name items[0] and one object: {msg}"
         );
     }
 }
@@ -406,8 +404,8 @@ fn doc_len_wildcard_one_or_zero_match_is_ambiguous() {
         );
         let msg = err.to_string();
         assert!(
-            msg.contains("items[0]") || msg.contains("[0]"),
-            "ambiguous len must name a concrete index: {msg}"
+            msg.contains("items[0]") && msg.contains("one object or array"),
+            "ambiguous len must name items[0] and one object or array: {msg}"
         );
     }
 }

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -1,6 +1,6 @@
 use crate::cli::global::GlobalFlags;
 use crate::exit;
-use crate::ops::doc::{detect_format, diff_values, flatten_value, parse_value};
+use crate::ops::doc::{diff_values, flatten_value, parse_value};
 use crate::plan::Operation;
 use clap::Args;
 use serde::Serialize;
@@ -257,14 +257,8 @@ impl DocAction {
 }
 
 fn load_file(path: &str) -> anyhow::Result<serde_json::Value> {
-    // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
-    let content = crate::files::load_text_strict(std::path::Path::new(path), path)?;
-    let format = detect_format(path)?;
-    crate::ops::doc::parse_doc_for_query(&content, &format)
-        .with_context(|| format!("parsing {path}"))
+    crate::ops::doc::load_for_query(std::path::Path::new(path))
 }
-
-use anyhow::Context;
 
 // ---------------------------------------------------------------------------
 // Write-mode output & operation builder

--- a/src/cmd/doc.rs
+++ b/src/cmd/doc.rs
@@ -1,6 +1,6 @@
 use crate::cli::global::GlobalFlags;
 use crate::exit;
-use crate::ops::doc::{detect_format, diff_values, flatten_value, parse_doc, parse_value};
+use crate::ops::doc::{detect_format, diff_values, flatten_value, parse_value};
 use crate::plan::Operation;
 use clap::Args;
 use serde::Serialize;
@@ -260,7 +260,8 @@ fn load_file(path: &str) -> anyhow::Result<serde_json::Value> {
     // Strict sole-path (#1894): binary / invalid UTF-8 → Binary / InvalidEncoding.
     let content = crate::files::load_text_strict(std::path::Path::new(path), path)?;
     let format = detect_format(path)?;
-    parse_doc(&content, &format).with_context(|| format!("parsing {path}"))
+    crate::ops::doc::parse_doc_for_query(&content, &format)
+        .with_context(|| format!("parsing {path}"))
 }
 
 use anyhow::Context;

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -183,6 +183,52 @@ mod basic {
         assert!(keys.contains(&"test"));
     }
 
+    #[test]
+    fn keys_and_len_empty_yaml_json_succeeds_like_empty_json() {
+        // #2283: empty / whitespace YAML keys/len at `.` must not type_error.
+        let dir = TempDir::new().unwrap();
+        for (name, body) in [
+            ("empty.yaml", ""),
+            ("ws.yaml", "   \n  \n"),
+            ("empty.json", ""),
+        ] {
+            let path = write_file(&dir, name, body);
+            let (output, code) = execute_with_mode(
+                &DocAction::Keys {
+                    file: path.clone(),
+                    selector: ".".into(),
+                },
+                OutputMode::Json,
+            )
+            .unwrap();
+            assert_eq!(code, exit::SUCCESS, "{name} keys exit: {output}");
+            let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+            assert_eq!(v["ok"], true, "{name} keys ok: {v}");
+            assert!(
+                v.get("error_kind").is_none(),
+                "{name} keys must be the ok path, not error_kind: {v}"
+            );
+            assert_eq!(v["value"], serde_json::json!([]), "{name} keys value: {v}");
+
+            let (output, code) = execute_with_mode(
+                &DocAction::Len {
+                    file: path,
+                    selector: ".".into(),
+                },
+                OutputMode::Json,
+            )
+            .unwrap();
+            assert_eq!(code, exit::SUCCESS, "{name} len exit: {output}");
+            let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+            assert_eq!(v["ok"], true, "{name} len ok: {v}");
+            assert!(
+                v.get("error_kind").is_none(),
+                "{name} len must be the ok path, not error_kind: {v}"
+            );
+            assert_eq!(v["value"], serde_json::json!(0), "{name} len value: {v}");
+        }
+    }
+
     // -- len ----------------------------------------------------------------
 
     #[test]

--- a/src/containment.rs
+++ b/src/containment.rs
@@ -60,14 +60,23 @@
 
 use std::path::{Component, Path, PathBuf};
 
+/// True when `text` is empty, whitespace-only, or only Unicode format
+/// characters that carry no semantic content (ZWSP/ZWNJ/ZWJ/BOM).
+///
+/// Shared by path blankness and empty-YAML query remapping. `str::trim`
+/// does not strip these format characters.
+pub(crate) fn is_blank_text(text: &str) -> bool {
+    text.chars().all(|c| {
+        c.is_whitespace() || matches!(c, '\u{200b}' | '\u{200c}' | '\u{200d}' | '\u{feff}')
+    })
+}
+
 /// True when a path string is empty, whitespace-only, or only Unicode
 /// format characters that do not form a real path component (ZWSP/ZWNJ/ZWJ/BOM).
 ///
 /// Empty paths would otherwise resolve as the workspace/cwd root (not a file).
 pub fn is_blank_path(path: &str) -> bool {
-    path.chars().all(|c| {
-        c.is_whitespace() || matches!(c, '\u{200b}' | '\u{200c}' | '\u{200d}' | '\u{feff}')
-    })
+    is_blank_text(path)
 }
 
 /// Canonicalize a path without the Windows `\\?\` UNC prefix when safe.

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -5,6 +5,7 @@
 //! entrypoints are one document surface; do not split for LOC alone.
 
 use crate::selector;
+use anyhow::Context;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::path::Path;
@@ -855,6 +856,18 @@ pub fn parse_doc_for_query(
         return Ok(serde_json::json!({}));
     }
     Ok(value)
+}
+
+/// Load and parse a JSON/YAML/TOML file for read-only queries.
+///
+/// Load first so a missing path peels as `not_found` even when the
+/// extension is absent or unsupported. Empty YAML is `{}` via
+/// [`parse_doc_for_query`]. Write paths keep [`parse_doc`].
+pub fn load_for_query(path: &Path) -> anyhow::Result<serde_json::Value> {
+    let display = path.to_string_lossy();
+    let content = crate::files::load_text_strict(path, &display)?;
+    let format = detect_format(&display)?;
+    parse_doc_for_query(&content, &format).with_context(|| format!("parsing {display}"))
 }
 
 /// Check whether YAML content contains multiple documents.

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -842,6 +842,21 @@ pub fn parse_doc(content: &str, format: &FileFormat) -> anyhow::Result<serde_jso
     }
 }
 
+/// Parse for read-only queries (keys/len/get/has).
+///
+/// Empty / whitespace-only YAML is `{}` so keys/len at `.` match empty
+/// JSON/TOML. Write bootstrap still uses [`parse_doc`] (empty YAML stays Null).
+pub fn parse_doc_for_query(
+    content: &str,
+    format: &FileFormat,
+) -> anyhow::Result<serde_json::Value> {
+    let value = parse_doc(content, format)?;
+    if matches!(format, FileFormat::Yaml) && content.trim().is_empty() && value.is_null() {
+        return Ok(serde_json::json!({}));
+    }
+    Ok(value)
+}
+
 /// Check whether YAML content contains multiple documents.
 ///
 /// A `---` on its own line is the YAML document separator. A single leading

--- a/src/ops/doc/mod.rs
+++ b/src/ops/doc/mod.rs
@@ -845,17 +845,19 @@ pub fn parse_doc(content: &str, format: &FileFormat) -> anyhow::Result<serde_jso
 
 /// Parse for read-only queries (keys/len/get/has).
 ///
-/// Empty / whitespace-only YAML is `{}` so keys/len at `.` match empty
-/// JSON/TOML. Write bootstrap still uses [`parse_doc`] (empty YAML stays Null).
+/// Empty / whitespace-only / BOM-ZWSP-only YAML is `{}` so keys/len at `.`
+/// match empty JSON/TOML. Write bootstrap still uses [`parse_doc`] (empty
+/// YAML stays Null). Comment-only and `---` preamble stay parsed YAML.
 pub fn parse_doc_for_query(
     content: &str,
     format: &FileFormat,
 ) -> anyhow::Result<serde_json::Value> {
-    let value = parse_doc(content, format)?;
-    if matches!(format, FileFormat::Yaml) && content.trim().is_empty() && value.is_null() {
+    // Blank-text check is on the source, not the parsed value: ZWSP-only
+    // YAML deserializes as a string, not Null, and trim() leaves it intact.
+    if matches!(format, FileFormat::Yaml) && crate::containment::is_blank_text(content) {
         return Ok(serde_json::json!({}));
     }
-    Ok(value)
+    parse_doc(content, format)
 }
 
 /// Load and parse a JSON/YAML/TOML file for read-only queries.

--- a/src/ops/doc/query.rs
+++ b/src/ops/doc/query.rs
@@ -119,11 +119,8 @@ fn format_selector(segments: &[selector::Segment]) -> String {
 }
 
 /// Concrete index paths for a multi-match keys/len selector (`items[*]` → `items[0]`).
-fn unique_index_examples(selector: &str) -> (String, String) {
-    let Ok(segs) = selector::parse(selector) else {
-        return ("items[0]".into(), "items[1]".into());
-    };
-    let pos = segs.iter().position(|s| {
+fn unique_index_examples(segments: &[selector::Segment]) -> (String, String) {
+    let pos = segments.iter().position(|s| {
         matches!(
             s,
             selector::Segment::Wildcard | selector::Segment::Predicate { .. }
@@ -131,8 +128,8 @@ fn unique_index_examples(selector: &str) -> (String, String) {
     });
     match pos {
         Some(i) => {
-            let mut first = segs.clone();
-            let mut second = segs;
+            let mut first = segments.to_vec();
+            let mut second = segments.to_vec();
             first[i] = selector::Segment::Index(0);
             second[i] = selector::Segment::Index(1);
             (format_selector(&first), format_selector(&second))
@@ -150,8 +147,8 @@ fn selector_has_multi_match_segment(segments: &[selector::Segment]) -> bool {
     })
 }
 
-fn unique_match_required_msg(op: &str, selector: &str) -> String {
-    let (a, b) = unique_index_examples(selector);
+fn unique_match_required_msg(op: &str, selector: &str, segments: &[selector::Segment]) -> String {
+    let (a, b) = unique_index_examples(segments);
     let need = if op == "keys" {
         "one object"
     } else {
@@ -163,23 +160,45 @@ fn unique_match_required_msg(op: &str, selector: &str) -> String {
     )
 }
 
-fn parent_selector_display(selector: &str) -> String {
-    if is_root_selector(selector) {
+fn parent_selector_display(segments: &[selector::Segment]) -> String {
+    if segments.len() <= 1 {
         return ".".into();
     }
-    let Ok(mut segs) = selector::parse(selector) else {
-        return ".".into();
-    };
-    if segs.len() <= 1 {
-        return ".".into();
-    }
-    segs.pop();
-    let formatted = format_selector(&segs);
+    let formatted = format_selector(&segments[..segments.len() - 1]);
     if formatted.is_empty() {
         ".".into()
     } else {
         formatted
     }
+}
+
+/// Unique target for keys/len: parse, refuse wildcard/predicate, eval once.
+fn unique_query_target<'a>(
+    root: &'a serde_json::Value,
+    selector: &str,
+    op: &str,
+) -> anyhow::Result<Option<&'a serde_json::Value>> {
+    let segments = selector::parse_anyhow(selector)?;
+    if selector_has_multi_match_segment(&segments) {
+        return Err(crate::exit::AmbiguousError {
+            msg: unique_match_required_msg(op, selector, &segments),
+        }
+        .into());
+    }
+    let results = selector::eval_result(root, &segments)?;
+    if results.is_empty() {
+        if let Some(hint) = array_root_bare_key_hint(root, &segments) {
+            return Err(crate::exit::TypeErrorError { msg: hint }.into());
+        }
+        return Ok(None);
+    }
+    if results.len() > 1 {
+        return Err(crate::exit::AmbiguousError {
+            msg: unique_match_required_msg(op, selector, &segments),
+        }
+        .into());
+    }
+    Ok(Some(results[0]))
 }
 
 /// Check whether a selector path exists.
@@ -217,31 +236,14 @@ pub enum QueryKeysResult {
 /// object keys at an array root (multi-doc YAML) return
 /// [`crate::exit::TypeErrorError`] like [`query_get`] / [`query_has`].
 pub fn query_keys(root: &serde_json::Value, selector: &str) -> anyhow::Result<QueryKeysResult> {
-    let segments = selector::parse_anyhow(selector)?;
-    if selector_has_multi_match_segment(&segments) {
-        return Err(crate::exit::AmbiguousError {
-            msg: unique_match_required_msg("keys", selector),
-        }
-        .into());
-    }
-    let results = selector::eval_result(root, &segments)?;
-    if results.is_empty() {
-        if let Some(hint) = array_root_bare_key_hint(root, &segments) {
-            return Err(crate::exit::TypeErrorError { msg: hint }.into());
-        }
+    let Some(target) = unique_query_target(root, selector, "keys")? else {
         return Ok(QueryKeysResult::NoMatch);
-    }
-    if results.len() > 1 {
-        return Err(crate::exit::AmbiguousError {
-            msg: unique_match_required_msg("keys", selector),
-        }
-        .into());
-    }
-    if let Some(obj) = results[0].as_object() {
+    };
+    if let Some(obj) = target.as_object() {
         Ok(QueryKeysResult::Keys(obj.keys().cloned().collect()))
     } else {
         Ok(QueryKeysResult::NotAnObject {
-            is_array: results[0].is_array(),
+            is_array: target.is_array(),
         })
     }
 }
@@ -262,27 +264,9 @@ pub enum QueryLenResult {
 /// selector matches more than one value, returns the same error. Bare object
 /// keys at an array root return type_error like [`query_get`].
 pub fn query_len(root: &serde_json::Value, selector: &str) -> anyhow::Result<QueryLenResult> {
-    let segments = selector::parse_anyhow(selector)?;
-    if selector_has_multi_match_segment(&segments) {
-        return Err(crate::exit::AmbiguousError {
-            msg: unique_match_required_msg("len", selector),
-        }
-        .into());
-    }
-    let results = selector::eval_result(root, &segments)?;
-    if results.is_empty() {
-        if let Some(hint) = array_root_bare_key_hint(root, &segments) {
-            return Err(crate::exit::TypeErrorError { msg: hint }.into());
-        }
+    let Some(target) = unique_query_target(root, selector, "len")? else {
         return Ok(QueryLenResult::NoMatch);
-    }
-    if results.len() > 1 {
-        return Err(crate::exit::AmbiguousError {
-            msg: unique_match_required_msg("len", selector),
-        }
-        .into());
-    }
-    let target = results[0];
+    };
     let len = target
         .as_array()
         .map(|a| a.len())
@@ -338,7 +322,7 @@ pub fn keys_at(root: &serde_json::Value, selector: &str) -> anyhow::Result<Vec<S
                          use keys on {display}[0] or len on {display}"
                     )
                 } else {
-                    let parent = parent_selector_display(selector);
+                    let parent = parent_selector_display(&selector::parse_anyhow(selector)?);
                     format!(
                         "doc keys: target at '{display}' is a scalar, not an object; \
                          use keys on {parent}"
@@ -373,7 +357,7 @@ pub fn len_at(root: &serde_json::Value, selector: &str) -> anyhow::Result<usize>
             } else {
                 selector
             };
-            let parent = parent_selector_display(selector);
+            let parent = parent_selector_display(&selector::parse_anyhow(selector)?);
             Err(crate::exit::TypeErrorError {
                 msg: format!(
                     "doc len: target at '{display}' is a scalar, not an array or object; \

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -63,6 +63,42 @@ mod basic {
     }
 
     #[test]
+    fn parse_empty_yaml_stays_null_for_write_bootstrap() {
+        // Write path uses parse_doc. Empty YAML must stay Null so `doc set`
+        // keeps the null-to-object bootstrap, not the JSON `{}` rewrite. #2283
+        assert_eq!(parse_doc("", &FileFormat::Yaml).unwrap(), json!(null));
+        assert_eq!(
+            parse_doc("   \n  \n", &FileFormat::Yaml).unwrap(),
+            json!(null)
+        );
+        let old = parse_doc("", &FileFormat::Yaml).unwrap();
+        let new = json!({"name": "app"});
+        let dumped = serialize_value_preserving("", &old, &new, &FileFormat::Yaml).unwrap();
+        assert_eq!(dumped, "name: app\n");
+    }
+
+    #[test]
+    fn parse_doc_for_query_empty_yaml_is_object() {
+        assert_eq!(
+            parse_doc_for_query("", &FileFormat::Yaml).unwrap(),
+            json!({})
+        );
+        assert_eq!(
+            parse_doc_for_query("   \n  \n", &FileFormat::Yaml).unwrap(),
+            json!({})
+        );
+        assert_eq!(
+            parse_doc_for_query("", &FileFormat::Json).unwrap(),
+            json!({})
+        );
+        // Explicit null is a scalar, not an empty file.
+        assert_eq!(
+            parse_doc_for_query("null\n", &FileFormat::Yaml).unwrap(),
+            json!(null)
+        );
+    }
+
+    #[test]
     fn parse_and_serialize_yaml_roundtrip() {
         let input = "a: 1\n";
         let val = parse_doc(input, &crate::ops::doc::FileFormat::Yaml).unwrap();

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -101,6 +101,16 @@ mod basic {
     }
 
     #[test]
+    fn load_for_query_empty_yaml_is_object() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("empty.yaml");
+        std::fs::write(&path, "").unwrap();
+        assert_eq!(load_for_query(&path).unwrap(), json!({}));
+        std::fs::write(&path, "   \n  \n").unwrap();
+        assert_eq!(load_for_query(&path).unwrap(), json!({}));
+    }
+
+    #[test]
     fn parse_and_serialize_yaml_roundtrip() {
         let input = "a: 1\n";
         let val = parse_doc(input, &crate::ops::doc::FileFormat::Yaml).unwrap();

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -71,6 +71,8 @@ mod basic {
             parse_doc("   \n  \n", &FileFormat::Yaml).unwrap(),
             json!(null)
         );
+        // Emit half: serialize_value_preserving dumps `name: app\n`. This is
+        // not a parse_doc oracle (those asserts are above).
         let old = parse_doc("", &FileFormat::Yaml).unwrap();
         let new = json!({"name": "app"});
         let dumped = serialize_value_preserving("", &old, &new, &FileFormat::Yaml).unwrap();

--- a/src/ops/doc/tests.rs
+++ b/src/ops/doc/tests.rs
@@ -98,6 +98,29 @@ mod basic {
             parse_doc_for_query("null\n", &FileFormat::Yaml).unwrap(),
             json!(null)
         );
+        // BOM / ZWSP are not stripped by trim(); query remap must still
+        // treat them as empty. Comment-only stays a scalar.
+        assert_eq!(
+            parse_doc_for_query("\u{feff}", &FileFormat::Yaml).unwrap(),
+            json!({})
+        );
+        assert_eq!(
+            parse_doc_for_query("\u{200b}", &FileFormat::Yaml).unwrap(),
+            json!({})
+        );
+        assert_eq!(
+            parse_doc_for_query("\u{feff}  \n  ", &FileFormat::Yaml).unwrap(),
+            json!({})
+        );
+        assert_eq!(
+            parse_doc_for_query("# hi\n", &FileFormat::Yaml).unwrap(),
+            json!(null)
+        );
+        // Leading `---` is YAML preamble, not blank text.
+        assert_eq!(
+            parse_doc_for_query("---\n", &FileFormat::Yaml).unwrap(),
+            json!(null)
+        );
     }
 
     #[test]

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -234,7 +234,7 @@ fn test_doc_len_omitted_selector_counts_root() {
         .arg(&file)
         .assert()
         .success()
-        .stdout(predicate::str::contains("2"));
+        .stdout(predicate::eq("2\n"));
 }
 
 #[test]
@@ -312,9 +312,10 @@ fn test_doc_keys_len_empty_yaml_json_succeeds_like_empty_json() {
 }
 
 #[test]
-fn test_doc_set_empty_yaml_write_bootstrap_unchanged() {
-    // Lock today's write: empty YAML set emits a mapping, and parse_doc is
-    // not rewritten to `{}` (that would change CST/bootstrap). #2283
+fn test_doc_set_empty_yaml_emits_mapping() {
+    // Cargo-bin lock: empty YAML `doc set --apply` writes `name: app\n`.
+    // This does not observe parse_doc (`set_at_path` already turns Null
+    // into {}). parse_doc == Null is locked in api/ops tests. #2283
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("empty.yaml");
     fs::write(&file, "").unwrap();
@@ -3755,8 +3756,8 @@ fn test_doc_keys_wildcard_json_is_ambiguous() {
     assert_eq!(v["error_kind"], "ambiguous", "{v}");
     let err = v["error"].as_str().unwrap_or("");
     assert!(
-        err.contains("items[0]") || err.contains("[0]"),
-        "ambiguous keys must name a concrete index: {v}"
+        err.contains("items[0]"),
+        "ambiguous keys must name items[0]: {v}"
     );
 }
 
@@ -3784,8 +3785,8 @@ fn test_doc_len_wildcard_json_is_ambiguous() {
     assert_eq!(v["error_kind"], "ambiguous", "{v}");
     let err = v["error"].as_str().unwrap_or("");
     assert!(
-        err.contains("items[0]") || err.contains("[0]"),
-        "ambiguous len must name a concrete index: {v}"
+        err.contains("items[0]"),
+        "ambiguous len must name items[0]: {v}"
     );
 }
 
@@ -3816,8 +3817,8 @@ fn test_doc_keys_wildcard_one_or_zero_json_is_ambiguous() {
         );
         let err = v["error"].as_str().unwrap_or("");
         assert!(
-            err.contains("items[0]") || err.contains("[0]"),
-            "ambiguous keys must name a concrete index: {v}"
+            err.contains("items[0]") && err.contains("one object") && !err.contains("or array"),
+            "ambiguous keys must name items[0] and one object: {v}"
         );
     }
 }
@@ -3849,8 +3850,8 @@ fn test_doc_len_wildcard_one_or_zero_json_is_ambiguous() {
         );
         let err = v["error"].as_str().unwrap_or("");
         assert!(
-            err.contains("items[0]") || err.contains("[0]"),
-            "ambiguous len must name a concrete index: {v}"
+            err.contains("items[0]") && err.contains("one object or array"),
+            "ambiguous len must name items[0] and one object or array: {v}"
         );
     }
 }

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -256,6 +256,81 @@ fn test_doc_len_multi_document_root() {
 }
 
 #[test]
+fn test_doc_keys_len_empty_yaml_json_succeeds_like_empty_json() {
+    // #2283: empty / whitespace YAML keys/len at `.` must match empty JSON.
+    let dir = TempDir::new().unwrap();
+    for (name, body) in [
+        ("empty.yaml", ""),
+        ("ws.yaml", "   \n  \n"),
+        ("empty.json", ""),
+    ] {
+        let file = dir.path().join(name);
+        fs::write(&file, body).unwrap();
+
+        let out = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "doc", "keys"])
+            .arg(&file)
+            .arg(".")
+            .output()
+            .unwrap();
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{name} keys must succeed, stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+        assert_eq!(v["ok"], true, "{name} keys: {v}");
+        assert!(
+            v.get("error_kind").is_none(),
+            "{name} keys must be the ok path: {v}"
+        );
+        assert_eq!(v["value"], serde_json::json!([]), "{name} keys value: {v}");
+
+        let out = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "doc", "len"])
+            .arg(&file)
+            .arg(".")
+            .output()
+            .unwrap();
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{name} len must succeed, stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+        assert_eq!(v["ok"], true, "{name} len: {v}");
+        assert!(
+            v.get("error_kind").is_none(),
+            "{name} len must be the ok path: {v}"
+        );
+        assert_eq!(v["value"], 0, "{name} len value: {v}");
+    }
+}
+
+#[test]
+fn test_doc_set_empty_yaml_write_bootstrap_unchanged() {
+    // Lock today's write: empty YAML set emits a mapping, and parse_doc is
+    // not rewritten to `{}` (that would change CST/bootstrap). #2283
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.yaml");
+    fs::write(&file, "").unwrap();
+
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--json", "--cwd"])
+        .arg(dir.path())
+        .args(["doc", "set", "empty.yaml", "name", "\"app\"", "--apply"])
+        .assert()
+        .code(0);
+
+    assert_eq!(fs::read_to_string(&file).unwrap(), "name: app\n");
+}
+
+#[test]
 fn test_doc_get_typo_key_json_did_you_mean() {
     let dir = TempDir::new().unwrap();
     let file = dir.path().join("config.toml");

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -3185,6 +3185,44 @@ async fn test_mcp_doc_len_multi_document_root() {
 }
 
 #[tokio::test]
+async fn test_mcp_doc_query_keys_len_empty_yaml() {
+    // #2283 sibling to keys/len fail-closed tests: empty YAML is `{}` on read.
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("empty.yaml"), "").unwrap();
+    fs::write(dir.path().join("ws.yaml"), "   \n  \n").unwrap();
+    fs::write(dir.path().join("empty.json"), "").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    for (path, action, expected) in [
+        ("empty.yaml", "keys", serde_json::json!([])),
+        ("empty.yaml", "len", serde_json::json!(0)),
+        ("ws.yaml", "keys", serde_json::json!([])),
+        ("ws.yaml", "len", serde_json::json!(0)),
+        ("empty.json", "keys", serde_json::json!([])),
+        ("empty.json", "len", serde_json::json!(0)),
+    ] {
+        let (is_error, val) = call_tool_value(
+            &client,
+            "doc_query",
+            serde_json::json!({"action": action, "path": path, "selector": "."}),
+        )
+        .await;
+        assert!(
+            !is_error,
+            "doc_query {action} on {path} must succeed, not type_error: {val}"
+        );
+        assert_eq!(
+            val, expected,
+            "doc_query {action} on {path} must match empty object: {val}"
+        );
+    }
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
 async fn test_mcp_doc_select_round_trip() {
     if !has_mcp_support() {
         return;

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -2887,8 +2887,8 @@ async fn test_mcp_doc_query_keys_wildcard_is_ambiguous() {
     );
     let msg = val["error"].as_str().unwrap_or("");
     assert!(
-        msg.contains("items[0]") || msg.contains("[0]"),
-        "doc_query keys ambiguous must name a concrete index: {val}"
+        msg.contains("items[0]"),
+        "doc_query keys ambiguous must name items[0]: {val}"
     );
     client.cancel().await.unwrap();
 }
@@ -2926,8 +2926,8 @@ async fn test_mcp_doc_query_len_wildcard_is_ambiguous() {
     );
     let msg = val["error"].as_str().unwrap_or("");
     assert!(
-        msg.contains("items[0]") || msg.contains("[0]"),
-        "doc_query len ambiguous must name a concrete index: {val}"
+        msg.contains("items[0]"),
+        "doc_query len ambiguous must name items[0]: {val}"
     );
     client.cancel().await.unwrap();
 }
@@ -2964,8 +2964,8 @@ async fn test_mcp_doc_query_keys_wildcard_one_or_zero_is_ambiguous() {
         );
         let msg = val["error"].as_str().unwrap_or("");
         assert!(
-            msg.contains("items[0]") || msg.contains("[0]"),
-            "doc_query keys ambiguous must name a concrete index: {val}"
+            msg.contains("items[0]") && msg.contains("one object") && !msg.contains("or array"),
+            "doc_query keys ambiguous must name items[0] and one object: {val}"
         );
     }
     client.cancel().await.unwrap();
@@ -3003,8 +3003,8 @@ async fn test_mcp_doc_query_len_wildcard_one_or_zero_is_ambiguous() {
         );
         let msg = val["error"].as_str().unwrap_or("");
         assert!(
-            msg.contains("items[0]") || msg.contains("[0]"),
-            "doc_query len ambiguous must name a concrete index: {val}"
+            msg.contains("items[0]") && msg.contains("one object or array"),
+            "doc_query len ambiguous must name items[0] and one object or array: {val}"
         );
     }
     client.cancel().await.unwrap();


### PR DESCRIPTION
Empty JSON already bootstraps to `{}` so `doc keys` / `doc len` succeed. Empty YAML stayed Null, so the same queries peeled `type_error`. Agents could not branch on one `error_kind`.

This PR remaps empty, whitespace-only, and BOM/ZWSP-only YAML to `{}` on the **read-only** query path (`parse_doc_for_query` / `load_for_query`). Write bootstrap is unchanged: `parse_doc` still returns Null, and `doc set` on an empty `.yaml` still writes a mapping.

Also:
- Shared `unique_query_target` for keys/len (no second parse for `items[0]` examples)
- Honest test locks (exact len stdout, require `items[0]`, parse_doc Null stays in unit tests)
- README test floor 4800+ (4810 tests)

Closes #2283
