### PR TITLE
fix(api): follow symlink targets on content patches

### DIFF
--- a/src/api/patch.rs
+++ b/src/api/patch.rs
@@ -161,6 +161,13 @@ fn patch_write(
         if pf.is_deletion {
             // file_delete snapshot: empty original for symlink / FIFO / socket.
             // apply_patch_with_loader is cfg-gated; this is the no-default path.
+            if !crate::ops::file::path_entry_exists(&load_path) {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    format!("file not found: {load_rel}"),
+                )
+                .into());
+            }
             let original = if crate::ops::file::is_regular_file_for_backup(&load_path) {
                 crate::files::load_text_strict(&load_path, load_rel).unwrap_or_default()
             } else {

--- a/src/api/tests.rs
+++ b/src/api/tests.rs
@@ -9742,6 +9742,93 @@ index e69de29..0000000\n";
     assert_eq!(fs::read_to_string(&secret).unwrap(), PAYLOAD);
 }
 
+/// Content patch on a workspace symlink must load the target text (#2290).
+/// The tx loader used to return `""` for every non-regular entry, so an
+/// add-only hunk overwrote the target with just the added lines.
+#[cfg(unix)]
+#[test]
+fn apply_patch_add_only_hunk_through_symlink_preserves_target() {
+    let dir = TempDir::new().unwrap();
+    let real = dir.path().join("real.txt");
+    const BODY: &str = "alpha\nbeta\ngamma\n";
+    fs::write(&real, BODY).unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let patch = "\
+--- a/link.txt
++++ b/link.txt
+@@ -0,0 +1,1 @@
++INJECTED
+";
+    let result = apply_patch(&link, patch, ApplyMode::Apply, None)
+        .expect("content patch through a live symlink");
+    assert!(result.changed);
+    let on_disk = fs::read_to_string(&real).unwrap();
+    assert_eq!(
+        on_disk, "INJECTED\nalpha\nbeta\ngamma\n",
+        "add-only hunk must prepend, not replace the target: {on_disk:?}"
+    );
+    assert!(
+        link.symlink_metadata().unwrap().file_type().is_symlink(),
+        "write-through must keep the symlink entry"
+    );
+}
+
+/// Context hunk on a symlink must apply against the target, not stale-fail
+/// against an empty original (#2290).
+#[cfg(unix)]
+#[test]
+fn apply_patch_context_hunk_through_symlink_applies() {
+    let dir = TempDir::new().unwrap();
+    let real = dir.path().join("real.txt");
+    fs::write(&real, "alpha\nbeta\ngamma\n").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let patch = "\
+--- a/link.txt
++++ b/link.txt
+@@ -1,3 +1,3 @@
+-alpha
++ALPHA
+ beta
+ gamma
+";
+    let result = apply_patch(&link, patch, ApplyMode::Apply, None)
+        .expect("context hunk through a live symlink");
+    assert!(result.changed);
+    assert_eq!(fs::read_to_string(&real).unwrap(), "ALPHA\nbeta\ngamma\n");
+}
+
+/// Missing empty-hunk delete must peel `not_found` on Apply and Check (#2291).
+/// The no-default `patch_write` arm used to report Check as `changed: true`.
+#[test]
+fn apply_patch_delete_missing_is_not_found() {
+    let dir = TempDir::new().unwrap();
+    let missing = dir.path().join("gone.txt");
+    let patch = "\
+diff --git a/gone.txt b/gone.txt\n\
+deleted file mode 100644\n\
+index e69de29..0000000\n";
+    let apply_err = apply_patch(&missing, patch, ApplyMode::Apply, None)
+        .expect_err("missing delete must error on Apply");
+    assert_eq!(
+        crate::fallback::error_kind_str(&apply_err),
+        Some("not_found"),
+        "Apply missing delete must peel not_found: {apply_err}"
+    );
+    assert!(
+        crate::fallback::is_not_found(&apply_err),
+        "Apply missing delete is_not_found: {apply_err}"
+    );
+    let check_err = apply_patch(&missing, patch, ApplyMode::Check, None)
+        .expect_err("missing delete must error on Check, not changed:true");
+    assert_eq!(
+        crate::fallback::error_kind_str(&check_err),
+        Some("not_found"),
+        "Check missing delete must peel not_found: {check_err}"
+    );
+}
+
 #[test]
 fn apply_patch_file_case_only_rename_preserves_inode_content() {
     let dir = TempDir::new().unwrap();

--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -710,18 +710,27 @@ pub fn find_similar_targets(content: &str, target: &str, max_results: usize) -> 
         return vec![];
     }
 
