### PR TITLE
test(doc): lock fail-closed YAML and empty get root

### DIFF
--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -475,6 +475,11 @@ fn doc_keys_and_len_bom_zwsp_yaml_match_empty() {
             0,
             "{name} len at . must be 0"
         );
+        assert_eq!(
+            doc_get(&file, ".").unwrap_or_else(|e| panic!("{name} get at .: {e}")),
+            serde_json::json!({}),
+            "{name} get at . must be {{}}"
+        );
     }
 }
 
@@ -489,6 +494,25 @@ fn doc_keys_comment_only_yaml_is_type_error() {
     assert!(
         crate::exit::is_type_error(&err),
         "comment-only YAML must stay type_error, got: {err}"
+    );
+}
+
+#[test]
+fn doc_keys_document_marker_yaml_is_type_error() {
+    // Leading `---` is YAML preamble, not blank text. parse_doc_for_query
+    // keeps Null; keys/len at `.` must stay type_error.
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("document.yaml");
+    fs::write(&file, "---\n").unwrap();
+    let keys_err = doc_keys(&file, ".").unwrap_err();
+    assert!(
+        crate::exit::is_type_error(&keys_err),
+        "document-marker YAML keys must stay type_error, got: {keys_err}"
+    );
+    let len_err = doc_len(&file, ".").unwrap_err();
+    assert!(
+        crate::exit::is_type_error(&len_err),
+        "document-marker YAML len must stay type_error, got: {len_err}"
     );
 }
 

