### PR TITLE
fix(api): snapshot regular files on empty-hunk patch delete

### DIFF
--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -160,11 +160,8 @@ fn patch_write(
         }
         if pf.is_deletion {
             // file_delete snapshot: empty original for symlink / FIFO / socket.
-            // Empty-hunk git delete must not follow (apply_patch_with_loader
-            // is cfg-gated on cli/files; this is the no-default path).
-            let original = if crate::ops::file::is_regular_file_for_backup(&load_path)
-                && !pf.hunks.is_empty()
-            {
+            // apply_patch_with_loader is cfg-gated; this is the no-default path.
+            let original = if crate::ops::file::is_regular_file_for_backup(&load_path) {
                 crate::files::load_text_strict(&load_path, load_rel).unwrap_or_default()
             } else {
                 String::new()

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -9655,6 +9655,31 @@ fn apply_patch_begin_patch_delete_symlink_outside_does_not_leak_target() {
     assert_eq!(fs::read_to_string(&secret).unwrap(), PAYLOAD);
 }
 
+/// Empty-hunk git delete of a regular file must populate `original_content`.
+/// Symlink/FIFO snapshot is empty; regular files still load (parity with
+/// `apply_patch_file` and tx).
+#[test]
+fn apply_patch_unified_delete_regular_file_snapshots_content() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("gone.txt");
+    const BODY: &str = "keep this text\n";
+    fs::write(&file, BODY).unwrap();
+    let patch = "\
+diff --git a/gone.txt b/gone.txt\n\
+deleted file mode 100644\n\
+index e69de29..0000000\n";
+    let result = apply_patch(&file, patch, ApplyMode::Apply, None)
+        .expect("empty-hunk delete of a regular file");
+    assert_eq!(
+        result.original_content, BODY,
+        "regular-file delete snapshot must load the file text"
+    );
+    assert!(
+        !file.exists(),
+        "deletion patch must unlink, not leave an empty file"
+    );
+}
+
 /// Unified-diff delete via `apply_patch` (tx loader) must not snapshot the
 /// outside symlink target. Empty-hunk git delete; no PathGuard so a follow
 /// load leaks into `original_content` on the unfixed path.


### PR DESCRIPTION
## Summary

On the no-default library path, an empty-hunk git delete of a regular file now snapshots the file text into `EditResult.original_content`, matching `apply_patch_file` and the tx engine.

## Problem

`apply_patch` without the `cli` or `files` features used `is_regular_file_for_backup && !pf.hunks.is_empty()` before calling `load_text_strict`. A git delete that is only `deleted file mode` (no hunks) therefore left `original_content` empty even when the file had text. Symlink, FIFO, and socket deletes already stay empty on purpose.

## Change

- `src/api/patch.rs`: load whenever the path is a regular file. Keep an empty snapshot only for non-regular entries.
- `src/api/tests.rs`: lock the regular-file empty-hunk delete snapshot and unlink.

## Validation

- Red: `cargo test --lib --no-default-features apply_patch_unified_delete_regular_file_snapshots_content` failed with `original_content == ""`.
- Green: same test plus the symlink-outside lock on `--no-default-features`, default features, and `--features ast,files`.
- `cargo test --lib --no-default-features`: 1719 passed.
- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`.

## Issue reference

Ref #2284
Ref #2288