-    let mut tokens: Vec<String> = content.lines().flat_map(extract_identifiers).collect();
+    // Dedup before materializing: HashSet<&str> over borrowed slices so
+    // repeated identifiers do not each allocate a String (#2292).
+    let mut seen = std::collections::HashSet::new();
+    let mut tokens: Vec<&str> = Vec::new();
+    for line in content.lines() {
+        for ident in extract_identifiers(line) {
+            if seen.insert(ident) {
+                tokens.push(ident);
+            }
+        }
+    }
     // Also try matching against whole lines for multi-word patterns.
     if target.contains(' ') || target.len() > 20 {
-        tokens.extend(
-            content
-                .lines()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string),
-        );
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if !trimmed.is_empty() && seen.insert(trimmed) {
+                tokens.push(trimmed);
+            }
+        }
     }
-    find_similar_among(tokens.iter().map(String::as_str), target, max_results)
+    find_similar_among(tokens, target, max_results)
 }
 
 /// Try anchor-based matching: find the target text using surrounding context lines.
@@ -1048,10 +1057,10 @@ fn best_token_similarity(content: &str, target: &str) -> Option<AnchorMatchResul
             if ident == target {
                 continue;
             }
-            let score = strsim::jaro_winkler(&ident, target);
+            let score = strsim::jaro_winkler(ident, target);
             if score > best_score {
                 best_score = score;
-                best_match = ident;
+                best_match = ident.to_string();
                 best_offset = offset + col;
             }
         }
@@ -1117,7 +1126,7 @@ fn advance_line_offset(content: &str, mut offset: usize, line: &str) -> usize {
 }
 
 /// Extract identifier-like tokens from a line of code.