--- a/src/cmd/doc_tests.rs
+++ b/src/cmd/doc_tests.rs
@@ -185,11 +185,14 @@ mod basic {
 
     #[test]
     fn keys_and_len_empty_yaml_json_succeeds_like_empty_json() {
-        // #2283: empty / whitespace YAML keys/len at `.` must not type_error.
+        // #2283: empty / whitespace / BOM / ZWSP YAML keys/len/get at `.`
+        // must match empty JSON. has is true for both Null and `{}`.
         let dir = TempDir::new().unwrap();
         for (name, body) in [
             ("empty.yaml", ""),
             ("ws.yaml", "   \n  \n"),
+            ("bom.yaml", "\u{feff}"),
+            ("zwsp.yaml", "\u{200b}"),
             ("empty.json", ""),
         ] {
             let path = write_file(&dir, name, body);
@@ -212,7 +215,7 @@ mod basic {
 
             let (output, code) = execute_with_mode(
                 &DocAction::Len {
-                    file: path,
+                    file: path.clone(),
                     selector: ".".into(),
                 },
                 OutputMode::Json,
@@ -226,6 +229,61 @@ mod basic {
                 "{name} len must be the ok path, not error_kind: {v}"
             );
             assert_eq!(v["value"], serde_json::json!(0), "{name} len value: {v}");
+
+            let (output, code) = execute_with_mode(
+                &DocAction::Get {
+                    file: path,
+                    selector: ".".into(),
+                },
+                OutputMode::Json,
+            )
+            .unwrap();
+            assert_eq!(code, exit::SUCCESS, "{name} get exit: {output}");
+            let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+            assert_eq!(v["ok"], true, "{name} get ok: {v}");
+            assert!(
+                v.get("error_kind").is_none(),
+                "{name} get must be the ok path, not error_kind: {v}"
+            );
+            assert_eq!(v["value"], serde_json::json!({}), "{name} get value: {v}");
+        }
+    }
+
+    #[test]
+    fn keys_and_len_comment_null_document_yaml_is_type_error() {
+        // # hi / explicit null / --- stay scalars. Do not remap to {}.
+        let dir = TempDir::new().unwrap();
+        for (name, body) in [
+            ("comment.yaml", "# hi\n"),
+            ("null.yaml", "null\n"),
+            ("document.yaml", "---\n"),
+        ] {
+            let path = write_file(&dir, name, body);
+            let (output, code) = execute_with_mode(
+                &DocAction::Keys {
+                    file: path.clone(),
+                    selector: ".".into(),
+                },
+                OutputMode::Json,
+            )
+            .unwrap();
+            assert_eq!(code, exit::FAILURE, "{name} keys exit: {output}");
+            let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+            assert_eq!(v["ok"], false, "{name} keys ok: {v}");
+            assert_eq!(v["error_kind"], "type_error", "{name} keys error_kind: {v}");
+
+            let (output, code) = execute_with_mode(
+                &DocAction::Len {
+                    file: path,
+                    selector: ".".into(),
+                },
+                OutputMode::Json,
+            )
+            .unwrap();
+            assert_eq!(code, exit::FAILURE, "{name} len exit: {output}");
+            let v: serde_json::Value = serde_json::from_str(&output).unwrap();
+            assert_eq!(v["ok"], false, "{name} len ok: {v}");
+            assert_eq!(v["error_kind"], "type_error", "{name} len error_kind: {v}");
         }
     }
 

--- a/tests/integration/doc_tests.rs
+++ b/tests/integration/doc_tests.rs
@@ -257,11 +257,14 @@ fn test_doc_len_multi_document_root() {
 
 #[test]
 fn test_doc_keys_len_empty_yaml_json_succeeds_like_empty_json() {
-    // #2283: empty / whitespace YAML keys/len at `.` must match empty JSON.
+    // #2283: empty / whitespace / BOM / ZWSP YAML keys/len/get at `.`
+    // must match empty JSON. has is true for both Null and `{}`.
     let dir = TempDir::new().unwrap();
     for (name, body) in [
         ("empty.yaml", ""),
         ("ws.yaml", "   \n  \n"),
+        ("bom.yaml", "\u{feff}"),
+        ("zwsp.yaml", "\u{200b}"),
         ("empty.json", ""),
     ] {
         let file = dir.path().join(name);
@@ -308,6 +311,75 @@ fn test_doc_keys_len_empty_yaml_json_succeeds_like_empty_json() {
             "{name} len must be the ok path: {v}"
         );
         assert_eq!(v["value"], 0, "{name} len value: {v}");
+
+        let out = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "doc", "get"])
+            .arg(&file)
+            .arg(".")
+            .output()
+            .unwrap();
+        assert_eq!(
+            out.status.code(),
+            Some(0),
+            "{name} get must succeed, stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+        assert_eq!(v["ok"], true, "{name} get: {v}");
+        assert!(
+            v.get("error_kind").is_none(),
+            "{name} get must be the ok path: {v}"
+        );
+        assert_eq!(v["value"], serde_json::json!({}), "{name} get value: {v}");
+    }
+}
+
+#[test]
+fn test_doc_keys_len_comment_null_document_yaml_is_type_error() {
+    // cargo-bin: # hi / explicit null / --- stay type_error on keys/len.
+    let dir = TempDir::new().unwrap();
+    for (name, body) in [
+        ("comment.yaml", "# hi\n"),
+        ("null.yaml", "null\n"),
+        ("document.yaml", "---\n"),
+    ] {
+        let file = dir.path().join(name);
+        fs::write(&file, body).unwrap();
+
+        let out = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "doc", "keys"])
+            .arg(&file)
+            .arg(".")
+            .output()
+            .unwrap();
+        assert_eq!(
+            out.status.code(),
+            Some(1),
+            "{name} keys must be type_error exit 1, stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+        assert_eq!(v["ok"], false, "{name} keys: {v}");
+        assert_eq!(v["error_kind"], "type_error", "{name} keys error_kind: {v}");
+
+        let out = Command::cargo_bin("patchloom")
+            .unwrap()
+            .args(["--json", "doc", "len"])
+            .arg(&file)
+            .arg(".")
+            .output()
+            .unwrap();
+        assert_eq!(
+            out.status.code(),
+            Some(1),
+            "{name} len must be type_error exit 1, stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+        assert_eq!(v["ok"], false, "{name} len: {v}");
+        assert_eq!(v["error_kind"], "type_error", "{name} len error_kind: {v}");
     }
 }
 

--- a/tests/integration/mcp_tool_tests.rs
+++ b/tests/integration/mcp_tool_tests.rs
@@ -3193,6 +3193,8 @@ async fn test_mcp_doc_query_keys_len_empty_yaml() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join("empty.yaml"), "").unwrap();
     fs::write(dir.path().join("ws.yaml"), "   \n  \n").unwrap();
+    fs::write(dir.path().join("bom.yaml"), "\u{feff}").unwrap();
+    fs::write(dir.path().join("zwsp.yaml"), "\u{200b}").unwrap();
     fs::write(dir.path().join("empty.json"), "").unwrap();
 
     let client = spawn_mcp_client(dir.path()).await;
@@ -3201,6 +3203,10 @@ async fn test_mcp_doc_query_keys_len_empty_yaml() {
         ("empty.yaml", "len", serde_json::json!(0)),
         ("ws.yaml", "keys", serde_json::json!([])),
         ("ws.yaml", "len", serde_json::json!(0)),
+        ("bom.yaml", "keys", serde_json::json!([])),
+        ("bom.yaml", "len", serde_json::json!(0)),
+        ("zwsp.yaml", "keys", serde_json::json!([])),
+        ("zwsp.yaml", "len", serde_json::json!(0)),
         ("empty.json", "keys", serde_json::json!([])),
         ("empty.json", "len", serde_json::json!(0)),
     ] {
@@ -3218,6 +3224,59 @@ async fn test_mcp_doc_query_keys_len_empty_yaml() {
             val, expected,
             "doc_query {action} on {path} must match empty object: {val}"
         );
+    }
+    for path in [
+        "empty.yaml",
+        "ws.yaml",
+        "bom.yaml",
+        "zwsp.yaml",
+        "empty.json",
+    ] {
+        let (is_error, val) = call_tool_value(
+            &client,
+            "doc_get",
+            serde_json::json!({"path": path, "selector": "."}),
+        )
+        .await;
+        assert!(!is_error, "doc_get on {path} must succeed: {val}");
+        assert_eq!(
+            val,
+            serde_json::json!({}),
+            "doc_get on {path} must be {{}}: {val}"
+        );
+    }
+    client.cancel().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_mcp_doc_keys_len_comment_null_document_yaml_is_type_error() {
+    // MCP: # hi / explicit null / --- stay type_error on keys/len.
+    if !has_mcp_support() {
+        return;
+    }
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("comment.yaml"), "# hi\n").unwrap();
+    fs::write(dir.path().join("null.yaml"), "null\n").unwrap();
+    fs::write(dir.path().join("document.yaml"), "---\n").unwrap();
+
+    let client = spawn_mcp_client(dir.path()).await;
+    for path in ["comment.yaml", "null.yaml", "document.yaml"] {
+        for action in ["keys", "len"] {
+            let (is_error, val) = call_tool_value(
+                &client,
+                "doc_query",
+                serde_json::json!({"action": action, "path": path, "selector": "."}),
+            )
+            .await;
+            assert!(
+                is_error,
+                "doc_query {action} on {path} must be is_error: {val}"
+            );
+            assert_eq!(
+                val["error_kind"], "type_error",
+                "doc_query {action} on {path} must set error_kind type_error: {val}"
+            );
+        }
     }
     client.cancel().await.unwrap();
 }


### PR DESCRIPTION
Lock the empty-YAML read contract on agent surfaces after #2285.

Empty, whitespace, BOM-only, and ZWSP-only YAML already return `[]` / `0` / `{}` for keys, len, and get at `.`. This PR adds the same locks on CLI unit, cargo-bin, MCP, and the library `---` case.

Comment-only `# hi`, explicit `null`, and a document marker `---` stay `error_kind: type_error` on keys/len. Write-side `parse_doc` bootstrap is unchanged.

Ref #2285
Ref #2283
