### PR TITLE
fix(api): report changed on empty-hunk apply_patch delete

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1179,10 +1179,19 @@ fn execution_result_to_edit_result(
         .changes
         .first()
         .and_then(|(abs_path, _, _)| result.exec_result.replace_match_meta.get(abs_path).cloned());
-    let (path_str, original, new_content) =
+    let (path_str, original, new_content, is_deletion) =
         if let Some((abs_path, orig, new)) = result.exec_result.changes.first() {
             let rel = crate::files::relative_display(abs_path, cwd);
-            (rel.to_string_lossy().to_string(), orig.clone(), new.clone())
+            // Tx keeps identity (orig == final) on the changes row so commit
+            // still runs; new_content must be empty for a delete (#2288).
+            let deleted = result.exec_result.deletions.contains(abs_path);
+            let new_content = if deleted { String::new() } else { new.clone() };
+            (
+                rel.to_string_lossy().to_string(),
+                orig.clone(),
+                new_content,
+                deleted,
+            )
         } else if let Some(abs_path) = result.exec_result.deletions.iter().next() {
             // File deletion: content is in the pending map.
             let rel = crate::files::relative_display(abs_path, cwd);
@@ -1192,14 +1201,19 @@ fn execution_result_to_edit_result(
                 .get(abs_path)
                 .map(|(orig, _)| orig.clone())
                 .unwrap_or_default();
-            (rel.to_string_lossy().to_string(), original, String::new())
+            (
+                rel.to_string_lossy().to_string(),
+                original,
+                String::new(),
+                true,
+            )
         } else if let Some(p) = mutation_path {
             // No file content change (e.g. idempotent doc.delete) but mutations
             // still carry path + removed counts for embedders (#1459).
-            (p, String::new(), String::new())
+            (p, String::new(), String::new(), false)
         } else {
             // No changes at all (e.g., replace with no matches + if_exists).
-            (String::new(), String::new(), String::new())
+            (String::new(), String::new(), String::new(), false)
         };
     // Prefer caller spelling when provided (parent-as-cwd collapses multi-
     // component relatives to basename via relative_display).
@@ -1217,6 +1231,10 @@ fn execution_result_to_edit_result(
     };
 
     let mut edit = build_edit_result(&path_str, original, new_content, applied, action, dest_path);
+    if is_deletion {
+        // Empty-file delete has orig == new == ""; still a change (#2288).
+        edit.changed = true;
+    }
     edit.removed = removed;
     edit.backup_session = backup_session;
     // build_edit_result already sets style_changed for doc.* actions (#2088).

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -9675,9 +9675,35 @@ index e69de29..0000000\n";
         "regular-file delete snapshot must load the file text"
     );
     assert!(
+        result.changed,
+        "empty-hunk delete must report changed (identity changes row is still a delete)"
+    );
+    assert!(
+        result.new_content.is_empty(),
+        "deleted file new_content must be empty, not the pre-delete text"
+    );
+    assert!(
         !file.exists(),
         "deletion patch must unlink, not leave an empty file"
     );
+}
+
+/// Empty-file delete is still a change: orig == new == "" on the tx row.
+#[cfg(any(feature = "cli", feature = "files"))]
+#[test]
+fn apply_patch_unified_delete_empty_file_reports_changed() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("empty.txt");
+    fs::write(&file, "").unwrap();
+    let patch = "\
+diff --git a/empty.txt b/empty.txt\n\
+deleted file mode 100644\n\
+index e69de29..0000000\n";
+    let result = apply_patch(&file, patch, ApplyMode::Apply, None)
+        .expect("empty-hunk delete of an empty regular file");
+    assert!(result.changed, "empty-file delete must report changed");
+    assert!(result.new_content.is_empty());
+    assert!(!file.exists(), "deletion patch must unlink the empty file");
 }
 
 /// Unified-diff delete via `apply_patch` (tx loader) must not snapshot the


### PR DESCRIPTION
## Summary

`apply_patch` with default features now reports `changed: true` and empty `new_content` for an empty-hunk git delete. The file was already unlinked; the adapter had treated the tx identity row as a no-op.

## Problem

The tx engine keeps `original == final` on the `changes` row so commit still runs. `execution_result_to_edit_result` preferred that row over `deletions`, so `build_edit_result` set `changed = false` and left `new_content` as the pre-delete text.

## Change

- `src/api/mod.rs`: if the first changes path is in `deletions`, emit empty `new_content` and force `changed`. Same force on the deletions-only branch (empty-file delete).
- `src/api/tests.rs`: lock `changed` and empty `new_content` on the regular-file snapshot test; add an empty-file delete lock.

## Validation

- Red: `cargo test --lib apply_patch_unified_delete_regular_file_snapshots_content` failed with `changed` false (default features).
- Green: `apply_patch_unified_delete` (3 tests default, 2 no-default including the symlink-outside lock).
- `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`.

## Issue reference

Closes #2288
Ref #2287
Ref #2284