-fn extract_identifiers(line: &str) -> Vec<String> {
+fn extract_identifiers(line: &str) -> Vec<&str> {
     extract_identifiers_with_offsets(line)
         .into_iter()
         .map(|(s, _)| s)
@@ -1125,30 +1134,28 @@ fn extract_identifiers(line: &str) -> Vec<String> {
 }
 
 /// Identifier tokens with byte offsets into `line` (#1694).
-fn extract_identifiers_with_offsets(line: &str) -> Vec<(String, usize)> {
+fn extract_identifiers_with_offsets(line: &str) -> Vec<(&str, usize)> {
     let mut identifiers = Vec::new();
-    let mut current = String::new();
-    let mut start = 0usize;
+    let mut start: Option<usize> = None;
     let mut i = 0usize;
 
     for ch in line.chars() {
         let clen = ch.len_utf8();
         if ch.is_alphanumeric() || ch == '_' {
-            if current.is_empty() {
-                start = i;
+            if start.is_none() {
+                start = Some(i);
             }
-            current.push(ch);
-        } else {
-            if current.len() >= 3 {
-                identifiers.push((std::mem::take(&mut current), start));
-            } else {
-                current.clear();
-            }
+        } else if let Some(s) = start.take()
+            && i - s >= 3
+        {
+            identifiers.push((&line[s..i], s));
         }
         i += clen;
     }
-    if current.len() >= 3 {
-        identifiers.push((current, start));
+    if let Some(s) = start
+        && i - s >= 3
+    {
+        identifiers.push((&line[s..i], s));
     }
 
     identifiers
@@ -1946,10 +1953,10 @@ mod tests {
     fn extract_identifiers_from_code() {
         let line = "fn process_request(data: &str) -> Result<()> {";
         let ids = extract_identifiers(line);
-        assert!(ids.contains(&"process_request".to_string()));
-        assert!(ids.contains(&"data".to_string()));
-        assert!(ids.contains(&"str".to_string()));
-        assert!(ids.contains(&"Result".to_string()));
+        assert!(ids.contains(&"process_request"));
+        assert!(ids.contains(&"data"));
+        assert!(ids.contains(&"str"));
+        assert!(ids.contains(&"Result"));
     }
 
     #[test]
@@ -2008,6 +2015,18 @@ mod tests {
         assert!(
             !similar.is_empty(),
             "should find similar multi-word targets"
+        );
+    }
+
+    #[test]
+    fn find_similar_targets_dedups_repeated_tokens() {
+        let content = "fn process_request() {}\nfn process_request() {}\nfn process_request() {}\n";
+        let similar = find_similar_targets(content, "process_requst", 3);
+        let hits: Vec<_> = similar.iter().filter(|s| *s == "process_request").collect();
+        assert_eq!(
+            hits.len(),
+            1,
+            "repeated identifiers must appear once: {similar:?}"
         );
     }
 

--- a/src/tx/patch_op.rs
+++ b/src/tx/patch_op.rs
@@ -40,17 +40,11 @@ pub(crate) fn execute_patch_op(op: &Operation, tx: &mut TxState<'_>) -> anyhow::
                 diff,
                 |path| {
                     let file_path = tx.cwd.join(path);
-                    // file_delete snapshot: do not follow symlink / FIFO / socket.
-                    if crate::ops::file::path_entry_exists(&file_path)
-                        && !crate::ops::file::is_regular_file_for_backup(&file_path)
-                    {
-                        if !tx.pending.contains_key(&file_path) {
-                            tx.existed_before.insert(file_path.clone());
-                            tx.pending
-                                .insert(file_path.clone(), (String::new(), String::new()));
-                        }
-                        return Ok(String::new());
-                    }
+                    // Content patches load through load_text_strict (follows a
+                    // live file symlink; FIFO/socket refuse without hanging).
+                    // Empty-hunk delete never reaches this loader
+                    // (ops::patch short-circuits); the deletion snapshot below
+                    // stays empty for symlink / FIFO / socket (#2290).
                     match read_file_content(tx.pending, tx.existed_before, &file_path) {
                         Ok(s) => Ok(s.to_string()),
                         Err(e)

--- a/tests/integration/patch_tests.rs
+++ b/tests/integration/patch_tests.rs
@@ -1996,6 +1996,49 @@ index e69de29..0000000
     assert_eq!(fs::read_to_string(&secret).unwrap(), PAYLOAD);
 }
 
+/// Add-only hunk through a workspace symlink must prepend, not wipe the
+/// target (#2290). CLI uses the same tx loader as default-features apply_patch.
+#[cfg(unix)]
+#[test]
+fn test_patch_add_only_hunk_through_symlink_preserves_target() {
+    let dir = TempDir::new().unwrap();
+    let real = dir.path().join("real.txt");
+    fs::write(&real, "alpha\nbeta\ngamma\n").unwrap();
+    let link = dir.path().join("link.txt");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+    let patch_file = dir.path().join("add.patch");
+    fs::write(
+        &patch_file,
+        "\
+--- a/link.txt
++++ b/link.txt
+@@ -0,0 +1,1 @@
++INJECTED
+",
+    )
+    .unwrap();
+    Command::cargo_bin("patchloom")
+        .unwrap()
+        .args(["--cwd"])
+        .arg(dir.path())
+        .args(["patch", "apply", "--apply"])
+        .arg(&patch_file)
+        .assert()
+        .success();
+    assert_eq!(
+        fs::read_to_string(&real).unwrap(),
+        "INJECTED\nalpha\nbeta\ngamma\n",
+        "add-only hunk must prepend through the symlink"
+    );
+    assert!(
+        fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "write-through must keep the symlink entry"
+    );
+}
+
 #[test]
 fn test_patch_begin_patch_double_delete_is_not_found() {
     let dir = TempDir::new().unwrap();


### PR DESCRIPTION
## Summary

Content patches on a workspace symlink load the target's text again. A missing empty-hunk delete peels `not_found` on the no-default library path. Similar-target collection no longer allocates a `String` per duplicate identifier.

## Problem

After the empty-hunk delete snapshot work (#2287 / #2289), the tx patch loader treated every non-regular path as an empty original. That guard was meant for delete snapshots. Empty-hunk delete never reaches the loader, so the guard only fired on content patches.

An add-only hunk against `""` wrote just the added lines through the symlink and wiped the target. A context hunk failed stale. The no-default `patch_write` delete arm skipped existence: Check reported `changed: true`, and Apply wrapped `remove_file` so `error_kind_str` could not peel `not_found`.

`find_similar_targets` collected every identifier occurrence into a `Vec<String>` before dedup.

## Change

- Drop the empty-original branch from the tx loader. Delete snapshot stays on the `is_deletion` arm (symlink / FIFO / socket stay empty).
- Check `path_entry_exists` on the no-default delete path and return `io::ErrorKind::NotFound` before backup or unlink.
- Collect unique borrowed identifier slices (`HashSet<&str>`) in `find_similar_targets`.

## Validation

Red without the fix, green after:

- `apply_patch_add_only_hunk_through_symlink_preserves_target` (lib, default and no-default)
- `apply_patch_context_hunk_through_symlink_applies`
- `apply_patch_delete_missing_is_not_found` (fails on `--no-default-features` without the existence check)
- `test_patch_add_only_hunk_through_symlink_preserves_target` (cargo-bin)
- Existing `apply_patch_unified_delete_symlink_outside_does_not_leak_target` still green
- `find_similar_targets_*` including dedup lock

`make check-fast` green locally.

Closes #2290
Closes #2291
Closes #2292
